### PR TITLE
fix FormItemColOption

### DIFF
--- a/components/form/FormItem.tsx
+++ b/components/form/FormItem.tsx
@@ -8,16 +8,12 @@ import { WrappedFormUtils } from './Form';
 import { FIELD_META_PROP } from './constants';
 import warning from '../_util/warning';
 
-export interface FormItemColOption extends ColProps {
-  span: number;
-}
-
 export interface FormItemProps {
   prefixCls?: string;
   id?: string;
   label?: React.ReactNode;
-  labelCol?: FormItemColOption;
-  wrapperCol?: FormItemColOption;
+  labelCol?: ColProps;
+  wrapperCol?: ColProps;
   help?: React.ReactNode;
   extra?: React.ReactNode;
   validateStatus?: 'success' | 'warning' | 'error' | 'validating';


### PR DESCRIPTION
`ColProps `中已经声明了 `span` props:  [col.tsx](https://github.com/ant-design/ant-design/blob/master/components/grid/col.tsx#L19)

`FormItemColOption ` 中又把它声明为必须的 props，但它并不必须，是可选的。

可见文档：https://ant.design/components/form-cn/#components-form-demo-register