### PR TITLE
Feat spin style

### DIFF
--- a/components/spin/index.en-US.md
+++ b/components/spin/index.en-US.md
@@ -16,5 +16,6 @@ When part of the page is waiting for asynchronous data or during a rendering pro
 |------------|----------------|-------------|--------------|
 | size       | enum           | default     | Size of dot in spin component, available in `small`, `default` and `large`. |
 | spinning   | boolean        | true        | Use in embedded mode, to modify loading state. |
+| spinStyle  | spin style object           | object   | -        |
 | tip    | string        | None        | Customize description content  |
 | delay | number (milliseconds) | None | Specifies a delay for loading state |

--- a/components/spin/index.tsx
+++ b/components/spin/index.tsx
@@ -10,6 +10,7 @@ export interface SpinProps {
   prefixCls?: string;
   className?: string;
   spinning?: boolean;
+  spinStyle?: React.CSSProperties;
   size?: 'small' | 'default' | 'large';
   tip?: string;
   delay?: number;
@@ -19,6 +20,7 @@ export default class Spin extends React.Component<SpinProps, any> {
   static defaultProps = {
     prefixCls: 'ant-spin',
     spinning: true,
+    spinStyle: null,
     size: 'default',
   };
 
@@ -26,6 +28,7 @@ export default class Spin extends React.Component<SpinProps, any> {
     prefixCls: PropTypes.string,
     className: PropTypes.string,
     spinning: PropTypes.bool,
+    spinStyle: PropTypes.object,
     size: PropTypes.oneOf(['small', 'default', 'large']),
   };
 
@@ -82,7 +85,7 @@ export default class Spin extends React.Component<SpinProps, any> {
     }
   }
   render() {
-    const { className, size, prefixCls, tip, ...restProps } = this.props;
+    const { className, size, prefixCls, tip, spinStyle, ...restProps } = this.props;
     const { spinning } = this.state;
 
     const spinClassName = classNames(prefixCls, {
@@ -119,11 +122,11 @@ export default class Spin extends React.Component<SpinProps, any> {
           {...divProps}
           component="div"
           className={`${prefixCls}-nested-loading`}
-          style={null}
+          style={spinStyle}
           transitionName="fade"
         >
           {spinning && <div key="loading">{spinElement}</div>}
-          <div className={containerClassName} key="container">
+          <div className={containerClassName} style={spinStyle} key="container">
             {this.props.children}
           </div>
         </Animate>

--- a/components/spin/index.zh-CN.md
+++ b/components/spin/index.zh-CN.md
@@ -17,5 +17,6 @@ subtitle: 加载中
 |------------|----------------|-------------|--------------|
 | size       | enum           | default     | spin组件中点的大小，可选值为 small default large |
 | spinning   | boolean        | true        | 用于内嵌其他组件的模式，可以关闭 loading 效果    |
+| spinStyle      | spin 的样式对象                           | object   | -             |
 | tip    | string        | 无        | 自定义描述文案 |
 | delay | number (毫秒) | 无 | 延迟显示 loading 效果 |


### PR DESCRIPTION
Hello,

I added the style property to the _Spin_ component. This is useful because it's impossible access to the _classNames_:
- `ant-spin-container`
- `ant-spin-nested-container`

In my case, for instance, I need setting the property height to 100% to both _classNames_.

I used the #4970, by @afc163 , as a reference.

Thanks a lot!