### PR TITLE
Add configuration function for table column className props

### DIFF
--- a/components/table/Column.tsx
+++ b/components/table/Column.tsx
@@ -14,7 +14,7 @@ export interface ColumnProps<T> {
   sorter?: boolean | ((a: any, b: any) => number);
   colSpan?: number;
   width?: string | number;
-  className?: string | (text: any, record: T, index: number) => string;
+  className?: string | ((text: any, record: T, index: number) => string);
   fixed?: boolean | ('left' | 'right');
   filterIcon?: React.ReactNode;
   filteredValue?: any[];

--- a/components/table/Column.tsx
+++ b/components/table/Column.tsx
@@ -14,7 +14,7 @@ export interface ColumnProps<T> {
   sorter?: boolean | ((a: any, b: any) => number);
   colSpan?: number;
   width?: string | number;
-  className?: string;
+  className?: string | (text: any, record: T, index: number) => string;
   fixed?: boolean | ('left' | 'right');
   filterIcon?: React.ReactNode;
   filteredValue?: any[];


### PR DESCRIPTION
And then we could use it like:
```

{
        title: 'count',
        dataIndex: 'num',
        key: 'num',
        width: '70',
        className: (num, record, index) => { return num>10 ? 'red-col' : ''; },
}, {
        title: '',
        dataIndex: 'index',
        key: 'index',
        width: '40',
        className: (num, record, index) => { return index>10 ? 'class-'+record.type : ''; },
        render: (text, record, index) => (parseInt(index) + 1),
},

```