### PR TITLE
fix: reuse div

### DIFF
--- a/components/modal/confirm.jsx
+++ b/components/modal/confirm.jsx
@@ -4,9 +4,12 @@ import Dialog from './index';
 import Icon from '../icon';
 import Button from '../button';
 
+let div;
 export default function (props) {
-  let div = document.createElement('div');
-  document.body.appendChild(div);
+  if (!div) {
+    div = document.createElement('div');
+    document.body.appendChild(div);
+  }
 
   let d;
   props = props || {};


### PR DESCRIPTION
relative: #669 

不是很想直接操作 DOM，所以无法完全把 div 移除。不过理了一下 `confirm`  的逻辑，应该不会有同时两个 confirm 的情况，所以可以重用。
