### PR TITLE
Fix the infinite & virtualized List is invisible that caused by its h…

### DIFF
--- a/components/list/demo/infinite-virtualized-load.md
+++ b/components/list/demo/infinite-virtualized-load.md
@@ -129,7 +129,7 @@ class VirtualizedExample extends React.Component {
       <List>
         {
           data.length > 0 && (
-            <WindowScroller scrollElement={null}>
+            <WindowScroller>
               {infiniteLoader}
             </WindowScroller>
           )


### PR DESCRIPTION
Fix the infinite & virtualized List is invisible that caused by its height can't be calculated

After fixing the bug. I found another weird bug which may be caused by react-virtualized:

While scrolling down the page, sometimes a few items at up position won't be rendered, and the number of actually rendered items is over than the number of ought to be rendered items. We can check the childElementCount of the `.ReactVirtualized__Grid__innerScrollContainer`. If we increase the `overscanRowCount` prop of `VList`, it will be more obvious.

Bug happens:
![image](https://user-images.githubusercontent.com/1303154/38746704-de786bf8-3f7a-11e8-895f-51d3671f886b.png)


First of all, thank you for your contribution! :-)

Please makes sure that these checkboxes are checked before submitting your PR, thank you!

* [x] Make sure that you propose PR to right branch: bugfix for `master`, feature for latest active branch `feature-x.x`.
* [x] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a PR to keep commit history clear.
* [ ] Add some descriptions and refer relative issues for you PR.

Extra checklist:

**if** *isBugFix* **:**

  * [ ] Make sure that you add at least one unit test for the bug which you had fixed.

**elif** *isNewFeature* **:**

  * [ ] Update API docs for the component.
  * [ ] Update/Add demo to demonstrate new feature.
  * [ ] Update TypeScript definition for the component.
  * [ ] Add unit tests for the feature.
