### PR TITLE
Add a less variable to opt out of form item colons

### DIFF
--- a/components/form/style/index.less
+++ b/components/form/style/index.less
@@ -98,7 +98,12 @@ input[type="checkbox"] {
       color: @label-color;
 
       &:after {
-        content: ":";
+        & when (@form-item-trailing-colon=true) {
+          content: ":";
+        }
+        & when not (@form-item-trailing-colon=true) {
+          content: " ";
+        }
         margin: 0 8px 0 2px;
         position: relative;
         top: -0.5px;

--- a/components/style/themes/default.less
+++ b/components/style/themes/default.less
@@ -194,6 +194,7 @@
 @label-required-color        : @highlight-color;
 @label-color                 : @text-color;
 @form-item-margin-bottom     : 24px;
+@form-item-trailing-colon    : true;
 
 // Input
 // ---


### PR DESCRIPTION
Colons disabled (@form-item-trailing-colon: false):

![image](https://cloud.githubusercontent.com/assets/3475472/25289817/2eb4bd52-2699-11e7-9e9d-013dee929895.png)

Colons enabled (@form-item-trailing-colon: true):

![image](https://cloud.githubusercontent.com/assets/3475472/25289840/4ef6a990-2699-11e7-8e5c-7f808d9a4bb3.png)

Our designer wanted to opt out of manadatory colons here