### PR TITLE
Add no hovering option for card grid items

### DIFF
--- a/components/card/Grid.tsx
+++ b/components/card/Grid.tsx
@@ -5,10 +5,11 @@ export interface CardGridProps {
   prefixCls?: string;
   style?: React.CSSProperties;
   className?: string;
+  noHovering?: boolean;
 }
 
 export default (props: CardGridProps) => {
-  const { prefixCls = 'ant-card', className, ...others } = props;
-  const classString = classNames(`${prefixCls}-grid`, className);
+  const { prefixCls = 'ant-card', className, noHovering, ...others } = props;
+  const classString = classNames(`${prefixCls}-grid`, className, { [`${prefixCls}-grid-no-hovering`]: noHovering });
   return <div {...others} className={classString} />;
 };

--- a/components/card/demo/grid-card-no-hovering.md
+++ b/components/card/demo/grid-card-no-hovering.md
@@ -1,35 +1,35 @@
 ---
 order: 6
 title:
-  zh-CN: 网格型内嵌卡片
-  en-US: Grid card
+  zh-CN: 网卡没有盘旋
+  en-US: Grid card no hovering
 ---
 
 ## zh-CN
 
-一种常见的卡片内容区隔模式。
+一网格样式卡，不盘旋
 
 ## en-US
 
-Grid style card content.
+Grid style card with no hovering on the first and last grid items
 
 ````jsx
 import { Card } from 'antd';
 
 const gridStyle = {
-  width: '25%',
+  width: '100%',
   textAlign: 'center',
 };
 
 ReactDOM.render(
   <Card title="Card Title">
+    <Card.Grid style={gridStyle} noHovering={true}>Content</Card.Grid>
     <Card.Grid style={gridStyle}>Content</Card.Grid>
     <Card.Grid style={gridStyle}>Content</Card.Grid>
     <Card.Grid style={gridStyle}>Content</Card.Grid>
     <Card.Grid style={gridStyle}>Content</Card.Grid>
     <Card.Grid style={gridStyle}>Content</Card.Grid>
-    <Card.Grid style={gridStyle}>Content</Card.Grid>
-    <Card.Grid style={gridStyle}>Content</Card.Grid>
+    <Card.Grid style={gridStyle} noHovering={true}>Content</Card.Grid>
   </Card>
 , mountNode);
 ````

--- a/components/card/demo/grid-card-no-hovering.md
+++ b/components/card/demo/grid-card-no-hovering.md
@@ -1,5 +1,5 @@
 ---
-order: 6
+order: 7
 title:
   zh-CN: 网卡没有盘旋
   en-US: Grid card no hovering

--- a/components/card/demo/grid-card.md
+++ b/components/card/demo/grid-card.md
@@ -22,7 +22,7 @@ const gridStyle = {
 };
 
 ReactDOM.render(
-  <Card title="Card Title">
+  <Card title="Card Title" noHovering>
     <Card.Grid style={gridStyle}>Content</Card.Grid>
     <Card.Grid style={gridStyle}>Content</Card.Grid>
     <Card.Grid style={gridStyle}>Content</Card.Grid>

--- a/components/card/style/index.less
+++ b/components/card/style/index.less
@@ -89,7 +89,7 @@
     float: left;
     padding: @card-padding-base;
     transition: all .3s;
-    &:hover {
+    &:not(&-no-hovering):hover {
       position: relative;
       z-index: 1;
       box-shadow: @box-shadow-base;


### PR DESCRIPTION
## Add noHovering option to Card Grid Component
I propose adding a noHovering option to the `<Grid.Card>` component which will allow you to specify which grid card items are hoverable. 

When you use the `noHovering` option on the main card component, card grid items are still hoverable; this will allow you to make all of your card grid components non-hoverable as well when this option is set to true on the main card component.

Please makes sure that these checkboxes are checked before submitting your PR, thank you!

* [x] Make sure that you propose PR to right branch: bugfix for `master`, feature for latest active branch `feature-x.x`.
* [x] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.

Extra checklist:

**if** *isBugFix* **:**

  * [ ] Make sure that you add at least one unit test for the bug which you had fixed.

**elif** *isNewFeature* **:**

  * [ ] Update API docs for the component.
  * [ ] Update/Add demo to demonstrate new feature.
  * [ ] Update TypeScript definition for the component.
  * [ ] Add unit tests for the feature.
