### PR TITLE
 fix the bug of mention while blur then focus

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "rc-collapse": "~1.6.4",
     "rc-dialog": "~6.2.1",
     "rc-dropdown": "~1.4.8",
-    "rc-editor-mention": "^0.2.2",
+    "rc-editor-mention": "~0.2.3",
     "rc-form": "~0.17.1",
     "rc-input-number": "~2.5.14",
     "rc-menu": "~4.13.0",


### PR DESCRIPTION
- 输入文字 @afc163  123
- 光标移到 @afc163 中，弹出建议。
- 点击输入框外部，失去焦点。
- 再点击 123，输入框得到焦点，光标移到 123 中，
- 此时建议会先弹出后消失

修复了此 bug
