### PR TITLE
append slash on URI

### DIFF
--- a/components/select/demo/coordinate.md
+++ b/components/select/demo/coordinate.md
@@ -5,7 +5,7 @@ title: 联动
 
 省市联动是典型的例子。
 
-推荐使用 [Cascader](/components/cascader) 组件。
+推荐使用 [Cascader](/components/cascader/) 组件。
 
 ````jsx
 import { Select } from 'antd';


### PR DESCRIPTION
On the [page](http://ant.design/components/select/) click `推荐使用 Cascader 组件。` will jump to 404
<img width="434" alt="screen shot 2016-08-25 at 10 39 13" src="https://cloud.githubusercontent.com/assets/3370345/17954827/34c9cf8e-6ab0-11e6-92e3-84eef6c3ce3c.png">

`/components/select` should be `components/select/`
- [x] Make sure you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
- [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
- [x] Rebase before creating a PR to keep commit history clear.
- [x] Add some descriptions and refer relative issues for you PR.
