### PR TITLE
Fix useage of babel-plugin-import

### DIFF
--- a/docs/react/introduce.zh-CN.md
+++ b/docs/react/introduce.zh-CN.md
@@ -112,9 +112,9 @@ import 'antd/dist/antd.css';  // or 'antd/dist/antd.less'
 - 手动引入
 
    ```jsx
-   import DatePicker from 'antd/lib/date-picker';  // 加载 JS
-   import 'antd/lib/date-picker/style/css';        // 加载 CSS
-   // import 'antd/lib/date-picker/style';         // 加载 LESS
+   import DatePicker from 'antd/es/date-picker';  // 加载 JS
+   import 'antd/es/date-picker/style/css';        // 加载 CSS
+   // import 'antd/es/date-picker/style';         // 加载 LESS
    ```
 
 ## 链接


### PR DESCRIPTION
If you use babel-plugin-import, and make config as this introduce:

 ```js
   // .babelrc or babel-loader option
   {
     "plugins": [
       ["import", { "libraryName": "antd", "libraryDirectory": "es", "style": "css" }] // `style: true` 会加载 less 文件
     ]
   }
   ```


The path of antd is `antd/es` not `antd/lib`.

First of all, thank you for your contribution! :-)

Please makes sure that these checkboxes are checked before submitting your PR, thank you!

* [ ] Make sure that you propose PR to right branch: bugfix for `master`, feature for latest active branch `feature-x.x`.
* [ ] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [ ] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [ ] Rebase before creating a PR to keep commit history clear.
* [ ] Add some descriptions and refer relative issues for you PR.

Extra checklist:

**if** *isBugFix* **:**

  * [ ] Make sure that you add at least one unit test for the bug which you had fixed.

**elif** *isNewFeature* **:**

  * [ ] Update API docs for the component.
  * [ ] Update/Add demo to demonstrate new feature.
  * [ ] Update TypeScript definition for the component.
  * [ ] Add unit tests for the feature.
