### PR TITLE
Use input-padding-horizontal to control autocomplete placeholder placing

### DIFF
--- a/components/auto-complete/style/index.less
+++ b/components/auto-complete/style/index.less
@@ -19,8 +19,8 @@
           line-height: @input-height-base;
         }
         &__placeholder {
-          margin-left: 8px;
-          margin-right: 8px;
+          margin-left: (@input-padding-horizontal + 1);
+          margin-right: (@input-padding-horizontal + 1);
         }
       }
     }


### PR DESCRIPTION
Without this patch if you modified the horizontal padding of an input the cursor position would not align with the placeholder. Vertical alignment was fine.