### PR TITLE
[checkbox][docs] fixes doc table extra column cell

### DIFF
--- a/components/checkbox/index.en-US.md
+++ b/components/checkbox/index.en-US.md
@@ -20,7 +20,7 @@ Checkbox.
 | checked | Specifies whether the checkbox is selected. | boolean | false |
 | defaultChecked | Specifies the initial state: whether or not the checkbox is selected. | boolean | false |
 | onChange | The callback function that is triggered when the state changes. | Function(e:Event) | - |
-| disabled | Disable checkbox | boolean | | false| 
+| disabled | Disable checkbox | boolean | false| 
 
 ### Checkbox Group
 
@@ -30,4 +30,4 @@ Checkbox.
 | value | Used for setting the currently selected value. | string[] | [] |
 | options  | Specifies options | string[] | [] |
 | onChange | The callback function that is triggered when the state changes. | Function(checkedValue) | - |
-| disabled | Disable all checkboxes | boolean | | false |
+| disabled | Disable all checkboxes | boolean | false |


### PR DESCRIPTION
Github markdown tables are not showing the extra cell in the `disabled` row. This removes an extra cell from that row.

![image](https://user-images.githubusercontent.com/2336595/28734572-7ac99dc6-7396-11e7-8a31-f9351b68f683.png)



Please makes sure that these checkboxes are checked before submitting your PR, thank you!

* [ ] Make sure that you propose PR to right branch: bugfix for `master`, feature for latest active branch `feature-x.x`.
* [x] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [ ] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.
