### PR TITLE
Allow Number type table keys. Make notification success, error, info, warn and warning non-optional

### DIFF
--- a/components/notification/index.tsx
+++ b/components/notification/index.tsx
@@ -148,18 +148,19 @@ function notice(args) {
   });
 }
 
-const api: {
-  success?(args: ArgsProps): void;
-  error?(args: ArgsProps): void;
-  info?(args: ArgsProps): void;
-  warn?(args: ArgsProps): void;
-  warning?(args: ArgsProps): void;
-
+interface Api {
+  success(args: ArgsProps): void;
+  error(args: ArgsProps): void;
+  info(args: ArgsProps): void;
+  warn(args: ArgsProps): void;
+  warning(args: ArgsProps): void;
   open(args: ArgsProps): void;
   close(key: string): void;
   config(options: ConfigProps): void;
   destroy(): void;
-} = {
+}
+
+const api = {
   open(args: ArgsProps) {
     notice(args);
   },
@@ -208,4 +209,4 @@ const api: {
 
 (api as any).warn = (api as any).warning;
 
-export default api;
+export default api as Api;

--- a/components/notification/index.tsx
+++ b/components/notification/index.tsx
@@ -148,7 +148,7 @@ function notice(args) {
   });
 }
 
-interface Api {
+export interface NotificationApi {
   success(args: ArgsProps): void;
   error(args: ArgsProps): void;
   info(args: ArgsProps): void;
@@ -209,4 +209,4 @@ const api = {
 
 (api as any).warn = (api as any).warning;
 
-export default api as Api;
+export default api as NotificationApi;

--- a/components/table/Table.tsx
+++ b/components/table/Table.tsx
@@ -50,8 +50,8 @@ export type TableColumnConfig<T> = ColumnProps<T>;
 
 export interface TableRowSelection<T> {
   type?: 'checkbox' | 'radio';
-  selectedRowKeys?: string[];
-  onChange?: (selectedRowKeys: string[], selectedRows: Object[]) => any;
+  selectedRowKeys?: string[] | number[];
+  onChange?: (selectedRowKeys: string[] | number[], selectedRows: Object[]) => any;
   getCheckboxProps?: (record: T) => Object;
   onSelect?: (record: T, selected: boolean, selectedRows: Object[]) => any;
   onSelectAll?: (selected: boolean, selectedRows: Object[], changeRows: Object[]) => any;
@@ -70,11 +70,11 @@ export interface TableProps<T> {
   rowKey?: string | ((record: T, index: number) => string);
   rowClassName?: (record: T, index: number) => string;
   expandedRowRender?: any;
-  defaultExpandedRowKeys?: string[];
-  expandedRowKeys?: string[];
+  defaultExpandedRowKeys?: string[] | number[];
+  expandedRowKeys?: string[] | number[];
   expandIconAsCell?: boolean;
   expandIconColumnIndex?: number;
-  onExpandedRowsChange?: (expandedRowKeys: string[]) => void;
+  onExpandedRowsChange?: (expandedRowKeys: string[] | number[]) => void;
   onExpand?: (expanded: boolean, record: T) => void;
   onChange?: (pagination: PaginationProps | boolean, filters: string[], sorter: Object) => any;
   loading?: boolean | SpinProps;


### PR DESCRIPTION
Re-open #6350:

Optional notification functions are frustrating and require a non-null check with strict TS:
```
if (notification.error) {
  notification.error({
    message: 'Oops!',
    description: 'You do not have permission to view that page, please contact the administrator.',
  });
}
```

DefinitelyTyped/React defines the Key type as `string | number` (see https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts#L31). Antd Table supports Number typed keys but TS interfaces do not.