### PR TITLE
Fix import of tomorrow style for highlightjs.

### DIFF
--- a/scripts/demo.js
+++ b/scripts/demo.js
@@ -1,6 +1,6 @@
 require('../style/index.less');
 require('../site/static/style.less');
-require('../site/static/tomorrow.less');
+require('../site/common/styles/tomorrow.less');
 
 window['css-animation'] = require('css-animation');
 window['react-router'] = require('react-router');


### PR DESCRIPTION
This fixes an error when running `npm test`:

```
ERROR in ./scripts/demo.js
Module not found: Error: Cannot resolve 'file' or 'directory' ../site/static/tomorrow.less in /Users/bruce/Development/workbench/ant-design/scripts
 @ ./scripts/demo.js 51:0-39
```

Just needed to use the correct path.
