### PR TITLE
Layout.Sider support responsive display

### DIFF
--- a/components/layout/Sider.tsx
+++ b/components/layout/Sider.tsx
@@ -39,7 +39,7 @@ export interface SiderProps {
   trigger?: React.ReactNode;
   width?: number | string;
   collapsedWidth?: number | string;
-  breakPoint?: 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+  breakpoint?: 'xs' | 'sm' | 'md' | 'lg' | 'xl';
 }
 
 export default class Sider extends React.Component<SiderProps, any> {
@@ -63,8 +63,8 @@ export default class Sider extends React.Component<SiderProps, any> {
     if (typeof window !== 'undefined') {
       matchMedia = window.matchMedia;
     }
-    if (matchMedia && props.breakPoint && props.breakPoint in dimensionMap) {
-      this.mql = matchMedia(`(max-width: ${dimensionMap[props.breakPoint]})`);
+    if (matchMedia && props.breakpoint && props.breakpoint in dimensionMap) {
+      this.mql = matchMedia(`(max-width: ${dimensionMap[props.breakpoint]})`);
     }
     let collapsed;
     if ('collapsed' in props) {
@@ -133,7 +133,7 @@ export default class Sider extends React.Component<SiderProps, any> {
       ...others,
     } = this.props;
     const divProps = omit(others, ['collapsed',
-      'defaultCollapsed', 'onCollapse', 'breakPoint']);
+      'defaultCollapsed', 'onCollapse', 'breakpoint']);
     const siderWidth = this.state.collapsed ? collapsedWidth : width;
     // special trigger when collapsedWidth == 0
     const zeroWidthTrigger = collapsedWidth === 0 || collapsedWidth === '0' ?

--- a/components/layout/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/layout/__tests__/__snapshots__/demo.test.js.snap
@@ -155,6 +155,91 @@ exports[`test renders ./components/layout/demo/custom-trigger.md correctly 1`] =
 </div>
 `;
 
+exports[`test renders ./components/layout/demo/responsive.md correctly 1`] = `
+<div
+  class="ant-layout ant-layout-has-sider">
+  <div
+    class="ant-layout-sider"
+    style="flex:0 0 200px;width:200px;">
+    <div
+      class="logo" />
+    <ul
+      aria-activedescendant=""
+      class="ant-menu ant-menu-inline  ant-menu-dark ant-menu-root"
+      role="menu"
+      tabindex="0">
+      <li
+        aria-selected="false"
+        class="ant-menu-item"
+        role="menuitem"
+        style="padding-left:24px;">
+        <i
+          class="anticon anticon-user" />
+        <span
+          class="nav-text">
+          nav 1
+        </span>
+      </li>
+      <li
+        aria-selected="false"
+        class="ant-menu-item"
+        role="menuitem"
+        style="padding-left:24px;">
+        <i
+          class="anticon anticon-video-camera" />
+        <span
+          class="nav-text">
+          nav 2
+        </span>
+      </li>
+      <li
+        aria-selected="false"
+        class="ant-menu-item"
+        role="menuitem"
+        style="padding-left:24px;">
+        <i
+          class="anticon anticon-upload" />
+        <span
+          class="nav-text">
+          nav 3
+        </span>
+      </li>
+      <li
+        aria-selected="true"
+        class="ant-menu-item-selected ant-menu-item"
+        role="menuitem"
+        style="padding-left:24px;">
+        <i
+          class="anticon anticon-user" />
+        <span
+          class="nav-text">
+          nav 4
+        </span>
+      </li>
+    </ul>
+  </div>
+  <div
+    class="ant-layout">
+    <div
+      class="ant-layout-header"
+      style="background:#fff;padding:0;" />
+    <div
+      class="ant-layout-content"
+      style="margin:24px 16px 0;">
+      <div
+        style="padding:24px;background:#fff;min-height:360px;">
+        content
+      </div>
+    </div>
+    <div
+      class="ant-layout-footer"
+      style="text-align:center;">
+      Ant Design ©2016 Created by Ant UED
+    </div>
+  </div>
+</div>
+`;
+
 exports[`test renders ./components/layout/demo/side.md correctly 1`] = `
 <div
   class="ant-layout ant-layout-has-sider">

--- a/components/layout/demo/responsive.md
+++ b/components/layout/demo/responsive.md
@@ -9,16 +9,24 @@ title:
 
 Layout.Sider 支持响应式布局。
 
+> 说明：配置 `breakPoint` 属性即生效，视窗宽度小于 `breakPoint` 时 Sider 缩小为 `collapsedWidth` 宽度，若将 `collapsedWidth` 设置为零，会出现特殊 trigger。
+
 ## en-US
 
 Layout.Sider supports responsive layout.
+
+> Note: You can get a responsive layout by setting `breakPoint`, the Sider will collapse to the width of `collapsedWidth` when window width is below the `breakPoint`. And a special trigger will appear if the `collapsedWidth` is set to `0`.
 
 ````jsx
 import { Layout, Menu, Icon } from 'antd';
 const { Header, Content, Footer, Sider } = Layout;
 
 ReactDOM.render(<Layout>
-  <Sider breakpoint="lg" onResponse={(below) => { console.log(below); }}>
+  <Sider
+    breakPoint="lg"
+    collapsedWidth="0"
+    onCollapse={(collapsed, type) => { console.log(collapsed, type); }}
+  >
     <div className="logo" />
     <Menu theme="dark" mode="inline" defaultSelectedKeys={['4']}>
       <Menu.Item key="1">

--- a/components/layout/demo/responsive.md
+++ b/components/layout/demo/responsive.md
@@ -9,13 +9,13 @@ title:
 
 Layout.Sider 支持响应式布局。
 
-> 说明：配置 `breakPoint` 属性即生效，视窗宽度小于 `breakPoint` 时 Sider 缩小为 `collapsedWidth` 宽度，若将 `collapsedWidth` 设置为零，会出现特殊 trigger。
+> 说明：配置 `breakpoint` 属性即生效，视窗宽度小于 `breakpoint` 时 Sider 缩小为 `collapsedWidth` 宽度，若将 `collapsedWidth` 设置为零，会出现特殊 trigger。
 
 ## en-US
 
 Layout.Sider supports responsive layout.
 
-> Note: You can get a responsive layout by setting `breakPoint`, the Sider will collapse to the width of `collapsedWidth` when window width is below the `breakPoint`. And a special trigger will appear if the `collapsedWidth` is set to `0`.
+> Note: You can get a responsive layout by setting `breakpoint`, the Sider will collapse to the width of `collapsedWidth` when window width is below the `breakpoint`. And a special trigger will appear if the `collapsedWidth` is set to `0`.
 
 ````jsx
 import { Layout, Menu, Icon } from 'antd';
@@ -23,7 +23,7 @@ const { Header, Content, Footer, Sider } = Layout;
 
 ReactDOM.render(<Layout>
   <Sider
-    breakPoint="lg"
+    breakpoint="lg"
     collapsedWidth="0"
     onCollapse={(collapsed, type) => { console.log(collapsed, type); }}
   >

--- a/components/layout/demo/responsive.md
+++ b/components/layout/demo/responsive.md
@@ -1,0 +1,63 @@
+---
+order: 5
+title:
+  zh-CN: 响应式布局
+  en-US: Responsive
+---
+
+## zh-CN
+
+Layout.Sider 支持响应式布局。
+
+## en-US
+
+Layout.Sider supports responsive layout.
+
+````jsx
+import { Layout, Menu, Icon } from 'antd';
+const { Header, Content, Footer, Sider } = Layout;
+
+ReactDOM.render(<Layout>
+  <Sider breakpoint="lg" onResponse={(below) => { console.log(below); }}>
+    <div className="logo" />
+    <Menu theme="dark" mode="inline" defaultSelectedKeys={['4']}>
+      <Menu.Item key="1">
+        <Icon type="user" />
+        <span className="nav-text">nav 1</span>
+      </Menu.Item>
+      <Menu.Item key="2">
+        <Icon type="video-camera" />
+        <span className="nav-text">nav 2</span>
+      </Menu.Item>
+      <Menu.Item key="3">
+        <Icon type="upload" />
+        <span className="nav-text">nav 3</span>
+      </Menu.Item>
+      <Menu.Item key="4">
+        <Icon type="user" />
+        <span className="nav-text">nav 4</span>
+      </Menu.Item>
+    </Menu>
+  </Sider>
+  <Layout>
+    <Header style={{ background: '#fff', padding: 0 }} />
+    <Content style={{ margin: '24px 16px 0' }}>
+      <div style={{ padding: 24, background: '#fff', minHeight: 360 }}>
+        content
+      </div>
+    </Content>
+    <Footer style={{ textAlign: 'center' }}>
+      Ant Design ©2016 Created by Ant UED
+    </Footer>
+  </Layout>
+</Layout>, mountNode);
+````
+
+````css
+#components-layout-demo-responsive .logo {
+  height: 32px;
+  background: #333;
+  border-radius: 6px;
+  margin: 16px;
+}
+````

--- a/components/layout/index.en-US.md
+++ b/components/layout/index.en-US.md
@@ -55,7 +55,7 @@ onCollapse | the callback function, can be executed by clicking the trigger or a
 trigger | specify the customized trigger, set to null to hide the trigger | string\|ReactNode| - |
 width | width of the sidebar | number\|string | 200
 collapsedWidth | width of the collapsed sidebar, by setting to `0` a special trigger will appear | number | 64
-breakPoint | breakPoint of the responsive layout | Enum { 'xs', 'sm', 'md', 'lg', 'xl' } | - |
+breakpoint | breakpoint of the responsive layout | Enum { 'xs', 'sm', 'md', 'lg', 'xl' } | - |
 style | to custom the styles | object | -
 className | container className | string | -
 

--- a/components/layout/index.en-US.md
+++ b/components/layout/index.en-US.md
@@ -55,6 +55,9 @@ onCollapse | the callback function, can be executed when you switch the sidebar,
 trigger | specify the customized trigger, set to null to hide the trigger | string\|ReactNode| - |
 width | width of the sidebar | number\|string | 200
 collapsedWidth | width of the collapsed sidebar, available only `collapsible: true` | number | 64
+breakpoint | breakpoint of the responsive layout | string: `xs` \| `sm` \| `md` \| `lg` \| `xl` | - |
+widthBelow | to set the Sider width when the window width is below the breakpoint | number\|string | `0` by default, means hide completely, and will be set to `collapsedWidth` when `collapsible=true`
+onResponse | the callback function, can be executed when the responsive layout is changing | function | (below: boolean) => {}
 style | to custom the styles | object | -
 className | container className | string | -
 

--- a/components/layout/index.en-US.md
+++ b/components/layout/index.en-US.md
@@ -51,13 +51,11 @@ Property | Description | Type | Default
 collapsible | whether can be collapsed | boolean | false
 defaultCollapsed | to set the initial status | boolean | false  |
 collapsed | to set the current status | boolean | -
-onCollapse | the callback function, can be executed when you switch the sidebar, available only `collapsible: true` | (collapsed) => {}  | -
+onCollapse | the callback function, can be executed by clicking the trigger or activating the responsive layout | (collapsed, type) => {}  | -
 trigger | specify the customized trigger, set to null to hide the trigger | string\|ReactNode| - |
 width | width of the sidebar | number\|string | 200
-collapsedWidth | width of the collapsed sidebar, available only `collapsible: true` | number | 64
-breakpoint | breakpoint of the responsive layout | string: `xs` \| `sm` \| `md` \| `lg` \| `xl` | - |
-widthBelow | to set the Sider width when the window width is below the breakpoint | number\|string | `0` by default, means hide completely, and will be set to `collapsedWidth` when `collapsible=true`
-onResponse | the callback function, can be executed when the responsive layout is changing | function | (below: boolean) => {}
+collapsedWidth | width of the collapsed sidebar, by setting to `0` a special trigger will appear | number | 64
+breakPoint | breakPoint of the responsive layout | Enum { 'xs', 'sm', 'md', 'lg', 'xl' } | - |
 style | to custom the styles | object | -
 className | container className | string | -
 

--- a/components/layout/index.zh-CN.md
+++ b/components/layout/index.zh-CN.md
@@ -56,7 +56,7 @@ title: Layout
 | trigger | 自定义 trigger，设置为 null 时隐藏 trigger | string\|ReactNode | - |
 | width | 宽度 | number\|string | 200 |
 | collapsedWidth | 收缩宽度，设置为 0 会出现特殊 trigger | number | 64 |
-| breakPoint | 触发响应式布局的断点 | Enum { 'xs', 'sm', 'md', 'lg', 'xl' } | - |
+| breakpoint | 触发响应式布局的断点 | Enum { 'xs', 'sm', 'md', 'lg', 'xl' } | - |
 | style | 指定样式 | object | - |
 | className | 容器 className | string | - |
 

--- a/components/layout/index.zh-CN.md
+++ b/components/layout/index.zh-CN.md
@@ -56,6 +56,9 @@ title: Layout
 | trigger | 自定义 trigger，设置为 null 时隐藏 trigger | string\|ReactNode | - |
 | width | 宽度 | number\|string | 200 |
 | collapsedWidth | 收缩宽度，仅当 `collapsible:true` 时生效 | number | 64 |
+| breakpoint | 触发响应式布局的断点 | string: `xs` \| `sm` \| `md` \| `lg` \| `xl` | - |
+| widthBelow | 视窗宽度低于 breakpoint 时的 Sider 宽度 | number\|string | 默认为 0，即全部隐藏，当可收起时默认为 collapsedWidth |
+| onResponse | 触发响应式布局的回调函数 | function | (below: boolean) => {} |
 | style | 指定样式 | object | - |
 | className | 容器 className | string | - |
 

--- a/components/layout/index.zh-CN.md
+++ b/components/layout/index.zh-CN.md
@@ -52,13 +52,11 @@ title: Layout
 | collapsible | 是否可收起 | boolean | false  |
 | defaultCollapsed | 是否默认收起 | boolean | false  |
 | collapsed | 当前收起状态 | boolean | - |
-| onCollapse | 展开-收起时的回调函数，仅当 `collapsible:true` 时生效 | (collapsed) => {} | - |
+| onCollapse | 展开-收起时的回调函数，有点击 trigger 以及响应式反馈两种方式可以触发 | (collapsed, type) => {} | - |
 | trigger | 自定义 trigger，设置为 null 时隐藏 trigger | string\|ReactNode | - |
 | width | 宽度 | number\|string | 200 |
-| collapsedWidth | 收缩宽度，仅当 `collapsible:true` 时生效 | number | 64 |
-| breakpoint | 触发响应式布局的断点 | string: `xs` \| `sm` \| `md` \| `lg` \| `xl` | - |
-| widthBelow | 视窗宽度低于 breakpoint 时的 Sider 宽度 | number\|string | 默认为 0，即全部隐藏，当可收起时默认为 collapsedWidth |
-| onResponse | 触发响应式布局的回调函数 | function | (below: boolean) => {} |
+| collapsedWidth | 收缩宽度，设置为 0 会出现特殊 trigger | number | 64 |
+| breakPoint | 触发响应式布局的断点 | Enum { 'xs', 'sm', 'md', 'lg', 'xl' } | - |
 | style | 指定样式 | object | - |
 | className | 容器 className | string | - |
 

--- a/components/layout/style/index.less
+++ b/components/layout/style/index.less
@@ -3,17 +3,6 @@
 
 @layout-prefix-cls: ~"@{ant-prefix}-layout";
 
-.make-sider(@size: ~'', @type: ~'') when (@{type} == '-banner') {
-  .@{layout-prefix-cls}-sider@{size}@{type} {
-    flex: 0 0 100%;
-  }
-}
-.make-sider(@size: ~'', @type: ~'') when (@{type} != '-banner') {
-  .@{layout-prefix-cls}-sider@{size}@{type} {
-    flex: 0 0 200px;
-  }
-}
-
 .@{layout-prefix-cls} {
   display: flex;
   flex-direction: column;
@@ -71,25 +60,31 @@
       background: tint(@heading-color, 20%);
       color: #fff;
     }
+
+    &-below-default {
+      & > * {
+        overflow: hidden;
+      }
+
+      &-trigger {
+        position: absolute;
+        top: @layout-header-height;
+        right: -@layout-below-trigger-width;
+        text-align: center;
+        width: @layout-below-trigger-width;
+        height: @layout-below-trigger-height;
+        line-height: @layout-below-trigger-height;
+        background: @layout-sider-background;
+        color: #fff;
+        font-size: @layout-below-trigger-width / 2;
+        border-radius: 0 @border-radius-base @border-radius-base 0;
+        cursor: pointer;
+        transition: background .3s ease;
+
+        &:hover {
+          background: tint(@layout-sider-background, 10%);
+        }
+      }
+    }
   }
-}
-
-.make-sider();
-
-.make-sider(-xs, -banner);
-
-@media (min-width: @screen-sm-min) {
-  .make-grid(-sm, -banner);
-}
-
-@media (min-width: @screen-md-min) {
-  .make-grid(-md, -banner);
-}
-
-@media (min-width: @screen-lg-min) {
-  .make-grid(-lg, -banner);
-}
-
-@media (min-width: @screen-xl-min) {
-  .make-grid(-xl, -banner);
 }

--- a/components/layout/style/index.less
+++ b/components/layout/style/index.less
@@ -61,7 +61,7 @@
       color: #fff;
     }
 
