### PR TITLE
code optimize

### DIFF
--- a/components/grid/row.tsx
+++ b/components/grid/row.tsx
@@ -44,12 +44,12 @@ export default class Row extends React.Component<RowProps, any> {
       if (!col) {
         return null;
       }
-      if (col.props) {
+      if (col.props && (gutter as number) > 0) {
         return cloneElement(col, {
-          style: (gutter as number) > 0 ? assign({}, {
+          style: assign({}, {
             paddingLeft: (gutter as number) / 2,
             paddingRight: (gutter as number) / 2,
-          }, col.props.style) : col.props.style,
+          }, col.props.style),
         });
       }
       return col;


### PR DESCRIPTION
row如果没有props.gutter，没必要去修改下层组件的props，原先的方式会导致无缘无故多了一个props.style属性，这样col需要特殊处理props.style undefined场景