### PR TITLE
Update Button English doc

### DIFF
--- a/components/button/index.en-US.md
+++ b/components/button/index.en-US.md
@@ -16,14 +16,14 @@ To get a customized button, just set `type`/`shape`/`size`/`loading`/`disabled`.
 
 Property | Description | Type | Default
 -----|-----|-----|------
-type | can be set to `primary` `dashed` `danger`(added in 2.7) or omitted | string | 'default'
-htmlType | to set the original `type` of `button`, see: [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#attr-type) | string | `button`
+type | can be set to `primary` `ghost` `dashed` `danger`(added in 2.7) or omitted (meaning `default`) | string | `default`
+htmlType | set the original html `type` of `button`, see: [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#attr-type) | string | `button`
 icon | set the icon of button, see: Icon component | string | -
 shape | can be set to `circle` or omitted | string | -
 size | can be set to `small` `large` or omitted | string | `default`
-loading | to set the loading status of button | boolean \| { delay: number } | `false`
+loading | set the loading status of button | boolean \| { delay: number } | false
 onClick | set the handler to handle `click` event | function | -
-ghost | make background transparent and invert text and border color, added in 2.7 | boolean | false
+ghost | make background transparent and invert text and border colors, added in 2.7 | boolean | false
 
 `<Button>Hello world!</Button>` will be rendered into `<button>Hello world!</button>`, and all the properties which are not listed above will be transferred to the `<button>` tag.
 


### PR DESCRIPTION
Fixed some typos. Added the ghost button type. Made the 'type' column of the API table a little more consistent, with strings represented with code tags.

I don't know where the interactive examples are located, but the ghost type needs to be added to the part about button types. Also, there are some minor typos in the examples.

Note, the ghost type is different from the ghost prop which inverts button colors.
