### PR TITLE
date-picker extend options

### DIFF
--- a/components/date-picker/demo/time.md
+++ b/components/date-picker/demo/time.md
@@ -13,6 +13,6 @@ function onChange(value) {
 }
 
 ReactDOM.render(
-<DatePicker showTime format="yyyy-MM-dd HH:mm:ss" placeholder="请选择时间" onChange={onChange} />
+<DatePicker showTime={{format:'HH:mm'}} format="yyyy-MM-dd HH:mm:ss" placeholder="请选择时间" onChange={onChange} />
 , mountNode);
 ````

--- a/components/date-picker/demo/time.md
+++ b/components/date-picker/demo/time.md
@@ -13,6 +13,6 @@ function onChange(value) {
 }
 
 ReactDOM.render(
-<DatePicker showTime={{format:'HH:mm'}} format="yyyy-MM-dd HH:mm:ss" placeholder="请选择时间" onChange={onChange} />
+<DatePicker showTime format="yyyy-MM-dd HH:mm:ss" placeholder="请选择时间" onChange={onChange} />
 , mountNode);
 ````

--- a/components/date-picker/index.md
+++ b/components/date-picker/index.md
@@ -34,9 +34,14 @@ english: DatePicker
 | popupStyle   | 格外的弹出日历样式   | object     | {}   |
 | size         | 输入框大小，`large` 高度为 32px，`small` 为 22px，默认是 28px | string   | 无  |
 | locale       | 国际化配置 | object   | [默认配置](https://github.com/ant-design/ant-design/issues/424)  |
-| showTime     | 增加时间选择功能 | bool | false  |
 | onOk         | 点击确定按钮的回调 | function(Date value) | 无 |
 | getCalendarContainer | 定义浮层的容器，默认为 body 上新建 div | function(trigger) | 无 |
+| showTime     | 增加时间选择功能 | bool | false  |
+| timeFormat     | 时间选择功能的时间格式 | string | "HH:mm:ss"、"HH:mm"、"mm:ss"  |
+| timeHideDisabledOptions     | 隐藏禁止选择的选项 | boolean | false |
+| timeDisabled            | 禁用全部操作 | bool | false |
+| timeDisabledHours       | 禁止时间选择小时选项 | function() | 无 |
+| timeDisabledMinutes     | 禁止选时间选择分钟选项 | function(selectedHour) | 无 |
 
 ### MonthPicker
 

--- a/components/date-picker/index.md
+++ b/components/date-picker/index.md
@@ -36,7 +36,7 @@ english: DatePicker
 | locale       | 国际化配置 | object   | [默认配置](https://github.com/ant-design/ant-design/issues/424)  |
 | onOk         | 点击确定按钮的回调 | function(Date value) | 无 |
 | getCalendarContainer | 定义浮层的容器，默认为 body 上新建 div | function(trigger) | 无 |
-| showTime     | 增加时间选择功能  | object | [TimePicker Options](http://ant.design/components/time-picker/#api) |
+| showTime     | 增加时间选择功能  | Object or Boolean | [TimePicker Options](http://ant.design/components/time-picker/#api) |
 
 ### MonthPicker
 
@@ -61,6 +61,7 @@ english: DatePicker
 | defaultValue | 默认日期       | [string/Date, string/Date]   | 无           |
 | format       | 展示的日期格式  | string    | "yyyy-MM-dd HH:mm:ss" |
 | onChange     | 时间发生变化的回调，发生在用户选择时间时 | function(date[], dateString[]) | 无           |
+| showTime     | 增加时间选择功能  | Object or Boolean | [TimePicker Options](http://ant.design/components/time-picker/#api) |
 
 `disabled` `style` `popupStyle` `size` `locale` `showTime` `onOk` `getCalendarContainer` 属性与 DatePicker 的一致。
 

--- a/components/date-picker/index.md
+++ b/components/date-picker/index.md
@@ -36,12 +36,7 @@ english: DatePicker
 | locale       | 国际化配置 | object   | [默认配置](https://github.com/ant-design/ant-design/issues/424)  |
 | onOk         | 点击确定按钮的回调 | function(Date value) | 无 |
 | getCalendarContainer | 定义浮层的容器，默认为 body 上新建 div | function(trigger) | 无 |
-| showTime     | 增加时间选择功能 | bool | false  |
-| timeFormat     | 时间选择功能的时间格式 | string | "HH:mm:ss"、"HH:mm"、"mm:ss"  |
-| timeHideDisabledOptions     | 隐藏禁止选择的选项 | boolean | false |
-| timeDisabled            | 禁用全部操作 | bool | false |
-| timeDisabledHours       | 禁止时间选择小时选项 | function() | 无 |
-| timeDisabledMinutes     | 禁止选时间选择分钟选项 | function(selectedHour) | 无 |
+| showTime     | 增加时间选择功能  | object | [TimePicker Options](http://ant.design/components/time-picker/#api) |
 
 ### MonthPicker
 

--- a/components/date-picker/wrapPicker.jsx
+++ b/components/date-picker/wrapPicker.jsx
@@ -95,6 +95,12 @@ export default function wrapPicker(Picker, defaultFormat) {
 
       const locale = this.getLocale();
 
+      const timeFormat = props.showTime && props.showTime.format;
+      const rcTimePickerProps = {
+          formatter: new DateTimeFormat(timeFormat || 'HH:mm:ss'),
+          showSecond: timeFormat && timeFormat.indexOf('ss') >= 0,
+          showHour: timeFormat && timeFormat.indexOf('HH') >= 0
+      };
       const timePicker = props.showTime ? (
         <TimePicker
           prefixCls="ant-time-picker"
@@ -102,8 +108,12 @@ export default function wrapPicker(Picker, defaultFormat) {
           locale={locale.timePickerLocale}
           transitionName="slide-up"
           {...props.showTime}
+          {...rcTimePickerProps}
           />
       ) : null;
+  
+      console.log(timePicker)
+      console.log('....')
 
       return (
         <Picker

--- a/components/date-picker/wrapPicker.jsx
+++ b/components/date-picker/wrapPicker.jsx
@@ -97,9 +97,9 @@ export default function wrapPicker(Picker, defaultFormat) {
 
       const timeFormat = props.showTime && props.showTime.format;
       const rcTimePickerProps = {
-          formatter: new DateTimeFormat(timeFormat || 'HH:mm:ss'),
-          showSecond: timeFormat && timeFormat.indexOf('ss') >= 0,
-          showHour: timeFormat && timeFormat.indexOf('HH') >= 0
+        formatter: new DateTimeFormat(timeFormat || 'HH:mm:ss'),
+        showSecond: timeFormat && timeFormat.indexOf('ss') >= 0,
+        showHour: timeFormat && timeFormat.indexOf('HH') >= 0
       };
       const timePicker = props.showTime ? (
         <TimePicker
@@ -111,9 +111,6 @@ export default function wrapPicker(Picker, defaultFormat) {
           {...rcTimePickerProps}
           />
       ) : null;
-  
-      console.log(timePicker)
-      console.log('....')
 
       return (
         <Picker

--- a/components/date-picker/wrapPicker.jsx
+++ b/components/date-picker/wrapPicker.jsx
@@ -103,12 +103,12 @@ export default function wrapPicker(Picker, defaultFormat) {
       };
       const timePicker = props.showTime ? (
         <TimePicker
+          {...props.showTime}
+          {...rcTimePickerProps}
           prefixCls="ant-time-picker"
           placeholder={locale.timePickerLocale.placeholder}
           locale={locale.timePickerLocale}
           transitionName="slide-up"
-          {...props.showTime}
-          {...rcTimePickerProps}
           />
       ) : null;
 

--- a/components/date-picker/wrapPicker.jsx
+++ b/components/date-picker/wrapPicker.jsx
@@ -94,8 +94,6 @@ export default function wrapPicker(Picker, defaultFormat) {
       });
 
       const locale = this.getLocale();
-      const showSecond = props.timeFormat && props.timeFormat.indexOf('ss') >= 0;
-      const showHour = props.timeFormat && props.timeFormat.indexOf('HH') >= 0;
 
       const timePicker = props.showTime ? (
         <TimePicker
@@ -103,13 +101,7 @@ export default function wrapPicker(Picker, defaultFormat) {
           placeholder={locale.timePickerLocale.placeholder}
           locale={locale.timePickerLocale}
           transitionName="slide-up"
-          hideDisabledOptions={props.timeHideDisabledOptions}
-          disabled={props.timeDisabled}
-          disabledHours={props.timeDisabledHours}
-          disabledMinutes={props.timeDisabledMinutes}
-          formatter={new DateTimeFormat(props.timeFormat || 'HH:mm:ss')}
-          showSecond={showSecond}
-          showHour={showHour}
+          {...props.showTime}
           />
       ) : null;
 

--- a/components/date-picker/wrapPicker.jsx
+++ b/components/date-picker/wrapPicker.jsx
@@ -94,12 +94,23 @@ export default function wrapPicker(Picker, defaultFormat) {
       });
 
       const locale = this.getLocale();
+      const showSecond = props.timeFormat && props.timeFormat.indexOf('ss') >= 0;
+      const showHour = props.timeFormat && props.timeFormat.indexOf('HH') >= 0;
+
       const timePicker = props.showTime ? (
         <TimePicker
           prefixCls="ant-time-picker"
           placeholder={locale.timePickerLocale.placeholder}
           locale={locale.timePickerLocale}
-          transitionName="slide-up" />
+          transitionName="slide-up"
+          hideDisabledOptions={props.timeHideDisabledOptions}
+          disabled={props.timeDisabled}
+          disabledHours={props.timeDisabledHours}
+          disabledMinutes={props.timeDisabledMinutes}
+          formatter={new DateTimeFormat(props.timeFormat || 'HH:mm:ss')}
+          showSecond={showSecond}
+          showHour={showHour}
+          />
       ) : null;
 
       return (

--- a/components/date-picker/wrapPicker.jsx
+++ b/components/date-picker/wrapPicker.jsx
@@ -103,8 +103,8 @@ export default function wrapPicker(Picker, defaultFormat) {
       };
       const timePicker = props.showTime ? (
         <TimePicker
-          {...props.showTime}
           {...rcTimePickerProps}
+          {...props.showTime}
           prefixCls="ant-time-picker"
           placeholder={locale.timePickerLocale.placeholder}
           locale={locale.timePickerLocale}


### PR DESCRIPTION
In my business scene I need to format the `time-picker` of `date-picker` when option `showTime` is setted.

And I found the scene is a general demand, eg [#771](https://github.com/ant-design/ant-design/issues/771).

So, I send this PR, please think about it. 
