### PR TITLE
change type of radio group value to any

### DIFF
--- a/components/radio/group.tsx
+++ b/components/radio/group.tsx
@@ -18,8 +18,8 @@ function getCheckedValue(children) {
 }
 
 export interface RadioGroupProps extends AbstractCheckboxGroupProps {
-  defaultValue?: string | number;
-  value?: string | number;
+  defaultValue?: any;
+  value?: any;
   onChange?: React.FormEventHandler<any>;
   size?: 'large' | 'default' | 'small';
   onMouseEnter?: React.FormEventHandler<any>;


### PR DESCRIPTION
1. The [type](https://github.com/ant-design/ant-design/blob/master/components/radio/radio.tsx#L10) of radio value is any.
2. The [document](https://ant.design/components/radio-cn/#RadioGroup) said type of radio group value is any.