### PR TITLE
ComponentDecorator return specific type instead of any

### DIFF
--- a/components/form/Form.tsx
+++ b/components/form/Form.tsx
@@ -111,7 +111,7 @@ export interface FormComponentProps {
 
 // https://github.com/DefinitelyTyped/DefinitelyTyped/issues/9951
 export interface ComponentDecorator<TOwnProps> {
-  (component: React.ComponentClass<FormComponentProps & TOwnProps>): any;
+  (component: React.ComponentClass<FormComponentProps & TOwnProps>): React.ComponentClass<TOwnProps>;
 }
 
 export default class Form extends React.Component<FormProps, any> {


### PR DESCRIPTION
Test.tsx

```tsx
interface TestProps {
    name: string;
}

class Test extends React.Component<TestProps & { form: WrappedFormUtils }, {}> {}

export default Form.create<TestProps>()(Test)
```

index.tsx

```tsx
import Test from './Test'

<Test
    // can get type checking and completion here
/>
```
