### PR TITLE
fix firefox Layout.Sider can't collapse to zero width

### DIFF
--- a/components/layout/style/index.less
+++ b/components/layout/style/index.less
@@ -41,6 +41,8 @@
     transition: all .3s @ease-out;
     position: relative;
     background: @layout-sider-background;
+     /* fix firefox can't set width smaller than content on flex item */
+    min-width: 0;
 
     &-has-trigger {
       padding-bottom: @layout-trigger-height;


### PR DESCRIPTION
close #5613 