### PR TITLE
Set the color on input suffix

### DIFF
--- a/components/input/style/mixin.less
+++ b/components/input/style/mixin.less
@@ -303,6 +303,7 @@
     transform: translateY(-50%);
     z-index: 2;
     line-height: 0;
+    color: @input-color;
   }
 
   .@{inputClass}-prefix {


### PR DESCRIPTION
By default the `input-suffix` uses `@text-color` which may not be readable on the input. In my case my text-color is white and input backgrounds are white.

`input-suffix` should instead use the `@input-color`