### PR TITLE
fix base.less @at-root syntax error

### DIFF
--- a/components/style/core/base.less
+++ b/components/style/core/base.less
@@ -56,9 +56,7 @@ html {
 }
 
 // IE10+ doesn't honor `<meta name="viewport">` in some cases.
-@at-root {
-  @-ms-viewport { width: device-width; }
-}
+@-ms-viewport { width: device-width; }
 
 // Shim for "new" HTML5 structural elements to display correctly (IE10, older browsers)
 article, aside, dialog, figcaption, figure, footer, header, hgroup, main, nav, section {


### PR DESCRIPTION
@at-root is not a right syntax in Less.
this error will make CSS parser doesn't work 