### PR TITLE
add custom close icon prop to tag component

### DIFF
--- a/components/tag/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/tag/__tests__/__snapshots__/demo.test.js.snap
@@ -303,6 +303,50 @@ exports[`renders ./components/tag/demo/control.md correctly 1`] = `
 </div>
 `;
 
+exports[`renders ./components/tag/demo/custom-close.md correctly 1`] = `
+<div>
+  <div
+    class="ant-tag"
+    data-show="true"
+  >
+    <span
+      class="ant-tag-text"
+    >
+      custom close 1
+    </span>
+    <i
+      class="anticon anticon-cross"
+    />
+  </div>
+  <div
+    class="ant-tag"
+    data-show="true"
+  >
+    <span
+      class="ant-tag-text"
+    >
+      custom close 2
+    </span>
+    <i
+      class="anticon anticon-cross"
+    />
+  </div>
+  <div
+    class="ant-tag"
+    data-show="true"
+  >
+    <span
+      class="ant-tag-text"
+    >
+      custom close 3
+    </span>
+    <i
+      class="anticon anticon-cross"
+    />
+  </div>
+</div>
+`;
+
 exports[`renders ./components/tag/demo/hot-tags.md correctly 1`] = `
 <div>
   <h6

--- a/components/tag/demo/custom-close.md
+++ b/components/tag/demo/custom-close.md
@@ -1,0 +1,79 @@
+---
+order: 5
+title:
+  zh-CN: Custom close icon
+  en-US: Custom close icon
+---
+
+## zh-CN
+
+Usage of Tag with custom close icon
+
+## en-US
+
+Usage of Tag with custom close icon
+
+````jsx
+import { Tag, Popconfirm, Icon } from 'antd';
+
+function log(e) {
+  console.log(e);
+}
+
+ReactDOM.render(
+  <div>
+    <Tag
+      closable
+      onClose={log}
+      customCloseIcon={onClose => (
+        <Popconfirm
+          title="Are you sure?"
+          onConfirm={onClose}
+          onCancel={() => {}}
+          okText="Yes"
+          cancelText="No"
+        >
+          <Icon type="cross" />
+        </Popconfirm>
+      )}
+    >
+      custom close 1
+    </Tag>
+    <Tag
+      closable
+      onClose={log}
+      customCloseIcon={onClose => (
+        <Popconfirm
+          title="Are you sure?"
+          onConfirm={onClose}
+          onCancel={() => {}}
+          okText="Yes"
+          cancelText="No"
+        >
+          <Icon type="cross" />
+        </Popconfirm>
+      )}
+    >
+      custom close 2
+    </Tag>
+    <Tag
+      closable
+      onClose={log}
+      customCloseIcon={onClose => (
+        <Popconfirm
+          title="Are you sure?"
+          onConfirm={onClose}
+          onCancel={() => {}}
+          okText="Yes"
+          cancelText="No"
+        >
+          <Icon type="cross" />
+        </Popconfirm>
+      )}
+    >
+      custom close 3
+    </Tag>
+  </div>,
+  mountNode
+);
+````

--- a/components/tag/index.en-US.md
+++ b/components/tag/index.en-US.md
@@ -20,6 +20,7 @@ Tag for categorizing or markup.
 | -------- | ----------- | ---- | ------- |
 | afterClose | Callback executed when close animation is completed | () => void | - |
 | closable | Whether Tag can be closed | boolean | `false` |
+| customCloseIcon | Your own custom close component | (onClose: Function) => React.ReactNode | - |
 | color | Color of the Tag | string | - |
 | onClose | Callback executed when tag is closed | (e) => void | - |
 

--- a/components/tag/index.tsx
+++ b/components/tag/index.tsx
@@ -14,6 +14,7 @@ export interface TagProps {
   color?: string;
   /** 标签是否可以关闭 */
   closable?: boolean;
+  customCloseIcon?: (onClose: Function) => React.ReactNode;
   /** 关闭时的回调 */
   onClose?: Function;
   /** 动画关闭后的回调 */
@@ -73,6 +74,12 @@ export default class Tag extends React.Component<TagProps, TagState> {
     }
   }
 
+  getCloseIcon = () => {
+    const { closable, customCloseIcon } = this.props;
+    if (!closable) { return ''; }
+    return customCloseIcon ? customCloseIcon(this.close) : <Icon type="cross" onClick={this.close} />;
+  }
+
   isPresetColor(color?: string): boolean {
     if (!color) { return false; }
     return (
@@ -82,8 +89,8 @@ export default class Tag extends React.Component<TagProps, TagState> {
   }
 
   render() {
-    const { prefixCls, closable, color, className, children, style, ...otherProps } = this.props;
-    const closeIcon = closable ? <Icon type="cross" onClick={this.close} /> : '';
+    const { prefixCls, closable, color, className, children, style, customCloseIcon, ...otherProps } = this.props;
+    const closeIcon = this.getCloseIcon();
     const isPresetColor = this.isPresetColor(color);
     const classString = classNames(prefixCls, {
       [`${prefixCls}-${color}`]: isPresetColor,


### PR DESCRIPTION
related issue: https://github.com/ant-design/ant-design/issues/9203

so now you can pass additional prop customCloseIcon to Tag component to render something other instead of close icon. In my case I needed Popconfirm above close icon, so with that pr it's easily possible to do.

* [x] Make sure that you propose PR to right branch: bugfix for `master`, feature for latest active branch `feature-x.x`.
* [x] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.

Extra checklist:

**if** *isBugFix* **:**

  * [ ] Make sure that you add at least one unit test for the bug which you had fixed.

**elif** *isNewFeature* **:**

  * [x] Update API docs for the component.
  * [x] Update/Add demo to demonstrate new feature.
  * [x] Update TypeScript definition for the component.
  * [ ] Add unit tests for the feature.

ps I've got some issue to render my demo locally at your website, idk how it works, I guess I need to mention new .md file somewhere in configs
