### PR TITLE
Fix input-number not setting the child input elements background

### DIFF
--- a/components/input-number/style/index.less
+++ b/components/input-number/style/index.less
@@ -75,6 +75,7 @@
     height: @input-height-base - 2px;
     transition: all 0.3s linear;
     color: @input-color;
+    background-color: @input-bg;
     border: 0;
     border-radius: @border-radius-base;
     padding: 0 7px;


### PR DESCRIPTION
Currently uses the default user-agent stylesheet input background