### PR TITLE
Add @switch-color to control switch colors

### DIFF
--- a/components/style/themes/default.less
+++ b/components/style/themes/default.less
@@ -393,6 +393,7 @@
 @switch-height: 22px;
 @switch-sm-height: 16px;
 @switch-disabled-opacity: 0.4;
+@switch-color: @primary-color;
 
 // Pagination
 // ---

--- a/components/switch/style/index.less
+++ b/components/switch/style/index.less
@@ -68,11 +68,11 @@
   }
 
   &-checked&-loading:before {
-    color: @primary-color;
+    color: @switch-color;
   }
 
   &:focus {
-    box-shadow: 0 0 0 2px fade(@primary-color, 20%);
+    box-shadow: 0 0 0 2px fade(@switch-color, 20%);
     outline: 0;
   }
 
@@ -127,7 +127,7 @@
   }
 
   &-checked {
-    background-color: @primary-color;
+    background-color: @switch-color;
 
     .@{switch-prefix-cls}-inner {
       margin-left: 6px;


### PR DESCRIPTION
My designers want the switch control to be our `@success-color` I was considering a couple ways to do this, e.g. adding a `type={"primary"|"success"|"error"}` which might also be reasonable but I wasnt sure if there were more use cases to justify doing this. It might be worth considering as well.

Cheers :)