### PR TITLE
修复 Pagination Item 改成 inline-block 布局之后的垂直对齐问题

### DIFF
--- a/components/pagination/style/index.less
+++ b/components/pagination/style/index.less
@@ -31,6 +31,7 @@
     height: 28px;
     line-height: 28px;
     text-align: center;
+    vertical-align: middle;
     list-style: none;
     display: inline-block;
     border: @border-width-base @border-style-base @border-color-base;
@@ -118,6 +119,7 @@
     height: 28px;
     line-height: 28px;
     text-align: center;
+    vertical-align: middle;
     transition: all 0.3s ease;
     display: inline-block;
   }
@@ -188,6 +190,7 @@
   &-options {
     display: inline-block;
     margin-left: 15px;
+    vertical-align: middle;
     &-size-changer {
       display: inline-block;
       margin-right: 10px;


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/4098913/24751161/194c92f4-1afb-11e7-87b6-3dc9bc82ef3c.png)
![image](https://cloud.githubusercontent.com/assets/4098913/24751179/2ce0ec84-1afb-11e7-9170-4c6410d923a0.png)

