### PR TITLE
fix: `visible` should not be set

### DIFF
--- a/components/popconfirm/index.jsx
+++ b/components/popconfirm/index.jsx
@@ -36,7 +36,6 @@ export default React.createClass({
       onCancel: noop,
       okText: '确定',
       cancelText: '取消',
-      visible: false,
       onVisibleChange() {},
     };
   },


### PR DESCRIPTION
`visible` 是用来判断 `Popconfirm` 是否受控组件的，所以不应设置默认值。

See: https://github.com/ant-design/ant-design/blob/develop-0.11.0/components/popconfirm/index.jsx#L44
