### PR TITLE
upgrade rc-animate to 2.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "moment": "^2.18.1",
     "omit.js": "^1.0.0",
     "prop-types": "^15.5.7",
-    "rc-animate": "^2.3.6",
+    "rc-animate": "^2.4.1",
     "rc-calendar": "~9.0.0",
     "rc-cascader": "~0.11.3",
     "rc-checkbox": "~2.0.3",


### PR DESCRIPTION
upgrade rc-animate to fix warning

```
WARNING in ./node_modules/antd/node_modules/rc-animate/es/AnimateChild.js
76:11-34 "export 'isCssAnimationSupported' was not found in 'css-animation'
```