### PR TITLE
Expose renderDate function for DatePicker

### DIFF
--- a/components/date-picker/RangePicker.tsx
+++ b/components/date-picker/RangePicker.tsx
@@ -179,7 +179,7 @@ export default class RangePicker extends React.Component<any, any> {
       disabledDate, disabledTime,
       showTime, showToday,
       ranges, onOk, locale, format,
-      renderDate,
+      dateRender,
     } = props;
     warning(!('onOK' in props), 'It should be `RangePicker[onOk]`, instead of `onOK`!');
 
@@ -222,7 +222,7 @@ export default class RangePicker extends React.Component<any, any> {
         dateInputPlaceholder={[startPlaceholder, endPlaceholder]}
         locale={locale.lang}
         onOk={onOk}
-        dateRender={renderDate}
+        dateRender={dateRender}
         value={showDate}
         onValueChange={this.handleShowDateChange}
         hoverValue={hoverValue}

--- a/components/date-picker/RangePicker.tsx
+++ b/components/date-picker/RangePicker.tsx
@@ -179,6 +179,7 @@ export default class RangePicker extends React.Component<any, any> {
       disabledDate, disabledTime,
       showTime, showToday,
       ranges, onOk, locale, format,
+      renderDate,
     } = props;
     warning(!('onOK' in props), 'It should be `RangePicker[onOk]`, instead of `onOK`!');
 
@@ -221,6 +222,7 @@ export default class RangePicker extends React.Component<any, any> {
         dateInputPlaceholder={[startPlaceholder, endPlaceholder]}
         locale={locale.lang}
         onOk={onOk}
+        dateRender={renderDate}
         value={showDate}
         onValueChange={this.handleShowDateChange}
         hoverValue={hoverValue}

--- a/components/date-picker/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/date-picker/__tests__/__snapshots__/demo.test.js.snap
@@ -81,6 +81,54 @@ exports[`renders ./components/date-picker/demo/basic.md correctly 1`] = `
 </div>
 `;
 
+exports[`renders ./components/date-picker/demo/date-render.md correctly 1`] = `
+<div>
+  <span
+    class="ant-calendar-picker"
+  >
+    <div>
+      <input
+        class="ant-calendar-picker-input ant-input"
+        placeholder="请选择日期"
+        readonly=""
+        value=""
+      />
+      <span
+        class="ant-calendar-picker-icon"
+      />
+    </div>
+  </span>
+  <span
+    class="ant-calendar-picker"
+  >
+    <span
+      class="ant-calendar-picker-input ant-input"
+    >
+      <input
+        class="ant-calendar-range-picker-input"
+        placeholder="开始日期"
+        readonly=""
+        value=""
+      />
+      <span
+        class="ant-calendar-range-picker-separator"
+      >
+         ~ 
+      </span>
+      <input
+        class="ant-calendar-range-picker-input"
+        placeholder="结束日期"
+        readonly=""
+        value=""
+      />
+      <span
+        class="ant-calendar-picker-icon"
+      />
+    </span>
+  </span>
+</div>
+`;
+
 exports[`renders ./components/date-picker/demo/disabled.md correctly 1`] = `
 <div>
   <span
@@ -468,54 +516,6 @@ exports[`renders ./components/date-picker/demo/presetted-ranges.md correctly 1`]
   <span
     class="ant-calendar-picker"
     style="width:300px;"
-  >
-    <span
-      class="ant-calendar-picker-input ant-input"
-    >
-      <input
-        class="ant-calendar-range-picker-input"
-        placeholder="开始日期"
-        readonly=""
-        value=""
-      />
-      <span
-        class="ant-calendar-range-picker-separator"
-      >
-         ~ 
-      </span>
-      <input
-        class="ant-calendar-range-picker-input"
-        placeholder="结束日期"
-        readonly=""
-        value=""
-      />
-      <span
-        class="ant-calendar-picker-icon"
-      />
-    </span>
-  </span>
-</div>
-`;
-
-exports[`renders ./components/date-picker/demo/render-date.md correctly 1`] = `
-<div>
-  <span
-    class="ant-calendar-picker"
-  >
-    <div>
-      <input
-        class="ant-calendar-picker-input ant-input"
-        placeholder="请选择日期"
-        readonly=""
-        value=""
-      />
-      <span
-        class="ant-calendar-picker-icon"
-      />
-    </div>
-  </span>
-  <span
-    class="ant-calendar-picker"
   >
     <span
       class="ant-calendar-picker-input ant-input"

--- a/components/date-picker/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/date-picker/__tests__/__snapshots__/demo.test.js.snap
@@ -497,6 +497,54 @@ exports[`renders ./components/date-picker/demo/presetted-ranges.md correctly 1`]
 </div>
 `;
 
+exports[`renders ./components/date-picker/demo/render-date.md correctly 1`] = `
+<div>
+  <span
+    class="ant-calendar-picker"
+  >
+    <div>
+      <input
+        class="ant-calendar-picker-input ant-input"
+        placeholder="请选择日期"
+        readonly=""
+        value=""
+      />
+      <span
+        class="ant-calendar-picker-icon"
+      />
+    </div>
+  </span>
+  <span
+    class="ant-calendar-picker"
+  >
+    <span
+      class="ant-calendar-picker-input ant-input"
+    >
+      <input
+        class="ant-calendar-range-picker-input"
+        placeholder="开始日期"
+        readonly=""
+        value=""
+      />
+      <span
+        class="ant-calendar-range-picker-separator"
+      >
+         ~ 
+      </span>
+      <input
+        class="ant-calendar-range-picker-input"
+        placeholder="结束日期"
+        readonly=""
+        value=""
+      />
+      <span
+        class="ant-calendar-picker-icon"
+      />
+    </span>
+  </span>
+</div>
+`;
+
 exports[`renders ./components/date-picker/demo/size.md correctly 1`] = `
 <div>
   <div

--- a/components/date-picker/createPicker.tsx
+++ b/components/date-picker/createPicker.tsx
@@ -115,6 +115,7 @@ export default function createPicker(TheCalendar): any {
           prefixCls={prefixCls}
           className={calendarClassName}
           onOk={props.onOk}
+          dateRender={props.renderDate}
           format={props.format}
           showToday={props.showToday}
           monthCellContentRender={props.monthCellContentRender}

--- a/components/date-picker/createPicker.tsx
+++ b/components/date-picker/createPicker.tsx
@@ -115,7 +115,7 @@ export default function createPicker(TheCalendar): any {
           prefixCls={prefixCls}
           className={calendarClassName}
           onOk={props.onOk}
-          dateRender={props.renderDate}
+          dateRender={props.dateRender}
           format={props.format}
           showToday={props.showToday}
           monthCellContentRender={props.monthCellContentRender}

--- a/components/date-picker/demo/date-render.md
+++ b/components/date-picker/demo/date-render.md
@@ -11,7 +11,7 @@ title:
 
 ## en-US
 
-We can customize the rendering of date cells in the calendar by providing a `renderDate` function to `DatePicker`.
+We can customize the rendering of date cells in the calendar by providing a `dateRender` function to `DatePicker`.
 
 ````jsx
 import { DatePicker } from 'antd';
@@ -20,7 +20,7 @@ const { RangePicker } = DatePicker;
 ReactDOM.render(
   <div>
     <DatePicker
-      renderDate={(current) => {
+      dateRender={(current) => {
         const style = {};
         if (current.date() === 1) {
           style.border = '1px solid';
@@ -35,7 +35,7 @@ ReactDOM.render(
       }}
     />
     <RangePicker
-      renderDate={(current) => {
+      dateRender={(current) => {
         const style = {};
         if (current.date() === 1) {
           style.border = '1px solid';

--- a/components/date-picker/demo/render-date.md
+++ b/components/date-picker/demo/render-date.md
@@ -1,0 +1,54 @@
+---
+order: 12
+title:
+  zh-CN: <Missing>
+  en-US: Customized Date Rendering
+---
+
+## zh-CN
+
+<Missing>
+
+## en-US
+
+We can customize the rendering of date cells in the calendar by providing a `renderDate` function to `DatePicker`.
+
+````jsx
+import { DatePicker } from 'antd';
+const { RangePicker } = DatePicker;
+
+ReactDOM.render(
+  <div>
+    <DatePicker
+      renderDate={(current) => {
+        const style = {};
+        if (current.date() === 1) {
+          style.border = '1px solid';
+          style.borderRadius = '50%';
+        }
+
+        return (
+          <div className="ant-calendar-date" style={style}>
+            {current.date()}
+          </div>
+        );
+      }}
+    />
+    <RangePicker
+      renderDate={(current) => {
+        const style = {};
+        if (current.date() === 1) {
+          style.border = '1px solid';
+          style.borderRadius = '50%';
+        }
+
+        return (
+          <div className="ant-calendar-date" style={style}>
+            {current.date()}
+          </div>
+        );
+      }}
+    />
+  </div>
+, mountNode);
+````

--- a/components/date-picker/index.en-US.md
+++ b/components/date-picker/index.en-US.md
@@ -49,6 +49,7 @@ The following APIs are shared by DatePicker, MonthPicker, RangePicker, WeekPicke
 | open | open state of picker | boolean | - |
 | onOpenChange   | a callback function, can be executed whether the popup calendar is popped up or closed | function(status) | - |
 | placeholder  | placeholder of date input | string\|RangePicker[] | - |
+| renderDate | custom rendering function for date cells | function(currentDate: moment, today: moment) => React.ReactNode | - |
 
 ### DatePicker
 

--- a/components/date-picker/index.en-US.md
+++ b/components/date-picker/index.en-US.md
@@ -49,7 +49,7 @@ The following APIs are shared by DatePicker, MonthPicker, RangePicker, WeekPicke
 | open | open state of picker | boolean | - |
 | onOpenChange   | a callback function, can be executed whether the popup calendar is popped up or closed | function(status) | - |
 | placeholder  | placeholder of date input | string\|RangePicker[] | - |
-| renderDate | custom rendering function for date cells | function(currentDate: moment, today: moment) => React.ReactNode | - |
+| dateRender | custom rendering function for date cells | function(currentDate: moment, today: moment) => React.ReactNode | - |
 
 ### DatePicker
 

--- a/components/date-picker/index.tsx
+++ b/components/date-picker/index.tsx
@@ -25,6 +25,7 @@ export interface PickerProps {
   onOpenChange?: (status: boolean) => void;
   disabledDate?: (current: moment.Moment) => boolean;
   renderExtraFooter?: () => React.ReactNode;
+  renderDate?: (current: moment.Moment, today: moment.Moment) => React.ReactNode;
 }
 
 export interface SinglePickerProps {

--- a/components/date-picker/index.tsx
+++ b/components/date-picker/index.tsx
@@ -25,7 +25,7 @@ export interface PickerProps {
   onOpenChange?: (status: boolean) => void;
   disabledDate?: (current: moment.Moment) => boolean;
   renderExtraFooter?: () => React.ReactNode;
-  renderDate?: (current: moment.Moment, today: moment.Moment) => React.ReactNode;
+  dateRender?: (current: moment.Moment, today: moment.Moment) => React.ReactNode;
 }
 
 export interface SinglePickerProps {

--- a/components/date-picker/index.zh-CN.md
+++ b/components/date-picker/index.zh-CN.md
@@ -50,6 +50,7 @@ moment.locale('zh-cn');
 | open | 控制弹层是否展开 | boolean | - |
 | onOpenChange   | 弹出日历和关闭日历的回调 | function(status) | 无 |
 | placeholder  | 输入框提示文字 | string\|RangePicker[] | - |
+| renderDate | ... | function(currentDate: moment, today: moment) => React.ReactNode | - |
 
 ### DatePicker
 

--- a/components/date-picker/index.zh-CN.md
+++ b/components/date-picker/index.zh-CN.md
@@ -50,7 +50,7 @@ moment.locale('zh-cn');
 | open | 控制弹层是否展开 | boolean | - |
 | onOpenChange   | 弹出日历和关闭日历的回调 | function(status) | 无 |
 | placeholder  | 输入框提示文字 | string\|RangePicker[] | - |
-| renderDate | ... | function(currentDate: moment, today: moment) => React.ReactNode | - |
+| dateRender | ... | function(currentDate: moment, today: moment) => React.ReactNode | - |
 
 ### DatePicker
 


### PR DESCRIPTION
Exposed [rc-calendar's](https://github.com/react-component/calendar) function for rendering individual date cells in the calendar. This can be used to customise certain dates in `DatePicker` and `RangePicker` (such as the first of the month in the added demo).

This is currently missing documentation in Chinese, I was hoping you could help me out with that (I don't unfortunately speak it myself).


Please makes sure that these checkboxes are checked before submitting your PR, thank you!

* [x] Make sure that you propose PR to right branch: bugfix for `master`, feature for latest active branch `feature-x.x`.
* [x] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.

Extra checklist:

  * [x] Update API docs for the component.
  * [x] Update/Add demo to demonstrate new feature.
  * [x] Update TypeScript definition for the component.
  * [x] Add unit tests for the feature.

Close: #7216