### PR TITLE
add a generic type for `FormCreateOption`

### DIFF
--- a/components/form/Form.tsx
+++ b/components/form/Form.tsx
@@ -9,10 +9,10 @@ import warning from '../_util/warning';
 import FormItem from './FormItem';
 import { FIELD_META_PROP } from './constants';
 
-export interface FormCreateOption {
-  onFieldsChange?: (props: any, fields: Array<any>) => void;
-  onValuesChange?: (props: any, values: any) => void;
-  mapPropsToFields?: (props: any) => void;
+export interface FormCreateOption<T> {
+  onFieldsChange?: (props: T, fields: Array<any>) => void;
+  onValuesChange?: (props: T, values: any) => void;
+  mapPropsToFields?: (props: T) => void;
   withRef?: boolean;
 }
 
@@ -139,7 +139,7 @@ export default class Form extends React.Component<FormProps, any> {
 
   static Item = FormItem;
 
-  static create = function<TOwnProps>(options?: FormCreateOption): ComponentDecorator<TOwnProps> {
+  static create = function<TOwnProps>(options?: FormCreateOption<TOwnProps>): ComponentDecorator<TOwnProps> {
     const formWrapper = createDOMForm({
       fieldNameProp: 'id',
       ...options,


### PR DESCRIPTION
By adding a generic type for `FormCreateOption`, we can now know what type the props in `mapPropsToFields`, `onFieldsChange `, `onValuesChange` is.

![image](https://user-images.githubusercontent.com/914329/29016216-227df9d2-7b84-11e7-858d-676d67261caf.png)
