### PR TITLE
Bugfix: Handle defaultSearchChange when suggestions contain ‘Nav’ items

### DIFF
--- a/components/mention/index.tsx
+++ b/components/mention/index.tsx
@@ -80,7 +80,14 @@ export default class Mention extends React.Component<MentionProps, MentionState>
   defaultSearchChange(value: String): void {
     const searchValue = value.toLowerCase();
     const filteredSuggestions = (this.props.suggestions || []).filter(
-      suggestion => suggestion.toLowerCase().indexOf(searchValue) !== -1,
+      suggestion => {
+        if (suggestion.type && suggestion.type === Nav) {
+          return suggestion.props.value ?
+            suggestion.props.value.toLowerCase().indexOf(searchValue) !== -1
+            : true;
+        }
+        return suggestion.toLowerCase().indexOf(searchValue) !== -1;
+      },
     );
     this.setState({
       suggestions: filteredSuggestions,


### PR DESCRIPTION
Fixing issue #7696; 
Please let me know if I should make changes here.

For the fix itself, when the `suggestions` array is passed in and comprises of `Nav` items, we use the `value` prop to run . the search and return the filteredSuggestions.