### PR TITLE
fix: Card.Meta title no ellipsis when text too long

### DIFF
--- a/components/card/style/index.less
+++ b/components/card/style/index.less
@@ -188,6 +188,9 @@
 
   &-meta {
     margin: -4px 0;
+    display: table;
+    table-layout: fixed;
+    width: 100%;
 
     &-content {
       display: table-row;


### PR DESCRIPTION
meta's title use display:table-cell , but not set tabel-layout at parent,so when the text too long ,it will not ellipsis



* [X] Make sure that you propose PR to right branch: bugfix for `master`, feature for latest active branch `feature-x.x`.
* [x] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [ ] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a PR to keep commit history clear.
* [ ] Add some descriptions and refer relative issues for you PR.