### PR TITLE
Fix RangePicker handleChange callback.

### DIFF
--- a/components/date-picker/RangePicker.jsx
+++ b/components/date-picker/RangePicker.jsx
@@ -42,7 +42,7 @@ export default React.createClass({
     const endDate = value[1] ? new Date(value[1].getTime()) : null;
     const startDateString = value[0] ? props.getFormatter().format(value[0]) : '';
     const endDateString = value[1] ? props.getFormatter().format(value[1]) : '';
-    props.props.onChange([startDate, endDate], [startDateString, endDateString]);
+    props.onChange([startDate, endDate], [startDateString, endDateString]);
   },
   render() {
     const props = this.props;


### PR DESCRIPTION
There was a minor typo in 2e86463a6ae4ceaad01572bafb2af41a0e9d05a8
which broke the `handleChange` callback (`this.props` was replaced with
`props.props` rather than just `props`).
