### PR TITLE
fix table pagination #1433

### DIFF
--- a/components/table/index.jsx
+++ b/components/table/index.jsx
@@ -95,9 +95,10 @@ export default class Table extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    if (('pagination' in nextProps) && nextProps.pagination !== false) {
+    const { pagination } = nextProps;
+    if (pagination && pagination.current) {
       this.setState({
-        pagination: { ...defaultPagination, ...this.state.pagination, ...nextProps.pagination },
+        pagination: { ...defaultPagination, ...this.state.pagination, ...pagination },
       });
     }
     // dataSource 的变化会清空选中项


### PR DESCRIPTION
If a `Table`'s `pagination` prop does not contain `current` prop, this `Table` should not be regarded as a controlled component.
An `Input` without `value` prop allows user interactions (change value), so should the `Table` without `current` prop. Changing input's value has no differences from changing pagination's current.
## Online Demo

Here comes the online demo. Please try both pagination and input component.
http://codepen.io/BetaRabbit/pen/EKLjom?editors=0110
