### PR TITLE
Use @primary-1 for collapse active state

### DIFF
--- a/components/collapse/style/index.less
+++ b/components/collapse/style/index.less
@@ -28,7 +28,7 @@
       transition: all .3s;
 
       &:active {
-        background-color: #eee!important;
+        background-color: @primary-1 !important;
       }
 
       .arrow {

--- a/components/collapse/style/index.less
+++ b/components/collapse/style/index.less
@@ -3,6 +3,8 @@
 
 @collapse-prefix-cls: ~"@{ant-prefix}-collapse";
 
+@collapse-hover-bg: @primary-1;
+
 .collapse-close() {
   .iconfont-size-under-12px(9px, 0);
 }
@@ -28,7 +30,7 @@
       transition: all .3s;
 
       &:active {
-        background-color: @primary-1 !important;
+        background-color: @collapse-hover-bg !important;
       }
 
       .arrow {

--- a/components/collapse/style/index.less
+++ b/components/collapse/style/index.less
@@ -3,7 +3,7 @@
 
 @collapse-prefix-cls: ~"@{ant-prefix}-collapse";
 
-@collapse-hover-bg: @primary-1;
+@collapse-active-bg: @primary-1;
 
 .collapse-close() {
   .iconfont-size-under-12px(9px, 0);
@@ -30,7 +30,7 @@
       transition: all .3s;
 
       &:active {
-        background-color: @collapse-hover-bg !important;
+        background-color: @collapse-active-bg !important;
       }
 
       .arrow {


### PR DESCRIPTION
`#eee` is a terrible colour on dark themes ;)

I selected `@primary-1` based on looking at the `:active` states used in several other places (such as `select`). 

Before:

![output](https://cloud.githubusercontent.com/assets/3475472/25356325/c2569466-2907-11e7-9525-ee50f57a71db.gif)


Now:

![output](https://cloud.githubusercontent.com/assets/3475472/25356279/9e2902fe-2907-11e7-8086-728186bd1204.gif)

