### PR TITLE
Add 'middle' as a valid value for `Table.props.size`

### DIFF
--- a/components/table/Table.tsx
+++ b/components/table/Table.tsx
@@ -52,7 +52,7 @@ export interface TableProps<T> {
   dropdownPrefixCls?: string;
   rowSelection?: TableRowSelection<T>;
   pagination?: PaginationProps | boolean;
-  size?: 'default' | 'small';
+  size?: 'default' | 'middle' | 'small';
   dataSource?: T[];
   columns?: ColumnProps<T>[];
   rowKey?: string | ((record: T, index: number) => string);

--- a/components/table/index.en-US.md
+++ b/components/table/index.en-US.md
@@ -54,7 +54,7 @@ const columns = [{
 |---------------|--------------------------|-----------------|--------------|
 | rowSelection  | row selection [config](#rowSelection)  | object  | null  |
 | pagination    | pagination [config](/components/pagination/), hide it via setting to `false` | object |  |
-| size          | size of table: `default` or `small`  | string | `default` |
+| size          | size of table: `default`, `middle` or `small`  | string | `default` |
 | dataSource    | data record array to be rendered | any[] |            |
 | columns       | columns of table | [ColumnProps](https://git.io/vMMXC)[] | - |
 | rowKey        | get row's key, could be a string or function | string\|Function(record):string | 'key' |


### PR DESCRIPTION
Dynamic settings at https://ant.design/components/table/#components-table-demo-dynamic-settings indicate that 'middle' is a valid option for `Table.props.size`, but this value is not valid according to the `Table.Props` interface, so I've added it.

--

First of all, thanks for your contribution! :-)

Please makes sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.
