### PR TITLE
fix components' get(Popup|Tooltip)Container method typescript interfa…

### DIFF
--- a/components/cascader/index.tsx
+++ b/components/cascader/index.tsx
@@ -59,6 +59,7 @@ export interface CascaderProps {
   onPopupVisibleChange?: (popupVisible: boolean) => void;
   prefixCls?: string;
   inputPrefixCls?: string;
+  getPopupContainer?: (triggerNode: Element) => HTMLElement;
 }
 
 function highlightKeyword(str: string, keyword: string, prefixCls: string) {

--- a/components/tooltip/index.tsx
+++ b/components/tooltip/index.tsx
@@ -22,7 +22,7 @@ export interface AbstractTooltipProps {
   trigger?: 'hover' | 'focus' | 'click';
   openClassName?: string;
   arrowPointAtCenter?: boolean;
-  getTooltipContainer?: (triggerNode: React.ReactNode) => HTMLElement;
+  getTooltipContainer?: (triggerNode: Element) => HTMLElement;
   children?: React.ReactElement<any>;
 }
 


### PR DESCRIPTION
Cascader Component Props missing the method getPopupContainer's interface.
#4300 

AbstractTooltipProps contain the method getTooltipContainer's interface, but triggerNode should not be `React.Node`.
the `triggerNode` is created by `ReactDom.findDOMNode()` 

https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/react-dom/index.d.ts#L14

