### PR TITLE
Fix imports for modules without default export

### DIFF
--- a/components/affix/index.tsx
+++ b/components/affix/index.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
 import addEventListener from 'rc-util/lib/Dom/addEventListener';
 import classNames from 'classnames';
 import shallowequal from 'shallowequal';

--- a/components/alert/index.tsx
+++ b/components/alert/index.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
 import Animate from 'rc-animate';
 import Icon from '../icon';
 import classNames from 'classnames';

--- a/components/anchor/AnchorLink.tsx
+++ b/components/anchor/AnchorLink.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import classNames from 'classnames';
 import AnchorHelper, { scrollTo } from './anchorHelper';
 

--- a/components/anchor/index.tsx
+++ b/components/anchor/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import classNames from 'classnames';
 import addEventListener from 'rc-util/lib/Dom/addEventListener';
 import AnchorLink from './AnchorLink';

--- a/components/auto-complete/index.tsx
+++ b/components/auto-complete/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import Select, { OptionProps, OptGroupProps } from '../select';
 import { Option, OptGroup } from 'rc-select';
 import classNames from 'classnames';

--- a/components/back-top/index.tsx
+++ b/components/back-top/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import Animate from 'rc-animate';
 import addEventListener from 'rc-util/lib/Dom/addEventListener';
 import classNames from 'classnames';

--- a/components/badge/ScrollNumber.tsx
+++ b/components/badge/ScrollNumber.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { createElement, Component } from 'react';
 import {findDOMNode} from 'react-dom';
 import isCssAnimationSupported from '../_util/isCssAnimationSupported';

--- a/components/badge/index.tsx
+++ b/components/badge/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import Animate from 'rc-animate';
 import ScrollNumber from './ScrollNumber';
 import classNames from 'classnames';

--- a/components/breadcrumb/Breadcrumb.tsx
+++ b/components/breadcrumb/Breadcrumb.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { cloneElement } from 'react';
 import warning from '../_util/warning';
 import BreadcrumbItem from './BreadcrumbItem';

