### PR TITLE
use PropTypes from 'prop-types' mdoule instead of React

### DIFF
--- a/components/affix/index.tsx
+++ b/components/affix/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import PropTypes from 'prop-types';
 import addEventListener from 'rc-util/lib/Dom/addEventListener';
 import classNames from 'classnames';
 import shallowequal from 'shallowequal';
@@ -60,9 +61,9 @@ export interface AffixProps {
 
 export default class Affix extends React.Component<AffixProps, any> {
   static propTypes = {
-    offsetTop: React.PropTypes.number,
-    offsetBottom: React.PropTypes.number,
-    target: React.PropTypes.func,
+    offsetTop: PropTypes.number,
+    offsetBottom: PropTypes.number,
+    target: PropTypes.func,
   };
 
   scrollEvent: any;

--- a/components/anchor/AnchorLink.tsx
+++ b/components/anchor/AnchorLink.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import AnchorHelper, { scrollTo } from './anchorHelper';
 
@@ -18,7 +19,7 @@ export interface AnchorLinkProps {
 export default class AnchorLink extends React.Component<AnchorLinkProps, any> {
   static __ANT_ANCHOR_LINK = true;
   static contextTypes = {
-    anchorHelper: React.PropTypes.any,
+    anchorHelper: PropTypes.any,
   };
 
   static defaultProps = {

--- a/components/anchor/index.tsx
+++ b/components/anchor/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import addEventListener from 'rc-util/lib/Dom/addEventListener';
 import AnchorLink from './AnchorLink';
@@ -27,7 +28,7 @@ export default class Anchor extends React.Component<AnchorProps, any> {
   };
 
   static childContextTypes = {
-    anchorHelper: React.PropTypes.any,
+    anchorHelper: PropTypes.any,
   };
 
   refs: {

--- a/components/breadcrumb/Breadcrumb.tsx
+++ b/components/breadcrumb/Breadcrumb.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { cloneElement } from 'react';
 import warning from '../_util/warning';
 import BreadcrumbItem from './BreadcrumbItem';
@@ -43,12 +44,12 @@ export default class Breadcrumb extends React.Component<BreadcrumbProps, any> {
   };
 
   static propTypes = {
-    prefixCls: React.PropTypes.string,
-    separator: React.PropTypes.node,
-    routes: React.PropTypes.array,
-    params: React.PropTypes.object,
-    linkRender: React.PropTypes.func,
-    nameRender: React.PropTypes.func,
+    prefixCls: PropTypes.string,
+    separator: PropTypes.node,
+    routes: PropTypes.array,
+    params: PropTypes.object,
+    linkRender: PropTypes.func,
+    nameRender: PropTypes.func,
   };
 
   componentDidMount() {

--- a/components/button/button.tsx
+++ b/components/button/button.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Icon from '../icon';
 import omit from 'omit.js';
@@ -60,14 +61,14 @@ export default class Button extends React.Component<ButtonProps, any> {
   };
 
   static propTypes = {
-    type: React.PropTypes.string,
-    shape: React.PropTypes.oneOf(['circle', 'circle-outline']),
-    size: React.PropTypes.oneOf(['large', 'default', 'small']),
-    htmlType: React.PropTypes.oneOf(['submit', 'button', 'reset']),
-    onClick: React.PropTypes.func,
-    loading: React.PropTypes.oneOfType([React.PropTypes.bool, React.PropTypes.object]),
-    className: React.PropTypes.string,
-    icon: React.PropTypes.string,
+    type: PropTypes.string,
+    shape: PropTypes.oneOf(['circle', 'circle-outline']),
+    size: PropTypes.oneOf(['large', 'default', 'small']),
+    htmlType: PropTypes.oneOf(['submit', 'button', 'reset']),
+    onClick: PropTypes.func,
+    loading: PropTypes.oneOfType([PropTypes.bool, PropTypes.object]),
+    className: PropTypes.string,
+    icon: PropTypes.string,
   };
 
   timeout: number;

--- a/components/checkbox/Group.tsx
+++ b/components/checkbox/Group.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Checkbox from './Checkbox';
 import PureRenderMixin from 'rc-util/lib/PureRenderMixin';
@@ -34,10 +35,10 @@ export default class CheckboxGroup extends React.Component<CheckboxGroupProps, C
     prefixCls: 'ant-checkbox-group',
   };
   static propTypes = {
-    defaultValue: React.PropTypes.array,
-    value: React.PropTypes.array,
-    options: React.PropTypes.array.isRequired,
-    onChange: React.PropTypes.func,
+    defaultValue: PropTypes.array,
+    value: PropTypes.array,
+    options: PropTypes.array.isRequired,
+    onChange: PropTypes.func,
   };
   constructor(props) {
     super(props);

--- a/components/date-picker/RangePicker.tsx
+++ b/components/date-picker/RangePicker.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import moment from 'moment';
+import PropTypes from 'prop-types';
 import RangeCalendar from 'rc-calendar/lib/RangeCalendar';
 import RcDatePicker from 'rc-calendar/lib/Picker';
 import classNames from 'classnames';
@@ -10,7 +11,7 @@ import warning from '../_util/warning';
 
 export default class RangePicker extends React.Component<any, any> {
   static contextTypes = {
-      antLocale: React.PropTypes.object,
+      antLocale: PropTypes.object,
   };
   static defaultProps = {
     prefixCls: 'ant-calendar',

--- a/components/date-picker/createPicker.tsx
+++ b/components/date-picker/createPicker.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import moment from 'moment';
+import PropTypes from 'prop-types';
 import MonthCalendar from 'rc-calendar/lib/MonthCalendar';
 import RcDatePicker from 'rc-calendar/lib/Picker';
 import classNames from 'classnames';
@@ -18,7 +19,7 @@ export default function createPicker(TheCalendar) {
   // use class typescript error
   const CalenderWrapper = React.createClass<any, any>({
     contextTypes: {
-      antLocale: React.PropTypes.object,
+      antLocale: PropTypes.object,
     },
     getDefaultProps() {
       return {

--- a/components/form/FormItem.tsx
+++ b/components/form/FormItem.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import PureRenderMixin from 'rc-util/lib/PureRenderMixin';
 import Row from '../row';
@@ -41,22 +42,22 @@ export default class FormItem extends React.Component<FormItemProps, any> {
   };
 
   static propTypes = {
-    prefixCls: React.PropTypes.string,
-    label: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.node]),
-    labelCol: React.PropTypes.object,
-    help: React.PropTypes.oneOfType([React.PropTypes.node, React.PropTypes.bool]),
-    validateStatus: React.PropTypes.oneOf(['', 'success', 'warning', 'error', 'validating']),
-    hasFeedback: React.PropTypes.bool,
-    wrapperCol: React.PropTypes.object,
-    className: React.PropTypes.string,
-    id: React.PropTypes.string,
-    children: React.PropTypes.node,
-    colon: React.PropTypes.bool,
+    prefixCls: PropTypes.string,
+    label: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+    labelCol: PropTypes.object,
+    help: PropTypes.oneOfType([PropTypes.node, PropTypes.bool]),
+    validateStatus: PropTypes.oneOf(['', 'success', 'warning', 'error', 'validating']),
+    hasFeedback: PropTypes.bool,
+    wrapperCol: PropTypes.object,
+    className: PropTypes.string,
+    id: PropTypes.string,
+    children: PropTypes.node,
+    colon: PropTypes.bool,
   };
 
   static contextTypes = {
-    form: React.PropTypes.object,
-    vertical: React.PropTypes.bool,
+    form: PropTypes.object,
+    vertical: PropTypes.bool,
   };
 
   context: FormItemContext;

--- a/components/grid/row.tsx
+++ b/components/grid/row.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Children, cloneElement } from 'react';
 import classNames from 'classnames';
 import assign from 'object-assign';
+import PropTypes from 'prop-types';
 
 export interface RowProps {
   className?: string;
@@ -19,13 +20,13 @@ export default class Row extends React.Component<RowProps, any> {
   };
 
   static propTypes = {
-    type: React.PropTypes.string,
-    align: React.PropTypes.string,
-    justify: React.PropTypes.string,
-    className: React.PropTypes.string,
-    children: React.PropTypes.node,
-    gutter: React.PropTypes.number,
-    prefixCls: React.PropTypes.string,
+    type: PropTypes.string,
+    align: PropTypes.string,
+    justify: PropTypes.string,
+    className: PropTypes.string,
+    children: PropTypes.node,
+    gutter: PropTypes.number,
+    prefixCls: PropTypes.string,
   };
   render() {
     const { type, justify, align, className, gutter, style, children,

--- a/components/locale-provider/index.tsx
+++ b/components/locale-provider/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { changeConfirmLocale } from '../modal/locale';
 
 export interface LocaleProviderProps {
@@ -18,11 +19,11 @@ export interface LocaleProviderProps {
 
 export default class LocaleProvider extends React.Component<LocaleProviderProps, any> {
   static propTypes = {
-    locale: React.PropTypes.object,
+    locale: PropTypes.object,
   };
 
   static childContextTypes = {
-    antLocale: React.PropTypes.object,
+    antLocale: PropTypes.object,
   };
 
   getChildContext() {

--- a/components/modal/Modal.tsx
+++ b/components/modal/Modal.tsx
@@ -1,6 +1,6 @@
-import { PropTypes } from 'react';
 import React from 'react';
 import Dialog from 'rc-dialog';
+import PropTypes from 'prop-types';
 import addEventListener from 'rc-util/lib/Dom/addEventListener';
 import Button from '../button';
 
@@ -93,7 +93,7 @@ export default class Modal extends React.Component<ModalProps, any> {
   };
 
   static contextTypes = {
-    antLocale: React.PropTypes.object,
+    antLocale: PropTypes.object,
   };
 
   context: ModalContext;

--- a/components/select/index.tsx
+++ b/components/select/index.tsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import RcSelect, { Option, OptGroup } from 'rc-select';
 import classNames from 'classnames';
 import warning from '../_util/warning';
@@ -90,7 +91,7 @@ export default class Select extends React.Component<SelectProps, any> {
   };
 
   static contextTypes = {
-    antLocale: React.PropTypes.object,
+    antLocale: PropTypes.object,
   };
 
   context: SelectContext;

--- a/components/table/Table.tsx
+++ b/components/table/Table.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import RcTable from 'rc-table';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import assign from 'object-assign';
 import Pagination, { PaginationProps } from '../pagination';
@@ -102,21 +103,21 @@ export default class Table<T> extends React.Component<TableProps<T>, any> {
   static ColumnGroup = ColumnGroup;
 
   static propTypes = {
-    dataSource: React.PropTypes.array,
-    columns: React.PropTypes.array,
-    prefixCls: React.PropTypes.string,
-    useFixedHeader: React.PropTypes.bool,
-    rowSelection: React.PropTypes.object,
-    className: React.PropTypes.string,
-    size: React.PropTypes.string,
-    loading: React.PropTypes.oneOfType([
-      React.PropTypes.bool,
-      React.PropTypes.object,
+    dataSource: PropTypes.array,
+    columns: PropTypes.array,
+    prefixCls: PropTypes.string,
+    useFixedHeader: PropTypes.bool,
+    rowSelection: PropTypes.object,
+    className: PropTypes.string,
+    size: PropTypes.string,
+    loading: PropTypes.oneOfType([
+      PropTypes.bool,
+      PropTypes.object,
     ]),
-    bordered: React.PropTypes.bool,
-    onChange: React.PropTypes.func,
-    locale: React.PropTypes.object,
-    dropdownPrefixCls: React.PropTypes.string,
+    bordered: PropTypes.bool,
+    onChange: PropTypes.func,
+    locale: PropTypes.object,
+    dropdownPrefixCls: PropTypes.string,
   };
 
   static defaultProps = {
@@ -135,7 +136,7 @@ export default class Table<T> extends React.Component<TableProps<T>, any> {
   };
 
   static contextTypes = {
-    antLocale: React.PropTypes.object,
+    antLocale: PropTypes.object,
   };
 
   context: TableContext;

--- a/components/upload/Upload.tsx
+++ b/components/upload/Upload.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import RcUpload from 'rc-upload';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import assign from 'object-assign';
 import Dragger from './Dragger';
@@ -41,7 +42,7 @@ export default class Upload extends React.Component<UploadProps, any> {
   };
 
   static contextTypes = {
-    antLocale: React.PropTypes.object,
+    antLocale: PropTypes.object,
   };
 
   context: UploadContext;

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "moment": "^2.18.1",
     "object-assign": "~4.1.0",
     "omit.js": "^0.1.0",
+    "prop-types": "^15.5.7",
     "rc-animate": "~2.3.0",
     "rc-calendar": "~7.8.0",
     "rc-cascader": "~0.11.0",

--- a/site/theme/template/Content/ComponentDoc.jsx
+++ b/site/theme/template/Content/ComponentDoc.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import DocumentTitle from 'react-document-title';
 import { FormattedMessage } from 'react-intl';
 import classNames from 'classnames';
@@ -9,7 +10,7 @@ import EditButton from './EditButton';
 
 export default class ComponentDoc extends React.Component {
   static contextTypes = {
-    intl: React.PropTypes.object,
+    intl: PropTypes.object,
   }
 
   constructor(props) {

--- a/site/theme/template/Content/Demo.jsx
+++ b/site/theme/template/Content/Demo.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import CopyToClipboard from 'react-copy-to-clipboard';
 import classNames from 'classnames';
@@ -9,7 +10,7 @@ import BrowserFrame from '../BrowserFrame';
 
 export default class Demo extends React.Component {
   static contextTypes = {
-    intl: React.PropTypes.object,
+    intl: PropTypes.object,
   }
 
   constructor(props) {

--- a/site/theme/template/Layout/index.jsx
+++ b/site/theme/template/Layout/index.jsx
@@ -1,5 +1,6 @@
 import React, { cloneElement } from 'react';
 import ReactDOM from 'react-dom';
+import PropTypes from 'prop-types';
 import { addLocaleData, IntlProvider } from 'react-intl';
 import { LocaleProvider } from 'antd';
 import enUS from 'antd/lib/locale-provider/en_US';
@@ -22,7 +23,7 @@ if (typeof window !== 'undefined') {
 
 export default class Layout extends React.Component {
   static contextTypes = {
-    router: React.PropTypes.object.isRequired,
+    router: PropTypes.object.isRequired,
   }
 
   constructor(props) {


### PR DESCRIPTION
 - as React.PropTypes is being deprecated
 - Warning: Accessing PropTypes via the main React package is deprecated. Use the prop-types package from npm instead.
 - Solution: https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html#migrating-from-react.proptypes

First of all, thanks for your contribution! :-)

Please makes sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you propose PR to correct branch: bugfix for `master`, feature for latest active branch `feature-x.x`. (I am not sure about this, please help me raise this PR against correct branch)
* [x] Make sure you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.
