### PR TITLE
Use background-color-active for table sort and selected backgrounds

### DIFF
--- a/components/style/themes/default.less
+++ b/components/style/themes/default.less
@@ -290,7 +290,9 @@
 // Table
 // --
 @table-header-bg: @background-color-base;
+@table-header-sort-bg: @background-color-active;
 @table-row-hover-bg: @primary-1;
+@table-selected-row-bg: #fafafa;
 @table-padding-vertical: 16px;
 @table-padding-horizontal: 8px;
 

--- a/components/table/style/index.less
+++ b/components/table/style/index.less
@@ -126,11 +126,11 @@
   }
 
   &-tbody > tr.@{table-prefix-cls}-row-selected {
-    background: #fafafa;
+    background: @table-selected-row-bg;
   }
 
   &-thead > tr > th.@{table-prefix-cls}-column-sort {
-    background: #eaeaea;
+    background: @table-header-sort-bg;
   }
 
   &-thead > tr > th,


### PR DESCRIPTION
This is also a minor tweak to the colors, ~~`#fafafa` -> `#eeeeee` and~~ `#eaeaea` -> `#eeeeee`. This is for consistency and to improve the ease of theming ant. For most cases, this change should not be noticeable 