### PR TITLE
Respect @layout-content-margin

### DIFF
--- a/components/layout/style/index.less
+++ b/components/layout/style/index.less
@@ -34,6 +34,7 @@
 
   &-content {
     flex: auto;
+    margin: @layout-content-margin;
   }
 
   &-sider {

--- a/components/style/themes/default.less
+++ b/components/style/themes/default.less
@@ -148,7 +148,7 @@
 @layout-header-padding     : 0 50px;
 @layout-footer-padding     : 24px 50px;
 @layout-sider-background   : @heading-color;
-@layout-content-margin     : 24px;
+@layout-content-margin     : 24px 0;
 @layout-trigger-height     : 48px;
 
 // z-index list


### PR DESCRIPTION
`@layout-content-margin` is currently configured as a setting in the `default.less` variable sheet, but this variable isn't currently used in the CSS.

This change makes `Layout` > `Content` respect the configured `@layout-content-margin` and slightly changes the default to `24px 0` so that the margin affects top and bottom margins.