### PR TITLE
Use @input-color to set InputNumber's color

### DIFF
--- a/components/input-number/style/index.less
+++ b/components/input-number/style/index.less
@@ -75,7 +75,7 @@
     line-height: @input-height-base - 2px;
     height: @input-height-base - 2px;
     transition: all 0.3s linear;
-    color: @text-color;
+    color: @input-color;
     border: 0;
     border-radius: @border-radius-base;
     padding: 0 7px;


### PR DESCRIPTION
`InputNumber` should use `@input-color` to set the color rather than `@text-color`