### PR TITLE
add the 'selectable' attribute to the tree component document 

### DIFF
--- a/components/tree/index.en-US.md
+++ b/components/tree/index.en-US.md
@@ -47,6 +47,7 @@ Almost anything can be represented in a tree structure. Examples include directo
 | -------- | ----------- | ---- | ------- |
 | disableCheckbox | Disables the checkbox of the treeNode | boolean | false |
 | disabled | Disables the treeNode | boolean | false |
+| selectable | Set whether the treeNode can be selected | boolean | true |
 | isLeaf | Determines if this is a leaf node(effective when `loadData` is specified) | boolean | false |
 | key | Used with (default)ExpandedKeys / (default)CheckedKeys / (default)SelectedKeys. P.S.: It must be unique in all of treeNodes of the tree! | string | internal calculated position of treeNode |
 | title | Title | string\|ReactNode | '---' |

--- a/components/tree/index.zh-CN.md
+++ b/components/tree/index.zh-CN.md
@@ -48,6 +48,7 @@ subtitle: 树形控件
 | --- | --- | --- | --- |
 | disableCheckbox | 禁掉 checkbox | boolean | false |
 | disabled | 禁掉响应 | boolean | false |
+| selectable | 设置节点是否可被选中 | boolean | true |
 | isLeaf | 设置为叶子节点(设置了`loadData`时有效) | boolean | false |
 | key | 被树的 (default)ExpandedKeys / (default)CheckedKeys / (default)SelectedKeys 属性所用。注意：整个树范围内的所有节点的 key 值不能重复！ | string | 内部计算出的节点位置 |
 | title | 标题 | string\|ReactNode | '---' |


### PR DESCRIPTION
Update API docs for the component.
add the 'selectable' attribute to the tree component document .
close issues [#8022](https://github.com/ant-design/ant-design/issues/8022)