### PR TITLE
Remove inconsisent progress-bar font

### DIFF
--- a/components/progress/style/index.less
+++ b/components/progress/style/index.less
@@ -53,7 +53,6 @@
     margin-left: 10px;
     vertical-align: middle;
     display: inline-block;
-    font-family: tahoma;
     position: relative;
     top: -1px;
     .@{iconfont-css-prefix} {


### PR DESCRIPTION
Not sure if there is background to this, but the progressbar fonts don't match the `@font-family` configured in less variables.