### PR TITLE
always concat paths wether there's a breadcrumbName or not

### DIFF
--- a/components/breadcrumb/index.jsx
+++ b/components/breadcrumb/index.jsx
@@ -38,14 +38,6 @@ export default class Breadcrumb extends React.Component {
     if (routes && routes.length > 0) {
       const paths = [];
       crumbs = routes.map((route, i) => {
-        if (!route.breadcrumbName) {
-          return null;
-        }
-        const name = route.breadcrumbName.replace(/\:(.*)/g, (replacement, key) => {
-          return params[key] || replacement;
-        });
-
-        let link;
         let path = route.path.replace(/^\//, '');
         Object.keys(params).forEach(key => {
           path = path.replace(`:${key}`, params[key]);
@@ -54,6 +46,14 @@ export default class Breadcrumb extends React.Component {
           paths.push(path);
         }
 
+        if (!route.breadcrumbName) {
+          return null;
+        }
+        const name = route.breadcrumbName.replace(/\:(.*)/g, (replacement, key) => {
+          return params[key] || replacement;
+        });
+
+        let link;
         if (i === routes.length - 1) {
           link = <span>{name}</span>;
         } else {


### PR DESCRIPTION
考虑某些情况下，我们的路由上并不需要 breadcrumbName,
如果在计算路径的时候跳过了这些路由，会导致面包屑 url 错误。
