### PR TITLE
Name classes without Ant* prefix.

### DIFF
--- a/components/badge/ScrollNumber.jsx
+++ b/components/badge/ScrollNumber.jsx
@@ -7,7 +7,7 @@ function getNumberArray(num) {
     num.toString().split('').reverse().map(i => Number(i)) : [];
 }
 
-class AntScrollNumber extends React.Component {
+export default class ScrollNumber extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
@@ -113,7 +113,7 @@ class AntScrollNumber extends React.Component {
   }
 }
 
-AntScrollNumber.defaultProps = {
+ScrollNumber.defaultProps = {
   prefixCls: 'ant-scroll-number',
   count: null,
   component: 'sup',
@@ -121,7 +121,7 @@ AntScrollNumber.defaultProps = {
   height: 18,
 };
 
-AntScrollNumber.propTypes = {
+ScrollNumber.propTypes = {
   count: React.PropTypes.oneOfType([
     React.PropTypes.string,
     React.PropTypes.number
@@ -130,5 +130,3 @@ AntScrollNumber.propTypes = {
   onAnimated: React.PropTypes.func,
   height: React.PropTypes.number,
 };
-
-export default AntScrollNumber;

--- a/components/badge/index.jsx
+++ b/components/badge/index.jsx
@@ -3,7 +3,7 @@ import Animate from 'rc-animate';
 import ScrollNumber from './ScrollNumber';
 import classNames from 'classnames';
 
-class AntBadge extends React.Component {
+export default class Badge extends React.Component {
   render() {
     let { count, prefixCls, overflowCount, className, style, children } = this.props;
     const dot = this.props.dot;
@@ -42,14 +42,14 @@ class AntBadge extends React.Component {
   }
 }
 
-AntBadge.defaultProps = {
+Badge.defaultProps = {
   prefixCls: 'ant-badge',
   count: null,
   dot: false,
   overflowCount: 99,
 };
 
-AntBadge.propTypes = {
+Badge.propTypes = {
   count: React.PropTypes.oneOfType([
     React.PropTypes.string,
     React.PropTypes.number
@@ -57,5 +57,3 @@ AntBadge.propTypes = {
   dot: React.PropTypes.bool,
   overflowCount: React.PropTypes.number,
 };
-
-export default AntBadge;

--- a/components/cascader/index.jsx
+++ b/components/cascader/index.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import Cascader from 'rc-cascader';
+import RcCascader from 'rc-cascader';
 import Input from '../input';
 import Icon from '../icon';
 import arrayTreeFilter from 'array-tree-filter';
 import classNames from 'classnames';
 
-class AntCascader extends React.Component {
+export default class Cascader extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
@@ -75,7 +75,7 @@ class AntCascader extends React.Component {
     delete otherProps.onChange;
 
     return (
-      <Cascader {...this.props}
+      <RcCascader {...this.props}
         value={this.state.value}
         popupVisible={this.state.popupVisible}
         onPopupVisibleChange={this.handlePopupVisibleChange}
@@ -95,12 +95,12 @@ class AntCascader extends React.Component {
             <Icon type="down" className={arrowCls} />
           </span>
         }
-      </Cascader>
+      </RcCascader>
     );
   }
 }
 
-AntCascader.defaultProps = {
+Cascader.defaultProps = {
   prefixCls: 'ant-cascader',
   placeholder: '请选择',
   transitionName: 'slide-up',
@@ -114,5 +114,3 @@ AntCascader.defaultProps = {
   allowClear: true,
   onPopupVisibleChange() {},
 };
-
-export default AntCascader;

--- a/components/collapse/index.jsx
+++ b/components/collapse/index.jsx
@@ -1,16 +1,14 @@
-import Collapse from 'rc-collapse';
+import RcCollapse from 'rc-collapse';
 import React from 'react';
 
-class AntCollapse extends React.Component {
+export default class Collapse extends React.Component {
   render() {
-    return <Collapse {...this.props} />;
+    return <RcCollapse {...this.props} />;
   }
 }
 
-AntCollapse.defaultProps = {
+Collapse.defaultProps = {
   prefixCls: 'ant-collapse',
 };
 
-AntCollapse.Panel = Collapse.Panel;
-
-export default AntCollapse;
+Collapse.Panel = Collapse.Panel;

--- a/components/date-picker/index.jsx
+++ b/components/date-picker/index.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import Calendar from 'rc-calendar';
+import RcCalendar from 'rc-calendar';
 import MonthCalendar from 'rc-calendar/lib/MonthCalendar';
-import DatePicker from 'rc-calendar/lib/Picker';
+import RcDatePicker from 'rc-calendar/lib/Picker';
 import GregorianCalendar from 'gregorian-calendar';
 import CalendarLocale from 'rc-calendar/lib/locale/zh_CN';
-import AntRangePicker from './RangePicker';
+import RangePicker from './RangePicker';
 import PickerMixin from './PickerMixin';
 import TimePicker from 'rc-time-picker';
 import classNames from 'classnames';
@@ -116,7 +116,7 @@ function createPicker(TheCalendar, defaultFormat) {
       }
       return (
         <span className={pickerClass} style={this.props.style}>
-          <DatePicker
+          <RcDatePicker
             transitionName={this.props.transitionName}
             disabled={this.props.disabled}
             calendar={calendar}
@@ -144,17 +144,17 @@ function createPicker(TheCalendar, defaultFormat) {
                 );
               }
             }
-          </DatePicker>
+          </RcDatePicker>
         </span>
       );
     }
   });
 }
 
-const AntDatePicker = createPicker(Calendar);
-const AntMonthPicker = createPicker(MonthCalendar, 'yyyy-MM');
+const DatePicker = createPicker(RcCalendar);
+const MonthPicker = createPicker(MonthCalendar, 'yyyy-MM');
 
-const AntCalendar = React.createClass({
+const Calendar = React.createClass({
   getDefaultProps() {
     return {
       locale: CalendarLocale,
@@ -162,12 +162,12 @@ const AntCalendar = React.createClass({
     };
   },
   render() {
-    return <Calendar {...this.props} />;
+    return <RcCalendar {...this.props} />;
   }
 });
 
-AntDatePicker.Calendar = AntCalendar;
-AntDatePicker.RangePicker = AntRangePicker;
-AntDatePicker.MonthPicker = AntMonthPicker;
+DatePicker.Calendar = Calendar;
+DatePicker.RangePicker = RangePicker;
+DatePicker.MonthPicker = MonthPicker;
 
-export default AntDatePicker;
+export default DatePicker;

--- a/components/menu/index.jsx
+++ b/components/menu/index.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import Menu, { Item, Divider, SubMenu, ItemGroup } from 'rc-menu';
+import RcMenu, { Item, Divider, SubMenu, ItemGroup } from 'rc-menu';
 import animation from '../common/openAnimation';
 
 function noop() {
 }
 
-const AntMenu = React.createClass({
+const Menu = React.createClass({
   getDefaultProps() {
     return {
       prefixCls: 'ant-menu',
@@ -76,13 +76,13 @@ const AntMenu = React.createClass({
         className,
       };
     }
-    return <Menu {...this.props} {...props} />;
+    return <RcMenu {...this.props} {...props} />;
   }
 });
 
-AntMenu.Divider = Divider;
-AntMenu.Item = Item;
-AntMenu.SubMenu = SubMenu;
-AntMenu.ItemGroup = ItemGroup;
+Menu.Divider = Divider;
+Menu.Item = Item;
+Menu.SubMenu = SubMenu;
+Menu.ItemGroup = ItemGroup;
 
-export default AntMenu;
+export default Menu;

--- a/components/modal/Modal.jsx
+++ b/components/modal/Modal.jsx
@@ -8,7 +8,7 @@ function noop() {}
 let mousePosition;
 let mousePositionEventBinded;
 
-const AntModal = React.createClass({
+const Modal = React.createClass({
   getDefaultProps() {
     return {
       prefixCls: 'ant-modal',
@@ -99,4 +99,4 @@ const AntModal = React.createClass({
   }
 });
 
-export default AntModal;
+export default Modal;

--- a/components/modal/index.jsx
+++ b/components/modal/index.jsx
@@ -1,8 +1,8 @@
-import AntModal from './Modal';
+import Modal from './Modal';
 import confirm from './confirm';
 import objectAssign from 'object-assign';
 
-AntModal.info = function (props) {
+Modal.info = function (props) {
   const config = objectAssign({}, props, {
     iconClassName: 'info-circle',
     okCancel: false,
@@ -10,7 +10,7 @@ AntModal.info = function (props) {
   return confirm(config);
 };
 
-AntModal.success = function (props) {
+Modal.success = function (props) {
   const config = objectAssign({}, props, {
     iconClassName: 'check-circle',
     okCancel: false,
@@ -18,7 +18,7 @@ AntModal.success = function (props) {
   return confirm(config);
 };
 
-AntModal.error = function (props) {
+Modal.error = function (props) {
   const config = objectAssign({}, props, {
     iconClassName: 'exclamation-circle',
     okCancel: false,
@@ -26,11 +26,11 @@ AntModal.error = function (props) {
   return confirm(config);
 };
 
-AntModal.confirm = function (props) {
+Modal.confirm = function (props) {
   const config = objectAssign({}, props, {
     okCancel: true,
   });
   return confirm(config);
 };
 
-export default AntModal;
+export default Modal;

--- a/components/pagination/index.jsx
+++ b/components/pagination/index.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Pagination from 'rc-pagination';
+import RcPagination from 'rc-pagination';
 import Select from '../select';
 import zhCN from './locale/zh_CN';
 
@@ -11,7 +11,7 @@ class MiniSelect extends React.Component {
 
 MiniSelect.Option = Select.Option;
 
-class AntPagination extends React.Component {
+export default class Pagination extends React.Component {
   render() {
     let className = this.props.className;
     let selectComponentClass = Select;
@@ -29,7 +29,7 @@ class AntPagination extends React.Component {
     }
 
     return (
-      <Pagination selectComponentClass={selectComponentClass}
+      <RcPagination selectComponentClass={selectComponentClass}
         selectPrefixCls="ant-select"
         {...this.props}
         locale={locale}
@@ -38,14 +38,12 @@ class AntPagination extends React.Component {
   }
 }
 
-AntPagination.defaultProps = {
+Pagination.defaultProps = {
   locale: zhCN,
   className: '',
   prefixCls: 'ant-pagination',
 };
 
-AntPagination.contextTypes = {
+Pagination.contextTypes = {
   antLocale: React.PropTypes.object,
 };
-
-export default AntPagination;

--- a/components/radio/index.jsx
+++ b/components/radio/index.jsx
@@ -1,7 +1,7 @@
-import AntRadio from './radio';
+import Radio from './radio';
 import Group from './group';
 import Button from './radioButton';
 
-AntRadio.Button = Button;
-AntRadio.Group = Group;
-export default AntRadio;
+Radio.Button = Button;
+Radio.Group = Group;
+export default Radio;

--- a/components/radio/radio.jsx
+++ b/components/radio/radio.jsx
@@ -1,8 +1,8 @@
-import Radio from 'rc-radio';
+import RcRadio from 'rc-radio';
 import React from 'react';
 import classNames from 'classnames';
 
-const AntRadio = React.createClass({
+const Radio = React.createClass({
   getDefaultProps() {
     return {
       prefixCls: 'ant-radio'
@@ -18,11 +18,11 @@ const AntRadio = React.createClass({
     });
     return (
       <label className={classString} style={style}>
-        <Radio {...this.props} style={null} children={null} />
+        <RcRadio {...this.props} style={null} children={null} />
         {children}
       </label>
     );
   }
 });
 
-export default AntRadio;
+export default Radio;

--- a/components/radio/radioButton.jsx
+++ b/components/radio/radioButton.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import AntRadio from './radio';
+import Radio from './radio';
 
 const RadioButton = React.createClass({
   getDefaultProps() {
@@ -9,7 +9,7 @@ const RadioButton = React.createClass({
   },
   render() {
     return (
-      <AntRadio {...this.props} />
+      <Radio {...this.props} />
     );
   }
 });

--- a/components/table/index.jsx
+++ b/components/table/index.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Table from 'rc-table';
+import RcTable from 'rc-table';
 import Checkbox from '../checkbox';
 import Radio from '../radio';
 import FilterDropdown from './filterDropdown';
@@ -27,7 +27,7 @@ const defaultPagination = {
   onShowSizeChange: noop,
 };
 
-let AntTable = React.createClass({
+let Table = React.createClass({
   getInitialState() {
     return {
       // 减少状态
@@ -604,7 +604,7 @@ let AntTable = React.createClass({
 
     let table = (
       <div>
-        <Table {...this.props}
+        <RcTable {...this.props}
           data={data}
           columns={columns}
           className={classString}
@@ -631,4 +631,4 @@ let AntTable = React.createClass({
   }
 });
 
-export default AntTable;
+export default Table;

--- a/components/tabs/index.jsx
+++ b/components/tabs/index.jsx
@@ -1,9 +1,9 @@
-import Tabs from 'rc-tabs';
+import RcTabs from 'rc-tabs';
 import React, { cloneElement } from 'react';
 import classNames from 'classnames';
 import Icon from '../icon';
 
-class AntTabs extends React.Component {
+export default class Tabs extends React.Component {
   constructor(props) {
     super(props);
     [
@@ -59,7 +59,7 @@ class AntTabs extends React.Component {
     }
 
     return (
-      <Tabs {...this.props}
+      <RcTabs {...this.props}
         className={className}
         tabBarExtraContent={
           <div className={`${prefixCls}-extra-content`}>
@@ -69,12 +69,12 @@ class AntTabs extends React.Component {
         onChange={this.handleChange}
         animation={animation}>
         {children}
-      </Tabs>
+      </RcTabs>
     );
   }
 }
 
-AntTabs.defaultProps = {
+Tabs.defaultProps = {
   prefixCls: 'ant-tabs',
   animation: 'slide-horizontal',
   type: 'line', // or 'card' 'editable-card'
@@ -82,6 +82,4 @@ AntTabs.defaultProps = {
   onEdit() {},
 };
 
-AntTabs.TabPane = Tabs.TabPane;
-
-export default AntTabs;
+Tabs.TabPane = RcTabs.TabPane;

--- a/components/tag/index.jsx
+++ b/components/tag/index.jsx
@@ -4,7 +4,7 @@ import Animate from 'rc-animate';
 import Icon from '../icon';
 import classNames from 'classnames';
 
-class AntTag extends React.Component {
+export default class Tag extends React.Component {
   constructor(props) {
     super(props);
 
@@ -61,11 +61,9 @@ class AntTag extends React.Component {
   }
 }
 
-AntTag.defaultProps = {
+Tag.defaultProps = {
   prefixCls: 'ant-tag',
   closable: false,
   onClose() {},
   afterClose() {},
 };
-
-export default AntTag;

--- a/components/time-picker/index.jsx
+++ b/components/time-picker/index.jsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import DateTimeFormat from 'gregorian-calendar-format';
-import TimePicker from 'rc-time-picker/lib/TimePicker';
+import RcTimePicker from 'rc-time-picker/lib/TimePicker';
 import objectAssign from 'object-assign';
 import defaultLocale from './locale/zh_CN';
 import classNames from 'classnames';
 import GregorianCalendar from 'gregorian-calendar';
 
-const AntTimePicker = React.createClass({
+const TimePicker = React.createClass({
   getDefaultProps() {
     return {
       format: 'HH:mm:ss',
@@ -105,7 +105,7 @@ const AntTimePicker = React.createClass({
     }
 
     return (
-      <TimePicker
+      <RcTimePicker
         {...props}
         className={className}
         locale={locale}
@@ -117,4 +117,4 @@ const AntTimePicker = React.createClass({
 
 });
 
-export default AntTimePicker;
+export default TimePicker;

--- a/components/upload/index.jsx
+++ b/components/upload/index.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Upload from 'rc-upload';
+import RcUpload from 'rc-upload';
 import assign from 'object-assign';
 import UploadList from './uploadList';
 import getFileItem from './getFileItem';
@@ -53,7 +53,7 @@ function genPercentAdd() {
   };
 }
 
-const AntUpload = React.createClass({
+const Upload = React.createClass({
   getInitialState() {
     return {
       fileList: this.props.fileList || this.props.defaultFileList || [],
@@ -249,11 +249,11 @@ const AntUpload = React.createClass({
             onDrop={this.onFileDrop}
             onDragOver={this.onFileDrop}
             onDragLeave={this.onFileDrop}>
-            <Upload {...props}>
+            <RcUpload {...props}>
               <div className={`${prefixCls}-drag-container`}>
                 {this.props.children}
               </div>
-            </Upload>
+            </RcUpload>
           </div>
           {uploadList}
         </span>
@@ -269,9 +269,9 @@ const AntUpload = React.createClass({
           <span className={this.props.className}>
             {uploadList}
             <div className={uploadButtonCls}>
-              <Upload {...props}>
+              <RcUpload {...props}>
                 {this.props.children}
-              </Upload>
+              </RcUpload>
             </div>
           </span>
         );
@@ -279,9 +279,9 @@ const AntUpload = React.createClass({
       return (
         <span className={this.props.className}>
           <div className={uploadButtonCls}>
-            <Upload {...props}>
+            <RcUpload {...props}>
               {this.props.children}
-            </Upload>
+            </RcUpload>
           </div>
           {uploadList}
         </span>
@@ -290,10 +290,10 @@ const AntUpload = React.createClass({
   }
 });
 
-AntUpload.Dragger = React.createClass({
+Upload.Dragger = React.createClass({
   render() {
-    return <AntUpload {...this.props} type="drag" style={{ height: this.props.height }} />;
+    return <Upload {...this.props} type="drag" style={{ height: this.props.height }} />;
   }
 });
 
-export default AntUpload;
+export default Upload;

--- a/components/validation/index.jsx
+++ b/components/validation/index.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import warning from 'warning';
 
-export default class AntValidation extends React.Component {
+export default class Validation extends React.Component {
   render() {
     warning(false, '`Validation` is removed, please use `Form` which has supported validation after antd@0.12.0,' +
     ' or you can just import Validation from \'rc-form-validation\' for compatibility');
@@ -9,7 +9,7 @@ export default class AntValidation extends React.Component {
   }
 }
 
-AntValidation.Validator = () => {};
-AntValidation.FieldMixin = {
+Validation.Validator = () => {};
+Validation.FieldMixin = {
   setField() {},
 };


### PR DESCRIPTION
Where necessary, prefix the classes imported from react-component
with 'Rc' rather than prefixing the Ant classes with 'Ant'.

The prefixing of Ant classes wasn't consistent and isn't necessary
in many cases.
