### PR TITLE
Add a less variable to control processing colors

### DIFF
--- a/components/badge/style/index.less
+++ b/components/badge/style/index.less
@@ -67,7 +67,7 @@
       background-color: @success-color;
     }
     &-processing {
-      background-color: @primary-color;
+      background-color: @processing-color;
       position: relative;
       &:after {
         position: absolute;
@@ -76,7 +76,7 @@
         width: 100%;
         height: 100%;
         border-radius: 50%;
-        border: 1px solid @primary-color;
+        border: 1px solid @processing-color;
         content: '';
         animation: antStatusProcessing 1.2s infinite ease-in-out;
       }

--- a/components/steps/style/index.less
+++ b/components/steps/style/index.less
@@ -2,7 +2,7 @@
 @import "../../style/mixins/index";
 
 @steps-prefix-cls: ~"@{ant-prefix}-steps";
-@process-icon-color: @primary-color;
+@process-icon-color: @processing-color;
 @process-title-color: @heading-color;
 @process-description-color: @text-color;
 @process-tail-color: @border-color-split;

--- a/components/style/themes/default.less
+++ b/components/style/themes/default.less
@@ -8,6 +8,7 @@
 @primary-color          : @blue-6;
 @info-color             : @blue-6;
 @success-color          : @green-6;
+@processing-color       : @primary-color;
 @error-color            : @red-6;
 @highlight-color        : @red-6;
 @warning-color          : @gold-6;
@@ -298,7 +299,7 @@
 
 // Progress
 // --
-@progress-default-color: @primary-color;
+@progress-default-color: @processing-color;
 @progress-remaining-color: @background-color-base;
 
 // Menu


### PR DESCRIPTION
The designers that be at my company would love the ability to control the `processing` colors of steps, progress bars and badges (they wanted progress to be green instead of blue :)

This pull request adds a less variable similar to other states (e.g. success, error, warning, etc) used throughout antd.