### PR TITLE
onVisibleChange called mistakenly when use "visible" props

### DIFF
--- a/components/tooltip/index.tsx
+++ b/components/tooltip/index.tsx
@@ -77,17 +77,23 @@ export default class Tooltip extends React.Component<TooltipProps, any> {
 
   componentWillReceiveProps(nextProps: TooltipProps) {
     if ('visible' in nextProps) {
-      this.setState({ visible: nextProps.visible });
+      let onVisibleChange = this.props.onVisibleChange;
+      const isNoTitle = this.isNoTitle();
+      if (onVisibleChange && !isNoTitle && this.state.visible !== nextProps.visible) {
+        onVisibleChange(nextProps.visible);
+      }
+      this.setState({ visible: isNoTitle ? false : nextProps.visible });
     }
   }
 
   onVisibleChange = (visible: boolean) => {
     const { onVisibleChange } = this.props;
     if (!('visible' in this.props)) {
-      this.setState({ visible: this.isNoTitle() ? false : visible });
-    }
-    if (onVisibleChange && !this.isNoTitle()) {
-      onVisibleChange(visible);
+      const isNoTitle: boolean = this.isNoTitle();
+      this.setState({ visible: isNoTitle ? false : visible });
+      if (onVisibleChange && !isNoTitle) {
+        onVisibleChange(visible);
+      }
     }
   }
 

--- a/components/tooltip/index.tsx
+++ b/components/tooltip/index.tsx
@@ -80,7 +80,7 @@ export default class Tooltip extends React.Component<TooltipProps, any> {
       let onVisibleChange = this.props.onVisibleChange;
       const isNoTitle = this.isNoTitle();
       if (onVisibleChange && !isNoTitle && this.state.visible !== nextProps.visible) {
-        onVisibleChange(nextProps.visible);
+        onVisibleChange((nextProps.visible) as boolean);
       }
       this.setState({ visible: isNoTitle ? false : nextProps.visible });
     }


### PR DESCRIPTION
when I use props "visible" to handle whether Component Tooltips show or not , function onVisibleChange is always called when the mouse enter.

error demo here: 
https://codepen.io/sisiea/pen/GyYNym

First of all, thank you for your contribution! :-)

Please makes sure that these checkboxes are checked before submitting your PR, thank you!

* [ ] Make sure that you propose PR to right branch: bugfix for `master`, feature for latest active branch `feature-x.x`.
* [ ] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [ ] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [ ] Rebase before creating a PR to keep commit history clear.
* [ ] Add some descriptions and refer relative issues for you PR.

Extra checklist:

**if** *isBugFix* **:**

  * [ ] Make sure that you add at least one unit test for the bug which you had fixed.

**elif** *isNewFeature* **:**

  * [ ] Update API docs for the component.
  * [ ] Update/Add demo to demonstrate new feature.
  * [ ] Update TypeScript definition for the component.
  * [ ] Add unit tests for the feature.
