### PR TITLE
fixed issue 5834, autocomplete is not being decorated

### DIFF
--- a/components/auto-complete/style/index.less
+++ b/components/auto-complete/style/index.less
@@ -31,7 +31,6 @@
     }
 
     .@{input-prefix-cls} {
-      .input();
       background: transparent;
     }
 
@@ -54,7 +53,7 @@
     }
 
     .@{input-prefix-cls} {
-      border: @border-width-base @border-style-base @border-color-base;
+      border-width: @border-width-base;
       &:focus,
       &:hover {
         .hover;

--- a/components/form/demo/register.md
+++ b/components/form/demo/register.md
@@ -14,9 +14,10 @@ title:
 Fill in this form to create a new account for you.
 
 ````jsx
-import { Form, Input, Tooltip, Icon, Cascader, Select, Row, Col, Checkbox, Button } from 'antd';
+import { Form, Input, Tooltip, Icon, Cascader, Select, Row, Col, Checkbox, Button, AutoComplete } from 'antd';
 const FormItem = Form.Item;
 const Option = Select.Option;
+const AutoCompleteOption = AutoComplete.Option;
 
 const residences = [{
   value: 'zhejiang',
@@ -45,6 +46,7 @@ const residences = [{
 class RegistrationForm extends React.Component {
   state = {
     confirmDirty: false,
+    autoCompleteResult: [],
   };
   handleSubmit = (e) => {
     e.preventDefault();
@@ -73,8 +75,21 @@ class RegistrationForm extends React.Component {
     }
     callback();
   }
+
+  handleWebsiteChange = (value) => {
+    let autoCompleteResult;
+    if (!value) {
+      autoCompleteResult = [];
+    } else {
+      autoCompleteResult = ['.com', '.org', '.net'].map(domain => `${value}${domain}`);
+    }
+    this.setState({ autoCompleteResult });
+  }
+
   render() {
     const { getFieldDecorator } = this.props.form;
+    const { autoCompleteResult } = this.state;
+
     const formItemLayout = {
       labelCol: {
         xs: { span: 24 },
@@ -104,6 +119,11 @@ class RegistrationForm extends React.Component {
         <Option value="86">+86</Option>
       </Select>
     );
+
+    const websiteOptions = autoCompleteResult.map((website) => {
+      return <AutoCompleteOption key={website}>{website}</AutoCompleteOption>;
+    });
+
     return (
       <Form onSubmit={this.handleSubmit}>
         <FormItem
@@ -188,6 +208,22 @@ class RegistrationForm extends React.Component {
             rules: [{ required: true, message: 'Please input your phone number!' }],
           })(
             <Input addonBefore={prefixSelector} />
+          )}
+        </FormItem>
+        <FormItem
+          {...formItemLayout}
+          label="Website"
+        >
+          {getFieldDecorator('website', {
+            rules: [{ required: true, message: 'Please input website!' }],
+          })(
+            <AutoComplete
+              dataSource={websiteOptions}
+              onChange={this.handleWebsiteChange}
+              placeholder="website"
+            >
+              <Input />
+            </AutoComplete>
           )}
         </FormItem>
         <FormItem

--- a/components/select/style/index.less
+++ b/components/select/style/index.less
@@ -248,7 +248,7 @@
     }
 
     .@{select-prefix-cls}-search__field {
-      border: 0;
+      border: 0 @border-style-base @border-color-base;
       font-size: 100%;
       height: 100%;
       width: 100%;


### PR DESCRIPTION
First of all, thanks for your contribution! :-)

Please makes sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you propose PR to correct branch: bugfix for `master`, feature for latest active branch `feature-x.x`.
* [x] Make sure you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.

The cause is because the `.has-error` class is being overwrote by 2 other css rules:
* ant-select style
`.@{select-prefix-cls}-search__field`
* auto-complete style
```
.@{input-prefix-cls} {
 input();
}
```
the `input()` creates duplicated css attributes, because auto-complete component already inject a <Input /> which already has `.ant-input` class (exact same attributes)

Also updated the sample file so you can test