### PR TITLE
fix Dropdown.Button Props

### DIFF
--- a/components/dropdown/dropdown-button.tsx
+++ b/components/dropdown/dropdown-button.tsx
@@ -1,13 +1,12 @@
 import React from 'react';
 import Button from '../button';
+import { ButtonGroupProps } from '../button/button-group';
 import Icon from '../icon';
 import Dropdown from './dropdown';
 const ButtonGroup = Button.Group;
 import classNames from 'classnames';
 
-export type DropdownButtonSize = 'small' | 'large';
-
-export interface DropdownButtonProps {
+export interface DropdownButtonProps extends ButtonGroupProps {
   prefixCls?: string;
   className?: string;
   type?: 'primary' | 'ghost' | 'dashed';
@@ -18,7 +17,6 @@ export interface DropdownButtonProps {
   visible?: boolean;
   disabled?: boolean;
   onVisibleChange?: (visible: boolean) => void;
-  size?: DropdownButtonSize;
   style?: React.CSSProperties;
   children?: any;
   placement?: 'topLeft' | 'topCenter' | 'topRight' | 'bottomLeft' | 'bottomCenter' | 'bottomRight';

--- a/components/dropdown/dropdown-button.tsx
+++ b/components/dropdown/dropdown-button.tsx
@@ -7,8 +7,6 @@ const ButtonGroup = Button.Group;
 import classNames from 'classnames';
 
 export interface DropdownButtonProps extends ButtonGroupProps {
-  prefixCls?: string;
-  className?: string;
   type?: 'primary' | 'ghost' | 'dashed';
   onClick?: React.MouseEventHandler<any>;
   trigger?: ('click' | 'hover')[];
@@ -17,7 +15,6 @@ export interface DropdownButtonProps extends ButtonGroupProps {
   visible?: boolean;
   disabled?: boolean;
   onVisibleChange?: (visible: boolean) => void;
-  style?: React.CSSProperties;
   children?: any;
   placement?: 'topLeft' | 'topCenter' | 'topRight' | 'bottomLeft' | 'bottomCenter' | 'bottomRight';
 }

--- a/components/dropdown/dropdown-button.tsx
+++ b/components/dropdown/dropdown-button.tsx
@@ -5,6 +5,8 @@ import Dropdown from './dropdown';
 const ButtonGroup = Button.Group;
 import classNames from 'classnames';
 
+export type DropdownButtonSize = 'small' | 'large';
+
 export interface DropdownButtonProps {
   prefixCls?: string;
   className?: string;
@@ -16,6 +18,7 @@ export interface DropdownButtonProps {
   visible?: boolean;
   disabled?: boolean;
   onVisibleChange?: (visible: boolean) => void;
+  size?: DropdownButtonSize;
   style?: React.CSSProperties;
   children?: any;
   placement?: 'topLeft' | 'topCenter' | 'topRight' | 'bottomLeft' | 'bottomCenter' | 'bottomRight';


### PR DESCRIPTION
Dropdown.Button 的实现支持传入 size 属性，但是在 DropdownButtonProps interface 中没有反映出来,导致按如下使用时:

```tsx
<DropdownButton overlay={Overlay} size='small'>我是小按钮</DropdownButton>
```
会报下面的错误:
```
Property 'size' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<Dropdown.Button>
```