### PR TITLE
Fix moment import (default instead of wildcard)

### DIFF
--- a/components/calendar/Header.tsx
+++ b/components/calendar/Header.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import * as moment from 'moment';
+import moment from 'moment';
 import { PREFIX_CLS } from './Constants';
 import Select from '../select';
 import { Group, Button, RadioChangeEvent } from '../radio';

--- a/components/calendar/index.tsx
+++ b/components/calendar/index.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import * as moment from 'moment';
+import moment from 'moment';
 import FullCalendar from 'rc-calendar/lib/FullCalendar';
 import LocaleReceiver from '../locale-provider/LocaleReceiver';
 import { PREFIX_CLS } from './Constants';

--- a/components/date-picker/RangePicker.tsx
+++ b/components/date-picker/RangePicker.tsx
@@ -1,6 +1,6 @@
 /* tslint:disable jsx-no-multiline-js */
 import * as React from 'react';
-import * as moment from 'moment';
+import moment from 'moment';
 import RangeCalendar from 'rc-calendar/lib/RangeCalendar';
 import RcDatePicker from 'rc-calendar/lib/Picker';
 import classNames from 'classnames';

--- a/components/date-picker/WeekPicker.tsx
+++ b/components/date-picker/WeekPicker.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import * as moment from 'moment';
+import moment from 'moment';
 import Calendar from 'rc-calendar';
 import RcDatePicker from 'rc-calendar/lib/Picker';
 import classNames from 'classnames';

--- a/components/date-picker/createPicker.tsx
+++ b/components/date-picker/createPicker.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import * as moment from 'moment';
+import moment from 'moment';
 import MonthCalendar from 'rc-calendar/lib/MonthCalendar';
 import RcDatePicker from 'rc-calendar/lib/Picker';
 import classNames from 'classnames';

--- a/components/date-picker/interface.tsx
+++ b/components/date-picker/interface.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import * as moment from 'moment';
+import moment from 'moment';
 import { TimePickerProps } from '../time-picker';
 
 export interface PickerProps {

--- a/components/locale-provider/index.tsx
+++ b/components/locale-provider/index.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import * as moment from 'moment';
+import moment from 'moment';
 import { ModalLocale, changeConfirmLocale } from '../modal/locale';
 
 export interface Locale {

--- a/components/time-picker/index.tsx
+++ b/components/time-picker/index.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import * as moment from 'moment';
+import moment from 'moment';
 import RcTimePicker from 'rc-time-picker/lib/TimePicker';
 import classNames from 'classnames';
 import LocaleReceiver from '../locale-provider/LocaleReceiver';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,8 @@
     "strictNullChecks": true,
     "moduleResolution": "node",
     "experimentalDecorators": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
     "jsx": "preserve",
     "noUnusedParameters": true,
     "noUnusedLocals": true,


### PR DESCRIPTION
* [x] Make sure that you propose PR to right branch: bugfix for `master`, feature for latest active branch `feature-x.x`.
* [x] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.

## What ?
This PR replaces all occurences of `import * as moment from 'moment'` to `import moment from 'moment'`. It also sets the following TypeScript options : 
- `allowSyntheticDefaultImports: true` to allow default imports even when typings don't declare them
- `esModuleInterop: true` to add ES6 interoperability code, this makes `allowSyntheticDefaultImports` not dangerous.

## Why ?
ES6 does not allow calling a namespace (in `import * as namespace from module`), because it is an object. This is problematic because Parcel uses Babel to transform ES6 modules to CommonJS, which strictly follow this standard. For more context see [moment#4488](https://github.com/moment/moment/issues/4488) and [parcel#530](https://github.com/parcel-bundler/parcel/pull/530).

It fixes #8876 and should make `antd` work on any bundler.

Extra checklist:

  * [ ] Make sure that you add at least one unit test for the bug which you had fixed.
    - I don't know if we can add a unit test for this as it depend on the bundler. I manually tested it on Parcel and Webpack
