### PR TITLE
In SliderProps type definition, replace `void` types with `null`.

### DIFF
--- a/components/slider/index.tsx
+++ b/components/slider/index.tsx
@@ -19,7 +19,7 @@ export interface SliderProps {
   range?: boolean;
   min?: number;
   max?: number;
-  step?: number | void;
+  step?: number | null;
   marks?: SliderMarks;
   dots?: boolean;
   value?: SliderValue;
@@ -29,7 +29,7 @@ export interface SliderProps {
   vertical?: boolean;
   onChange?: (value: SliderValue) => void;
   onAfterChange?: (value: SliderValue) => void;
-  tipFormatter?: void | ((value: number) => React.ReactNode);
+  tipFormatter?: null | ((value: number) => React.ReactNode);
   className?: string;
   id?: string;
 }


### PR DESCRIPTION
With TypeScript compiler option ‘strictNullChecks’ enabled, the value `null` cannot be assigned to type `void`. This means, for instance, that it’s impossible to pass a `null` value for prop `step`. I don’t expect that substituting `null` for `void` in these type definitions should cause anyone difficulty; because these are optional props, a consumer of this component should be able to pass `null` or `undefined` safely, whether or not the compiler is using strict null checks.

First of all, thank you for your contribution! :-)

Please makes sure that these checkboxes are checked before submitting your PR, thank you!

* [x] Make sure that you propose PR to right branch: bugfix for `master`, feature for latest active branch `feature-x.x`.
* [x] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.

Extra checklist:

**if** *isBugFix* **:**

  * [N/A] Make sure that you add at least one unit test for the bug which you had fixed. (type change only; should have no runtime effects)

**elif** *isNewFeature* **:**

  * [ ] Update API docs for the component.
  * [ ] Update/Add demo to demonstrate new feature.
  * [ ] Update TypeScript definition for the component.
  * [ ] Add unit tests for the feature.
