### PR TITLE
feat: add table padding parameters for customizing

### DIFF
--- a/components/style/themes/default.less
+++ b/components/style/themes/default.less
@@ -256,6 +256,8 @@
 // --
 @table-header-bg: @background-color-base;
 @table-row-hover-bg: @primary-1;
+@table-padding-vertical: 16px;
+@table-padding-horizontal: 8px;
 
 // TimePicker
 // ---

--- a/components/table/style/index.less
+++ b/components/table/style/index.less
@@ -75,7 +75,7 @@
   }
 
   &-footer {
-    padding: 16px 8px;
+    padding: @table-padding-vertical @table-padding-horizontal;
     background: @table-header-bg;
     border-radius: 0 0 @border-radius-base @border-radius-base;
     position: relative;
@@ -95,7 +95,7 @@
   }
 
   &-title {
-    padding: 16px 0;
+    padding: @table-padding-vertical 0;
     position: relative;
     top: 1px;
     border-radius: @border-radius-base @border-radius-base 0 0;
@@ -103,8 +103,8 @@
 
   &.@{table-prefix-cls}-bordered &-title {
     border: @border-width-base @border-style-base @border-color-split;
-    padding-left: 8px;
-    padding-right: 8px;
+    padding-left: @table-padding-horizontal;
+    padding-right: @table-padding-horizontal;
   }
 
   &-title + &-content {
@@ -135,7 +135,7 @@
 
   &-thead > tr > th,
   &-tbody > tr > td {
-    padding: 16px 8px;
+    padding: @table-padding-vertical @table-padding-horizontal;
     word-break: break-all;
   }
 
@@ -361,7 +361,7 @@
 
   &-placeholder {
     position: relative;
-    padding: 16px 8px;
+    padding: @table-padding-vertical @table-padding-horizontal;
     background: @component-background;
     border-bottom: @border-width-base @border-style-base @border-color-split;
     text-align: center;


### PR DESCRIPTION
Basically, I use columns.render and columns.title to add padding of table columns, but when sorter and filter applied, padding will be added before the icons of them unexpectedly

![image](https://cloud.githubusercontent.com/assets/5318333/25121137/3a0ed888-2453-11e7-934a-25f86f90f032.png)


I think css overriding is complex and confusing, so is this a better way to allow user to customize table padding?

And am i missing something?

cc @benjycui 