### PR TITLE
interface define error

### DIFF
--- a/components/table/index.zh-CN.md
+++ b/components/table/index.zh-CN.md
@@ -141,7 +141,7 @@ import { Table } from 'antd';
 import { TableColumnConfig } from 'antd/lib/table/Table';
 
 interface IUser {
-  key: number,
+  key: number;
   name: string;
 }
 


### PR DESCRIPTION
fix: interface Properties should be separated by semicolons
