### PR TITLE
fix: make Mention autosize height by default, close: #9068

### DIFF
--- a/components/mention/style/index.less
+++ b/components/mention/style/index.less
@@ -13,6 +13,8 @@
 
   .@{mention-prefix-cls}-editor {
     .input;
+    min-height: @input-height-base;
+    height: auto; // To override height in .input mixin
     line-height: @line-height-base;
     padding: 0;
     display: block;


### PR DESCRIPTION
Close: https://github.com/ant-design/ant-design/issues/9068