### PR TITLE
Using padding for tree node gaps

### DIFF
--- a/components/tree/style/index.less
+++ b/components/tree/style/index.less
@@ -11,8 +11,8 @@
   padding: 5px;
   font-size: @font-size-base;
   li {
-    padding: 0;
-    margin: 7px 0;
+    padding: 3.5px 0;
+    margin: 0;
     list-style: none;
     white-space: nowrap;
     outline: 0;
@@ -112,6 +112,14 @@
           }
         }
       }
+    }
+  }
+  > li {
+    &:first-child {
+      padding-top: 7px;
+    }
+    &:last-child {
+      padding-bottom: 7px;
     }
   }
   &-child-tree {


### PR DESCRIPTION
margin 的间距没法触发 drop 。

fix #4371