### PR TITLE
remove hardcoded inputs height

### DIFF
--- a/components/form/style/index.less
+++ b/components/form/style/index.less
@@ -435,7 +435,7 @@ form {
   .@{ant-prefix}-input,
   .@{ant-prefix}-input-group .@{ant-prefix}-input,
   .@{ant-prefix}-input-group .@{ant-prefix}-input-group-addon {
-    height: 28px;
+    height: @input-height-base;
   }
 }
 

--- a/components/input-number/style/index.less
+++ b/components/input-number/style/index.less
@@ -15,7 +15,7 @@
   margin: 0;
   padding: 0;
   font-size: @font-size-base;
-  height: 28px;
+  height: @input-height-base;
   display: inline-block;
   border: 1px solid @border-color-base;
   border-radius: @border-radius-base;

--- a/components/pagination/style/index.less
+++ b/components/pagination/style/index.less
@@ -27,9 +27,9 @@
     cursor: pointer;
     border-radius: @border-radius-base;
     user-select: none;
-    min-width: 28px;
-    height: 28px;
-    line-height: 28px;
+    min-width: @input-height-base;
+    height: @input-height-base;
+    line-height: @input-height-base;
     text-align: center;
     list-style: none;
     float: left;
@@ -115,9 +115,9 @@
     color: @text-color;
     border-radius: @border-radius-base;
     list-style: none;
-    min-width: 28px;
-    height: 28px;
-    line-height: 28px;
+    min-width: @input-height-base;
+    height: @input-height-base;
+    line-height: @input-height-base;
     float: left;
     text-align: center;
     transition: all 0.3s ease;
@@ -199,8 +199,8 @@
 
     &-quick-jumper {
       float: left;
-      height: 28px;
-      line-height: 28px;
+      height: @input-height-base;
+      line-height: @input-height-base;
 
       input {
         .input;

--- a/components/pagination/style/index.less
+++ b/components/pagination/style/index.less
@@ -27,9 +27,9 @@
     cursor: pointer;
     border-radius: @border-radius-base;
     user-select: none;
-    min-width: @input-height-base;
-    height: @input-height-base;
-    line-height: @input-height-base;
+    min-width: 28px;
+    height: 28px;
+    line-height: 28px;
     text-align: center;
     list-style: none;
     float: left;

--- a/components/pagination/style/index.less
+++ b/components/pagination/style/index.less
@@ -115,9 +115,9 @@
     color: @text-color;
     border-radius: @border-radius-base;
     list-style: none;
-    min-width: @input-height-base;
-    height: @input-height-base;
-    line-height: @input-height-base;
+    min-width: 28px;
+    height: 28px;
+    line-height: 28px;
     float: left;
     text-align: center;
     transition: all 0.3s ease;

--- a/components/radio/style/index.less
+++ b/components/radio/style/index.less
@@ -115,7 +115,7 @@ span.@{radio-prefix-cls} + * {
 
 .@{radio-prefix-cls}-button-wrapper {
   margin: 0;
-  height: 28px;
+  height: @input-height-base;
   line-height: 26px;
   color: @btn-default-color;
   display: inline-block;
@@ -138,12 +138,12 @@ span.@{radio-prefix-cls} + * {
   }
 
   .@{radio-group-prefix-cls}-large & {
-    height: 32px;
+    height: @input-height-lg;
     line-height: 30px;
   }
 
   .@{radio-group-prefix-cls}-small & {
-    height: 22px;
+    height: @input-height-sm;
     line-height: 20px;
     padding: 0 12px;
     &:first-child {

--- a/components/select/style/index.less
+++ b/components/select/style/index.less
@@ -137,7 +137,7 @@
   }
 
   &-selection--single {
-    height: 28px;
+    height: @input-height-base;
     position: relative;
     cursor: pointer;
   }
@@ -160,13 +160,13 @@
 
   &-lg {
     .@{select-prefix-cls}-selection--single {
-      height: 32px;
+      height: @input-height-lg;
     }
     .@{select-prefix-cls}-selection__rendered {
       line-height: 30px;
     }
     .@{select-prefix-cls}-selection--multiple {
-      min-height: 32px;
+      min-height: @input-height-lg;
       .@{select-prefix-cls}-selection__rendered {
         li {
           height: 24px;
@@ -181,13 +181,13 @@
       border-radius: @border-radius-sm;
     }
     .@{select-prefix-cls}-selection--single {
-      height: 22px;
+      height: @input-height-sm;
     }
     .@{select-prefix-cls}-selection__rendered {
       line-height: 20px;
     }
     .@{select-prefix-cls}-selection--multiple {
-      min-height: 22px;
+      min-height: @input-height-sm;
       .@{select-prefix-cls}-selection__rendered {
         li {
           height: 14px;
@@ -268,7 +268,7 @@
   }
 
   &-selection--multiple {
-    min-height: 28px;
+    min-height: @input-height-base;
     cursor: text;
     padding-bottom: 3px;
     .clearfix;

--- a/components/switch/style/index.less
+++ b/components/switch/style/index.less
@@ -8,7 +8,7 @@
   position: relative;
   display: inline-block;
   box-sizing: border-box;
-  height: 22px;
+  height: @input-height-base;
   min-width: 44px;
   line-height: 20px;
   vertical-align: middle;


### PR DESCRIPTION
This PR concerns #4144 

However it would be nice to put the line-height of the components dynamic. Because changing the height of the inputs will not change the line-height.

Close: https://github.com/ant-design/ant-design/issues/4144