### PR TITLE
Use input-padding-horizontal to control autocomplete placeholder placing

### DIFF
--- a/components/auto-complete/style/index.less
+++ b/components/auto-complete/style/index.less
@@ -18,8 +18,8 @@
           height: 100%;
         }
         &__placeholder {
-          margin-left: 8px;
-          margin-right: 8px;
+          margin-left: (@input-padding-horizontal + 1);
+          margin-right: (@input-padding-horizontal + 1);
           top: @input-height-base / 2;
         }
       }


### PR DESCRIPTION
Without this patch if you modified the horizontal padding of an input the cursor position would not align with the placeholder. Vertical alignment was fine.