### PR TITLE
not aligned after customizing the size of input

### DIFF
--- a/components/date-picker/style/RangePicker.less
+++ b/components/date-picker/style/RangePicker.less
@@ -3,8 +3,8 @@
 .@{calendar-prefix-cls}-range-picker-input {
   background-color: transparent;
   border: 0;
-  height: 18px;
-  line-height: 18px;
+  height: 100%;
+  line-height: 100%;
   outline: 0;
   width: 43%;
   text-align: center;


### PR DESCRIPTION
For some reasons I customized the size of <Input/>. Now the default height of <Input> is 40px. But there's a problem in <RangePicker/> after doing that: the texts and icon inside it are not aligned vertically at center.

![image](https://cloud.githubusercontent.com/assets/12868055/24905727/7aefa24a-1ee7-11e7-894d-b0102c13e2e6.png)

When I look into the code I found the height of `ant-calendar-range-picker-input` is 18px. I modified it to 100% and it aligned. I'm not sure if it can affect the other code.

----------------------------------------
因为某些原因我自定义了 <Input/> 的尺寸，现在它的默认高度是40px。但是当我使用 <RangePicker/> 组件时，我发现了一个问题：输入框里面的文字和图标在垂直方向不能居中对齐。我看了一下 css 代码，发现里面的 `ant-calendar-range-picker-input` 高度是固定的18px，我把它改成100%就可以垂直居中对齐了。我不知道这个改动是否会影响其他代码。

First of all, thanks for your contribution! :-)

Please makes sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you propose PR to correct branch: bugfix for `master`, feature for latest active branch `feature-x.x`.
* [x] Make sure you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.
