### PR TITLE
Ts fixes

### DIFF
--- a/components/notification/index.tsx
+++ b/components/notification/index.tsx
@@ -149,11 +149,11 @@ function notice(args) {
 }
 
 const api: {
-  success?(args: ArgsProps): void;
-  error?(args: ArgsProps): void;
-  info?(args: ArgsProps): void;
-  warn?(args: ArgsProps): void;
-  warning?(args: ArgsProps): void;
+  success(args: ArgsProps): void;
+  error(args: ArgsProps): void;
+  info(args: ArgsProps): void;
+  warn(args: ArgsProps): void;
+  warning(args: ArgsProps): void;
 
   open(args: ArgsProps): void;
   close(key: string): void;

--- a/components/table/Table.tsx
+++ b/components/table/Table.tsx
@@ -50,8 +50,8 @@ export type TableColumnConfig<T> = ColumnProps<T>;
 
 export interface TableRowSelection<T> {
   type?: 'checkbox' | 'radio';
-  selectedRowKeys?: string[];
-  onChange?: (selectedRowKeys: string[], selectedRows: Object[]) => any;
+  selectedRowKeys?: string[] | number[];
+  onChange?: (selectedRowKeys: string[] | number[], selectedRows: Object[]) => any;
   getCheckboxProps?: (record: T) => Object;
   onSelect?: (record: T, selected: boolean, selectedRows: Object[]) => any;
   onSelectAll?: (selected: boolean, selectedRows: Object[], changeRows: Object[]) => any;
@@ -67,14 +67,14 @@ export interface TableProps<T> {
   size?: 'default' | 'middle' | 'small';
   dataSource?: T[];
   columns?: ColumnProps<T>[];
-  rowKey?: string | ((record: T, index: number) => string);
+  rowKey?: string | ((record: T, index: number) => string | number);
   rowClassName?: (record: T, index: number) => string;
   expandedRowRender?: any;
-  defaultExpandedRowKeys?: string[];
-  expandedRowKeys?: string[];
+  defaultExpandedRowKeys?: string[] | number[];
+  expandedRowKeys?: string[] | number[];
   expandIconAsCell?: boolean;
   expandIconColumnIndex?: number;
-  onExpandedRowsChange?: (expandedRowKeys: string[]) => void;
+  onExpandedRowsChange?: (expandedRowKeys: string[] | number[]) => void;
   onExpand?: (expanded: boolean, record: T) => void;
   onChange?: (pagination: PaginationProps | boolean, filters: string[], sorter: Object) => any;
   loading?: boolean | SpinProps;


### PR DESCRIPTION
Optional notification functions are frustrating and require a non-null check with strict TS:
```
if (notification.error) {
  notification.error({
    message: 'Oops!',
    description: 'You do not have permission to view that page, please contact the administrator.',
  });
}
```

DefinitelyTyped/React defines the Key type as `string | number` (see https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts#L31). Antd Table supports Number typed keys but TS interfaces do not.