### PR TITLE
Fix: setting 'heigh: 100%' on Sider and the wrapped element can't tak…

### DIFF
--- a/components/layout/style/index.less
+++ b/components/layout/style/index.less
@@ -47,6 +47,10 @@
     /* fix firefox can't set width smaller than content on flex item */
     min-width: 0;
 
+    &-children {
+      height: 100%;
+    }
+
     &-has-trigger {
       padding-bottom: @layout-trigger-height;
     }


### PR DESCRIPTION
Fix: setting 'heigh: 100%' on Sider and the wrapped element can't take the desired effects

The problem is caused by this [line](https://github.com/ant-design/ant-design/blob/master/components/layout/Sider.tsx#L184). This [Codepen demo]( https://codepen.io/zheeeng/pen/gGaZRx
) contains the comparison between the HTML and the commented HTML. In CSS, the commented style fix the issue.

Please makes sure that these checkboxes are checked before submitting your PR, thank you!

* [x] Make sure that you propose PR to right branch: bugfix for `master`, feature for latest active branch `feature-x.x`.
* [x] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.

Extra checklist:

**if** *isBugFix* **:**

  * [ ] Make sure that you add at least one unit test for the bug which you had fixed.

**elif** *isNewFeature* **:**

  * [ ] Update API docs for the component.
  * [ ] Update/Add demo to demonstrate new feature.
  * [ ] Update TypeScript definition for the component.
  * [ ] Add unit tests for the feature.
