### PR TITLE
[v 2.0]antD首页从英文切换到中文时，replace导致链接错误

### DIFF
--- a/site/theme/template/Layout/Header.jsx
+++ b/site/theme/template/Layout/Header.jsx
@@ -87,7 +87,7 @@ export default class Header extends React.Component {
     if (utils.isLocalStorageNameSupported()) {
       localStorage.setItem('locale', utils.isZhCN(pathname) ? 'en-US' : 'zh-CN');
     }
-    location.href = location.href.replace(
+    location.href = location.origin + location.pathname.replace(
       location.pathname,
       utils.getLocalizedPathname(pathname, !utils.isZhCN(pathname)),
     );

--- a/site/theme/template/Layout/Header.jsx
+++ b/site/theme/template/Layout/Header.jsx
@@ -84,10 +84,13 @@ export default class Header extends React.Component {
 
   handleLangChange = () => {
     const pathname = this.props.location.pathname;
+    const currentProtocol = location.protocol + '//';
+    const currentHref = location.href.substr(currentProtocol.length);
+    
     if (utils.isLocalStorageNameSupported()) {
       localStorage.setItem('locale', utils.isZhCN(pathname) ? 'en-US' : 'zh-CN');
     }
-    location.href = location.origin + location.pathname.replace(
+    location.href = currentProtocol + currentHref.replace(
       location.pathname,
       utils.getLocalizedPathname(pathname, !utils.isZhCN(pathname)),
     );


### PR DESCRIPTION
英转中URL问题，上一版使用了location.origin + location.pathname，会丢失query和hash。此版本原理还是用location.href做replace，鉴于首页pathname可能是/会在替换中匹配到https:后的第一个/，所以先把href的protocol部分提取出来，再做replace，最后再拼回去做跳转。

First of all, thanks for your contribution! :-)

Please makes sure these boxes are checked before submitting your PR, thank you!

* [ ] Make sure you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [ ] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [ ] Rebase before creating a PR to keep commit history clear.
* [ ] Add some descriptions and refer relative issues for you PR.