### PR TITLE
Bump up rc-notification version to 3.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "rc-form": "^2.1.0",
     "rc-input-number": "~4.0.0",
     "rc-menu": "~6.2.0",
-    "rc-notification": "~3.0.0",
+    "rc-notification": "~3.1.0",
     "rc-pagination": "~1.16.1",
     "rc-progress": "~2.2.2",
     "rc-rate": "~2.4.0",


### PR DESCRIPTION
Bump up `rc-notification` version to 3.1.0 that supports notification update by key