### PR TITLE
修复firefox下无数据且固定表头时ant-table-body占高度的问题

### DIFF
--- a/components/table/style/index.less
+++ b/components/table/style/index.less
@@ -444,6 +444,12 @@
     margin-bottom: -20px;
   }
 
+  /* fix firefox scrollbar bug */
+  &-fixed-header&-empty &-scroll &-body {
+    padding-bottom: 20px;
+    margin-bottom: -20px;
+  }
+
   &-fixed-left,
   &-fixed-right {
     position: absolute;


### PR DESCRIPTION
close #3567
