### PR TITLE
Fix for issue #5712

### DIFF
--- a/components/locale-provider/style/index.less
+++ b/components/locale-provider/style/index.less
@@ -1,1 +1,3 @@
 // placeholder
+@import "../../style/themes/default";
+@import "../../style/core/index";


### PR DESCRIPTION
Using webpack + babel-plugin-import, we can create a custom theme defined in a JS file. However, when we use LocaleProvider, ant-design's LESS variables such as colors are undefined. This PR makes the necessary inclusion of LESS files so that ant-design's LESS variables continue to be defined when LocaleProvider is used.

First of all, thanks for your contribution! :-)

Please makes sure these boxes are checked before submitting your PR, thank you!

* [x ] Make sure you propose PR to correct branch: bugfix for `master`, feature for latest active branch `feature-x.x`.
* [x ] Make sure you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x ] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x ] Rebase before creating a PR to keep commit history clear.
* [x ] Add some descriptions and refer relative issues for you PR.
