### PR TITLE
Ensure checkbox props cache is cleared after dataSource changes.

### DIFF
--- a/components/table/Table.tsx
+++ b/components/table/Table.tsx
@@ -195,14 +195,6 @@ export default class Table<T> extends React.Component<TableProps<T>, any> {
         return { pagination: newPagination };
       });
     }
-    // dataSource 的变化会清空选中项
-    if ('dataSource' in nextProps &&
-        nextProps.dataSource !== this.props.dataSource) {
-      this.store.setState({
-        selectionDirty: false,
-      });
-      this.CheckboxPropsCache = {};
-    }
     if (nextProps.rowSelection &&
         'selectedRowKeys' in nextProps.rowSelection) {
       this.store.setState({
@@ -214,6 +206,14 @@ export default class Table<T> extends React.Component<TableProps<T>, any> {
       )) {
         this.CheckboxPropsCache = {};
       }
+    }
+    // dataSource 的变化会清空选中项
+    if ('dataSource' in nextProps &&
+        nextProps.dataSource !== this.props.dataSource) {
+      this.store.setState({
+        selectionDirty: false,
+      });
+      this.CheckboxPropsCache = {};
     }
 
     if (this.getSortOrderColumns(nextProps.columns).length > 0) {

--- a/components/table/__tests__/Table.rowSelection.test.js
+++ b/components/table/__tests__/Table.rowSelection.test.js
@@ -163,4 +163,24 @@ describe('Table.rowSelection', () => {
     wrapper.find('input').first().simulate('change', { target: { checked: true } });
     expect(handleSelectAll).toBeCalledWith(true, data, data);
   });
+
+  // https://github.com/ant-design/ant-design/issues/4245
+  it('handles disabled checkbox correctly when dataSource changes', () => {
+    const data = [
+      { key: 0, name: 'Jack', disabled: false },
+      { key: 1, name: 'Lucy', disabled: false },
+    ];
+    const rowSelection = {
+      getCheckboxProps: (record) => ({ disabled: record.disabled }),
+    };
+    const wrapper = mount(createTable({ rowSelection }));
+    const newData = [
+      { key: 0, name: 'Jack', disabled: true },
+      { key: 1, name: 'Lucy', disabled: true },
+    ];
+    wrapper.setProps({ dataSource: newData });
+    wrapper.find('input').forEach(checkbox => {
+      expect(checkbox.props().disabled).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
Fix #4245

[这里](https://github.com/ant-design/ant-design/blob/5d72c6d7e51dbe70ded98da0c87befd0f61c76d8/components/table/Table.tsx#L208-L210)会导致 SelectionCheckboxAll.tsx 里调用 getCheckboxPropsByItem 导致缓存的里的结果是根据旧的 dataSource 计算的，所以把 dataSource 的判断写到下面，确保缓存被清掉。