### PR TITLE
阻止点击穿透

### DIFF
--- a/components/table/style/index.less
+++ b/components/table/style/index.less
@@ -503,6 +503,7 @@
   &-fixed-right {
     position: absolute;
     top: 0;
+    z-index:1;
     overflow: hidden;
     transition: box-shadow .3s ease;
     border-radius: 0;


### PR DESCRIPTION
当表头某列固定到左侧或者右侧，水平方向滚动表格，使单元格中有Checkbox 等可点击元素滚动到固定列一下，固定列上面的a标签单击会穿透到底非固定列。

First of all, thank you for your contribution! :-)

Please makes sure that these checkboxes are checked before submitting your PR, thank you!

* [ ] Make sure that you propose PR to right branch: bugfix for `master`, feature for latest active branch `feature-x.x`.
* [ ] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [ ] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [ ] Rebase before creating a PR to keep commit history clear.
* [ ] Add some descriptions and refer relative issues for you PR.

Extra checklist:

**if** *isBugFix* **:**

  * [ ] Make sure that you add at least one unit test for the bug which you had fixed.

**elif** *isNewFeature* **:**

  * [ ] Update API docs for the component.
  * [ ] Update/Add demo to demonstrate new feature.
  * [ ] Update TypeScript definition for the component.
  * [ ] Add unit tests for the feature.
