### PR TITLE
Add selectable option into Menu documentation

### DIFF
--- a/components/menu/index.en-US.md
+++ b/components/menu/index.en-US.md
@@ -30,6 +30,7 @@ More layout and samples: [layout](/docs/spec/layout).
 |----------|---------------|----------|--------------|
 | theme    | color of the theme | string: `light` `dark` | `light` |
 | mode | type of the menu; vertical, horizontal, and inline modes are supported | string: vertical horizontal inline | vertical |
+| selectable | allow selecting menu items | boolean | true |
 | selectedKeys | array with the keys of currently selected menu items | string[] |      |
 | defaultSelectedKeys | array with the keys of default selected menu items | string[] |      |
 | openKeys | array with the keys of currently opened sub menus | string[] |  |
@@ -58,7 +59,7 @@ More layout and samples: [layout](/docs/spec/layout).
 | disabled    | disabled or not | boolean   |  false  |
 | key   | unique id of the menu item |  string |  |
 | title    | title of the sub menu | string\|ReactNode   |    |
-| children | sub menus or sub menu items | Arrat<MenuItem\|SubMenu> |  |
+| children | sub menus or sub menu items | Array<MenuItem\|SubMenu> |  |
 | onTitleClick | callback of the clicked sub menu title | Function({ eventKey, domEvent }) |  |
 
 ### Menu.ItemGroup props


### PR DESCRIPTION
I had to read the source code to figure out that there was a property called selectable. So hopefully this will help save someone time. (Though this is an option in the rc-menu I made a PR there to add it in the doc also https://github.com/react-component/menu/pull/79)

(I was trying to make a contextmenu out of this menu component which is why I needed to turn selectable off)