### PR TITLE
Add tokenSeparators prop to Select TS definitions

### DIFF
--- a/components/select/index.tsx
+++ b/components/select/index.tsx
@@ -36,6 +36,7 @@ export interface SelectProps {
   dropdownStyle?: React.CSSProperties;
   dropdownMenuStyle?: React.CSSProperties;
   onChange?: (value: SelectValue) => void;
+  tokenSeparators?: string[];
 }
 
 export interface OptionProps {


### PR DESCRIPTION
[The documentation](https://ant.design/components/select/) lists the `tokenSeparators` property on the `Select` component, but the TypeScript definition for the component does not contain the `tokenSeparators` property. The underlying `rc-select` component [defines tokenSeparators](https://github.com/react-component/select/blob/master/src/Select.jsx#L79) as `PropTypes.arrayOf(PropTypes.string)`, so I've added it as an optional TypeScript property of type `string[]`.

- Add tokenSeparators to SelectProps in Select Component