### PR TITLE
Input add autoFocus prop (for ts checking)

### DIFF
--- a/components/input/Input.tsx
+++ b/components/input/Input.tsx
@@ -59,6 +59,7 @@ export interface InputProps {
   prefix?: React.ReactNode;
   suffix?: React.ReactNode;
   spellCheck?: boolean;
+  autoFocus?: boolean;
 }
 
 export default class Input extends Component<InputProps, any> {


### PR DESCRIPTION
Currently, using `autoFocus` will cause TS error

```
Property 'autoFocus' does not exist on ...
```