### PR TITLE
Change way to add package.version

### DIFF
--- a/components/__tests__/__snapshots__/index.test.js.snap
+++ b/components/__tests__/__snapshots__/index.test.js.snap
@@ -50,5 +50,6 @@ Array [
   "Tooltip",
   "Mention",
   "Upload",
+  "version",
 ]
 `;

--- a/components/index.tsx
+++ b/components/index.tsx
@@ -106,3 +106,5 @@ export { default as Tooltip } from './tooltip';
 export { default as Mention } from './mention';
 
 export { default as Upload } from './upload';
+
+export { default as version } from './version';

--- a/components/version/index.tsx
+++ b/components/version/index.tsx
@@ -1,0 +1,3 @@
+import * as pkg from '../../package.json';
+
+export default (pkg as any).version;

--- a/components/version/style/index.tsx
+++ b/components/version/style/index.tsx
@@ -1,0 +1,2 @@
+// empty file prevent babel-plugin-import error
+import '../../style/index.less';

--- a/scripts/prepub.js
+++ b/scripts/prepub.js
@@ -7,14 +7,18 @@ const fs = require('fs');
 const path = require('path');
 const packageInfo = require('../package.json');
 
-if (fs.existsSync(path.join(__dirname, '../dist'))) {
+if (fs.existsSync(path.join(__dirname, '../lib'))) {
   // Build package.json version to lib/version/index.js
   // prevent json-loader needing in user-side
+  const versionFilePath = path.join(process.cwd(), 'lib', 'version', 'index.js');
+  const versionFileContent = fs.readFileSync(versionFilePath).toString();
   fs.writeFileSync(
-    path.join(process.cwd(), 'lib', 'version', 'index.js'),
-    `module.exports = '${packageInfo.version}';\n`
+    versionFilePath,
+    versionFileContent.replace(`require('../../package.json')`, `{ version: '${packageInfo.version}' }`)
   );
+}
 
+if (fs.existsSync(path.join(__dirname, '../dist'))) {
   // Build a entry less file to dist/antd.less
   console.log('Building a entry less file to dist/antd.less');
   const componentsPath = path.join(process.cwd(), 'components');

--- a/scripts/prepub.js
+++ b/scripts/prepub.js
@@ -3,41 +3,19 @@
 /* eslint-disable */
 'use strict';
 
-// Build a entry less file to dist/antd.less
 const fs = require('fs');
 const path = require('path');
 const packageInfo = require('../package.json');
 
 if (fs.existsSync(path.join(__dirname, '../dist'))) {
-  fs.writeFileSync(path.join(process.cwd(), 'lib', 'version.js'), `
-module.exports = '${packageInfo.version}';
-`);
+  // Build package.json version to lib/version/index.js
+  // prevent json-loader needing in user-side
+  fs.writeFileSync(
+    path.join(process.cwd(), 'lib', 'version', 'index.js'),
+    `module.exports = '${packageInfo.version}';\n`
+  );
 
-  const antdV = `
-  (function(root) {
-	if(typeof exports === 'object' && typeof module === 'object')
-		module.exports.version = '${packageInfo.version}';
-	else
-		root["antd"].version = '${packageInfo.version}';
-})(this);
-`;
-
-  const antdPath = path.join(process.cwd(), 'dist', 'antd.js');
-  const antdMinPath = path.join(process.cwd(), 'dist', 'antd.min.js');
-
-  if (fs.existsSync(antdPath)) {
-    const content = fs.readFileSync(antdPath, 'utf-8');
-    const minContent = fs.readFileSync(antdMinPath, 'utf-8');
-    fs.writeFileSync(antdPath, `
-${content}
-${antdV}
-`);
-    fs.writeFileSync(antdMinPath, `
-${minContent}
-${antdV}
-`);
-  }
-
+  // Build a entry less file to dist/antd.less
   console.log('Building a entry less file to dist/antd.less');
   const componentsPath = path.join(process.cwd(), 'components');
   let componentsLessContent = '';

--- a/tests/__snapshots__/index.test.js.snap
+++ b/tests/__snapshots__/index.test.js.snap
@@ -50,5 +50,6 @@ Array [
   "Tooltip",
   "Mention",
   "Upload",
+  "version",
 ]
 `;

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import path from 'path';
+import pkg from '../package.json';
 
 describe('antd dist files', () => {
   // https://github.com/ant-design/ant-design/issues/1638
@@ -18,6 +19,11 @@ describe('antd dist files', () => {
         antdJsContent.toString()
         .indexOf('function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }')
       ).toBe(-1);
+    });
+
+    it('should have antd.version', () => {
+      const antd = require('../dist/antd'); // eslint-disable-line global-require
+      expect(antd.version).toBe(pkg.version);
     });
   }
 });

--- a/typings/custom-typings.d.ts
+++ b/typings/custom-typings.d.ts
@@ -83,3 +83,8 @@ declare var process: {
     NODE_ENV: string
   }
 };
+
+declare module "*.json" {
+  const value: any;
+  export default value;
+}


### PR DESCRIPTION
improve for #4751 

close #4844

1. Fix `style` of `babel-plugin-import`;
2. Fix `root['antd']` undefined of `antd/dist/antd.js`;
3. Add test case.