### PR TITLE
Resolving issue with TypeScript for children of LocaleProvider

### DIFF
--- a/components/locale-provider/index.tsx
+++ b/components/locale-provider/index.tsx
@@ -13,7 +13,7 @@ export interface LocaleProviderProps {
     Transfer?: Object,
     Select?: Object,
   };
-  children: any;
+  children?: React.ReactElement<any>;
 }
 
 export default class LocaleProvider extends React.Component<LocaleProviderProps, any> {


### PR DESCRIPTION
Found an issue when trying to wrap a component with the LocaleProvider:

```
<LocaleProvider locale={enUS}><DatePicker /></LocaleProvider>
```

Apparently there's an issue with typescript where you'll get the following error:

    error TS2324: Property 'children' is missing in type 'IntrinsicAttributes & IntrinsicClassAttributes<LocaleProvider> & { children?: ReactNode; } & Loca...'.


Making the change from:

```
children: any;
```

to:

```
children?: React.ReactElement<any>
```

Resolves the issue.

Similar to issue reported here:
https://github.com/ant-design/ant-design/issues/4140

I found the approach to resolve this issue from the following pull request:
https://github.com/DefinitelyTyped/DefinitelyTyped/pull/12632/files/a28743f6483ba813d46cc316eac8a21e54e8719f#diff-9ae0a9df19960a2d1b9608f30f6b19b3

