### PR TITLE
Use the prop-types package from npm instead of React.PropTypes

### DIFF
--- a/components/badge/index.tsx
+++ b/components/badge/index.tsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import Animate from 'rc-animate';
 import ScrollNumber from './ScrollNumber';
 import classNames from 'classnames';

--- a/components/breadcrumb/BreadcrumbItem.tsx
+++ b/components/breadcrumb/BreadcrumbItem.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { PropTypes } from 'react';
+import PropTypes from 'prop-types';
 
 export interface BreadcrumbItemProps {
   prefixCls?: string;

--- a/components/calendar/index.tsx
+++ b/components/calendar/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { PropTypes } from 'react';
+import PropTypes from 'prop-types';
 import moment from 'moment';
 import FullCalendar from 'rc-calendar/lib/FullCalendar';
 import { PREFIX_CLS } from './Constants';

--- a/components/checkbox/Checkbox.tsx
+++ b/components/checkbox/Checkbox.tsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import RcCheckbox from 'rc-checkbox';
 import shallowEqual from 'shallowequal';

--- a/components/form/Form.tsx
+++ b/components/form/Form.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { PropTypes } from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import createDOMForm from 'rc-form/lib/createDOMForm';
 import PureRenderMixin from 'rc-util/lib/PureRenderMixin';

--- a/components/grid/col.tsx
+++ b/components/grid/col.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { PropTypes } from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import assign from 'object-assign';
 

--- a/components/locale-provider/injectLocale.tsx
+++ b/components/locale-provider/injectLocale.tsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 export interface ComponentProps {
   locale?: any;

--- a/components/progress/progress.tsx
+++ b/components/progress/progress.tsx
@@ -1,4 +1,4 @@
-import { PropTypes } from 'react';
+import PropTypes from 'prop-types';
 import React from 'react';
 import Icon from '../icon';
 import { Circle } from 'rc-progress';

--- a/components/radio/group.tsx
+++ b/components/radio/group.tsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import shallowEqual from 'shallowequal';
 import Radio from './radio';

--- a/components/radio/radio.tsx
+++ b/components/radio/radio.tsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import RcRadio from 'rc-radio';
 import classNames from 'classnames';
 import shallowEqual from 'shallowequal';

--- a/components/radio/radioButton.tsx
+++ b/components/radio/radioButton.tsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { AbstractCheckboxProps } from '../checkbox/Checkbox';
 import Radio from './radio';
 

--- a/components/rate/index.tsx
+++ b/components/rate/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { PropTypes } from 'react';
+import PropTypes from 'prop-types';
 import RcRate from 'rc-rate';
 import Icon from '../icon';
 

--- a/components/spin/index.tsx
+++ b/components/spin/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { PropTypes } from 'react';
+import PropTypes from 'prop-types';
 import { findDOMNode } from 'react-dom';
 import classNames from 'classnames';
 import Animate from 'rc-animate';

--- a/components/steps/index.tsx
+++ b/components/steps/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { PropTypes } from 'react';
+import PropTypes from 'prop-types';
 import RcSteps from 'rc-steps';
 
 export interface StepsProps {

--- a/components/switch/index.tsx
+++ b/components/switch/index.tsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import RcSwitch from 'rc-switch';
 import classNames from 'classnames';
 

--- a/components/transfer/index.tsx
+++ b/components/transfer/index.tsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import List, { TransferListProps } from './list';
 import Operation from './operation';

--- a/docs/react/practical-projects.en-US.md
+++ b/docs/react/practical-projects.en-US.md
@@ -108,7 +108,8 @@ Let's create a `ProductList` component that we can use in multiple places to sho
 Create `components/ProductList.js` and typing:
 
 ```javascript
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { Table, Popconfirm, Button } from 'antd';
 
 const ProductList = ({ onDelete, products }) => {

--- a/docs/react/practical-projects.zh-CN.md
+++ b/docs/react/practical-projects.zh-CN.md
@@ -108,7 +108,8 @@ export default Products;
 新建 `components/ProductList.js` 文件：
 
 ```javascript
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { Table, Popconfirm, Button } from 'antd';
 
 const ProductList = ({ onDelete, products }) => {

--- a/site/theme/template/Content/MainContent.jsx
+++ b/site/theme/template/Content/MainContent.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { Link } from 'bisheng/router';
 import { Row, Col, Menu, Icon } from 'antd';
 import classNames from 'classnames';

--- a/site/theme/template/Layout/Header.jsx
+++ b/site/theme/template/Layout/Header.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { Link } from 'bisheng/router';
 import { FormattedMessage } from 'react-intl';
 import classNames from 'classnames';


### PR DESCRIPTION
Warning: Accessing PropTypes via the main React package is deprecated. Use the prop-types package from npm instead.

Noticed that this has been fixed in [2.9.2](https://ant.design/changelog#2.9.2) and the pull request: [#5723](https://github.com/ant-design/ant-design/pull/5723)

But there are still some remaining uses of PropTypes from React, so I create this pull request to remove the warning.