### PR TITLE
fix: hide loading icon at first

### DIFF
--- a/style/components/button.less
+++ b/style/components/button.less
@@ -47,6 +47,7 @@
     content: "\e610";
     position: absolute;
     opacity: 0;
+    visibility: hidden;
     transition: opacity 0.5s ease;
   }
 
@@ -62,6 +63,7 @@
       top: 50%;
       margin-top: -6px;
       opacity: 1;
+      visibility: visible;
     }
   }
 


### PR DESCRIPTION
之前使用 `opacity: 0` 隐藏 loading，现在改为 `visibility: hidden`。
