### PR TITLE
Add collapse styles to default.less

### DIFF
--- a/components/collapse/style/index.less
+++ b/components/collapse/style/index.less
@@ -66,9 +66,14 @@
   &-content {
     overflow: hidden;
     color: @text-color;
-    padding: @collapse-content-padding;
+    padding: 0 @collapse-content-padding-right 0 @collapse-content-padding-left;
     background-color: @collapse-content-bg;
     border-top: @border-width-base @border-style-base @border-color-base;
+
+    & > &-box {
+      padding-top: @collapse-content-padding-top;
+      padding-bottom: @collapse-content-padding-bottom;
+    }
 
     &-inactive {
       display: none;

--- a/components/collapse/style/index.less
+++ b/components/collapse/style/index.less
@@ -3,8 +3,6 @@
 
 @collapse-prefix-cls: ~"@{ant-prefix}-collapse";
 
-@collapse-header-bg: @collapse-header-background-color;
-
 .collapse-close() {
   transform: rotate(0);
 }
@@ -69,7 +67,7 @@
     overflow: hidden;
     color: @text-color;
     padding: @collapse-content-padding;
-    background-color: @collapse-content-background-color;
+    background-color: @collapse-content-bg;
     border-top: @border-width-base @border-style-base @border-color-base;
 
     & > &-box {

--- a/components/collapse/style/index.less
+++ b/components/collapse/style/index.less
@@ -3,6 +3,8 @@
 
 @collapse-prefix-cls: ~"@{ant-prefix}-collapse";
 
+@collapse-header-bg: @collapse-header-background-color;
+
 .collapse-close() {
   transform: rotate(0);
 }
@@ -29,7 +31,7 @@
     > .@{collapse-prefix-cls}-header {
       line-height: 22px;
       padding: @collapse-header-padding;
-      background-color: @collapse-header-background-color;
+      background-color: @collapse-header-bg;
       color: @heading-color;
       cursor: pointer;
       position: relative;

--- a/components/collapse/style/index.less
+++ b/components/collapse/style/index.less
@@ -12,6 +12,7 @@
 
 .@{collapse-prefix-cls} {
   .reset-component;
+  background-color: @collapse-header-bg;
   border-radius: @border-radius-base;
   border: @border-width-base @border-style-base @border-color-base;
   border-bottom: 0;
@@ -29,7 +30,6 @@
     > .@{collapse-prefix-cls}-header {
       line-height: 22px;
       padding: @collapse-header-padding;
-      background-color: @collapse-header-bg;
       color: @heading-color;
       cursor: pointer;
       position: relative;

--- a/components/collapse/style/index.less
+++ b/components/collapse/style/index.less
@@ -66,13 +66,11 @@
   &-content {
     overflow: hidden;
     color: @text-color;
-    padding: 0 @collapse-content-padding-right 0 @collapse-content-padding-left;
     background-color: @collapse-content-bg;
     border-top: @border-width-base @border-style-base @border-color-base;
 
     & > &-box {
-      padding-top: @collapse-content-padding-top;
-      padding-bottom: @collapse-content-padding-bottom;
+      padding: @collapse-content-padding;
     }
 
     &-inactive {

--- a/components/collapse/style/index.less
+++ b/components/collapse/style/index.less
@@ -70,10 +70,6 @@
     background-color: @collapse-content-bg;
     border-top: @border-width-base @border-style-base @border-color-base;
 
-    & > &-box {
-      padding: @collapse-content-box-padding;
-    }
-
     &-inactive {
       display: none;
     }

--- a/components/collapse/style/index.less
+++ b/components/collapse/style/index.less
@@ -3,9 +3,6 @@
 
 @collapse-prefix-cls: ~"@{ant-prefix}-collapse";
 
-@collapse-header-bg: @background-color-light;
-@collapse-active-bg: @background-color-base;
-
 .collapse-close() {
   transform: rotate(0);
 }
@@ -15,7 +12,6 @@
 
 .@{collapse-prefix-cls} {
   .reset-component;
-  background-color: @collapse-header-bg;
   border-radius: @border-radius-base;
   border: @border-width-base @border-style-base @border-color-base;
   border-bottom: 0;
@@ -32,7 +28,8 @@
 
     > .@{collapse-prefix-cls}-header {
       line-height: 22px;
-      padding: 12px 0 12px 40px;
+      padding: @collapse-header-padding;
+      background-color: @collapse-header-background-color;
       color: @heading-color;
       cursor: pointer;
       position: relative;
@@ -69,13 +66,12 @@
   &-content {
     overflow: hidden;
     color: @text-color;
-    padding: 0 @padding-md;
-    background-color: @component-background;
+    padding: @collapse-content-padding;
+    background-color: @collapse-content-background-color;
     border-top: @border-width-base @border-style-base @border-color-base;
 
     & > &-box {
-      padding-top: @padding-md;
-      padding-bottom: @padding-md;
+      padding: @collapse-content-box-padding;
     }
 
     &-inactive {

--- a/components/style/themes/default.less
+++ b/components/style/themes/default.less
@@ -466,6 +466,5 @@
 // ---
 @collapse-header-padding:             12px 0 12px 40px;
 @collapse-header-bg:                  @background-color-light;
-@collapse-content-padding:            0 @padding-md;
+@collapse-content-padding:            @padding-md;
 @collapse-content-bg:                 @component-background;
-@collapse-content-box-padding:        @padding-md 0 @padding-md 0;

--- a/components/style/themes/default.less
+++ b/components/style/themes/default.less
@@ -466,5 +466,8 @@
 // ---
 @collapse-header-padding:             12px 0 12px 40px;
 @collapse-header-bg:                  @background-color-light;
-@collapse-content-padding:            @padding-md;
+@collapse-content-padding-top:        @padding-md;
+@collapse-content-padding-right:      @padding-md;
+@collapse-content-padding-bottom:     @padding-md;
+@collapse-content-padding-left:       @padding-md;
 @collapse-content-bg:                 @component-background;

--- a/components/style/themes/default.less
+++ b/components/style/themes/default.less
@@ -465,7 +465,7 @@
 // Collapse
 // ---
 @collapse-header-padding:             12px 0 12px 40px;
-@collapse-header-background-color:    #fafafa;
+@collapse-header-background-color:    @background-color-light;
 @collapse-content-padding:            0 @padding-md;
 @collapse-content-background-color:   @component-background;
 @collapse-content-box-padding:        @padding-md 0 @padding-md 0;

--- a/components/style/themes/default.less
+++ b/components/style/themes/default.less
@@ -461,3 +461,11 @@
 @slider-dot-border-color-active:      tint(@primary-color, 50%);
 @slider-disabled-color:               @disabled-color;
 @slider-disabled-background-color:    @component-background;
+
+// Collapse
+// ---
+@collapse-header-padding:             12px 0 12px 40px;
+@collapse-header-background-color:    #fafafa;
+@collapse-content-padding:            0 @padding-md;
+@collapse-content-background-color:   @component-background;
+@collapse-content-box-padding:        @padding-md 0 @padding-md 0;

--- a/components/style/themes/default.less
+++ b/components/style/themes/default.less
@@ -465,7 +465,7 @@
 // Collapse
 // ---
 @collapse-header-padding:             12px 0 12px 40px;
-@collapse-header-background-color:    @background-color-light;
+@collapse-header-bg:                  @background-color-light;
 @collapse-content-padding:            0 @padding-md;
-@collapse-content-background-color:   @component-background;
+@collapse-content-bg:                 @component-background;
 @collapse-content-box-padding:        @padding-md 0 @padding-md 0;

--- a/components/style/themes/default.less
+++ b/components/style/themes/default.less
@@ -466,5 +466,5 @@
 // ---
 @collapse-header-padding:             12px 0 12px 40px;
 @collapse-header-bg:                  @background-color-light;
-@collapse-content-padding:            @padding-md @padding-md @padding-md @padding-md;
+@collapse-content-padding:            @padding-md;
 @collapse-content-bg:                 @component-background;

--- a/components/style/themes/default.less
+++ b/components/style/themes/default.less
@@ -466,8 +466,5 @@
 // ---
 @collapse-header-padding:             12px 0 12px 40px;
 @collapse-header-bg:                  @background-color-light;
-@collapse-content-padding-top:        @padding-md;
-@collapse-content-padding-right:      @padding-md;
-@collapse-content-padding-bottom:     @padding-md;
-@collapse-content-padding-left:       @padding-md;
+@collapse-content-padding:            @padding-md @padding-md @padding-md @padding-md;
 @collapse-content-bg:                 @component-background;


### PR DESCRIPTION
First of all, thank you for your contribution! :-)

Please makes sure that these checkboxes are checked before submitting your PR, thank you!

* [x] Make sure that you propose PR to right branch: bugfix for `master`, feature for latest active branch `feature-x.x`.
* [x] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.

[Related Issue](https://github.com/ant-design/ant-design/issues/9923)

This pushes color and padding for the Collapse component into defaults so they can easily be overridden.

I set up the values such that the Collapse will not change appearances for anyone currently using the defaults (or any values those defaults were using), but allows a user to remove all of the padding from both the header and the content of a Collapse.

Properties added to `default.less`:

```
@collapse-header-padding          
@collapse-header-bg
@collapse-content-padding         
@collapse-content-bg
```

I couldn't see any tests around default styles for any of the other components, but if these changes are testable I'll be happy to go back and add them. 

I don't think this requires any updates to documentation.

Extra checklist:

  ~~* [ ] Update API docs for the component.~~
  ~~* [ ] Update/Add demo to demonstrate new feature.~~
  ~~* [ ] Update TypeScript definition for the component.~~
  ~~* [ ] Add unit tests for the feature.~~
