### PR TITLE
controlled filterDropdown props in antd@1.x

### DIFF
--- a/components/table/Table.jsx
+++ b/components/table/Table.jsx
@@ -798,11 +798,12 @@ export default class Table extends React.Component {
             ? `${prefixCls}-with-pagination`
             : `${prefixCls}-without-pagination`;
     const spinClassName = this.props.loading ? `${paginationPatchClass} ${prefixCls}-spin-holder` : '';
-    table = <Spin className={spinClassName} spinning={this.props.loading}>{table}</Spin>;
     return (
       <div className={`${className} clearfix`} style={style}>
-        {table}
-        {this.renderPagination()}
+        <Spin className={spinClassName} spinning={this.props.loading}>
+          {table}
+          {this.renderPagination()}
+        </Spin>
       </div>
     );
   }

--- a/components/table/Table.jsx
+++ b/components/table/Table.jsx
@@ -503,7 +503,7 @@ export default class Table extends React.Component {
     const columns = this.props.columns.concat();
     if (rowSelection) {
       const data = this.getFlatCurrentPageData().filter((item) => {
-        if (this.props.rowSelection.getCheckboxProps) {
+        if (rowSelection.getCheckboxProps) {
           return !this.getCheckboxPropsByItem(item).disabled;
         }
         return true;
@@ -526,7 +526,7 @@ export default class Table extends React.Component {
         render: this.renderSelectionRadio,
         className: `${prefixCls}-selection-column`,
       };
-      if (this.props.rowSelection.type !== 'radio') {
+      if (rowSelection.type !== 'radio') {
         const checkboxAllDisabled = data.every(item => this.getCheckboxPropsByItem(item).disabled);
         selectionColumn.render = this.renderSelectionCheckBox;
         selectionColumn.title = (

--- a/components/table/demo/custom-filter-panel.md
+++ b/components/table/demo/custom-filter-panel.md
@@ -1,0 +1,123 @@
+---
+order: 19
+title: 自定义筛选菜单 
+---
+
+## zh-CN
+
+通过 `filterDropdown`、`filterDropdownVisible` 和 `filterDropdownVisibleChange` 定义自定义的列筛选功能，并实现一个搜索列的示例。
+
+## en-US
+
+Implement a customized column search example via `filterDropdown`, `filterDropdownVisible` and `filterDropdownVisibleChange`.
+
+````jsx
+import { Table, Input, Button } from 'antd';
+
+const data = [{
+  key: '1',
+  name: 'John Brown',
+  age: 32,
+  address: 'New York No. 1 Lake Park',
+}, {
+  key: '2',
+  name: 'Jim Green',
+  age: 42,
+  address: 'London No. 1 Lake Park',
+}, {
+  key: '3',
+  name: 'Joe Black',
+  age: 32,
+  address: 'Sidney No. 1 Lake Park',
+}, {
+  key: '4',
+  name: 'Jim Red',
+  age: 32,
+  address: 'London No. 2 Lake Park',
+}];
+
+const App = React.createClass({
+  getInitialState() {
+    return {
+      filterDropdownVisible: false,
+      data,
+      searchText: '',
+    };
+  },
+  onInputChange(e) {
+    this.setState({ searchText: e.target.value });
+  },
+  onSearch() {
+    const { searchText } = this.state;
+    const reg = new RegExp(searchText, 'gi');
+    this.setState({
+      filterDropdownVisible: false,
+      data: data.map((record) => {
+        const match = record.name.match(reg);
+        if (!match) {
+          return null;
+        }
+        return {
+          ...record,
+          name: (
+            <span>
+              {record.name.split(reg).map((text, i) => (
+                i > 0 ? [<span className="highlight">{match[0]}</span>, text] : text
+              ))}
+            </span>
+          ),
+        };
+      }).filter(record => !!record),
+    });
+  },
+  render() {
+    const columns = [{
+      title: 'Name',
+      dataIndex: 'name',
+      key: 'name',
+      filterDropdown: (
+        <div className="custom-filter-dropdown">
+          <Input
+            placeholder="Search name"
+            value={this.state.searchText}
+            onChange={this.onInputChange}
+            onPressEnter={this.onSearch}
+          />
+          <Button type="primary" onClick={this.onSearch}>Search</Button>
+        </div>
+      ),
+      filterDropdownVisible: this.state.filterDropdownVisible,
+      onFilterDropdownVisibleChange: visible => this.setState({ filterDropdownVisible: visible }),
+    }, {
+      title: 'Age',
+      dataIndex: 'age',
+      key: 'age',
+    }, {
+      title: 'Address',
+      dataIndex: 'address',
+      key: 'address',
+    }];
+    return <Table columns={columns} dataSource={this.state.data} />;
+  },
+});
+
+ReactDOM.render(<App />, mountNode);
+````
+
+````css
+.custom-filter-dropdown {
+  padding: 8px;
+  border-radius: 6px;
+  background: #fff;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, .2);
+}
+
+.custom-filter-dropdown input {
+  width: 130px;
+  margin-right: 8px;
+}
+
+.highlight {
+  color: #f50;
+}
+````

--- a/components/table/index.md
+++ b/components/table/index.md
@@ -89,6 +89,8 @@ const columns = [{
 | onFilter   | 本地模式下，确定筛选的运行函数 | Function    | - |
 | filterMultiple | 是否多选 | Boolean    | true    |
 | filterDropdown | 可以自定义筛选菜单，此函数只负责渲染图层，需要自行编写各种交互 | React.Element | - |
+| filterDropdownVisible | 用于控制自定义筛选菜单是否可见 | Boolean | - |
+| onFilterDropdownVisibleChange | 自定义筛选菜单可见变化时调用 | function(visible) {} | - |
 | sorter     | 排序函数，本地排序使用一个函数，需要服务端排序可设为 true | Function or Boolean | - |
 | colSpan    | 表头列合并,设置为 0 时，不渲染 | Number      |         |
 | width      | 列宽度 | String or Number | -  |

--- a/components/table/style/index.less
+++ b/components/table/style/index.less
@@ -97,6 +97,12 @@
     }
   }
 
+  // https://github.com/ant-design/ant-design/issues/4373
+  &-without-column-header &-title + &-content,
+  &-without-column-header table {
+    border-radius: 0;
+  }
+
   &-tbody > tr.@{table-prefix-cls}-row-selected {
     background: #fafafa;
   }

--- a/components/upload/index.jsx
+++ b/components/upload/index.jsx
@@ -281,7 +281,7 @@ export default class Upload extends React.Component {
     });
 
     const uploadButton = (
-      <div className={uploadButtonCls} style={{ display: this.props.children ? '' : 'none'}}>
+      <div className={uploadButtonCls} style={{ display: this.props.children ? '' : 'none' }}>
         <RcUpload {...props} ref="upload" />
       </div>
     );


### PR DESCRIPTION
+ 实现Table 自定义filterDropdown的显示隐藏控制
+ 统一使用prefixCls， 
+ 添加一个自定义filterDropdown的demo

参考自
> https://github.com/ant-design/ant-design/blob/2.6.0/components/table/Table.tsx
> https://github.com/ant-design/ant-design/blob/2.6.0/components/table/filterDropdown.tsx

请审核下，如果没问题，能否尽快发布一个小版本，谢谢！:eyes:
