### PR TITLE
<CheckboxGroup /> support className

### DIFF
--- a/components/radio/group.tsx
+++ b/components/radio/group.tsx
@@ -78,6 +78,9 @@ export default class RadioGroup extends React.Component<RadioGroupProps, any> {
     }
 
     const onChange = this.props.onChange;
+    if (ev.target.value === this.props.value) {
+      return;
+    }
     if (onChange) {
       onChange(ev);
     }

--- a/components/radio/group.tsx
+++ b/components/radio/group.tsx
@@ -71,17 +71,19 @@ export default class RadioGroup extends React.Component<RadioGroupProps, any> {
     return PureRenderMixin.shouldComponentUpdate.apply(this, args);
   }
   onRadioChange = (ev) => {
+    let lastValue;
+    const { value } = ev.target;
     if (!('value' in this.props)) {
+      lastValue = this.state.value;
       this.setState({
-        value: ev.target.value,
+        value,
       });
+    } else {
+      lastValue = this.props.value;
     }
 
     const onChange = this.props.onChange;
-    if (ev.target.value === this.props.value) {
-      return;
-    }
-    if (onChange) {
+    if (onChange && value !== lastValue) {
       onChange(ev);
     }
   }


### PR DESCRIPTION
当前 `<CheckboxGroup />` 组件不支持 `className`，然后不方便开发者自定义样式，比如[垂直布局](http://codepen.io/ystarlongzi/pen/oYaMbW)。

然后参照了 `<RadioGroup />` 组件代码，使 `<CheckboxGroup />` 支持 `className`。