### PR TITLE
missing the array first element xs

### DIFF
--- a/scripts/sort-api-table.js
+++ b/scripts/sort-api-table.js
@@ -29,7 +29,7 @@ const sizeBreakPoints = ['xs', 'sm', 'md', 'lg', 'xl'];
 
 const groups = {
   isDynamic: val => /^on[A-Z]/.test(val),
-  isSize: val => sizeBreakPoints.indexOf(val) > 0,
+  isSize: val => sizeBreakPoints.indexOf(val) > -1,
 };
 
 function asciiSort(prev, next) {


### PR DESCRIPTION
Sorry, my bad.

The markdown table like [this](https://github.com/monkindey/antd-api-sort/blob/master/test/fixtures/grid/index.md)

Running the script.

actual 

```js
['offset', 'order', 'pull', 'push', 'span', 'xs', 'y', 'sm', 'md', 'lg', 'xl'];
```

expected

```js
['offset', 'order', 'pull', 'push', 'span', 'y', 'xs', 'sm', 'md', 'lg', 'xl'];
```

* [x] Make sure that you propose PR to right branch: bugfix for `master`, feature for latest active branch `feature-x.x`.
* [x] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a PR to keep commit history clear.
* ~~[ ] Add some descriptions and refer relative issues for you PR.~~
* ~~[ ] Update API docs for the component.~~
* ~~[ ] Update/Add demo to demonstrate new feature.~~
* ~~[ ] Update TypeScript definition for the component.~~
* ~~[ ] Add unit tests for the feature.~~
