### PR TITLE
Fallback table record key to data index.

### DIFF
--- a/components/table/Table.tsx
+++ b/components/table/Table.tsx
@@ -560,7 +560,7 @@ export default class Table<T> extends React.Component<TableProps<T>, any> {
     warning(recordKey !== undefined,
       'Each record in table should have a unique `key` prop, or set `rowKey` to an unique primary key.'
     );
-    return recordKey;
+    return recordKey === undefined ? index : recordKey;
   }
 
   renderRowSelection() {


### PR DESCRIPTION
上个 PR #4185 讨论结果是 key 不要 fallback 到 index 上，但是发现这样其实照成了跟之前的行为不一致，让那些原来没设置 rowKey 又用了 index 做 key 的代码不能正常工作。所以还是让 key 能 fallback 到 index 上，但是警告还是能显示。