### PR TITLE
fix: antd build fail

### DIFF
--- a/components/affix/index.jsx
+++ b/components/affix/index.jsx
@@ -89,8 +89,8 @@ let Affix = React.createClass({
 
   render() {
     const className = rcUtil.classSet({
-      [`${this.props.className}`]: this.props.className,
-      ['ant-affix']: this.state.affix
+      [this.props.className]: this.props.className,
+      'ant-affix': this.state.affix
     });
 
     return (

--- a/components/affix/index.jsx
+++ b/components/affix/index.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import joinClasses from 'react/lib/joinClasses';
 import rcUtil from 'rc-util';
 
 function getScroll(w, top) {
@@ -89,12 +88,14 @@ let Affix = React.createClass({
   },
 
   render() {
-    let affix = this.state.affix ? 'ant-affix' : '';
-    let className = this.props.className;
+    const className = rcUtil.classSet({
+      [`${this.props.className}`]: this.props.className,
+      ['ant-affix']: this.state.affix
+    });
 
     return (
       <div {...this.props}>
-        <div className={joinClasses(className, affix)} style={this.state.affixStyle}>
+        <div className={className} style={this.state.affixStyle}>
           {this.props.children}
         </div>
       </div>

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "rc-tree": "~0.15.4",
     "rc-upload": "~1.6.4",
     "rc-util": "~2.0.3",
-    "react-slick": "~0.7.0",
+    "react-slick": "~0.8.0",
     "reqwest-without-xhr2": "~2.0.2",
     "util-deprecate": "~1.0.1",
     "velocity-animate": "~1.2.2"


### PR DESCRIPTION
因为部份 react-component 的依赖是这样的 `"react": "^0.13.x"`，所以删除 `node_modules` 后，重新 `tnpm install` 的话，安装的是 react@0.14.x。

由于原来的代码引用了一些 react@0.14.x 不兼容的依赖，所以需要更新这部分代码。

如果这个 PR 合并了的话，应该也需要 pick 到 master 上，不然在重新 `tnpm install` 后，maser 的代码应该也是 build 不了的。
