### PR TITLE
Updated button text color setting

### DIFF
--- a/components/button/style/mixin.less
+++ b/components/button/style/mixin.less
@@ -87,6 +87,11 @@
   color: @color;
   background-color: @background;
   border-color: @border;
+  
+  > span {
+    color: @color;
+  }
+  
   // a inside Button which only work in Chrome
   // http://stackoverflow.com/a/17253457
   > a:only-child {


### PR DESCRIPTION
If span color is set globally, @btn-primary-color and other variables from default.less will not be used because span is more specific. Set the colour on the span of the text instead of setting it on the button.