### PR TITLE
Fix empty table placehoder style

### DIFF
--- a/components/table/style/index.less
+++ b/components/table/style/index.less
@@ -341,6 +341,7 @@
   }
 
   &-placeholder {
+    position: relative;
     padding: 16px 8px;
     background: @component-background;
     border-bottom: @border-width-base @border-style-base @border-color-split;

--- a/components/table/style/index.less
+++ b/components/table/style/index.less
@@ -333,6 +333,10 @@
           display: none;
         }
       }
+
+      .@{table-prefix-cls}-placeholder {
+        border: 0;
+      }
     }
   }
 


### PR DESCRIPTION
1. Fixed header 的时候"暂无数据"会被遮住；
2. small 的时候下面会有两条边框。

http://codepen.io/yesmeck/pen/VPqqZR?editors=0010


Before:

![before](https://cloud.githubusercontent.com/assets/465125/22921277/db3423d2-f2d3-11e6-9b0e-ab6e37097d65.png)


After:

![after](https://cloud.githubusercontent.com/assets/465125/22921282/df1138aa-f2d3-11e6-8650-7dcae3457eea.png)
