### PR TITLE
fix #2126

### DIFF
--- a/components/pagination/style/index.less
+++ b/components/pagination/style/index.less
@@ -127,6 +127,7 @@
   &-prev,
   &-next {
     border: 1px solid @border-color-base;
+    background-color: #fff;
 
     a {
       color: #666;


### PR DESCRIPTION
给 `Pagination` 的 prev，next button加背景色，避免深色背景下看不清。
