### PR TITLE
bugfix：修复menu-inline-collapsed状态下的样式问题

### DIFF
--- a/components/menu/style/index.less
+++ b/components/menu/style/index.less
@@ -197,9 +197,7 @@
         line-height: 42px;
         margin: 0;
         + span {
-          max-width: 0;
-          display: inline-block;
-          opacity: 0;
+          display: none;
         }
       }
     }


### PR DESCRIPTION
Menu的menu-inline-collapsed状态下，若menu.item中的文字太长，会出现icon不可见的问题（中文只要2个字就会出问题）。
既然不展示文字，直接display: none是否即可解决问题。