### PR TITLE
fix:  issue 5707 override the default a:focus style when it nested in menu component

### DIFF
--- a/components/menu/style/index.less
+++ b/components/menu/style/index.less
@@ -53,6 +53,9 @@
     &:hover {
       color: @primary-color;
     }
+    &:focus {
+      text-decoration: none;
+    }
     &:before {
       position: absolute;
       background-color: transparent;


### PR DESCRIPTION
#5707 
