### PR TITLE
fix: BackTop target

### DIFF
--- a/components/back-top/index.tsx
+++ b/components/back-top/index.tsx
@@ -54,9 +54,8 @@ export default class BackTop extends React.Component<BackTopProps, any> {
 
   constructor(props) {
     super(props);
-    const scrollTop = getScroll(props.target(), true);
     this.state = {
-      visible: scrollTop > props.visibilityHeight,
+      visible: false,
     };
   }
 
@@ -94,6 +93,7 @@ export default class BackTop extends React.Component<BackTopProps, any> {
   }
 
   componentDidMount() {
+    this.handleScroll();
     this.scrollEvent = addEventListener(this.props.target(), 'scroll', this.handleScroll);
   }
 


### PR DESCRIPTION
Fix #3366 

有个问题，不知道原来设计的时候这个`target`是什么意思？因为有这几种情况：
1. scroll 事件绑定在`target`上，返回的点也是`target`
2. scroll 事件绑定在`window`上，但是返回的点是`target`
3. scroll 事件绑定在`target`上，但是返回的点是`window`
