### PR TITLE
Form item vertical align

### DIFF
--- a/components/form/style/index.less
+++ b/components/form/style/index.less
@@ -6,9 +6,9 @@
 @import "./mixin";
 
 @form-prefix-cls: ~"@{ant-prefix}-form";
-@form-component-height: @input-height-base;
+@form-component-height: @input-height-lg;
 @form-feedback-icon-size: 14px;
-@form-help-margin-top: 2px;
+@form-help-margin-top: -2px;
 
 .@{form-prefix-cls} {
   .reset-component;
@@ -97,7 +97,7 @@ input[type="checkbox"] {
   &-label {
     text-align: right;
     vertical-align: middle;
-    line-height: @form-component-height;
+    line-height: @form-component-height - 0.0001px;
     display: inline-block;
     overflow: hidden;
     white-space: nowrap;
@@ -245,6 +245,18 @@ form {
     // Fix https://github.com/ant-design/ant-design/issues/6097
     &:only-child {
       display: block;
+      position: relative;
+      top: (@input-height-lg - @input-height-base) / 2;
+
+      &.@{ant-prefix}-select-sm,
+      &.@{ant-prefix}-cascader-picker-small {
+        top: (@input-height-lg - @input-height-sm) / 2;
+      }
+
+      &.@{ant-prefix}-select-lg,
+      &.@{ant-prefix}-cascader-picker-large {
+        top: 0;
+      }
     }
   }
 
@@ -259,6 +271,12 @@ form {
   .@{ant-prefix}-input-group-addon .@{ant-prefix}-cascader-picker {
     &:only-child {
       display: inline-block;
+      top: 0;
+
+      &.@{ant-prefix}-select-sm,
+      &.@{ant-prefix}-cascader-picker-small {
+        top: 0;
+      }
     }
   }
 
@@ -289,7 +307,7 @@ form {
 
   .@{ant-prefix}-select-selection--single {
     margin-left: -1px;
-    height: @input-height-base;
+    height: @input-height-lg;
     background-color: #eee;
     .@{ant-prefix}-select-selection__rendered {
       padding-left: 8px;
@@ -409,8 +427,8 @@ form {
     right: 0;
     visibility: visible;
     pointer-events: none;
-    .square(@input-height-base);
-    line-height: @input-height-base;
+    .square(@input-height-lg);
+    line-height: @input-height-lg;
     text-align: center;
     font-size: @form-feedback-icon-size;
     animation: zoomIn .3s @ease-out-back;

--- a/components/form/style/index.less
+++ b/components/form/style/index.less
@@ -275,15 +275,9 @@ form {
 
   // fix input with addon position. https://github.com/ant-design/ant-design/issues/8243
   .@{ant-prefix}-input-group-wrapper {
-    position: relative;
-    top: (@input-height-lg - @input-height-base) / 2;
-
-    &.@{ant-prefix}-input-group-wrapper-lg {
-      top: 0;
-    }
-
     &.@{ant-prefix}-input-group-wrapper-sm {
-      top: (@input-height-lg - @input-height-sm) / 2;
+      position: relative;
+      top: (@input-height-base - @input-height-sm) / 2;
     }
   }
 
@@ -294,14 +288,17 @@ form {
   .@{ant-prefix}-select-lg,
   .@{ant-prefix}-calendar-picker-large,
   .@{ant-prefix}-time-picker-large,
-  .@{ant-prefix}-radio-group-large {
+  .@{ant-prefix}-radio-group-large,
+  .@{ant-prefix}-input-group-wrapper-lg .@{ant-prefix}-input-group-addon {
     position: relative;
     top: (@input-height-base - @input-height-lg) / 2;
   }
 
   .@{ant-prefix}-cascader-picker-large,
-  .@{ant-prefix}-calendar-picker-large {
-    .@{ant-prefix}-input-lg {
+  .@{ant-prefix}-calendar-picker-large,
+  .@{ant-prefix}-input-group-wrapper-lg .@{ant-prefix}-input-group-addon {
+    .@{ant-prefix}-input-lg,
+    .@{ant-prefix}-select-lg {
       top: 0;
     }
   }

--- a/components/form/style/index.less
+++ b/components/form/style/index.less
@@ -6,9 +6,9 @@
 @import "./mixin";
 
 @form-prefix-cls: ~"@{ant-prefix}-form";
-@form-component-height: @input-height-lg;
+@form-component-height: @input-height-base;
 @form-feedback-icon-size: 14px;
-@form-help-margin-top: -2px;
+@form-help-margin-top: 2px;
 
 .@{form-prefix-cls} {
   .reset-component;
@@ -245,17 +245,11 @@ form {
     // Fix https://github.com/ant-design/ant-design/issues/6097
     &:only-child {
       display: block;
-      position: relative;
-      top: (@input-height-lg - @input-height-base) / 2;
 
       &.@{ant-prefix}-select-sm,
       &.@{ant-prefix}-cascader-picker-small {
-        top: (@input-height-lg - @input-height-sm) / 2;
-      }
-
-      &.@{ant-prefix}-select-lg,
-      &.@{ant-prefix}-cascader-picker-large {
-        top: 0;
+        position: relative;
+        top: (@input-height-base - @input-height-sm) / 2;
       }
     }
   }
@@ -271,7 +265,6 @@ form {
   .@{ant-prefix}-input-group-addon .@{ant-prefix}-cascader-picker {
     &:only-child {
       display: inline-block;
-      top: 0;
 
       &.@{ant-prefix}-select-sm,
       &.@{ant-prefix}-cascader-picker-small {
@@ -293,6 +286,25 @@ form {
       top: (@input-height-lg - @input-height-sm) / 2;
     }
   }
+
+  // fix large size vertical align. https://github.com/ant-design/ant-design/issues/8336
+  .@{ant-prefix}-input-lg,
+  .@{ant-prefix}-input-number-lg,
+  .@{ant-prefix}-cascader-picker-large,
+  .@{ant-prefix}-select-lg,
+  .@{ant-prefix}-calendar-picker-large,
+  .@{ant-prefix}-time-picker-large,
+  .@{ant-prefix}-radio-group-large {
+    position: relative;
+    top: (@input-height-base - @input-height-lg) / 2;
+  }
+
+  .@{ant-prefix}-cascader-picker-large,
+  .@{ant-prefix}-calendar-picker-large {
+    .@{ant-prefix}-input-lg {
+      top: 0;
+    }
+  }
 }
 
 // Input combined with select
@@ -307,7 +319,7 @@ form {
 
   .@{ant-prefix}-select-selection--single {
     margin-left: -1px;
-    height: @input-height-lg;
+    height: @input-height-base;
     background-color: #eee;
     .@{ant-prefix}-select-selection__rendered {
       padding-left: 8px;
@@ -427,8 +439,8 @@ form {
     right: 0;
     visibility: visible;
     pointer-events: none;
-    .square(@input-height-lg);
-    line-height: @input-height-lg;
+    .square(@input-height-base);
+    line-height: @input-height-base;
     text-align: center;
     font-size: @form-feedback-icon-size;
     animation: zoomIn .3s @ease-out-back;

--- a/components/style/themes/default.less
+++ b/components/style/themes/default.less
@@ -235,7 +235,7 @@
 // ---
 @label-required-color        : @highlight-color;
 @label-color                 : @heading-color;
-@form-item-margin-bottom     : 32px;
+@form-item-margin-bottom     : 24px;
 @form-item-trailing-colon    : true;
 @form-vertical-label-padding : 0 0 8px;
 @form-vertical-label-margin  : 0;

--- a/components/style/themes/default.less
+++ b/components/style/themes/default.less
@@ -235,7 +235,7 @@
 // ---
 @label-required-color        : @highlight-color;
 @label-color                 : @heading-color;
-@form-item-margin-bottom     : 24px;
+@form-item-margin-bottom     : 32px;
 @form-item-trailing-colon    : true;
 @form-vertical-label-padding : 0 0 8px;
 @form-vertical-label-margin  : 0;


### PR DESCRIPTION
- fix feedback icon and label(of large size input control) vertical align issue. see #8336 
- fix Cascader and Select(including AutoComplete) of small type can not vertical align when no help item exist.  ↓

<img width="926" alt="2017-11-30 11 18 44" src="https://user-images.githubusercontent.com/7017767/33411426-902e1fc0-d5c0-11e7-96bf-20d6c09ce67b.png">

close #8336 
