### PR TITLE
Use babel as the eslint parser.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,4 +1,5 @@
 {
+  "parser": "babel-eslint",
   "extends": ["eslint-config-airbnb"],
   "env": {
     "browser": true,

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "autoprefixer": "^6.3.3",
     "babel-cli": "^6.2.0",
     "babel-core": "^6.2.1",
+    "babel-eslint": "^6.0.0-beta.6",
     "babel-jest": "^6.0.1",
     "babel-loader": "^6.2.0",
     "babel-plugin-add-module-exports": "^0.1.1",


### PR DESCRIPTION
This allows eslint to validate all of the code that babel is
configured to accept. Without this, eslint won't validate code
that is part of ES7.

We use the beta for 6.0 to avoid https://github.com/babel/babel-eslint/issues/249
