### PR TITLE
MenuItem: avoid rendering Tooltip unless necessary

### DIFF
--- a/components/menu/MenuItem.tsx
+++ b/components/menu/MenuItem.tsx
@@ -18,13 +18,17 @@ class MenuItem extends React.Component<any, any> {
   render() {
     const { inlineCollapsed } = this.context;
     const props = this.props;
-    return <Tooltip
-      title={inlineCollapsed && props.level === 1 ? props.children : ''}
-      placement="right"
-      overlayClassName={`${props.rootPrefixCls}-inline-collapsed-tooltip`}
-    >
-      <Item {...props} ref={this.saveMenuItem} />
-    </Tooltip>;
+    const item = <Item {...props} ref={this.saveMenuItem} />;
+    if (inlineCollapsed && props.level === 1) {
+      return <Tooltip
+        title={inlineCollapsed && props.level === 1 ? props.children : ''}
+        placement="right"
+        overlayClassName={`${props.rootPrefixCls}-inline-collapsed-tooltip`}
+      >
+        {item}
+      </Tooltip>;
+    }
+    return item;
   }
 }
 


### PR DESCRIPTION
First of all, thank you for your contribution! :-)

Please makes sure that these checkboxes are checked before submitting your PR, thank you!

* [x] Make sure that you propose PR to right branch: bugfix for `master`, feature for latest active branch `feature-x.x`.
* [x] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.

Extra checklist:

**if** *isBugFix* **:**

  * [ ] Make sure that you add at least one unit test for the bug which you had fixed.

**elif** *isNewFeature* **:**

  * [ ] Update API docs for the component.
  * [ ] Update/Add demo to demonstrate new feature.
  * [ ] Update TypeScript definition for the component.
  * [ ] Add unit tests for the feature.

---

https://github.com/ant-design/ant-design/pull/6686
Right now Ant Design renders `Tooltip` for every MenuItem component, which in fact has no use for `inlineCollapsed == false || props.level !== 1` MenuItems. By not rendering `Tooltip` when possible we can reduce the memory footprint and saves a lot of component update / vdom diff