### PR TITLE
BUGFIX: Make iconfont usable standalone

### DIFF
--- a/components/style/core/iconfont.less
+++ b/components/style/core/iconfont.less
@@ -1,5 +1,7 @@
+@import '../themes/default';
+@import "../mixins/iconfont";
+
 // font-face
-// @icon-url： 字体源文件的地址
 @font-face {
   font-family: 'anticon';
   src: url('@{icon-url}.eot'); /* IE9*/


### PR DESCRIPTION
Similar to motion.less, import all dependencies needed to generate iconfont.less by itself.