### PR TITLE
fixed collapse IE8/Safari

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "rc-animate": "~1.1.0",
     "rc-calendar": "~3.14.0",
     "rc-checkbox": "~1.1.1",
-    "rc-collapse": "~1.2.3",
+    "rc-collapse": "~1.3.0",
     "rc-dialog": "~5.0.1",
     "rc-dropdown": "~1.3.3",
     "rc-form-validation": "~2.4.7",

--- a/style/components/collapse.less
+++ b/style/components/collapse.less
@@ -31,7 +31,7 @@
         color: #666;
         display: inline-block;
         margin-right: 8px;
-        content:"\e60f";
+        content: "\e60f";
         #arrow > .close();
         vertical-align: middle;
         transition: transform 0.24s ease;
@@ -43,8 +43,6 @@
 
   &-content {
     height: 0;
-    transition-duration: .24s;
-    transition-timing-function: @ease-out-circ;
     overflow: hidden;
     color: @text-color;
     padding: 0 16px;
@@ -56,6 +54,12 @@
     }
   }
 
+  &-collapsing {
+    transition-duration: .3s;
+    transition-timing-function: cubic-bezier(0.215, 0.61, 0.355, 1);
+    transition-property: height;
+  }
+
   &-item:last-child {
     > .@{collapse-prefix-cls}-content {
       border-radius: 0 0 3px 3px;
@@ -63,6 +67,7 @@
   }
 
   &-content-active {
+    height: auto;
   }
 
   & > &-item-active {


### PR DESCRIPTION
修复 Collapse 在 IE8 和 Safari 下的问题
[折叠动画闪动](https://github.com/ant-design/ant-design/issues/161)
[嵌套 Demo 里内部面板收缩时，外部面板不能收缩](https://github.com/ant-design/ant-design/issues/138)
