### PR TITLE
fix press `ESC` key don't call onCalcel callback function

### DIFF
--- a/components/modal/confirm.tsx
+++ b/components/modal/confirm.tsx
@@ -30,7 +30,7 @@ export default function confirm(config) {
     (props.okCancel ? runtimeLocale.okText : runtimeLocale.justOkText);
   props.cancelText = props.cancelText || runtimeLocale.cancelText;
 
-  function close() {
+  function close(e) {
     const unmountResult = ReactDOM.unmountComponentAtNode(div);
     if (unmountResult && div.parentNode) {
       div.parentNode.removeChild(div);

--- a/components/modal/confirm.tsx
+++ b/components/modal/confirm.tsx
@@ -34,6 +34,7 @@ export default function confirm(config) {
     const unmountResult = ReactDOM.unmountComponentAtNode(div);
     if (unmountResult && div.parentNode) {
       div.parentNode.removeChild(div);
+      props.onCancel(e);
     }
   }
 


### PR DESCRIPTION
fix issue [5203](https://github.com/ant-design/ant-design/issues/5203)