### PR TITLE
documentation form

### DIFF
--- a/components/form/index.en-US.md
+++ b/components/form/index.en-US.md
@@ -97,9 +97,9 @@ If the form has been decorated by `Form.create` then it has `this.props.form` pr
 
 After wrapped by `getFieldDecorator`, `value`(or other property defined by `valuePropName`) `onChange`(or other property defined by `trigger`) props will be added to form controls，the flow of form data will be handled by Form which will cause:
 
-1. You shouldn't to use `onChange` to collect data, but you still can listen to `onChange`(and so on) events.
+1. You shouldn't use `onChange` to collect data, but you still can listen to `onChange`(and so on) events.
 2. You can not set value of form control via `value` `defaultValue` prop, and you should set default value with `initialValue` in `getFieldDecorator` instead.
-3. You shouldn't to call `setState` manually, please use `this.props.form.setFieldsValue` to change value programmatically.
+3. You shouldn't call `setState` manually, please use `this.props.form.setFieldsValue` to change value programmatically.
 
 #### Special attention
 


### PR DESCRIPTION
Correct typo on the documentation
- remove to from 'shouldn't to use' and 'shouldn't to call'
