### PR TITLE
 Rewrite Checkbox in typescript

### DIFF
--- a/components/_util/splitObject.tsx
+++ b/components/_util/splitObject.tsx
@@ -1,4 +1,4 @@
-export default function splitObject(obj, parts) {
+export default function splitObject(obj, parts) : Array<any>{
   let left = {};
   let right = {};
   Object.keys(obj).forEach((k)=> {

--- a/components/checkbox/Group.tsx
+++ b/components/checkbox/Group.tsx
@@ -1,8 +1,34 @@
-import React from 'react';
+import * as React from 'react';
 import Checkbox from './index';
 import PureRenderMixin from 'react-addons-pure-render-mixin';
 import assign from 'object-assign';
-export default class CheckboxGroup extends React.Component {
+
+export interface CheckboxOptionType {
+  label:string,
+  value:string,
+  disabled?:boolean
+}
+
+interface CheckboxGroupProps {
+  /** 默认选中的选项*/
+  defaultValue?:Array<string>,
+  /** 指定选中的选项*/
+  value?:Array<string>,
+  /** 指定可选项*/
+  options?:Array<CheckboxOptionType> | Array<string>,
+  /** 变化时回调函数*/
+  onChange?:(checkedValue:Array<string>) => void,
+
+  disabled?:boolean,
+
+  style?:React.CSSProperties
+}
+
+interface CheckboxGroupState {
+  value: any;
+}
+
+export default class CheckboxGroup extends React.Component<CheckboxGroupProps, CheckboxGroupState> {
   static defaultProps = {
     options: [],
     defaultValue: [],

--- a/components/checkbox/index.tsx
+++ b/components/checkbox/index.tsx
@@ -1,10 +1,26 @@
 import RcCheckbox from 'rc-checkbox';
-import React from 'react';
+import * as React from 'react';
 import CheckboxGroup from './Group';
 import classNames from 'classnames';
 import PureRenderMixin from 'react-addons-pure-render-mixin';
 import splitObject from '../_util/splitObject';
-export default class Checkbox extends React.Component {
+
+interface CheckboxProps {
+  /** 指定当前是否选中*/
+  checked?:boolean,
+  /** 初始是否选中*/
+  defaultChecked?:boolean,
+  /** 变化时回调函数*/
+  onChange?:React.FormEventHandler,
+
+  style?:React.CSSProperties,
+
+  disabled?: boolean,
+
+  className?: string,
+}
+
+export default class Checkbox extends React.Component<CheckboxProps, any> {
   static Group = CheckboxGroup;
   static defaultProps = {
     prefixCls: 'ant-checkbox',

--- a/components/collapse/index.tsx
+++ b/components/collapse/index.tsx
@@ -1,5 +1,5 @@
 import RcCollapse from 'rc-collapse';
-import React from 'react';
+import * as React from 'react';
 
 export interface CollapseProps {
   activeKey?:Array<string> | string,


### PR DESCRIPTION
- add return type of function splitObject
- rewrite `import React from 'react'` to `import * as React from 'react'`
- rewrite Checkbox in typescript
