### PR TITLE
antD首页从英文切换到中文时，replace导致链接错误

### DIFF
--- a/site/theme/template/Layout/Header.jsx
+++ b/site/theme/template/Layout/Header.jsx
@@ -87,7 +87,7 @@ export default class Header extends React.Component {
     if (utils.isLocalStorageNameSupported()) {
       localStorage.setItem('locale', utils.isZhCN(pathname) ? 'en-US' : 'zh-CN');
     }
-    location.href = location.href.replace(
+    location.href = location.origin + location.pathname.replace(
       location.pathname,
       utils.getLocalizedPathname(pathname, !utils.isZhCN(pathname)),
     );


### PR DESCRIPTION
首页从英文转到中文，点击header上的“中文”时，链接会跳到 https://ant.design/index-cn/ant.design/ （Chrome）或者 https://index-cn/ant.design/ （Safari）

bug来自handleLangChange函数下，最后对location.href.replace操作时出错，原因来自replace匹配到location.href的第一个/
('https://ant.design/').replace('/', '/index-cn') 的运行结果是 https:/index-cn/ant.design/ 

为了避免replace匹配到location.href的第一个/，我建议的方案是使用 location.origin + location.pathname.replace

btw，我clone下来后，执行npm run start或npm run site时有个模块在报错，所以我没有办法在本地测试运行，建议在merge前再测测。我修复的方法是执行compile后，把.js涉及的函数写成demo测试的，不过解决逻辑应该没错。

最后，感谢antD团队开发出那么棒的UI~

First of all, thanks for your contribution! :-)

Please makes sure these boxes are checked before submitting your PR, thank you!

* [ ] Make sure you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [ ] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [ ] Rebase before creating a PR to keep commit history clear.
* [ ] Add some descriptions and refer relative issues for you PR.
