### PR TITLE
Fix beforeUpload will stop uploading when return undefined

### DIFF
--- a/components/upload/Upload.tsx
+++ b/components/upload/Upload.tsx
@@ -223,13 +223,13 @@ export default class Upload extends React.Component<UploadProps, any> {
       return true;
     }
     const result = this.props.beforeUpload(file, fileList);
-    if (!result) {
+    if (result === false) {
       this.onChange({
         file,
         fileList,
       });
       return false;
-    } else if ((result as PromiseLike<any>).then) {
+    } else if (result && (result as PromiseLike<any>).then) {
       return result;
     }
     return true;

--- a/components/upload/__tests__/upload.test.js
+++ b/components/upload/__tests__/upload.test.js
@@ -53,4 +53,58 @@ describe('Upload', () => {
       },
     });
   });
+
+  it('should not stop upload when return value of beforeUpload is not false', (done) => {
+    const data = jest.fn();
+    const props = {
+      action: 'http://upload.com',
+      beforeUpload: () => false,
+      data,
+      onChange: () => {
+        expect(data).not.toBeCalled();
+        done();
+      },
+    };
+
+    const wrapper = mount(
+      <Upload {...props}>
+        <button>upload</button>
+      </Upload>
+    );
+
+    wrapper.find('input').simulate('change', {
+      target: {
+        files: [
+          { filename: 'foo.png' },
+        ],
+      },
+    });
+  });
+
+  it('should not stop upload when return value of beforeUpload is not false', (done) => {
+    const data = jest.fn();
+    const props = {
+      action: 'http://upload.com',
+      beforeUpload() {},
+      data,
+      onChange: () => {
+        expect(data).toBeCalled();
+        done();
+      },
+    };
+
+    const wrapper = mount(
+      <Upload {...props}>
+        <button>upload</button>
+      </Upload>
+    );
+
+    wrapper.find('input').simulate('change', {
+      target: {
+        files: [
+          { filename: 'foo.png' },
+        ],
+      },
+    });
+  });
 });


### PR DESCRIPTION
```js
beforeUpload() {}  // broken version(2.13.4/2.13.5): will stop upload
beforeUpload() { return false; }  // correct version: stop upload when return false exactly
```

---

related commits and issues:

- https://github.com/ant-design/ant-design/commit/9dc4102cdd8b1e3d065ee931cdf6a8a5cc28bffd#diff-acbc5b5a934d606b6e433909267f3d13
- https://github.com/ant-design/ant-design/issues/7833

cc @nikogu 