### PR TITLE
Move filterOption to AbstractSelectProps in Select Component

### DIFF
--- a/components/select/index.tsx
+++ b/components/select/index.tsx
@@ -19,6 +19,7 @@ export interface AbstractSelectProps {
   disabled?: boolean;
   style?: React.CSSProperties;
   placeholder?: string;
+  filterOption?: boolean | ((inputValue: string, option: Object) => any);
 }
 
 export interface SelectProps extends AbstractSelectProps {
@@ -26,7 +27,6 @@ export interface SelectProps extends AbstractSelectProps {
   defaultValue?: SelectValue;
   combobox?: boolean;
   multiple?: boolean;
-  filterOption?: boolean | ((inputValue: string, option: Object) => any);
   tags?: boolean;
   onSelect?: (value: SelectValue, option: Object) => any;
   onDeselect?: (value: SelectValue) => any;


### PR DESCRIPTION
Currently the Autocomplete component breaks in Typescript when calling filterOption.

Autocomplete props extend AbstractSelectProps, but filterOption is only available in SelectProps. I have just rearranged so both components can use filterOption.