### PR TITLE
Mark refs to private

### DIFF
--- a/components/affix/index.tsx
+++ b/components/affix/index.tsx
@@ -69,7 +69,6 @@ export default class Affix extends React.Component<AffixProps, any> {
   scrollEvent: any;
   resizeEvent: any;
   timeout: any;
-  fixedNode: HTMLElement;
 
   events = [
     'resize',
@@ -82,6 +81,8 @@ export default class Affix extends React.Component<AffixProps, any> {
   ];
 
   eventHandlers = {};
+
+  private fixedNode: HTMLElement;
 
   constructor(props) {
     super(props);

--- a/components/anchor/Anchor.tsx
+++ b/components/anchor/Anchor.tsx
@@ -95,7 +95,7 @@ export default class Anchor extends React.Component<AnchorProps, any> {
     antAnchor: PropTypes.object,
   };
 
-  inkNode: HTMLElement;
+  private inkNode: HTMLElement;
 
   private links: String[];
   private scrollEvent: any;

--- a/components/calendar/Header.tsx
+++ b/components/calendar/Header.tsx
@@ -24,7 +24,7 @@ export default class Header extends React.Component<HeaderProps, any> {
     yearSelectTotal: 20,
   };
 
-  calenderHeaderNode: any;
+  private calenderHeaderNode: any;
 
   getYearSelectElement(year) {
     const { yearSelectOffset, yearSelectTotal, locale, prefixCls, fullscreen } = this.props;

--- a/components/card/index.tsx
+++ b/components/card/index.tsx
@@ -36,12 +36,12 @@ export interface CardProps {
 export default class Card extends Component<CardProps, {}> {
   static Grid: typeof Grid = Grid;
   static Meta: typeof Meta = Meta;
-  container: HTMLDivElement;
   resizeEvent: any;
   updateWiderPaddingCalled: boolean;
   state = {
     widerPadding: false,
   };
+  private container: HTMLDivElement;
   componentDidMount() {
     this.updateWiderPadding();
     this.resizeEvent = addEventListener(window, 'resize', this.updateWiderPadding);

--- a/components/carousel/index.tsx
+++ b/components/carousel/index.tsx
@@ -74,9 +74,9 @@ export default class Carousel extends React.Component<CarouselProps, any> {
     draggable: false,
   };
 
-  slick: any;
-
   innerSlider: any;
+
+  private slick: any;
 
   constructor() {
     super();

--- a/components/cascader/index.tsx
+++ b/components/cascader/index.tsx
@@ -108,7 +108,7 @@ export default class Cascader extends React.Component<CascaderProps, any> {
 
   cachedOptions: CascaderOptionType[];
 
-  input: Input;
+  private input: Input;
 
   constructor(props) {
     super(props);

--- a/components/input/Search.tsx
+++ b/components/input/Search.tsx
@@ -12,7 +12,7 @@ export default class Search extends React.Component<SearchProps, any> {
     prefixCls: 'ant-input-search',
   };
 
-  input: Input;
+  private input: Input;
 
   onSearch = () => {
     const { onSearch } = this.props;

--- a/components/input/TextArea.tsx
+++ b/components/input/TextArea.tsx
@@ -37,10 +37,12 @@ export default class TextArea extends React.Component<TextAreaProps & HTMLTextar
   };
 
   nextFrameActionId: number;
-  textAreaRef: HTMLTextAreaElement;
+
   state = {
     textareaStyles: null,
   };
+
+  private textAreaRef: HTMLTextAreaElement;
 
   componentDidMount() {
     this.resizeTextarea();

--- a/components/list/index.tsx
+++ b/components/list/index.tsx
@@ -88,7 +88,6 @@ export default class List extends Component<ListProps> {
   scrollEvent: any;
   resizeEvent: any;
   timeout: any;
-  node: any;
 
   events = [
     'resize',
@@ -101,6 +100,8 @@ export default class List extends Component<ListProps> {
   ];
   infiniteLoaded = false;
   eventHandlers = {};
+
+  private node: any;
 
   getChildContext() {
     return {

--- a/components/popconfirm/index.tsx
+++ b/components/popconfirm/index.tsx
@@ -23,7 +23,7 @@ abstract class Popconfirm extends React.Component<PopconfirmProps, any> {
     okType: 'primary',
   };
 
-  tooltip: Tooltip;
+  private tooltip: Tooltip;
 
   constructor(props: PopconfirmProps) {
     super(props);

--- a/components/popover/index.tsx
+++ b/components/popover/index.tsx
@@ -19,7 +19,7 @@ export default class Popover extends React.Component<PopoverProps, any> {
     overlayStyle: {},
   };
 
-  tooltip: Tooltip;
+  private tooltip: Tooltip;
 
   getPopupDomNode() {
     return this.tooltip.getPopupDomNode();

--- a/components/time-picker/index.tsx
+++ b/components/time-picker/index.tsx
@@ -55,7 +55,7 @@ abstract class TimePicker extends React.Component<TimePickerProps, any> {
     transitionName: 'slide-up',
   };
 
-  timePickerRef: any;
+  private timePickerRef: any;
 
   constructor(props: TimePickerProps) {
     super(props);

--- a/components/tooltip/index.tsx
+++ b/components/tooltip/index.tsx
@@ -59,7 +59,7 @@ export default class Tooltip extends React.Component<TooltipProps, any> {
     autoAdjustOverflow: true,
   };
 
-  tooltip: any;
+  private tooltip: any;
 
   constructor(props: TooltipProps) {
     super(props);

--- a/components/upload/Upload.tsx
+++ b/components/upload/Upload.tsx
@@ -49,7 +49,7 @@ export default class Upload extends React.Component<UploadProps, any> {
   recentUploadStatus: boolean | PromiseLike<any>;
   progressTimer: any;
 
-  upload: any;
+  private upload: any;
 
   constructor(props) {
     super(props);


### PR DESCRIPTION
These changes only effect TypeScript users. Refs should not be accessed, otherwise we should document them.