### PR TITLE
fix Dropdown.Button's type definition

### DIFF
--- a/components/dropdown/dropdown.tsx
+++ b/components/dropdown/dropdown.tsx
@@ -1,6 +1,7 @@
 import React, { cloneElement } from 'react';
 import RcDropdown from 'rc-dropdown';
 import classNames from 'classnames';
+import DropdownButton from './dropdown-button';
 import warning from '../_util/warning';
 
 export interface DropDownProps {
@@ -16,7 +17,7 @@ export interface DropDownProps {
 }
 
 export default class Dropdown extends React.Component<DropDownProps, any> {
-  static Button: React.ReactNode;
+  static Button: typeof DropdownButton;
   static defaultProps = {
     prefixCls: 'ant-dropdown',
     mouseEnterDelay: 0.15,


### PR DESCRIPTION
`Dropdown.Button` 的类型并不是 React.ReactNode, 在 Typescript 中直接使用会报如下错误:

`JSX element type Dropdown.Button does not have any construct or call signatures`