### PR TITLE
Add variable for Pagination font-weight when active

### DIFF
--- a/components/pagination/style/index.less
+++ b/components/pagination/style/index.less
@@ -66,7 +66,7 @@
 
     &-active {
       border-color: @primary-color;
-      font-weight: 500;
+      font-weight: @pagination-font-weight-active;
 
       a {
         color: @primary-color;

--- a/components/style/themes/default.less
+++ b/components/style/themes/default.less
@@ -430,6 +430,7 @@
 @pagination-item-size: 32px;
 @pagination-item-size-sm: 24px;
 @pagination-font-family: Arial;
+@pagination-font-weight-active: 500;
 
 // Breadcrumb
 // ---


### PR DESCRIPTION
(Reposting) Adds a variable for `font-weight` to the active item in the `<Pagination />` component.

Why? When using a font other than the default, sometimes a visual shift occurs when transitioning font-weight. Transitioning font-weight is notoriously flaky across browsers.
eg: http://jmp.sh/d5Hh97i

* [x] Changes for `master`
* [x] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.
