### PR TITLE
update Modal.<type>'s locale on LocaleProvider componentWillMount (fixes #5493)

### DIFF
--- a/components/locale-provider/index.tsx
+++ b/components/locale-provider/index.tsx
@@ -34,7 +34,7 @@ export default class LocaleProvider extends React.Component<LocaleProviderProps,
     };
   }
 
-  componentDidMount() {
+  componentWillMount() {
     this.componentDidUpdate();
   }
 


### PR DESCRIPTION
Fixes #5493 by ensuring that the correct locale is set for `Modal.<type>` before any children are mounted.

---
Please makes sure these boxes are checked before submitting your PR, thank you!

* [X] Make sure you propose PR to correct branch: bugfix for `master`, feature for latest active branch `feature-x.x`.
* [X] Make sure you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [X] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [X] Rebase before creating a PR to keep commit history clear.
* [X] Add some descriptions and refer relative issues for you PR.
