### PR TITLE
Convert Popover & Spin to ES2015 classes.

### DIFF
--- a/components/popover/index.jsx
+++ b/components/popover/index.jsx
@@ -5,18 +5,7 @@ import getPlacements from './placements';
 const placements = getPlacements();
 const prefixCls = 'ant-popover';
 
-const Popover = React.createClass({
-  getDefaultProps() {
-    return {
-      prefixCls,
-      placement: 'top',
-      trigger: 'hover',
-      mouseEnterDelay: 0.1,
-      mouseLeaveDelay: 0.1,
-      overlayStyle: {}
-    };
-  },
-
+export default class Popover extends React.Component {
   render() {
     const transitionName = ({
       top: 'zoom-down',
@@ -42,11 +31,11 @@ const Popover = React.createClass({
         {this.props.children}
       </Tooltip>
     );
-  },
+  }
 
   getPopupDomNode() {
     return this.refs.tooltip.getPopupDomNode();
-  },
+  }
 
   getOverlay() {
     return (
@@ -57,7 +46,14 @@ const Popover = React.createClass({
         </div>
       </div>
     );
-  },
-});
+  }
+}
 
-export default Popover;
+Popover.defaultProps = {
+  prefixCls,
+  placement: 'top',
+  trigger: 'hover',
+  mouseEnterDelay: 0.1,
+  mouseLeaveDelay: 0.1,
+  overlayStyle: {}
+};

--- a/components/spin/index.jsx
+++ b/components/spin/index.jsx
@@ -2,22 +2,10 @@ import React from 'react';
 import classNames from 'classnames';
 import { isCssAnimationSupported } from 'css-animation';
 
-const AntSpin = React.createClass({
-  getDefaultProps() {
-    return {
-      prefixCls: 'ant-spin',
-      spining: true,
-    };
-  },
-
-  propTypes: {
-    className: React.PropTypes.string,
-    size: React.PropTypes.oneOf(['small', 'default', 'large']),
-  },
-
+export default class Spin extends React.Component {
   isNestedPattern() {
     return !!(this.props && this.props.children);
-  },
+  }
 
   render() {
     const { className, size, prefixCls, tip } = this.props;
@@ -56,6 +44,14 @@ const AntSpin = React.createClass({
     }
     return spinElement;
   }
-});
+}
 
-export default AntSpin;
+Spin.defaultProps = {
+  prefixCls: 'ant-spin',
+  spining: true,
+};
+
+Spin.propTypes = {
+  className: React.PropTypes.string,
+  size: React.PropTypes.oneOf(['small', 'default', 'large']),
+};


### PR DESCRIPTION
This is a continuation of the work from #1223, working on the task laid out in #1179.
