### PR TITLE
fix the current page status issue after removing all the data in last…

### DIFF
--- a/components/table/Table.tsx
+++ b/components/table/Table.tsx
@@ -118,7 +118,14 @@ export default class Table extends React.Component {
     if (('pagination' in nextProps) && nextProps.pagination !== false) {
       this.setState(previousState => {
         const newPagination = assign({}, defaultPagination, previousState.pagination, nextProps.pagination);
-        newPagination.current = newPagination.current || 1;
+        let newCurrent = newPagination.current || 1;
+
+        // 如果因为删除导致总数小于当前页数，页数减1
+        if ((newCurrent - 1) * newPagination.pageSize >= newPagination.total) {
+          newCurrent --;
+        }
+
+        newPagination.current = newCurrent;
         return { pagination: newPagination };
       });
     }


### PR DESCRIPTION
First of all, thanks for your contribution! :-)

Please makes sure these boxes are checked before submitting your PR, thank you!
- [x] Make sure you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
- [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
- [x] Rebase before creating a PR to keep commit history clear.
- [x] Add some descriptions and refer relative issues for you PR.

… page

When there are more than one page, and user keeps removing the data from the last page, the table will render again after the data source changing. However, when we remove the last one item on the page, the table will be "No data here", since it's current-page is still the last one, which beyond the total records.

当有多页数据展现，而用户删除最后一页的数据直到页面上的最后一条也被删除，页面会显示：“没有数据”，因为页数此时已经超过了记录总数。代码中只是简单的判断当前页码是否超出总数，如若超过便减1。本地已经跑了 npm run lint, 也是从master上直接新的commit，似乎不用rebase。如有不妥还请指出，谢谢！
