### PR TITLE
Add maxLength prop to Input, TextArea

### DIFF
--- a/components/input/Input.tsx
+++ b/components/input/Input.tsx
@@ -27,6 +27,7 @@ export interface InputProps extends AbstractInputProps {
   id?: number | string;
   name?: string;
   size?: 'large' | 'default' | 'small';
+  maxLength?: string;
   disabled?: boolean;
   readOnly?: boolean;
   addonBefore?: React.ReactNode;
@@ -62,6 +63,7 @@ export default class Input extends Component<InputProps, any> {
       PropTypes.number,
     ]),
     size: PropTypes.oneOf(['small', 'default', 'large']),
+    maxLength: PropTypes.string,
     disabled: PropTypes.bool,
     value: PropTypes.any,
     defaultValue: PropTypes.any,

--- a/components/input/__tests__/__snapshots__/index.test.js.snap
+++ b/components/input/__tests__/__snapshots__/index.test.js.snap
@@ -1,5 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Input should support maxLength 1`] = `
+<Input
+  disabled={false}
+  maxLength="3"
+  prefixCls="ant-input"
+  type="text"
+>
+  <input
+    className="ant-input"
+    disabled={false}
+    maxLength="3"
+    onKeyDown={[Function]}
+    type="text"
+  />
+</Input>
+`;
+
 exports[`TextArea should support disabled 1`] = `
 <TextArea
   disabled={true}
@@ -8,6 +25,21 @@ exports[`TextArea should support disabled 1`] = `
   <textarea
     className="ant-input ant-input-disabled"
     disabled={true}
+    onChange={[Function]}
+    onKeyDown={[Function]}
+    style={Object {}}
+  />
+</TextArea>
+`;
+
+exports[`TextArea should support maxLength 1`] = `
+<TextArea
+  maxLength="10"
+  prefixCls="ant-input"
+>
+  <textarea
+    className="ant-input"
+    maxLength="10"
     onChange={[Function]}
     onKeyDown={[Function]}
     style={Object {}}

--- a/components/input/__tests__/index.test.js
+++ b/components/input/__tests__/index.test.js
@@ -7,6 +7,15 @@ const { TextArea } = Input;
 
 const delay = timeout => new Promise(resolve => setTimeout(resolve, timeout));
 
+
+describe('Input', () => {
+  it('should support maxLength', async () => {
+    const wrapper = mount(
+      <Input maxLength="3" />
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
+});
 describe('TextArea', () => {
   it('should auto calculate height according to content length', async () => {
     const wrapper = mount(
@@ -24,6 +33,13 @@ describe('TextArea', () => {
   it('should support disabled', async () => {
     const wrapper = mount(
       <TextArea disabled />
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should support maxLength', async () => {
+    const wrapper = mount(
+      <TextArea maxLength="10" />
     );
     expect(wrapper).toMatchSnapshot();
   });


### PR DESCRIPTION
Note: html `maxlength` property is `maxLength` in React