### PR TITLE
"ReferenceError: env is not defined" error

### DIFF
--- a/docs/react/use-in-typescript.en-US.md
+++ b/docs/react/use-in-typescript.en-US.md
@@ -179,7 +179,7 @@ $ yarn add react-app-rewire-less --dev
   const { getLoader } = require("react-app-rewired");
 + const rewireLess = require('react-app-rewire-less');
 
-  module.exports = function override(config) {
+  module.exports = function override(config, env) {
     const tsLoader = getLoader(
       config.module.rules,
       rule =>


### PR DESCRIPTION
Getting "ReferenceError: env is not defined" error while using react-scripts-ts-antd and applying above without env

First of all, thank you for your contribution! :-)

Please makes sure that these checkboxes are checked before submitting your PR, thank you!

* [x] Make sure that you propose PR to right branch: bugfix for `master`, feature for latest active branch `feature-x.x`.
* [x] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.

Extra checklist:

**if** *isBugFix* **:**

  * [x] Make sure that you add at least one unit test for the bug which you had fixed.

**elif** *isNewFeature* **:**

  * [x] Update API docs for the component.
  * [x] Update/Add demo to demonstrate new feature.
  * [x] Update TypeScript definition for the component.
  * [x] Add unit tests for the feature.
