### PR TITLE
Fix <Switch /> small margin

### DIFF
--- a/components/style/themes/default.less
+++ b/components/style/themes/default.less
@@ -422,6 +422,7 @@
 // ---
 @switch-height: 22px;
 @switch-sm-height: 16px;
+@switch-sm-checked-margin-left: -(@switch-sm-height - 3px);
 @switch-disabled-opacity: 0.4;
 @switch-color: @primary-color;
 

--- a/components/switch/style/index.less
+++ b/components/switch/style/index.less
@@ -107,7 +107,7 @@
     &:before,
     &:after {
       left: 100%;
-      margin-left: -12.5px;
+      margin-left: -(@switch-sm-height - 3px);
     }
 
     .@{switch-prefix-cls}-inner {

--- a/components/switch/style/index.less
+++ b/components/switch/style/index.less
@@ -107,7 +107,7 @@
     &:before,
     &:after {
       left: 100%;
-      margin-left: -(@switch-sm-height - 3px);
+      margin-left: @switch-sm-checked-margin-left;
     }
 
     .@{switch-prefix-cls}-inner {


### PR DESCRIPTION
This should be 13px. Size of the circle (12px) + spacing to match the left size(1px).
https://github.com/ant-design/ant-design/blob/master/components/switch/style/index.less#L110

**Issue using current value of -12.5px:**
![screen shot 2018-03-09 at 2 26 22 pm](https://user-images.githubusercontent.com/940022/37226403-c95c109c-23a7-11e8-91bf-65ff914bbe92.png)

**Issue solved:**
![screen shot 2018-03-09 at 2 26 17 pm](https://user-images.githubusercontent.com/940022/37226410-cf48957a-23a7-11e8-8a4a-3ec5c52e79ce.png)

* [x] branch master
* [x] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.