### PR TITLE
check this.container exists updating WiderPadding

### DIFF
--- a/components/card/index.tsx
+++ b/components/card/index.tsx
@@ -41,17 +41,19 @@ export default class Card extends Component<CardProps> {
   }
   @throttleByAnimationFrameDecorator()
   updateWiderPadding() {
-    // 936 is a magic card width pixer number indicated by designer
-    const WIDTH_BOUDARY_PX = 936;
-    if (this.container.offsetWidth >= WIDTH_BOUDARY_PX && !this.state.widerPadding) {
-      this.setState({ widerPadding: true }, () => {
-        this.updateWiderPaddingCalled = true; // first render without css transition
-      });
-    }
-    if (this.container.offsetWidth < WIDTH_BOUDARY_PX && this.state.widerPadding) {
-      this.setState({ widerPadding: false }, () => {
-        this.updateWiderPaddingCalled = true; // first render without css transition
-      });
+    if (this.container) {
+      // 936 is a magic card width pixer number indicated by designer
+      const WIDTH_BOUDARY_PX = 936;
+      if (this.container.offsetWidth >= WIDTH_BOUDARY_PX && !this.state.widerPadding) {
+        this.setState({ widerPadding: true }, () => {
+          this.updateWiderPaddingCalled = true; // first render without css transition
+        });
+      }
+      if (this.container.offsetWidth < WIDTH_BOUDARY_PX && this.state.widerPadding) {
+        this.setState({ widerPadding: false }, () => {
+          this.updateWiderPaddingCalled = true; // first render without css transition
+        });
+      }
     }
   }
   saveRef = (node: HTMLDivElement) => {


### PR DESCRIPTION
before doing updating wider padding for Card, always check if the container exists first.

First of all, thank you for your contribution! :-)

Please makes sure that these checkboxes are checked before submitting your PR, thank you!

* [x] Make sure that you propose PR to right branch: bugfix for `master`, feature for latest active branch `feature-x.x`.
* [x] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.

Extra checklist:

**if** *isBugFix* **:**

  * [ ] Make sure that you add at least one unit test for the bug which you had fixed.
