### PR TITLE
proper class on avatar when image doesnt exist

### DIFF
--- a/components/avatar/index.tsx
+++ b/components/avatar/index.tsx
@@ -83,7 +83,7 @@ export default class Avatar extends React.Component<AvatarProps, AvatarState> {
 
     const classString = classNames(prefixCls, className, sizeCls, {
       [`${prefixCls}-${shape}`]: shape,
-      [`${prefixCls}-image`]: src,
+      [`${prefixCls}-image`]: src && this.state.isImgExist,
       [`${prefixCls}-icon`]: icon,
     });
 


### PR DESCRIPTION
When Avatar is rerendered because the image didnt exist, wrong class is applied today which makes the background transparent for Icon or text.  This PR fixes that.


Thanks

Please makes sure that these checkboxes are checked before submitting your PR, thank you!

* [x] Make sure that you propose PR to right branch: bugfix for `master`, feature for latest active branch `feature-x.x`.
* [x] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.

Extra checklist:

**if** *isBugFix* **:**

  * [ ] Make sure that you add at least one unit test for the bug which you had fixed.
