### PR TITLE
Fix RangePicker TimePicker component locking background to white

### DIFF
--- a/components/date-picker/style/RangePicker.less
+++ b/components/date-picker/style/RangePicker.less
@@ -191,7 +191,7 @@
       &-combobox {
         display: inline-block;
         height: 100%;
-        background-color: white;
+        background-color: @component-background;
         border-top: @border-width-base @border-style-base @border-color-split;
       }
       &-select {


### PR DESCRIPTION
Because the background here is locked to white and the foreground is set to `@text-color` the TimePicker combo ends up not working for dark themes.

Thank you!