-    &-below-default {
+    &-zero-width {
       & > * {
         overflow: hidden;
       }
@@ -69,14 +69,14 @@
       &-trigger {
         position: absolute;
         top: @layout-header-height;
-        right: -@layout-below-trigger-width;
+        right: -@layout-zero-trigger-width;
         text-align: center;
-        width: @layout-below-trigger-width;
-        height: @layout-below-trigger-height;
-        line-height: @layout-below-trigger-height;
+        width: @layout-zero-trigger-width;
+        height: @layout-zero-trigger-height;
+        line-height: @layout-zero-trigger-height;
         background: @layout-sider-background;
         color: #fff;
-        font-size: @layout-below-trigger-width / 2;
+        font-size: @layout-zero-trigger-width / 2;
         border-radius: 0 @border-radius-base @border-radius-base 0;
         cursor: pointer;
         transition: background .3s ease;

--- a/components/layout/style/index.less
+++ b/components/layout/style/index.less
@@ -3,6 +3,17 @@
 
 @layout-prefix-cls: ~"@{ant-prefix}-layout";
 
+.make-sider(@size: ~'', @type: ~'') when (@{type} == '-banner') {
+  .@{layout-prefix-cls}-sider@{size}@{type} {
+    flex: 0 0 100%;
+  }
+}
+.make-sider(@size: ~'', @type: ~'') when (@{type} != '-banner') {
+  .@{layout-prefix-cls}-sider@{size}@{type} {
+    flex: 0 0 200px;
+  }
+}
+
 .@{layout-prefix-cls} {
   display: flex;
   flex-direction: column;
@@ -61,4 +72,24 @@
       color: #fff;
     }
   }
+}
+
+.make-sider();
+
+.make-sider(-xs, -banner);
+
+@media (min-width: @screen-sm-min) {
+  .make-grid(-sm, -banner);
+}
+
+@media (min-width: @screen-md-min) {
+  .make-grid(-md, -banner);
+}
+
+@media (min-width: @screen-lg-min) {
+  .make-grid(-lg, -banner);
+}
+
+@media (min-width: @screen-xl-min) {
+  .make-grid(-xl, -banner);
 }

--- a/components/style/themes/default.less
+++ b/components/style/themes/default.less
@@ -150,13 +150,15 @@
 @grid-gutter-width      : 0;
 
 // Layout
-@layout-body-background    : #ececec;
-@layout-header-background  : @heading-color;
-@layout-header-height      : 64px;
-@layout-header-padding     : 0 50px;
-@layout-footer-padding     : 24px 50px;
-@layout-sider-background   : @heading-color;
-@layout-trigger-height     : 48px;
+@layout-body-background      : #ececec;
+@layout-header-background    : @heading-color;
+@layout-header-height        : 64px;
+@layout-header-padding       : 0 50px;
+@layout-footer-padding       : 24px 50px;
+@layout-sider-background     : @heading-color;
+@layout-trigger-height       : 48px;
+@layout-below-trigger-width  : 36px;
+@layout-below-trigger-height : 42px;
 
 // z-index list
 @zindex-affix           : 10;

--- a/components/style/themes/default.less
+++ b/components/style/themes/default.less
@@ -157,8 +157,8 @@
 @layout-footer-padding       : 24px 50px;
 @layout-sider-background     : @heading-color;
 @layout-trigger-height       : 48px;
-@layout-below-trigger-width  : 36px;
-@layout-below-trigger-height : 42px;
+@layout-zero-trigger-width  : 36px;
+@layout-zero-trigger-height : 42px;
 
 // z-index list
 @zindex-affix           : 10;


### PR DESCRIPTION
- only support one breakpoint now
- with default style


`normally`
<img width="742" alt="2017-02-18 1 59 30" src="https://cloud.githubusercontent.com/assets/7017767/23077061/efa07a30-f57d-11e6-9a5e-cda01a684147.png">

`below the breakpoint`
<img width="564" alt="2017-02-18 1 58 25" src="https://cloud.githubusercontent.com/assets/7017767/23077043/dc977c36-f57d-11e6-9cbf-dabcd50285e6.png">

`below the breakpoint and expanded`
<img width="560" alt="2017-02-18 1 58 15" src="https://cloud.githubusercontent.com/assets/7017767/23077033/d5569934-f57d-11e6-92b3-72a38d64b5c9.png">

