### PR TITLE
add warning when using Breadcrumb without its Item

### DIFF
--- a/components/breadcrumb/Breadcrumb.tsx
+++ b/components/breadcrumb/Breadcrumb.tsx
@@ -91,10 +91,23 @@ export default class Breadcrumb extends React.Component<BreadcrumbProps, any> {
       });
     } else if (children) {
       crumbs = React.Children.map(children, (element: any, index) => {
-        return cloneElement(element, {
-          separator,
-          key: index,
-        });
+        const hasBreadcrumbItem = element.type.name === 'BreadcrumbItem';
+        if (!hasBreadcrumbItem) {
+          warning(
+            hasBreadcrumbItem,
+            ' `BreadcrumbItem` is required as the wrapper of chilren element. '
+          );
+          return (
+            <BreadcrumbItem separator={separator} key={index}>
+              {element}
+            </BreadcrumbItem>
+          );
+        } else {
+          return cloneElement(element, {
+            separator,
+            key: index,
+          });
+        }
       });
     }
     return (

--- a/components/breadcrumb/Breadcrumb.tsx
+++ b/components/breadcrumb/Breadcrumb.tsx
@@ -91,23 +91,14 @@ export default class Breadcrumb extends React.Component<BreadcrumbProps, any> {
       });
     } else if (children) {
       crumbs = React.Children.map(children, (element: any, index) => {
-        const hasBreadcrumbItem = element.type.name === 'BreadcrumbItem';
-        if (!hasBreadcrumbItem) {
-          warning(
-            hasBreadcrumbItem,
-            ' `BreadcrumbItem` is required as the wrapper of chilren element. '
-          );
-          return (
-            <BreadcrumbItem separator={separator} key={index}>
-              {element}
-            </BreadcrumbItem>
-          );
-        } else {
-          return cloneElement(element, {
-            separator,
-            key: index,
-          });
-        }
+        warning(
+          element.type === BreadcrumbItem,
+          ' `BreadcrumbItem` is required as the wrapper of chilren element. '
+        );
+        return cloneElement(element, {
+          separator,
+          key: index,
+        });
       });
     }
     return (


### PR DESCRIPTION
fix issue ' Warning: Unknown prop `separator` on <div> tag. When I using Breadcrumb #4403'

ps: 我是个前端beginner， - ( ゜- ゜)つロ， 这是我第一个PR welcome, 如果写错或者还有更好的写法请大神指正。thanks

First of all, thanks for your contribution! :-)

Please makes sure these boxes are checked before submitting your PR, thank you!

* [ ] Make sure you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [ ] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [ ] Rebase before creating a PR to keep commit history clear.
* [ ] Add some descriptions and refer relative issues for you PR.
