### PR TITLE
add onPreview onRemove override on upload.

### DIFF
--- a/components/upload/index.jsx
+++ b/components/upload/index.jsx
@@ -172,11 +172,21 @@ const AntUpload = React.createClass({
     }
   },
 
+  handlePreview(file) {
+    if ('onPreview' in this.props) {
+      this.props.onPreview(file);
+    }
+  },
+
   handleManualRemove(file) {
     /*eslint-disable */
     file.status = 'removed';
     /*eslint-enable */
-    this.handleRemove(file);
+    if ('onRemove' in this.props) {
+      this.props.onRemove(file);
+    } else {
+      this.handleRemove(file);
+    }
   },
 
   onChange(info) {
@@ -235,6 +245,7 @@ const AntUpload = React.createClass({
       uploadList = (
         <UploadList listType={this.props.listType}
           items={this.state.fileList}
+          onPreview={this.handlePreview}
           onRemove={this.handleManualRemove} />
       );
     }

--- a/components/upload/uploadList.jsx
+++ b/components/upload/uploadList.jsx
@@ -28,6 +28,10 @@ export default React.createClass({
   handleClose(file) {
     this.props.onRemove(file);
   },
+  handlePreview(file, e) {
+    e.preventDefault();
+    return this.props.onPreview(file);
+  },
   componentDidUpdate() {
     if (this.props.listType !== 'picture' && this.props.listType !== 'picture-card') {
       return;
@@ -65,6 +69,7 @@ export default React.createClass({
           }
         } else {
           icon = (<a className={`${prefixCls}-list-item-thumbnail`}
+            onClick={this.handlePreview.bind(this, file)}
             href={file.url}
             target="_blank"><img src={file.thumbUrl || file.url} alt={file.name} /></a>
           );
@@ -87,13 +92,13 @@ export default React.createClass({
           <div className={`${prefixCls}-list-item-info`}>
             {icon}
             {file.url
-               ? <a href={file.url} target="_blank" className={`${prefixCls}-list-item-name`}>{file.name}</a>
+               ? <a onClick={this.handlePreview.bind(this, file)} href={file.url} target="_blank" className={`${prefixCls}-list-item-name`}>{file.name}</a>
                : <span className={`${prefixCls}-list-item-name`}>{file.name}</span>}
             {
               this.props.listType === 'picture-card' && file.status !== 'uploading'
               ? (
                 <span>
-                  <a href={file.url} target="_blank" style={{ pointerEvents: file.url ? '' : 'none' }}><Icon type="eye-o" /></a>
+                  <a onClick={this.handlePreview.bind(this, file)} href={file.url} target="_blank" style={{ pointerEvents: file.url ? '' : 'none' }}><Icon type="eye-o" /></a>
                   <Icon type="delete" onClick={this.handleClose.bind(this, file)} />
                 </span>
               ) : <Icon type="cross" onClick={this.handleClose.bind(this, file)} />


### PR DESCRIPTION
(Regarding #1221 )
Add onRemove and onPreview property to Upload

This allows user to customize how they ware behaved. (e.g, I don't want preview to open up the image in a new window, instead, I want to add it to the text editor, etc.)
