### PR TITLE
fix typo in less good

### DIFF
--- a/components/switch/style/index.less
+++ b/components/switch/style/index.less
@@ -56,7 +56,7 @@
     font-family: anticon;
     animation: loadingCircle 1s infinite linear;
     text-align: center;
-    background: transprent;
+    background: transparent;
     z-index: 1;
     display: none;
     font-size: 12px;


### PR DESCRIPTION
Fix `background` property value by changing it from `transprent` to `transparent`.  Fixes #9290 