### PR TITLE
fix issues in #2441

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "rc-collapse": "~1.6.4",
     "rc-dialog": "~6.2.1",
     "rc-dropdown": "~1.4.8",
-    "rc-editor-mention": "~0.1.10",
+    "rc-editor-mention": "^0.2.2",
     "rc-form": "~0.17.1",
     "rc-input-number": "~2.5.14",
     "rc-menu": "~4.12.4",


### PR DESCRIPTION
- [x] 点击第一个例子的输入框，展开下拉菜单。点击第二个输入框，输入 @，此时第一个输入框中的下拉菜单会再次出现。
- [ ] （未复现）有时点击第一个输入框，输入光标会跑到已输入文字前面去。
- [x] 缺少下拉动画。
