### PR TITLE
fix input value/defaultValue prop

### DIFF
--- a/components/input/Input.jsx
+++ b/components/input/Input.jsx
@@ -101,6 +101,9 @@ export default class Input extends React.Component {
     }
     if ('value' in props) {
       props.value = fixControlledValue(props.value);
+      // Input elements must be either controlled or uncontrolled,
+      // specify either the value prop, or the defaultValue prop, but not both.
+      delete props.defaultValue;
     }
     switch (props.type) {
       case 'textarea':


### PR DESCRIPTION
- [x] Make sure you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
- [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
- [x] Rebase before creating a PR to keep commit history clear.
- [x] Add some descriptions and refer relative issues for you PR.

Input elements must be either controlled or uncontrolled, specify either the value prop, or the defaultValue prop, but not both.

More info: https://fb.me/react-controlled-components
