### PR TITLE
improve Form.create ts definition of Form

### DIFF
--- a/components/form/Form.tsx
+++ b/components/form/Form.tsx
@@ -75,14 +75,11 @@ export type WrappedFormUtils = {
 }
 
 export interface FormComponentProps {
-  form?: WrappedFormUtils;
+  form: WrappedFormUtils;
 }
 
-export class FormComponent extends React.Component<FormComponentProps, {}> {
-}
-
-export interface ComponentDecorator {
-  <T extends (typeof FormComponent)>(component: T): T;
+export interface ComponentDecorator<TOwnProps> {
+  (component: React.ComponentClass<FormComponentProps & TOwnProps>): React.ComponentClass<TOwnProps>;
 }
 
 export default class Form extends React.Component<FormProps, any> {
@@ -109,7 +106,7 @@ export default class Form extends React.Component<FormProps, any> {
 
   static Item = FormItem;
 
-  static create = (options?: FormCreateOption): ComponentDecorator => {
+  static create = <TOwnProps extends any>(options?: FormCreateOption): ComponentDecorator<TOwnProps> => {
     const formWrapper = createDOMForm(assign({
       fieldNameProp: 'id',
     }, options, {

--- a/components/form/Form.tsx
+++ b/components/form/Form.tsx
@@ -106,7 +106,7 @@ export default class Form extends React.Component<FormProps, any> {
 
   static Item = FormItem;
 
-  static create = <TOwnProps extends any>(options?: FormCreateOption): ComponentDecorator<TOwnProps> => {
+  static create = function<TOwnProps>(options?: FormCreateOption): ComponentDecorator<TOwnProps> {
     const formWrapper = createDOMForm(assign({
       fieldNameProp: 'id',
     }, options, {


### PR DESCRIPTION
when set `strictNullChecks: true` in `tsconfig.json`, `this.props.form` ts definition is `WrappedFormUtils | undefined`, it is unreasonable, so I make it necessary.
![image](https://cloud.githubusercontent.com/assets/16483610/24136247/d4ba7ad4-0e48-11e7-9246-99a6cb3356fc.png)
