### PR TITLE
Minor typo in dropdown API - [contentMenu]

### DIFF
--- a/components/dropdown/index.en-US.md
+++ b/components/dropdown/index.en-US.md
@@ -38,7 +38,7 @@ You should use [Menu](/components/menu/) as `overlay`. The menu items and divide
 | overlay | the dropdown menu | [Menu](/components/menu) | - |
 | placement | placement of pop menu: `bottomLeft` `bottomCenter` `bottomRight` `topLeft` `topCenter` `topRight` | String | `bottomLeft` |
 | size | size of the button, the same as [Button](/components/button) | string | `default` |
-| trigger | the trigger mode which executes the drop-down action | Array&lt;`click`\|`hover`\|`contentMenu`&gt; | `['hover']` |
+| trigger | the trigger mode which executes the drop-down action | Array&lt;`click`\|`hover`\|`contextMenu`&gt; | `['hover']` |
 | type | type of the button, the same as [Button](/components/button) | string | `default` |
 | visible | whether the dropdown menu is visible | boolean | - |
 | onClick | a callback function, the same as [Button](/components/button), which will be executed when you click the button on the left | Function | - |


### PR DESCRIPTION
I suspect there's a typo in the page:

in the `trigger` API description is listed as 3rd option:
```
contentMenu
```
I suspect you meant
```
contextMenu
```

If so this PR is just fixing this minor overlook.


Please note that no test were added since it's just a very minor document update.