### PR TITLE
refactor Input.Search

### DIFF
--- a/components/input/Search.tsx
+++ b/components/input/Search.tsx
@@ -3,7 +3,6 @@ import classNames from 'classnames';
 import Input from './Input';
 import Icon from '../icon';
 import splitObject from '../_util/splitObject';
-import omit from 'omit.js';
 
 export interface SearchProps {
   className?: string;
@@ -13,70 +12,47 @@ export interface SearchProps {
   defaultValue?: any;
   value?: any;
   onChange?: React.FormEventHandler<any>;
-  onSearch?: React.FormEventHandler<any>;
+  onSearch?: (value: string) => any;
+  size?: 'large' | 'default' | 'small';
+  disabled?: boolean;
+  readOnly?: boolean;
 }
 
 export default class Search extends React.Component<SearchProps, any> {
   static defaultProps = {
     prefixCls: 'ant-input-search',
+    onSearch() {},
   };
-  constructor(props) {
-    super(props);
-    let value;
-    if ('value' in props) {
-      value = props.value;
-    } else if ('defaultValue' in props) {
-      value = props.defaultValue;
-    } else {
-      value = '';
-    }
-    this.state = {
-      value,
-      focus: false,
-    };
-  }
-  onChange = (e) => {
-    if (!('value' in this.props)) {
-      this.setState({ value: e.target.value });
-    }
-    const onChange = this.props.onChange;
-    if (onChange) {
-      onChange(e);
-    }
-  }
+  input: any;
   onSearch = () => {
-    if (this.state.focus && this.props.onSearch) {
-      this.props.onSearch(this.state.value);
-    } else if (!this.state.focus) {
-      this.setState({ focus: true });
+    const { onSearch } = this.props;
+    if (onSearch) {
+      onSearch(this.input.refs.input.value);
     }
+    this.input.refs.input.focus();
   }
   render() {
-    const [{ className, placeholder, prefixCls }, others] = splitObject(
-      this.props, ['className', 'placeholder', 'prefixCls']
+    const [{ className, prefixCls, style }, others] = splitObject(
+      this.props, ['className', 'prefixCls', 'style']
     );
-    // Fix https://fb.me/react-unknown-prop
-    const otherProps = omit(others, [
-      'defaultValue',
-      'value',
-      'onChange',
-      'onSearch',
-    ]);
+    delete others.onSearch;
     const wrapperCls = classNames({
       [`${prefixCls}-wrapper`]: true,
-      [`${prefixCls}-wrapper-focus`]: this.state.focus,
       [className]: !!className,
     });
     return (
-      <div className={wrapperCls} {...otherProps}>
+      <div className={wrapperCls} style={style}>
         <Input
           className={prefixCls}
-          placeholder={placeholder}
-          value={this.state.value}
-          onChange={this.onChange}
           onPressEnter={this.onSearch}
+          ref={node => this.input = node}
+          {...others}
         />
-        <Icon className={`${prefixCls}-icon`} onClick={this.onSearch} type="search" />
+        <Icon
+          className={`${prefixCls}-icon`}
+          onClick={this.onSearch}
+          type="search"
+        />
       </div>
     );
   }

--- a/components/input/demo/search-input.md
+++ b/components/input/demo/search-input.md
@@ -15,9 +15,9 @@ Example of creating a search box by grouping a standard input with a search butt
 
 ````jsx
 import { Input } from 'antd';
-const InputSearch = Input.Search;
+const Search = Input.Search;
 
 ReactDOM.render(
-  <InputSearch placeholder="input search text" onSearch={value => console.log(value)} />
+  <Search placeholder="input search text" onSearch={value => console.log(value)} />
 , mountNode);
 ````

--- a/components/input/index.en-US.md
+++ b/components/input/index.en-US.md
@@ -29,17 +29,16 @@ Keyboard and mouse can be used for providing or changing data.
 | onPressEnter | The callback function that is triggered when pressing Enter key. | function(e) |   |   |
 | autosize | Height autosize feature, available when type="textarea". | bool or object | `true` or `{ minRows: 2, maxRows: 6 }` | false |
 
-> When `Input` is used in a `Form.Item` context, if the `Form.Item` has the `id` and `options` props defined  
+> When `Input` is used in a `Form.Item` context, if the `Form.Item` has the `id` and `options` props defined
 then `value`, `defaultValue`, and `id` props are automatically set.
 
 #### Input.Search
 
 | Property  | Description                          | Type       |  Available Values  | Default |
 |-----------|------------------------------------------|------------|-------|--------|
-| defaultValue | The initial value. | any |  |  |
-| value | The content value. | any |  |  |
-| onChange | The callback function that is triggered when you change the value. | function(e) |  |  |
-| onSearch | The callback function that is triggered when you click on the search-icon or press Enter key. | function |  |  |
+| onSearch | The callback function that is triggered when you click on the search-icon or press Enter key. | function(value) |  |  |
+
+Support all props of `Input`.
 
 #### Input.Group
 

--- a/components/input/index.zh-CN.md
+++ b/components/input/index.zh-CN.md
@@ -35,10 +35,9 @@ title: Input
 
 | 参数      | 说明                                     | 类型       |  可选值 | 默认值 |
 |-----------|------------------------------------------|------------|-------|--------|
-| defaultValue | 初始默认值 | any |  |  |
-| value | value 值 | any |  |  |
-| onChange | 值改变的回调 | function(e) |  |  |
-| onSearch | 点击搜索或按下回车键时的回调 | function |  |  |
+| onSearch | 点击搜索或按下回车键时的回调 | function(value) |  |  |
+
+其余属性和 Input 一致。
 
 #### Input.Group
 

--- a/components/input/style/search-input.less
+++ b/components/input/style/search-input.less
@@ -25,7 +25,7 @@
     }
   }
 
-  &:hover .@{ant-prefix}-input-search {
+  &:hover .@{ant-prefix}-input-search:not[disabled] {
     border: 1px solid @input-hover-border-color;
   }
 }

--- a/components/input/style/search-input.less
+++ b/components/input/style/search-input.less
@@ -5,40 +5,27 @@
 
 .@{ant-prefix}-input-search-wrapper {
   display: inline-block;
-  vertical-align: middle;
   position: relative;
-  min-width: 24px;
-  height: @input-height-base;
 
   .@{ant-prefix}-input-search {
-    opacity: 0;
-    width: 0;
     transition: all .3s ease;
-  }
-
-  .@{ant-prefix}-input-search-icon {
-    position: absolute;
-    line-height: @input-height-base;
-    left: 0;
-    cursor: pointer;
-    font-size: 24px;
-    transition: all .3s ease;
-
-    &:hover {
-      color: @input-hover-border-color;
+    &-icon {
+      position: absolute;
+      right: 8px;
+      cursor: pointer;
+      transition: all .3s ease;
+      font-size: 14px;
+      height: 20px;
+      line-height: 20px;
+      top: 50%;
+      margin-top: -10px;
+      &:hover {
+        color: @input-hover-border-color;
+      }
     }
   }
-}
 
-.@{ant-prefix}-input-search-wrapper-focus {
-  .@{ant-prefix}-input-search {
-    opacity: 1;
-    width: 100%;
-  }
-
-  .@{ant-prefix}-input-search-icon {
-    left: 100%;
-    margin-left: -22px;
-    font-size: 14px;
+  &:hover .@{ant-prefix}-input-search {
+    border: 1px solid @input-hover-border-color;
   }
 }

--- a/components/input/style/search-input.less
+++ b/components/input/style/search-input.less
@@ -29,3 +29,47 @@
     border: 1px solid @input-hover-border-color;
   }
 }
+
+// code blow is keeped for compatibility
+// do not delete until 3.x
+.@{ant-prefix}-search-input-wrapper {
+  display: inline-block;
+  vertical-align: middle;
+}
+
+.@{ant-prefix}-search-input {
+  &.@{ant-prefix}-input-group .@{ant-prefix}-input:first-child,
+  &.@{ant-prefix}-input-group .@{ant-prefix}-select:first-child {
+    border-radius: @border-radius-base;
+    position: absolute;
+    top: -1px;
+    width: 100%;
+  }
+
+  &.@{ant-prefix}-input-group .@{ant-prefix}-input:first-child {
+    padding-right: 36px;
+  }
+
+  .@{ant-prefix}-search-btn {
+    .btn-default;
+    border-radius: 0 @border-radius-base - 1 @border-radius-base - 1 0;
+    left: -1px;
+    position: relative;
+    border-width: 0 0 0 1px;
+    z-index: 2;
+    padding-left: 8px;
+    padding-right: 8px;
+    &:hover {
+      border-color: @border-color-base;
+    }
+  }
+  &&-focus .@{ant-prefix}-search-btn-noempty,
+  &:hover .@{ant-prefix}-search-btn-noempty {
+    .btn-primary;
+  }
+  .@{ant-prefix}-select-combobox {
+    .@{ant-prefix}-select-selection__rendered {
+      margin-right: 29px;
+    }
+  }
+}

--- a/components/tree/demo/search.md
+++ b/components/tree/demo/search.md
@@ -17,6 +17,7 @@ Searchable Tree.
 import { Tree, Input } from 'antd';
 
 const TreeNode = Tree.TreeNode;
+const Search = Input.Search;
 
 const x = 3;
 const y = 2;
@@ -129,7 +130,7 @@ class SearchTree extends React.Component {
     });
     return (
       <div>
-        <Input
+        <Search
           style={{ width: 200 }}
           placeholder="Search"
           onChange={this.onChange}

--- a/tests/input/__snapshots__/demo.test.js.snap
+++ b/tests/input/__snapshots__/demo.test.js.snap
@@ -175,8 +175,7 @@ exports[`test renders ./components/input/demo/search-input.md correctly 1`] = `
     <input
       class="ant-input ant-input-search"
       placeholder="input search text"
-      type="text"
-      value="" />
+      type="text" />
   </span>
   <i
     class="anticon anticon-search ant-input-search-icon" />

--- a/tests/tree/__snapshots__/demo.test.js.snap
+++ b/tests/tree/__snapshots__/demo.test.js.snap
@@ -525,14 +525,19 @@ exports[`test renders ./components/tree/demo/dynamic.md correctly 1`] = `
 
 exports[`test renders ./components/tree/demo/search.md correctly 1`] = `
 <div>
-  <span
-    class="ant-input-wrapper">
-    <input
-      class="ant-input"
-      placeholder="Search"
-      style="width:200px;"
-      type="text" />
-  </span>
+  <div
+    class="ant-input-search-wrapper"
+    style="width:200px;">
+    <span
+      class="ant-input-wrapper">
+      <input
+        class="ant-input ant-input-search"
+        placeholder="Search"
+        type="text" />
+    </span>
+    <i
+      class="anticon anticon-search ant-input-search-icon" />
+  </div>
   <ul
     class="ant-tree"
     role="tree-node"


### PR DESCRIPTION
#3861

---

1. 移除了图标变输入框的效果，只保留静态的搜索框。
2. 修复 size 等属性不可用的问题。
3. 简化代码。
4. Tree 的搜索例子中使用 `Input.Search`。
5. 保留旧的 `.ant-search-input` 样式代码，以保证兼容性。