### PR TITLE
Optimize the button tip about `expand/hide all code`

### DIFF
--- a/site/theme/template/Content/ComponentDoc.jsx
+++ b/site/theme/template/Content/ComponentDoc.jsx
@@ -102,7 +102,7 @@ export default class ComponentDoc extends React.Component {
               <Icon
                 type="appstore"
                 className={expandTriggerClass}
-                title="展开全部代码"
+                title={expand ? '收起全部代码' : '展开全部代码'}
                 onClick={this.handleExpandToggle}
               />
             </h2>


### PR DESCRIPTION
现在即使已经展开了代码还是会提示 `展开全部代码`，所以加了一个 `收起全部代码`
^_^