### PR TITLE
Add focus and blur support to InputNumber

### DIFF
--- a/components/input-number/index.tsx
+++ b/components/input-number/index.tsx
@@ -27,6 +27,8 @@ export default class InputNumber extends React.Component<InputNumberProps, any> 
     prefixCls: 'ant-input-number',
     step: 1,
   };
+  
+  private inputNumberRef: any;
 
   render() {
     const { className, size, ...others } = this.props;
@@ -35,10 +37,10 @@ export default class InputNumber extends React.Component<InputNumberProps, any> 
       [`${this.props.prefixCls}-sm`]: size === 'small',
     }, className);
 
-    return <RcInputNumber ref="inputnumber" className={inputNumberClass} {...others} />;
+    return <RcInputNumber ref={c => this.inputNumberRef = c} className={inputNumberClass} {...others} />;
   }
 
   focus() {
-    this.refs.inputnumber.focus();
+    this.inputNumberRef.focus();
   }
 }

--- a/components/input-number/index.tsx
+++ b/components/input-number/index.tsx
@@ -35,6 +35,10 @@ export default class InputNumber extends React.Component<InputNumberProps, any> 
       [`${this.props.prefixCls}-sm`]: size === 'small',
     }, className);
 
-    return <RcInputNumber className={inputNumberClass} {...others} />;
+    return <RcInputNumber ref="inputnumber" className={inputNumberClass} {...others} />;
+  }
+
+  focus() {
+    this.refs.inputnumber.focus();
   }
 }

--- a/components/input-number/index.tsx
+++ b/components/input-number/index.tsx
@@ -27,7 +27,7 @@ export default class InputNumber extends React.Component<InputNumberProps, any> 
     prefixCls: 'ant-input-number',
     step: 1,
   };
-  
+
   private inputNumberRef: any;
 
   render() {
@@ -42,5 +42,9 @@ export default class InputNumber extends React.Component<InputNumberProps, any> 
 
   focus() {
     this.inputNumberRef.focus();
+  }
+
+  blur() {
+    this.inputNumberRef.blur();
   }
 }


### PR DESCRIPTION
Useful for focusing the first field in a form which in this case may be an InputNumber
```
<InputNumber ref={(input) => this.amountInput = input} />
```
then inside lifecycle method like `componentDidUpdate`
```
this.amountInput.focus()
```

Brings into line with [Input.focus](https://github.com/ant-design/ant-design/blob/master/components/input/Input.tsx#L96)

Related to [PR 7577](https://github.com/ant-design/ant-design/pull/7577) against Master 