### PR TITLE
Add className prop to DatePicker

### DIFF
--- a/components/date-picker/RangePicker.tsx
+++ b/components/date-picker/RangePicker.tsx
@@ -222,11 +222,13 @@ export default class RangePicker extends React.Component<any, any> {
       />
     ) : null;
 
+    const className = classNames(props.className, props.pickerInputClass);
+
     const input = ({ value: inputValue }) => {
       const start = inputValue[0];
       const end = inputValue[1];
       return (
-        <span className={props.pickerInputClass} disabled={props.disabled}>
+        <span className={className} disabled={props.disabled}>
           <input
             disabled={props.disabled}
             readOnly

--- a/components/date-picker/createPicker.tsx
+++ b/components/date-picker/createPicker.tsx
@@ -135,7 +135,7 @@ export default function createPicker(TheCalendar): any {
       ) : null;
 
       const input = ({ value: inputValue }) => (
-        <div>
+        <div className={props.className}>
           <input
             disabled={props.disabled}
             readOnly

--- a/components/date-picker/index.en-US.md
+++ b/components/date-picker/index.en-US.md
@@ -73,6 +73,7 @@ The following APIs are shared by DatePicker, MonthPicker, RangePicker.
 | format       | to set the date format, refer to [moment.js](http://momentjs.com/) | string   | "YYYY-MM" |
 | onChange     | a callback function, can be executed when the selected time is changing | function(date: moment, dateString: string) | -           |
 | monthCellContentRender | Custom month cell content render method | function(date, locale): ReactNode | - |
+| className | picker className | string | '' |
 
 ### RangePicker
 
@@ -88,6 +89,7 @@ The following APIs are shared by DatePicker, MonthPicker, RangePicker.
 | ranges       | preseted ranges for quick selection | { [range: string]: [moment](http://momentjs.com/)[] } | - |
 | renderExtraFooter | render extra footer in panel | () => React.ReactNode | - |
 | onOk | callback when click ok button | function() | - |
+| className | picker className | string | '' |
 
 <style>
 .code-box-demo .ant-calendar-picker {

--- a/components/date-picker/index.en-US.md
+++ b/components/date-picker/index.en-US.md
@@ -62,6 +62,7 @@ The following APIs are shared by DatePicker, MonthPicker, RangePicker.
 | disabledTime | to specify the time that cannot be selected | function(date) | - |
 | onOk | callback when click ok button | function() | - |
 | renderExtraFooter | render extra footer in panel | () => React.ReactNode | - |
+| className | picker className | string | '' |
 
 ### MonthPicker
 

--- a/components/date-picker/index.tsx
+++ b/components/date-picker/index.tsx
@@ -51,11 +51,13 @@ export interface DatePickerProps extends PickerProps, SinglePickerProps {
 const DatePicker = wrapPicker(createPicker(RcCalendar)) as React.ClassicComponentClass<DatePickerProps>;
 
 export interface MonthPickerProps extends PickerProps, SinglePickerProps {
+  className?: string;
   placeholder?: string;
 }
 const MonthPicker = wrapPicker(createPicker(MonthCalendar), 'YYYY-MM');
 
 export interface RangePickerProps extends PickerProps {
+  className?: string;
   value?: [moment.Moment, moment.Moment];
   defaultValue?: [moment.Moment, moment.Moment];
   defaultPickerValue?: [moment.Moment, moment.Moment];

--- a/components/date-picker/index.tsx
+++ b/components/date-picker/index.tsx
@@ -34,6 +34,7 @@ export interface SinglePickerProps {
 }
 
 export interface DatePickerProps extends PickerProps, SinglePickerProps {
+  className?: string;
   showTime?: TimePickerProps | boolean;
   showToday?: boolean;
   open?: boolean;


### PR DESCRIPTION
Add `className` prop to `DatePicker` (like in `TimePicker`)
- Updated DatePicker docs (English)
- Tests are passing
- Lint is passing