### PR TITLE
fix(tag): this should be the true `afterclose`

### DIFF
--- a/components/tag/index.tsx
+++ b/components/tag/index.tsx
@@ -64,12 +64,12 @@ export default class Tag extends React.Component<TagProps, TagState> {
       this.setState({
         closed: true,
         closing: false,
+      }, () => {
+        const afterClose = this.props.afterClose;
+        if (afterClose) {
+          afterClose();
+        }
       });
-
-      const afterClose = this.props.afterClose;
-      if (afterClose) {
-        afterClose();
-      }
     }
   }
 


### PR DESCRIPTION
got this problem because I want do something when the tag is close(like set some somes state in the outer component), but meet some issues

First of all, thank you for your contribution! :-)

Please makes sure that these checkboxes are checked before submitting your PR, thank you!

* [x] Make sure that you propose PR to right branch: bugfix for `master`, feature for latest active branch `feature-x.x`.
* [x] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.

Extra checklist:

**if** *isBugFix* **:**

  * [x] Make sure that you add at least one unit test for the bug which you had fixed.

**elif** *isNewFeature* **:**

  * [x] Update API docs for the component.
  * [x] Update/Add demo to demonstrate new feature.
  * [x] Update TypeScript definition for the component.
  * [x] Add unit tests for the feature.
