### PR TITLE
fix SearchProps

### DIFF
--- a/components/input/Search.tsx
+++ b/components/input/Search.tsx
@@ -1,16 +1,10 @@
 import React from 'react';
 import classNames from 'classnames';
-import Input, { AbstractInputProps } from './Input';
+import Input, { InputProps } from './Input';
 import Icon from '../icon';
 
-export interface SearchProps extends AbstractInputProps {
-  placeholder?: string;
+export interface SearchProps extends InputProps {
   onSearch?: (value: string) => any;
-  onChange?: React.FormEventHandler<any>;
-  size?: 'large' | 'default' | 'small';
-  disabled?: boolean;
-  readOnly?: boolean;
-  name?: string;
 }
 
 export default class Search extends React.Component<SearchProps, any> {


### PR DESCRIPTION
Input.Search 的实现是把除了 Search 需要的 props 以外的 props 都传给了 Input，所以 SearchProps 应该是直接继承 InputProps，现在继承 AbstractInputProps 的方式导致一些明明可用的 props 传入却会让 TS 报错，比如：`addonBefore`