### PR TITLE
fix type of column dataIndex

### DIFF
--- a/components/table/Table.tsx
+++ b/components/table/Table.tsx
@@ -696,7 +696,7 @@ export default class Table<T> extends React.Component<TableProps<T>, TableState<
     const { prefixCls, dropdownPrefixCls } = this.props;
     const { sortOrder } = this.state;
     return treeMap(columns, (originColumn, i) => {
-      let column = { ...originColumn };
+      let column: ColumnProps<T> = { ...originColumn };
       let key = this.getColumnKey(column, i) as string;
       let filterDropdown;
       let sortButton;

--- a/components/table/interface.tsx
+++ b/components/table/interface.tsx
@@ -9,7 +9,7 @@ export type ColumnFilterItem = { text: string; value: string, children?: ColumnF
 export interface ColumnProps<T> {
   title?: React.ReactNode;
   key?: React.Key;
-  dataIndex?: string;
+  dataIndex?: keyof T;
   render?: (text: any, record: T, index: number) => React.ReactNode;
   filters?: ColumnFilterItem[];
   onFilter?: (value: any, record: T) => boolean;


### PR DESCRIPTION
This can check if key is in the object

```ts
interface User {
    name: string;
} 

const columns:  ColumnProps<User> = {
    dataIndex: "age" // compile error here, since age is not in the User
}
```