### PR TITLE
Add transition for the ant-tabs-ink-bar width

### DIFF
--- a/components/tabs/style/index.less
+++ b/components/tabs/style/index.less
@@ -20,7 +20,7 @@
     background-color: @primary-color;
     transform-origin: 0 0;
     &-animated {
-      transition: transform 0.3s @ease-in-out;
+      transition: transform 0.3s @ease-in-out, width 0.3s @ease-in-out;
     }
   }
 


### PR DESCRIPTION
Currently when Tabs titles have very different width, the ink-bar width change without transition.
