### PR TITLE
【Please review】Fixes for supporting TypeScript 2.0.3

### DIFF
--- a/components/alert/index.tsx
+++ b/components/alert/index.tsx
@@ -18,7 +18,7 @@ export interface AlertProps {
   /** Additional content of Alert */
   description?: React.ReactNode;
   /** Callback when close Alert */
-  onClose?: (event) => void;
+  onClose?: React.MouseEventHandler;
   /** Whether to show icon */
   showIcon?: boolean;
   style?: React.CSSProperties;

--- a/components/auto-complete/index.tsx
+++ b/components/auto-complete/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import Select, { Option, OptGroup } from '../select';
+import Select, { OptionProps, OptGroupProps } from '../select';
+import { Option, OptGroup } from 'rc-select';
 import classNames from 'classnames';
 
 export interface SelectedValue {
@@ -23,13 +24,13 @@ export interface AutoCompleteProps {
   defaultValue?: string | Array<any> | SelectedValue | Array<SelectedValue>;
   value?: string | Array<any> | SelectedValue | Array<SelectedValue>;
   allowClear?: boolean;
-  onChange?: (value) => void;
+  onChange?: (value: string | Array<any> | SelectedValue | Array<SelectedValue>) => void;
   disabled?: boolean;
 }
 
 export default class AutoComplete extends React.Component<AutoCompleteProps, any> {
-  static Option = Option;
-  static OptGroup = OptGroup;
+  static Option = Option as React.ClassicComponentClass<OptionProps>;
+  static OptGroup = OptGroup as React.ClassicComponentClass<OptGroupProps>;
 
   static defaultProps = {
     prefixCls: 'ant-select',

--- a/components/back-top/index.tsx
+++ b/components/back-top/index.tsx
@@ -25,7 +25,7 @@ const easeInOutCubic = (t, b, c, d) => {
 
 export interface BackTopProps {
   visibilityHeight?: number;
-  onClick?: (event) => void;
+  onClick?: React.MouseEventHandler;
   target?: () => HTMLElement | Window;
   prefixCls?: string;
   className?: string;

--- a/components/breadcrumb/Breadcrumb.tsx
+++ b/components/breadcrumb/Breadcrumb.tsx
@@ -8,7 +8,7 @@ export interface BreadcrumbProps {
   routes?: Array<any>;
   params?: Object;
   separator?: string | React.ReactNode;
-  itemRender?: (route, params, routes, paths) => React.ReactNode;
+  itemRender?: (route: any, params: any, routes: Array<any>, paths: Array<string>) => React.ReactNode;
   style?: React.CSSProperties;
 };
 

--- a/components/date-picker/index.tsx
+++ b/components/date-picker/index.tsx
@@ -16,7 +16,7 @@ export interface PickerProps {
   popupStyle?: React.CSSProperties;
   locale?: any;
   size?: 'large' | 'small' | 'default';
-  getCalendarContainer?: (trigger) => React.ReactNode;
+  getCalendarContainer?: (trigger: any) => React.ReactNode;
   prefixCls?: string;
   inputPrefixCls?: string;
 }

--- a/components/form/Form.tsx
+++ b/components/form/Form.tsx
@@ -62,7 +62,7 @@ export type WrappedFormUtils = {
     /** 收集子节点的值的时机 */
     trigger?: string;
     /** 可以把 onChange 的参数转化为控件的值，例如 DatePicker 可设为：(date, dateString) => dateString */
-    getValueFromEvent?: (...args) => any;
+    getValueFromEvent?: (...args: any[]) => any;
     /** 校验子节点值的时机 */
     validateTrigger?: string;
     /** 校验规则，参见 [async-validator](https://github.com/yiminghe/async-validator) */

--- a/components/icon/index.tsx
+++ b/components/icon/index.tsx
@@ -6,7 +6,7 @@ export interface IconProps {
   type: string;
   className?: string;
   title?: string;
-  onClick?: (e) => void;
+  onClick?: React.MouseEventHandler;
   spin?: boolean;
 }
 

--- a/components/message/index.tsx
+++ b/components/message/index.tsx
@@ -55,7 +55,7 @@ function notice(
 
 type ConfigContent = React.ReactNode | string;
 type ConfigDuration = number;
-type ConfigOnClose = () => void;
+export type ConfigOnClose = () => void;
 
 export interface ConfigOptions {
   top?: number;
@@ -64,7 +64,7 @@ export interface ConfigOptions {
 }
 
 export default {
-  info(content: ConfigContent, duration?: ConfigDuration, onClose?: ConfigOnClose) {
+  info(content: ConfigContent, duration?: ConfigDuration, onClose?: () => ConfigOnClose) {
     return notice(content, duration, 'info', onClose);
   },
   success(content: ConfigContent, duration?: ConfigDuration, onClose?: ConfigOnClose) {

--- a/components/notification/index.tsx
+++ b/components/notification/index.tsx
@@ -97,7 +97,7 @@ const api: {
   error?(args: ArgsProps): void;
   info?(args: ArgsProps): void;
   warn?(args: ArgsProps): void;
-  warning?(args: ArgsProps) : void;
+  warning?(args: ArgsProps): void;
 
   open(args: ArgsProps): void;
   close(key: string): void;

--- a/components/notification/index.tsx
+++ b/components/notification/index.tsx
@@ -92,8 +92,19 @@ function notice(args) {
   });
 }
 
-const api = {
-  open(args) {
+const api: {
+  success?(args: ArgsProps): void;
+  error?(args: ArgsProps): void;
+  info?(args: ArgsProps): void;
+  warn?(args: ArgsProps): void;
+  warning?(args: ArgsProps) : void;
+
+  open(args: ArgsProps): void;
+  close(key: string): void;
+  config(options: ConfigProps): void;
+  destroy(): void;
+} = {
+  open(args: ArgsProps) {
     notice(args);
   },
   close(key) {

--- a/components/select/index.tsx
+++ b/components/select/index.tsx
@@ -35,7 +35,7 @@ export interface SelectProps {
   style?: React.CSSProperties;
   dropdownStyle?: React.CSSProperties;
   dropdownMenuStyle?: React.CSSProperties;
-  onChange?: (value) => void;
+  onChange?: (value: SelectValue) => void;
 }
 
 export interface OptionProps {
@@ -53,7 +53,8 @@ export interface SelectContext {
   };
 }
 
-export { Option, OptGroup };
+//=> It is needless to export the declaration of below two inner components.
+//export { Option, OptGroup };
 
 export default class Select extends React.Component<SelectProps, any> {
   static Option = Option as React.ClassicComponentClass<OptionProps>;

--- a/components/select/index.tsx
+++ b/components/select/index.tsx
@@ -53,8 +53,8 @@ export interface SelectContext {
   };
 }
 
-//=> It is needless to export the declaration of below two inner components.
-//export { Option, OptGroup };
+// => It is needless to export the declaration of below two inner components.
+// export { Option, OptGroup };
 
 export default class Select extends React.Component<SelectProps, any> {
   static Option = Option as React.ClassicComponentClass<OptionProps>;

--- a/components/switch/index.tsx
+++ b/components/switch/index.tsx
@@ -12,6 +12,7 @@ export interface SwitchProps {
   onChange?: (checked: boolean) => any;
   checkedChildren?: React.ReactNode;
   unCheckedChildren?: React.ReactNode;
+  disabled?: boolean;
 }
 
 export default class Switch extends React.Component<SwitchProps, any> {

--- a/components/table/Table.tsx
+++ b/components/table/Table.tsx
@@ -750,7 +750,7 @@ export default class Table extends React.Component<TableProps, any> {
     const { pagination } = this.state;
     if (pagination.size) {
       size = pagination.size;
-    } else if (this.props.size === 'middle' || this.props.size === 'small') {
+    } else if (this.props.size as string === 'middle' || this.props.size === 'small') {
       size = 'small';
     }
     let total = pagination.total || this.getLocalData().length;

--- a/components/table/filterDropdown.tsx
+++ b/components/table/filterDropdown.tsx
@@ -6,7 +6,7 @@ import Checkbox from '../checkbox';
 import Radio from '../radio';
 
 export interface FilterDropdownMenuWrapperProps {
-  onClick?: Function;
+  onClick?: React.MouseEventHandler;
   children?: any;
   className?: string;
 }

--- a/components/tabs/index.tsx
+++ b/components/tabs/index.tsx
@@ -75,7 +75,7 @@ export default class Tabs extends React.Component<TabsProps, any> {
     } = this.props;
     let className = classNames({
       [this.props.className]: !!this.props.className,
-      [`${prefixCls}-mini`]: size === 'small' || size === 'mini',
+      [`${prefixCls}-mini`]: size === 'small' || size as string === 'mini',
       [`${prefixCls}-vertical`]: tabPosition === 'left' || tabPosition === 'right',
       [`${prefixCls}-card`]: type.indexOf('card') >= 0,
       [`${prefixCls}-${type}`]: true,

--- a/components/upload/interface.tsx
+++ b/components/upload/interface.tsx
@@ -30,7 +30,7 @@ export interface UploadProps {
   defaultFileList?: Array<File>;
   fileList?: Array<File>;
   action: string;
-  data?: Object | ((File) => any);
+  data?: Object | ((file: File) => any);
   headers?: HttpRequestHeader;
   showUploadList?: boolean;
   multiple?: boolean;


### PR DESCRIPTION
First of all, thanks for your contribution! :-)

Please makes sure these boxes are checked before submitting your PR, thank you!
- [x] Make sure you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
- [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
- [x] Rebase before creating a PR to keep commit history clear.
- [x] Add some descriptions and refer relative issues for you PR.

---

Hi All, 

I have finished the fixes for issue #3358 , and tested the antd lib and my project using both tsc 2.0.3 and tsc 1.18.10. 

Please review. Thanks in advance.

B.R.
Albert Zheng

---
#### What are fixed?
1. Below compiling errors of antd lib reported by tsc 2.0.3 are fixed:
   
   ``` bash
   [vagrant@localhost ant-design]$ npm run compile
   
   > antd@2.0.1 compile /home/vagrant/github/ant-design
   > antd-tools run compile
   
   antd-tools run compile
   components/table/Table.tsx(753,16): error TS2365: Operator '===' cannot be applied to types '"default" | "small"' and '"middle"'.
   components/table/filterDropdown.tsx(15,32): error TS2322: Type 'Function' is not assignable to type 'EventHandler<MouseEvent>'.
   components/table/filterDropdown.tsx(15,32): error TS2322: Type 'Function' is not assignable to type 'EventHandler<MouseEvent>'.
     Type 'Function' provides no match for the signature '(event: MouseEvent): void'
   components/tabs/index.tsx(78,50): error TS2365: Operator '===' cannot be applied to types '"default"' and '"mini"'.
   components/message/index.tsx(66,1): error TS4082: Default export of the module has or is using private name 'ConfigOnClose'.
   [10:36:07] TypeScript: 4 semantic errors
   [10:36:07] TypeScript: 1 emit error
   [10:36:07] TypeScript: emit failed
   ```
2. Compiling errors of App project reported by tsc 2.0.3 in #3358 .
