### PR TITLE
add `min-width`

### DIFF
--- a/components/table/style/index.less
+++ b/components/table/style/index.less
@@ -148,12 +148,14 @@
   &-thead > tr > th.@{table-prefix-cls}-selection-column,
   &-tbody > tr > td.@{table-prefix-cls}-selection-column {
     text-align: center;
+    min-width: 62px;
     width: 62px;
   }
 
   &-expand-icon-th,
   &-row-expand-icon-cell {
     text-align: center;
+    min-width: 50px;
     width: 50px;
   }
 


### PR DESCRIPTION
selection-column and expand-icon-th
if the width total of your columns >= 100%, must have `min-width`.

#5423