### PR TITLE
Adds onFocus and onBlur to Select properties.

### DIFF
--- a/components/select/demo/search.md
+++ b/components/select/demo/search.md
@@ -21,6 +21,14 @@ function handleChange(value) {
   console.log(`selected ${value}`);
 }
 
+function handleBlur() {
+  console.log('blur');
+}
+
+function handleFocus() {
+  console.log('focus');
+}
+
 ReactDOM.render(
   <Select
     showSearch
@@ -28,6 +36,8 @@ ReactDOM.render(
     placeholder="Select a person"
     optionFilterProp="children"
     onChange={handleChange}
+    onFocus={handleFocus}
+    onBlur={handleBlur}
     filterOption={(input, option) => option.props.children.toLowerCase().indexOf(input.toLowerCase()) >= 0}
   >
     <Option value="jack">Jack</Option>

--- a/components/select/index.tsx
+++ b/components/select/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import RcSelect, { Option, OptGroup } from 'rc-select';
+import RcSelect, { Option, OptGroup, SelectPropTypes as RcSelectPropTypes } from 'rc-select';
 import classNames from 'classnames';
 import warning from '../_util/warning';
 
@@ -41,6 +41,8 @@ export interface SelectProps extends AbstractSelectProps {
   onChange?: (value: SelectValue) => void;
   onSelect?: (value: SelectValue, option: Object) => any;
   onDeselect?: (value: SelectValue) => any;
+  onBlur?: () => any;
+  onFocus?: () => any;
   dropdownMatchSelectWidth?: boolean;
   optionFilterProp?: string;
   defaultActiveFirstOption?: boolean;
@@ -65,6 +67,19 @@ export interface SelectContext {
   };
 }
 
+export const SelectPropTypes = {
+  ...RcSelectPropTypes,
+  prefixCls: PropTypes.string,
+  className: PropTypes.string,
+  size: PropTypes.oneOf(['default', 'large', 'small']),
+  combobox: PropTypes.bool,
+  notFoundContent: PropTypes.any,
+  showSearch: PropTypes.bool,
+  optionLabelProp: PropTypes.string,
+  transitionName: PropTypes.string,
+  choiceTransitionName: PropTypes.string,
+};
+
 // => It is needless to export the declaration of below two inner components.
 // export { Option, OptGroup };
 
@@ -79,17 +94,7 @@ export default class Select extends React.Component<SelectProps, any> {
     choiceTransitionName: 'zoom',
   };
 
-  static propTypes = {
-    prefixCls: PropTypes.string,
-    className: PropTypes.string,
-    size: PropTypes.oneOf(['default', 'large', 'small']),
-    combobox: PropTypes.bool,
-    notFoundContent: PropTypes.any,
-    showSearch: PropTypes.bool,
-    optionLabelProp: PropTypes.string,
-    transitionName: PropTypes.string,
-    choiceTransitionName: PropTypes.string,
-  };
+  static propTypes = SelectPropTypes;
 
   static contextTypes = {
     antLocale: PropTypes.object,


### PR DESCRIPTION
Added missing onFocus and onBlur to Select properties.

They are already documented on https://ant.design/components/select/

I consider this a bug that they don't actually exist in the TypeScript interface.

Importing rc-select PropTypes because we are passing the unused props to rc-select.