### PR TITLE
Use ES2015 classes instead of React.createClass.

### DIFF
--- a/components/breadcrumb/index.jsx
+++ b/components/breadcrumb/index.jsx
@@ -1,20 +1,7 @@
 import React, { cloneElement } from 'react';
 
-const BreadcrumbItem = React.createClass({
-  getDefaultProps() {
-    return {
-      prefixCls: 'ant-breadcrumb',
-      separator: '/',
-    };
-  },
-  propTypes: {
-    prefixCls: React.PropTypes.string,
-    separator: React.PropTypes.oneOfType([
-      React.PropTypes.string,
-      React.PropTypes.element,
-    ]),
-    href: React.PropTypes.string,
-  },
+/* Exported as Breadcrumb.Item */
+class BreadcrumbItem extends React.Component {
   render() {
     const { prefixCls, separator, children } = this.props;
     let link = <a className={`${prefixCls}-link`} {...this.props}>{children}</a>;
@@ -28,25 +15,23 @@ const BreadcrumbItem = React.createClass({
       </span>
     );
   }
-});
+}
 
-const Breadcrumb = React.createClass({
-  getDefaultProps() {
-    return {
-      prefixCls: 'ant-breadcrumb',
-      separator: '/',
-      linkRender: (href, name) => <a href={`#${href}`}>{name}</a>,
-    };
-  },
-  propTypes: {
-    prefixCls: React.PropTypes.string,
-    separator: React.PropTypes.oneOfType([
-      React.PropTypes.string,
-      React.PropTypes.element,
-    ]),
-    routes: React.PropTypes.array,
-    params: React.PropTypes.object,
-  },
+BreadcrumbItem.defaultProps = {
+  prefixCls: 'ant-breadcrumb',
+  separator: '/',
+};
+
+BreadcrumbItem.propTypes = {
+  prefixCls: React.PropTypes.string,
+  separator: React.PropTypes.oneOfType([
+    React.PropTypes.string,
+    React.PropTypes.element,
+  ]),
+  href: React.PropTypes.string,
+};
+
+export default class Breadcrumb extends React.Component {
   render() {
     let crumbs;
     const { separator, prefixCls, routes, params, children, linkRender } = this.props;
@@ -90,7 +75,22 @@ const Breadcrumb = React.createClass({
       </div>
     );
   }
-});
+}
+
+Breadcrumb.defaultProps = {
+  prefixCls: 'ant-breadcrumb',
+  separator: '/',
+  linkRender: (href, name) => <a href={`#${href}`}>{name}</a>,
+};
+
+Breadcrumb.propTypes = {
+  prefixCls: React.PropTypes.string,
+  separator: React.PropTypes.oneOfType([
+    React.PropTypes.string,
+    React.PropTypes.element,
+  ]),
+  routes: React.PropTypes.array,
+  params: React.PropTypes.object,
+};
 
 Breadcrumb.Item = BreadcrumbItem;
-export default Breadcrumb;

--- a/components/checkbox/index.jsx
+++ b/components/checkbox/index.jsx
@@ -3,12 +3,7 @@ import React from 'react';
 import Group from './Group';
 import classNames from 'classnames';
 
-const Checkbox = React.createClass({
-  getDefaultProps() {
-    return {
-      prefixCls: 'ant-checkbox'
-    };
-  },
+export default class Checkbox extends React.Component {
   render() {
     const { prefixCls, style, children, className, ...restProps } = this.props;
     const classString = classNames({
@@ -22,8 +17,10 @@ const Checkbox = React.createClass({
       </label>
     );
   }
-});
+}
+
+Checkbox.defaultProps = {
+  prefixCls: 'ant-checkbox'
+};
 
 Checkbox.Group = Group;
-
-export default Checkbox;

--- a/components/dropdown/dropdown-button.jsx
+++ b/components/dropdown/dropdown-button.jsx
@@ -5,21 +5,7 @@ import Dropdown from './dropdown';
 const ButtonGroup = Button.Group;
 import classNames from 'classnames';
 
-export default React.createClass({
-  getDefaultProps() {
-    return {
-      align: {
-        points: ['tr', 'br'],
-        overlay: {
-          adjustX: 1,
-          adjustY: 1,
-        },
-        offset: [0, 4],
-        targetOffset: [0, 0],
-      },
-      type: 'default',
-    };
-  },
+export default class DropdownButton extends React.Component {
   render() {
     const { type, overlay, trigger, align, children, className, ...restProps } = this.props;
     const cls = classNames({
@@ -37,4 +23,17 @@ export default React.createClass({
       </ButtonGroup>
     );
   }
-});
+}
+
+DropdownButton.defaultProps = {
+  align: {
+    points: ['tr', 'br'],
+    overlay: {
+      adjustX: 1,
+      adjustY: 1,
+    },
+    offset: [0, 4],
+    targetOffset: [0, 0],
+  },
+  type: 'default',
+};

--- a/components/dropdown/dropdown.jsx
+++ b/components/dropdown/dropdown.jsx
@@ -1,20 +1,19 @@
 import React from 'react';
-import Dropdown from 'rc-dropdown';
+import RcDropdown from 'rc-dropdown';
 
-export default React.createClass({
-  getDefaultProps() {
-    return {
-      transitionName: 'slide-up',
-      prefixCls: 'ant-dropdown',
-    };
-  },
+export default class Dropdown extends React.Component {
   render() {
     const { overlay, ...otherProps } = this.props;
     const menu = React.cloneElement(overlay, {
       openTransitionName: 'zoom-big',
     });
     return (
-      <Dropdown {...otherProps} overlay={menu} />
+      <RcDropdown {...otherProps} overlay={menu} />
     );
   }
-});
+}
+
+Dropdown.defaultProps = {
+  transitionName: 'slide-up',
+  prefixCls: 'ant-dropdown',
+};

--- a/components/steps/index.jsx
+++ b/components/steps/index.jsx
@@ -1,33 +1,30 @@
 import React from 'react';
-import Steps from 'rc-steps';
+import RcSteps from 'rc-steps';
 
-const AntSteps = React.createClass({
-  getDefaultProps() {
-    return {
-      prefixCls: 'ant-steps',
-      iconPrefix: 'ant',
-      maxDescriptionWidth: 100,
-      current: 0
-    };
-  },
+export default class Steps extends React.Component {
   render() {
     let maxDescriptionWidth = this.props.maxDescriptionWidth;
     if (this.props.direction === 'vertical') {
       maxDescriptionWidth = 'auto';
     }
     return (
-      <Steps size={this.props.size}
+      <RcSteps size={this.props.size}
         current={this.props.current}
         direction={this.props.direction}
         iconPrefix={this.props.iconPrefix}
         maxDescriptionWidth={maxDescriptionWidth}
         prefixCls={this.props.prefixCls}>
         {this.props.children}
-      </Steps>
+      </RcSteps>
     );
   }
-});
+}
 
-AntSteps.Step = Steps.Step;
+Steps.defaultProps = {
+  prefixCls: 'ant-steps',
+  iconPrefix: 'ant',
+  maxDescriptionWidth: 100,
+  current: 0
+};
 
-export default AntSteps;
+Steps.Step = RcSteps.Step;

--- a/components/timeline/index.jsx
+++ b/components/timeline/index.jsx
@@ -1,15 +1,8 @@
 import React from 'react';
 import classNames from 'classnames';
 
-const TimelineItem = React.createClass({
-  getDefaultProps() {
-    return {
-      prefixCls: 'ant-timeline',
-      color: 'blue',
-      last: false,
-      pending: false,
-    };
-  },
+/* Exported as Timeline.Item */
+class TimelineItem extends React.Component {
   render() {
     const { prefixCls, color, last, children, pending } = this.props;
     const itemClassName = classNames({
@@ -25,14 +18,16 @@ const TimelineItem = React.createClass({
       </li>
     );
   }
-});
+}
 
-const Timeline = React.createClass({
-  getDefaultProps() {
-    return {
-      prefixCls: 'ant-timeline',
-    };
-  },
+TimelineItem.defaultProps = {
+  prefixCls: 'ant-timeline',
+  color: 'blue',
+  last: false,
+  pending: false,
+};
+
+export default class Timeline extends React.Component {
   render() {
     const { prefixCls, children, pending } = this.props;
     const pendingNode = typeof pending === 'boolean' ? null : pending;
@@ -55,8 +50,10 @@ const Timeline = React.createClass({
       </ul>
     );
   }
-});
+}
+
+Timeline.defaultProps = {
+  prefixCls: 'ant-timeline',
+};
 
 Timeline.Item = TimelineItem;
-
-export default Timeline;


### PR DESCRIPTION
Make Breadcrumb, Checkbox, Dropdown, Steps and Timeline
components use ES2015 classes rather than React.createClass.

This includes:
- getDefaultProps method becomes a defaultProps value on the
  constructor.
- propTypes becomes a value on the constructor.

This is work in progress on resolving #1179.
