### PR TITLE
update dependencies to support both React 15 and 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "rc-tree-select": "~1.10.2",
     "rc-upload": "~2.4.0",
     "rc-util": "^4.0.4",
-    "react-lazy-load": "^3.0.10",
+    "react-lazy-load": "^3.0.12",
     "react-slick": "~0.15.4",
     "shallowequal": "^1.0.1",
     "warning": "~3.0.0"

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "rc-upload": "~2.4.0",
     "rc-util": "^4.0.4",
     "react-lazy-load": "^3.0.10",
-    "react-slick": "~0.15.0",
+    "react-slick": "~0.15.4",
     "shallowequal": "^1.0.1",
     "warning": "~3.0.0"
   },


### PR DESCRIPTION
The peerDependencies of latest `react-slick` and `react-lazy-load ` are:
```
"peerDependencies": {
    "react": "^0.14.0 || ^15.0.1 || ^16.0.0",
    "react-dom": "^0.14.0 || ^15.0.1 || ^16.0.0"
},
```