### PR TITLE
 Added selectionColumnWidth to TableRowSelection

### DIFF
--- a/components/table/Table.tsx
+++ b/components/table/Table.tsx
@@ -640,7 +640,7 @@ export default class Table<T> extends React.Component<TableProps<T>, TableState<
         render: this.renderSelectionBox(rowSelection.type),
         className: selectionColumnClass,
         fixed: rowSelection.fixed,
-        width: rowSelection.selectionColumnWidth,
+        width: rowSelection.columnWidth,
       };
       if (rowSelection.type !== 'radio') {
         const checkboxAllDisabled = data.every((item, index) => this.getCheckboxPropsByItem(item, index).disabled);

--- a/components/table/Table.tsx
+++ b/components/table/Table.tsx
@@ -640,6 +640,7 @@ export default class Table<T> extends React.Component<TableProps<T>, TableState<
         render: this.renderSelectionBox(rowSelection.type),
         className: selectionColumnClass,
         fixed: rowSelection.fixed,
+        width: rowSelection.selectionColumnWidth,
       };
       if (rowSelection.type !== 'radio') {
         const checkboxAllDisabled = data.every((item, index) => this.getCheckboxPropsByItem(item, index).disabled);

--- a/components/table/index.en-US.md
+++ b/components/table/index.en-US.md
@@ -145,7 +145,7 @@ Properties for row selection.
 | getCheckboxProps | Get Checkbox or Radio props | Function(record) | - |
 | hideDefaultSelections | Remove the default `Select All` and `Select Invert` selections | boolean | `false` |
 | selectedRowKeys | Controlled selected row keys | string\[] | \[] |
-| selectionColumnWidth | Set the width of the selection column | string\|number | - |
+| columnWidth | Set the width of the selection column | string\|number | - |
 | selections | Custom selection [config](#rowSelection), only displays default selections when set to `true` | object\[]\|boolean | - |
 | type | `checkbox` or `radio` | `checkbox` \| `radio` | `checkbox` |
 | onChange | Callback executed when selected rows change | Function(selectedRowKeys, selectedRows) | - |

--- a/components/table/index.en-US.md
+++ b/components/table/index.en-US.md
@@ -145,6 +145,7 @@ Properties for row selection.
 | getCheckboxProps | Get Checkbox or Radio props | Function(record) | - |
 | hideDefaultSelections | Remove the default `Select All` and `Select Invert` selections | boolean | `false` |
 | selectedRowKeys | Controlled selected row keys | string\[] | \[] |
+| selectionColumnWidth | Set the width of the selection column | string\|number | - |
 | selections | Custom selection [config](#rowSelection), only displays default selections when set to `true` | object\[]\|boolean | - |
 | type | `checkbox` or `radio` | `checkbox` \| `radio` | `checkbox` |
 | onChange | Callback executed when selected rows change | Function(selectedRowKeys, selectedRows) | - |

--- a/components/table/index.zh-CN.md
+++ b/components/table/index.zh-CN.md
@@ -146,6 +146,7 @@ const columns = [{
 | getCheckboxProps | 选择框的默认属性配置 | Function(record) | - |
 | hideDefaultSelections | 去掉『全选』『反选』两个默认选项 | boolean | false |
 | selectedRowKeys | 指定选中项的 key 数组，需要和 onChange 进行配合 | string\[] | \[] |
+| selectionColumnWidth | 自定义列表选择框宽度 | string\|number | - |
 | selections | 自定义选择项 [配置项](#selection), 设为 `true` 时使用默认选择项 | object\[]\|boolean | true |
 | type | 多选/单选，`checkbox` or `radio` | string | `checkbox` |
 | onChange | 选中项发生变化的时的回调 | Function(selectedRowKeys, selectedRows) | - |

--- a/components/table/index.zh-CN.md
+++ b/components/table/index.zh-CN.md
@@ -146,7 +146,7 @@ const columns = [{
 | getCheckboxProps | 选择框的默认属性配置 | Function(record) | - |
 | hideDefaultSelections | 去掉『全选』『反选』两个默认选项 | boolean | false |
 | selectedRowKeys | 指定选中项的 key 数组，需要和 onChange 进行配合 | string\[] | \[] |
-| selectionColumnWidth | 自定义列表选择框宽度 | string\|number | - |
+| columnWidth | 自定义列表选择框宽度 | string\|number | - |
 | selections | 自定义选择项 [配置项](#selection), 设为 `true` 时使用默认选择项 | object\[]\|boolean | true |
 | type | 多选/单选，`checkbox` or `radio` | string | `checkbox` |
 | onChange | 选中项发生变化的时的回调 | Function(selectedRowKeys, selectedRows) | - |

--- a/components/table/interface.tsx
+++ b/components/table/interface.tsx
@@ -69,7 +69,7 @@ export interface TableRowSelection<T> {
   selections?: SelectionItem[] | boolean;
   hideDefaultSelections?: boolean;
   fixed?: boolean;
-  selectionColumnWidth?: string | number;
+  columnWidth?: string | number;
 }
 
 export interface TableProps<T> {

--- a/components/table/interface.tsx
+++ b/components/table/interface.tsx
@@ -69,6 +69,7 @@ export interface TableRowSelection<T> {
   selections?: SelectionItem[] | boolean;
   hideDefaultSelections?: boolean;
   fixed?: boolean;
+  selectionColumnWidth?: string | number;
 }
 
 export interface TableProps<T> {


### PR DESCRIPTION
Fixes #8247 
You can pass selectionColumnWidth in rowSelection to specify the width of the selection column.
