### PR TITLE
文档中 API 参数说明表格字体修改

### DIFF
--- a/site/common/styles/markdown.less
+++ b/site/common/styles/markdown.less
@@ -178,7 +178,7 @@
 }
 
 .markdown.api-container table {
-  font-family: consolas;
+  font-family: Consolas, Menlo, Courier, monospace;
   font-size: 13px;
 }
 


### PR DESCRIPTION
原本的 `consolas` 在 Mac 系统上会回落至宋体，影响阅读体验
