### PR TITLE
Remove span.ant-tag-text in Tag, and remove type casting in Dropdown

### DIFF
--- a/components/dropdown/dropdown.tsx
+++ b/components/dropdown/dropdown.tsx
@@ -49,16 +49,18 @@ export default class Dropdown extends React.Component<DropDownProps, any> {
   }
 
   render() {
-    const { children, prefixCls, overlay, trigger, disabled } = this.props;
-    const dropdownTrigger = React.cloneElement(children as any, {
-      className: classNames((children as any).props.className, `${prefixCls}-trigger`),
+    const { children, prefixCls, overlay: overlayElements, trigger, disabled } = this.props;
+
+    const child = React.Children.only(children);
+    const overlay = React.Children.only(overlayElements);
+
+    const dropdownTrigger = React.cloneElement(child, {
+      className: classNames(child.props.className, `${prefixCls}-trigger`),
       disabled,
     });
     // menu cannot be selectable in dropdown defaultly
-    const overlayProps = overlay && (overlay as any).props;
-    const selectable = (overlayProps && 'selectable' in overlayProps)
-      ? overlayProps.selectable : false;
-    const fixedModeOverlay = React.cloneElement(overlay as any, {
+    const selectable = overlay.props.selectable || false;
+    const fixedModeOverlay = React.cloneElement(overlay, {
       mode: 'vertical',
       selectable,
     });

--- a/components/tag/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/tag/__tests__/__snapshots__/demo.test.js.snap
@@ -6,35 +6,23 @@ exports[`renders ./components/tag/demo/basic.md correctly 1`] = `
     class="ant-tag"
     data-show="true"
   >
-    <span
-      class="ant-tag-text"
-    >
-      Tag 1
-    </span>
+    Tag 1
   </div>
   <div
     class="ant-tag"
     data-show="true"
   >
-    <span
-      class="ant-tag-text"
+    <a
+      href="https://github.com/ant-design/ant-design/issues/1862"
     >
-      <a
-        href="https://github.com/ant-design/ant-design/issues/1862"
-      >
-        Link
-      </a>
-    </span>
+      Link
+    </a>
   </div>
   <div
     class="ant-tag"
     data-show="true"
   >
-    <span
-      class="ant-tag-text"
-    >
-      Tag 2
-    </span>
+    Tag 2
     <i
       class="anticon anticon-cross"
     />
@@ -43,11 +31,7 @@ exports[`renders ./components/tag/demo/basic.md correctly 1`] = `
     class="ant-tag"
     data-show="true"
   >
-    <span
-      class="ant-tag-text"
-    >
-      Prevent Default
-    </span>
+    Prevent Default
     <i
       class="anticon anticon-cross"
     />
@@ -87,111 +71,67 @@ exports[`renders ./components/tag/demo/colorful.md correctly 1`] = `
       class="ant-tag ant-tag-magenta"
       data-show="true"
     >
-      <span
-        class="ant-tag-text"
-      >
-        magenta
-      </span>
+      magenta
     </div>
     <div
       class="ant-tag ant-tag-red"
       data-show="true"
     >
-      <span
-        class="ant-tag-text"
-      >
-        red
-      </span>
+      red
     </div>
     <div
       class="ant-tag ant-tag-volcano"
       data-show="true"
     >
-      <span
-        class="ant-tag-text"
-      >
-        volcano
-      </span>
+      volcano
     </div>
     <div
       class="ant-tag ant-tag-orange"
       data-show="true"
     >
-      <span
-        class="ant-tag-text"
-      >
-        orange
-      </span>
+      orange
     </div>
     <div
       class="ant-tag ant-tag-gold"
       data-show="true"
     >
-      <span
-        class="ant-tag-text"
-      >
-        gold
-      </span>
+      gold
     </div>
     <div
       class="ant-tag ant-tag-lime"
       data-show="true"
     >
-      <span
-        class="ant-tag-text"
-      >
-        lime
-      </span>
+      lime
     </div>
     <div
       class="ant-tag ant-tag-green"
       data-show="true"
     >
-      <span
-        class="ant-tag-text"
-      >
-        green
-      </span>
+      green
     </div>
     <div
       class="ant-tag ant-tag-cyan"
       data-show="true"
     >
-      <span
-        class="ant-tag-text"
-      >
-        cyan
-      </span>
+      cyan
     </div>
     <div
       class="ant-tag ant-tag-blue"
       data-show="true"
     >
-      <span
-        class="ant-tag-text"
-      >
-        blue
-      </span>
+      blue
     </div>
     <div
       class="ant-tag ant-tag-geekblue"
       data-show="true"
     >
-      <span
-        class="ant-tag-text"
-      >
-        geekblue
-      </span>
+      geekblue
     </div>
     <div
       class="ant-tag ant-tag-purple"
       data-show="true"
     >
-      <span
-        class="ant-tag-text"
-      >
-        purple
-      </span>
+      purple
     </div>
   </div>
   <h4
@@ -205,44 +145,28 @@ exports[`renders ./components/tag/demo/colorful.md correctly 1`] = `
       data-show="true"
       style="background-color:#f50"
     >
-      <span
-        class="ant-tag-text"
-      >
-        #f50
-      </span>
+      #f50
     </div>
     <div
       class="ant-tag ant-tag-has-color"
       data-show="true"
       style="background-color:#2db7f5"
     >
-      <span
-        class="ant-tag-text"
-      >
-        #2db7f5
-      </span>
+      #2db7f5
     </div>
     <div
       class="ant-tag ant-tag-has-color"
       data-show="true"
       style="background-color:#87d068"
     >
-      <span
-        class="ant-tag-text"
-      >
-        #87d068
-      </span>
+      #87d068
     </div>
     <div
       class="ant-tag ant-tag-has-color"
       data-show="true"
       style="background-color:#108ee9"
     >
-      <span
-        class="ant-tag-text"
-      >
-        #108ee9
-      </span>
+      #108ee9
     </div>
   </div>
 </div>
@@ -254,21 +178,13 @@ exports[`renders ./components/tag/demo/control.md correctly 1`] = `
     class="ant-tag"
     data-show="true"
   >
-    <span
-      class="ant-tag-text"
-    >
-      Unremovable
-    </span>
+    Unremovable
   </div>
   <div
     class="ant-tag"
     data-show="true"
   >
-    <span
-      class="ant-tag-text"
-    >
-      Tag 2
-    </span>
+    Tag 2
     <i
       class="anticon anticon-cross"
     />
@@ -277,11 +193,7 @@ exports[`renders ./components/tag/demo/control.md correctly 1`] = `
     class="ant-tag"
     data-show="true"
   >
-    <span
-      class="ant-tag-text"
-    >
-      Tag 3
-    </span>
+    Tag 3
     <i
       class="anticon anticon-cross"
     />
@@ -291,14 +203,10 @@ exports[`renders ./components/tag/demo/control.md correctly 1`] = `
     data-show="true"
     style="background:#fff;border-style:dashed"
   >
-    <span
-      class="ant-tag-text"
-    >
-      <i
-        class="anticon anticon-plus"
-      />
-       New Tag
-    </span>
+    <i
+      class="anticon anticon-plus"
+    />
+     New Tag
   </div>
 </div>
 `;

--- a/components/tag/index.tsx
+++ b/components/tag/index.tsx
@@ -106,7 +106,7 @@ export default class Tag extends React.Component<TagProps, TagState> {
         className={classString}
         style={tagStyle}
       >
-        <span className={`${prefixCls}-text`}>{children}</span>
+        {children}
         {closeIcon}
       </div>
     );

--- a/components/tag/style/index.less
+++ b/components/tag/style/index.less
@@ -29,14 +29,6 @@
     color: @tag-default-color;
   }
 
-  &-text {
-    a:first-child:last-child {
-      display: inline-block;
-      margin: 0 -8px;
-      padding: 0 8px;
-    }
-  }
-
   .@{iconfont-css-prefix}-cross {
     .iconfont-size-under-12px(10px);
     cursor: pointer;

--- a/components/tag/style/index.less
+++ b/components/tag/style/index.less
@@ -29,6 +29,12 @@
     color: @tag-default-color;
   }
 
+  >a:first-child:last-child {
+    display: inline-block;
+    margin: 0 -8px;
+    padding: 0 8px;
+  }
+
   .@{iconfont-css-prefix}-cross {
     .iconfont-size-under-12px(10px);
     cursor: pointer;


### PR DESCRIPTION
tow commits:

1. Warp React.ReactNode with span element is not suggested. It may cause anti-specification problem: `<span><span>I'm spec breaker</span></span>`. span is not a general tags container.

    Another benefit from this change is keeping the same structure with CheckableTag.

    After inspecting the removing of the style of .ant-tag-text, seems to bring no problems. The old example employed this CSS class has gone long long time ago. See: https://github.com/ant-design/ant-design/commit/0635877a5199a521c5477d6c659030736bc7f19a

2. By codes, the children and the overlay of Dropdown must be **single** and **valid React.ReactElement**. React.Children.only takes it and report more friendly React internal built error messages.

    At present: `<Dropdown>hello<a /></Dropdown>`, causes unfriendly error messages.
---

First of all, thank you for your contribution! :-)

Please makes sure that these checkboxes are checked before submitting your PR, thank you!

* [x] Make sure that you propose PR to right branch: bugfix for `master`, feature for latest active branch `feature-x.x`.
* [x] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.

Extra checklist:

**if** *isBugFix* **:**

  * [ ] Make sure that you add at least one unit test for the bug which you had fixed.

**elif** *isNewFeature* **:**

  * [ ] Update API docs for the component.
  * [ ] Update/Add demo to demonstrate new feature.
  * [ ] Update TypeScript definition for the component.
  * [ ] Add unit tests for the feature.
