### PR TITLE
deps: upgrade rc-slider

### DIFF
--- a/components/slider/demo/mark.md
+++ b/components/slider/demo/mark.md
@@ -14,7 +14,7 @@ ReactDOM.render(
   <p>包含关系</p>
   <Slider marks={["状态1","状态2","状态3","状态4"]} defaultIndex={1} />
   <p>并列关系</p>
-  <Slider marks={["状态1","状态2","状态3","状态4"]} isIncluded={false} defaultIndex={1} />
+  <Slider marks={["状态1","状态2","状态3","状态4"]} included={false} defaultIndex={1} />
 </div>
 , document.getElementById('components-slider-demo-mark'));
 ````

--- a/components/slider/demo/range.md
+++ b/components/slider/demo/range.md
@@ -2,7 +2,7 @@
 
 - order: 4
 
-设置 `range` 为 `true`，将会渲染两个滑块，此时应用 `defaultValues` `values` 设置滑块的值，而非 `defaultValue` `values`。
+设置 `range` 为 `true`，将会渲染两个滑块。
 
 ---
 
@@ -11,8 +11,8 @@ import { Slider } from 'antd';
 
 ReactDOM.render(
 <div>
-  <Slider range={true} defaultValues={[0, 30]} />
-  <Slider range={true} step={10} values={[20, 50]} />
+  <Slider range defaultValue={[0, 30]} />
+  <Slider range step={10} value={[20, 50]} />
 </div>
 , document.getElementById('components-slider-demo-range'));
 ````

--- a/components/slider/index.md
+++ b/components/slider/index.md
@@ -19,12 +19,10 @@
 | min        | Number			| 0				| 最小值
 | max        | Number			| 100           | 最大值
 | step       | Number			| 1				| 步长，取值必须大于 0，并且可被 (max - min) 整除
-| value      | Number 			|            	| 当 `range` 为 `false` 时，设置当前取值
-| values     | [Number, Number] |             	| 当 `range` 为 `true` 时，设置当前取值
-| defaultValue      | Number 			| 0           	| 当 `range` 为 `false` 时，设置初始取值
-| defaultValues     | [Number, Number]  | [0, 0]        | 当 `range` 为 `true` 时，设置初始取值
+| value             | Number or [Number, Number]|             | 设置当前取值。当 `range` 为 `false` 时，使用 `Number`。否则用 `[Number, Number]`
+| defaultValue      | Number or [Number, Number]| 0 or [0, 0] | 设置初始取值。当 `range` 为 `false` 时，使用 `Number`。否则用 `[Number, Number]`
 | marks      | Array		    | [] 			| 分段标记，标记每一个 step，如果 step 属性没有定义，则 `marks` 属性会被忽略。当 `range` 为 `true` 时，忽略该属性
-| isIncluded | Boolean			| true			| 分段式滑块，值为 true 时表示值为包含关系，false 表示并列
+| included   | Boolean			| true			| 分段式滑块，值为 true 时表示值为包含关系，false 表示并列
 | index      | Number 			|            	| 为具备 `step` 或者 `marks` 的 slider 提供滑块操作的当前位置。当 `range` 为 `true` 时，忽略该属性
 | defaultIndex      | Number 			| 0           	| 为具备 `step` 或者 `marks` 的 slider 提供滑块操作的初始位置。当 `range` 为 `true` 时，忽略该属性
 | disabled   | Boolean 			| false         | 值为 `true` 时，滑块为 disable 禁用状态

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "rc-queue-anim": "~0.10.5",
     "rc-radio": "~2.0.0",
     "rc-select": "~5.0.0",
-    "rc-slider": "~1.6.0",
+    "rc-slider": "~2.0.0",
     "rc-steps": "~1.4.0",
     "rc-switch": "~1.2.0",
     "rc-table": "~3.4.0",


### PR DESCRIPTION
重命名了 `Slider` 的 API，由于 0.9.x 发布时已经包含 `isIncluded`，所以做了兼容，`isIncluded` 与 `included` 共存并功能相同。
