### PR TITLE
Add @active-item-bg to control hover and active states

### DIFF
--- a/components/calendar/style/index.less
+++ b/components/calendar/style/index.less
@@ -100,7 +100,7 @@
     transition: all .3s;
 
     &:hover {
-      background: @active-item-bg;
+      background: @item-hover-bg;
       cursor: pointer;
     }
 
@@ -195,7 +195,7 @@
     transition: background .3s;
 
     &:hover {
-      background: @active-item-bg;
+      background: @item-hover-bg;
       cursor: pointer;
     }
 

--- a/components/calendar/style/index.less
+++ b/components/calendar/style/index.less
@@ -100,7 +100,7 @@
     transition: all .3s;
 
     &:hover {
-      background: @primary-1;
+      background: @active-item-bg;
       cursor: pointer;
     }
 
@@ -195,7 +195,7 @@
     transition: background .3s;
 
     &:hover {
-      background: @primary-1;
+      background: @active-item-bg;
       cursor: pointer;
     }
 

--- a/components/cascader/style/index.less
+++ b/components/cascader/style/index.less
@@ -162,7 +162,7 @@
     white-space: nowrap;
     transition: all 0.3s;
     &:hover {
-      background: @active-item-bg;
+      background: @item-hover-bg;
     }
     &-disabled {
       cursor: not-allowed;

--- a/components/cascader/style/index.less
+++ b/components/cascader/style/index.less
@@ -162,7 +162,7 @@
     white-space: nowrap;
     transition: all 0.3s;
     &:hover {
-      background: @primary-1;
+      background: @active-item-bg;
     }
     &-disabled {
       cursor: not-allowed;

--- a/components/collapse/style/index.less
+++ b/components/collapse/style/index.less
@@ -4,7 +4,7 @@
 @collapse-prefix-cls: ~"@{ant-prefix}-collapse";
 
 @collapse-header-bg: @background-color-base;
-@collapse-active-bg: @active-item-bg;
+@collapse-active-bg: @background-color-active;
 
 .collapse-close() {
   .iconfont-size-under-12px(9px, 0);

--- a/components/collapse/style/index.less
+++ b/components/collapse/style/index.less
@@ -2,8 +2,9 @@
 @import "../../style/mixins/index";
 
 @collapse-prefix-cls: ~"@{ant-prefix}-collapse";
-@collapse-active-bg: #eee;
+
 @collapse-header-bg: @background-color-base;
+@collapse-active-bg: @active-item-bg;
 
 .collapse-close() {
   .iconfont-size-under-12px(9px, 0);

--- a/components/date-picker/style/Calendar.less
+++ b/components/date-picker/style/Calendar.less
@@ -186,7 +186,7 @@
     }
 
     &:hover {
-      background: @primary-1;
+      background: @active-item-bg;
       cursor: pointer;
     }
 

--- a/components/date-picker/style/Calendar.less
+++ b/components/date-picker/style/Calendar.less
@@ -186,7 +186,7 @@
     }
 
     &:hover {
-      background: @active-item-bg;
+      background: @item-hover-bg;
       cursor: pointer;
     }
 

--- a/components/date-picker/style/DecadePanel.less
+++ b/components/date-picker/style/DecadePanel.less
@@ -47,7 +47,7 @@
   transition: background 0.3s ease;
 
   &:hover {
-    background: @active-item-bg;
+    background: @item-hover-bg;
     cursor: pointer;
   }
 }

--- a/components/date-picker/style/DecadePanel.less
+++ b/components/date-picker/style/DecadePanel.less
@@ -47,7 +47,7 @@
   transition: background 0.3s ease;
 
   &:hover {
-    background: @primary-1;
+    background: @active-item-bg;
     cursor: pointer;
   }
 }

--- a/components/date-picker/style/MonthPanel.less
+++ b/components/date-picker/style/MonthPanel.less
@@ -69,7 +69,7 @@
   transition: background 0.3s ease;
 
   &:hover {
-    background: @active-item-bg;
+    background: @item-hover-bg;
     cursor: pointer;
   }
 }

--- a/components/date-picker/style/MonthPanel.less
+++ b/components/date-picker/style/MonthPanel.less
@@ -69,7 +69,7 @@
   transition: background 0.3s ease;
 
   &:hover {
-    background: @primary-1;
+    background: @active-item-bg;
     cursor: pointer;
   }
 }

