### PR TITLE
fix render unuse className when type is undefined

### DIFF
--- a/components/grid/row.tsx
+++ b/components/grid/row.tsx
@@ -31,8 +31,8 @@ export default class Row extends React.Component<RowProps, any> {
     const classes = classNames({
       [prefixCls]: !type,
       [`${prefixCls}-${type}`]: type,
-      [`${prefixCls}-${type}-${justify}`]: justify,
-      [`${prefixCls}-${type}-${align}`]: align,
+      [`${prefixCls}-${type}-${justify}`]: type && justify,
+      [`${prefixCls}-${type}-${align}`]: type && align,
     }, className);
     const rowStyle = gutter > 0 ? assign({}, {
       marginLeft: gutter / -2,


### PR DESCRIPTION
When grid component props `type` is not set to `flex`, but `justify` or `align` is set, className will be rendered such as `.ant-row-undefined-center`. It's unfriendly.
