### PR TITLE
chore: use static transitionName to avoid unintended behavior

### DIFF
--- a/components/cascader/index.tsx
+++ b/components/cascader/index.tsx
@@ -109,7 +109,6 @@ export default class Cascader extends React.Component<CascaderProps, CascaderSta
     prefixCls: 'ant-cascader',
     inputPrefixCls: 'ant-input',
     placeholder: 'Please select',
-    transitionName: 'slide-up',
     popupPlacement: 'bottomLeft',
     options: [],
     disabled: false,
@@ -315,7 +314,6 @@ export default class Cascader extends React.Component<CascaderProps, CascaderSta
       'onChange',
       'options',
       'popupPlacement',
-      'transitionName',
       'displayRender',
       'onPopupVisibleChange',
       'changeOnSelect',
@@ -389,6 +387,7 @@ export default class Cascader extends React.Component<CascaderProps, CascaderSta
         onPopupVisibleChange={this.handlePopupVisibleChange}
         onChange={this.handleChange}
         dropdownMenuColumnStyle={dropdownMenuColumnStyle}
+        transitionName="slide-up"
       >
         {input}
       </RcCascader>


### PR DESCRIPTION
Currently `transitionName` is set by `defaultProps` and is pass to `RcCascader` by spread props.

But this prop is not mentioned in the document and users should not be able to change it, therefore I set it as a constant string instead.