### PR TITLE
Fix table scroll x

### DIFF
--- a/components/table/style/index.less
+++ b/components/table/style/index.less
@@ -488,7 +488,6 @@
     overflow: auto;
     overflow-x: hidden;
     table {
-      width: auto;
       min-width: 100%;
     }
   }


### PR DESCRIPTION
See https://codesandbox.io/s/9lx4jj4n7r

`scroll: { x: true }` does not work when set width of `.ant-table-scroll table` to `auto`.