### PR TITLE
Favor 'export default' over 'module.exports'.

### DIFF
--- a/components/affix/index.jsx
+++ b/components/affix/index.jsx
@@ -123,4 +123,4 @@ const Affix = React.createClass({
 
 });
 
-module.exports = Affix;
+export default Affix;

--- a/components/common/openAnimation.js
+++ b/components/common/openAnimation.js
@@ -42,4 +42,4 @@ const animation = {
   },
 };
 
-module.exports = animation;
+export default animation;

--- a/components/form/Form.jsx
+++ b/components/form/Form.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import classNames from 'classnames';
 
-class Form extends React.Component {
+export default class Form extends React.Component {
   getChildContext() {
     return {
       form: this.props.form,
@@ -40,5 +40,3 @@ Form.defaultProps = {
 Form.childContextTypes = {
   form: React.PropTypes.object,
 };
-
-module.exports = Form;

--- a/components/form/FormItem.jsx
+++ b/components/form/FormItem.jsx
@@ -7,7 +7,7 @@ function prefixClsFn(prefixCls, ...args) {
   }).join(' ');
 }
 
-class FormItem extends React.Component {
+export default class FormItem extends React.Component {
   _getLayoutClass(colDef) {
     if (!colDef) {
       return '';
@@ -191,5 +191,3 @@ FormItem.defaultProps = {
 FormItem.contextTypes = {
   form: React.PropTypes.object,
 };
-
-module.exports = FormItem;

--- a/components/input/index.jsx
+++ b/components/input/index.jsx
@@ -123,5 +123,5 @@ Input.defaultProps = {
   type: 'text',
 };
 
-module.exports = Input;
-module.exports.Group = Group;
+Input.Group = Group;
+export default Input;

--- a/components/locale-provider/en_US.js
+++ b/components/locale-provider/en_US.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
   Pagination: require('rc-pagination/lib/locale/en_US'),
   DatePicker: require('../date-picker/locale/en_US'),
   TimePicker: require('../time-picker/locale/en_US'),


### PR DESCRIPTION
In pull #1181, @afc163 said that `module.exports` should be corrected to using `export default` where applicable.  This pull request does so.

Where an ES2015 class is being used (rather than `React.createClass`), this prefers to use `export default class ...` rather than a separate export for the class.
