### PR TITLE
Add Anchor[getContainer]

### DIFF
--- a/components/anchor/index.en-US.md
+++ b/components/anchor/index.en-US.md
@@ -19,6 +19,7 @@ For displaying anchor hyperlinks on page and jumping between them.
 | -------- | ----------- | ---- | ------- |
 | affix | Fixed mode of Anchor | boolean | true |
 | bounds | Bounding distance of anchor area | number | 5(px) |
+| getContainer | Scrolling container | () => HTMLElement | () => window  |
 | offsetBottom | Pixels to offset from bottom when calculating position of scroll | number | - |
 | offsetTop | Pixels to offset from top when calculating position of scroll | number | 0 |
 | showInkInFixed | Whether show ink-balls in Fixed mode | boolean | false |

--- a/components/anchor/index.zh-CN.md
+++ b/components/anchor/index.zh-CN.md
@@ -20,6 +20,7 @@ title: Anchor
 | --- | --- | --- | --- |
 | affix | 固定模式 | boolean | true |
 | bounds | 锚点区域边界 | number | 5(px) |
+| getContainer | 指定滚动的容器 | () => HTMLElement | () => window |
 | offsetBottom | 距离窗口底部达到指定偏移量后触发 | number |  |
 | offsetTop | 距离窗口顶部达到指定偏移量后触发 | number |  |
 | showInkInFixed | 固定模式是否显示小圆点 | boolean | false |


### PR DESCRIPTION
The original `Anchor[target]` is not documented and not functional. Renamed it to `getContainer` to make it more consistent with semantics.

Also fixes #9358