### PR TITLE
table/demo/reset-filter - A little more meaningful filter

### DIFF
--- a/components/table/demo/reset-filter.md
+++ b/components/table/demo/reset-filter.md
@@ -83,7 +83,7 @@ const App = React.createClass({
         { text: '姓胡的', value: '胡' },
       ],
       filteredValue: filteredInfo.name,
-      onFilter: (value, record) => record.name.indexOf(value) === 0,
+      onFilter: (value, record) => record.name.includes(value),
       sorter: (a, b) => a.name.length - b.name.length,
       sortOrder: sortedInfo.columnKey === 'name' && sortedInfo.order,
     }, {
@@ -101,7 +101,7 @@ const App = React.createClass({
         { text: '西湖', value: '西湖' },
       ],
       filteredValue: filteredInfo.address,
-      onFilter: (value, record) => record.address.indexOf(value) === 0,
+      onFilter: (value, record) => record.address.includes(value),
       sorter: (a, b) => a.address.length - b.address.length,
       sortOrder: sortedInfo.columnKey === 'address' && sortedInfo.order,
     }];


### PR DESCRIPTION
I just propose a small change on `onFilter` functions for `name` and `address` columns.
As most of the people expect, a filter means looking into the whole value, and not only for that value to start with the selected chars.

Usage example: all the entries whose name includes `Doe` filter are shown
![image](https://cloud.githubusercontent.com/assets/14140226/17632533/8a8b3e14-60d1-11e6-8e14-33c250403192.png)
