### PR TITLE
修复当form.item label独占一行时右对齐的问题

### DIFF
--- a/components/form/style/index.less
+++ b/components/form/style/index.less
@@ -47,6 +47,7 @@ input[type="checkbox"] {
     cursor: @cursor-disabled;
   }
 }
+
 // These classes are used on elements with <label> descendants
 .ant-radio,
 .ant-checkbox {
@@ -84,6 +85,7 @@ input[type="checkbox"] {
     text-align: right;
     vertical-align: middle;
     padding: 7px 0;
+    display: inline-block;
 
     label {
       color: @label-color;


### PR DESCRIPTION
在表单组件中label独占一行的时候回出现右对齐的问题
演示: [http://codepen.io/yeliex/pen/grKmEk](http://codepen.io/yeliex/pen/grKmEk)
- [x] Make sure you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
- [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
- [x] Rebase before creating a PR to keep commit history clear.
- [x] Add some descriptions and refer relative issues for you PR.
