### PR TITLE
do somthing after slide up animation of Alert component

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -21,8 +21,8 @@ If you want to read change logs before `2.0.0`, please visit [GitHub](https://gi
 
 `2018-02-26`
 
-- 🐞 Fix issue resulting in SubMenu can not been shown correctly when `defaultOpenKeys` includes nonexistent key. [#8475](https://github.com/ant-design/ant-design/issues/8475)
-- 🐞 Fix issue resulting in DatePicker's value can not been controlled correctly. [#8885](https://github.com/ant-design/ant-design/issues/8885)
+- 🐞 Fix issue resulting in SubMenu can not be shown correctly when `defaultOpenKeys` includes a nonexistent key. [#8475](https://github.com/ant-design/ant-design/issues/8475)
+- 🐞 Fix issue resulting in DatePicker's value can not be controlled correctly. [#8885](https://github.com/ant-design/ant-design/issues/8885)
 
 ## 2.13.11
 

--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -17,6 +17,13 @@ If you want to read change logs before `2.0.0`, please visit [GitHub](https://gi
 
 ---
 
+## 2.13.12
+
+`2018-02-26`
+
+- 🐞 Fix issue resulting in SubMenu can not been shown correctly when `defaultOpenKeys` includes nonexistent key. [#8475](https://github.com/ant-design/ant-design/issues/8475)
+- 🐞 Fix issue resulting in DatePicker's value can not been controlled correctly. [#8885](https://github.com/ant-design/ant-design/issues/8885)
+
 ## 2.13.11
 
 `2017-12-01`

--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -17,6 +17,20 @@ If you want to read change logs before `2.0.0`, please visit [GitHub](https://gi
 
 ---
 
+## 2.13.11
+
+`2017-12-01`
+
+- 📝 Improve support of TypeScript. [#8394](https://github.com/ant-design/ant-design/pull/8394) [#8395](https://github.com/ant-design/ant-design/pull/8395) [@burdell](https://github.com/burdell) [@khayalan-mathew](https://github.com/khayalan-mathew)
+- 🐞 Fixed Tooltip missing `defaultVisible` property. [#8257](https://github.com/ant-design/ant-design/issues/8257)
+- 🐞 Fixed Modal `footer` property is overwrited when customing this property. [#8379](https://github.com/ant-design/ant-design/issues/8379)
+- 🐞 Fixed `fileList` shown incorrect when `beforeUpload` of Upload return `false`. [#8036](https://github.com/ant-design/ant-design/issues/8036)
+- 🐞 Fixed vertical align of Form.Item's feedback shown incorrect when Input `size` property is `default\small`. [#8243](https://github.com/ant-design/ant-design/issues/8243)
+- 🐞 Fixed nested Form.Item style incorrect. [#8320](https://github.com/ant-design/ant-design/issues/8320)
+- 🐞 Fixed Form.Item height are different between Chrome with Safari. [#8220](https://github.com/ant-design/ant-design/issues/8220)
+- 🐞 Fixed links where inside Form.Item's label are unavailable to click. [bf70d30](https://github.com/ant-design/ant-design/commit/bf70d30a60595916a38671f384ed17cbd0c4ba5d)
+- 🐞 Fixed Progress word wrap. [#8239](https://github.com/ant-design/ant-design/issues/8239)
+
 ## 2.13.10
 
 `2017-11-12`

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -17,6 +17,20 @@ timeline: true
 
 ---
 
+## 2.13.11
+
+`2017-12-01`
+
+- 📝 完善组件对 TypeScript 的支持。[#8394](https://github.com/ant-design/ant-design/pull/8394) [#8395](https://github.com/ant-design/ant-design/pull/8395) [@burdell](https://github.com/burdell) [@khayalan-mathew](https://github.com/khayalan-mathew)
+- 🐞 修复了 Tooltip 不支持 `defaultVisible` 属性的问题。[#8257](https://github.com/ant-design/ant-design/issues/8257)
+- 🐞 修复了 Modal 组件在传入自定义 `footer` 的时候默认 `footer` 被覆盖的问题。[#8379](https://github.com/ant-design/ant-design/issues/8379)
+- 🐞 修复了 Upload 组件在 `beforeUpload` 中返回 `false` 时，修改 `fileList` 导致上传列表展示不正常的问题。[#8036](https://github.com/ant-design/ant-design/issues/8036)
+- 🐞 修复了 Form 表单的信息回显在当 Input 组件 `size` 属性为 `default\small` 时没有对齐的问题。[#8243](https://github.com/ant-design/ant-design/issues/8243)
+- 🐞 修复了 Form.Item 在互相嵌套时样式异常的问题。[#8320](https://github.com/ant-design/ant-design/issues/8320)
+- 🐞 修复了 Form.Item 在 Chrome 和 Safari 下高度不一致的问题。 [#8220](https://github.com/ant-design/ant-design/issues/8220)
+- 🐞 修复了 Form.Item 在部分情况下 label 内链接无法点击的问题。 [bf70d30](https://github.com/ant-design/ant-design/commit/bf70d30a60595916a38671f384ed17cbd0c4ba5d)
+- 🐞 修复了 Progress 对于折行的场景兼容性问题。[#8239](https://github.com/ant-design/ant-design/issues/8239)
+
 ## 2.13.10
 
 `2017-11-12`

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -17,6 +17,13 @@ timeline: true
 
 ---
 
+## 2.13.12
+
+`2018-02-26`
+
+- 🐞 修复 Menu 的 `defaultOpenKeys` 包含不存在的 key 时，子菜单不能正确显示的问题。 [#8475](https://github.com/ant-design/ant-design/issues/8475)
+- 🐞 修复 DatePicker 的值不能正确受控的问题。[#8885](https://github.com/ant-design/ant-design/issues/8885)
+
 ## 2.13.11
 
 `2017-12-01`

--- a/components/anchor/Anchor.tsx
+++ b/components/anchor/Anchor.tsx
@@ -42,9 +42,12 @@ function easeInOutCubic(t: number, b: number, c: number, d: number) {
 }
 
 const reqAnimFrame = getRequestAnimationFrame();
+const sharpMatcherRegx = /#([^#]+)$/;
 function scrollTo(href: string, offsetTop = 0, target, callback = () => { }) {
   const scrollTop = getScroll(target(), true);
-  const targetElement = document.getElementById(href.substring(1));
+  const sharpLinkMatch = sharpMatcherRegx.exec(href);
+  if (!sharpLinkMatch) { return; }
+  const targetElement = document.getElementById(sharpLinkMatch[1]);
   if (!targetElement) {
     return;
   }
@@ -174,7 +177,9 @@ export default class Anchor extends React.Component<AnchorProps, any> {
 
     const linkSections: Array<Section> = [];
     this.links.forEach(link => {
-      const target = document.getElementById(link.substring(1));
+      const sharpLinkMatch = sharpMatcherRegx.exec(link.toString());
+      if (!sharpLinkMatch) { return; }
+      const target = document.getElementById(sharpLinkMatch[1]);
       if (target && getOffsetTop(target) < offsetTop + bounds) {
         const top = getOffsetTop(target);
         linkSections.push({

--- a/components/anchor/__tests__/Anchor.test.js
+++ b/components/anchor/__tests__/Anchor.test.js
@@ -17,4 +17,48 @@ describe('Anchor Render', () => {
     wrapper.node.handleScroll();
     expect(wrapper.node.state).not.toBe(null);
   });
+
+  it('Anchor render perfectly for complete href - click', () => {
+    const wrapper = mount(
+      <Anchor>
+        <Link href="http://www.example.com/#API" title="API" />
+      </Anchor>
+    );
+    wrapper.find('a[href="http://www.example.com/#API"]').simulate('click');
+    expect(wrapper.node.state.activeLink).toBe('http://www.example.com/#API');
+  });
+
+  it('Anchor render perfectly for complete href - scoll', () => {
+    let root = document.getElementById('root');
+    if (!root) {
+      root = document.createElement('div', { id: 'root' });
+      root.id = 'root';
+      document.body.appendChild(root);
+    }
+    mount(<div id="API">Hello</div>, { attachTo: root });
+    const wrapper = mount(
+      <Anchor>
+        <Link href="http://www.example.com/#API" title="API" />
+      </Anchor>
+    );
+    wrapper.node.handleScroll();
+    expect(wrapper.node.state.activeLink).toBe('http://www.example.com/#API');
+  });
+
+  it('Anchor render perfectly for complete href - scollTo', () => {
+    let root = document.getElementById('root');
+    if (!root) {
+      root = document.createElement('div', { id: 'root' });
+      root.id = 'root';
+      document.body.appendChild(root);
+    }
+    mount(<div id="API">Hello</div>, { attachTo: root });
+    const wrapper = mount(
+      <Anchor>
+        <Link href="##API" title="API" />
+      </Anchor>
+    );
+    wrapper.node.handleScrollTo('##API');
+    expect(wrapper.node.state.activeLink).toBe('##API');
+  });
 });

--- a/components/calendar/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/calendar/__tests__/__snapshots__/demo.test.js.snap
@@ -218,7 +218,7 @@ exports[`renders ./components/calendar/demo/basic.md correctly 1`] = `
             <td
               class="ant-fullcalendar-cell ant-fullcalendar-last-month-cell"
               role="gridcell"
-              title="2016年10月31日"
+              title="2016/10/31"
             >
               <div
                 class="ant-fullcalendar-date"
@@ -236,7 +236,7 @@ exports[`renders ./components/calendar/demo/basic.md correctly 1`] = `
             <td
               class="ant-fullcalendar-cell"
               role="gridcell"
-              title="2016年11月1日"
+              title="2016/11/01"
             >
               <div
                 class="ant-fullcalendar-date"
@@ -254,7 +254,7 @@ exports[`renders ./components/calendar/demo/basic.md correctly 1`] = `
             <td
               class="ant-fullcalendar-cell"
               role="gridcell"
-              title="2016年11月2日"
+              title="2016/11/02"
             >
               <div
                 class="ant-fullcalendar-date"
@@ -272,7 +272,7 @@ exports[`renders ./components/calendar/demo/basic.md correctly 1`] = `
             <td
               class="ant-fullcalendar-cell"
               role="gridcell"
-              title="2016年11月3日"
+              title="2016/11/03"
             >
               <div
                 class="ant-fullcalendar-date"
@@ -290,7 +290,7 @@ exports[`renders ./components/calendar/demo/basic.md correctly 1`] = `
             <td
               class="ant-fullcalendar-cell"
               role="gridcell"
-              title="2016年11月4日"
+              title="2016/11/04"
             >
               <div
                 class="ant-fullcalendar-date"
@@ -308,7 +308,7 @@ exports[`renders ./components/calendar/demo/basic.md correctly 1`] = `
             <td
               class="ant-fullcalendar-cell"
               role="gridcell"
-              title="2016年11月5日"
+              title="2016/11/05"
             >
               <div
                 class="ant-fullcalendar-date"
@@ -326,7 +326,7 @@ exports[`renders ./components/calendar/demo/basic.md correctly 1`] = `
             <td
               class="ant-fullcalendar-cell"
               role="gridcell"
-              title="2016年11月6日"
+              title="2016/11/06"
             >
               <div
                 class="ant-fullcalendar-date"
@@ -349,7 +349,7 @@ exports[`renders ./components/calendar/demo/basic.md correctly 1`] = `
             <td
               class="ant-fullcalendar-cell"
               role="gridcell"
-              title="2016年11月7日"
+              title="2016/11/07"
             >
               <div
                 class="ant-fullcalendar-date"
@@ -367,7 +367,7 @@ exports[`renders ./components/calendar/demo/basic.md correctly 1`] = `
             <td
               class="ant-fullcalendar-cell"
               role="gridcell"
-              title="2016年11月8日"
+              title="2016/11/08"
             >
               <div
                 class="ant-fullcalendar-date"
@@ -385,7 +385,7 @@ exports[`renders ./components/calendar/demo/basic.md correctly 1`] = `
             <td
               class="ant-fullcalendar-cell"
               role="gridcell"
-              title="2016年11月9日"
+              title="2016/11/09"
             >
               <div
                 class="ant-fullcalendar-date"
@@ -403,7 +403,7 @@ exports[`renders ./components/calendar/demo/basic.md correctly 1`] = `
             <td
               class="ant-fullcalendar-cell"
               role="gridcell"
-              title="2016年11月10日"
+              title="2016/11/10"
             >
               <div
                 class="ant-fullcalendar-date"
@@ -421,7 +421,7 @@ exports[`renders ./components/calendar/demo/basic.md correctly 1`] = `
             <td
               class="ant-fullcalendar-cell"
               role="gridcell"
-              title="2016年11月11日"
+              title="2016/11/11"
             >
               <div
                 class="ant-fullcalendar-date"
@@ -439,7 +439,7 @@ exports[`renders ./components/calendar/demo/basic.md correctly 1`] = `
             <td
               class="ant-fullcalendar-cell"
               role="gridcell"
-              title="2016年11月12日"
+              title="2016/11/12"
             >
               <div
                 class="ant-fullcalendar-date"
@@ -457,7 +457,7 @@ exports[`renders ./components/calendar/demo/basic.md correctly 1`] = `
             <td
               class="ant-fullcalendar-cell"
               role="gridcell"
-              title="2016年11月13日"
+              title="2016/11/13"
             >
               <div
                 class="ant-fullcalendar-date"
@@ -480,7 +480,7 @@ exports[`renders ./components/calendar/demo/basic.md correctly 1`] = `
             <td
               class="ant-fullcalendar-cell"
               role="gridcell"
-              title="2016年11月14日"
+              title="2016/11/14"
             >
               <div
                 class="ant-fullcalendar-date"
@@ -498,7 +498,7 @@ exports[`renders ./components/calendar/demo/basic.md correctly 1`] = `
             <td
               class="ant-fullcalendar-cell"
               role="gridcell"
-              title="2016年11月15日"
+              title="2016/11/15"
             >
               <div
                 class="ant-fullcalendar-date"
@@ -516,7 +516,7 @@ exports[`renders ./components/calendar/demo/basic.md correctly 1`] = `
             <td
               class="ant-fullcalendar-cell"
               role="gridcell"
-              title="2016年11月16日"
+              title="2016/11/16"
             >
               <div
                 class="ant-fullcalendar-date"
@@ -534,7 +534,7 @@ exports[`renders ./components/calendar/demo/basic.md correctly 1`] = `
             <td
               class="ant-fullcalendar-cell"
               role="gridcell"
-              title="2016年11月17日"
+              title="2016/11/17"
             >
               <div
                 class="ant-fullcalendar-date"
@@ -552,7 +552,7 @@ exports[`renders ./components/calendar/demo/basic.md correctly 1`] = `
             <td
               class="ant-fullcalendar-cell"
               role="gridcell"
-              title="2016年11月18日"
+              title="2016/11/18"
             >
               <div
                 class="ant-fullcalendar-date"
@@ -570,7 +570,7 @@ exports[`renders ./components/calendar/demo/basic.md correctly 1`] = `
             <td
               class="ant-fullcalendar-cell"
               role="gridcell"
-              title="2016年11月19日"
+              title="2016/11/19"
             >
               <div
                 class="ant-fullcalendar-date"
@@ -588,7 +588,7 @@ exports[`renders ./components/calendar/demo/basic.md correctly 1`] = `
             <td
               class="ant-fullcalendar-cell"
               role="gridcell"
-              title="2016年11月20日"
+              title="2016/11/20"
             >
               <div
                 class="ant-fullcalendar-date"
@@ -611,7 +611,7 @@ exports[`renders ./components/calendar/demo/basic.md correctly 1`] = `
             <td
               class="ant-fullcalendar-cell"
               role="gridcell"
-              title="2016年11月21日"
+              title="2016/11/21"
             >
               <div
                 class="ant-fullcalendar-date"
@@ -629,7 +629,7 @@ exports[`renders ./components/calendar/demo/basic.md correctly 1`] = `
             <td
               class="ant-fullcalendar-cell ant-fullcalendar-today ant-fullcalendar-selected-day"
               role="gridcell"
-              title="2016年11月22日"
+              title="2016/11/22"
             >
               <div
                 class="ant-fullcalendar-date"
@@ -647,7 +647,7 @@ exports[`renders ./components/calendar/demo/basic.md correctly 1`] = `
             <td
               class="ant-fullcalendar-cell"
               role="gridcell"
-              title="2016年11月23日"
+              title="2016/11/23"
             >
               <div
                 class="ant-fullcalendar-date"
@@ -665,7 +665,7 @@ exports[`renders ./components/calendar/demo/basic.md correctly 1`] = `
             <td
               class="ant-fullcalendar-cell"
               role="gridcell"
-              title="2016年11月24日"
+              title="2016/11/24"
             >
               <div
                 class="ant-fullcalendar-date"
@@ -683,7 +683,7 @@ exports[`renders ./components/calendar/demo/basic.md correctly 1`] = `
             <td
               class="ant-fullcalendar-cell"
               role="gridcell"
-              title="2016年11月25日"
+              title="2016/11/25"
             >
               <div
                 class="ant-fullcalendar-date"
@@ -701,7 +701,7 @@ exports[`renders ./components/calendar/demo/basic.md correctly 1`] = `
             <td
               class="ant-fullcalendar-cell"
               role="gridcell"
-              title="2016年11月26日"
+              title="2016/11/26"
             >
               <div
                 class="ant-fullcalendar-date"
@@ -719,7 +719,7 @@ exports[`renders ./components/calendar/demo/basic.md correctly 1`] = `
             <td
               class="ant-fullcalendar-cell"
               role="gridcell"
-              title="2016年11月27日"
+              title="2016/11/27"
             >
               <div
                 class="ant-fullcalendar-date"
@@ -742,7 +742,7 @@ exports[`renders ./components/calendar/demo/basic.md correctly 1`] = `
             <td
               class="ant-fullcalendar-cell"
               role="gridcell"
-              title="2016年11月28日"
+              title="2016/11/28"
             >
               <div
                 class="ant-fullcalendar-date"
@@ -760,7 +760,7 @@ exports[`renders ./components/calendar/demo/basic.md correctly 1`] = `
             <td
               class="ant-fullcalendar-cell"
               role="gridcell"
-              title="2016年11月29日"
+              title="2016/11/29"
             >
               <div
                 class="ant-fullcalendar-date"
@@ -778,7 +778,7 @@ exports[`renders ./components/calendar/demo/basic.md correctly 1`] = `
             <td
               class="ant-fullcalendar-cell"
               role="gridcell"
-              title="2016年11月30日"
+              title="2016/11/30"
             >
               <div
                 class="ant-fullcalendar-date"
@@ -796,7 +796,7 @@ exports[`renders ./components/calendar/demo/basic.md correctly 1`] = `
             <td
               class="ant-fullcalendar-cell ant-fullcalendar-next-month-btn-day"
               role="gridcell"
-              title="2016年12月1日"
+              title="2016/12/01"
             >
               <div
                 class="ant-fullcalendar-date"
@@ -814,7 +814,7 @@ exports[`renders ./components/calendar/demo/basic.md correctly 1`] = `
             <td
               class="ant-fullcalendar-cell ant-fullcalendar-next-month-btn-day"
               role="gridcell"
-              title="2016年12月2日"
+              title="2016/12/02"
             >
               <div
                 class="ant-fullcalendar-date"
@@ -832,7 +832,7 @@ exports[`renders ./components/calendar/demo/basic.md correctly 1`] = `
             <td
               class="ant-fullcalendar-cell ant-fullcalendar-next-month-btn-day"
               role="gridcell"
-              title="2016年12月3日"
+              title="2016/12/03"
             >
               <div
                 class="ant-fullcalendar-date"
@@ -850,7 +850,7 @@ exports[`renders ./components/calendar/demo/basic.md correctly 1`] = `
             <td
               class="ant-fullcalendar-cell ant-fullcalendar-next-month-btn-day"
               role="gridcell"
-              title="2016年12月4日"
+              title="2016/12/04"
             >
               <div
                 class="ant-fullcalendar-date"
@@ -873,7 +873,7 @@ exports[`renders ./components/calendar/demo/basic.md correctly 1`] = `
             <td
               class="ant-fullcalendar-cell ant-fullcalendar-next-month-btn-day"
               role="gridcell"
-              title="2016年12月5日"
+              title="2016/12/05"
             >
               <div
                 class="ant-fullcalendar-date"
@@ -891,7 +891,7 @@ exports[`renders ./components/calendar/demo/basic.md correctly 1`] = `
             <td
               class="ant-fullcalendar-cell ant-fullcalendar-next-month-btn-day"
               role="gridcell"
-              title="2016年12月6日"
+              title="2016/12/06"
             >
               <div
                 class="ant-fullcalendar-date"
@@ -909,7 +909,7 @@ exports[`renders ./components/calendar/demo/basic.md correctly 1`] = `
             <td
               class="ant-fullcalendar-cell ant-fullcalendar-next-month-btn-day"
               role="gridcell"
-              title="2016年12月7日"
+              title="2016/12/07"
             >
               <div
                 class="ant-fullcalendar-date"
@@ -927,7 +927,7 @@ exports[`renders ./components/calendar/demo/basic.md correctly 1`] = `
             <td
               class="ant-fullcalendar-cell ant-fullcalendar-next-month-btn-day"
               role="gridcell"
-              title="2016年12月8日"
+              title="2016/12/08"
             >
               <div
                 class="ant-fullcalendar-date"
@@ -945,7 +945,7 @@ exports[`renders ./components/calendar/demo/basic.md correctly 1`] = `
             <td
               class="ant-fullcalendar-cell ant-fullcalendar-next-month-btn-day"
               role="gridcell"
-              title="2016年12月9日"
+              title="2016/12/09"
             >
               <div
                 class="ant-fullcalendar-date"
@@ -963,7 +963,7 @@ exports[`renders ./components/calendar/demo/basic.md correctly 1`] = `
             <td
               class="ant-fullcalendar-cell ant-fullcalendar-next-month-btn-day"
               role="gridcell"
-              title="2016年12月10日"
+              title="2016/12/10"
             >
               <div
                 class="ant-fullcalendar-date"
@@ -981,7 +981,7 @@ exports[`renders ./components/calendar/demo/basic.md correctly 1`] = `
             <td
               class="ant-fullcalendar-cell ant-fullcalendar-next-month-btn-day"
               role="gridcell"
-              title="2016年12月11日"
+              title="2016/12/11"
             >
               <div
                 class="ant-fullcalendar-date"
@@ -1225,7 +1225,7 @@ exports[`renders ./components/calendar/demo/card.md correctly 1`] = `
               <td
                 class="ant-fullcalendar-cell ant-fullcalendar-last-month-cell"
                 role="gridcell"
-                title="2016年10月31日"
+                title="2016/10/31"
               >
                 <div
                   class="ant-fullcalendar-date"
@@ -1243,7 +1243,7 @@ exports[`renders ./components/calendar/demo/card.md correctly 1`] = `
               <td
                 class="ant-fullcalendar-cell"
                 role="gridcell"
-                title="2016年11月1日"
+                title="2016/11/01"
               >
                 <div
                   class="ant-fullcalendar-date"
@@ -1261,7 +1261,7 @@ exports[`renders ./components/calendar/demo/card.md correctly 1`] = `
               <td
                 class="ant-fullcalendar-cell"
                 role="gridcell"
-                title="2016年11月2日"
+                title="2016/11/02"
               >
                 <div
                   class="ant-fullcalendar-date"
@@ -1279,7 +1279,7 @@ exports[`renders ./components/calendar/demo/card.md correctly 1`] = `
               <td
                 class="ant-fullcalendar-cell"
                 role="gridcell"
-                title="2016年11月3日"
+                title="2016/11/03"
               >
                 <div
                   class="ant-fullcalendar-date"
@@ -1297,7 +1297,7 @@ exports[`renders ./components/calendar/demo/card.md correctly 1`] = `
               <td
                 class="ant-fullcalendar-cell"
                 role="gridcell"
-                title="2016年11月4日"
+                title="2016/11/04"
               >
                 <div
                   class="ant-fullcalendar-date"
@@ -1315,7 +1315,7 @@ exports[`renders ./components/calendar/demo/card.md correctly 1`] = `
               <td
                 class="ant-fullcalendar-cell"
                 role="gridcell"
-                title="2016年11月5日"
+                title="2016/11/05"
               >
                 <div
                   class="ant-fullcalendar-date"
@@ -1333,7 +1333,7 @@ exports[`renders ./components/calendar/demo/card.md correctly 1`] = `
               <td
                 class="ant-fullcalendar-cell"
                 role="gridcell"
-                title="2016年11月6日"
+                title="2016/11/06"
               >
                 <div
                   class="ant-fullcalendar-date"
@@ -1356,7 +1356,7 @@ exports[`renders ./components/calendar/demo/card.md correctly 1`] = `
               <td
                 class="ant-fullcalendar-cell"
                 role="gridcell"
-                title="2016年11月7日"
+                title="2016/11/07"
               >
                 <div
                   class="ant-fullcalendar-date"
@@ -1374,7 +1374,7 @@ exports[`renders ./components/calendar/demo/card.md correctly 1`] = `
               <td
                 class="ant-fullcalendar-cell"
                 role="gridcell"
-                title="2016年11月8日"
+                title="2016/11/08"
               >
                 <div
                   class="ant-fullcalendar-date"
@@ -1392,7 +1392,7 @@ exports[`renders ./components/calendar/demo/card.md correctly 1`] = `
               <td
                 class="ant-fullcalendar-cell"
                 role="gridcell"
-                title="2016年11月9日"
+                title="2016/11/09"
               >
                 <div
                   class="ant-fullcalendar-date"
@@ -1410,7 +1410,7 @@ exports[`renders ./components/calendar/demo/card.md correctly 1`] = `
               <td
                 class="ant-fullcalendar-cell"
                 role="gridcell"
-                title="2016年11月10日"
+                title="2016/11/10"
               >
                 <div
                   class="ant-fullcalendar-date"
@@ -1428,7 +1428,7 @@ exports[`renders ./components/calendar/demo/card.md correctly 1`] = `
               <td
                 class="ant-fullcalendar-cell"
                 role="gridcell"
-                title="2016年11月11日"
+                title="2016/11/11"
               >
                 <div
                   class="ant-fullcalendar-date"
@@ -1446,7 +1446,7 @@ exports[`renders ./components/calendar/demo/card.md correctly 1`] = `
               <td
                 class="ant-fullcalendar-cell"
                 role="gridcell"
-                title="2016年11月12日"
+                title="2016/11/12"
               >
                 <div
                   class="ant-fullcalendar-date"
@@ -1464,7 +1464,7 @@ exports[`renders ./components/calendar/demo/card.md correctly 1`] = `
               <td
                 class="ant-fullcalendar-cell"
                 role="gridcell"
-                title="2016年11月13日"
+                title="2016/11/13"
               >
                 <div
                   class="ant-fullcalendar-date"
@@ -1487,7 +1487,7 @@ exports[`renders ./components/calendar/demo/card.md correctly 1`] = `
               <td
                 class="ant-fullcalendar-cell"
                 role="gridcell"
-                title="2016年11月14日"
+                title="2016/11/14"
               >
                 <div
                   class="ant-fullcalendar-date"
@@ -1505,7 +1505,7 @@ exports[`renders ./components/calendar/demo/card.md correctly 1`] = `
               <td
                 class="ant-fullcalendar-cell"
                 role="gridcell"
-                title="2016年11月15日"
+                title="2016/11/15"
               >
                 <div
                   class="ant-fullcalendar-date"
@@ -1523,7 +1523,7 @@ exports[`renders ./components/calendar/demo/card.md correctly 1`] = `
               <td
                 class="ant-fullcalendar-cell"
                 role="gridcell"
-                title="2016年11月16日"
+                title="2016/11/16"
               >
                 <div
                   class="ant-fullcalendar-date"
@@ -1541,7 +1541,7 @@ exports[`renders ./components/calendar/demo/card.md correctly 1`] = `
               <td
                 class="ant-fullcalendar-cell"
                 role="gridcell"
-                title="2016年11月17日"
+                title="2016/11/17"
               >
                 <div
                   class="ant-fullcalendar-date"
@@ -1559,7 +1559,7 @@ exports[`renders ./components/calendar/demo/card.md correctly 1`] = `
               <td
                 class="ant-fullcalendar-cell"
                 role="gridcell"
-                title="2016年11月18日"
+                title="2016/11/18"
               >
                 <div
                   class="ant-fullcalendar-date"
@@ -1577,7 +1577,7 @@ exports[`renders ./components/calendar/demo/card.md correctly 1`] = `
               <td
                 class="ant-fullcalendar-cell"
                 role="gridcell"
-                title="2016年11月19日"
+                title="2016/11/19"
               >
                 <div
                   class="ant-fullcalendar-date"
@@ -1595,7 +1595,7 @@ exports[`renders ./components/calendar/demo/card.md correctly 1`] = `
               <td
                 class="ant-fullcalendar-cell"
                 role="gridcell"
-                title="2016年11月20日"
+                title="2016/11/20"
               >
                 <div
                   class="ant-fullcalendar-date"
@@ -1618,7 +1618,7 @@ exports[`renders ./components/calendar/demo/card.md correctly 1`] = `
               <td
                 class="ant-fullcalendar-cell"
                 role="gridcell"
-                title="2016年11月21日"
+                title="2016/11/21"
               >
                 <div
                   class="ant-fullcalendar-date"
@@ -1636,7 +1636,7 @@ exports[`renders ./components/calendar/demo/card.md correctly 1`] = `
               <td
                 class="ant-fullcalendar-cell ant-fullcalendar-today ant-fullcalendar-selected-day"
                 role="gridcell"
-                title="2016年11月22日"
+                title="2016/11/22"
               >
                 <div
                   class="ant-fullcalendar-date"
@@ -1654,7 +1654,7 @@ exports[`renders ./components/calendar/demo/card.md correctly 1`] = `
               <td
                 class="ant-fullcalendar-cell"
                 role="gridcell"
-                title="2016年11月23日"
+                title="2016/11/23"
               >
                 <div
                   class="ant-fullcalendar-date"
@@ -1672,7 +1672,7 @@ exports[`renders ./components/calendar/demo/card.md correctly 1`] = `
               <td
                 class="ant-fullcalendar-cell"
                 role="gridcell"
-                title="2016年11月24日"
+                title="2016/11/24"
               >
                 <div
                   class="ant-fullcalendar-date"
@@ -1690,7 +1690,7 @@ exports[`renders ./components/calendar/demo/card.md correctly 1`] = `
               <td
                 class="ant-fullcalendar-cell"
                 role="gridcell"
-                title="2016年11月25日"
+                title="2016/11/25"
               >
                 <div
                   class="ant-fullcalendar-date"
@@ -1708,7 +1708,7 @@ exports[`renders ./components/calendar/demo/card.md correctly 1`] = `
               <td
                 class="ant-fullcalendar-cell"
                 role="gridcell"
-                title="2016年11月26日"
+                title="2016/11/26"
               >
                 <div
                   class="ant-fullcalendar-date"
@@ -1726,7 +1726,7 @@ exports[`renders ./components/calendar/demo/card.md correctly 1`] = `
               <td
                 class="ant-fullcalendar-cell"
                 role="gridcell"
-                title="2016年11月27日"
+                title="2016/11/27"
               >
                 <div
                   class="ant-fullcalendar-date"
@@ -1749,7 +1749,7 @@ exports[`renders ./components/calendar/demo/card.md correctly 1`] = `
               <td
                 class="ant-fullcalendar-cell"
                 role="gridcell"
-                title="2016年11月28日"
+                title="2016/11/28"
               >
                 <div
                   class="ant-fullcalendar-date"
@@ -1767,7 +1767,7 @@ exports[`renders ./components/calendar/demo/card.md correctly 1`] = `
               <td
                 class="ant-fullcalendar-cell"
                 role="gridcell"
-                title="2016年11月29日"
+                title="2016/11/29"
               >
                 <div
                   class="ant-fullcalendar-date"
@@ -1785,7 +1785,7 @@ exports[`renders ./components/calendar/demo/card.md correctly 1`] = `
               <td
                 class="ant-fullcalendar-cell"
                 role="gridcell"
-                title="2016年11月30日"
+                title="2016/11/30"
               >
                 <div
                   class="ant-fullcalendar-date"
@@ -1803,7 +1803,7 @@ exports[`renders ./components/calendar/demo/card.md correctly 1`] = `
               <td
                 class="ant-fullcalendar-cell ant-fullcalendar-next-month-btn-day"
                 role="gridcell"
-                title="2016年12月1日"
+                title="2016/12/01"
               >
                 <div
                   class="ant-fullcalendar-date"
@@ -1821,7 +1821,7 @@ exports[`renders ./components/calendar/demo/card.md correctly 1`] = `
               <td
                 class="ant-fullcalendar-cell ant-fullcalendar-next-month-btn-day"
                 role="gridcell"
-                title="2016年12月2日"
+                title="2016/12/02"
               >
                 <div
                   class="ant-fullcalendar-date"
@@ -1839,7 +1839,7 @@ exports[`renders ./components/calendar/demo/card.md correctly 1`] = `
               <td
                 class="ant-fullcalendar-cell ant-fullcalendar-next-month-btn-day"
                 role="gridcell"
-                title="2016年12月3日"
+                title="2016/12/03"
               >
                 <div
                   class="ant-fullcalendar-date"
@@ -1857,7 +1857,7 @@ exports[`renders ./components/calendar/demo/card.md correctly 1`] = `
               <td
                 class="ant-fullcalendar-cell ant-fullcalendar-next-month-btn-day"
                 role="gridcell"
-                title="2016年12月4日"
+                title="2016/12/04"
               >
                 <div
                   class="ant-fullcalendar-date"
@@ -1880,7 +1880,7 @@ exports[`renders ./components/calendar/demo/card.md correctly 1`] = `
               <td
                 class="ant-fullcalendar-cell ant-fullcalendar-next-month-btn-day"
                 role="gridcell"
-                title="2016年12月5日"
+                title="2016/12/05"
               >
                 <div
                   class="ant-fullcalendar-date"
@@ -1898,7 +1898,7 @@ exports[`renders ./components/calendar/demo/card.md correctly 1`] = `
               <td
                 class="ant-fullcalendar-cell ant-fullcalendar-next-month-btn-day"
                 role="gridcell"
-                title="2016年12月6日"
+                title="2016/12/06"
               >
                 <div
                   class="ant-fullcalendar-date"
@@ -1916,7 +1916,7 @@ exports[`renders ./components/calendar/demo/card.md correctly 1`] = `
               <td
                 class="ant-fullcalendar-cell ant-fullcalendar-next-month-btn-day"
                 role="gridcell"
-                title="2016年12月7日"
+                title="2016/12/07"
               >
                 <div
                   class="ant-fullcalendar-date"
@@ -1934,7 +1934,7 @@ exports[`renders ./components/calendar/demo/card.md correctly 1`] = `
               <td
                 class="ant-fullcalendar-cell ant-fullcalendar-next-month-btn-day"
                 role="gridcell"
-                title="2016年12月8日"
+                title="2016/12/08"
               >
                 <div
                   class="ant-fullcalendar-date"
@@ -1952,7 +1952,7 @@ exports[`renders ./components/calendar/demo/card.md correctly 1`] = `
               <td
                 class="ant-fullcalendar-cell ant-fullcalendar-next-month-btn-day"
                 role="gridcell"
-                title="2016年12月9日"
+                title="2016/12/09"
               >
                 <div
                   class="ant-fullcalendar-date"
@@ -1970,7 +1970,7 @@ exports[`renders ./components/calendar/demo/card.md correctly 1`] = `
               <td
                 class="ant-fullcalendar-cell ant-fullcalendar-next-month-btn-day"
                 role="gridcell"
-                title="2016年12月10日"
+                title="2016/12/10"
               >
                 <div
                   class="ant-fullcalendar-date"
@@ -1988,7 +1988,7 @@ exports[`renders ./components/calendar/demo/card.md correctly 1`] = `
               <td
                 class="ant-fullcalendar-cell ant-fullcalendar-next-month-btn-day"
                 role="gridcell"
-                title="2016年12月11日"
+                title="2016/12/11"
               >
                 <div
                   class="ant-fullcalendar-date"
@@ -2230,7 +2230,7 @@ exports[`renders ./components/calendar/demo/notice-calendar.md correctly 1`] = `
             <td
               class="ant-fullcalendar-cell ant-fullcalendar-last-month-cell"
               role="gridcell"
-              title="2016年10月31日"
+              title="2016/10/31"
             >
               <div
                 class="ant-fullcalendar-date"
@@ -2252,7 +2252,7 @@ exports[`renders ./components/calendar/demo/notice-calendar.md correctly 1`] = `
             <td
               class="ant-fullcalendar-cell"
               role="gridcell"
-              title="2016年11月1日"
+              title="2016/11/01"
             >
               <div
                 class="ant-fullcalendar-date"
@@ -2274,7 +2274,7 @@ exports[`renders ./components/calendar/demo/notice-calendar.md correctly 1`] = `
             <td
               class="ant-fullcalendar-cell"
               role="gridcell"
-              title="2016年11月2日"
+              title="2016/11/02"
             >
               <div
                 class="ant-fullcalendar-date"
@@ -2296,7 +2296,7 @@ exports[`renders ./components/calendar/demo/notice-calendar.md correctly 1`] = `
             <td
               class="ant-fullcalendar-cell"
               role="gridcell"
-              title="2016年11月3日"
+              title="2016/11/03"
             >
               <div
                 class="ant-fullcalendar-date"
@@ -2318,7 +2318,7 @@ exports[`renders ./components/calendar/demo/notice-calendar.md correctly 1`] = `
             <td
               class="ant-fullcalendar-cell"
               role="gridcell"
-              title="2016年11月4日"
+              title="2016/11/04"
             >
               <div
                 class="ant-fullcalendar-date"
@@ -2340,7 +2340,7 @@ exports[`renders ./components/calendar/demo/notice-calendar.md correctly 1`] = `
             <td
               class="ant-fullcalendar-cell"
               role="gridcell"
-              title="2016年11月5日"
+              title="2016/11/05"
             >
               <div
                 class="ant-fullcalendar-date"
@@ -2362,7 +2362,7 @@ exports[`renders ./components/calendar/demo/notice-calendar.md correctly 1`] = `
             <td
               class="ant-fullcalendar-cell"
               role="gridcell"
-              title="2016年11月6日"
+              title="2016/11/06"
             >
               <div
                 class="ant-fullcalendar-date"
@@ -2389,7 +2389,7 @@ exports[`renders ./components/calendar/demo/notice-calendar.md correctly 1`] = `
             <td
               class="ant-fullcalendar-cell"
               role="gridcell"
-              title="2016年11月7日"
+              title="2016/11/07"
             >
               <div
                 class="ant-fullcalendar-date"
@@ -2411,7 +2411,7 @@ exports[`renders ./components/calendar/demo/notice-calendar.md correctly 1`] = `
             <td
               class="ant-fullcalendar-cell"
               role="gridcell"
-              title="2016年11月8日"
+              title="2016/11/08"
             >
               <div
                 class="ant-fullcalendar-date"
@@ -2450,7 +2450,7 @@ exports[`renders ./components/calendar/demo/notice-calendar.md correctly 1`] = `
             <td
               class="ant-fullcalendar-cell"
               role="gridcell"
-              title="2016年11月9日"
+              title="2016/11/09"
             >
               <div
                 class="ant-fullcalendar-date"
@@ -2472,7 +2472,7 @@ exports[`renders ./components/calendar/demo/notice-calendar.md correctly 1`] = `
             <td
               class="ant-fullcalendar-cell"
               role="gridcell"
-              title="2016年11月10日"
+              title="2016/11/10"
             >
               <div
                 class="ant-fullcalendar-date"
@@ -2519,7 +2519,7 @@ exports[`renders ./components/calendar/demo/notice-calendar.md correctly 1`] = `
             <td
               class="ant-fullcalendar-cell"
               role="gridcell"
-              title="2016年11月11日"
+              title="2016/11/11"
             >
               <div
                 class="ant-fullcalendar-date"
@@ -2541,7 +2541,7 @@ exports[`renders ./components/calendar/demo/notice-calendar.md correctly 1`] = `
             <td
               class="ant-fullcalendar-cell"
               role="gridcell"
-              title="2016年11月12日"
+              title="2016/11/12"
             >
               <div
                 class="ant-fullcalendar-date"
@@ -2563,7 +2563,7 @@ exports[`renders ./components/calendar/demo/notice-calendar.md correctly 1`] = `
             <td
               class="ant-fullcalendar-cell"
               role="gridcell"
-              title="2016年11月13日"
+              title="2016/11/13"
             >
               <div
                 class="ant-fullcalendar-date"
@@ -2590,7 +2590,7 @@ exports[`renders ./components/calendar/demo/notice-calendar.md correctly 1`] = `
             <td
               class="ant-fullcalendar-cell"
               role="gridcell"
-              title="2016年11月14日"
+              title="2016/11/14"
             >
               <div
                 class="ant-fullcalendar-date"
@@ -2612,7 +2612,7 @@ exports[`renders ./components/calendar/demo/notice-calendar.md correctly 1`] = `
             <td
               class="ant-fullcalendar-cell"
               role="gridcell"
-              title="2016年11月15日"
+              title="2016/11/15"
             >
               <div
                 class="ant-fullcalendar-date"
@@ -2683,7 +2683,7 @@ exports[`renders ./components/calendar/demo/notice-calendar.md correctly 1`] = `
             <td
               class="ant-fullcalendar-cell"
               role="gridcell"
-              title="2016年11月16日"
+              title="2016/11/16"
             >
               <div
                 class="ant-fullcalendar-date"
@@ -2705,7 +2705,7 @@ exports[`renders ./components/calendar/demo/notice-calendar.md correctly 1`] = `
             <td
               class="ant-fullcalendar-cell"
               role="gridcell"
-              title="2016年11月17日"
+              title="2016/11/17"
             >
               <div
                 class="ant-fullcalendar-date"
@@ -2727,7 +2727,7 @@ exports[`renders ./components/calendar/demo/notice-calendar.md correctly 1`] = `
             <td
               class="ant-fullcalendar-cell"
               role="gridcell"
-              title="2016年11月18日"
+              title="2016/11/18"
             >
               <div
                 class="ant-fullcalendar-date"
@@ -2749,7 +2749,7 @@ exports[`renders ./components/calendar/demo/notice-calendar.md correctly 1`] = `
             <td
               class="ant-fullcalendar-cell"
               role="gridcell"
-              title="2016年11月19日"
+              title="2016/11/19"
             >
               <div
                 class="ant-fullcalendar-date"
@@ -2771,7 +2771,7 @@ exports[`renders ./components/calendar/demo/notice-calendar.md correctly 1`] = `
             <td
               class="ant-fullcalendar-cell"
               role="gridcell"
-              title="2016年11月20日"
+              title="2016/11/20"
             >
               <div
                 class="ant-fullcalendar-date"
@@ -2798,7 +2798,7 @@ exports[`renders ./components/calendar/demo/notice-calendar.md correctly 1`] = `
             <td
               class="ant-fullcalendar-cell"
               role="gridcell"
-              title="2016年11月21日"
+              title="2016/11/21"
             >
               <div
                 class="ant-fullcalendar-date"
@@ -2820,7 +2820,7 @@ exports[`renders ./components/calendar/demo/notice-calendar.md correctly 1`] = `
             <td
               class="ant-fullcalendar-cell ant-fullcalendar-today ant-fullcalendar-selected-day"
               role="gridcell"
-              title="2016年11月22日"
+              title="2016/11/22"
             >
               <div
                 class="ant-fullcalendar-date"
@@ -2842,7 +2842,7 @@ exports[`renders ./components/calendar/demo/notice-calendar.md correctly 1`] = `
             <td
               class="ant-fullcalendar-cell"
               role="gridcell"
-              title="2016年11月23日"
+              title="2016/11/23"
             >
               <div
                 class="ant-fullcalendar-date"
@@ -2864,7 +2864,7 @@ exports[`renders ./components/calendar/demo/notice-calendar.md correctly 1`] = `
             <td
               class="ant-fullcalendar-cell"
               role="gridcell"
-              title="2016年11月24日"
+              title="2016/11/24"
             >
               <div
                 class="ant-fullcalendar-date"
@@ -2886,7 +2886,7 @@ exports[`renders ./components/calendar/demo/notice-calendar.md correctly 1`] = `
             <td
               class="ant-fullcalendar-cell"
               role="gridcell"
-              title="2016年11月25日"
+              title="2016/11/25"
             >
               <div
                 class="ant-fullcalendar-date"
@@ -2908,7 +2908,7 @@ exports[`renders ./components/calendar/demo/notice-calendar.md correctly 1`] = `
             <td
               class="ant-fullcalendar-cell"
               role="gridcell"
-              title="2016年11月26日"
+              title="2016/11/26"
             >
               <div
                 class="ant-fullcalendar-date"
@@ -2930,7 +2930,7 @@ exports[`renders ./components/calendar/demo/notice-calendar.md correctly 1`] = `
             <td
               class="ant-fullcalendar-cell"
               role="gridcell"
-              title="2016年11月27日"
+              title="2016/11/27"
             >
               <div
                 class="ant-fullcalendar-date"
@@ -2957,7 +2957,7 @@ exports[`renders ./components/calendar/demo/notice-calendar.md correctly 1`] = `
             <td
               class="ant-fullcalendar-cell"
               role="gridcell"
-              title="2016年11月28日"
+              title="2016/11/28"
             >
               <div
                 class="ant-fullcalendar-date"
@@ -2979,7 +2979,7 @@ exports[`renders ./components/calendar/demo/notice-calendar.md correctly 1`] = `
             <td
               class="ant-fullcalendar-cell"
               role="gridcell"
-              title="2016年11月29日"
+              title="2016/11/29"
             >
               <div
                 class="ant-fullcalendar-date"
@@ -3001,7 +3001,7 @@ exports[`renders ./components/calendar/demo/notice-calendar.md correctly 1`] = `
             <td
               class="ant-fullcalendar-cell"
               role="gridcell"
-              title="2016年11月30日"
+              title="2016/11/30"
             >
               <div
                 class="ant-fullcalendar-date"
@@ -3023,7 +3023,7 @@ exports[`renders ./components/calendar/demo/notice-calendar.md correctly 1`] = `
             <td
               class="ant-fullcalendar-cell ant-fullcalendar-next-month-btn-day"
               role="gridcell"
-              title="2016年12月1日"
+              title="2016/12/01"
             >
               <div
                 class="ant-fullcalendar-date"
@@ -3045,7 +3045,7 @@ exports[`renders ./components/calendar/demo/notice-calendar.md correctly 1`] = `
             <td
               class="ant-fullcalendar-cell ant-fullcalendar-next-month-btn-day"
               role="gridcell"
-              title="2016年12月2日"
+              title="2016/12/02"
             >
               <div
                 class="ant-fullcalendar-date"
@@ -3067,7 +3067,7 @@ exports[`renders ./components/calendar/demo/notice-calendar.md correctly 1`] = `
             <td
               class="ant-fullcalendar-cell ant-fullcalendar-next-month-btn-day"
               role="gridcell"
-              title="2016年12月3日"
+              title="2016/12/03"
             >
               <div
                 class="ant-fullcalendar-date"
@@ -3089,7 +3089,7 @@ exports[`renders ./components/calendar/demo/notice-calendar.md correctly 1`] = `
             <td
               class="ant-fullcalendar-cell ant-fullcalendar-next-month-btn-day"
               role="gridcell"
-              title="2016年12月4日"
+              title="2016/12/04"
             >
               <div
                 class="ant-fullcalendar-date"
@@ -3116,7 +3116,7 @@ exports[`renders ./components/calendar/demo/notice-calendar.md correctly 1`] = `
             <td
               class="ant-fullcalendar-cell ant-fullcalendar-next-month-btn-day"
               role="gridcell"
-              title="2016年12月5日"
+              title="2016/12/05"
             >
               <div
                 class="ant-fullcalendar-date"
@@ -3138,7 +3138,7 @@ exports[`renders ./components/calendar/demo/notice-calendar.md correctly 1`] = `
             <td
               class="ant-fullcalendar-cell ant-fullcalendar-next-month-btn-day"
               role="gridcell"
-              title="2016年12月6日"
+              title="2016/12/06"
             >
               <div
                 class="ant-fullcalendar-date"
@@ -3160,7 +3160,7 @@ exports[`renders ./components/calendar/demo/notice-calendar.md correctly 1`] = `
             <td
               class="ant-fullcalendar-cell ant-fullcalendar-next-month-btn-day"
               role="gridcell"
-              title="2016年12月7日"
+              title="2016/12/07"
             >
               <div
                 class="ant-fullcalendar-date"
@@ -3182,7 +3182,7 @@ exports[`renders ./components/calendar/demo/notice-calendar.md correctly 1`] = `
             <td
               class="ant-fullcalendar-cell ant-fullcalendar-next-month-btn-day"
               role="gridcell"
-              title="2016年12月8日"
+              title="2016/12/08"
             >
               <div
                 class="ant-fullcalendar-date"
@@ -3221,7 +3221,7 @@ exports[`renders ./components/calendar/demo/notice-calendar.md correctly 1`] = `
             <td
               class="ant-fullcalendar-cell ant-fullcalendar-next-month-btn-day"
               role="gridcell"
-              title="2016年12月9日"
+              title="2016/12/09"
             >
               <div
                 class="ant-fullcalendar-date"
@@ -3243,7 +3243,7 @@ exports[`renders ./components/calendar/demo/notice-calendar.md correctly 1`] = `
             <td
               class="ant-fullcalendar-cell ant-fullcalendar-next-month-btn-day"
               role="gridcell"
-              title="2016年12月10日"
+              title="2016/12/10"
             >
               <div
                 class="ant-fullcalendar-date"
@@ -3290,7 +3290,7 @@ exports[`renders ./components/calendar/demo/notice-calendar.md correctly 1`] = `
             <td
               class="ant-fullcalendar-cell ant-fullcalendar-next-month-btn-day"
               role="gridcell"
-              title="2016年12月11日"
+              title="2016/12/11"
             >
               <div
                 class="ant-fullcalendar-date"
@@ -3549,7 +3549,7 @@ exports[`renders ./components/calendar/demo/select.md correctly 1`] = `
               <td
                 class="ant-fullcalendar-cell ant-fullcalendar-last-month-cell"
                 role="gridcell"
-                title="2016年12月26日"
+                title="2016/12/26"
               >
                 <div
                   class="ant-fullcalendar-date"
@@ -3567,7 +3567,7 @@ exports[`renders ./components/calendar/demo/select.md correctly 1`] = `
               <td
                 class="ant-fullcalendar-cell ant-fullcalendar-last-month-cell"
                 role="gridcell"
-                title="2016年12月27日"
+                title="2016/12/27"
               >
                 <div
                   class="ant-fullcalendar-date"
@@ -3585,7 +3585,7 @@ exports[`renders ./components/calendar/demo/select.md correctly 1`] = `
               <td
                 class="ant-fullcalendar-cell ant-fullcalendar-last-month-cell"
                 role="gridcell"
-                title="2016年12月28日"
+                title="2016/12/28"
               >
                 <div
                   class="ant-fullcalendar-date"
@@ -3603,7 +3603,7 @@ exports[`renders ./components/calendar/demo/select.md correctly 1`] = `
               <td
                 class="ant-fullcalendar-cell ant-fullcalendar-last-month-cell"
                 role="gridcell"
-                title="2016年12月29日"
+                title="2016/12/29"
               >
                 <div
                   class="ant-fullcalendar-date"
@@ -3621,7 +3621,7 @@ exports[`renders ./components/calendar/demo/select.md correctly 1`] = `
               <td
                 class="ant-fullcalendar-cell ant-fullcalendar-last-month-cell"
                 role="gridcell"
-                title="2016年12月30日"
+                title="2016/12/30"
               >
                 <div
                   class="ant-fullcalendar-date"
@@ -3639,7 +3639,7 @@ exports[`renders ./components/calendar/demo/select.md correctly 1`] = `
               <td
                 class="ant-fullcalendar-cell ant-fullcalendar-last-month-cell"
                 role="gridcell"
-                title="2016年12月31日"
+                title="2016/12/31"
               >
                 <div
                   class="ant-fullcalendar-date"
@@ -3657,7 +3657,7 @@ exports[`renders ./components/calendar/demo/select.md correctly 1`] = `
               <td
                 class="ant-fullcalendar-cell"
                 role="gridcell"
-                title="2017年1月1日"
+                title="2017/01/01"
               >
                 <div
                   class="ant-fullcalendar-date"
@@ -3680,7 +3680,7 @@ exports[`renders ./components/calendar/demo/select.md correctly 1`] = `
               <td
                 class="ant-fullcalendar-cell"
                 role="gridcell"
-                title="2017年1月2日"
+                title="2017/01/02"
               >
                 <div
                   class="ant-fullcalendar-date"
@@ -3698,7 +3698,7 @@ exports[`renders ./components/calendar/demo/select.md correctly 1`] = `
               <td
                 class="ant-fullcalendar-cell"
                 role="gridcell"
-                title="2017年1月3日"
+                title="2017/01/03"
               >
                 <div
                   class="ant-fullcalendar-date"
@@ -3716,7 +3716,7 @@ exports[`renders ./components/calendar/demo/select.md correctly 1`] = `
               <td
                 class="ant-fullcalendar-cell"
                 role="gridcell"
-                title="2017年1月4日"
+                title="2017/01/04"
               >
                 <div
                   class="ant-fullcalendar-date"
@@ -3734,7 +3734,7 @@ exports[`renders ./components/calendar/demo/select.md correctly 1`] = `
               <td
                 class="ant-fullcalendar-cell"
                 role="gridcell"
-                title="2017年1月5日"
+                title="2017/01/05"
               >
                 <div
                   class="ant-fullcalendar-date"
@@ -3752,7 +3752,7 @@ exports[`renders ./components/calendar/demo/select.md correctly 1`] = `
               <td
                 class="ant-fullcalendar-cell"
                 role="gridcell"
-                title="2017年1月6日"
+                title="2017/01/06"
               >
                 <div
                   class="ant-fullcalendar-date"
@@ -3770,7 +3770,7 @@ exports[`renders ./components/calendar/demo/select.md correctly 1`] = `
               <td
                 class="ant-fullcalendar-cell"
                 role="gridcell"
-                title="2017年1月7日"
+                title="2017/01/07"
               >
                 <div
                   class="ant-fullcalendar-date"
@@ -3788,7 +3788,7 @@ exports[`renders ./components/calendar/demo/select.md correctly 1`] = `
               <td
                 class="ant-fullcalendar-cell"
                 role="gridcell"
-                title="2017年1月8日"
+                title="2017/01/08"
               >
                 <div
                   class="ant-fullcalendar-date"
@@ -3811,7 +3811,7 @@ exports[`renders ./components/calendar/demo/select.md correctly 1`] = `
               <td
                 class="ant-fullcalendar-cell"
                 role="gridcell"
-                title="2017年1月9日"
+                title="2017/01/09"
               >
                 <div
                   class="ant-fullcalendar-date"
@@ -3829,7 +3829,7 @@ exports[`renders ./components/calendar/demo/select.md correctly 1`] = `
               <td
                 class="ant-fullcalendar-cell"
                 role="gridcell"
-                title="2017年1月10日"
+                title="2017/01/10"
               >
                 <div
                   class="ant-fullcalendar-date"
@@ -3847,7 +3847,7 @@ exports[`renders ./components/calendar/demo/select.md correctly 1`] = `
               <td
                 class="ant-fullcalendar-cell"
                 role="gridcell"
-                title="2017年1月11日"
+                title="2017/01/11"
               >
                 <div
                   class="ant-fullcalendar-date"
@@ -3865,7 +3865,7 @@ exports[`renders ./components/calendar/demo/select.md correctly 1`] = `
               <td
                 class="ant-fullcalendar-cell"
                 role="gridcell"
-                title="2017年1月12日"
+                title="2017/01/12"
               >
                 <div
                   class="ant-fullcalendar-date"
@@ -3883,7 +3883,7 @@ exports[`renders ./components/calendar/demo/select.md correctly 1`] = `
               <td
                 class="ant-fullcalendar-cell"
                 role="gridcell"
-                title="2017年1月13日"
+                title="2017/01/13"
               >
                 <div
                   class="ant-fullcalendar-date"
@@ -3901,7 +3901,7 @@ exports[`renders ./components/calendar/demo/select.md correctly 1`] = `
               <td
                 class="ant-fullcalendar-cell"
                 role="gridcell"
-                title="2017年1月14日"
+                title="2017/01/14"
               >
                 <div
                   class="ant-fullcalendar-date"
@@ -3919,7 +3919,7 @@ exports[`renders ./components/calendar/demo/select.md correctly 1`] = `
               <td
                 class="ant-fullcalendar-cell"
                 role="gridcell"
-                title="2017年1月15日"
+                title="2017/01/15"
               >
                 <div
                   class="ant-fullcalendar-date"
@@ -3942,7 +3942,7 @@ exports[`renders ./components/calendar/demo/select.md correctly 1`] = `
               <td
                 class="ant-fullcalendar-cell"
                 role="gridcell"
-                title="2017年1月16日"
+                title="2017/01/16"
               >
                 <div
                   class="ant-fullcalendar-date"
@@ -3960,7 +3960,7 @@ exports[`renders ./components/calendar/demo/select.md correctly 1`] = `
               <td
                 class="ant-fullcalendar-cell"
                 role="gridcell"
-                title="2017年1月17日"
+                title="2017/01/17"
               >
                 <div
                   class="ant-fullcalendar-date"
@@ -3978,7 +3978,7 @@ exports[`renders ./components/calendar/demo/select.md correctly 1`] = `
               <td
                 class="ant-fullcalendar-cell"
                 role="gridcell"
-                title="2017年1月18日"
+                title="2017/01/18"
               >
                 <div
                   class="ant-fullcalendar-date"
@@ -3996,7 +3996,7 @@ exports[`renders ./components/calendar/demo/select.md correctly 1`] = `
               <td
                 class="ant-fullcalendar-cell"
                 role="gridcell"
-                title="2017年1月19日"
+                title="2017/01/19"
               >
                 <div
                   class="ant-fullcalendar-date"
@@ -4014,7 +4014,7 @@ exports[`renders ./components/calendar/demo/select.md correctly 1`] = `
               <td
                 class="ant-fullcalendar-cell"
                 role="gridcell"
-                title="2017年1月20日"
+                title="2017/01/20"
               >
                 <div
                   class="ant-fullcalendar-date"
@@ -4032,7 +4032,7 @@ exports[`renders ./components/calendar/demo/select.md correctly 1`] = `
               <td
                 class="ant-fullcalendar-cell"
                 role="gridcell"
-                title="2017年1月21日"
+                title="2017/01/21"
               >
                 <div
                   class="ant-fullcalendar-date"
@@ -4050,7 +4050,7 @@ exports[`renders ./components/calendar/demo/select.md correctly 1`] = `
               <td
                 class="ant-fullcalendar-cell"
                 role="gridcell"
-                title="2017年1月22日"
+                title="2017/01/22"
               >
                 <div
                   class="ant-fullcalendar-date"
@@ -4073,7 +4073,7 @@ exports[`renders ./components/calendar/demo/select.md correctly 1`] = `
               <td
                 class="ant-fullcalendar-cell"
                 role="gridcell"
-                title="2017年1月23日"
+                title="2017/01/23"
               >
                 <div
                   class="ant-fullcalendar-date"
@@ -4091,7 +4091,7 @@ exports[`renders ./components/calendar/demo/select.md correctly 1`] = `
               <td
                 class="ant-fullcalendar-cell"
                 role="gridcell"
-                title="2017年1月24日"
+                title="2017/01/24"
               >
                 <div
                   class="ant-fullcalendar-date"
@@ -4109,7 +4109,7 @@ exports[`renders ./components/calendar/demo/select.md correctly 1`] = `
               <td
                 class="ant-fullcalendar-cell ant-fullcalendar-selected-day"
                 role="gridcell"
-                title="2017年1月25日"
+                title="2017/01/25"
               >
                 <div
                   class="ant-fullcalendar-date"
@@ -4127,7 +4127,7 @@ exports[`renders ./components/calendar/demo/select.md correctly 1`] = `
               <td
                 class="ant-fullcalendar-cell"
                 role="gridcell"
-                title="2017年1月26日"
+                title="2017/01/26"
               >
                 <div
                   class="ant-fullcalendar-date"
@@ -4145,7 +4145,7 @@ exports[`renders ./components/calendar/demo/select.md correctly 1`] = `
               <td
                 class="ant-fullcalendar-cell"
                 role="gridcell"
-                title="2017年1月27日"
+                title="2017/01/27"
               >
                 <div
                   class="ant-fullcalendar-date"
@@ -4163,7 +4163,7 @@ exports[`renders ./components/calendar/demo/select.md correctly 1`] = `
               <td
                 class="ant-fullcalendar-cell"
                 role="gridcell"
-                title="2017年1月28日"
+                title="2017/01/28"
               >
                 <div
                   class="ant-fullcalendar-date"
@@ -4181,7 +4181,7 @@ exports[`renders ./components/calendar/demo/select.md correctly 1`] = `
               <td
                 class="ant-fullcalendar-cell"
                 role="gridcell"
-                title="2017年1月29日"
+                title="2017/01/29"
               >
                 <div
                   class="ant-fullcalendar-date"
@@ -4204,7 +4204,7 @@ exports[`renders ./components/calendar/demo/select.md correctly 1`] = `
               <td
                 class="ant-fullcalendar-cell"
                 role="gridcell"
-                title="2017年1月30日"
+                title="2017/01/30"
               >
                 <div
                   class="ant-fullcalendar-date"
@@ -4222,7 +4222,7 @@ exports[`renders ./components/calendar/demo/select.md correctly 1`] = `
               <td
                 class="ant-fullcalendar-cell"
                 role="gridcell"
-                title="2017年1月31日"
+                title="2017/01/31"
               >
                 <div
                   class="ant-fullcalendar-date"
@@ -4240,7 +4240,7 @@ exports[`renders ./components/calendar/demo/select.md correctly 1`] = `
               <td
                 class="ant-fullcalendar-cell ant-fullcalendar-next-month-btn-day"
                 role="gridcell"
-                title="2017年2月1日"
+                title="2017/02/01"
               >
                 <div
                   class="ant-fullcalendar-date"
@@ -4258,7 +4258,7 @@ exports[`renders ./components/calendar/demo/select.md correctly 1`] = `
               <td
                 class="ant-fullcalendar-cell ant-fullcalendar-next-month-btn-day"
                 role="gridcell"
-                title="2017年2月2日"
+                title="2017/02/02"
               >
                 <div
                   class="ant-fullcalendar-date"
@@ -4276,7 +4276,7 @@ exports[`renders ./components/calendar/demo/select.md correctly 1`] = `
               <td
                 class="ant-fullcalendar-cell ant-fullcalendar-next-month-btn-day"
                 role="gridcell"
-                title="2017年2月3日"
+                title="2017/02/03"
               >
                 <div
                   class="ant-fullcalendar-date"
@@ -4294,7 +4294,7 @@ exports[`renders ./components/calendar/demo/select.md correctly 1`] = `
               <td
                 class="ant-fullcalendar-cell ant-fullcalendar-next-month-btn-day"
                 role="gridcell"
-                title="2017年2月4日"
+                title="2017/02/04"
               >
                 <div
                   class="ant-fullcalendar-date"
@@ -4312,7 +4312,7 @@ exports[`renders ./components/calendar/demo/select.md correctly 1`] = `
               <td
                 class="ant-fullcalendar-cell ant-fullcalendar-next-month-btn-day"
                 role="gridcell"
-                title="2017年2月5日"
+                title="2017/02/05"
               >
                 <div
                   class="ant-fullcalendar-date"

--- a/components/collapse/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/collapse/__tests__/__snapshots__/demo.test.js.snap
@@ -6,6 +6,7 @@ exports[`renders ./components/collapse/demo/accordion.md correctly 1`] = `
 >
   <div
     class="ant-collapse-item"
+    role="tablist"
   >
     <div
       aria-expanded="false"
@@ -20,6 +21,7 @@ exports[`renders ./components/collapse/demo/accordion.md correctly 1`] = `
   </div>
   <div
     class="ant-collapse-item"
+    role="tablist"
   >
     <div
       aria-expanded="false"
@@ -34,6 +36,7 @@ exports[`renders ./components/collapse/demo/accordion.md correctly 1`] = `
   </div>
   <div
     class="ant-collapse-item"
+    role="tablist"
   >
     <div
       aria-expanded="false"
@@ -55,6 +58,7 @@ exports[`renders ./components/collapse/demo/basic.md correctly 1`] = `
 >
   <div
     class="ant-collapse-item ant-collapse-item-active"
+    role="tablist"
   >
     <div
       aria-expanded="true"
@@ -85,6 +89,7 @@ exports[`renders ./components/collapse/demo/basic.md correctly 1`] = `
   </div>
   <div
     class="ant-collapse-item"
+    role="tablist"
   >
     <div
       aria-expanded="false"
@@ -99,6 +104,7 @@ exports[`renders ./components/collapse/demo/basic.md correctly 1`] = `
   </div>
   <div
     class="ant-collapse-item ant-collapse-item-disabled"
+    role="tablist"
   >
     <div
       aria-expanded="false"
@@ -120,6 +126,7 @@ exports[`renders ./components/collapse/demo/borderless.md correctly 1`] = `
 >
   <div
     class="ant-collapse-item ant-collapse-item-active"
+    role="tablist"
   >
     <div
       aria-expanded="true"
@@ -150,6 +157,7 @@ exports[`renders ./components/collapse/demo/borderless.md correctly 1`] = `
   </div>
   <div
     class="ant-collapse-item"
+    role="tablist"
   >
     <div
       aria-expanded="false"
@@ -164,6 +172,7 @@ exports[`renders ./components/collapse/demo/borderless.md correctly 1`] = `
   </div>
   <div
     class="ant-collapse-item"
+    role="tablist"
   >
     <div
       aria-expanded="false"
@@ -185,6 +194,7 @@ exports[`renders ./components/collapse/demo/custom.md correctly 1`] = `
 >
   <div
     class="ant-collapse-item ant-collapse-item-active"
+    role="tablist"
     style="background:#f7f7f7;border-radius:4px;margin-bottom:24px;border:0;overflow:hidden;"
   >
     <div
@@ -216,6 +226,7 @@ exports[`renders ./components/collapse/demo/custom.md correctly 1`] = `
   </div>
   <div
     class="ant-collapse-item"
+    role="tablist"
     style="background:#f7f7f7;border-radius:4px;margin-bottom:24px;border:0;overflow:hidden;"
   >
     <div
@@ -231,6 +242,7 @@ exports[`renders ./components/collapse/demo/custom.md correctly 1`] = `
   </div>
   <div
     class="ant-collapse-item"
+    role="tablist"
     style="background:#f7f7f7;border-radius:4px;margin-bottom:24px;border:0;overflow:hidden;"
   >
     <div
@@ -253,6 +265,7 @@ exports[`renders ./components/collapse/demo/mix.md correctly 1`] = `
 >
   <div
     class="ant-collapse-item"
+    role="tablist"
   >
     <div
       aria-expanded="false"
@@ -267,6 +280,7 @@ exports[`renders ./components/collapse/demo/mix.md correctly 1`] = `
   </div>
   <div
     class="ant-collapse-item"
+    role="tablist"
   >
     <div
       aria-expanded="false"
@@ -281,6 +295,7 @@ exports[`renders ./components/collapse/demo/mix.md correctly 1`] = `
   </div>
   <div
     class="ant-collapse-item"
+    role="tablist"
   >
     <div
       aria-expanded="false"

--- a/components/date-picker/__tests__/__snapshots__/RangePicker.test.js.snap
+++ b/components/date-picker/__tests__/__snapshots__/RangePicker.test.js.snap
@@ -171,7 +171,7 @@ exports[`RangePicker show month panel according to value 1`] = `
                       <td
                         class="ant-calendar-cell ant-calendar-last-month-cell"
                         role="gridcell"
-                        title="1999年12月27日"
+                        title="1999/12/27"
                       >
                         <div
                           aria-disabled="false"
@@ -184,7 +184,7 @@ exports[`RangePicker show month panel according to value 1`] = `
                       <td
                         class="ant-calendar-cell ant-calendar-last-month-cell"
                         role="gridcell"
-                        title="1999年12月28日"
+                        title="1999/12/28"
                       >
                         <div
                           aria-disabled="false"
@@ -197,7 +197,7 @@ exports[`RangePicker show month panel according to value 1`] = `
                       <td
                         class="ant-calendar-cell ant-calendar-last-month-cell"
                         role="gridcell"
-                        title="1999年12月29日"
+                        title="1999/12/29"
                       >
                         <div
                           aria-disabled="false"
@@ -210,7 +210,7 @@ exports[`RangePicker show month panel according to value 1`] = `
                       <td
                         class="ant-calendar-cell ant-calendar-last-month-cell"
                         role="gridcell"
-                        title="1999年12月30日"
+                        title="1999/12/30"
                       >
                         <div
                           aria-disabled="false"
@@ -223,7 +223,7 @@ exports[`RangePicker show month panel according to value 1`] = `
                       <td
                         class="ant-calendar-cell ant-calendar-last-month-cell"
                         role="gridcell"
-                        title="1999年12月31日"
+                        title="1999/12/31"
                       >
                         <div
                           aria-disabled="false"
@@ -236,7 +236,7 @@ exports[`RangePicker show month panel according to value 1`] = `
                       <td
                         class="ant-calendar-cell ant-calendar-selected-day"
                         role="gridcell"
-                        title="2000年1月1日"
+                        title="2000/01/01"
                       >
                         <div
                           aria-disabled="false"
@@ -249,7 +249,7 @@ exports[`RangePicker show month panel according to value 1`] = `
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年1月2日"
+                        title="2000/01/02"
                       >
                         <div
                           aria-disabled="false"
@@ -267,7 +267,7 @@ exports[`RangePicker show month panel according to value 1`] = `
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年1月3日"
+                        title="2000/01/03"
                       >
                         <div
                           aria-disabled="false"
@@ -280,7 +280,7 @@ exports[`RangePicker show month panel according to value 1`] = `
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年1月4日"
+                        title="2000/01/04"
                       >
                         <div
                           aria-disabled="false"
@@ -293,7 +293,7 @@ exports[`RangePicker show month panel according to value 1`] = `
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年1月5日"
+                        title="2000/01/05"
                       >
                         <div
                           aria-disabled="false"
@@ -306,7 +306,7 @@ exports[`RangePicker show month panel according to value 1`] = `
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年1月6日"
+                        title="2000/01/06"
                       >
                         <div
                           aria-disabled="false"
@@ -319,7 +319,7 @@ exports[`RangePicker show month panel according to value 1`] = `
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年1月7日"
+                        title="2000/01/07"
                       >
                         <div
                           aria-disabled="false"
@@ -332,7 +332,7 @@ exports[`RangePicker show month panel according to value 1`] = `
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年1月8日"
+                        title="2000/01/08"
                       >
                         <div
                           aria-disabled="false"
@@ -345,7 +345,7 @@ exports[`RangePicker show month panel according to value 1`] = `
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年1月9日"
+                        title="2000/01/09"
                       >
                         <div
                           aria-disabled="false"
@@ -363,7 +363,7 @@ exports[`RangePicker show month panel according to value 1`] = `
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年1月10日"
+                        title="2000/01/10"
                       >
                         <div
                           aria-disabled="false"
@@ -376,7 +376,7 @@ exports[`RangePicker show month panel according to value 1`] = `
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年1月11日"
+                        title="2000/01/11"
                       >
                         <div
                           aria-disabled="false"
@@ -389,7 +389,7 @@ exports[`RangePicker show month panel according to value 1`] = `
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年1月12日"
+                        title="2000/01/12"
                       >
                         <div
                           aria-disabled="false"
@@ -402,7 +402,7 @@ exports[`RangePicker show month panel according to value 1`] = `
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年1月13日"
+                        title="2000/01/13"
                       >
                         <div
                           aria-disabled="false"
@@ -415,7 +415,7 @@ exports[`RangePicker show month panel according to value 1`] = `
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年1月14日"
+                        title="2000/01/14"
                       >
                         <div
                           aria-disabled="false"
@@ -428,7 +428,7 @@ exports[`RangePicker show month panel according to value 1`] = `
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年1月15日"
+                        title="2000/01/15"
                       >
                         <div
                           aria-disabled="false"
@@ -441,7 +441,7 @@ exports[`RangePicker show month panel according to value 1`] = `
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年1月16日"
+                        title="2000/01/16"
                       >
                         <div
                           aria-disabled="false"
@@ -459,7 +459,7 @@ exports[`RangePicker show month panel according to value 1`] = `
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年1月17日"
+                        title="2000/01/17"
                       >
                         <div
                           aria-disabled="false"
@@ -472,7 +472,7 @@ exports[`RangePicker show month panel according to value 1`] = `
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年1月18日"
+                        title="2000/01/18"
                       >
                         <div
                           aria-disabled="false"
@@ -485,7 +485,7 @@ exports[`RangePicker show month panel according to value 1`] = `
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年1月19日"
+                        title="2000/01/19"
                       >
                         <div
                           aria-disabled="false"
@@ -498,7 +498,7 @@ exports[`RangePicker show month panel according to value 1`] = `
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年1月20日"
+                        title="2000/01/20"
                       >
                         <div
                           aria-disabled="false"
@@ -511,7 +511,7 @@ exports[`RangePicker show month panel according to value 1`] = `
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年1月21日"
+                        title="2000/01/21"
                       >
                         <div
                           aria-disabled="false"
@@ -524,7 +524,7 @@ exports[`RangePicker show month panel according to value 1`] = `
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年1月22日"
+                        title="2000/01/22"
                       >
                         <div
                           aria-disabled="false"
@@ -537,7 +537,7 @@ exports[`RangePicker show month panel according to value 1`] = `
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年1月23日"
+                        title="2000/01/23"
                       >
                         <div
                           aria-disabled="false"
@@ -555,7 +555,7 @@ exports[`RangePicker show month panel according to value 1`] = `
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年1月24日"
+                        title="2000/01/24"
                       >
                         <div
                           aria-disabled="false"
@@ -568,7 +568,7 @@ exports[`RangePicker show month panel according to value 1`] = `
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年1月25日"
+                        title="2000/01/25"
                       >
                         <div
                           aria-disabled="false"
@@ -581,7 +581,7 @@ exports[`RangePicker show month panel according to value 1`] = `
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年1月26日"
+                        title="2000/01/26"
                       >
                         <div
                           aria-disabled="false"
@@ -594,7 +594,7 @@ exports[`RangePicker show month panel according to value 1`] = `
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年1月27日"
+                        title="2000/01/27"
                       >
                         <div
                           aria-disabled="false"
@@ -607,7 +607,7 @@ exports[`RangePicker show month panel according to value 1`] = `
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年1月28日"
+                        title="2000/01/28"
                       >
                         <div
                           aria-disabled="false"
@@ -620,7 +620,7 @@ exports[`RangePicker show month panel according to value 1`] = `
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年1月29日"
+                        title="2000/01/29"
                       >
                         <div
                           aria-disabled="false"
@@ -633,7 +633,7 @@ exports[`RangePicker show month panel according to value 1`] = `
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年1月30日"
+                        title="2000/01/30"
                       >
                         <div
                           aria-disabled="false"
@@ -651,7 +651,7 @@ exports[`RangePicker show month panel according to value 1`] = `
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年1月31日"
+                        title="2000/01/31"
                       >
                         <div
                           aria-disabled="false"
@@ -664,7 +664,7 @@ exports[`RangePicker show month panel according to value 1`] = `
                       <td
                         class="ant-calendar-cell ant-calendar-next-month-btn-day"
                         role="gridcell"
-                        title="2000年2月1日"
+                        title="2000/02/01"
                       >
                         <div
                           aria-disabled="false"
@@ -677,7 +677,7 @@ exports[`RangePicker show month panel according to value 1`] = `
                       <td
                         class="ant-calendar-cell ant-calendar-next-month-btn-day"
                         role="gridcell"
-                        title="2000年2月2日"
+                        title="2000/02/02"
                       >
                         <div
                           aria-disabled="false"
@@ -690,7 +690,7 @@ exports[`RangePicker show month panel according to value 1`] = `
                       <td
                         class="ant-calendar-cell ant-calendar-next-month-btn-day"
                         role="gridcell"
-                        title="2000年2月3日"
+                        title="2000/02/03"
                       >
                         <div
                           aria-disabled="false"
@@ -703,7 +703,7 @@ exports[`RangePicker show month panel according to value 1`] = `
                       <td
                         class="ant-calendar-cell ant-calendar-next-month-btn-day"
                         role="gridcell"
-                        title="2000年2月4日"
+                        title="2000/02/04"
                       >
                         <div
                           aria-disabled="false"
@@ -716,7 +716,7 @@ exports[`RangePicker show month panel according to value 1`] = `
                       <td
                         class="ant-calendar-cell ant-calendar-next-month-btn-day"
                         role="gridcell"
-                        title="2000年2月5日"
+                        title="2000/02/05"
                       >
                         <div
                           aria-disabled="false"
@@ -729,7 +729,7 @@ exports[`RangePicker show month panel according to value 1`] = `
                       <td
                         class="ant-calendar-cell ant-calendar-next-month-btn-day"
                         role="gridcell"
-                        title="2000年2月6日"
+                        title="2000/02/06"
                       >
                         <div
                           aria-disabled="false"
@@ -904,7 +904,7 @@ exports[`RangePicker show month panel according to value 1`] = `
                       <td
                         class="ant-calendar-cell ant-calendar-last-month-cell"
                         role="gridcell"
-                        title="2000年1月31日"
+                        title="2000/01/31"
                       >
                         <div
                           aria-disabled="false"
@@ -917,7 +917,7 @@ exports[`RangePicker show month panel according to value 1`] = `
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年2月1日"
+                        title="2000/02/01"
                       >
                         <div
                           aria-disabled="false"
@@ -930,7 +930,7 @@ exports[`RangePicker show month panel according to value 1`] = `
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年2月2日"
+                        title="2000/02/02"
                       >
                         <div
                           aria-disabled="false"
@@ -943,7 +943,7 @@ exports[`RangePicker show month panel according to value 1`] = `
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年2月3日"
+                        title="2000/02/03"
                       >
                         <div
                           aria-disabled="false"
@@ -956,7 +956,7 @@ exports[`RangePicker show month panel according to value 1`] = `
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年2月4日"
+                        title="2000/02/04"
                       >
                         <div
                           aria-disabled="false"
@@ -969,7 +969,7 @@ exports[`RangePicker show month panel according to value 1`] = `
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年2月5日"
+                        title="2000/02/05"
                       >
                         <div
                           aria-disabled="false"
@@ -982,7 +982,7 @@ exports[`RangePicker show month panel according to value 1`] = `
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年2月6日"
+                        title="2000/02/06"
                       >
                         <div
                           aria-disabled="false"
@@ -1000,7 +1000,7 @@ exports[`RangePicker show month panel according to value 1`] = `
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年2月7日"
+                        title="2000/02/07"
                       >
                         <div
                           aria-disabled="false"
@@ -1013,7 +1013,7 @@ exports[`RangePicker show month panel according to value 1`] = `
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年2月8日"
+                        title="2000/02/08"
                       >
                         <div
                           aria-disabled="false"
@@ -1026,7 +1026,7 @@ exports[`RangePicker show month panel according to value 1`] = `
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年2月9日"
+                        title="2000/02/09"
                       >
                         <div
                           aria-disabled="false"
@@ -1039,7 +1039,7 @@ exports[`RangePicker show month panel according to value 1`] = `
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年2月10日"
+                        title="2000/02/10"
                       >
                         <div
                           aria-disabled="false"
@@ -1052,7 +1052,7 @@ exports[`RangePicker show month panel according to value 1`] = `
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年2月11日"
+                        title="2000/02/11"
                       >
                         <div
                           aria-disabled="false"
@@ -1065,7 +1065,7 @@ exports[`RangePicker show month panel according to value 1`] = `
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年2月12日"
+                        title="2000/02/12"
                       >
                         <div
                           aria-disabled="false"
@@ -1078,7 +1078,7 @@ exports[`RangePicker show month panel according to value 1`] = `
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年2月13日"
+                        title="2000/02/13"
                       >
                         <div
                           aria-disabled="false"
@@ -1096,7 +1096,7 @@ exports[`RangePicker show month panel according to value 1`] = `
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年2月14日"
+                        title="2000/02/14"
                       >
                         <div
                           aria-disabled="false"
@@ -1109,7 +1109,7 @@ exports[`RangePicker show month panel according to value 1`] = `
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年2月15日"
+                        title="2000/02/15"
                       >
                         <div
                           aria-disabled="false"
@@ -1122,7 +1122,7 @@ exports[`RangePicker show month panel according to value 1`] = `
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年2月16日"
+                        title="2000/02/16"
                       >
                         <div
                           aria-disabled="false"
@@ -1135,7 +1135,7 @@ exports[`RangePicker show month panel according to value 1`] = `
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年2月17日"
+                        title="2000/02/17"
                       >
                         <div
                           aria-disabled="false"
@@ -1148,7 +1148,7 @@ exports[`RangePicker show month panel according to value 1`] = `
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年2月18日"
+                        title="2000/02/18"
                       >
                         <div
                           aria-disabled="false"
@@ -1161,7 +1161,7 @@ exports[`RangePicker show month panel according to value 1`] = `
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年2月19日"
+                        title="2000/02/19"
                       >
                         <div
                           aria-disabled="false"
@@ -1174,7 +1174,7 @@ exports[`RangePicker show month panel according to value 1`] = `
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年2月20日"
+                        title="2000/02/20"
                       >
                         <div
                           aria-disabled="false"
@@ -1192,7 +1192,7 @@ exports[`RangePicker show month panel according to value 1`] = `
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年2月21日"
+                        title="2000/02/21"
                       >
                         <div
                           aria-disabled="false"
@@ -1205,7 +1205,7 @@ exports[`RangePicker show month panel according to value 1`] = `
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年2月22日"
+                        title="2000/02/22"
                       >
                         <div
                           aria-disabled="false"
@@ -1218,7 +1218,7 @@ exports[`RangePicker show month panel according to value 1`] = `
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年2月23日"
+                        title="2000/02/23"
                       >
                         <div
                           aria-disabled="false"
@@ -1231,7 +1231,7 @@ exports[`RangePicker show month panel according to value 1`] = `
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年2月24日"
+                        title="2000/02/24"
                       >
                         <div
                           aria-disabled="false"
@@ -1244,7 +1244,7 @@ exports[`RangePicker show month panel according to value 1`] = `
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年2月25日"
+                        title="2000/02/25"
                       >
                         <div
                           aria-disabled="false"
@@ -1257,7 +1257,7 @@ exports[`RangePicker show month panel according to value 1`] = `
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年2月26日"
+                        title="2000/02/26"
                       >
                         <div
                           aria-disabled="false"
@@ -1270,7 +1270,7 @@ exports[`RangePicker show month panel according to value 1`] = `
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年2月27日"
+                        title="2000/02/27"
                       >
                         <div
                           aria-disabled="false"
@@ -1288,7 +1288,7 @@ exports[`RangePicker show month panel according to value 1`] = `
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年2月28日"
+                        title="2000/02/28"
                       >
                         <div
                           aria-disabled="false"
@@ -1301,7 +1301,7 @@ exports[`RangePicker show month panel according to value 1`] = `
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年2月29日"
+                        title="2000/02/29"
                       >
                         <div
                           aria-disabled="false"
@@ -1314,7 +1314,7 @@ exports[`RangePicker show month panel according to value 1`] = `
                       <td
                         class="ant-calendar-cell ant-calendar-next-month-btn-day"
                         role="gridcell"
-                        title="2000年3月1日"
+                        title="2000/03/01"
                       >
                         <div
                           aria-disabled="false"
@@ -1327,7 +1327,7 @@ exports[`RangePicker show month panel according to value 1`] = `
                       <td
                         class="ant-calendar-cell ant-calendar-next-month-btn-day"
                         role="gridcell"
-                        title="2000年3月2日"
+                        title="2000/03/02"
                       >
                         <div
                           aria-disabled="false"
@@ -1340,7 +1340,7 @@ exports[`RangePicker show month panel according to value 1`] = `
                       <td
                         class="ant-calendar-cell ant-calendar-next-month-btn-day"
                         role="gridcell"
-                        title="2000年3月3日"
+                        title="2000/03/03"
                       >
                         <div
                           aria-disabled="false"
@@ -1353,7 +1353,7 @@ exports[`RangePicker show month panel according to value 1`] = `
                       <td
                         class="ant-calendar-cell ant-calendar-next-month-btn-day"
                         role="gridcell"
-                        title="2000年3月4日"
+                        title="2000/03/04"
                       >
                         <div
                           aria-disabled="false"
@@ -1366,7 +1366,7 @@ exports[`RangePicker show month panel according to value 1`] = `
                       <td
                         class="ant-calendar-cell ant-calendar-next-month-btn-day"
                         role="gridcell"
-                        title="2000年3月5日"
+                        title="2000/03/05"
                       >
                         <div
                           aria-disabled="false"
@@ -1384,7 +1384,7 @@ exports[`RangePicker show month panel according to value 1`] = `
                       <td
                         class="ant-calendar-cell ant-calendar-next-month-btn-day"
                         role="gridcell"
-                        title="2000年3月6日"
+                        title="2000/03/06"
                       >
                         <div
                           aria-disabled="false"
@@ -1397,7 +1397,7 @@ exports[`RangePicker show month panel according to value 1`] = `
                       <td
                         class="ant-calendar-cell ant-calendar-next-month-btn-day"
                         role="gridcell"
-                        title="2000年3月7日"
+                        title="2000/03/07"
                       >
                         <div
                           aria-disabled="false"
@@ -1410,7 +1410,7 @@ exports[`RangePicker show month panel according to value 1`] = `
                       <td
                         class="ant-calendar-cell ant-calendar-next-month-btn-day"
                         role="gridcell"
-                        title="2000年3月8日"
+                        title="2000/03/08"
                       >
                         <div
                           aria-disabled="false"
@@ -1423,7 +1423,7 @@ exports[`RangePicker show month panel according to value 1`] = `
                       <td
                         class="ant-calendar-cell ant-calendar-next-month-btn-day"
                         role="gridcell"
-                        title="2000年3月9日"
+                        title="2000/03/09"
                       >
                         <div
                           aria-disabled="false"
@@ -1436,7 +1436,7 @@ exports[`RangePicker show month panel according to value 1`] = `
                       <td
                         class="ant-calendar-cell ant-calendar-next-month-btn-day"
                         role="gridcell"
-                        title="2000年3月10日"
+                        title="2000/03/10"
                       >
                         <div
                           aria-disabled="false"
@@ -1449,7 +1449,7 @@ exports[`RangePicker show month panel according to value 1`] = `
                       <td
                         class="ant-calendar-cell ant-calendar-next-month-btn-day"
                         role="gridcell"
-                        title="2000年3月11日"
+                        title="2000/03/11"
                       >
                         <div
                           aria-disabled="false"
@@ -1462,7 +1462,7 @@ exports[`RangePicker show month panel according to value 1`] = `
                       <td
                         class="ant-calendar-cell ant-calendar-next-month-btn-day"
                         role="gridcell"
-                        title="2000年3月12日"
+                        title="2000/03/12"
                       >
                         <div
                           aria-disabled="false"
@@ -1676,7 +1676,7 @@ exports[`RangePicker switch to corresponding month panel when click presetted ra
                       <td
                         class="ant-calendar-cell ant-calendar-last-month-cell"
                         role="gridcell"
-                        title="1999年12月27日"
+                        title="1999/12/27"
                       >
                         <div
                           aria-disabled="false"
@@ -1689,7 +1689,7 @@ exports[`RangePicker switch to corresponding month panel when click presetted ra
                       <td
                         class="ant-calendar-cell ant-calendar-last-month-cell"
                         role="gridcell"
-                        title="1999年12月28日"
+                        title="1999/12/28"
                       >
                         <div
                           aria-disabled="false"
@@ -1702,7 +1702,7 @@ exports[`RangePicker switch to corresponding month panel when click presetted ra
                       <td
                         class="ant-calendar-cell ant-calendar-last-month-cell"
                         role="gridcell"
-                        title="1999年12月29日"
+                        title="1999/12/29"
                       >
                         <div
                           aria-disabled="false"
@@ -1715,7 +1715,7 @@ exports[`RangePicker switch to corresponding month panel when click presetted ra
                       <td
                         class="ant-calendar-cell ant-calendar-last-month-cell"
                         role="gridcell"
-                        title="1999年12月30日"
+                        title="1999/12/30"
                       >
                         <div
                           aria-disabled="false"
@@ -1728,7 +1728,7 @@ exports[`RangePicker switch to corresponding month panel when click presetted ra
                       <td
                         class="ant-calendar-cell ant-calendar-last-month-cell"
                         role="gridcell"
-                        title="1999年12月31日"
+                        title="1999/12/31"
                       >
                         <div
                           aria-disabled="false"
@@ -1741,7 +1741,7 @@ exports[`RangePicker switch to corresponding month panel when click presetted ra
                       <td
                         class="ant-calendar-cell ant-calendar-selected-day"
                         role="gridcell"
-                        title="2000年1月1日"
+                        title="2000/01/01"
                       >
                         <div
                           aria-disabled="false"
@@ -1754,7 +1754,7 @@ exports[`RangePicker switch to corresponding month panel when click presetted ra
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年1月2日"
+                        title="2000/01/02"
                       >
                         <div
                           aria-disabled="false"
@@ -1772,7 +1772,7 @@ exports[`RangePicker switch to corresponding month panel when click presetted ra
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年1月3日"
+                        title="2000/01/03"
                       >
                         <div
                           aria-disabled="false"
@@ -1785,7 +1785,7 @@ exports[`RangePicker switch to corresponding month panel when click presetted ra
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年1月4日"
+                        title="2000/01/04"
                       >
                         <div
                           aria-disabled="false"
@@ -1798,7 +1798,7 @@ exports[`RangePicker switch to corresponding month panel when click presetted ra
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年1月5日"
+                        title="2000/01/05"
                       >
                         <div
                           aria-disabled="false"
@@ -1811,7 +1811,7 @@ exports[`RangePicker switch to corresponding month panel when click presetted ra
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年1月6日"
+                        title="2000/01/06"
                       >
                         <div
                           aria-disabled="false"
@@ -1824,7 +1824,7 @@ exports[`RangePicker switch to corresponding month panel when click presetted ra
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年1月7日"
+                        title="2000/01/07"
                       >
                         <div
                           aria-disabled="false"
@@ -1837,7 +1837,7 @@ exports[`RangePicker switch to corresponding month panel when click presetted ra
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年1月8日"
+                        title="2000/01/08"
                       >
                         <div
                           aria-disabled="false"
@@ -1850,7 +1850,7 @@ exports[`RangePicker switch to corresponding month panel when click presetted ra
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年1月9日"
+                        title="2000/01/09"
                       >
                         <div
                           aria-disabled="false"
@@ -1868,7 +1868,7 @@ exports[`RangePicker switch to corresponding month panel when click presetted ra
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年1月10日"
+                        title="2000/01/10"
                       >
                         <div
                           aria-disabled="false"
@@ -1881,7 +1881,7 @@ exports[`RangePicker switch to corresponding month panel when click presetted ra
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年1月11日"
+                        title="2000/01/11"
                       >
                         <div
                           aria-disabled="false"
@@ -1894,7 +1894,7 @@ exports[`RangePicker switch to corresponding month panel when click presetted ra
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年1月12日"
+                        title="2000/01/12"
                       >
                         <div
                           aria-disabled="false"
@@ -1907,7 +1907,7 @@ exports[`RangePicker switch to corresponding month panel when click presetted ra
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年1月13日"
+                        title="2000/01/13"
                       >
                         <div
                           aria-disabled="false"
@@ -1920,7 +1920,7 @@ exports[`RangePicker switch to corresponding month panel when click presetted ra
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年1月14日"
+                        title="2000/01/14"
                       >
                         <div
                           aria-disabled="false"
@@ -1933,7 +1933,7 @@ exports[`RangePicker switch to corresponding month panel when click presetted ra
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年1月15日"
+                        title="2000/01/15"
                       >
                         <div
                           aria-disabled="false"
@@ -1946,7 +1946,7 @@ exports[`RangePicker switch to corresponding month panel when click presetted ra
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年1月16日"
+                        title="2000/01/16"
                       >
                         <div
                           aria-disabled="false"
@@ -1964,7 +1964,7 @@ exports[`RangePicker switch to corresponding month panel when click presetted ra
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年1月17日"
+                        title="2000/01/17"
                       >
                         <div
                           aria-disabled="false"
@@ -1977,7 +1977,7 @@ exports[`RangePicker switch to corresponding month panel when click presetted ra
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年1月18日"
+                        title="2000/01/18"
                       >
                         <div
                           aria-disabled="false"
@@ -1990,7 +1990,7 @@ exports[`RangePicker switch to corresponding month panel when click presetted ra
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年1月19日"
+                        title="2000/01/19"
                       >
                         <div
                           aria-disabled="false"
@@ -2003,7 +2003,7 @@ exports[`RangePicker switch to corresponding month panel when click presetted ra
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年1月20日"
+                        title="2000/01/20"
                       >
                         <div
                           aria-disabled="false"
@@ -2016,7 +2016,7 @@ exports[`RangePicker switch to corresponding month panel when click presetted ra
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年1月21日"
+                        title="2000/01/21"
                       >
                         <div
                           aria-disabled="false"
@@ -2029,7 +2029,7 @@ exports[`RangePicker switch to corresponding month panel when click presetted ra
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年1月22日"
+                        title="2000/01/22"
                       >
                         <div
                           aria-disabled="false"
@@ -2042,7 +2042,7 @@ exports[`RangePicker switch to corresponding month panel when click presetted ra
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年1月23日"
+                        title="2000/01/23"
                       >
                         <div
                           aria-disabled="false"
@@ -2060,7 +2060,7 @@ exports[`RangePicker switch to corresponding month panel when click presetted ra
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年1月24日"
+                        title="2000/01/24"
                       >
                         <div
                           aria-disabled="false"
@@ -2073,7 +2073,7 @@ exports[`RangePicker switch to corresponding month panel when click presetted ra
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年1月25日"
+                        title="2000/01/25"
                       >
                         <div
                           aria-disabled="false"
@@ -2086,7 +2086,7 @@ exports[`RangePicker switch to corresponding month panel when click presetted ra
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年1月26日"
+                        title="2000/01/26"
                       >
                         <div
                           aria-disabled="false"
@@ -2099,7 +2099,7 @@ exports[`RangePicker switch to corresponding month panel when click presetted ra
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年1月27日"
+                        title="2000/01/27"
                       >
                         <div
                           aria-disabled="false"
@@ -2112,7 +2112,7 @@ exports[`RangePicker switch to corresponding month panel when click presetted ra
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年1月28日"
+                        title="2000/01/28"
                       >
                         <div
                           aria-disabled="false"
@@ -2125,7 +2125,7 @@ exports[`RangePicker switch to corresponding month panel when click presetted ra
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年1月29日"
+                        title="2000/01/29"
                       >
                         <div
                           aria-disabled="false"
@@ -2138,7 +2138,7 @@ exports[`RangePicker switch to corresponding month panel when click presetted ra
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年1月30日"
+                        title="2000/01/30"
                       >
                         <div
                           aria-disabled="false"
@@ -2156,7 +2156,7 @@ exports[`RangePicker switch to corresponding month panel when click presetted ra
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年1月31日"
+                        title="2000/01/31"
                       >
                         <div
                           aria-disabled="false"
@@ -2169,7 +2169,7 @@ exports[`RangePicker switch to corresponding month panel when click presetted ra
                       <td
                         class="ant-calendar-cell ant-calendar-next-month-btn-day"
                         role="gridcell"
-                        title="2000年2月1日"
+                        title="2000/02/01"
                       >
                         <div
                           aria-disabled="false"
@@ -2182,7 +2182,7 @@ exports[`RangePicker switch to corresponding month panel when click presetted ra
                       <td
                         class="ant-calendar-cell ant-calendar-next-month-btn-day"
                         role="gridcell"
-                        title="2000年2月2日"
+                        title="2000/02/02"
                       >
                         <div
                           aria-disabled="false"
@@ -2195,7 +2195,7 @@ exports[`RangePicker switch to corresponding month panel when click presetted ra
                       <td
                         class="ant-calendar-cell ant-calendar-next-month-btn-day"
                         role="gridcell"
-                        title="2000年2月3日"
+                        title="2000/02/03"
                       >
                         <div
                           aria-disabled="false"
@@ -2208,7 +2208,7 @@ exports[`RangePicker switch to corresponding month panel when click presetted ra
                       <td
                         class="ant-calendar-cell ant-calendar-next-month-btn-day"
                         role="gridcell"
-                        title="2000年2月4日"
+                        title="2000/02/04"
                       >
                         <div
                           aria-disabled="false"
@@ -2221,7 +2221,7 @@ exports[`RangePicker switch to corresponding month panel when click presetted ra
                       <td
                         class="ant-calendar-cell ant-calendar-next-month-btn-day"
                         role="gridcell"
-                        title="2000年2月5日"
+                        title="2000/02/05"
                       >
                         <div
                           aria-disabled="false"
@@ -2234,7 +2234,7 @@ exports[`RangePicker switch to corresponding month panel when click presetted ra
                       <td
                         class="ant-calendar-cell ant-calendar-next-month-btn-day"
                         role="gridcell"
-                        title="2000年2月6日"
+                        title="2000/02/06"
                       >
                         <div
                           aria-disabled="false"
@@ -2409,7 +2409,7 @@ exports[`RangePicker switch to corresponding month panel when click presetted ra
                       <td
                         class="ant-calendar-cell ant-calendar-last-month-cell"
                         role="gridcell"
-                        title="2000年1月31日"
+                        title="2000/01/31"
                       >
                         <div
                           aria-disabled="false"
@@ -2422,7 +2422,7 @@ exports[`RangePicker switch to corresponding month panel when click presetted ra
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年2月1日"
+                        title="2000/02/01"
                       >
                         <div
                           aria-disabled="false"
@@ -2435,7 +2435,7 @@ exports[`RangePicker switch to corresponding month panel when click presetted ra
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年2月2日"
+                        title="2000/02/02"
                       >
                         <div
                           aria-disabled="false"
@@ -2448,7 +2448,7 @@ exports[`RangePicker switch to corresponding month panel when click presetted ra
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年2月3日"
+                        title="2000/02/03"
                       >
                         <div
                           aria-disabled="false"
@@ -2461,7 +2461,7 @@ exports[`RangePicker switch to corresponding month panel when click presetted ra
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年2月4日"
+                        title="2000/02/04"
                       >
                         <div
                           aria-disabled="false"
@@ -2474,7 +2474,7 @@ exports[`RangePicker switch to corresponding month panel when click presetted ra
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年2月5日"
+                        title="2000/02/05"
                       >
                         <div
                           aria-disabled="false"
@@ -2487,7 +2487,7 @@ exports[`RangePicker switch to corresponding month panel when click presetted ra
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年2月6日"
+                        title="2000/02/06"
                       >
                         <div
                           aria-disabled="false"
@@ -2505,7 +2505,7 @@ exports[`RangePicker switch to corresponding month panel when click presetted ra
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年2月7日"
+                        title="2000/02/07"
                       >
                         <div
                           aria-disabled="false"
@@ -2518,7 +2518,7 @@ exports[`RangePicker switch to corresponding month panel when click presetted ra
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年2月8日"
+                        title="2000/02/08"
                       >
                         <div
                           aria-disabled="false"
@@ -2531,7 +2531,7 @@ exports[`RangePicker switch to corresponding month panel when click presetted ra
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年2月9日"
+                        title="2000/02/09"
                       >
                         <div
                           aria-disabled="false"
@@ -2544,7 +2544,7 @@ exports[`RangePicker switch to corresponding month panel when click presetted ra
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年2月10日"
+                        title="2000/02/10"
                       >
                         <div
                           aria-disabled="false"
@@ -2557,7 +2557,7 @@ exports[`RangePicker switch to corresponding month panel when click presetted ra
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年2月11日"
+                        title="2000/02/11"
                       >
                         <div
                           aria-disabled="false"
@@ -2570,7 +2570,7 @@ exports[`RangePicker switch to corresponding month panel when click presetted ra
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年2月12日"
+                        title="2000/02/12"
                       >
                         <div
                           aria-disabled="false"
@@ -2583,7 +2583,7 @@ exports[`RangePicker switch to corresponding month panel when click presetted ra
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年2月13日"
+                        title="2000/02/13"
                       >
                         <div
                           aria-disabled="false"
@@ -2601,7 +2601,7 @@ exports[`RangePicker switch to corresponding month panel when click presetted ra
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年2月14日"
+                        title="2000/02/14"
                       >
                         <div
                           aria-disabled="false"
@@ -2614,7 +2614,7 @@ exports[`RangePicker switch to corresponding month panel when click presetted ra
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年2月15日"
+                        title="2000/02/15"
                       >
                         <div
                           aria-disabled="false"
@@ -2627,7 +2627,7 @@ exports[`RangePicker switch to corresponding month panel when click presetted ra
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年2月16日"
+                        title="2000/02/16"
                       >
                         <div
                           aria-disabled="false"
@@ -2640,7 +2640,7 @@ exports[`RangePicker switch to corresponding month panel when click presetted ra
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年2月17日"
+                        title="2000/02/17"
                       >
                         <div
                           aria-disabled="false"
@@ -2653,7 +2653,7 @@ exports[`RangePicker switch to corresponding month panel when click presetted ra
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年2月18日"
+                        title="2000/02/18"
                       >
                         <div
                           aria-disabled="false"
@@ -2666,7 +2666,7 @@ exports[`RangePicker switch to corresponding month panel when click presetted ra
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年2月19日"
+                        title="2000/02/19"
                       >
                         <div
                           aria-disabled="false"
@@ -2679,7 +2679,7 @@ exports[`RangePicker switch to corresponding month panel when click presetted ra
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年2月20日"
+                        title="2000/02/20"
                       >
                         <div
                           aria-disabled="false"
@@ -2697,7 +2697,7 @@ exports[`RangePicker switch to corresponding month panel when click presetted ra
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年2月21日"
+                        title="2000/02/21"
                       >
                         <div
                           aria-disabled="false"
@@ -2710,7 +2710,7 @@ exports[`RangePicker switch to corresponding month panel when click presetted ra
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年2月22日"
+                        title="2000/02/22"
                       >
                         <div
                           aria-disabled="false"
@@ -2723,7 +2723,7 @@ exports[`RangePicker switch to corresponding month panel when click presetted ra
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年2月23日"
+                        title="2000/02/23"
                       >
                         <div
                           aria-disabled="false"
@@ -2736,7 +2736,7 @@ exports[`RangePicker switch to corresponding month panel when click presetted ra
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年2月24日"
+                        title="2000/02/24"
                       >
                         <div
                           aria-disabled="false"
@@ -2749,7 +2749,7 @@ exports[`RangePicker switch to corresponding month panel when click presetted ra
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年2月25日"
+                        title="2000/02/25"
                       >
                         <div
                           aria-disabled="false"
@@ -2762,7 +2762,7 @@ exports[`RangePicker switch to corresponding month panel when click presetted ra
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年2月26日"
+                        title="2000/02/26"
                       >
                         <div
                           aria-disabled="false"
@@ -2775,7 +2775,7 @@ exports[`RangePicker switch to corresponding month panel when click presetted ra
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年2月27日"
+                        title="2000/02/27"
                       >
                         <div
                           aria-disabled="false"
@@ -2793,7 +2793,7 @@ exports[`RangePicker switch to corresponding month panel when click presetted ra
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年2月28日"
+                        title="2000/02/28"
                       >
                         <div
                           aria-disabled="false"
@@ -2806,7 +2806,7 @@ exports[`RangePicker switch to corresponding month panel when click presetted ra
                       <td
                         class="ant-calendar-cell"
                         role="gridcell"
-                        title="2000年2月29日"
+                        title="2000/02/29"
                       >
                         <div
                           aria-disabled="false"
@@ -2819,7 +2819,7 @@ exports[`RangePicker switch to corresponding month panel when click presetted ra
                       <td
                         class="ant-calendar-cell ant-calendar-next-month-btn-day"
                         role="gridcell"
-                        title="2000年3月1日"
+                        title="2000/03/01"
                       >
                         <div
                           aria-disabled="false"
@@ -2832,7 +2832,7 @@ exports[`RangePicker switch to corresponding month panel when click presetted ra
                       <td
                         class="ant-calendar-cell ant-calendar-next-month-btn-day"
                         role="gridcell"
-                        title="2000年3月2日"
+                        title="2000/03/02"
                       >
                         <div
                           aria-disabled="false"
@@ -2845,7 +2845,7 @@ exports[`RangePicker switch to corresponding month panel when click presetted ra
                       <td
                         class="ant-calendar-cell ant-calendar-next-month-btn-day"
                         role="gridcell"
-                        title="2000年3月3日"
+                        title="2000/03/03"
                       >
                         <div
                           aria-disabled="false"
@@ -2858,7 +2858,7 @@ exports[`RangePicker switch to corresponding month panel when click presetted ra
                       <td
                         class="ant-calendar-cell ant-calendar-next-month-btn-day"
                         role="gridcell"
-                        title="2000年3月4日"
+                        title="2000/03/04"
                       >
                         <div
                           aria-disabled="false"
@@ -2871,7 +2871,7 @@ exports[`RangePicker switch to corresponding month panel when click presetted ra
                       <td
                         class="ant-calendar-cell ant-calendar-next-month-btn-day"
                         role="gridcell"
-                        title="2000年3月5日"
+                        title="2000/03/05"
                       >
                         <div
                           aria-disabled="false"
@@ -2889,7 +2889,7 @@ exports[`RangePicker switch to corresponding month panel when click presetted ra
                       <td
                         class="ant-calendar-cell ant-calendar-next-month-btn-day"
                         role="gridcell"
-                        title="2000年3月6日"
+                        title="2000/03/06"
                       >
                         <div
                           aria-disabled="false"
@@ -2902,7 +2902,7 @@ exports[`RangePicker switch to corresponding month panel when click presetted ra
                       <td
                         class="ant-calendar-cell ant-calendar-next-month-btn-day"
                         role="gridcell"
-                        title="2000年3月7日"
+                        title="2000/03/07"
                       >
                         <div
                           aria-disabled="false"
@@ -2915,7 +2915,7 @@ exports[`RangePicker switch to corresponding month panel when click presetted ra
                       <td
                         class="ant-calendar-cell ant-calendar-next-month-btn-day"
                         role="gridcell"
-                        title="2000年3月8日"
+                        title="2000/03/08"
                       >
                         <div
                           aria-disabled="false"
@@ -2928,7 +2928,7 @@ exports[`RangePicker switch to corresponding month panel when click presetted ra
                       <td
                         class="ant-calendar-cell ant-calendar-next-month-btn-day"
                         role="gridcell"
-                        title="2000年3月9日"
+                        title="2000/03/09"
                       >
                         <div
                           aria-disabled="false"
@@ -2941,7 +2941,7 @@ exports[`RangePicker switch to corresponding month panel when click presetted ra
                       <td
                         class="ant-calendar-cell ant-calendar-next-month-btn-day"
                         role="gridcell"
-                        title="2000年3月10日"
+                        title="2000/03/10"
                       >
                         <div
                           aria-disabled="false"
@@ -2954,7 +2954,7 @@ exports[`RangePicker switch to corresponding month panel when click presetted ra
                       <td
                         class="ant-calendar-cell ant-calendar-next-month-btn-day"
                         role="gridcell"
-                        title="2000年3月11日"
+                        title="2000/03/11"
                       >
                         <div
                           aria-disabled="false"
@@ -2967,7 +2967,7 @@ exports[`RangePicker switch to corresponding month panel when click presetted ra
                       <td
                         class="ant-calendar-cell ant-calendar-next-month-btn-day"
                         role="gridcell"
-                        title="2000年3月12日"
+                        title="2000/03/12"
                       >
                         <div
                           aria-disabled="false"

--- a/components/date-picker/createPicker.tsx
+++ b/components/date-picker/createPicker.tsx
@@ -37,6 +37,7 @@ export default function createPicker(TheCalendar): any {
       }
       this.state = {
         value,
+        showDate: value,
       };
     }
 
@@ -44,6 +45,7 @@ export default function createPicker(TheCalendar): any {
       if ('value' in nextProps) {
         this.setState({
           value: nextProps.value,
+          showDate: nextProps.value,
         });
       }
     }
@@ -66,13 +68,20 @@ export default function createPicker(TheCalendar): any {
     handleChange = (value) => {
       const props = this.props;
       if (!('value' in props)) {
-        this.setState({ value });
+        this.setState({
+          value,
+          showDate: value,
+        });
       }
       props.onChange(value, (value && value.format(props.format)) || '');
     }
 
+    handleCalendarChange = (value: moment.Moment) => {
+      this.setState({ showDate: value });
+    }
+
     render() {
-      const { value } = this.state;
+      const { value, showDate } = this.state;
       const props = omit(this.props, ['onChange']);
       const { prefixCls, locale } = props;
 
@@ -116,6 +125,8 @@ export default function createPicker(TheCalendar): any {
           showToday={props.showToday}
           monthCellContentRender={props.monthCellContentRender}
           renderFooter={this.renderFooter}
+          onChange={this.handleCalendarChange}
+          value={showDate}
         />
       );
 
@@ -156,13 +167,14 @@ export default function createPicker(TheCalendar): any {
         ...props.style,
         ...pickerStyle,
       };
+
       return (
         <span className={classNames(props.className, props.pickerClass)} style={style}>
           <RcDatePicker
             {...props}
             {...pickerChangeHandler}
             calendar={calendar}
-            value={pickerValue}
+            value={value}
             prefixCls={`${prefixCls}-picker-container`}
             style={props.popupStyle}
           >

--- a/components/menu/__tests__/index.test.js
+++ b/components/menu/__tests__/index.test.js
@@ -138,7 +138,6 @@ describe('Menu', () => {
   });
 
   it('should always follow openKeys when mode is switched', () => {
-    jest.useRealTimers();
     const wrapper = mount(
       <Menu defaultOpenKeys={['1']} mode="inline">
         <Menu.Item key="menu1">
@@ -158,14 +157,39 @@ describe('Menu', () => {
     expect(wrapper.find('.ant-menu-sub').at(0).hasClass('ant-menu-inline')).toBe(true);
     expect(wrapper.find('.ant-menu-sub').at(0).hasClass('ant-menu-hidden')).toBe(false);
     wrapper.setProps({ inlineCollapsed: true });
-    setTimeout(() => {
-      // 动画结束后套样式;
-      expect(wrapper.find('.ant-menu-sub').at(0).hasClass('ant-menu-vertical')).toBe(true);
-      expect(wrapper.find('.ant-menu-sub').at(0).hasClass('ant-menu-hidden')).toBe(true);
-      wrapper.setProps({ inlineCollapsed: false });
-      expect(wrapper.find('.ant-menu-sub').at(0).hasClass('ant-menu-inline')).toBe(true);
-      expect(wrapper.find('.ant-menu-sub').at(0).hasClass('ant-menu-hidden')).toBe(false);
-    }, 300);
+    jest.runAllTimers();
+    expect(wrapper.find('.ant-menu-sub').at(0).hasClass('ant-menu-vertical')).toBe(true);
+    expect(wrapper.find('.ant-menu-sub').at(0).hasClass('ant-menu-hidden')).toBe(true);
+    wrapper.setProps({ inlineCollapsed: false });
+    expect(wrapper.find('.ant-menu-sub').at(0).hasClass('ant-menu-inline')).toBe(true);
+    expect(wrapper.find('.ant-menu-sub').at(0).hasClass('ant-menu-hidden')).toBe(false);
+  });
+
+  it('inlineCollapsed should works well when specify a not existed default openKeys', () => {
+    const wrapper = mount(
+      <Menu defaultOpenKeys={['not-existed']} mode="inline">
+        <Menu.Item key="menu1">
+          <Icon type="inbox" />
+          <span>Option</span>
+        </Menu.Item>
+        <SubMenu key="1" title="submenu1">
+          <Menu.Item key="submenu1">
+            Option
+          </Menu.Item>
+          <Menu.Item key="submenu2">
+            Option
+          </Menu.Item>
+        </SubMenu>
+      </Menu>
+    );
+    expect(wrapper.find('.ant-menu-sub').length).toBe(0);
+    wrapper.setProps({ inlineCollapsed: true });
+    jest.runAllTimers();
+    wrapper.find('.ant-menu-submenu-title').at(0).simulate('mouseEnter');
+    jest.runAllTimers();
+    expect(wrapper.find('.ant-menu-submenu').at(0).hasClass('ant-menu-submenu-vertical')).toBe(true);
+    expect(wrapper.find('.ant-menu-submenu').at(0).hasClass('ant-menu-submenu-open')).toBe(true);
+    expect(wrapper.find('.ant-menu-sub').length).toBe(1);
   });
 
   it('should open submenu when click submenu title (inline)', () => {

--- a/components/menu/index.tsx
+++ b/components/menu/index.tsx
@@ -63,6 +63,7 @@ export default class Menu extends React.Component<MenuProps, any> {
     siderCollapsed: PropTypes.bool,
   };
   switchModeFromInline: boolean;
+  leaveAnimationExecutedWhenInlineCollapsed: boolean;
   inlineOpenKeys = [];
   constructor(props) {
     super(props);
@@ -138,7 +139,8 @@ export default class Menu extends React.Component<MenuProps, any> {
   }
   getRealMenuMode() {
     const inlineCollapsed = this.getInlineCollapsed();
-    if (this.switchModeFromInline && inlineCollapsed) {
+    if (this.switchModeFromInline && inlineCollapsed && this.leaveAnimationExecutedWhenInlineCollapsed) {
+      this.leaveAnimationExecutedWhenInlineCollapsed = false;
       return 'inline';
     }
     const { mode } = this.props;
@@ -175,6 +177,8 @@ export default class Menu extends React.Component<MenuProps, any> {
             leave: (node, done) => animation.leave(node, () => {
               // Make sure inline menu leave animation finished before mode is switched
               this.switchModeFromInline = false;
+              // Fix https://github.com/ant-design/ant-design/issues/8475
+              this.leaveAnimationExecutedWhenInlineCollapsed = true;
               this.setState({});
               done();
             }),

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "ansi-styles": "^3.2.0",
     "antd-tools": "~2.1.0",
     "babel-cli": "^6.18.0",
-    "babel-eslint": "^8.0.1",
+    "babel-eslint": "8.0.2",
     "babel-plugin-import": "^1.0.0",
     "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-es2015": "^6.18.0",

--- a/package.json
+++ b/package.json
@@ -82,8 +82,8 @@
     "warning": "~3.0.0"
   },
   "devDependencies": {
-    "@types/react": "^16.0.21",
-    "@types/react-dom": "~0.14.18",
+    "@types/react": "16.0.21",
+    "@types/react-dom": "0.14.18",
     "ansi-styles": "^3.2.0",
     "antd-tools": "~2.1.0",
     "babel-cli": "^6.18.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "antd",
-  "version": "2.13.11",
+  "version": "2.13.12",
   "title": "Ant Design",
   "description": "An enterprise-class UI design language and React-based implementation",
   "homepage": "http://ant.design/",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "antd",
-  "version": "2.13.10",
+  "version": "2.13.11",
   "title": "Ant Design",
   "description": "An enterprise-class UI design language and React-based implementation",
   "homepage": "http://ant.design/",


### PR DESCRIPTION
I difficultly use Alert.onClose to beautifully close it.

problem case:
```javascript
class ProblemView extends React.Component {
  constructor(props) {
    super(props);

    this.state = {
      show: true
    };
  }

  render() {
    return (
      <div>
        <p>this view just indicate design defect in Alert.</p>
        {
          this.state.show ? (
            <Alert
              closable
              message="Alert Message..."
              onClose={() => this.setState({show: false})}
            />
          ):null
        }
      </div>
    )
  }
}
```
In above code, the alert slide-up animation can not be working, because the parent state(ProblemView) distribute update action maybe faster than itself animation during the closing effect.

So, antd should move `onClose` to bottom of `animationEnd` or add `onAfterClosed` property to fixed it, just like this:
```javascript
handleClose = (e) => {
  e.preventDefault();
  let dom = ReactDOM.findDOMNode(this) as HTMLElement;
  dom.style.height = `${dom.offsetHeight}px`;
  dom.style.height = `${dom.offsetHeight}px`;

  this.setState({
    closing: false,
  });
  // I cancel call function of onClose from `handleClose`
};
animationEnd = () => {
  this.setState({
    closed: true,
    closing: true,
  });
  (this.props.onAfterClosed || this.props.onClose || noop)();
};
```

Q: why I can do it?
A: The `onClose` feature is too little avail to slide up a alert message, most of the time I just want to smooth close the alert, because the alert has a slide-up animation during it's closing.