### PR TITLE
Remove Input autoComplete restriction to allow more complex auto-filling behaviour

### DIFF
--- a/components/input/Input.tsx
+++ b/components/input/Input.tsx
@@ -37,7 +37,7 @@ export interface InputProps extends AbstractInputProps {
   onClick?: React.FormEventHandler<any>;
   onFocus?: React.FormEventHandler<any>;
   onBlur?: React.FormEventHandler<any>;
-  autoComplete?: 'on' | 'off';
+  autoComplete?: string;
   prefix?: React.ReactNode;
   suffix?: React.ReactNode;
   spellCheck?: boolean;


### PR DESCRIPTION
As well as **`on`** and **`off`** there are many other possible values such as **`email`**, **`username`**, **`new-password`**, **`current-password`** and credit card options to help the browser autofill. 

References
- https://www.chromium.org/developers/design-documents/form-styles-that-chromium-understands
- https://developers.google.com/web/updates/2015/06/checkout-faster-with-autofill