### PR TITLE
Upgrade create-react-class to 15.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "array-tree-filter": "~1.0.0",
     "babel-runtime": "6.x",
     "classnames": "~2.2.0",
-    "create-react-class": "^15.5.3",
+    "create-react-class": "^15.6.0",
     "css-animation": "^1.2.5",
     "dom-closest": "^0.2.0",
     "lodash.debounce": "^4.0.8",


### PR DESCRIPTION
`react-create-class ^15.5.3` is throwing warnings about isMounted in development on `react ^15.6.1`. Upgrade to `react-create-class ^15.6.0` to fix.

Resolves #6564, #6565, #6790.

![screen shot 2017-07-25 at 1 53 25 am](https://user-images.githubusercontent.com/7931323/28549943-f19b5914-70dd-11e7-8cff-edfb8bf0ccdc.png)
