### PR TITLE
Use ES2015 classes instead of React.createClass.

### DIFF
--- a/components/affix/index.jsx
+++ b/components/affix/index.jsx
@@ -32,24 +32,15 @@ function getOffset(element) {
   };
 }
 
-let Affix = React.createClass({
+class Affix extends React.Component {
 
-  getDefaultProps() {
-    return {
-      offset: 0
-    };
-  },
-
-  propTypes: {
-    offset: React.PropTypes.number
-  },
-
-  getInitialState() {
-    return {
+  constructor(props) {
+    super(props);
+    this.state = {
       affix: false,
       affixStyle: null
     };
-  },
+  }
 
   handleScroll() {
     let affix = this.state.affix;
@@ -73,12 +64,12 @@ let Affix = React.createClass({
         affixStyle: null
       });
     }
-  },
+  }
 
   componentDidMount() {
-    this.scrollEvent = rcUtil.Dom.addEventListener(window, 'scroll', this.handleScroll);
-    this.resizeEvent = rcUtil.Dom.addEventListener(window, 'resize', this.handleScroll);
-  },
+    this.scrollEvent = rcUtil.Dom.addEventListener(window, 'scroll', this.handleScroll.bind(this));
+    this.resizeEvent = rcUtil.Dom.addEventListener(window, 'resize', this.handleScroll.bind(this));
+  }
 
   componentWillUnmount() {
     if (this.scrollEvent) {
@@ -87,7 +78,7 @@ let Affix = React.createClass({
     if (this.resizeEvent) {
       this.resizeEvent.remove();
     }
-  },
+  }
 
   render() {
     const className = classNames({
@@ -104,6 +95,14 @@ let Affix = React.createClass({
     );
   }
 
-});
+}
+
+Affix.propTypes = {
+  offset: React.PropTypes.number
+};
+
+Affix.defaultProps = {
+  offset: 0
+};
 
 module.exports = Affix;

--- a/components/alert/index.jsx
+++ b/components/alert/index.jsx
@@ -4,20 +4,14 @@ import Animate from 'rc-animate';
 import Icon from '../icon';
 import classNames from 'classnames';
 
-export default React.createClass({
-  getDefaultProps() {
-    return {
-      prefixCls: 'ant-alert',
-      showIcon: false,
-      onClose() {}
-    };
-  },
-  getInitialState() {
-    return {
+export default class Alert extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
       closing: true,
       closed: false
     };
-  },
+  }
   handleClose(e) {
     e.preventDefault();
     let dom = ReactDOM.findDOMNode(this);
@@ -30,13 +24,13 @@ export default React.createClass({
       closing: false
     });
     this.props.onClose.call(this, e);
-  },
+  }
   animationEnd() {
     this.setState({
       closed: true,
       closing: true
     });
-  },
+  }
   render() {
     let {
       closable, description, type, prefixCls, message, closeText, showIcon
@@ -82,16 +76,22 @@ export default React.createClass({
       <Animate component=""
         showProp="data-show"
         transitionName="slide-up"
-        onEnd={this.animationEnd}>
+        onEnd={this.animationEnd.bind(this)}>
         <div data-show={this.state.closing} className={alertCls}>
           {showIcon ? <Icon className="ant-alert-icon" type={iconType} /> : null}
           <span className={`${prefixCls}-message`}>{message}</span>
           <span className={`${prefixCls}-description`}>{description}</span>
-          {closable ? <a onClick={this.handleClose} className={`${prefixCls}-close-icon`}>
+          {closable ? <a onClick={this.handleClose.bind(this)} className={`${prefixCls}-close-icon`}>
             {closeText || <Icon type="cross" />}
           </a> : null}
         </div>
       </Animate>
     );
   }
-});
+}
+
+Alert.defaultProps = {
+  prefixCls: 'ant-alert',
+  showIcon: false,
+  onClose() {}
+};

--- a/components/badge/demo/change.md
+++ b/components/badge/demo/change.md
@@ -10,29 +10,30 @@
 import { Badge, Button, Icon } from 'antd';
 const ButtonGroup = Button.Group;
 
-const Test = React.createClass({
-  getInitialState() {
-    return {
+class Test extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
       count: 5,
       show: true,
     };
-  },
+  }
   increase() {
     const count = this.state.count + 1;
     this.setState({ count });
-  },
+  }
   decline() {
     let count = this.state.count - 1;
     if (count < 0) {
       count = 0;
     }
     this.setState({ count });
-  },
+  }
   onClick() {
     this.setState({
       show: !this.state.show,
     });
-  },
+  }
   render() {
     return (
       <div>
@@ -44,21 +45,21 @@ const Test = React.createClass({
         </Badge>
         <div style={{ marginTop: 10 }}>
           <ButtonGroup>
-            <Button type="ghost" onClick={this.decline}>
+            <Button type="ghost" onClick={this.decline.bind(this)}>
               <Icon type="minus" />
             </Button>
-            <Button type="ghost" onClick={this.increase}>
+            <Button type="ghost" onClick={this.increase.bind(this)}>
               <Icon type="plus" />
             </Button>
           </ButtonGroup>
-          <Button type="ghost" onClick={this.onClick} style={{ marginLeft: 8 }}>
+          <Button type="ghost" onClick={this.onClick.bind(this)} style={{ marginLeft: 8 }}>
             切换红点显隐
           </Button>
         </div>
       </div>
     );
   }
-});
+}
 
 ReactDOM.render(
   <Test />

--- a/components/breadcrumb/demo/router.md
+++ b/components/breadcrumb/demo/router.md
@@ -11,7 +11,7 @@ const ReactRouter = require('react-router');
 let { Router, Route, Link, hashHistory } = ReactRouter;
 import { Breadcrumb } from 'antd';
 
-const Apps = React.createClass({
+class Apps extends React.Component {
   render() {
     return (
       <ul className="app-list">
@@ -24,9 +24,9 @@ const Apps = React.createClass({
       </ul>
     );
   }
-});
+}
 
-const Home = React.createClass({
+class Home extends React.Component {
   render() {
     return (
       <div>
@@ -47,7 +47,7 @@ const Home = React.createClass({
       </div>
     );
   }
-});
+}
 
 ReactDOM.render(
   <Router history={hashHistory}>

--- a/components/breadcrumb/index.jsx
+++ b/components/breadcrumb/index.jsx
@@ -1,20 +1,6 @@
 import React, { cloneElement } from 'react';
 
-const BreadcrumbItem = React.createClass({
-  getDefaultProps() {
-    return {
-      prefixCls: 'ant-breadcrumb',
-      separator: '/',
-    };
-  },
-  propTypes: {
-    prefixCls: React.PropTypes.string,
-    separator: React.PropTypes.oneOfType([
-      React.PropTypes.string,
-      React.PropTypes.element,
-    ]),
-    href: React.PropTypes.string,
-  },
+class BreadcrumbItem extends React.Component {
   render() {
     const { prefixCls, separator, children } = this.props;
     let link = <a className={`${prefixCls}-link`} {...this.props}>{children}</a>;
@@ -28,24 +14,23 @@ const BreadcrumbItem = React.createClass({
       </span>
     );
   }
-});
+}
 
-const Breadcrumb = React.createClass({
-  getDefaultProps() {
-    return {
-      prefixCls: 'ant-breadcrumb',
-      separator: '/',
-    };
-  },
-  propTypes: {
-    prefixCls: React.PropTypes.string,
-    separator: React.PropTypes.oneOfType([
-      React.PropTypes.string,
-      React.PropTypes.element,
-    ]),
-    routes: React.PropTypes.array,
-    params: React.PropTypes.object,
-  },
+BreadcrumbItem.defaultProps = {
+  prefixCls: 'ant-breadcrumb',
+  separator: '/',
+};
+
+BreadcrumbItem.propsTypes = {
+  prefixCls: React.PropTypes.string,
+  separator: React.PropTypes.oneOfType([
+    React.PropTypes.string,
+    React.PropTypes.element,
+  ]),
+  href: React.PropTypes.string,
+};
+
+class Breadcrumb extends React.Component {
   render() {
     let crumbs;
     const { separator, prefixCls, routes, params, children } = this.props;
@@ -89,7 +74,22 @@ const Breadcrumb = React.createClass({
       </div>
     );
   }
-});
+}
+
+Breadcrumb.defaultProps = {
+  prefixCls: 'ant-breadcrumb',
+  separator: '/',
+};
+
+Breadcrumb.propTypes = {
+  prefixCls: React.PropTypes.string,
+  separator: React.PropTypes.oneOfType([
+    React.PropTypes.string,
+    React.PropTypes.element,
+  ]),
+  routes: React.PropTypes.array,
+  params: React.PropTypes.object,
+};
 
 Breadcrumb.Item = BreadcrumbItem;
 export default Breadcrumb;

--- a/components/button/demo/loading.md
+++ b/components/button/demo/loading.md
@@ -9,19 +9,20 @@
 ````jsx
 import { Button, Icon } from 'antd';
 
-const App = React.createClass({
-  getInitialState() {
-    return {
+class App extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
       loading: false,
       iconLoading: false,
     };
-  },
+  }
   enterLoading() {
     this.setState({ loading: true });
-  },
+  }
   enterIconLoading() {
     this.setState({ iconLoading: true });
-  },
+  }
   render() {
     return (
       <div>
@@ -35,16 +36,16 @@ const App = React.createClass({
           加载中
         </Button>
         <br />
-        <Button type="primary" loading={this.state.loading} onClick={this.enterLoading}>
+        <Button type="primary" loading={this.state.loading} onClick={this.enterLoading.bind(this)}>
           点击变加载
         </Button>
-        <Button type="primary" loading={this.state.iconLoading} onClick={this.enterIconLoading}>
+        <Button type="primary" loading={this.state.iconLoading} onClick={this.enterIconLoading.bind(this)}>
           <Icon type="poweroff" />点击变加载
         </Button>
       </div>
     );
   }
-});
+}
 
 ReactDOM.render(<App />, mountNode);
 ````

--- a/components/carousel/index.jsx
+++ b/components/carousel/index.jsx
@@ -17,13 +17,7 @@ import Carousel from 'react-slick';
 import React from 'react';
 import assign from 'object-assign';
 
-const AntCarousel = React.createClass({
-  getDefaultProps() {
-    return {
-      dots: true,
-      arrows: false,
-    };
-  },
+class AntCarousel extends React.Component {
   render() {
     let props = assign({}, this.props);
 
@@ -43,6 +37,11 @@ const AntCarousel = React.createClass({
       </div>
     );
   }
-});
+}
+
+AntCarousel.defaultProps = {
+  dots: true,
+  arrows: false,
+};
 
 export default AntCarousel;

--- a/components/cascader/demo/custom-trigger.md
+++ b/components/cascader/demo/custom-trigger.md
@@ -25,29 +25,30 @@ const options = [{
   }],
 }];
 
-const CitySwitcher = React.createClass({
-  getInitialState() {
-    return {
+class CitySwitcher extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
       text: '未选择',
     };
-  },
+  }
   onChange(value, selectedOptions) {
     this.setState({
       text: selectedOptions.map(o => o.label).join(', '),
     });
-  },
+  }
   render() {
     return (
       <span>
         {this.state.text}
         &nbsp;
-        <Cascader options={options} onChange={this.onChange}>
+        <Cascader options={options} onChange={this.onChange.bind(this)}>
           <a href="#">切换城市</a>
         </Cascader>
       </span>
     );
-  },
-});
+  }
+}
 
 ReactDOM.render(<CitySwitcher />, mountNode);
 ````

--- a/components/checkbox/Group.jsx
+++ b/components/checkbox/Group.jsx
@@ -1,22 +1,9 @@
 import React from 'react';
 import Checkbox from './index';
 
-export default React.createClass({
-  getDefaultProps() {
-    return {
-      options: [],
-      defaultValue: [],
-      onChange() {},
-    };
-  },
-  propTypes: {
-    defaultValue: React.PropTypes.array,
-    value: React.PropTypes.array,
-    options: React.PropTypes.array.isRequired,
-    onChange: React.PropTypes.func,
-  },
-  getInitialState() {
-    const props = this.props;
+export default class CheckboxGroup extends React.Component {
+  constructor(props) {
+    super(props);
     let value;
     if ('value' in props) {
       value = props.value;
@@ -24,14 +11,14 @@ export default React.createClass({
       value = props.defaultValue;
     }
     return { value };
-  },
+  }
   componentWillReceiveProps(nextProps) {
     if ('value' in nextProps) {
       this.setState({
         value: nextProps.value || [],
       });
     }
-  },
+  }
   toggleOption(option) {
     const optionIndex = this.state.value.indexOf(option);
     const value = [...this.state.value];
@@ -44,7 +31,7 @@ export default React.createClass({
       this.setState({ value });
     }
     this.props.onChange(value);
-  },
+  }
   render() {
     const options = this.props.options;
     return (
@@ -61,5 +48,18 @@ export default React.createClass({
         }
       </div>
     );
-  },
-});
+  }
+}
+
+CheckboxGroup.defaultProps = {
+  options: [],
+  defaultValue: [],
+  onChange() {},
+};
+
+CheckboxGroup.propTypes = {
+  defaultValue: React.PropTypes.array,
+  value: React.PropTypes.array,
+  options: React.PropTypes.array.isRequired,
+  onChange: React.PropTypes.func,
+};

--- a/components/checkbox/demo/controller.md
+++ b/components/checkbox/demo/controller.md
@@ -9,13 +9,14 @@
 ````jsx
 import { Checkbox, Button } from 'antd';
 
-const App = React.createClass({
-  getInitialState() {
-    return {
+class App extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
       checked: true,
       disabled: false
     };
-  },
+  }
   render() {
     const label = `${this.state.checked ? '选中' : '取消'}-${this.state.disabled ? '不可用' : '可用'}`;
     return (
@@ -24,37 +25,37 @@ const App = React.createClass({
           <label>
             <Checkbox checked={this.state.checked}
               disabled={this.state.disabled}
-              onChange={this.onChange} />
+              onChange={this.onChange.bind(this)} />
               {label}
             </label>
           </p>
           <p>
             <Button type="primary" size="small"
-              onClick={this.toggleChecked}>
+              onClick={this.toggleChecked.bind(this)}>
               {!this.state.checked ? '选中' : '取消'}
             </Button>
             <Button style={{ marginLeft: '10px' }}
               type="primary" size="small"
-              onClick={this.toggleDisable}>
+              onClick={this.toggleDisable.bind(this)}>
               {!this.state.disabled ? '不可用' : '可用'}
             </Button>
           </p>
         </div>
     );
-  },
+  }
   toggleChecked() {
     this.setState({ checked: !this.state.checked });
-  },
+  }
   toggleDisable() {
     this.setState({ disabled: !this.state.disabled });
-  },
+  }
   onChange(e) {
     console.log('checked = ', e.target.checked);
     this.setState({
       checked: e.target.checked,
     });
   }
-});
+}
 
 ReactDOM.render(<App />, mountNode);
 ````

