### PR TITLE
fix formItem vertical align

### DIFF
--- a/components/form/style/index.less
+++ b/components/form/style/index.less
@@ -6,9 +6,9 @@
 @import "./mixin";
 
 @form-prefix-cls: ~"@{ant-prefix}-form";
-@form-component-height: @input-height-base;
+@form-component-height: @input-height-lg;
 @form-feedback-icon-size: 14px;
-@form-help-margin-top: 2px;
+@form-help-margin-top: -2px;
 
 .@{form-prefix-cls} {
   .reset-component;
@@ -97,7 +97,7 @@ input[type="checkbox"] {
   &-label {
     text-align: right;
     vertical-align: middle;
-    line-height: @form-component-height;
+    line-height: @form-component-height - 0.0001px;
     display: inline-block;
     overflow: hidden;
     white-space: nowrap;
@@ -245,6 +245,18 @@ form {
     // Fix https://github.com/ant-design/ant-design/issues/6097
     &:only-child {
       display: block;
+      position: relative;
+      top: (@input-height-lg - @input-height-base) / 2;
+
+      &.@{ant-prefix}-select-sm,
+      &.@{ant-prefix}-cascader-picker-small {
+        top: (@input-height-lg - @input-height-sm) / 2;
+      }
+
+      &.@{ant-prefix}-select-lg,
+      &.@{ant-prefix}-cascader-picker-large {
+        top: 0;
+      }
     }
   }
 
@@ -259,6 +271,12 @@ form {
   .@{ant-prefix}-input-group-addon .@{ant-prefix}-cascader-picker {
     &:only-child {
       display: inline-block;
+      top: 0;
+
+      &.@{ant-prefix}-select-sm,
+      &.@{ant-prefix}-cascader-picker-small {
+        top: 0;
+      }
     }
   }
 }
@@ -275,7 +293,7 @@ form {
 
   .@{ant-prefix}-select-selection--single {
     margin-left: -1px;
-    height: @input-height-base;
+    height: @input-height-lg;
     background-color: #eee;
     .@{ant-prefix}-select-selection__rendered {
       padding-left: 8px;
@@ -395,8 +413,8 @@ form {
     right: 0;
     visibility: visible;
     pointer-events: none;
-    .square(@input-height-base);
-    line-height: @input-height-base;
+    .square(@input-height-lg);
+    line-height: @input-height-lg;
     text-align: center;
     font-size: @form-feedback-icon-size;
     animation: zoomIn .3s @ease-out-back;

--- a/components/style/themes/default.less
+++ b/components/style/themes/default.less
@@ -235,7 +235,7 @@
 // ---
 @label-required-color        : @highlight-color;
 @label-color                 : @heading-color;
-@form-item-margin-bottom     : 32px;
+@form-item-margin-bottom     : 24px;
 @form-item-trailing-colon    : true;
 @form-vertical-label-padding : 0 0 8px;
 @form-vertical-label-margin  : 0;


### PR DESCRIPTION
- fix feedback icon and label(of large size input control) vertical align issue. see #8336 
- fix Cascader and Select(including AutoComplete) of small type can not vertical align when no help item exist.  ↓

<img width="926" alt="2017-11-30 11 18 44" src="https://user-images.githubusercontent.com/7017767/33411426-902e1fc0-d5c0-11e7-96bf-20d6c09ce67b.png">

close #8336 
