### PR TITLE
change children prop of TableProps to React.ReactNode

### DIFF
--- a/components/radio/interface.tsx
+++ b/components/radio/interface.tsx
@@ -10,7 +10,7 @@ export interface RadioGroupProps extends AbstractCheckboxGroupProps {
   onMouseEnter?: React.MouseEventHandler<HTMLDivElement>;
   onMouseLeave?: React.MouseEventHandler<HTMLDivElement>;
   name?: string;
-  children: React.ReactNode;
+  children?: React.ReactNode;
 }
 
 export interface RadioGroupState {

--- a/components/table/interface.tsx
+++ b/components/table/interface.tsx
@@ -104,7 +104,7 @@ export interface TableProps<T> {
   bodyStyle?: React.CSSProperties;
   className?: string;
   style?: React.CSSProperties;
-  children?: React.ReactChildren;
+  children?: React.ReactNode;
 }
 
 export interface TableStateFilters {
@@ -170,6 +170,6 @@ export interface FilterMenuProps<T> {
 
 export interface FilterMenuState {
   selectedKeys: string[];
-  keyPathOfSelectedItem: {[key: string]: string};
+  keyPathOfSelectedItem: { [key: string]: string };
   visible?: boolean;
 }


### PR DESCRIPTION
change children prop of TableProps to React.ReactNode 

It was ReactChildren 

oh...and it looks like VSCode made a formatting update on save

Please makes sure that these checkboxes are checked before submitting your PR, thank you!

* [* ] Make sure that you propose PR to right branch: bugfix for `master`, feature for latest active branch `feature-x.x`.
* [* ] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
*
* [ *] Add some descriptions and refer relative issues for you PR.



**elif** *isNewFeature* **:**


  * [* ] Update TypeScript definition for the component.

