### PR TITLE
fix Button.Group type definition

### DIFF
--- a/components/button/button-group.tsx
+++ b/components/button/button-group.tsx
@@ -10,7 +10,7 @@ export interface ButtonGroupProps {
   prefixCls?: string;
 }
 
-export default function ButtonGroup(props: ButtonGroupProps) {
+const ButtonGroup: React.SFC<ButtonGroupProps> = (props) => {
   const { prefixCls = 'ant-btn-group', size = '', className, ...others } = props;
 
   // large => lg
@@ -31,4 +31,6 @@ export default function ButtonGroup(props: ButtonGroupProps) {
   }, className);
 
   return <div {...others} className={classes} />;
-}
+};
+
+export default ButtonGroup;


### PR DESCRIPTION
ButtonGroup 定义有误

因为 ButtonGroup 可以接收子组件，所以 props 中应该包含 children?: React.ReactNode
现在的定义会导致下面的报错:
```tsx
<Button.Group><Button/></Button.Group>

// [ts] Type '{ children: Element; }' has no properties in common with type 'IntrinsicAttributes & ButtonGroupProps'.
```

[React.SFC](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts#L279) 已经做好了对 props 的封装，所以直接将 ButtonGroup 定义成 React.SFC