### PR TITLE
Fix calendar input background to use @input-bg

### DIFF
--- a/components/date-picker/style/Calendar.less
+++ b/components/date-picker/style/Calendar.less
@@ -109,6 +109,7 @@
     outline: 0;
     height: 22px;
     color: @input-color;
+    background: @input-bg;
   }
 
   &-week-number {


### PR DESCRIPTION
Currently it correctly sets the color but not the background. Rangepicker's use the correct value.