### PR TITLE
fix: should not set default value for `open` #818

### DIFF
--- a/components/time-picker/index.jsx
+++ b/components/time-picker/index.jsx
@@ -15,7 +15,6 @@ const AntTimePicker = React.createClass({
       align: {
         offset: [0, -2],
       },
-      open: false,
       disabled: false,
       disabledHours: undefined,
       disabledMinutes: undefined,


### PR DESCRIPTION
Close: #818

写下来权当备忘：

之前好像也改过这种神奇的 bug，都是同一个原因，就是为那些在 `componentWillReceiveProps` 中会用到的属性设置了默认值，see: https://github.com/react-component/time-picker/blob/master/src/TimePicker.jsx#L85 。这样会影响 `componentWillReceiveProps` 里面的逻辑的，因为设置了默认值后，这个属性就必然存在，而值却不一定是用户想要的。
