### PR TITLE
Add variables for customizing alert text and heading colors

### DIFF
--- a/components/alert/style/index.less
+++ b/components/alert/style/index.less
@@ -2,11 +2,14 @@
 
 @alert-prefix-cls: ~"@{ant-prefix}-alert";
 
+@alert-message-color: @heading-color;
+@alert-text-color: @text-color;
+
 .@{alert-prefix-cls} {
   position: relative;
   padding: 8px 48px 8px 38px;
   border-radius: @border-radius-base;
-  color: @text-color;
+  color: @alert-text-color;
   font-size: @font-size-base;
   line-height: 16px;
   margin-bottom: 10px;
@@ -114,7 +117,7 @@
 
   &-with-description &-message {
     font-size: @font-size-lg;
-    color: @heading-color;
+    color: @alert-message-color;
     display: block;
     margin-bottom: 4px;
   }


### PR DESCRIPTION
As alerts have different backgrounds than `@component-background` and `@body-background` the user may want to customize the text color for these.