### PR TITLE
Use default background for button states

### DIFF
--- a/components/button/style/mixin.less
+++ b/components/button/style/mixin.less
@@ -198,7 +198,7 @@
   &:focus,
   &:active,
   &.active {
-    background: #fff;
+    background: @btn-default-bg;
   }
 }
 


### PR DESCRIPTION
"Dark" themes need that.

Also, would be good to have a separate variable named `@btn-default-hover-bg` and set it to `@btn-default-bg`.