### PR TITLE
fix: InputGroup demo

### DIFF
--- a/components/input/demo/group.md
+++ b/components/input/demo/group.md
@@ -115,7 +115,7 @@ class CompactDemo extends React.Component {
             <Option value="2">Except</Option>
           </Select>
           <Input style={{ width: 100, textAlign: 'center' }} placeholder="Minimum" />
-          <Input style={{ width: 24, borderLeft: 0, pointerEvents: 'none' }} placeholder="~" />
+          <Input style={{ width: 24, borderLeft: 0, pointerEvents: 'none', backgroundColor: '#fff' }} placeholder="~" disabled />
           <Input style={{ width: 100, textAlign: 'center', borderLeft: 0 }} placeholder="Maximum" />
         </InputGroup>
         <br />


### PR DESCRIPTION
在 `InputGroup` 的示例里 ， 在先focus在Minimum处，摁 `Tab` 键，中间的连接符会被意外focus，并可以输入内容，很奇怪的行为。

![image](https://user-images.githubusercontent.com/8564681/28964341-f11aca24-793e-11e7-9557-b62c958603e2.png)
