### PR TITLE
补充Table组件缺少的columns的属性类型定义

### DIFF
--- a/components/table/Table.tsx
+++ b/components/table/Table.tsx
@@ -96,7 +96,7 @@ interface TableContext {
 export default class Table extends React.Component<TableProps, any> {
   static propTypes = {
     dataSource: React.PropTypes.array,
-    columns: React.PropTypes.array,
+    columns: React.PropTypes.array.isRequired,
     prefixCls: React.PropTypes.string,
     useFixedHeader: React.PropTypes.bool,
     rowSelection: React.PropTypes.object,

--- a/components/table/Table.tsx
+++ b/components/table/Table.tsx
@@ -96,6 +96,7 @@ interface TableContext {
 export default class Table extends React.Component<TableProps, any> {
   static propTypes = {
     dataSource: React.PropTypes.array,
+    columns: React.PropTypes.array,
     prefixCls: React.PropTypes.string,
     useFixedHeader: React.PropTypes.bool,
     rowSelection: React.PropTypes.object,


### PR DESCRIPTION
我们在实现一些组件的业务封装的时候，利用原始组件的propTypes定义作为标准来过滤透传的属性，此时发现Table缺少columns的定义，而这个属性还是个必须的属性。
