### PR TITLE
fix: set `-has-trigger` class in sider when `-trigger` div exists

### DIFF
--- a/components/layout/Sider.tsx
+++ b/components/layout/Sider.tsx
@@ -212,7 +212,7 @@ export default class Sider extends React.Component<SiderProps, SliderState> {
     };
     const siderCls = classNames(className, prefixCls, {
       [`${prefixCls}-collapsed`]: !!this.state.collapsed,
-      [`${prefixCls}-has-trigger`]: !!trigger,
+      [`${prefixCls}-has-trigger`]: collapsible && trigger !== null && !zeroWidthTrigger,
       [`${prefixCls}-below`]: !!this.state.below,
       [`${prefixCls}-zero-width`]: siderWidth === 0 || siderWidth === '0' || siderWidth === '0px',
     });

--- a/components/layout/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/layout/__tests__/__snapshots__/demo.test.js.snap
@@ -688,7 +688,7 @@ exports[`renders ./components/layout/demo/side.md correctly 1`] = `
   style="min-height:100vh"
 >
   <div
-    class="ant-layout-sider"
+    class="ant-layout-sider ant-layout-sider-has-trigger"
     style="flex:0 0 200px;max-width:200px;min-width:200px;width:200px"
   >
     <div

--- a/components/layout/__tests__/index.test.js
+++ b/components/layout/__tests__/index.test.js
@@ -24,4 +24,14 @@ describe('Layout', () => {
     );
     expect(wrapper.find('.ant-layout').hasClass('ant-layout-has-sider')).toBe(true);
   });
+
+  it('detect `${prefixCls}-has-trigger` class in sider when `${prefixCls}-trigger` div tag exists', async () => {
+    const wrapper = mount(
+      <Layout>
+        <div><Sider collapsible>Sider</Sider></div>
+        <Content>Content</Content>
+      </Layout>
+    );
+    expect(wrapper.find('.ant-layout-sider').hasClass('ant-layout-sider-has-trigger')).toBe(true);
+  });
 });

--- a/components/layout/__tests__/index.test.js
+++ b/components/layout/__tests__/index.test.js
@@ -25,7 +25,7 @@ describe('Layout', () => {
     expect(wrapper.find('.ant-layout').hasClass('ant-layout-has-sider')).toBe(true);
   });
 
-  it('detect `${prefixCls}-has-trigger` class in sider when `${prefixCls}-trigger` div tag exists', async () => {
+  it('detect ant-layout-sider-has-trigger class in sider when ant-layout-sider-trigger div tag exists', async () => {
     const wrapper = mount(
       <Layout>
         <div><Sider collapsible>Sider</Sider></div>


### PR DESCRIPTION
Hey guys, thanks for the awesome antd project! I'm using antd library for our project thanks to you guys.
I encountered this bug tonight, so I fixed and added test for that.
FYI, the issue have been submitted as #9398.
If you have any question, please feel free to comment.

Fixed #9398 

-------

First of all, thank you for your contribution! :-)

Please makes sure that these checkboxes are checked before submitting your PR, thank you!

* [ v] Make sure that you propose PR to right branch: bugfix for `master`, feature for latest active branch `feature-x.x`.
* [ v] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [ v] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [v ] Rebase before creating a PR to keep commit history clear.
* [v ] Add some descriptions and refer relative issues for you PR.

Extra checklist:

**if** *isBugFix* **:**

  * [v ] Make sure that you add at least one unit test for the bug which you had fixed.
