### PR TITLE
Replace property `spining` with `spinning`

### DIFF
--- a/components/spin/demo/nested.md
+++ b/components/spin/demo/nested.md
@@ -27,7 +27,7 @@ const Card = React.createClass({
     );
     return (
       <div>
-        <Spin spining={this.state.loading}>{container}</Spin>
+        <Spin spinning={this.state.loading}>{container}</Spin>
         切换加载状态：<Switch checked={this.state.loading} onChange={this.toggle} />
       </div>
     );

--- a/components/spin/index.jsx
+++ b/components/spin/index.jsx
@@ -6,6 +6,8 @@ import { isCssAnimationSupported } from 'css-animation';
 export default class Spin extends React.Component {
   static defaultProps = {
     prefixCls: 'ant-spin',
+    spinning: true,
+    // Backwards support
     spining: true,
   }
 
@@ -27,13 +29,14 @@ export default class Spin extends React.Component {
 
   render() {
     const { className, size, prefixCls, tip } = this.props;
+    const spinning = this.props.spinning && this.props.spining;
 
     let spinClassName = classNames({
       [prefixCls]: true,
       [`${prefixCls}-sm`]: size === 'small',
       [`${prefixCls}-lg`]: size === 'large',
       [className]: !!className,
-      [`${prefixCls}-spining`]: this.props.spining,
+      [`${prefixCls}-spinning`]: spinning,
       [`${prefixCls}-show-text`]: !!this.props.tip,
     });
 
@@ -48,7 +51,7 @@ export default class Spin extends React.Component {
 
     if (this.isNestedPattern()) {
       return (
-        <div className={this.props.spining ? (`${prefixCls}-nested-loading`) : ''}>
+        <div className={spinning ? (`${prefixCls}-nested-loading`) : ''}>
           {spinElement}
           <div className={`${prefixCls}-container`}>
             {this.props.children}

--- a/components/spin/index.md
+++ b/components/spin/index.md
@@ -18,5 +18,5 @@ english: Spin
 | 参数       | 类型           | 默认值      | 说明         |
 |------------|----------------|-------------|--------------|
 | size       | enum           | default     | spin组件中点的大小，可选值为 small default large |
-| spining    | boolean        | true        | 用于内嵌其他组件的模式，可以关闭 loading 效果    |
+| spinning   | boolean        | true        | 用于内嵌其他组件的模式，可以关闭 loading 效果    |
 | tip    | string        | 无        | 自定义描述文案 |

--- a/style/components/spin.less
+++ b/style/components/spin.less
@@ -18,7 +18,7 @@
   transition: opacity 0.3s @ease-in-out-circ;
   font-size: @font-size-base;
 
-  &-spining {
+  &-spinning {
     opacity: 1;
     position: static;
     visibility: visible;


### PR DESCRIPTION
It might be easy for users to just misuse `spinning`, which is the correct spelling, without reading the [docs](http://ant.design/components/spin/#api) very carefully.

The commit(s) below will also support `spining` while providing an option to use `spinning`. But I suggest only `spinning` should be mentioned in the usage docs.
