### PR TITLE
Add inputPrefixCls for Search component

### DIFF
--- a/components/input/Search.tsx
+++ b/components/input/Search.tsx
@@ -4,11 +4,13 @@ import Input, { InputProps } from './Input';
 import Icon from '../icon';
 
 export interface SearchProps extends InputProps {
+  inputPrefixCls?: string;
   onSearch?: (value: string) => any;
 }
 
 export default class Search extends React.Component<SearchProps, any> {
   static defaultProps = {
+    inputPrefixCls: 'ant-input',
     prefixCls: 'ant-input-search',
   };
   input: any;
@@ -20,7 +22,7 @@ export default class Search extends React.Component<SearchProps, any> {
     this.input.focus();
   }
   render() {
-    const { className, prefixCls, ...others } = this.props;
+    const { className, inputPrefixCls, prefixCls, ...others } = this.props;
     delete (others as any).onSearch;
     const searchSuffix = (
       <Icon
@@ -34,6 +36,7 @@ export default class Search extends React.Component<SearchProps, any> {
         onPressEnter={this.onSearch}
         {...others}
         className={classNames(prefixCls, className)}
+        prefixCls={inputPrefixCls}
         suffix={searchSuffix}
         ref={node => this.input = node}
       />


### PR DESCRIPTION
Similar to `tooltipPrefixCls` for `Slider` or `selectPrefixCls` for `Pagination`, this allows the `Input` within `Search` to be styled properly.