### PR TITLE
Dropdown.Button as a single non-wrappable element

### DIFF
--- a/components/dropdown/style/index.less
+++ b/components/dropdown/style/index.less
@@ -162,6 +162,8 @@
 }
 
 .@{dropdown-prefix-cls}-button {
+  white-space: nowrap;
+
   &.@{ant-prefix}-btn-group > .@{ant-prefix}-btn:last-child:not(:first-child) {
     padding-right: 7px;
   }


### PR DESCRIPTION
When a `Dropdown.Button` is rendered inside of an element that isn't wide enough to contain both the button itself as well as the dropdown button, the text wraps around and the elements are displayed on different lines.

This PR adds a single `white-space: nowrap;` rule so that the elements are always displayed on the same line.

In the example below, the `Dropdown.Button` is displayed inside a table cell with `width: ".1%"`, to push it to the far right.

Before:
![image](https://cloud.githubusercontent.com/assets/1621758/21467281/a8ef9c2c-c9e7-11e6-9420-af5769553433.png)

After:
![image](https://cloud.githubusercontent.com/assets/1621758/21467276/9ca4331a-c9e7-11e6-84a2-34d5eaea68c7.png)
