### PR TITLE
fix issue #9359

### DIFF
--- a/components/badge/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/badge/__tests__/__snapshots__/demo.test.js.snap
@@ -426,6 +426,13 @@ exports[`renders ./components/badge/demo/dot.md correctly 1`] = `
   <span
     class="ant-badge"
   >
+    <i
+      class="anticon anticon-notification"
+    />
+  </span>
+  <span
+    class="ant-badge"
+  >
     <a
       href="#"
     >

--- a/components/badge/__tests__/index.test.js
+++ b/components/badge/__tests__/index.test.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import Badge from '../index';
+
+describe('Badge', () => {
+  test('badge dot not scaling count > 9', () => {
+    const badge = mount(<Badge count={10} dot />);
+    expect(badge.find('.ant-card-multiple-words').length).toBe(0);
+  });
+  test('badge dot not showing count == 0', () => {
+    const badge = mount(<Badge count={0} dot />);
+    expect(badge.find('.ant-badge-dot').length).toBe(0);
+  });
+});

--- a/components/badge/demo/dot.md
+++ b/components/badge/demo/dot.md
@@ -12,6 +12,7 @@ title:
 ## en-US
 
 This will simply display a red badge, without a specific count.
+If count equals 0, it won't display the dot.
 
 ````jsx
 import { Badge, Icon } from 'antd';
@@ -19,6 +20,9 @@ import { Badge, Icon } from 'antd';
 ReactDOM.render(
   <div>
     <Badge dot>
+      <Icon type="notification" />
+    </Badge>
+    <Badge count={0} dot>
       <Icon type="notification" />
     </Badge>
     <Badge dot>

--- a/components/badge/index.tsx
+++ b/components/badge/index.tsx
@@ -60,7 +60,7 @@ export default class Badge extends React.Component<BadgeProps, any> {
       ...restProps,
     } = this.props;
     let displayCount = (count as number) > (overflowCount as number) ? `${overflowCount}+` : count;
-    const isZero = displayCount === '0' || displayCount === 0; 
+    const isZero = displayCount === '0' || displayCount === 0;
     const isDot = (dot && !isZero) || status;
     // dot mode don't need count
     if (isDot) {

--- a/components/badge/index.tsx
+++ b/components/badge/index.tsx
@@ -59,14 +59,13 @@ export default class Badge extends React.Component<BadgeProps, any> {
       offset,
       ...restProps,
     } = this.props;
-    const isDot = dot || status;
     let displayCount = (count as number) > (overflowCount as number) ? `${overflowCount}+` : count;
+    const isZero = displayCount === '0' || displayCount === 0; 
+    const isDot = (dot && !isZero) || status;
     // dot mode don't need count
     if (isDot) {
       displayCount = '';
     }
-
-    const isZero = displayCount === '0' || displayCount === 0;
     const isEmpty = displayCount === null || displayCount === undefined || displayCount === '';
     const hidden = (isEmpty || (isZero && !showZero)) && !isDot;
     const statusCls = classNames({
@@ -76,7 +75,7 @@ export default class Badge extends React.Component<BadgeProps, any> {
     const scrollNumberCls = classNames({
       [`${prefixCls}-dot`]: isDot,
       [`${prefixCls}-count`]: !isDot,
-      [`${prefixCls}-multiple-words`]: count && count.toString && count.toString().length > 1,
+      [`${prefixCls}-multiple-words`]: !isDot && count && count.toString && count.toString().length > 1,
       [`${prefixCls}-status-${status}`]: !!status,
     });
     const badgeCls = classNames(className, prefixCls, {


### PR DESCRIPTION
fixed issue #9359 
new behavior of dot badge is if only dot is stated it will always display the dot, but if additionaly a count prop is provided it will only show if count != 0.

additionally the badge won't be bigger if count > 10, if badge is a dot

First of all, thank you for your contribution! :-)

Please makes sure that these checkboxes are checked before submitting your PR, thank you!

* [x] Make sure that you propose PR to right branch: bugfix for `master`, feature for latest active branch `feature-x.x`.
* [x] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.

Extra checklist:

**if** *isBugFix* **:**

  * [x] Make sure that you add at least one unit test for the bug which you had fixed.
