### PR TITLE
README.md added Manual import of style - Use modularized antd

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ import 'antd/dist/antd.css';  // or 'antd/dist/antd.less'
 
    ```jsx
    import DatePicker from 'antd/lib/date-picker';  // just for js
+   import 'antd/lib/date-picker/style/css';  // with style
    ```
 
 


### PR DESCRIPTION
There is added information in README.md about manual style import for modularized use added. As mentioned in antd FAQ https://github.com/ant-design/ant-design/wiki/FAQ#i-just-want-to-use-menubuttonetc-but-it-seems-that-i-have-to-import-the-whole-antd-and-its-style
