### PR TITLE
Add warning about declaring Table class in render function

### DIFF
--- a/components/table/index.en-US.md
+++ b/components/table/index.en-US.md
@@ -154,6 +154,7 @@ const data: IUser[] = [{
   name: 'Jack',
 }];
 
+// Do not declare class inside render function
 class UserTable extends Table<IUser> {}
 
 <UserTable columns={columns} dataSource={data} />


### PR DESCRIPTION
I followed the 'Using in TypeScript' instructions and hit an issue where the Table always rerendered. This was because I had declared `class UserTable extends Table<IUser> {}` inside the render function. Moving `class UserTable extends Table<IUser> {}` outside the render function fixed the issue.