### PR TITLE
docs: 修改 Layout  组件文档中 `breakpoint width` 与代码不一致的问题

### DIFF
--- a/components/layout/index.en-US.md
+++ b/components/layout/index.en-US.md
@@ -103,9 +103,10 @@ The sidebar.
 ```js
 {
   xs: '480px',
-  sm: '768px',
-  md: '992px',
-  lg: '1200px',
-  xl: '1600px',
+  sm: '576px',
+  md: '768px',
+  lg: '992px',
+  xl: '1200px',
+  xxl: '1600px',
 }
 ```

--- a/components/layout/index.zh-CN.md
+++ b/components/layout/index.zh-CN.md
@@ -104,9 +104,10 @@ title: Layout
 ```js
 {
   xs: '480px',
-  sm: '768px',
-  md: '992px',
-  lg: '1200px',
-  xl: '1600px',
+  sm: '576px',
+  md: '768px',
+  lg: '992px',
+  xl: '1200px',
+  xxl: '1600px',
 }
 ```


### PR DESCRIPTION
文档里 `breakpoint width`  对应的值好像乱套了，但是代码里是没问题的~