### PR TITLE
Menu theme demo switch style, close: #3327

### DIFF
--- a/components/menu/demo/theme.md
+++ b/components/menu/demo/theme.md
@@ -37,7 +37,7 @@ const Sider = React.createClass({
   render() {
     return (
       <div>
-        <Switch onChange={this.changeTheme} checkedChildren="dark" unCheckedChildren="light" />
+        <Switch onChange={this.changeTheme} checkedChildren={<Icon type="eye" />} unCheckedChildren={<Icon type="eye-o" />} />
         <br />
         <br />
         <Menu theme={this.state.theme}


### PR DESCRIPTION
Icons for menu theme switcher instead of texts
`<Icon type="eye" />` for dark and `<Icon type="eye-o" />` for light 
Texts `'dark'` and `'light'` were too long and did not fit in the menu theme switcher.
