### PR TITLE
add inline prop to DatePicker

### DIFF
--- a/components/date-picker/demo/inline.md
+++ b/components/date-picker/demo/inline.md
@@ -1,0 +1,36 @@
+---
+order: 2
+title: 
+  zh-CN: 适应宽度
+  en-US: Inline width
+---
+
+## zh-CN
+
+`inline` 使输入框适应父元素的宽度。
+
+## en-US
+
+By using `inline`, you can adapt the width of `DatePicker` to the parent.
+
+
+````jsx
+import { DatePicker } from 'antd';
+
+ReactDOM.render(
+  <div width="100%">
+    <div>
+      <DatePicker />
+    </div>
+    <div>
+      <DatePicker inline />
+    </div>
+    <div>
+      <DatePicker.RangePicker />
+    </div>
+    <div>
+      <DatePicker.RangePicker inline />
+    </div>
+  </div>
+, mountNode);
+````

--- a/components/date-picker/index.en-US.md
+++ b/components/date-picker/index.en-US.md
@@ -51,6 +51,7 @@ By clicking the input box, you can select a date from a popup calendar.
 | style        | to customize the style of the input box     | Object     | {}   |
 | popupStyle   | to customize the style of the popup calendar   | Object     | {}   |
 | size         | determine the size of the input box, the height of `large` and `small`, are 32px and 22px respectively, while default size is 28px | String   | -  |
+| inline       | adapt width to the parent   | bool   | false  |
 | locale       | localization configuration | Object   | [default](https://github.com/ant-design/ant-design/issues/424)  |
 | getCalendarContainer | to set the container of the floating layer, while the default is to create a `div` element in `body` | function(trigger) | - |
 

--- a/components/date-picker/index.zh-CN.md
+++ b/components/date-picker/index.zh-CN.md
@@ -33,6 +33,7 @@ english: DatePicker
 | style        | 自定义输入框样式     | object     | {}   |
 | popupStyle   | 格外的弹出日历样式   | object     | {}   |
 | size         | 输入框大小，`large` 高度为 32px，`small` 为 22px，默认是 28px | string   | 无  |
+| inline       | 使输入框适应父元素的宽度   | bool   | false  |
 | locale       | 国际化配置 | object   | [默认配置](https://github.com/ant-design/ant-design/issues/424)  |
 | toggleOpen   | 弹出日历和关闭日历的回调 | function(status) | 无 |
 | getCalendarContainer | 定义浮层的容器，默认为 body 上新建 div | function(trigger) | 无 |

--- a/components/date-picker/style/Picker.less
+++ b/components/date-picker/style/Picker.less
@@ -37,6 +37,11 @@
   > input {
     outline: none;
   }
+
+  &-inline {
+    width: 100%;
+  }
+
   &-clear {
     opacity: 0;
     z-index: -1;

--- a/components/date-picker/wrapPicker.jsx
+++ b/components/date-picker/wrapPicker.jsx
@@ -18,6 +18,7 @@ export default function wrapPicker(Picker, defaultFormat) {
       align: {
         offset: [0, -9],
       },
+      inline: false,
     }
 
     static contextTypes = {
@@ -64,6 +65,7 @@ export default function wrapPicker(Picker, defaultFormat) {
       const props = this.props;
       const pickerClass = classNames({
         'ant-calendar-picker': true,
+        'ant-calendar-picker-inline': props.inline,
       });
       const pickerInputClass = classNames({
         'ant-calendar-range-picker': true,


### PR DESCRIPTION
Example: http://codepen.io/anon/pen/gwpXyk?editors=0110

当容器(父元素)宽度比较大时,DatePicker的最大宽度固定,可能会留下太多空白很难看(尤其是在Form或者Layout中)

First of all, thanks for your contribution! :-)

Please makes sure these boxes are checked before submitting your PR, thank you!
- [x] Make sure you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
- [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
- [x] Rebase before creating a PR to keep commit history clear.
- [x] Add some descriptions and refer relative issues for you PR.
