### PR TITLE
fix Card children type

### DIFF
--- a/components/card/index.tsx
+++ b/components/card/index.tsx
@@ -13,7 +13,7 @@ export interface CardProps {
   style?: React.CSSProperties;
   loading?: boolean;
   noHovering?: boolean;
-  children?: React.ReactChild;
+  children?: React.ReactNode;
   id?: string;
   className?: string;
 }


### PR DESCRIPTION
Card's children should be `React.ReactNode`