### PR TITLE
fix lint

### DIFF
--- a/components/date-picker/demo/locale.md
+++ b/components/date-picker/demo/locale.md
@@ -9,16 +9,11 @@ title: 国际化
 import { DatePicker } from 'antd';
 import enUS from 'antd/lib/date-picker/locale/en_US';
 
-const App = React.createClass({
-  render() {
-    const customLocale = {
-      timezoneOffset: 0 * 60,
-      firstDayOfWeek: 0,
-      minimalDaysInFirstWeek: 1,
-    };
-    return <DatePicker locale={{ ...enUS, ...customLocale }} />;
-  }
-});
+const customLocale = {
+  timezoneOffset: 0 * 60,
+  firstDayOfWeek: 0,
+  minimalDaysInFirstWeek: 1,
+};
 
-ReactDOM.render(<App />, mountNode);
+ReactDOM.render(<DatePicker locale={{ ...enUS, ...customLocale }} />, mountNode);
 ````

--- a/components/form/FormItem.jsx
+++ b/components/form/FormItem.jsx
@@ -2,9 +2,7 @@ import React from 'react';
 import classNames from 'classnames';
 
 function prefixClsFn(prefixCls, ...args) {
-  return args.map((s) => {
-    return `${prefixCls}-${s}`;
-  }).join(' ');
+  return args.map((s) => `${prefixCls}-${s}`).join(' ');
 }
 
 export default class FormItem extends React.Component {

--- a/components/table/index.jsx
+++ b/components/table/index.jsx
@@ -289,9 +289,7 @@ export default class Table extends React.Component {
     if (checked) {
       selectedRowKeys.push(this.getRecordKey(record, rowIndex));
     } else {
-      selectedRowKeys = selectedRowKeys.filter((i) => {
-        return key !== i;
-      });
+      selectedRowKeys = selectedRowKeys.filter((i) => key !== i);
     }
     this.setState({
       selectionDirty: true,

--- a/site/component/MainContent/index.jsx
+++ b/site/component/MainContent/index.jsx
@@ -117,9 +117,7 @@ export default class MainContent extends React.Component {
     }
 
     if (Array.isArray(menu)) {
-      return menu.reduce((acc, item) => {
-        return acc.concat(this.flattenMenu(item));
-      }, []);
+      return menu.reduce((acc, item) => acc.concat(this.flattenMenu(item)), []);
     }
 
     return this.flattenMenu(menu.props.children);

--- a/site/entry/utils.js
+++ b/site/entry/utils.js
@@ -51,9 +51,7 @@ export function generateContainer(data) {
 
 export function generateIndex(data) {
   const menuItems = getMenuItems(data);
-  const firstChild = menuItems.topLevel.topLevel.filter((item) => {
-    return !item.disabled;
-  })[0];
+  const firstChild = menuItems.topLevel.topLevel.filter((item) => !item.disabled)[0];
   return (
     <IndexRedirect key="index"
       to={fileNameToPath(firstChild.fileName)} />


### PR DESCRIPTION
扫了一下全部的文件，修复 `arrow-body-style` 规则时跳过了以下三种情况：

1、`{ return a && b && c && d }` 里条件过多，比如：

```
    [(node) => {
      return isElement(node) &&
        getTagName(node) === 'p' &&
        getTagName(getChildren(node)[0]) === 'img' &&
        /preview-img/gi.test(getAttributes(getChildren(node)[0]).class);
    }
```

2、后面跟着很多的链式调用，比如：

```
    const options = Object.keys(componentsList).map((key) => {
      return componentsList[key];
    }).filter(({ meta }) => {
      return /^component/.test(meta.fileName);
    }).map(({ meta }) => {
      //...
    });
```

3、返回的是一个 React Element 集合，比如：

```
    const imagesList = imgsMeta.map((meta, index) => {
      return (
        <div key={index}>
          <div className="image-modal-container">
            <img {...meta} alt={meta.alt} />
          </div>
        </div>
      );
    });
```

出于可读性和可维护性的考虑，以上三种情况建议不强行上  `arrow-body-style`，另外，这三种情况其实还挺多的，所以这个规则目前也没有多大的意义