--- a/components/breadcrumb/BreadcrumbItem.tsx
+++ b/components/breadcrumb/BreadcrumbItem.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import splitObject from '../_util/splitObject';
 
 export interface BreadcrumbItemProps {

--- a/components/button/button-group.tsx
+++ b/components/button/button-group.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import classNames from 'classnames';
 import splitObject from '../_util/splitObject';
 

--- a/components/button/button.tsx
+++ b/components/button/button.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import classNames from 'classnames';
 import { findDOMNode } from 'react-dom';
 import Icon from '../icon';

--- a/components/calendar/Header.tsx
+++ b/components/calendar/Header.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import moment from 'moment';
+import * as React from 'react';
+import * as moment from 'moment';
 import { PREFIX_CLS } from './Constants';
 import Select from '../select';
 import { Group, Button } from '../radio';

--- a/components/calendar/demo/custom-render.md
+++ b/components/calendar/demo/custom-render.md
@@ -15,7 +15,7 @@ This component can be rendered by using `dateCellRender` and `monthCellRender` w
 
 ````jsx
 import { Calendar } from 'antd';
-import moment from 'moment';
+import * as moment from 'moment';
 
 function dateCellRender(value) {
   return <div>Custom date {value.date()}</div>;

--- a/components/calendar/demo/locale.md
+++ b/components/calendar/demo/locale.md
@@ -16,7 +16,7 @@ To set the language. en_US, zh_CN are supported by default.
 ````jsx
 import { Calendar } from 'antd';
 import enUS from 'antd/lib/calendar/locale/en_US';
-import moment from 'moment';
+import * as moment from 'moment';
 // It's recommended to set moment locale globally, otherwise, you need to set it by `value` or `defaultValue`
 // moment.locale('en');
 

--- a/components/calendar/index.tsx
+++ b/components/calendar/index.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
+import * as React from 'react';
 import { PropTypes } from 'react';
-import moment from 'moment';
+import * as moment from 'moment';
 import FullCalendar from 'rc-calendar/lib/FullCalendar';
 import { PREFIX_CLS } from './Constants';
 import Header from './Header';

--- a/components/card/index.tsx
+++ b/components/card/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import classNames from 'classnames';
 import splitObject from '../_util/splitObject';
 

--- a/components/carousel/index.tsx
+++ b/components/carousel/index.tsx
@@ -16,7 +16,7 @@ if (typeof window !== 'undefined') {
 }
 
 import SlickCarousel from 'react-slick';
-import React from 'react';
+import * as React from 'react';
 
 export type CarouselEffect = 'scrollx' | 'fade'
 // Carousel

--- a/components/cascader/index.tsx
+++ b/components/cascader/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import RcCascader from 'rc-cascader';
 import Input from '../input';
 import Icon from '../icon';

--- a/components/checkbox/Group.tsx
+++ b/components/checkbox/Group.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import Checkbox from './index';
 import PureRenderMixin from 'rc-util/lib/PureRenderMixin';
 

--- a/components/checkbox/index.tsx
+++ b/components/checkbox/index.tsx
@@ -1,5 +1,5 @@
 import RcCheckbox from 'rc-checkbox';
-import React from 'react';
+import * as React from 'react';
 import CheckboxGroup from './Group';
 import classNames from 'classnames';
 import PureRenderMixin from 'rc-util/lib/PureRenderMixin';

--- a/components/collapse/index.tsx
+++ b/components/collapse/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import RcCollapse from 'rc-collapse';
 import classNames from 'classnames';
 

--- a/components/date-picker/Calendar.tsx
+++ b/components/date-picker/Calendar.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import CalendarLocale from 'rc-calendar/lib/locale/zh_CN';
 import RcCalendar from 'rc-calendar';
 

--- a/components/date-picker/RangePicker.tsx
+++ b/components/date-picker/RangePicker.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import moment from 'moment';
+import * as React from 'react';
+import * as moment from 'moment';
 import RangeCalendar from 'rc-calendar/lib/RangeCalendar';
 import RcDatePicker from 'rc-calendar/lib/Picker';
 import classNames from 'classnames';

--- a/components/date-picker/createPicker.tsx
+++ b/components/date-picker/createPicker.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import moment from 'moment';
+import * as React from 'react';
+import * as moment from 'moment';
 import MonthCalendar from 'rc-calendar/lib/MonthCalendar';
 import RcDatePicker from 'rc-calendar/lib/Picker';
 import classNames from 'classnames';

--- a/components/date-picker/index.tsx
+++ b/components/date-picker/index.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import moment from 'moment';
+import * as React from 'react';
+import * as moment from 'moment';
 import assign from 'object-assign';
 import RcCalendar from 'rc-calendar';
 import MonthCalendar from 'rc-calendar/lib/MonthCalendar';

--- a/components/date-picker/locale/zh_CN.tsx
+++ b/components/date-picker/locale/zh_CN.tsx
@@ -3,7 +3,7 @@ import TimePickerLocale from '../../time-picker/locale/zh_CN';
 import assign from 'object-assign';
 
 // To set the default locale of moment to zh-cn globally.
-import moment from 'moment';
+import * as moment from 'moment';
 import 'moment/locale/zh-cn';
 moment.locale('zh-cn');
 

--- a/components/date-picker/wrapPicker.tsx
+++ b/components/date-picker/wrapPicker.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { PropTypes } from 'react';
 import TimePickerPanel from 'rc-time-picker/lib/Panel';
 import classNames from 'classnames';

--- a/components/dropdown/dropdown-button.tsx
+++ b/components/dropdown/dropdown-button.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import Button from '../button';
 import Icon from '../icon';
 import Dropdown from './dropdown';

--- a/components/dropdown/dropdown.tsx
+++ b/components/dropdown/dropdown.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import RcDropdown from 'rc-dropdown';
 
 export interface DropDownProps {

--- a/components/form/Form.tsx
+++ b/components/form/Form.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { PropTypes } from 'react';
 import classNames from 'classnames';
 import createDOMForm from 'rc-form/lib/createDOMForm';

--- a/components/form/FormItem.tsx
+++ b/components/form/FormItem.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import classNames from 'classnames';
 import PureRenderMixin from 'rc-util/lib/PureRenderMixin';
 import Row from '../row';

--- a/components/grid/col.tsx
+++ b/components/grid/col.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { PropTypes } from 'react';
 import classNames from 'classnames';
 import assign from 'object-assign';

--- a/components/grid/row.tsx
+++ b/components/grid/row.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Children, cloneElement } from 'react';
 import classNames from 'classnames';
 import assign from 'object-assign';

--- a/components/input-number/index.tsx
+++ b/components/input-number/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import classNames from 'classnames';
 import RcInputNumber from 'rc-input-number';
 import splitObject from '../_util/splitObject';

--- a/components/input/Group.tsx
+++ b/components/input/Group.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import classNames from 'classnames';
 
 export interface GroupProps {

--- a/components/input/Input.tsx
+++ b/components/input/Input.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Component, PropTypes } from 'react';
 import classNames from 'classnames';
 import calculateNodeHeight from './calculateNodeHeight';

--- a/components/input/Search.tsx
+++ b/components/input/Search.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import classNames from 'classnames';
 import Input from './Input';
 import Icon from '../icon';

--- a/components/locale-provider/en_US.tsx
+++ b/components/locale-provider/en_US.tsx
@@ -1,4 +1,4 @@
-import moment from 'moment';
+import * as moment from 'moment';
 moment.locale('en');
 
 import Pagination from 'rc-pagination/lib/locale/en_US';

--- a/components/locale-provider/index.tsx
+++ b/components/locale-provider/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { changeConfirmLocale } from '../modal/locale';
 
 export interface LocaleProviderProps {

--- a/components/locale-provider/pt_BR.tsx
+++ b/components/locale-provider/pt_BR.tsx
@@ -1,4 +1,4 @@
-import moment from 'moment';
+import * as moment from 'moment';
 import 'moment/locale/pt-br';
 moment.locale('pt-br');
 

--- a/components/locale-provider/ru_RU.tsx
+++ b/components/locale-provider/ru_RU.tsx
@@ -2,7 +2,7 @@
  * Created by Andrey Gayvoronsky on 13/04/16.
  */
 
-import moment from 'moment';
+import * as moment from 'moment';
 import 'moment/locale/ru';
 moment.locale('ru');
 

--- a/components/mention/index.tsx
+++ b/components/mention/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import RcMention, { Nav, toString, toEditorState, getMentions } from 'rc-editor-mention';
 import classNames from 'classnames';
 import Icon from '../icon';

--- a/components/menu/index.tsx
+++ b/components/menu/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import RcMenu, { Item, Divider, SubMenu, ItemGroup } from 'rc-menu';
 import animation from '../_util/openAnimation';
 import warning from '../_util/warning';

--- a/components/message/index.tsx
+++ b/components/message/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import Notification from 'rc-notification';
 import Icon from '../icon';
 

--- a/components/modal/Modal.tsx
+++ b/components/modal/Modal.tsx
@@ -1,5 +1,5 @@
 import { PropTypes } from 'react';
-import React from 'react';
+import * as React from 'react';
 import Dialog from 'rc-dialog';
 import addEventListener from 'rc-util/lib/Dom/addEventListener';
 import Button from '../button';

--- a/components/modal/confirm.tsx
+++ b/components/modal/confirm.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
 import Dialog from './Modal';
 import Icon from '../icon';
 import Button from '../button';

--- a/components/modal/index.tsx
+++ b/components/modal/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import Modal from './Modal';
 import confirm from './confirm';
 import assign from 'object-assign';

--- a/components/notification/index.tsx
+++ b/components/notification/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import Notification from 'rc-notification';
 import Icon from '../icon';
 import assign from 'object-assign';

--- a/components/pagination/MiniSelect.tsx
+++ b/components/pagination/MiniSelect.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import Select, { OptionProps } from '../select';
 
 export default class MiniSelect extends React.Component<any, any> {

--- a/components/pagination/Pagination.tsx
+++ b/components/pagination/Pagination.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import RcPagination from 'rc-pagination';
 import Select from '../select';
 import MiniSelect from './MiniSelect';

--- a/components/popconfirm/index.tsx
+++ b/components/popconfirm/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import Tooltip from '../tooltip';
 import Icon from '../icon';
 import Button from '../button';

--- a/components/popover/index.tsx
+++ b/components/popover/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import assign from 'object-assign';
 import Tooltip from '../tooltip';
 

--- a/components/progress/progress.tsx
+++ b/components/progress/progress.tsx
@@ -1,5 +1,5 @@
 import { PropTypes } from 'react';
-import React from 'react';
+import * as React from 'react';
 import Icon from '../icon';
 import { Circle } from 'rc-progress';
 import classNames from 'classnames';

--- a/components/radio/group.tsx
+++ b/components/radio/group.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import classNames from 'classnames';
 import Radio from './radio';
 import RadioButton from './radioButton';

--- a/components/radio/radio.tsx
+++ b/components/radio/radio.tsx
@@ -1,5 +1,5 @@
 import RcRadio from 'rc-radio';
-import React from 'react';
+import * as React from 'react';
 import classNames from 'classnames';
 import PureRenderMixin from 'rc-util/lib/PureRenderMixin';
 

--- a/components/radio/radioButton.tsx
+++ b/components/radio/radioButton.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import Radio from './radio';
 
 export interface RadioButtonProps {

--- a/components/rate/index.tsx
+++ b/components/rate/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { PropTypes } from 'react';
 import RcRate from 'rc-rate';
 

--- a/components/select/index.tsx
+++ b/components/select/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { PropTypes } from 'react';
 import RcSelect, { Option, OptGroup } from 'rc-select';
 import classNames from 'classnames';

--- a/components/slider/index.tsx
+++ b/components/slider/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { PropTypes } from 'react';
 import RcSlider from 'rc-slider';
 

--- a/components/spin/index.tsx
+++ b/components/spin/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { PropTypes } from 'react';
 import { findDOMNode } from 'react-dom';
 import classNames from 'classnames';

--- a/components/steps/index.tsx
+++ b/components/steps/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { PropTypes } from 'react';
 import RcSteps from 'rc-steps';
 

--- a/components/switch/index.tsx
+++ b/components/switch/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { PropTypes } from 'react';
 import RcSwitch from 'rc-switch';
 import classNames from 'classnames';

--- a/components/table/Column.tsx
+++ b/components/table/Column.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import RcTable from 'rc-table';
 
 export interface ColumnProps<T> {

--- a/components/table/ColumnGroup.tsx
+++ b/components/table/ColumnGroup.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import RcTable from 'rc-table';
 
 export interface ColumnGroupProps {

--- a/components/table/FilterDropdownMenuWrapper.tsx
+++ b/components/table/FilterDropdownMenuWrapper.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 export interface FilterDropdownMenuWrapperProps {
   onClick?: React.MouseEventHandler<any>;

--- a/components/table/SelectionBox.tsx
+++ b/components/table/SelectionBox.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import Checkbox from '../checkbox';
 import Radio from '../radio';
 import { Store } from './createStore';

--- a/components/table/SelectionCheckboxAll.tsx
+++ b/components/table/SelectionCheckboxAll.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import Checkbox from '../checkbox';
 import { Store } from './createStore';
 

--- a/components/table/Table.tsx
+++ b/components/table/Table.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import RcTable from 'rc-table';
 import FilterDropdown from './filterDropdown';
 import Pagination, { PaginationProps } from '../pagination';

--- a/components/table/filterDropdown.tsx
+++ b/components/table/filterDropdown.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import Menu, { SubMenu, Item as MenuItem } from 'rc-menu';
 import Dropdown from '../dropdown';
 import Icon from '../icon';

--- a/components/table/util.tsx
+++ b/components/table/util.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import assign from 'object-assign';
 import Column from './Column';
 import ColumnGroup from './ColumnGroup';

--- a/components/tabs/index.tsx
+++ b/components/tabs/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { cloneElement } from 'react';
 import RcTabs, { TabPane } from 'rc-tabs';
 import ScrollableInkTabBar from 'rc-tabs/lib/ScrollableInkTabBar';

--- a/components/tag/CheckableTag.tsx
+++ b/components/tag/CheckableTag.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import classNames from 'classnames';
 import splitObject from '../_util/splitObject';
 

--- a/components/tag/index.tsx
+++ b/components/tag/index.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
 import Animate from 'rc-animate';
 import classNames from 'classnames';
 import omit from 'omit.js';

--- a/components/time-picker/index.tsx
+++ b/components/time-picker/index.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import moment from 'moment';
+import * as React from 'react';
+import * as moment from 'moment';
 import RcTimePicker from 'rc-time-picker/lib/TimePicker';
 import classNames from 'classnames';
 import assign from 'object-assign';

--- a/components/timeline/Timeline.tsx
+++ b/components/timeline/Timeline.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import classNames from 'classnames';
 import TimelineItem from './TimelineItem';
 import splitObject from '../_util/splitObject';

--- a/components/timeline/TimelineItem.tsx
+++ b/components/timeline/TimelineItem.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import classNames from 'classnames';
 import splitObject from '../_util/splitObject';
 

--- a/components/tooltip/index.tsx
+++ b/components/tooltip/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { cloneElement } from 'react';
 import RcTooltip from 'rc-tooltip';
 import getPlacements from './placements';

--- a/components/transfer/index.tsx
+++ b/components/transfer/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { PropTypes } from 'react';
 import classNames from 'classnames';
 import List from './list';

--- a/components/transfer/item.tsx
+++ b/components/transfer/item.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import classNames from 'classnames';
 import PureRenderMixin from 'rc-util/lib/PureRenderMixin';
 import assign from 'object-assign';

--- a/components/transfer/list.tsx
+++ b/components/transfer/list.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import Search from './search';
 import classNames from 'classnames';
 import Animate from 'rc-animate';

--- a/components/transfer/operation.tsx
+++ b/components/transfer/operation.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import Button from '../button';
 import Icon from '../icon';
 

--- a/components/transfer/search.tsx
+++ b/components/transfer/search.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import Icon from '../icon';
 import Input from '../input';
 

--- a/components/tree-select/index.tsx
+++ b/components/tree-select/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import RcTreeSelect, { TreeNode, SHOW_ALL, SHOW_PARENT, SHOW_CHILD } from 'rc-tree-select';
 import classNames from 'classnames';
 import { TreeSelectProps, TreeSelectContext } from './interface';

--- a/components/tree-select/interface.tsx
+++ b/components/tree-select/interface.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 export interface TreeData {
   key: string;

--- a/components/tree/index.tsx
+++ b/components/tree/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import RcTree, { TreeNode } from 'rc-tree';
 import animation from '../_util/openAnimation';
 

--- a/components/upload/index.tsx
+++ b/components/upload/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import RcUpload from 'rc-upload';
 import UploadList from './uploadList';
 import getFileItem from './getFileItem';

--- a/components/upload/interface.tsx
+++ b/components/upload/interface.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 export type UploadFileStatus = 'error' | 'success' | 'done' | 'uploading' | 'removed'
 

--- a/components/upload/uploadList.tsx
+++ b/components/upload/uploadList.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import Animate from 'rc-animate';
 import Icon from '../icon';
 import Progress from '../progress';


### PR DESCRIPTION
The latest Typescript compiler v2.0.10 gives a "Module has no default export." error for imports of the form: `import React from 'react';`
The correct form is: `import * as React from 'react';`

This PR fixes the imports for modules React, ReactDOM and moment in all TSX files.