### PR TITLE
Fixing typos

### DIFF
--- a/components/locale-provider/bg_BG.tsx
+++ b/components/locale-provider/bg_BG.tsx
@@ -21,12 +21,12 @@ export default {
     selectInvert: 'Обръщане',
   },
   Modal: {
-    okText: 'Дибре',
+    okText: 'Добре',
     cancelText: 'Отказ',
-    justOkText: 'Дибре',
+    justOkText: 'Добре',
   },
   Popconfirm: {
-    okText: 'Дибре',
+    okText: 'Добре',
     cancelText: 'Отказ',
   },
   Transfer: {


### PR DESCRIPTION
It should be "Добре" instead of "Дибре".

Just like `filterConfirm`

Reference: https://translate.google.bg/#en/bg/Ok
