### PR TITLE
Implement Table.Column and Table.ColumnGroup

### DIFF
--- a/components/table/Column.tsx
+++ b/components/table/Column.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import RcTable from 'rc-table';
+
+export interface ColumnProps<T> {
+  title?: React.ReactNode;
+  key?: string;
+  dataIndex?: string;
+  render?: (text: any, record: T, index: number) => React.ReactNode;
+  filters?: { text: string; value: string }[];
+  onFilter?: (value: any, record: T) => boolean;
+  filterMultiple?: boolean;
+  filterDropdown?: React.ReactNode;
+  sorter?: boolean | ((a: any, b: any) => number);
+  colSpan?: number;
+  width?: string | number;
+  className?: string;
+  fixed?: boolean | ('left' | 'right');
+  filteredValue?: any[];
+  sortOrder?: boolean | ('ascend' | 'descend');
+}
+
+export default class Column<T> extends (RcTable.Column as React.ComponentClass<ColumnProps<T>>) {}

--- a/components/table/ColumnGroup.tsx
+++ b/components/table/ColumnGroup.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import RcTable from 'rc-table';
+
+export interface ColumnGroupProps {
+  title?: React.ReactNode;
+}
+
+export default class ColumnGroup extends (RcTable.ColumnGroup as React.ComponentClass<ColumnGroupProps>) {}

--- a/components/table/demo/bordered.md
+++ b/components/table/demo/bordered.md
@@ -1,5 +1,5 @@
 ---
-order: 10
+order: 11
 title:
   en-US: border, title and footer
   zh-CN: 带边框

--- a/components/table/demo/colspan-rowspan.md
+++ b/components/table/demo/colspan-rowspan.md
@@ -1,5 +1,5 @@
 ---
-order: 13
+order: 14
 title:
   en-US: colSpan and rowSpan
   zh-CN: 表格行/列合并

--- a/components/table/demo/dynamic-settings.md
+++ b/components/table/demo/dynamic-settings.md
@@ -1,5 +1,5 @@
 ---
-order: 21
+order: 22
 title:
   en-US: Dynamic Settings
   zh-CN: 动态控制表格属性

--- a/components/table/demo/expand-children.md
+++ b/components/table/demo/expand-children.md
@@ -1,5 +1,5 @@
 ---
-order: 15
+order: 16
 title:
   en-US: Tree data
   zh-CN: 树形数据展示

--- a/components/table/demo/expand.md
+++ b/components/table/demo/expand.md
@@ -1,5 +1,5 @@
 ---
-order: 12
+order: 13
 title:
   en-US: Expandable Row
   zh-CN: 可展开

--- a/components/table/demo/fixed-columns-header.md
+++ b/components/table/demo/fixed-columns-header.md
@@ -1,5 +1,5 @@
 ---
-order: 18
+order: 19
 title:
   en-US: Fixed Columns and Header
   zh-CN: 固定头和列

--- a/components/table/demo/fixed-columns.md
+++ b/components/table/demo/fixed-columns.md
@@ -1,5 +1,5 @@
 ---
-order: 17
+order: 18
 title:
   en-US: Fixed Columns
   zh-CN: 固定列

--- a/components/table/demo/fixed-header.md
+++ b/components/table/demo/fixed-header.md
@@ -1,5 +1,5 @@
 ---
-order: 16
+order: 17
 title:
   en-US: Fixed Header
   zh-CN: 固定表头

--- a/components/table/demo/grouping-columns.md
+++ b/components/table/demo/grouping-columns.md
@@ -1,5 +1,5 @@
 ---
-order: 20
+order: 21
 title:
   en-US: Grouping table head
   zh-CN: 表头分组

--- a/components/table/demo/head.md
+++ b/components/table/demo/head.md
@@ -1,5 +1,5 @@
 ---
-order: 6
+order: 7
 title:
   en-US: Filter and sorter
   zh-CN: 筛选和排序

--- a/components/table/demo/jsx.md
+++ b/components/table/demo/jsx.md
@@ -1,0 +1,82 @@
+---
+order: 1
+title:
+  en-US: JSX style API
+  zh-CN: JSX 风格的 API
+---
+
+## zh-CN
+
+使用 JSX 风格的 API（2.5.0 以后引入）
+
+## en-US
+
+Using JSX style API (introduced in 2.5.0)
+
+````jsx
+import { Table, Icon } from 'antd';
+
+const { Column, ColumnGroup } = Table;
+
+const data = [{
+  key: '1',
+  firstName: 'John',
+  lastName: 'Brown',
+  age: 32,
+  address: 'New York No. 1 Lake Park',
+}, {
+  key: '2',
+  firstName: 'Jim',
+  lastName: 'Green',
+  age: 42,
+  address: 'London No. 1 Lake Park',
+}, {
+  key: '3',
+  firstName: 'Joe',
+  lastName: 'Black',
+  age: 32,
+  address: 'Sidney No. 1 Lake Park',
+}];
+
+ReactDOM.render(
+  <Table dataSource={data}>
+    <ColumnGroup title="Name">
+      <Column
+        title="First Name"
+        dataIndex="firstName"
+        key="firstName"
+      />
+      <Column
+        title="Last Name"
+        dataIndex="lastName"
+        key="lastName"
+      />
+    </ColumnGroup>
+    <Column
+      title="Age"
+      dataIndex="age"
+      key="age"
+    />
+    <Column
+      title="Address"
+      dataIndex="address"
+      key="address"
+    />
+    <Column
+      title="Action"
+      key="action"
+      render={(text, record) => (
+        <span>
+          <a href="#">Action 一 {record.name}</a>
+          <span className="ant-divider" />
+          <a href="#">Delete</a>
+          <span className="ant-divider" />
+          <a href="#" className="ant-dropdown-link">
+            More actions<Icon type="down" />
+          </a>
+        </span>
+      )}
+    />
+  </Table>
+, mountNode);
+````

