### PR TITLE
Allow to use date format provided by locale

### DIFF
--- a/components/date-picker/wrapPicker.tsx
+++ b/components/date-picker/wrapPicker.tsx
@@ -25,7 +25,7 @@ function getColumns({ showHour, showMinute, showSecond, use12Hours }: any) {
 export default function wrapPicker(Picker: React.ComponentClass<any>, defaultFormat?: string): any {
   return class PickerWrapper extends React.Component<any, any> {
     static defaultProps = {
-      format: defaultFormat || 'YYYY-MM-DD',
+      format: defaultFormat,
       transitionName: 'slide-up',
       popupStyle: {},
       onChange() {
@@ -93,7 +93,7 @@ export default function wrapPicker(Picker: React.ComponentClass<any>, defaultFor
 
     renderPicker = (locale: any, localeCode: string) => {
       const props = this.props;
-      const { prefixCls, inputPrefixCls } = props;
+      const { prefixCls, inputPrefixCls, format } = props;
       const pickerClass = classNames(`${prefixCls}-picker`, {
         [`${prefixCls}-picker-${props.size}`]: !!props.size,
       });
@@ -125,6 +125,7 @@ export default function wrapPicker(Picker: React.ComponentClass<any>, defaultFor
       return (
         <Picker
           {...props}
+          format={format ? format : locale.lang.dateFormat}
           ref={this.savePicker}
           pickerClass={pickerClass}
           pickerInputClass={pickerInputClass}


### PR DESCRIPTION
Currently there is no option to use date format provided by locale. Since the locale is always available from `this.getDefaultLocale` we can use it as a default value for the `format` prop and omit of setting the default 'YYY-MM-DD' value.

First of all, thank you for your contribution! :-)

Please makes sure that these checkboxes are checked before submitting your PR, thank you!

* [x] Make sure that you propose PR to right branch: bugfix for `master`, feature for latest active branch `feature-x.x`.
* [x] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.

Extra checklist:

**if** *isBugFix* **:**

  * [ ] Make sure that you add at least one unit test for the bug which you had fixed.

**elif** *isNewFeature* **:**

  * [ ] Update API docs for the component.
  * [ ] Update/Add demo to demonstrate new feature.
  * [ ] Update TypeScript definition for the component.
  * [ ] Add unit tests for the feature.
