### PR TITLE
 modal 添加小屏幕适配。

### DIFF
--- a/components/modal/style/modal.less
+++ b/components/modal/style/modal.less
@@ -128,3 +128,16 @@
     overflow: hidden;
   }
 }
+
+
+@media (max-width: 768px) {
+  .@{dialog-prefix-cls} {
+    width: auto !important;
+    margin: 10px;
+  }
+  .vertical-center-modal {
+    .@{dialog-prefix-cls} {
+      flex: 1;
+    }
+  }
+}


### PR DESCRIPTION
- close #2597 
- 加入 768px 断点。当屏幕小于 768 时，宽度 auto 且 margin:10。其他不变。