--- a/components/checkbox/index.jsx
+++ b/components/checkbox/index.jsx
@@ -2,16 +2,15 @@ import RcCheckbox from 'rc-checkbox';
 import React from 'react';
 import Group from './Group';
 
-const Checkbox = React.createClass({
-  getDefaultProps() {
-    return {
-      prefixCls: 'ant-checkbox'
-    };
-  },
+class Checkbox extends React.Component {
   render() {
     return <RcCheckbox {...this.props} />;
   }
-});
+}
+
+Checkbox.defaultProps = {
+  prefixCls: 'ant-checkbox'
+};
 
 Checkbox.Group = Group;
 

--- a/components/dropdown/dropdown-button.jsx
+++ b/components/dropdown/dropdown-button.jsx
@@ -5,21 +5,7 @@ import Dropdown from './dropdown';
 const ButtonGroup = Button.Group;
 import classNames from 'classnames';
 
-export default React.createClass({
-  getDefaultProps() {
-    return {
-      align: {
-        points: ['tr', 'br'],
-        overlay: {
-          adjustX: 1,
-          adjustY: 1,
-        },
-        offset: [0, 4],
-        targetOffset: [0, 0],
-      },
-      type: 'default',
-    };
-  },
+export default class DropdownButton extends React.Component {
   render() {
     const { type, overlay, trigger, align, children, className, ...restProps } = this.props;
     const cls = classNames({
@@ -37,4 +23,17 @@ export default React.createClass({
       </ButtonGroup>
     );
   }
-});
+}
+
+DropdownButton.defaultProps = {
+  align: {
+    points: ['tr', 'br'],
+    overlay: {
+      adjustX: 1,
+      adjustY: 1,
+    },
+    offset: [0, 4],
+    targetOffset: [0, 0],
+  },
+  type: 'default',
+};

--- a/components/dropdown/dropdown.jsx
+++ b/components/dropdown/dropdown.jsx
@@ -1,15 +1,7 @@
 import React from 'react';
 import Dropdown from 'rc-dropdown';
 
-export default React.createClass({
-  getDefaultProps() {
-    return {
-      transitionName: 'slide-up',
-      prefixCls: 'ant-dropdown',
-      mouseEnterDelay: 0.15,
-      mouseLeaveDelay: 0.1,
-    };
-  },
+export default class AntDropdown extends React.Component {
   render() {
     const { overlay, ...otherProps } = this.props;
     const menu = React.cloneElement(overlay, {
@@ -19,4 +11,11 @@ export default React.createClass({
       <Dropdown {...otherProps} overlay={menu} />
     );
   }
-});
+}
+
+AntDropdown.defaultProps = {
+  transitionName: 'slide-up',
+  prefixCls: 'ant-dropdown',
+  mouseEnterDelay: 0.15,
+  mouseLeaveDelay: 0.1,
+};

--- a/docs/react/getting-started.md
+++ b/docs/react/getting-started.md
@@ -49,25 +49,26 @@ $ npm install
 import React from 'react';
 import { DatePicker, message } from 'antd';
 
-const App = React.createClass({
-  getInitialState() {
-    return {
+class App extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
       date: ''
     };
-  },
+  }
   handleChange(value) {
     message.info('您选择的日期是: ' + value.toString());
     this.setState({
       date: value
     });
-  },
+  }
   render() {
     return <div style={{width: 400, margin: '100px auto'}}>
-      <DatePicker onChange={this.handleChange} />
+      <DatePicker onChange={this.handleChange.bind(this)} />
       <div style={{marginTop: 20}}>当前日期：{this.state.date.toString()}</div>
     </div>;
   }
-});
+}
 
 export default App;
 ```


### PR DESCRIPTION
Make `Affix`, `Alert`, `Badge`, `Breadcrumb`, `Button`, `Carousel`,
`Checkbox` and `Dropdown` components use ES2015 classes rather
than `React.createClass`.

This is a start on addressing issue #1179.

This includes:
- `getDefaultProps` method becomes a `defaultProps` value on the
  constructor.
- `propTypes` becomes a value on the constructor.
- `getInitialState` becomes a constructor function that initializes
  `this.state` directly.
- Event callbacks have to have `this` bound.
