### PR TITLE
fix: fix CheckboxGroup defaultValue bug

### DIFF
--- a/components/checkbox/Group.jsx
+++ b/components/checkbox/Group.jsx
@@ -21,7 +21,7 @@ export default React.createClass({
     if ('value' in props) {
       value = props.value;
     } else if ('defaultValue' in props) {
-      value = props.defaultValue;
+      value = [...props.defaultValue];
     }
     return { value };
   },


### PR DESCRIPTION
getDefaultProps 返回的 props 是静态的，会在多个实例间共享，在初始化 state.value 需要拷贝一份新的
