### PR TITLE
Use @input-color to set calendar's input color

### DIFF
--- a/components/date-picker/style/Calendar.less
+++ b/components/date-picker/style/Calendar.less
@@ -108,6 +108,7 @@
     cursor: auto;
     outline: 0;
     height: 22px;
+    color: @input-color;
   }
 
   &-week-number {


### PR DESCRIPTION
Calendars parent component sets the color to `@text-color`. The selected date color should override this color to use `@input-color` to avoid issues shown below (with dark themes)

![image](https://cloud.githubusercontent.com/assets/3475472/23526873/b16e5000-ff61-11e6-860d-0776265ed4a7.png)

![image](https://cloud.githubusercontent.com/assets/3475472/23526885/bd410d50-ff61-11e6-8e62-9b6a56ef9063.png)
