### PR TITLE
Update incorrect signature for onChange

### DIFF
--- a/components/auto-complete/index.en-US.md
+++ b/components/auto-complete/index.en-US.md
@@ -33,7 +33,7 @@ const dataSource = ['12345', '23456', '34567'];
 | optionLabelProp | Which prop value of option will render as content of select. | string | `children` |
 | placeholder | placeholder of input | string | - |
 | value | selected option | string\|string\[]\|{ key: string, label: string\|ReactNode }\|Array&lt;{ key: string, label: string\|ReactNode }> | - |
-| onChange | Called when select an option or input value change, or value of input is changed | function(value, label) | - |
+| onChange | Called when select an option or input value change, or value of input is changed | function(value) | - |
 | onSearch | Called when searching items. | function(value) | - |
 | onSelect | Called when a option is selected. param is option's value and option instance. | function(value, option) | - |
 


### PR DESCRIPTION
This is a typo fix since the signature has changed and isn't updated in the docs.

https://github.com/ant-design/ant-design/blob/0933201652e8717894389cdcdcad0e3426198b23/components/auto-complete/index.tsx#L26