### PR TITLE
Add is_IS locale

### DIFF
--- a/components/calendar/locale/is_IS.tsx
+++ b/components/calendar/locale/is_IS.tsx
@@ -1,0 +1,2 @@
+import is_IS from '../../date-picker/locale/is_IS';
+export default is_IS;

--- a/components/date-picker/locale/is_IS.tsx
+++ b/components/date-picker/locale/is_IS.tsx
@@ -1,0 +1,19 @@
+import CalendarLocale from 'rc-calendar/lib/locale/is_IS';
+import TimePickerLocale from '../../time-picker/locale/is_IS';
+
+// Merge into a locale object
+const locale = {
+  lang: {
+    placeholder: 'Veldu dag',
+    rangePlaceholder: ['Upphafsdagur', 'Lokadagur'],
+    ...CalendarLocale,
+  },
+  timePickerLocale: {
+    ...TimePickerLocale,
+  },
+};
+
+// All settings at:
+// https://github.com/ant-design/ant-design/blob/master/components/date-picker/locale/example.json
+
+export default locale;

--- a/components/locale-provider/__tests__/index.test.js
+++ b/components/locale-provider/__tests__/index.test.js
@@ -32,8 +32,9 @@ import faIR from '../fa_IR';
 import elGR from '../el_GR';
 import nbNO from '../nb_NO';
 import srRS from '../sr_RS';
+import isIS from '../is_IS';
 
-const locales = [enUS, ptBR, ruRU, esES, svSE, frBE, deDE, nlNL, caES, csCZ, koKR, etEE, skSK, jaJP, trTR, zhTW, fiFI, plPL, bgBG, enGB, frFR, nlBE, itIT, viVN, thTH, faIR, elGR, nbNO, srRS];
+const locales = [enUS, ptBR, ruRU, esES, svSE, frBE, deDE, nlNL, caES, csCZ, koKR, etEE, skSK, jaJP, trTR, zhTW, fiFI, plPL, bgBG, enGB, frFR, nlBE, itIT, viVN, thTH, faIR, elGR, nbNO, srRS, isIS];
 
 const Option = Select.Option;
 const RangePicker = DatePicker.RangePicker;

--- a/components/locale-provider/is_IS.tsx
+++ b/components/locale-provider/is_IS.tsx
@@ -1,0 +1,47 @@
+import moment from 'moment';
+moment.locale('is');
+
+import Pagination from 'rc-pagination/lib/locale/is_IS';
+import DatePicker from '../date-picker/locale/is_IS';
+import TimePicker from '../time-picker/locale/is_IS';
+import Calendar from '../calendar/locale/is_IS';
+
+export default {
+  locale: 'is',
+  Pagination,
+  DatePicker,
+  TimePicker,
+  Calendar,
+  Table: {
+    filterTitle: 'Afmarkanir',
+    filterConfirm: 'Staðfesta',
+    filterReset: 'Núllstilla',
+    emptyText: 'Engin gögn',
+    selectAll: 'Velja allt',
+    selectInvert: 'Viðsnúa vali',
+  },
+  Modal: {
+    okText: 'Áfram',
+    cancelText: 'Hætta við',
+    justOkText: 'Í lagi',
+  },
+  Popconfirm: {
+    okText: 'Áfram',
+    cancelText: 'Hætta við',
+  },
+  Transfer: {
+    notFoundContent: 'Engar færslur',
+    searchPlaceholder: 'Leita hér',
+    itemUnit: 'færsla',
+    itemsUnit: 'færslur',
+  },
+  Select: {
+    notFoundContent: 'Ekkert finnst',
+  },
+  Upload: {
+    uploading: 'Hleð upp...',
+    removeFile: 'Fjarlægja skrá',
+    uploadError: 'Villa við að hlaða upp',
+    previewFile: 'Forskoða skrá',
+  },
+};

--- a/components/time-picker/locale/is_IS.tsx
+++ b/components/time-picker/locale/is_IS.tsx
@@ -1,0 +1,5 @@
+const locale = {
+  placeholder: 'Velja tíma',
+};
+
+export default locale;

--- a/docs/react/i18n.en-US.md
+++ b/docs/react/i18n.en-US.md
@@ -40,6 +40,7 @@ Supported languages:
 |French (Belgium)|fr_BE|
 |French (France)|fr_FR|
 |German|de_DE|
+|Icelandic|is_IS|
 |Italian|it_IT|
 |Japanese|ja_JP|
 |Korean|ko_KR|


### PR DESCRIPTION
Added Icelandic locale.

Separate PR created for rc-pagination component with the corresponding locale.
react-component/pagination#109

Separate PR created for rc-calendar component with the corresponding locale.
react-component/calendar#295

will this be added to the ant.design v2.13.x? as well as ant.design v3.0