### PR TITLE
update timepicker component and fix a bug when clear input.

### DIFF
--- a/components/timepicker/index.jsx
+++ b/components/timepicker/index.jsx
@@ -53,7 +53,11 @@ const AntTimepicker = React.createClass({
   },
 
   handleChange(value) {
-    this.props.onChange(new Date(value.getTime()));
+    let args = null;
+    if (value) {
+      args = new Date(value.getTime());
+    }
+    this.props.onChange(args);
   },
 
   getLocale() {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "rc-switch": "~1.3.1",
     "rc-table": "~3.6.1",
     "rc-tabs": "~5.5.0",
-    "rc-time-picker": "~0.6.0",
+    "rc-time-picker": "~0.7.1",
     "rc-tooltip": "~3.2.0",
     "rc-tree": "~0.19.0",
     "rc-trigger": "~1.0.6",

--- a/style/components/timepicker/Panel.less
+++ b/style/components/timepicker/Panel.less
@@ -1,4 +1,4 @@
-.@{timepicker-prefix-cls}-panel {
+.@{timepicker-prefix-cls}-panel-inner {
   display: inline-block;
   position: relative;
   outline: none;

--- a/style/components/timepicker/Picker.less
+++ b/style/components/timepicker/Picker.less
@@ -1,4 +1,4 @@
-.@{timepicker-prefix-cls}-container {
+.@{timepicker-prefix-cls}-panel {
   z-index: 1070;
   position: absolute;
 


### PR DESCRIPTION
- 修改 panel 的 className
- 修复点击 clear 按钮显示 React warning 的问题
- 在 Ant Design 中，如果发现返回内容为空，也将 null 传给 onChange。（原本 value.getTime() 因为 value 为空会报错）
