### PR TITLE
modify popconfirm & popover & tooltip placement

### DIFF
--- a/components/popconfirm/demo/placement.md
+++ b/components/popconfirm/demo/placement.md
@@ -19,14 +19,14 @@ React.render(<div>
   <Popconfirm placement="left" title={text} onConfirm={confirm}>
     <a href="javascript:;">左边</a>
   </Popconfirm>
-  <Popconfirm placement="right" title={text} onConfirm={confirm}>
-    <a href="javascript:;">右边</a>
-  </Popconfirm>
   <Popconfirm placement="top" title={text} onConfirm={confirm}>
     <a href="javascript:;">上边</a>
   </Popconfirm>
   <Popconfirm placement="bottom" title={text} onConfirm={confirm}>
     <a href="javascript:;">下边</a>
+  </Popconfirm>
+  <Popconfirm placement="right" title={text} onConfirm={confirm}>
+    <a href="javascript:;">右边</a>
   </Popconfirm>
 </div>, document.getElementById('components-popconfirm-demo-placement'));
 ````

--- a/components/popover/demo/placement.md
+++ b/components/popover/demo/placement.md
@@ -18,14 +18,14 @@ React.render(<div>
   <Popover placement="left" title={text} overlay={content}>
     <button className="ant-btn">左</button>
   </Popover>
-  <Popover placement="right" title={text} overlay={content}>
-    <button className="ant-btn">右</button>
-  </Popover>
   <Popover placement="top" title={text} overlay={content}>
     <button className="ant-btn">上</button>
   </Popover>
   <Popover placement="bottom" title={text} overlay={content}>
     <button className="ant-btn">下</button>
+  </Popover>
+  <Popover placement="right" title={text} overlay={content}>
+    <button className="ant-btn">右</button>
   </Popover>
 </div>, document.getElementById('components-popover-demo-placement'));
 ````

--- a/components/tooltip/demo/placement.md
+++ b/components/tooltip/demo/placement.md
@@ -15,14 +15,14 @@ React.render(
     <Tooltip placement="left" title={text}>
       <a href="#">左边左边</a>
     </Tooltip>
-    <Tooltip placement="right" title={text}>
-      <a href="#">右边右边</a>
-    </Tooltip>
     <Tooltip placement="top" title={text}>
       <a href="#">上边上边</a>
     </Tooltip>
     <Tooltip placement="bottom" title={text}>
       <a href="#">下边下边</a>
+    </Tooltip>
+    <Tooltip placement="right" title={text}>
+      <a href="#">右边右边</a>
     </Tooltip>
   </div>
 , document.getElementById('components-tooltip-demo-placement'));


### PR DESCRIPTION
修改 popconfirm & popover & tooltip 位置 Demo 中的顺序（左右上下改为左上下右），以免右方的弹出层遮挡后面的触发对象
