### PR TITLE
add afterClose to Alert

### DIFF
--- a/components/alert/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/alert/__tests__/__snapshots__/demo.test.js.snap
@@ -366,6 +366,34 @@ exports[`renders ./components/alert/demo/icon.md correctly 1`] = `
 </div>
 `;
 
+exports[`renders ./components/alert/demo/smooth-closed.md correctly 1`] = `
+<div>
+  <div
+    class="ant-alert ant-alert-success ant-alert-no-icon"
+    data-show="true"
+  >
+    <span
+      class="ant-alert-message"
+    >
+      Alert Message Text
+    </span>
+    <span
+      class="ant-alert-description"
+    />
+    <a
+      class="ant-alert-close-icon"
+    >
+      <i
+        class="anticon anticon-cross"
+      />
+    </a>
+  </div>
+  <p>
+    placeholder text here
+  </p>
+</div>
+`;
+
 exports[`renders ./components/alert/demo/style.md correctly 1`] = `
 <div>
   <div

--- a/components/alert/demo/smooth-closed.md
+++ b/components/alert/demo/smooth-closed.md
@@ -1,0 +1,48 @@
+---
+order: 7
+title:
+  zh-CN: 平滑地卸载
+  en-US: Smoothly Unmount
+---
+
+## zh-CN
+
+平滑、自然的卸载提示
+
+## en-US
+
+Smoothly and unaffectedly unmount Alert.
+
+````jsx
+import { Alert } from 'antd';
+
+class App extends React.Component {
+  state = {
+    visiable: true,
+  }
+  handleClose = () => {
+    this.setState({ visiable: false });
+  }
+  render() {
+    return (
+      <div>
+        {
+          this.state.visiable ? (
+            <Alert
+              message="Alert Message Text"
+              type="success"
+              closable
+              afterClose={this.handleClose}
+            />
+          ) : null
+        }
+        <p>placeholder text here</p>
+      </div>
+    );
+  }
+}
+
+ReactDOM.render(
+  <App />
+, mountNode);
+````

--- a/components/alert/index.tsx
+++ b/components/alert/index.tsx
@@ -21,6 +21,8 @@ export interface AlertProps {
   description?: React.ReactNode;
   /** Callback when close Alert */
   onClose?: React.MouseEventHandler<HTMLAnchorElement>;
+  /** Trigger when animation ending of Alert */
+  afterClose?: Function;
   /** Whether to show icon */
   showIcon?: boolean;
   iconType?: string;
@@ -56,6 +58,7 @@ export default class Alert extends React.Component<AlertProps, any> {
       closed: true,
       closing: true,
     });
+    (this.props.afterClose || noop)();
   }
   render() {
     let {


### PR DESCRIPTION
To smoothly unmount `<Alert />`.

problem case:
```javascript
class ProblemView extends React.Component {
  constructor(props) {
    super(props);

    this.state = {
      show: true
    };
  }

  render() {
    return (
      <div>
        {
          this.state.show ? (
            <Alert
              closable
              message="Alert Message..."
              onClose={() => this.setState({show: false})}
            />
          ):null
        }
        <p>this view just indicate design defect in Alert.</p>
      </div>
    )
  }
}
```

I need to keep user actions, and shown or hiden <Alert /> is an action.
So the parent node should record all children states, page view will be appeared under friendly.

So I want to add `afterClose` to `<Alert />` to deep fixed it.