### PR TITLE
fix btn-group mixin bug

### DIFF
--- a/style/mixins/button.less
+++ b/style/mixins/button.less
@@ -253,15 +253,15 @@
     padding-left: 8px;
   }
 
-  > & {
+ & > & {
     float: left;
   }
 
-  > &:not(:first-child):not(:last-child) > .@{btnClassName} {
+ & > &:not(:first-child):not(:last-child) > .@{btnClassName} {
     border-radius: 0;
   }
 
-  > &:first-child:not(:last-child) {
+ & > &:first-child:not(:last-child) {
     > .@{btnClassName}:last-child {
       border-bottom-right-radius: 0;
       border-top-right-radius: 0;
@@ -269,7 +269,7 @@
     }
   }
 
-  > &:last-child:not(:first-child) > .@{btnClassName}:first-child {
+ & > &:last-child:not(:first-child) > .@{btnClassName}:first-child {
     border-bottom-left-radius: 0;
     border-top-left-radius: 0;
     padding-left: 8px;


### PR DESCRIPTION
in less, we need to put **&** before **>** if there is a **&** after **>**, otherwise the generated css will be wrong, for example:

less style like this

``` css
span {
  color: #fff;
    > & {
     color: #fff;
     }
}
```

will produce

``` css
span {
  color: #fff;
}
 > span {
  color: #fff;
}
```

which is wrong, what expected is 

``` css
span {
  color: #fff;
}
 span > span {
  color: #fff;
}
```

I wonder if this is a bug in less.
