### PR TITLE
Fix type definition for Card Component.

### DIFF
--- a/components/card/index.tsx
+++ b/components/card/index.tsx
@@ -18,7 +18,7 @@ export interface CardProps {
   className?: string;
 }
 
-export default class Card extends Component<CardProps> {
+export default class Card extends Component<CardProps, {}> {
   static Grid: typeof Grid = Grid;
   container: HTMLDivElement;
   resizeEvent: any;


### PR DESCRIPTION
`React.Component<P, S>` requires two parameters. The second parameter (State) has only recently become optional in a newer version of `@types/react`.

Upgrading to this has several major/breaking changes elsewhere. I would prefer to explicitly define State as `{}` in this case.

First of all, thank you for your contribution! :-)

Please makes sure that these checkboxes are checked before submitting your PR, thank you!

* [x] Make sure that you propose PR to right branch: bugfix for `master`, feature for latest active branch `feature-x.x`.
* [x] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.

Extra checklist:

**if** *isBugFix* **:**

  * [ ] Make sure that you add at least one unit test for the bug which you had fixed.

**elif** *isNewFeature* **:**

  * [ ] Update API docs for the component.
  * [ ] Update/Add demo to demonstrate new feature.
  * [ ] Update TypeScript definition for the component.
  * [ ] Add unit tests for the feature.
