### PR TITLE
Complicate with less 3

### DIFF
--- a/components/style/color/bezierEasing.less
+++ b/components/style/color/bezierEasing.less
@@ -100,6 +100,8 @@
   };
 
   this.colorEasing = BezierEasing(0.26, 0.09, 0.37, 0.18);
+  // less 3 requires a return
+  return '';
 })()`;
 }
 // It is hacky way to make this function will be compiled preferentially by less


### PR DESCRIPTION
Fix #7850

`git cherry-pick 9634bea391dd2b7b17f1e89383577e248081a044`, fixes build w/ `less ^3` for 2.x branch.