### PR TITLE
[Carousel] Add possibility to use exposed methods (next, prev, goTo)

### DIFF
--- a/components/carousel/__tests__/index.test.js
+++ b/components/carousel/__tests__/index.test.js
@@ -3,11 +3,19 @@ import { mount } from 'enzyme';
 import Carousel from '..';
 
 describe('Carousel', () => {
-  it('should has innerSlider', () => {
+  it('should have innerSlider', () => {
     const wrapper = mount(<Carousel><div /></Carousel>);
     const { innerSlider } = wrapper.instance();
     const innerSliderFromRefs = wrapper.instance().slick.innerSlider;
     expect(innerSlider).toBe(innerSliderFromRefs);
     expect(typeof innerSlider.slickNext).toBe('function');
+  });
+  
+  it('should have exposed slick methods', () => {
+    const wrapper = mount(<Carousel><div /></Carousel>);
+    const { next, prev, goTo } = wrapper.instance();
+    expect(typeof next).toBe('function');
+    expect(typeof prev).toBe('function');
+    expect(typeof goTo).toBe('function');
   });
 });

--- a/components/carousel/__tests__/index.test.js
+++ b/components/carousel/__tests__/index.test.js
@@ -10,7 +10,7 @@ describe('Carousel', () => {
     expect(innerSlider).toBe(innerSliderFromRefs);
     expect(typeof innerSlider.slickNext).toBe('function');
   });
-  
+
   it('should have exposed slick methods', () => {
     const wrapper = mount(<Carousel><div /></Carousel>);
     const { next, prev, goTo } = wrapper.instance();

--- a/components/carousel/index.tsx
+++ b/components/carousel/index.tsx
@@ -83,6 +83,10 @@ export default class Carousel extends React.Component<CarouselProps, {}> {
     this.onWindowResized = debounce(this.onWindowResized, 500, {
       leading: false,
     });
+
+    this.next = this.next.bind(this);
+    this.prev = this.prev.bind(this);
+    this.goTo = this.goTo.bind(this);
   }
 
   componentDidMount() {


### PR DESCRIPTION
This will allow to use exposed react-slick methods (next, prev, goTo).

**Current behaviour:**
```js
this.slider.innerSlider.slickNext();
```

**Will be with this PR:**
```js
this.slider.next();
```

Related issues:
* #7484
* #7191

Extra checklist:

  * [X] Make sure that you add at least one unit test for the bug which you had fixed.