### PR TITLE
chore: remove useless `ref` property

### DIFF
--- a/components/upload/uploadList.jsx
+++ b/components/upload/uploadList.jsx
@@ -32,8 +32,7 @@ export default React.createClass({
           <div className={prefixCls + '-list-item-info'}>
             <Icon type="paper-clip" />
             <span className="ant-upload-item-name">{file.name}</span>
-            <Icon type="cross" ref="theCloseBtn"
-              onClick={this.handleClose.bind(this, file)} />
+            <Icon type="cross" onClick={this.handleClose.bind(this, file)} />
           </div>
           { progress }
         </div>


### PR DESCRIPTION
Icon 是 Stateless function components，不应设置 ref 的，并且已经确认没有用到这个 ref。
