### PR TITLE
Make Table keyRow required

### DIFF
--- a/components/table/SelectionCheckboxAll.tsx
+++ b/components/table/SelectionCheckboxAll.tsx
@@ -5,8 +5,8 @@ import { Store } from './createStore';
 export interface SelectionCheckboxAllProps {
   store: Store;
   disabled: boolean;
-  getCheckboxPropsByItem: (item) => any;
-  getRecordKey: (record, index?) => string;
+  getCheckboxPropsByItem: (item, index) => any;
+  getRecordKey: (record, index) => string;
   data: any[];
   onChange: (e) => void;
 }
@@ -50,7 +50,7 @@ export default class SelectionCheckboxAll extends React.Component<SelectionCheck
     if (type === 'every' || type === 'some') {
       return (
         byDefaultChecked
-        ? data[type](item => getCheckboxPropsByItem(item).defaultChecked)
+        ? data[type]((item, i) => getCheckboxPropsByItem(item, i).defaultChecked)
         : data[type]((item, i) =>
               store.getState().selectedRowKeys.indexOf(getRecordKey(item, i)) >= 0)
       );

--- a/components/table/Table.tsx
+++ b/components/table/Table.tsx
@@ -54,7 +54,7 @@ export interface TableProps<T> {
   size?: 'default' | 'small';
   dataSource?: T[];
   columns?: ColumnProps<T>[];
-  rowKey?: string | ((record: T, index: number) => string);
+  rowKey: string | ((record: T, index: number) => string);
   rowClassName?: (record: T, index: number) => string;
   expandedRowRender?: any;
   defaultExpandedRowKeys?: string[];
@@ -156,12 +156,12 @@ export default class Table<T> extends React.Component<TableProps<T>, any> {
     });
   }
 
-  getCheckboxPropsByItem = (item) => {
+  getCheckboxPropsByItem = (item, index) => {
     const { rowSelection = {} } = this.props;
     if (!rowSelection.getCheckboxProps) {
       return {};
     }
-    const key = this.getRecordKey(item);
+    const key = this.getRecordKey(item, index);
     // Cache checkboxProps
     if (!this.CheckboxPropsCache[key]) {
       this.CheckboxPropsCache[key] = rowSelection.getCheckboxProps(item);
@@ -175,7 +175,7 @@ export default class Table<T> extends React.Component<TableProps<T>, any> {
       return [];
     }
     return this.getFlatData()
-      .filter(item => this.getCheckboxPropsByItem(item).defaultChecked)
+      .filter((item, index) => this.getCheckboxPropsByItem(item, index).defaultChecked)
       .map((record, rowIndex) => this.getRecordKey(record, rowIndex));
   }
 
@@ -465,7 +465,7 @@ export default class Table<T> extends React.Component<TableProps<T>, any> {
     const defaultSelection = this.store.getState().selectionDirty ? [] : this.getDefaultSelection();
     const selectedRowKeys = this.store.getState().selectedRowKeys.concat(defaultSelection);
     const changableRowKeys = data
-      .filter(item => !this.getCheckboxPropsByItem(item).disabled)
+      .filter((item, i) => !this.getCheckboxPropsByItem(item, i).disabled)
       .map((item, i) => this.getRecordKey(item, i));
 
     // 记录变化的列
@@ -532,7 +532,7 @@ export default class Table<T> extends React.Component<TableProps<T>, any> {
   renderSelectionBox = (type) => {
     return (_, record, index) => {
       let rowIndex = this.getRecordKey(record, index); // 从 1 开始
-      const props = this.getCheckboxPropsByItem(record);
+      const props = this.getCheckboxPropsByItem(record, index);
       const handleChange = (e) => {
         type === 'radio' ? this.handleRadioSelect(record, rowIndex, e) :
                            this.handleSelect(record, rowIndex, e);
@@ -553,25 +553,21 @@ export default class Table<T> extends React.Component<TableProps<T>, any> {
     };
   }
 
-  getRecordKey = (record, index?): string => {
+  getRecordKey = (record, index): string => {
     const rowKey = this.props.rowKey;
     if (typeof rowKey === 'function') {
       return rowKey(record, index);
     }
-    let recordKey = record[rowKey as string] !== undefined ? record[rowKey as string] : index;
-    warning(recordKey !== undefined,
-      'Each record in table should have a unique `key` prop, or set `rowKey` to an unique primary key.'
-    );
-    return recordKey;
+    return record[rowKey as string];
   }
 
   renderRowSelection() {
     const { prefixCls, rowSelection } = this.props;
     const columns = this.columns.concat();
     if (rowSelection) {
-      const data = this.getFlatCurrentPageData().filter((item) => {
+      const data = this.getFlatCurrentPageData().filter((item, index) => {
         if (rowSelection.getCheckboxProps) {
-          return !this.getCheckboxPropsByItem(item).disabled;
+          return !this.getCheckboxPropsByItem(item, index).disabled;
         }
         return true;
       });
@@ -581,7 +577,7 @@ export default class Table<T> extends React.Component<TableProps<T>, any> {
         className: `${prefixCls}-selection-column`,
       };
       if (rowSelection.type !== 'radio') {
-        const checkboxAllDisabled = data.every(item => this.getCheckboxPropsByItem(item).disabled);
+        const checkboxAllDisabled = data.every((item, index) => this.getCheckboxPropsByItem(item, index).disabled);
         selectionColumn.title  = (
           <SelectionCheckboxAll
             store={this.store}


### PR DESCRIPTION
1. 用数组的 index 做 key 不靠谱；
2. 原来的 [getRecordKey](https://github.com/ant-design/ant-design/blob/66f7b050eb6391e8a417f2250d594e082a86d688/components/table/Table.tsx#L556-L566)  的 index 参数是可选的，导致 rowKey 为方法时候，不是每次都能接收到 index 参数。


相关 issue：#4171、#4145