### PR TITLE
调整卡片样式

### DIFF
--- a/components/card/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/card/__tests__/__snapshots__/demo.test.js.snap
@@ -569,7 +569,7 @@ exports[`renders ./components/card/demo/simple.md correctly 1`] = `
 exports[`renders ./components/card/demo/tabs.md correctly 1`] = `
 <div>
   <div
-    class="ant-card ant-card-bordered"
+    class="ant-card ant-card-bordered ant-card-contain-tabs"
     style="width:100%;"
   >
     <div>
@@ -681,7 +681,7 @@ exports[`renders ./components/card/demo/tabs.md correctly 1`] = `
   <br />
   <br />
   <div
-    class="ant-card ant-card-bordered"
+    class="ant-card ant-card-bordered ant-card-contain-tabs"
     style="width:100%;"
   >
     <div>

--- a/components/card/index.tsx
+++ b/components/card/index.tsx
@@ -112,6 +112,7 @@ export default class Card extends Component<CardProps, {}> {
       [`${prefixCls}-wider-padding`]: this.state.widerPadding,
       [`${prefixCls}-padding-transition`]: this.updateWiderPaddingCalled,
       [`${prefixCls}-contain-grid`]: this.isContainGrid(),
+      [`${prefixCls}-contain-tabs`]: tabList && tabList.length,
       [`${prefixCls}-type-${type}`]: !!type,
     });
 

--- a/components/card/style/index.less
+++ b/components/card/style/index.less
@@ -34,6 +34,7 @@
 
     &-title {
       font-size: @font-size-lg;
+      min-height: @card-head-height;
       padding: @card-head-padding 0;
       text-overflow: ellipsis;
       overflow: hidden;
@@ -103,7 +104,11 @@
     }
   }
 
-  &-contain-tabs &-head-title,
+  &-contain-tabs &-head-title {
+    padding-bottom: 0;
+    min-height: @card-head-height - @card-head-padding;
+  }
+
   &-contain-tabs &-extra {
     padding-bottom: 0;
   }
@@ -181,6 +186,7 @@
     background: @background-color-base;
 
     &-title {
+      min-height: @card-inner-head-height;
       padding: @card-inner-head-padding 0;
     }
   }

--- a/components/card/style/index.less
+++ b/components/card/style/index.less
@@ -34,8 +34,7 @@
 
     &-title {
       font-size: @font-size-lg;
-      height: @card-head-height;
-      line-height: @card-head-height;
+      padding: @card-head-padding 0;
       text-overflow: ellipsis;
       overflow: hidden;
       white-space: nowrap;
@@ -46,17 +45,8 @@
 
     .@{ant-prefix}-tabs {
       margin-bottom: -17px;
-      margin-top: -8px;
+      margin-top: 4px;
       clear: both;
-
-      // For align with extra
-      &:only-child {
-        margin-top: 0;
-
-        .@{ant-prefix}-tabs-nav .@{ant-prefix}-tabs-tab {
-          padding: 13px 20px 15px;
-        }
-      }
 
       &-bar {
         border-bottom: @border-width-base @border-style-base @border-color-split;
@@ -66,7 +56,7 @@
 
   &-extra {
     float: right;
-    line-height: @card-head-height;
+    padding: @card-head-padding + 1.5px 0;
   }
 
   &-body {
@@ -111,6 +101,11 @@
       z-index: 1;
       box-shadow: @box-shadow-base;
     }
+  }
+
+  &-contain-tabs &-head-title,
+  &-contain-tabs &-extra {
+    padding-bottom: 0;
   }
 
   &-cover > * {
@@ -172,10 +167,6 @@
     padding: @card-padding-base @card-padding-wider;
   }
 
-  &-wider-padding &-extra {
-    right: @card-padding-wider;
-  }
-
   &-padding-transition &-head,
   &-padding-transition &-body {
     transition: padding .3s;
@@ -190,8 +181,7 @@
     background: @background-color-base;
 
     &-title {
-      height: @card-inner-head-height;
-      line-height: @card-inner-head-height;
+      padding: @card-inner-head-padding 0;
     }
   }
 
@@ -200,7 +190,7 @@
   }
 
   &-type-inner &-extra {
-    right: @card-padding-base;
+    padding: @card-inner-head-padding + 1.5px 0;
   }
 
   &-meta {

--- a/components/style/themes/default.less
+++ b/components/style/themes/default.less
@@ -337,10 +337,10 @@
 
 // Card
 // ---
-@card-head-height: 48px;
 @card-head-color: @heading-color;
 @card-head-background: @component-background;
-@card-inner-head-height: 46px;
+@card-head-padding: 16px;
+@card-inner-head-padding: 12px;
 @card-actions-background: @background-color-base;
 
 // Tabs

--- a/components/style/themes/default.less
+++ b/components/style/themes/default.less
@@ -337,6 +337,8 @@
 
 // Card
 // ---
+@card-head-height: 48px;
+@card-inner-head-height: 46px;
 @card-head-color: @heading-color;
 @card-head-background: @component-background;
 @card-head-padding: 16px;

--- a/components/tabs/style/index.less
+++ b/components/tabs/style/index.less
@@ -167,7 +167,7 @@
         margin-right: 0;
       }
 
-      padding: 8px 20px;
+      padding: 12px 20px;
       transition: color 0.3s @ease-in-out;
       cursor: pointer;
       text-decoration: none;


### PR DESCRIPTION
[视觉稿](https://lark.alipay.com/ui-assets/leu0s4/61926)

- 除字号大小统一调整外，按照视觉稿调整了卡片的样式
- head 部分删掉了 `@card-head-height` `@card-inner-head-height`，改用 padding 实现
- 按照 [tabs-视觉稿](https://lark.alipay.com/ui-assets/leu0s4/61878) 微调了 tabs 的样式