### PR TITLE
Allow temp value to be modified from onSelect in datePicker

### DIFF
--- a/components/date-picker/createPicker.tsx
+++ b/components/date-picker/createPicker.tsx
@@ -62,7 +62,12 @@ export default function createPicker(TheCalendar) {
     },
 
     handleTempChange(tempValue) {
-      this.setState({ tempValue });
+      const onSelect = this.props.onSelect;
+
+      // allow temp value to be modified from onSelect callback
+      const modValue = onSelect && onSelect(tempValue) || tempValue;
+      
+      this.setState({ tempValue: modValue });
     },
 
     // Clear temp value and trigger onChange when hide DatePicker[showTime] panel

--- a/components/date-picker/createPicker.tsx
+++ b/components/date-picker/createPicker.tsx
@@ -66,7 +66,7 @@ export default function createPicker(TheCalendar) {
 
       // allow temp value to be modified from onSelect callback
       const modValue = onSelect && onSelect(tempValue) || tempValue;
-      
+
       this.setState({ tempValue: modValue });
     },
 


### PR DESCRIPTION
Allow passing `onSelect` to date picker. If passed `onSelect` handler returns a modified `moment` instance, then replace selected value. 

This is useful when selecting dates, but when we want to control default time instead of current system time. 

Thank you for considering this PR. 