--- a/components/date-picker/style/RangePicker.less
+++ b/components/date-picker/style/RangePicker.less
@@ -130,7 +130,7 @@
     &:before {
       content: '';
       display: block;
-      background: @active-item-bg;
+      background: @item-active-bg;
       border-radius: 0;
       border: 0;
       position: absolute;

--- a/components/date-picker/style/RangePicker.less
+++ b/components/date-picker/style/RangePicker.less
@@ -130,7 +130,7 @@
     &:before {
       content: '';
       display: block;
-      background: @primary-1;
+      background: @active-item-bg;
       border-radius: 0;
       border: 0;
       position: absolute;

--- a/components/date-picker/style/TimePicker.less
+++ b/components/date-picker/style/TimePicker.less
@@ -96,7 +96,7 @@
     }
 
     li:hover {
-      background: @active-item-bg;
+      background: @item-hover-bg;
     }
 
     li&-option-selected {

--- a/components/date-picker/style/TimePicker.less
+++ b/components/date-picker/style/TimePicker.less
@@ -96,7 +96,7 @@
     }
 
     li:hover {
-      background: @primary-1;
+      background: @active-item-bg;
     }
 
     li&-option-selected {

--- a/components/date-picker/style/YearPanel.less
+++ b/components/date-picker/style/YearPanel.less
@@ -50,7 +50,7 @@
   transition: background 0.3s ease;
 
   &:hover {
-    background: @active-item-bg;
+    background: @item-hover-bg;
     cursor: pointer;
   }
 }

--- a/components/date-picker/style/YearPanel.less
+++ b/components/date-picker/style/YearPanel.less
@@ -50,7 +50,7 @@
   transition: background 0.3s ease;
 
   &:hover {
-    background: @primary-1;
+    background: @active-item-bg;
     cursor: pointer;
   }
 }

