### PR TITLE
Add autoHide to Pagination

### DIFF
--- a/components/pagination/Pagination.tsx
+++ b/components/pagination/Pagination.tsx
@@ -13,6 +13,7 @@ export interface PaginationProps {
   defaultPageSize?: number;
   pageSize?: number;
   onChange?: (page: number, pageSize?: number) => void;
+  hideOnSinglePage?: boolean;
   showSizeChanger?: boolean;
   pageSizeOptions?: string[];
   onShowSizeChange?: (current: number, size: number) => void;

--- a/components/pagination/index.en-US.md
+++ b/components/pagination/index.en-US.md
@@ -26,6 +26,7 @@ A long list can be divided into several pages by `Pagination`, and only one page
 | itemRender | to customize item innerHTML | (page, type: 'page' \| 'prev' \| 'next', originalElement) => React.ReactNode | - |
 | pageSize | number of data items per page | number | - |
 | pageSizeOptions | specify the sizeChanger options | string\[] | ['10', '20', '30', '40'] |
+| hideOnSinglePage | Whether to hide pager on single page | boolean | false |
 | showQuickJumper | determine whether you can jump to pages directly | boolean | false |
 | showSizeChanger | determine whether `pageSize` can be changed | boolean | false |
 | showTotal | to display the total number and range | Function(total, range) | - |

--- a/components/pagination/index.zh-CN.md
+++ b/components/pagination/index.zh-CN.md
@@ -27,6 +27,7 @@ cols: 1
 | itemRender | 用于自定义页码的结构，可用于优化 SEO | (page, type: 'page' \| 'prev' \| 'next', originalElement) => React.ReactNode | - |
 | pageSize | 每页条数 | number | - |
 | pageSizeOptions | 指定每页可以显示多少条 | string\[] | ['10', '20', '30', '40'] |
+| hideOnSinglePage | 只有一页时是否隐藏分页器 | boolean | false |
 | showQuickJumper | 是否可以快速跳转至某页 | boolean | false |
 | showSizeChanger | 是否可以改变 pageSize | boolean | false |
 | showTotal | 用于显示数据总量和当前数据顺序 | Function(total, range) | - |

--- a/components/table/__tests__/Table.pagination.test.js
+++ b/components/table/__tests__/Table.pagination.test.js
@@ -37,6 +37,21 @@ describe('Table.pagination', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
+  it('should not show pager if pagination.hideOnSinglePage is true and only 1 page', () => {
+    const wrapper = mount(createTable({ pagination: { pageSize: 3, hideOnSinglePage: true } }));
+    expect(wrapper.find('.ant-pagination')).toHaveLength(1);
+    wrapper.setProps({ pagination: { pageSize: 3, hideOnSinglePage: false } });
+    expect(wrapper.find('.ant-pagination')).toHaveLength(1);
+    wrapper.setProps({ pagination: { pageSize: 4, hideOnSinglePage: true } });
+    expect(wrapper.find('.ant-pagination')).toHaveLength(0);
+    wrapper.setProps({ pagination: { pageSize: 4, hideOnSinglePage: false } });
+    expect(wrapper.find('.ant-pagination')).toHaveLength(1);
+    wrapper.setProps({ pagination: { pageSize: 5, hideOnSinglePage: true } });
+    expect(wrapper.find('.ant-pagination')).toHaveLength(0);
+    wrapper.setProps({ pagination: { pageSize: 5, hideOnSinglePage: false } });
+    expect(wrapper.find('.ant-pagination')).toHaveLength(1);
+  });
+
   it('paginate data', () => {
     const wrapper = mount(createTable());
 

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "rc-input-number": "~4.0.0",
     "rc-menu": "~6.2.0",
     "rc-notification": "~3.0.0",
-    "rc-pagination": "~1.12.4",
+    "rc-pagination": "~1.13.0",
     "rc-progress": "~2.2.2",
     "rc-rate": "~2.4.0",
     "rc-select": "~7.5.0",


### PR DESCRIPTION
It's quite cumbersome to show pagination when there is only 1 page.

Code like this can help but you need to define a const `pageSize` and not elegant.
```js
const pageSize = 20;

<Table pagination={data.length > pageSize && { pageSize }} />
```

This is a common requirement so better to have a prop specifically for it.

`autoHidePagination` default is `false`, so it will not break any current behavior.

May refer to #4173