### PR TITLE
Establish a ref to the select component

### DIFF
--- a/components/select/index.tsx
+++ b/components/select/index.tsx
@@ -148,6 +148,7 @@ export default class Select extends React.Component<SelectProps, any> {
       <RcSelect
         {...restProps}
         {...modeConfig}
+        ref="select"
         prefixCls={prefixCls}
         className={cls}
         optionLabelProp={optionLabelProp || 'children'}


### PR DESCRIPTION
I have just established a ref to the `select` component in order to access to the `rs-select` component definition and be able to customize the behaviors for such component when rendering in a HOC. I think `refs` should be provided broadly for all components for that purpose.