### PR TITLE
Fixed react-virtualized demo scroll position when other element resize

### DIFF
--- a/components/list/demo/loadmore.md
+++ b/components/list/demo/loadmore.md
@@ -55,6 +55,9 @@ class LoadMoreList extends React.Component {
       this.setState({
         data,
         loadingMore: false,
+      }, () => {
+        // Resetting window's offsetTop so as to display react-virtualized demo underfloor.
+        window.dispatchEvent(new Event('resize'));
       });
     });
   }


### PR DESCRIPTION
https://github.com/bvaughn/react-virtualized/blob/master/source/WindowScroller/WindowScroller.js

Call resize event can trigger `updatePosition` method to reset scroll position because of `loadmore demo` will change the document height. 

Continue to find a more elegant way.