### PR TITLE
fix: Field feedback offset position on vertical forms, Close #9153

### DIFF
--- a/components/form/demo/layout.md
+++ b/components/form/demo/layout.md
@@ -29,6 +29,7 @@ class FormLayoutDemo extends React.Component {
   }
   render() {
     const { formLayout } = this.state;
+    const { getFieldDecorator } = this.props.form;
     const formItemLayout = formLayout === 'horizontal' ? {
       labelCol: { span: 4 },
       wrapperCol: { span: 14 },
@@ -51,15 +52,21 @@ class FormLayoutDemo extends React.Component {
           </FormItem>
           <FormItem
             label="Field A"
+            hasFeedback
             {...formItemLayout}
           >
-            <Input placeholder="input placeholder" />
+            {getFieldDecorator('fieldA', { rules: [{ required: true }] })(
+              <Input placeholder="input placeholder" />
+            )}
           </FormItem>
           <FormItem
             label="Field B"
+            hasFeedback
             {...formItemLayout}
           >
-            <Input placeholder="input placeholder" />
+            {getFieldDecorator('fieldB', { rules: [{ required: true }] })(
+              <Input placeholder="input placeholder" />
+            )}
           </FormItem>
           <FormItem {...buttonItemLayout}>
             <Button type="primary">Submit</Button>
@@ -70,5 +77,8 @@ class FormLayoutDemo extends React.Component {
   }
 }
 
-ReactDOM.render(<FormLayoutDemo />, mountNode);
+
+const WrappedRegistrationForm = Form.create()(FormLayoutDemo);
+
+ReactDOM.render(<WrappedRegistrationForm />, mountNode);
 ````

--- a/components/form/style/index.less
+++ b/components/form/style/index.less
@@ -320,7 +320,7 @@ form {
     padding-bottom: 8px;
   }
   .@{form-prefix-cls}-item-control {
-    line-height: @line-height-base;
+    line-height: @form-component-max-height - 0.0001px;
   }
   .@{form-prefix-cls}-explain,
   .@{form-prefix-cls}-extra {


### PR DESCRIPTION
Fixes bug described in #9153. Updates also Form layout demo (`components/form/demo/layout.md`) to see how Form.Field behaves in vertical forms and with `hasFeedback` enabled.