### PR TITLE
fix bug: notification 只有在存在btn情况下才能调用close

### DIFF
--- a/components/notification/index.jsx
+++ b/components/notification/index.jsx
@@ -59,6 +59,7 @@ function notice(args) {
       duration: duration,
       closable: true,
       onClose: args.onClose,
+      key: args.key,
       style: {}
     });
   } else {
@@ -73,6 +74,7 @@ function notice(args) {
         duration: duration,
         closable: true,
         onClose: args.onClose,
+        key: args.key,
         style: {}
       });
     } else {


### PR DESCRIPTION
无btn情况下没有传递key，调用 notification.close 无法匹配到实例
