### PR TITLE
Added react and react-dom as peerDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
   "typings": "lib/index.d.ts",
   "license": "MIT",
   "peerDependencies": {
-    "react": ">=15.0.0",
-    "react-dom": ">=15.0.0"
+    "react": "~0.14.0 || >=15.0.0",
+    "react-dom": "~0.14.0 || >=15.0.0"
   },
   "dependencies": {
     "array-tree-filter": "~1.0.0",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,10 @@
   ],
   "typings": "lib/index.d.ts",
   "license": "MIT",
+  "peerDependencies": {
+    "react": ">=15.0.0",
+    "react-dom": ">=15.0.0"
+  },
   "dependencies": {
     "array-tree-filter": "~1.0.0",
     "babel-runtime": "6.x",


### PR DESCRIPTION
Adds `react` and `react-dom` as peerDependencies for `antd`. Users that try to install antd without react will get helpful install-time warnings.

Some tools like [bundlephobia.com](https://bundlephobia.com) also use the `peerDependency` field to understand which dependencies are external to the package, and shouldn't be accounted for when calculating bundle size. Without this hint, it would fail.
