### PR TITLE
Make confirm closable when onOk/onCancel has more than one params

### DIFF
--- a/components/modal/ActionButton.tsx
+++ b/components/modal/ActionButton.tsx
@@ -54,6 +54,8 @@ export default class ActionButton extends React.Component<ActionButtonProps, Act
           // See: https://github.com/ant-design/ant-design/issues/6183
           this.setState({ loading: false });
         });
+      } else {
+        closeModal();
       }
     } else {
       closeModal();


### PR DESCRIPTION
```jsx
Modal.confirm({
  onOk: _ => resolve(true),
  onCancel: _ => resolve(false)
})
```

Confirm will be closable in this way:

![image](https://user-images.githubusercontent.com/9346008/33523996-168b0e62-d84f-11e7-9d6e-5e1c59aefaca.png)
