### PR TITLE
 Autocomplete async bug

### DIFF
--- a/components/auto-complete/InputElement.tsx
+++ b/components/auto-complete/InputElement.tsx
@@ -10,6 +10,7 @@ export default class InputElement extends React.Component<any, any> {
     };
   }
   set refs(ref) {
+    this.ele = ref.ele;
   }
 
   focus = () => {

--- a/components/auto-complete/InputElement.tsx
+++ b/components/auto-complete/InputElement.tsx
@@ -4,6 +4,14 @@ import { findDOMNode } from 'react-dom';
 export default class InputElement extends React.Component<any, any> {
   private ele: HTMLInputElement;
 
+  get refs(): any {
+    return {
+      input: findDOMNode(this.ele),
+    };
+  }
+  set refs(ref) {
+  }
+
   focus = () => {
     this.ele.focus ? this.ele.focus() : (findDOMNode(this.ele) as HTMLInputElement).focus();
   }

--- a/components/auto-complete/demo/antd.md
+++ b/components/auto-complete/demo/antd.md
@@ -26,13 +26,15 @@ class Complete extends React.Component {
   }
 
   handleChange = (value) => {
-    this.setState({
-      dataSource: !value ? [] : [
-        value,
-        value + value,
-        value + value + value,
-      ],
-    });
+    setTimeout(() => {
+      this.setState({
+        dataSource: !value ? [] : [
+          value,
+          value + value,
+          value + value + value,
+        ],
+      });
+    }, 500);
   }
 
   handleKeyPress = (ev) => {


### PR DESCRIPTION
 + ref https://github.com/react-component/select/pull/177
 + getInputDOMNode cannot get correct input element, so `document.activeElement
 === this.getInputDOMNode())` will always false.
 + add scheme of `getInputElement`: if getInputElement returns an `React.Element`, the element must implemented `refs.input` to point to its real input element.