### PR TITLE
refactor: 调整env的判断方式，避免用户手动构建时将console提示打包到生产环境bundle

### DIFF
--- a/components/index.tsx
+++ b/components/index.tsx
@@ -1,6 +1,6 @@
 /* eslint no-console:0 */
 // this file is not used if use https://github.com/ant-design/babel-plugin-import
-if (process.env.NODE_ENV !== 'production') {
+if (process.env.NODE_ENV === 'development') {
   if (typeof console !== 'undefined' && console.warn) {
     console.warn(`You are using prebuilt antd,
 please use https://www.npmjs.com/package/babel-plugin-import to reduce app bundle size.`);


### PR DESCRIPTION
![console](http://ww1.sinaimg.cn/large/af5dc4c7gw1f9woz7rn9yj21kw05kn00.jpg)

## 问题
在[蚂蚁金融云](https://www.cloud.alipay.com/)的console里看到了如上图antd的warning

## 跟踪代码
 - 判断条件： https://github.com/ant-design/ant-design/blob/master/components/index.tsx#L3 
 - 未压缩打包： `process.env.NODE_ENV='development'`  see https://github.com/ant-design/antd-tools/blob/master/lib/getWebpackConfig.js#L89
  - 压缩打包： `process.env.NODE_ENV='production'`  see https://github.com/ant-tool/atool-build/blob/master/src/build.js#L35
- 理论上正常压缩后的bundle被uglify之后应该不会包含这个warning逻辑
## 结论
- 猜测金融云可能是开发者手动构建antd，然而没有指定`process.env.NODE_ENV='production'`
- 这个PR改了下判断的方式，确保只有指定了development环境的构建bundle才会包含有warning