### PR TITLE
Object cloning in flatArray is performed only if object has 'childrenName' field.

### DIFF
--- a/components/table/util.tsx
+++ b/components/table/util.tsx
@@ -4,11 +4,15 @@ export function flatArray(data: Object[] = [], childrenName = 'children') {
   const result: Object[] = [];
   const loop = (array) => {
     array.forEach(item => {
-      const newItem = { ...item };
-      delete newItem[childrenName];
-      result.push(newItem);
-      if (item[childrenName] && item[childrenName].length > 0) {
-        loop(item[childrenName]);
+      if (item[childrenName]) {
+        const newItem = { ...item };
+        delete newItem[childrenName];
+        result.push(newItem);
+        if (item[childrenName].length > 0) {
+          loop(item[childrenName]);
+        }
+      } else {
+        result.push(item);
       }
     });
   };


### PR DESCRIPTION
`spread`-style object cloning leads to object `prototype` change, which makes it impossible to use custom class objects as `dataSource` for Table component.

At least, cloning is not required if there is no `childrenName` field.

I can also change:
```
const newItem = { ...item };
```
to 
```
const newItem = Object.create(item);
```
to preserve `prototype` even in case with nested rows, as suggested [here](https://stackoverflow.com/a/28152032/769192), but I'm not sure whether it will brake something.
