### PR TITLE
Fix cascader not using @component-background

### DIFF
--- a/components/cascader/style/index.less
+++ b/components/cascader/style/index.less
@@ -22,7 +22,7 @@
     display: inline-block;
     cursor: pointer;
     font-size: @font-size-base;
-    background-color: #fff;
+    background-color: @component-background;
     border-radius: @border-radius-base;
     outline: 0;
 
@@ -62,7 +62,7 @@
       position: absolute;
       right: 8px;
       z-index: 2;
-      background: #fff;
+      background: @component-background;
       top: 50%;
       font-size: @font-size-base;
       color: @disabled-color;
@@ -106,7 +106,7 @@
   }
   &-menus {
     font-size: @font-size-base;
-    background: #fff;
+    background: @component-background;
     position: absolute;
     z-index: @zindex-dropdown;
     border-radius: @border-radius-base;


### PR DESCRIPTION
Also, its a bit of a shame that `cascader` and `select` styles aren't consistent for the input elements when they are clearable :(. It'd be really nice if they both implemented the same clearable/dropdown arrow mixins