### PR TITLE
Control checkbox button size with btn-height base instead of input-height base

### DIFF
--- a/components/radio/style/index.less
+++ b/components/radio/style/index.less
@@ -139,8 +139,8 @@ span.@{radio-prefix-cls} + * {
 
 .@{radio-prefix-cls}-button-wrapper {
   margin: 0;
-  height: @input-height-base;
-  line-height: @input-height-base - 2px;
+  height: @btn-height-base;
+  line-height: @btn-height-base - 2px;
   color: @radio-button-color;
   display: inline-block;
   transition: all 0.3s ease;


### PR DESCRIPTION
Checkbox buttons more closely align with buttons in terms of style instead of an input (at least our designers believe so :). We've gone as far as overriding the complete checkbox button wrappers to consume and be based off of the `button/mixin.less` styles (which I can include in a separate PR if you're interested).