--- a/components/dropdown/style/index.less
+++ b/components/dropdown/style/index.less
@@ -74,11 +74,11 @@
       &-selected,
       &-selected > a {
         color: @primary-color;
-        background-color: @primary-1;
+        background-color: @active-item-bg;
       }
 
       &:hover {
-        background-color: @primary-1;
+        background-color: @active-item-bg;
       }
 
       &-disabled {

--- a/components/dropdown/style/index.less
+++ b/components/dropdown/style/index.less
@@ -74,11 +74,11 @@
       &-selected,
       &-selected > a {
         color: @primary-color;
-        background-color: @active-item-bg;
+        background-color: @item-active-bg;
       }
 
       &:hover {
-        background-color: @active-item-bg;
+        background-color: @item-hover-bg;
       }
 
       &-disabled {

--- a/components/mention/style/index.less
+++ b/components/mention/style/index.less
@@ -76,10 +76,13 @@
     overflow: hidden;
     transition: background 0.3s;
 
-    &:hover,
+    &:hover {
+      background-color: @item-hover-bg;
+    }
+
     &.focus,
     &-active {
-      background-color: @active-item-bg;
+      background-color: @item-active-bg;
     }
 
     &-disabled {

--- a/components/mention/style/index.less
+++ b/components/mention/style/index.less
@@ -79,7 +79,7 @@
     &:hover,
     &.focus,
     &-active {
-      background-color: @primary-1;
+      background-color: @active-item-bg;
     }
 
     &-disabled {

--- a/components/menu/style/index.less
+++ b/components/menu/style/index.less
@@ -40,7 +40,7 @@
 
   &-item:active,
   &-submenu-title:active {
-    background: @active-item-bg;
+    background: @item-active-bg;
   }
 
   &-submenu &-sub {
@@ -108,7 +108,7 @@
   }
 
   &:not(&-horizontal) &-item-selected {
-    background-color: @active-item-bg;
+    background-color: @item-active-bg;
   }
 
   &-horizontal,

--- a/components/menu/style/index.less
+++ b/components/menu/style/index.less
@@ -40,7 +40,7 @@
 
   &-item:active,
   &-submenu-title:active {
-    background: @primary-1;
+    background: @active-item-bg;
   }
 
   &-submenu &-sub {
@@ -108,7 +108,7 @@
   }
 
   &:not(&-horizontal) &-item-selected {
-    background-color: @primary-1;
+    background-color: @active-item-bg;
   }
 
   &-horizontal,

--- a/components/select/style/index.less
+++ b/components/select/style/index.less
@@ -128,7 +128,7 @@
   }
 
   &-disabled &-selection--multiple &-selection__choice {
-    background: #e9e9e9;
+    background: @background-color-active;
     color: #aaa;
     padding-right: 10px;
     &__remove {
@@ -479,7 +479,7 @@
       &-selected {
         &,
         &:hover {
-          background-color: @background-color-base;
+          background-color: @background-color-active;
           font-weight: bold;
           color: @text-color;
         }

--- a/components/select/style/index.less
+++ b/components/select/style/index.less
@@ -462,7 +462,7 @@
 
       &:hover,
       &-active {
-        background-color: @primary-1;
+        background-color: @active-item-bg;
       }
 
       &-disabled {

--- a/components/select/style/index.less
+++ b/components/select/style/index.less
@@ -460,9 +460,12 @@
       overflow: hidden;
       transition: background 0.3s ease;
 
-      &:hover,
+      &:hover {
+        background-color: @item-hover-bg;
+      }
+
       &-active {
-        background-color: @active-item-bg;
+        background-color: @item-active-bg;
       }
 
       &-disabled {

--- a/components/style/themes/default.less
+++ b/components/style/themes/default.less
@@ -101,6 +101,7 @@
 // Default background color for disabled states, Collapse wrappers,
 // and several active and hover states.
 @background-color-base  : #f7f7f7;
+@background-color-active: #eee;
 
 // Disabled states
 @disabled-color         : fade(#000, 25%);
@@ -320,10 +321,6 @@
 @card-head-height: 48px;
 @card-head-color: @heading-color;
 @card-head-background: @component-background;
-
-// Cascader
-// ---
-@cascader-active-color: @background-color-base;
 
 // Tabs
 // ---

--- a/components/style/themes/default.less
+++ b/components/style/themes/default.less
@@ -59,9 +59,10 @@
 @border-radius-base     : 4px;
 @border-radius-sm       : 2px;
 
-// The background color used when an item (such as a list item or table cell)
-// is active or hovered.
-@active-item-bg         : @primary-1;
+// The background colors for active and hover states for things like
+// list items or table cells.
+@item-active-bg         : @primary-1;
+@item-hover-bg          : @primary-1;
 
 // ICONFONT
 @iconfont-css-prefix    : anticon;

--- a/components/style/themes/default.less
+++ b/components/style/themes/default.less
@@ -59,6 +59,10 @@
 @border-radius-base     : 4px;
 @border-radius-sm       : 2px;
 
+// The background color used when an item (such as a list item or table cell)
+// is active or hovered.
+@active-item-bg         : @primary-1;
+
 // ICONFONT
 @iconfont-css-prefix    : anticon;
 @icon-url               : "https://at.alicdn.com/t/font_0qcp222wvwijm7vi";

--- a/components/time-picker/style/index.less
+++ b/components/time-picker/style/index.less
@@ -126,7 +126,7 @@
     }
 
     li:hover {
-      background: @primary-1;
+      background: @active-item-bg;
     }
 
     li&-option-selected {

--- a/components/time-picker/style/index.less
+++ b/components/time-picker/style/index.less
@@ -126,7 +126,7 @@
     }
 
     li:hover {
-      background: @active-item-bg;
+      background: @item-hover-bg;
     }
 
     li&-option-selected {

--- a/components/transfer/style/index.less
+++ b/components/transfer/style/index.less
@@ -102,7 +102,7 @@
 
       &-item:not(&-item-disabled):hover {
         cursor: pointer;
-        background-color: @primary-1;
+        background-color: @active-item-bg;
       }
 
       &-item-disabled {

--- a/components/transfer/style/index.less
+++ b/components/transfer/style/index.less
@@ -102,7 +102,7 @@
 
       &-item:not(&-item-disabled):hover {
         cursor: pointer;
-        background-color: @active-item-bg;
+        background-color: @item-hover-bg;
       }
 
       &-item-disabled {

--- a/components/tree-select/style/index.less
+++ b/components/tree-select/style/index.less
@@ -38,10 +38,10 @@
       color: @text-color;
       transition: all 0.3s ease;
       &:hover {
-        background-color: @active-item-bg;
+        background-color: @item-hover-bg;
       }
       &.@{select-tree-prefix-cls}-node-selected {
-        background-color: @primary-2;
+        background-color: @item-active-bg;
       }
     }
     span {

--- a/components/tree-select/style/index.less
+++ b/components/tree-select/style/index.less
@@ -38,7 +38,7 @@
       color: @text-color;
       transition: all 0.3s ease;
       &:hover {
-        background-color: @primary-1;
+        background-color: @active-item-bg;
       }
       &.@{select-tree-prefix-cls}-node-selected {
         background-color: @primary-2;

--- a/components/tree/style/index.less
+++ b/components/tree/style/index.less
@@ -64,7 +64,7 @@
       color: @text-color;
       transition: all 0.3s ease;
       &:hover {
-        background-color: @active-item-bg;
+        background-color: @item-hover-bg;
       }
       &.@{tree-prefix-cls}-node-selected {
         background-color: @primary-2;

--- a/components/tree/style/index.less
+++ b/components/tree/style/index.less
@@ -64,7 +64,7 @@
       color: @text-color;
       transition: all 0.3s ease;
       &:hover {
-        background-color: @primary-1;
+        background-color: @active-item-bg;
       }
       &.@{tree-prefix-cls}-node-selected {
         background-color: @primary-2;

--- a/components/upload/style/index.less
+++ b/components/upload/style/index.less
@@ -159,7 +159,7 @@
     }
 
     &:hover &-info {
-      background-color: @active-item-bg;
+      background-color: @item-hover-bg;
     }
 
     &:hover .@{iconfont-css-prefix}-cross {

--- a/components/upload/style/index.less
+++ b/components/upload/style/index.less
@@ -159,7 +159,7 @@
     }
 
     &:hover &-info {
-      background-color: @primary-1;
+      background-color: @active-item-bg;
     }
 
     &:hover .@{iconfont-css-prefix}-cross {


### PR DESCRIPTION
`@primary-color` is used for a couple distinct purposes (alert backgrounds, hover/active backgrounds, calendar colors). I've added a variable to help control the appearance of hover and active states. 

I've found I wanted to control alert info backgrounds seperately from hover/active states and `@primary-1` seemed to make more sense for the `-info` background