### PR TITLE
Change AutoCompleteProps to extend SelectProps

### DIFF
--- a/components/auto-complete/index.tsx
+++ b/components/auto-complete/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Select, { SelectProps, OptionProps, OptGroupProps } from '../select';
+import Select, { AbstractSelectProps, OptionProps, OptGroupProps } from '../select';
 import { Option, OptGroup } from 'rc-select';
 import classNames from 'classnames';
 
@@ -11,21 +11,12 @@ export interface SelectedValue {
 export interface DataSourceItemObject { value: string; text: string; };
 export type DataSourceItemType = string | DataSourceItemObject;
 
-export interface AutoCompleteProps extends SelectProps {
-  size?: 'large' | 'small' | 'default';
-  className?: string;
-  notFoundContent?: Element;
+export interface AutoCompleteProps extends AbstractSelectProps {
   dataSource: DataSourceItemType[];
-  prefixCls?: string;
-  transitionName?: string;
-  optionLabelProp?: string;
-  choiceTransitionName?: string;
-  showSearch?: boolean;
   defaultValue?: string | Array<any> | SelectedValue | Array<SelectedValue>;
   value?: string | Array<any> | SelectedValue | Array<SelectedValue>;
-  allowClear?: boolean;
   onChange?: (value: string | Array<any> | SelectedValue | Array<SelectedValue>) => void;
-  disabled?: boolean;
+  onSelect?: (value: string | Array<any> | SelectedValue | Array<SelectedValue>, option: Object) => any;
 }
 
 export default class AutoComplete extends React.Component<AutoCompleteProps, any> {

--- a/components/auto-complete/index.tsx
+++ b/components/auto-complete/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Select, { OptionProps, OptGroupProps } from '../select';
+import Select, { SelectProps, OptionProps, OptGroupProps } from '../select';
 import { Option, OptGroup } from 'rc-select';
 import classNames from 'classnames';
 
@@ -11,7 +11,7 @@ export interface SelectedValue {
 export interface DataSourceItemObject { value: string; text: string; };
 export type DataSourceItemType = string | DataSourceItemObject;
 
-export interface AutoCompleteProps {
+export interface AutoCompleteProps extends SelectProps {
   size?: 'large' | 'small' | 'default';
   className?: string;
   notFoundContent?: Element;

--- a/components/select/index.tsx
+++ b/components/select/index.tsx
@@ -6,33 +6,36 @@ import classNames from 'classnames';
 export type SelectValue = string | any[] | { key: string, label: React.ReactNode } |
  Array<{ key: string, label: React.ReactNode }>;
 
-export interface SelectProps {
-  prefixCls?: string;
+export interface AbstractSelectProps {
+  size?: 'default' | 'large' | 'small';
   className?: string;
+  notFoundContent?: React.ReactNode | null;
+  prefixCls?: string;
+  transitionName?: string;
+  optionLabelProp?: string;
+  choiceTransitionName?: string;
+  showSearch?: boolean;
+  allowClear?: boolean;
+  disabled?: boolean;
+  style?: React.CSSProperties;
+  placeholder?: string;
+}
+
+export interface SelectProps extends AbstractSelectProps {
   value?: SelectValue;
   defaultValue?: SelectValue;
-  size?: 'default' | 'large' | 'small';
   combobox?: boolean;
-  notFoundContent?: React.ReactNode | null;
-  showSearch?: boolean;
-  transitionName?: string;
-  choiceTransitionName?: string;
   multiple?: boolean;
-  allowClear?: boolean;
   filterOption?: boolean | ((inputValue: string, option: Object) => any);
   tags?: boolean;
   onSelect?: (value: SelectValue, option: Object) => any;
   onDeselect?: (value: SelectValue) => any;
   onSearch?: (value: string) => any;
-  placeholder?: string;
   dropdownMatchSelectWidth?: boolean;
   optionFilterProp?: string;
-  optionLabelProp?: string;
-  disabled?: boolean;
   defaultActiveFirstOption?: boolean;
   labelInValue?: boolean;
   getPopupContainer?: (triggerNode: React.ReactNode) => React.ReactNode | HTMLElement;
-  style?: React.CSSProperties;
   dropdownStyle?: React.CSSProperties;
   dropdownMenuStyle?: React.CSSProperties;
   onChange?: (value: SelectValue) => void;


### PR DESCRIPTION
According to documentation: https://ant.design/components/auto-complete/

"Since AutoComplete is based on Select, so besides the following API, AutoComplete has the same API as Select"

This PR changes AutoCompleteProps interface to extend SelectProps

Otherwise examples from that URL will not work in TypeScript

eg.

```tsx
<AutoComplete
        dataSource={dataSource}
        style={{ width: 200 }} // -> TS ERROR
        onSelect={onSelect} // -> TS ERROR
        onChange={this.handleChange}
        placeholder="input here" // -> TS ERROR
      />
```