### PR TITLE
Fix menu item clickable region

### DIFF
--- a/components/menu/style/index.less
+++ b/components/menu/style/index.less
@@ -63,8 +63,6 @@
     &:before {
       position: absolute;
       background-color: transparent;
-      width: 100%;
-      height: 100%;
       top: 0;
       left: 0;
       bottom: 0;
@@ -285,6 +283,9 @@
         color: @menu-item-color;
         &:hover {
           color: @menu-highlight-color;
+        }
+        &:before {
+          bottom: -2px;
         }
       }
     }


### PR DESCRIPTION
水平菜单中菜单项内有链接，点击菜单项底部无效，因为绝对定位相对的是菜单项的 padding-box，但菜单项存在 2px 的 border-bottom

**current**

https://codesandbox.io/s/ko89m052vo

![current](https://user-images.githubusercontent.com/2224764/37637311-e92dc7b0-2c41-11e8-838d-bbcdecb3ab3a.gif)

**with fix**

https://codesandbox.io/s/6j445q06n3

![withfix](https://user-images.githubusercontent.com/2224764/37637314-eb0e8772-2c41-11e8-8dfb-f38d68056baa.gif)