--- a/components/table/demo/nopagination.md
+++ b/components/table/demo/nopagination.md
@@ -1,5 +1,5 @@
 ---
-order: 8
+order: 9
 title:
   en-US: No pagination
   zh-CN: 不显示分页

--- a/components/table/demo/paging.md
+++ b/components/table/demo/paging.md
@@ -1,5 +1,5 @@
 ---
-order: 5
+order: 6
 title:
   en-US: pagination
   zh-CN: 分页

--- a/components/table/demo/reset-filter.md
+++ b/components/table/demo/reset-filter.md
@@ -1,5 +1,5 @@
 ---
-order: 6
+order: 7
 title:
   en-US: Reset filters and sorters
   zh-CN: 可控的筛选和排序

--- a/components/table/demo/row-selection-and-operation.md
+++ b/components/table/demo/row-selection-and-operation.md
@@ -1,5 +1,5 @@
 ---
-order: 2
+order: 3
 title:
   en-US: Selection and operation
   zh-CN: 选择和操作

--- a/components/table/demo/row-selection-props.md
+++ b/components/table/demo/row-selection-props.md
@@ -1,5 +1,5 @@
 ---
-order: 3
+order: 4
 title:
   en-US: Checkbox props
   zh-CN: 选择框属性

--- a/components/table/demo/row-selection.md
+++ b/components/table/demo/row-selection.md
@@ -1,5 +1,5 @@
 ---
-order: 1
+order: 2
 title:
   en-US: selection
   zh-CN: 可选择

--- a/components/table/demo/size.md
+++ b/components/table/demo/size.md
@@ -1,5 +1,5 @@
 ---
-order: 9
+order: 10
 title:
   en-US: size
   zh-CN: 紧凑型

