### PR TITLE
make children prop of RadioGroupProps optional

### DIFF
--- a/components/radio/interface.tsx
+++ b/components/radio/interface.tsx
@@ -10,7 +10,7 @@ export interface RadioGroupProps extends AbstractCheckboxGroupProps {
   onMouseEnter?: React.MouseEventHandler<HTMLDivElement>;
   onMouseLeave?: React.MouseEventHandler<HTMLDivElement>;
   name?: string;
-  children: React.ReactNode;
+  children?: React.ReactNode;
 }
 
 export interface RadioGroupState {


### PR DESCRIPTION

typescript 2.5.2 is complaining.   make children prop of RadioGroupProps optional.  


Please makes sure that these checkboxes are checked before submitting your PR, thank you!

* [x] Make sure that you propose PR to right branch: bugfix for `master`, feature for latest active branch `feature-x.x`.
* [ ] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [ ] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [ ] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.

Extra checklist:

**if** *isBugFix* **:**

  * [ ] Make sure that you add at least one unit test for the bug which you had fixed.

**elif** *isNewFeature* **:**

  * [ ] Update API docs for the component.
  * [ ] Update/Add demo to demonstrate new feature.
  * [x] Update TypeScript definition for the component.
  * [ ] Add unit tests for the feature.
