### PR TITLE
Set height of inavtive TabPane to zero

### DIFF
--- a/components/tabs/style/index.less
+++ b/components/tabs/style/index.less
@@ -201,6 +201,10 @@
       flex-shrink: 0;
       width: 100%;
     }
+
+    .@{tab-prefix-cls}-tabpane-inactive {
+      height: 0;
+    }
   }
 
   &-vertical {


### PR DESCRIPTION
原因是现在的实现改成了用 tarnslateX 位移来隐藏不显示的元素，导致`.ant-tabs-content`会一直被最高的那个 pane 撑起来。

 fix #3377 