--- a/components/table/index.en-US.md
+++ b/components/table/index.en-US.md
@@ -78,7 +78,7 @@ const columns = [{
 
 ### Column
 
-One of Property `columns` for describing column.
+One of Property `columns` for descriping column, Column has the same API.
 
 | Property      | Description              | Type            |  Default     |
 |---------------|--------------------------|-----------------|--------------|
@@ -99,6 +99,12 @@ One of Property `columns` for describing column.
 | className  | className of this column            | String          |  -      |
 | fixed      | set column to be fixed: `true`(same as left) `'left'` `'right'` | Boolean or String | false |
 | sortOrder | controlled sorted value: `'ascend'` `'descend'` `false` | Boolean or String | - |
+
+### ColumnGroup
+
+| Property      | Description              | Type            |  Default     |
+|---------------|--------------------------|-----------------|--------------|
+| title      | title of the column group   | String or React.Element | - |
 
 ### rowSelection
 

--- a/components/table/index.zh-CN.md
+++ b/components/table/index.zh-CN.md
@@ -79,7 +79,7 @@ const columns = [{
 
 ### Column
 
-列描述数据对象，是 columns 中的一项。
+列描述数据对象，是 columns 中的一项，Column 使用相同的 API。
 
 | 参数       | 说明                       | 类型            |  默认值  |
 |-----------|----------------------------|-----------------|---------|
@@ -100,6 +100,12 @@ const columns = [{
 | className  | 列的 className             | String          |  -      |
 | fixed      | 列是否固定，可选 `true`(等效于 left) `'left'` `'right'` | Boolean or String | false |
 | sortOrder | 排序的受控属性，外界可用此控制列的排序，可设置为 `'ascend'` `'descend'` `false` | Boolean or String | - |
+
+### ColumnGroup
+
+| 参数       | 说明                       | 类型            |  默认值  |
+|-----------|----------------------------|-----------------|---------|
+| title      | 列头显示文字               | String or React.Element | - |
 
 ### rowSelection
 

--- a/components/table/util.tsx
+++ b/components/table/util.tsx
@@ -1,4 +1,8 @@
+import React from 'react';
 import assign from 'object-assign';
+import Column from './Column';
+import ColumnGroup from './ColumnGroup';
+
 export function flatArray(data: Object[] = [], childrenName = 'children') {
   const result: Object[] = [];
   const loop = (array) => {
@@ -23,4 +27,26 @@ export function treeMap(tree: Object[], mapper: Function, childrenName = 'childr
     }
     return assign({}, mapper(node, index), extra);
   });
+}
+
+export function normalizeColumns(elements) {
+  const columns: any[] = [];
+  React.Children.forEach(elements, (element: React.ReactElement<any>) => {
+    if (!isColumnElement(element)) {
+      return;
+    }
+    const column = assign({}, element.props);
+    if (element.key) {
+      column.key = element.key;
+    }
+    if (element.type as any === ColumnGroup) {
+      column.children = normalizeColumns(column.children);
+    }
+    columns.push(column);
+  });
+  return columns;
+}
+
+function isColumnElement(element) {
+  return element && (element.type === Column || element.type === ColumnGroup);
 }

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "rc-slider": "~5.2.0",
     "rc-steps": "~2.2.0",
     "rc-switch": "~1.4.2",
-    "rc-table": "~5.0.0",
+    "rc-table": "~5.2.0",
     "rc-tabs": "~7.0.5",
     "rc-time-picker": "~2.2.1",
     "rc-tooltip": "~3.4.2",

--- a/tests/table/Table.test.js
+++ b/tests/table/Table.test.js
@@ -2,6 +2,10 @@ import React from 'react';
 import createStore from '../../components/table/createStore';
 import Table from '../../components/table';
 import TestUtils from 'react-addons-test-utils';
+import { render } from 'enzyme';
+import { renderToJson } from 'enzyme-to-json';
+
+const { Column, ColumnGroup } = Table;
 
 describe('Table', () => {
   describe('row selection', () => {
@@ -86,6 +90,46 @@ describe('Table', () => {
 
       expect(checkboxes[1].disabled).toBe(false);
       expect(checkboxes[2].disabled).toBe(true);
+    });
+  });
+
+  describe('JSX style API', () => {
+    it('renders correctly', () => {
+      const data = [{
+        key: '1',
+        firstName: 'John',
+        lastName: 'Brown',
+        age: 32,
+      }, {
+        key: '2',
+        firstName: 'Jim',
+        lastName: 'Green',
+        age: 42,
+      }];
+
+      const wrapper = render(
+        <Table dataSource={data} pagination={false}>
+          <ColumnGroup title="Name">
+            <Column
+              title="First Name"
+              dataIndex="firstName"
+              key="firstName"
+            />
+            <Column
+              title="Last Name"
+              dataIndex="lastName"
+              key="lastName"
+            />
+          </ColumnGroup>
+          <Column
+            title="Age"
+            dataIndex="age"
+            key="age"
+          />
+        </Table>
+      );
+
+      expect(renderToJson(wrapper)).toMatchSnapshot();
     });
   });
 })

--- a/tests/table/__snapshots__/Table.test.js.snap
+++ b/tests/table/__snapshots__/Table.test.js.snap
@@ -1,0 +1,105 @@
+exports[`Table JSX style API renders correctly 1`] = `
+<div
+  class=" clearfix">
+  <div
+    class="ant-spin-nested-loading">
+    <div
+      class="ant-spin-container">
+      <div
+        class="ant-table ant-table-large ant-table-scroll-position-left">
+        <div
+          class="ant-table-content">
+          <div
+            class="">
+            <span>
+              <div
+                class="ant-table-body">
+                <table
+                  class="">
+                  <colgroup>
+                    <col />
+                    <col />
+                    <col />
+                  </colgroup>
+                  <thead
+                    class="ant-table-thead">
+                    <tr>
+                      <th
+                        class=""
+                        colspan="2">
+                        <span>
+                          Name
+                        </span>
+                      </th>
+                      <th
+                        class=""
+                        rowspan="2">
+                        <span>
+                          Age
+                        </span>
+                      </th>
+                    </tr>
+                    <tr>
+                      <th
+                        class="">
+                        <span>
+                          First Name
+                        </span>
+                      </th>
+                      <th
+                        class="">
+                        <span>
+                          Last Name
+                        </span>
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody
+                    class="ant-table-tbody">
+                    <tr
+                      class="ant-table-row  ant-table-row-level-0">
+                      <td
+                        class="">
+                        <span
+                          class="ant-table-row-indent indent-level-0"
+                          style="padding-left:0px;" />
+                        John
+                      </td>
+                      <td
+                        class="">
+                        Brown
+                      </td>
+                      <td
+                        class="">
+                        32
+                      </td>
+                    </tr>
+                    <tr
+                      class="ant-table-row  ant-table-row-level-0">
+                      <td
+                        class="">
+                        <span
+                          class="ant-table-row-indent indent-level-0"
+                          style="padding-left:0px;" />
+                        Jim
+                      </td>
+                      <td
+                        class="">
+                        Green
+                      </td>
+                      <td
+                        class="">
+                        42
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;


### PR DESCRIPTION
Close #2029 

发现跟  react-component/table 那样要重新实现一遍。

然后我担心引入这个后又多了一个性能陷阱，因为直接在 Table 里嵌套 Column 的话 props.children 每次都是新的，columns 也就每次都是新的了。

