### PR TITLE
bugfix: fix implicit any in SelectionCheckboxAllProps

### DIFF
--- a/components/table/SelectionCheckboxAll.tsx
+++ b/components/table/SelectionCheckboxAll.tsx
@@ -15,8 +15,8 @@ export interface SelectionCheckboxAllProps {
   store: Store;
   locale: any;
   disabled: boolean;
-  getCheckboxPropsByItem: (item, index) => any;
-  getRecordKey: (record, index?) => string;
+  getCheckboxPropsByItem: (item: any, index: number) => any;
+  getRecordKey: (record: any, index?: number) => string;
   data: any[];
   prefixCls: string | undefined;
   onSelect: (key: string, index: number, selectFunc: any) => void;


### PR DESCRIPTION
fix exposed implicit type any in checkbox props by item values getCheckboxPropsByItem and getRecordKey
fixes ant-design/ant-design#5206
