### PR TITLE
Use componentDidMount to replace componentWillMount

### DIFF
--- a/components/list/demo/infinite-load.md
+++ b/components/list/demo/infinite-load.md
@@ -38,7 +38,7 @@ class InfiniteListExample extends React.Component {
       },
     });
   }
-  componentWillMount() {
+  componentDidMount() {
     this.getData((res) => {
       this.setState({
         data: res.results,

--- a/components/list/demo/infinite-virtualized-load.md
+++ b/components/list/demo/infinite-virtualized-load.md
@@ -46,7 +46,7 @@ class VirtualizedExample extends React.Component {
       },
     });
   }
-  componentWillMount() {
+  componentDidMount() {
     this.getData((res) => {
       this.setState({
         data: res.results,

--- a/components/locale-provider/index.tsx
+++ b/components/locale-provider/index.tsx
@@ -53,7 +53,7 @@ export default class LocaleProvider extends React.Component<LocaleProviderProps,
     };
   }
 
-  componentWillMount() {
+  componentDidMount() {
     setMomentLocale(this.props.locale);
     this.componentDidUpdate();
   }


### PR DESCRIPTION
Use componentDidMount to replace componentWillMount: componentWillMount is deprecating.

First of all, thank you for your contribution! :-)

Please makes sure that these checkboxes are checked before submitting your PR, thank you!

* [x] Make sure that you propose PR to right branch: bugfix for `master`, feature for latest active branch `feature-x.x`.
* [x] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a PR to keep commit history clear.
* [ ] Add some descriptions and refer relative issues for you PR.

Extra checklist:

**if** *isBugFix* **:**

  * [ ] Make sure that you add at least one unit test for the bug which you had fixed.

**elif** *isNewFeature* **:**

  * [ ] Update API docs for the component.
  * [ ] Update/Add demo to demonstrate new feature.
  * [ ] Update TypeScript definition for the component.
  * [ ] Add unit tests for the feature.
