### PR TITLE
Avoid circular reference with infinite children

### DIFF
--- a/components/auto-complete/index.tsx
+++ b/components/auto-complete/index.tsx
@@ -52,7 +52,7 @@ export default class AutoComplete extends React.Component<AutoCompleteProps, any
     const element = children && React.isValidElement(children) && children.type !== Option ?
       React.Children.only(this.props.children) : <Input />;
     return (
-      <InputElement {...element.props}>{element}</InputElement>
+      <InputElement>{element}</InputElement>
     );
   }
 


### PR DESCRIPTION
Because {element} is a child of `<InputElement>`, we get a circular reference when also adding "element.props" to `<InputElement>`, as `<InputElement>` will be cloned to `<{element}>` later. As a consequence, we get an infinitive circular loop of Element->Props->Children->Element->Props->Children->Element->Props->Children->…

React seems to detect and automatically fix this infinitive loop. But when using the smaller and faster Inferno as a replacement library of React, we get a **"RangeError: Maximum call stack size exceeded"**.

This commit fixes this bug by not attaching {...element.props} to `<InputElement>`.

All tests did pass and I did not notice any changes in the behaviour of the AutoComplete component. But after this code change, AutoComplete works even with Inferno, and not only with React.