### PR TITLE
Added tabIndex (+other html props) to the Button

### DIFF
--- a/components/button/button.tsx
+++ b/components/button/button.tsx
@@ -38,7 +38,7 @@ export type ButtonType = 'primary' | 'ghost' | 'dashed' | 'danger';
 export type ButtonShape = 'circle' | 'circle-outline';
 export type ButtonSize = 'small' | 'default' | 'large';
 
-export interface ButtonProps {
+export interface ButtonProps extends React.HTMLProps<Button> {
   type?: ButtonType;
   htmlType?: string;
   icon?: string;


### PR DESCRIPTION
There is missing `tabIndex` property in TypeScript declaration. Other possibility might be just add`tabIndex?: number;`, but I guess we could do a generic fix by extending from `React.HTMLProps`

  