### PR TITLE
feat: support multi children for Form.Item

### DIFF
--- a/components/form/FormItem.jsx
+++ b/components/form/FormItem.jsx
@@ -28,16 +28,16 @@ export default class FormItem extends React.Component {
     return props.help;
   }
 
-  getOnlyChildren() {
+  getOnlyControl() {
     const children = React.Children.toArray(this.props.children);
-    if (children.length === 1) {
-      return children[0];
-    }
-    return null;
+    const child = children.filter((c) => {
+      return c.props && '__meta' in c.props;
+    })[0];
+    return child !== undefined ? child : null;
   }
 
   getChildProp(prop) {
-    const child = this.getOnlyChildren();
+    const child = this.getOnlyControl();
     return child && child.props && child.props[prop];
   }
 

--- a/components/form/demo/validate-other.md
+++ b/components/form/demo/validate-other.md
@@ -7,7 +7,7 @@
 ---
 
 ````jsx
-import { Select, Radio, Checkbox, Button, DatePicker, InputNumber, Form, Cascader } from 'antd';
+import { Select, Radio, Checkbox, Button, DatePicker, InputNumber, Form, Cascader, Icon } from 'antd';
 const Option = Select.Option;
 const RadioGroup = Radio.Group;
 const createForm = Form.create;
@@ -134,6 +134,7 @@ let Demo = React.createClass({
             <Radio value="male">男</Radio>
             <Radio value="female">女</Radio>
           </RadioGroup>
+          <span><Icon type="info-circle-o" /> 暂不支持其它性别</span>
         </FormItem>
 
         <FormItem


### PR DESCRIPTION
允许 `Form.Item` 内有多个 child，不过只允许其中一个使用 `getFieldProps`。

主要是为了支持这种使用场景：

![image](https://cloud.githubusercontent.com/assets/3580607/14074986/d1225d0c-f507-11e5-814b-2a73a55b83f5.png)
