### PR TITLE
Setting button text colour on span

### DIFF
--- a/components/button/style/mixin.less
+++ b/components/button/style/mixin.less
@@ -87,6 +87,11 @@
   color: @color;
   background-color: @background;
   border-color: @border;
+  
+  > span {
+    color: @color;
+  }
+  
   // a inside Button which only work in Chrome
   // http://stackoverflow.com/a/17253457
   > a:only-child {

--- a/components/button/style/mixin.less
+++ b/components/button/style/mixin.less
@@ -87,11 +87,9 @@
   color: @color;
   background-color: @background;
   border-color: @border;
-  
   > span {
     color: @color;
   }
-  
   // a inside Button which only work in Chrome
   // http://stackoverflow.com/a/17253457
   > a:only-child {


### PR DESCRIPTION
If there is a global span colour specified, the colour of the button will not be set even if variables such as @btn-primary-color are set by the consumer of the library.

To fix this, the colour should be set on the span directly.