### PR TITLE
css: duplicated background-color #910

### DIFF
--- a/style/components/radio.less
+++ b/style/components/radio.less
@@ -37,7 +37,6 @@
       border-left: 0;
       content: ' ';
       background-color: @primary-color;
-      background: #fff;
       opacity: 0;
       transition: transform @radio-duration @ease-in-out-circ, opacity @radio-duration @ease-in-out-circ, background-color @radio-duration @ease-in-out-circ;
     }


### PR DESCRIPTION
Close: #910 

这个 https://github.com/ant-design/ant-design/commit/27975606f1c05c9fc6118d548cecb6917b987461 commit 提到是新设计规范，但是觉得白色背景怎么都不符合预期。
