### PR TITLE
feat: pass this.props.form as context automatically

### DIFF
--- a/components/form/Form.jsx
+++ b/components/form/Form.jsx
@@ -15,23 +15,12 @@ export default class Form extends React.Component {
     prefixCls: React.PropTypes.string,
     horizontal: React.PropTypes.bool,
     inline: React.PropTypes.bool,
-    form: React.PropTypes.object,
     children: React.PropTypes.any,
     onSubmit: React.PropTypes.func,
   }
 
-  static childContextTypes = {
-    form: React.PropTypes.object,
-  }
-
   shouldComponentUpdate(...args) {
     return PureRenderMixin.shouldComponentUpdate.apply(this, args);
-  }
-
-  getChildContext() {
-    return {
-      form: this.props.form,
-    };
   }
 
   render() {

--- a/components/form/demo/dynamic-form-item.md
+++ b/components/form/demo/dynamic-form-item.md
@@ -70,7 +70,7 @@ let Demo = React.createClass({
       );
     });
     return (
-      <Form horizontal form={this.props.form}>
+      <Form horizontal>
         {formItems}
         <Form.Item wrapperCol={{ span: 18, offset: 6 }}>
           <Button onClick={this.add} style={{ marginRight: 8 }}>新增好朋友</Button>

--- a/components/form/demo/form-in-modal.md
+++ b/components/form/demo/form-in-modal.md
@@ -39,7 +39,7 @@ let Demo = React.createClass({
       <div>
         <Button type="primary" onClick={this.showModal}>点击有惊喜</Button>
         <Modal title="登录" visible={this.state.visible} onOk={this.handleSubmit} onCancel={this.hideModal}>
-          <Form horizontal form={this.props.form}>
+          <Form horizontal>
             <FormItem
               {...formItemLayout}
               label="用户名"

--- a/components/form/demo/validate-basic.md
+++ b/components/form/demo/validate-basic.md
@@ -109,7 +109,7 @@ let BasicDemo = React.createClass({
       wrapperCol: { span: 12 },
     };
     return (
-      <Form horizontal form={this.props.form}>
+      <Form horizontal>
         <FormItem
           {...formItemLayout}
           label="用户名"

--- a/components/form/demo/validate-customized.md
+++ b/components/form/demo/validate-customized.md
@@ -140,7 +140,7 @@ let Demo = React.createClass({
     };
     return (
       <div>
-        <Form horizontal form={this.props.form}>
+        <Form horizontal>
           <Row>
             <Col span="18">
               <FormItem

--- a/components/form/demo/validate-other.md
+++ b/components/form/demo/validate-other.md
@@ -107,7 +107,7 @@ let Demo = React.createClass({
       wrapperCol: { span: 12 },
     };
     return (
-      <Form horizontal form={this.props.form}>
+      <Form horizontal>
         <FormItem
           {...formItemLayout}
           label="国籍"

--- a/components/form/index.jsx
+++ b/components/form/index.jsx
@@ -1,7 +1,8 @@
+import React, { PropTypes } from 'react';
+import createDOMForm from 'rc-form/lib/createDOMForm';
 import Form from './Form';
 import FormItem from './FormItem';
 import ValueMixin from './ValueMixin';
-import createDOMForm from 'rc-form/lib/createDOMForm';
 import { FIELD_META_PROP } from './constants';
 
 Form.create = (o = {}) => {
@@ -10,8 +11,25 @@ Form.create = (o = {}) => {
     fieldNameProp: 'id',
     fieldMetaProp: FIELD_META_PROP,
   };
+  const formWrapper = createDOMForm(options);
 
-  return createDOMForm(options);
+  /* eslint-disable react/prefer-es6-class */
+  return (Component) => formWrapper(React.createClass({
+    propTypes: {
+      form: PropTypes.object.isRequired,
+    },
+    childContextTypes: {
+      form: PropTypes.object.isRequired,
+    },
+    getChildContext() {
+      return {
+        form: this.props.form,
+      };
+    },
+    render() {
+      return <Component {...this.props} />;
+    },
+  }));
 };
 Form.Item = FormItem;
 

--- a/components/form/index.md
+++ b/components/form/index.md
@@ -38,7 +38,6 @@ english: Form
 
 | 参数      | 说明                                     | 类型       | 默认值 |
 |-----------|------------------------------------------|------------|-------|
-| form | 经 `Form.create()` 包装过的组件会自带 `this.props.form` 属性，直接传给 Form 即可 | object | 无 |
 | horizontal | 水平排列布局 | boolean  | false    |
 | inline | 行内排列布局 | boolean | false |
 | onSubmit | 数据验证成功后回调事件 | Function(e:Event) |  |


### PR DESCRIPTION
@fool2fish 鱼姐也踩坑了。。

简化：

``` jsx
<Form form={this.props.form}>
  ...
</Form>
```

为：

``` jsx
<Form>
  ...
</Form>
```
