### PR TITLE
fix ts checking

### DIFF
--- a/components/checkbox/Checkbox.tsx
+++ b/components/checkbox/Checkbox.tsx
@@ -12,7 +12,7 @@ export interface AbstractCheckboxProps {
   checked?: boolean;
   style?: React.CSSProperties;
   disabled?: boolean;
-  onChange?: React.FormEventHandler<any>;
+  onChange?: React.ChangeEventHandler<HTMLInputElement>;
   onMouseEnter?: React.MouseEventHandler<any>;
   onMouseLeave?: React.MouseEventHandler<any>;
   value?: any;

--- a/components/select/index.tsx
+++ b/components/select/index.tsx
@@ -55,6 +55,7 @@ export interface SelectProps extends AbstractSelectProps {
 export interface OptionProps {
   disabled?: boolean;
   value?: any;
+  title?: string;
 }
 
 export interface OptGroupProps {


### PR DESCRIPTION
- Add title prop to Option component
- fix Checkbox onChange type, current type is incorrect
   ```tsx
   <Checkbox onChange={e => console.log(e.target.checked)} /> // Property 'checked' does not exist on type 'EventTarget'.
   ```