### PR TITLE
Fix wrong List property (#10123)

### DIFF
--- a/components/list/__tests__/index.test.js
+++ b/components/list/__tests__/index.test.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import List from '..';
+
+const ListItem = List.Item;
+
+describe('List', () => {
+  it('locale not passed to internal div', async () => {
+    const locale = { emptyText: 'Custom text' };
+    const renderItem = item => <ListItem>{item}</ListItem>;
+    const dataSource = [];
+
+    const wrapper = mount(
+      <List renderItem={renderItem} dataSource={dataSource} locale={locale} />
+    );
+    expect(wrapper.find('div').first().props().locale).toBe(undefined);
+  });
+});

--- a/components/list/index.tsx
+++ b/components/list/index.tsx
@@ -129,6 +129,7 @@ export default class List extends React.Component<ListProps> {
       header,
       footer,
       loading,
+      locale,
       ...rest,
     } = this.props;
 


### PR DESCRIPTION
This diff excludes `locale` from `rest` variable to
avoid passing to div.

Close #10123

First of all, thank you for your contribution! :-)

Please makes sure that these checkboxes are checked before submitting your PR, thank you!

* [x] Make sure that you propose PR to right branch: bugfix for `master`, feature for latest active branch `feature-x.x`.
* [x] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.

Extra checklist:

**if** *isBugFix* **:**

  * [x] Make sure that you add at least one unit test for the bug which you had fixed.

**elif** *isNewFeature* **:**

  * [ ] Update API docs for the component.
  * [ ] Update/Add demo to demonstrate new feature.
  * [ ] Update TypeScript definition for the component.
  * [ ] Add unit tests for the feature.
