### PR TITLE
Add and pass ids to modal buttons

### DIFF
--- a/components/locale-provider/__tests__/index.test.js
+++ b/components/locale-provider/__tests__/index.test.js
@@ -87,7 +87,11 @@ const App = () => (
 
 describe('Locale Provider', () => {
   beforeAll(() => {
-    MockDate.set(moment('2017-09-18T03:30:07.795Z').valueOf() + (new Date().getTimezoneOffset() * 60 * 1000));
+    const mockDate = moment('2017-09-18T03:30:07.795Z');
+    let offset = new Date().getTimezoneOffset();
+    offset = mockDate.isDST() ? 2 * offset : offset;
+    const mockNow = mockDate.valueOf() + (offset * 60 * 1000);
+    MockDate.set(mockNow);
   });
 
   afterAll(() => {

--- a/components/modal/Modal.tsx
+++ b/components/modal/Modal.tsx
@@ -39,6 +39,7 @@ export interface ModalProps {
   destroyOnClose?: boolean;
   style?: React.CSSProperties;
   wrapClassName?: string;
+  wrapProps?: object;
   maskTransitionName?: string;
   transitionName?: string;
   className?: string;
@@ -151,6 +152,7 @@ export default class Modal extends React.Component<ModalProps, {}> {
       <div>
         <Button
           onClick={this.handleCancel}
+          aria-label="cancel"
         >
           {cancelText || locale.cancelText}
         </Button>
@@ -158,6 +160,7 @@ export default class Modal extends React.Component<ModalProps, {}> {
           type={okType}
           loading={confirmLoading}
           onClick={this.handleOk}
+          aria-label="ok"
         >
           {okText || locale.okText}
         </Button>

--- a/components/modal/__tests__/Modal.test.js
+++ b/components/modal/__tests__/Modal.test.js
@@ -44,4 +44,20 @@ describe('Modal', () => {
     const wrapper = mount(<ModalTester footer={null} />);
     expect(wrapper.render()).toMatchSnapshot();
   });
+
+  it('should assign aria-labels to default ok and cancel button', () => {
+    const wrapProps = {
+      id: 'test',
+    };
+    const wrapper = mount(<ModalTester wrapProps={wrapProps} />);
+    expect(wrapper.render()).toMatchSnapshot();
+  });
+
+  it('should pass wrapper props to dialog', () => {
+    const wrapProps = {
+      id: 'test',
+    };
+    const wrapper = mount(<ModalTester wrapProps={wrapProps} />);
+    expect(wrapper.render()).toMatchSnapshot();
+  });
 });

--- a/components/modal/__tests__/__snapshots__/Modal.test.js.snap
+++ b/components/modal/__tests__/__snapshots__/Modal.test.js.snap
@@ -38,6 +38,7 @@ exports[`Modal render correctly 1`] = `
           >
             <div>
               <button
+                aria-label="cancel"
                 class="ant-btn"
                 type="button"
               >
@@ -46,6 +47,7 @@ exports[`Modal render correctly 1`] = `
                 </span>
               </button>
               <button
+                aria-label="ok"
                 class="ant-btn ant-btn-primary"
                 type="button"
               >
@@ -100,6 +102,148 @@ exports[`Modal render without footer 1`] = `
             class="ant-modal-body"
           >
             Here is content of Modal
+          </div>
+        </div>
+        <div
+          style="width: 0px; height: 0px; overflow: hidden;"
+          tabindex="0"
+        >
+          sentinel
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Modal should assign aria-labels to default ok and cancel button 1`] = `
+<div>
+  <div />
+  <div>
+    <div
+      class="ant-modal-mask fade-appear"
+    />
+    <div
+      class="ant-modal-wrap "
+      id="test"
+      role="dialog"
+      tabindex="-1"
+    >
+      <div
+        class="ant-modal zoom-appear"
+        role="document"
+        style="width: 520px;"
+      >
+        <div
+          class="ant-modal-content"
+        >
+          <button
+            aria-label="Close"
+            class="ant-modal-close"
+          >
+            <span
+              class="ant-modal-close-x"
+            />
+          </button>
+          <div
+            class="ant-modal-body"
+          >
+            Here is content of Modal
+          </div>
+          <div
+            class="ant-modal-footer"
+          >
+            <div>
+              <button
+                aria-label="cancel"
+                class="ant-btn"
+                type="button"
+              >
+                <span>
+                  Cancel
+                </span>
+              </button>
+              <button
+                aria-label="ok"
+                class="ant-btn ant-btn-primary"
+                type="button"
+              >
+                <span>
+                  OK
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
+        <div
+          style="width: 0px; height: 0px; overflow: hidden;"
+          tabindex="0"
+        >
+          sentinel
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Modal should pass wrapper props to dialog 1`] = `
+<div>
+  <div />
+  <div>
+    <div
+      class="ant-modal-mask fade-appear"
+    />
+    <div
+      class="ant-modal-wrap "
+      id="test"
+      role="dialog"
+      tabindex="-1"
+    >
+      <div
+        class="ant-modal zoom-appear"
+        role="document"
+        style="width: 520px;"
+      >
+        <div
+          class="ant-modal-content"
+        >
+          <button
+            aria-label="Close"
+            class="ant-modal-close"
+          >
+            <span
+              class="ant-modal-close-x"
+            />
+          </button>
+          <div
+            class="ant-modal-body"
+          >
+            Here is content of Modal
+          </div>
+          <div
+            class="ant-modal-footer"
+          >
+            <div>
+              <button
+                aria-label="cancel"
+                class="ant-btn"
+                type="button"
+              >
+                <span>
+                  Cancel
+                </span>
+              </button>
+              <button
+                aria-label="ok"
+                class="ant-btn ant-btn-primary"
+                type="button"
+              >
+                <span>
+                  OK
+                </span>
+              </button>
+            </div>
           </div>
         </div>
         <div

--- a/components/modal/index.en-US.md
+++ b/components/modal/index.en-US.md
@@ -36,6 +36,7 @@ and so on.
 | visible | Whether the modal dialog is visible or not | boolean | false |
 | width | Width of the modal dialog | string\|number | 520 |
 | wrapClassName | The class name of the container of the modal dialog | string | - |
+| wrapProps | Props for the container of the modal dialog | object | - |
 | zIndex | The `z-index` of the Modal | Number | 1000 |
 | onCancel | Specify a function that will be called when a user clicks mask, close button on top right or Cancel button | function(e) | - |
 | onOk | Specify a function that will be called when a user clicks the OK button | function(e) | - |


### PR DESCRIPTION
This PR enables us to define an id for the default modal buttons and makes automated browser testing much easier.

- add id property to Button / ActionButton
- add okId and cancelId properties to modal and pass them down to the buttons
- update modal documentation (en)

I could use some help with the zh translation of the documentation...