### PR TITLE
Fix card head style property

### DIFF
--- a/components/card/style/index.less
+++ b/components/card/style/index.less
@@ -22,7 +22,7 @@
   &-head {
     height: @card-head-height;
     line-height: @card-head-height;
-    background-color: @card-head-background;
+    background: @card-head-background;
     border-bottom: @border-width-base @border-style-base @border-color-split;
     padding: 0 24px;
 

--- a/components/card/style/index.less
+++ b/components/card/style/index.less
@@ -22,7 +22,7 @@
   &-head {
     height: @card-head-height;
     line-height: @card-head-height;
-    background-color: @card-head-color;
+    background-color: @card-head-background;
     border-bottom: @border-width-base @border-style-base @border-color-split;
     padding: 0 24px;
 
@@ -33,7 +33,7 @@
       width: 100%;
       overflow: hidden;
       white-space: nowrap;
-      color: @card-head-bgcolor;
+      color: @card-head-color;
       font-weight: 500;
     }
   }

--- a/components/card/style/index.less
+++ b/components/card/style/index.less
@@ -20,8 +20,9 @@
   }
 
   &-head {
-    height: 48px;
-    line-height: 48px;
+    height: @card-head-height;
+    line-height: @card-head-height;
+    background-color: @card-head-color;
     border-bottom: @border-width-base @border-style-base @border-color-split;
     padding: 0 24px;
 
@@ -32,7 +33,7 @@
       width: 100%;
       overflow: hidden;
       white-space: nowrap;
-      color: @heading-color;
+      color: @card-head-bgcolor;
       font-weight: 500;
     }
   }

--- a/components/style/themes/default.less
+++ b/components/style/themes/default.less
@@ -264,3 +264,9 @@
 // ---
 @rate-star-color: #f5a623;
 @rate-star-bg: #e9e9e9;
+
+// Card
+// ---
+@card-head-height: 48px;
+@card-head-color: @heading-color;
+@card-head-bgcolor: @component-background;

--- a/components/style/themes/default.less
+++ b/components/style/themes/default.less
@@ -269,4 +269,4 @@
 // ---
 @card-head-height: 48px;
 @card-head-color: @heading-color;
-@card-head-bgcolor: @component-background;
+@card-head-background: @component-background;


### PR DESCRIPTION
I did a pull request yesterday, now looking back, I think changing from `background-color` to `background` makes more sense (line 25), because that gives more flexibility to the mixin. (eg, use shorthand)