### PR TITLE
add params to ModalFunc

### DIFF
--- a/type-definitions/antd.d.ts
+++ b/type-definitions/antd.d.ts
@@ -853,6 +853,7 @@ declare namespace Antd {
   type ModalFunc = (options: {
     visible?: boolean,
     title?: React.ReactNode | string,
+    content?: React.ReactNode | string,
     onOk?: Function,
     onCancel?: Function,
     width?: string | number,


### PR DESCRIPTION
Add a optional params "content" to ModalFunc when calling

```
Modal.info( {
        title: '通知',
        content:'aaaaaa'
      } )
```
