### PR TITLE
fixed modal content overflowed

### DIFF
--- a/components/modal/__tests__/Modal.test.js
+++ b/components/modal/__tests__/Modal.test.js
@@ -44,4 +44,13 @@ describe('Modal', () => {
     const wrapper = mount(<ModalTester footer={null} />);
     expect(wrapper.render()).toMatchSnapshot();
   });
+
+  it('render with very long word fill in title', () => {
+    const wrapper = mount(
+      <ModalTester
+        title="Modal very long title:1:abcdefghijklmnopqrstuvwxyz:it:is:so:long:maybe:over:mask:view"
+      />
+    );
+    expect(wrapper.render()).toMatchSnapshot();
+  });
 });

--- a/components/modal/__tests__/__snapshots__/Modal.test.js.snap
+++ b/components/modal/__tests__/__snapshots__/Modal.test.js.snap
@@ -68,6 +68,85 @@ exports[`Modal render correctly 1`] = `
 </div>
 `;
 
+exports[`Modal render with very long word fill in title 1`] = `
+<div>
+  <div />
+  <div>
+    <div
+      class="ant-modal-mask fade-appear"
+    />
+    <div
+      aria-labelledby="rcDialogTitle2"
+      class="ant-modal-wrap "
+      role="dialog"
+      tabindex="-1"
+    >
+      <div
+        class="ant-modal zoom-appear"
+        role="document"
+        style="width: 520px;"
+      >
+        <div
+          class="ant-modal-content"
+        >
+          <button
+            aria-label="Close"
+            class="ant-modal-close"
+          >
+            <span
+              class="ant-modal-close-x"
+            />
+          </button>
+          <div
+            class="ant-modal-header"
+          >
+            <div
+              class="ant-modal-title"
+              id="rcDialogTitle2"
+            >
+              Modal very long title:1:abcdefghijklmnopqrstuvwxyz:it:is:so:long:maybe:over:mask:view
+            </div>
+          </div>
+          <div
+            class="ant-modal-body"
+          >
+            Here is content of Modal
+          </div>
+          <div
+            class="ant-modal-footer"
+          >
+            <div>
+              <button
+                class="ant-btn"
+                type="button"
+              >
+                <span>
+                  Cancel
+                </span>
+              </button>
+              <button
+                class="ant-btn ant-btn-primary"
+                type="button"
+              >
+                <span>
+                  OK
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
+        <div
+          style="width: 0px; height: 0px; overflow: hidden;"
+          tabindex="0"
+        >
+          sentinel
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Modal render without footer 1`] = `
 <div>
   <div />

--- a/components/modal/style/modal.less
+++ b/components/modal/style/modal.less
@@ -91,6 +91,7 @@
     padding: 24px;
     font-size: @font-size-base;
     line-height: @line-height-base;
+    word-wrap: break-word;
   }
 
   &-footer {


### PR DESCRIPTION
The modal content will be overflowed, if the content is a long english word.
Just like this:
```javascript
Modal.confirm({
  title: "Modal very long title:1:abcdefghijklmnopqrstuvwxyz:it:is:so:long:long:long:long:maybe:over:mask:view",
  content: "Modal content is very:long:long:long:long:abcdefghijklmnopqrstuvwxyz:string:filled:it:and:it:is:terrible",
  maskClosable: true,
});
```

I solved this problem by adding broken words