### PR TITLE
rc-editor-mention up to date and support multiple prefix token

### DIFF
--- a/components/mention/demo/multiple-trigger.md
+++ b/components/mention/demo/multiple-trigger.md
@@ -1,0 +1,61 @@
+---
+order: 8
+title:
+  zh-CN: 自定义触发字符
+  en-US: Customize Trigger Token
+---
+
+## zh-CN
+
+通过 `prefix` 属性自定义触发字符。默认为 `@`, 可以定义为数组。
+
+## en-US
+
+Customize Trigger Token by `prefix` props. Default to `@`, `Array<string>` also supported.
+
+````__react
+import { Mention } from 'antd';
+const { toString, toEditorState } = Mention;
+
+function onChange(editorState) {
+  console.log(toString(editorState));
+}
+
+function onSelect(suggestion) {
+  console.log('onSelect', suggestion);
+}
+
+const users = ['afc163', 'benjycui', 'yiminghe', 'jljsj33', 'dqaria', 'RaoHai'];
+const tags = ['1.0', '2.0', '3.0'];
+
+class App extends React.Component {
+  constructor(props) {
+    super();
+    this.state = {
+      suggestions: [],
+    };
+  }
+  onSearchChange = (value, trigger) => {
+    console.log('onSearchChange', value, trigger);
+    const dataSource = trigger === '@' ? users : tags;
+    this.setState({
+      suggestions: dataSource.filter(item => item.indexOf(value) !== -1)
+    });
+  }
+  render() {
+    return <Mention
+      style={{ width: '100%', height: 100 }}
+      onChange={onChange}
+      placeholder="input @ to mention people, # to mention tag"
+      prefix={['@', '#']}
+      onSearchChange={this.onSearchChange}
+      suggestions={this.state.suggestions}
+      onSelect={onSelect}
+    />
+  }
+}
+
+ReactDOM.render(
+  <App />
+, mountNode);
+````

--- a/components/mention/index.en-US.md
+++ b/components/mention/index.en-US.md
@@ -34,13 +34,13 @@ When need to mention someone or something.
 |----------|---------------|----------|--------------|
 | suggestions    | suggestion content | Array<string\|Mention.Nav> | [] |
 | suggestionStyle | style of suggestion container | object | {} |
-| onSearchChange | Callback function called when search content changes | function(value:string) | [] |
+| onSearchChange | Callback function called when search content changes | function(value:string, trigger: string) | [] |
 | onChange | Callback function called when content of input changes | function(editorState: EditorState) | null |
 | onSelect | Callback function called when select from suggestions | function(suggestion: string, data?: any) | null |
 | notFoundContent| suggestion when suggestions empty | string | '无匹配结果，轻敲空格完成输入' |
 | loading | loading mode | boolean | false |
 | multiLines | multilines mode | boolean | false |
-| prefix | character which will trigger Mention to show mention list | string | '@' |
+| prefix | character which will trigger Mention to show mention list | string or Array<string> | '@' |
 | defaultValue | default value | EditorState, you can use `Mention.toEditorState` to convert text to `EditorState` | null |
 | value | core state of mention | EditorState | null |
 | placeholder | placeholder of input | string | null |

--- a/components/mention/index.tsx
+++ b/components/mention/index.tsx
@@ -56,9 +56,9 @@ export default class Mention extends React.Component<MentionProps, MentionState>
     }
   }
 
-  onSearchChange = (value) => {
+  onSearchChange = (value, prefix) => {
     if (this.props.onSearchChange) {
-      return this.props.onSearchChange(value);
+      return this.props.onSearchChange(value, prefix);
     }
     return this.defaultSearchChange(value);
   }

--- a/components/mention/index.zh-CN.md
+++ b/components/mention/index.zh-CN.md
@@ -34,13 +34,13 @@ title: Mention
 |----------|---------------|----------|--------------|
 | suggestions    | 建议内容 | Array<string\|Mention.Nav> | [] |
 | suggestionStyle | 弹出下拉框样式 | object | {} |
-| onSearchChange | 输入框中 @ 变化时回调 | function(value:string) | [] |
+| onSearchChange | 输入框中 @ 变化时回调 | function(value:string, trigger: string) | [] |
 | onChange | 输入框内容变化时回调 | function(editorState: EditorState) | null |
 | onSelect | 下拉框选择建议时回调 | function(suggestion: string, data?: any) | null |
 | notFoundContent| 未找到时的内容 | string | '无匹配结果，轻敲空格完成输入' |
 | loading | 加载中 | boolean | false |
 | multiLines | 多行模式 | boolean | false |
-| prefix | 触发弹出下拉框的字符 | string | '@' |
+| prefix | 触发弹出下拉框的字符 | string or Array<string> | '@' |
 | placeholder | 输入框默认文字 | string | null |
 | defaultValue | 默认值 | EditorState, 可以用 Mention.toEditorState(text) 把文字转换成 EditorState | null |
 | value | 值 | EditorState | null |

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "rc-collapse": "~1.6.4",
     "rc-dialog": "~6.5.0",
     "rc-dropdown": "~1.4.8",
-    "rc-editor-mention": "~0.3.0",
+    "rc-editor-mention": "~0.4.1",
     "rc-form": "~1.3.0",
     "rc-input-number": "~3.0.0",
     "rc-menu": "~5.0.9",
@@ -187,6 +187,10 @@
     "collectCoverageFrom": [
       "components/**/*.{ts,tsx}",
       "!components/*/style/index.tsx"
+    ],
+     "transformIgnorePatterns": [
+      "/node_modules/",
+      "/dist/antd.js"
     ]
   },
   "pre-commit": [

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "rc-collapse": "~1.6.4",
     "rc-dialog": "~6.5.0",
     "rc-dropdown": "~1.4.8",
-    "rc-editor-mention": "~0.4.1",
+    "rc-editor-mention": "~0.5.2",
     "rc-form": "~1.3.0",
     "rc-input-number": "~3.0.0",
     "rc-menu": "~5.0.9",


### PR DESCRIPTION
* draft-js@0.9.0 -> draft-js@0.10.0
* rc-editor-mention@0.3.x -> rc-editor-mention@0.5.2
* close #4797。
  * `<Mention prefix={['@', '#']} />` supported .
  * onSearchChange 添加第二个参数 trigger: `onSearchChange(value, trigger:string) `, 值为当前触发 suggestion 的 token。
  * 原先的用法仍旧兼容.
