### PR TITLE
Locale/nb no

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -141,6 +141,7 @@ Tino D <ginodeis@gmail.com>
 Tyler <chaotyler@gmail.com>
 Vadim Macagon <vadim.macagon@gmail.com>
 Valentin Vichnal <valentin@vichnal.com>
+Vemund Santi <veund@santi.no>
 Vincent Zhang <vxzhong@qq.com>
 Walter Barbagallo <turbometalskater@gmail.com>
 Warren Seymour <warren@fountainhead.tech>

--- a/components/calendar/locale/nb_NO.tsx
+++ b/components/calendar/locale/nb_NO.tsx
@@ -1,0 +1,2 @@
+import nb_NO from '../../date-picker/locale/nb_NO';
+export default nb_NO;

--- a/components/date-picker/locale/nb_NO.tsx
+++ b/components/date-picker/locale/nb_NO.tsx
@@ -1,0 +1,19 @@
+import CalendarLocale from 'rc-calendar/lib/locale/nb_NO';
+import TimePickerLocale from '../../time-picker/locale/nb_NO';
+
+// Merge into a locale object
+const locale = {
+  lang: {
+    placeholder: 'Velg dato',
+    rangePlaceholder: ['Startdato', 'Sluttdato'],
+    ...CalendarLocale,
+  },
+  timePickerLocale: {
+    ...TimePickerLocale,
+  },
+};
+
+// All settings at:
+// https://github.com/ant-design/ant-design/blob/master/components/date-picker/locale/example.json
+
+export default locale;

--- a/components/locale-provider/__tests__/index.test.js
+++ b/components/locale-provider/__tests__/index.test.js
@@ -28,8 +28,9 @@ import plPL from '../pl_PL';
 import bgBG from '../bg_BG';
 import viVN from '../vi_VN';
 import thTH from '../th_TH';
+import nbNO from '../nb_NO';
 
-const locales = [enUS, ptBR, ruRU, esES, svSE, frBE, deDE, nlNL, caES, csCZ, koKR, etEE, skSK, jaJP, trTR, zhTW, fiFI, plPL, bgBG, enGB, frFR, nlBE, itIT, viVN, thTH];
+const locales = [enUS, ptBR, ruRU, esES, svSE, frBE, deDE, nlNL, caES, csCZ, koKR, etEE, skSK, jaJP, trTR, zhTW, fiFI, plPL, bgBG, enGB, frFR, nlBE, itIT, viVN, thTH, nbNO];
 
 const Option = Select.Option;
 const RangePicker = DatePicker.RangePicker;

--- a/components/locale-provider/nb_NO.tsx
+++ b/components/locale-provider/nb_NO.tsx
@@ -1,0 +1,60 @@
+import moment from 'moment';
+moment.locale('nb');
+
+// import Pagination from 'rc-pagination/lib/locale/nb_NO';
+import DatePicker from '../date-picker/locale/nb_NO';
+import TimePicker from '../time-picker/locale/nb_NO';
+import Calendar from '../calendar/locale/nb_NO';
+
+export default {
+  locale: 'nb',
+  DatePicker,
+  TimePicker,
+  Calendar,
+  // Replace with rc-pagination/lib/locale/nb_NO
+  // when rc-pagination supports nb_NO
+  Pagination: {
+    items_per_page: 'per side',
+    jump_to: 'Gå til side',
+    page: '',
+
+    prev_page: 'Forrige side',
+    next_page: 'Neste side',
+    prev_5: '5 forrige',
+    next_5: '5 neste',
+    prev_3: '3 forrige',
+    next_3: '3 neste',
+  },
+  Table: {
+    filterTitle: 'Filtermeny',
+    filterConfirm: 'OK',
+    filterReset: 'Nullstill',
+    emptyText: 'Ingen data',
+    selectAll: 'Velg alle',
+    selectInvert: 'Inverter valg',
+  },
+  Modal: {
+    okText: 'OK',
+    cancelText: 'Avbryt',
+    justOkText: 'OK',
+  },
+  Popconfirm: {
+    okText: 'OK',
+    cancelText: 'Avbryt',
+  },
+  Transfer: {
+    notFoundContent: 'Ingen treff',
+    searchPlaceholder: 'Søk her',
+    itemUnit: 'element',
+    itemsUnit: 'elementer',
+  },
+  Select: {
+    notFoundContent: 'Ingen treff',
+  },
+  Upload: {
+    uploading: 'Laster opp...',
+    removeFile: 'Fjern fil',
+    uploadError: 'Feil ved opplastning',
+    previewFile: 'Forhåndsvisning',
+  },
+};

--- a/components/time-picker/locale/nb_NO.tsx
+++ b/components/time-picker/locale/nb_NO.tsx
@@ -1,0 +1,5 @@
+const locale = {
+  placeholder: 'Velg tid',
+};
+
+export default locale;

--- a/docs/react/i18n.en-US.md
+++ b/docs/react/i18n.en-US.md
@@ -43,6 +43,7 @@ Supported languages:
 |Italian|it_IT|
 |Japanese|ja_JP|
 |Korean|ko_KR|
+|Norwegian|nb_NO|
 |Polish|pl_PL|
 |Portuguese (Brazil)|pt_BR|
 |Russian|ru_RU|

--- a/docs/react/i18n.zh-CN.md
+++ b/docs/react/i18n.zh-CN.md
@@ -41,6 +41,7 @@ return (
 |意大利语|it_IT|
 |日语|ja_JP|
 |韩语/朝鲜语|ko_KR|
+|挪威|nb_NO|
 |波兰语|pl_PL|
 |葡萄牙语|pt_BR|
 |俄罗斯语|ru_RU|


### PR DESCRIPTION
Adds i18n support for Norwegian Bokmål, one of the official languages in Norway. 
Updates docs to display i18n support of nb_NO.