### PR TITLE
Update dropdown.less

### DIFF
--- a/style/components/dropdown.less
+++ b/style/components/dropdown.less
@@ -46,7 +46,6 @@
     box-shadow: @box-shadow-base;
     background-clip: padding-box;
     border: 1px solid @border-color-base;
-    overflow: hidden;
 
     &-item,
     &-submenu-title {
@@ -89,6 +88,10 @@
 
       &:last-child {
         border-radius: 0 0 @border-radius-base @border-radius-base;
+      }
+
+      &:only-child {
+        border-radius: @border-radius-base;
       }
 
       &-divider {


### PR DESCRIPTION
去除 menu 中的 `overflow: hidden` (会导致子菜单无法显示)
改为用伪类 `only-child`
