### PR TITLE
Added missing getFieldsError in WrappedFormUtils

### DIFF
--- a/components/form/Form.tsx
+++ b/components/form/Form.tsx
@@ -48,6 +48,7 @@ export type WrappedFormUtils = {
                           callback?: (erros: any, values: any) => void): void;
   /** 获取某个输入控件的 Error */
   getFieldError(name: string): Object[];
+  getFieldsError(names?: Array<string>): Object[];
   /** 判断一个输入控件是否在校验状态*/
   isFieldValidating(name: string): boolean;
   /** 重置一组输入控件的值与状态，如不传入参数，则重置所有组件 */


### PR DESCRIPTION
The [documentation](https://ant.design/components/form/#Form.create(options)) states that the Form API includes a `getFieldsError ` function, but there it is not included in the [WrappedFormUtils](https://github.com/ant-design/ant-design/blob/master/components/form/Form.tsx#L50) type. This PR adds `getFieldsError ` to the type alias based upon rc-form's function defined [here](https://github.com/react-component/form/blob/master/src/createBaseForm.js), which takes an optional array of field names (strings) as a parameter.