### PR TITLE
Add locale ca_ES (Catalan)

### DIFF
--- a/components/calendar/locale/ca_ES.tsx
+++ b/components/calendar/locale/ca_ES.tsx
@@ -1,0 +1,2 @@
+import ca_ES from '../../date-picker/locale/ca_ES';
+export default ca_ES;

--- a/components/date-picker/locale/ca_ES.tsx
+++ b/components/date-picker/locale/ca_ES.tsx
@@ -1,0 +1,17 @@
+import CalendarLocale from 'rc-calendar/lib/locale/ca_ES';
+import TimePickerLocale from '../../time-picker/locale/ca_ES';
+import assign from 'object-assign';
+
+// 统一合并为完整的 Locale
+const locale = {
+  lang: assign({
+    placeholder: 'Seleccionar data',
+    rangePlaceholder: ['Data inicial', 'Data final'],
+  }, CalendarLocale),
+  timePickerLocale: assign({}, TimePickerLocale),
+};
+
+// All settings at:
+// https://github.com/ant-design/ant-design/blob/master/components/date-picker/locale/example.json
+
+export default locale;

--- a/components/locale-provider/__tests__/index.test.js
+++ b/components/locale-provider/__tests__/index.test.js
@@ -11,6 +11,7 @@ import svSE from '../sv_SE';
 import frBE from '../fr_BE';
 import deDE from '../de_DE';
 import nlNL from '../nl_NL';
+import caES from '../ca_ES';
 
 const Option = Select.Option;
 const RangePicker = DatePicker.RangePicker;
@@ -56,7 +57,7 @@ const App = () => (
 
 describe('Locale Provider', () => {
   it('should display the text as locale changed', () => {
-    [enUS, ptBR, ruRU, esES, svSE, frBE, deDE, nlNL].forEach((locale) => {
+    [enUS, ptBR, ruRU, esES, svSE, frBE, deDE, nlNL, caES].forEach((locale) => {
       const wrapper = mount(
         <LocaleProvider locale={locale}>
           <App />

--- a/components/locale-provider/ca_ES.tsx
+++ b/components/locale-provider/ca_ES.tsx
@@ -1,0 +1,39 @@
+import moment from 'moment';
+moment.locale('ca');
+
+import Pagination from 'rc-pagination/lib/locale/ca_ES';
+import DatePicker from '../date-picker/locale/ca_ES';
+import TimePicker from '../time-picker/locale/ca_ES';
+import Calendar from '../calendar/locale/ca_ES';
+
+export default {
+  locale: 'en',
+  Pagination,
+  DatePicker,
+  TimePicker,
+  Calendar,
+  Table: {
+    filterTitle: 'Filtrar Menu',
+    filterConfirm: 'OK',
+    filterReset: 'Restablir',
+    emptyText: 'Sense dades',
+  },
+  Modal: {
+    okText: 'OK',
+    cancelText: 'Cancel·lar',
+    justOkText: 'OK',
+  },
+  Popconfirm: {
+    okText: 'OK',
+    cancelText: 'Cancel·lar',
+  },
+  Transfer: {
+    notFoundContent: 'No trobat',
+    searchPlaceholder: 'Cercar aquí',
+    itemUnit: 'item',
+    itemsUnit: 'items',
+  },
+  Select: {
+    notFoundContent: 'No trobat',
+  },
+};

--- a/components/locale-provider/ca_ES.tsx
+++ b/components/locale-provider/ca_ES.tsx
@@ -7,7 +7,7 @@ import TimePicker from '../time-picker/locale/ca_ES';
 import Calendar from '../calendar/locale/ca_ES';
 
 export default {
-  locale: 'en',
+  locale: 'ca',
   Pagination,
   DatePicker,
   TimePicker,

--- a/components/time-picker/locale/ca_ES.tsx
+++ b/components/time-picker/locale/ca_ES.tsx
@@ -1,0 +1,5 @@
+const locale = {
+  placeholder: 'Seleccionar hora',
+};
+
+export default locale;


### PR DESCRIPTION
Hello,


I added the local for ca_ES (Catalan). Therefore, this fork only have four new files:
```
components/calendar/locale/ca_ES.tsx
components/date-picker/locale/ca_ES.tsx
components/locale-provider/ca_ES.tsx
components/time-picker/locale/ca_ES.tsx
```

And a modified file:
```
components/locale-provider/__tests__/index.test.js
```

Previously to this fork, I updated to other projects:
- rc-calendar: https://github.com/react-component/calendar/pull/213
- rc-pagination: https://github.com/react-component/pagination/pull/59

Finally, I run:
```
antd-tools run ts-lint
antd-tools run compile
```

Everything it's OK. Waiting for your fork :smile: 