### PR TITLE
Missing Option const

### DIFF
--- a/components/calendar/Header.jsx
+++ b/components/calendar/Header.jsx
@@ -3,6 +3,8 @@ import { PREFIX_CLS } from './Constants';
 import Select from '../select';
 import { Group, Button } from '../radio';
 
+const { Option } = Select;
+
 function noop() {}
 
 export default class Header extends React.Component {


### PR DESCRIPTION
Cause `Option is not defined` error
