### PR TITLE
fix(button): use React.HTMLProps for button's props

### DIFF
--- a/components/button/button.tsx
+++ b/components/button/button.tsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import omit from 'omit.js';
 import Icon from '../icon';
+import { Omit } from '../_util/type';
 import Group from './button-group';
 
 const rxTwoCNChar = /^[\u4e00-\u9fa5]{2}$/;
@@ -38,28 +39,25 @@ export type ButtonType = 'default' | 'primary' | 'ghost' | 'dashed' | 'danger';
 export type ButtonShape = 'circle' | 'circle-outline';
 export type ButtonSize = 'small' | 'default' | 'large';
 
-export interface ButtonProps {
+export interface BaseButtonProps<T> extends Omit<React.HTMLProps<T>, 'size'> {
   type?: ButtonType;
   htmlType?: string;
   icon?: string;
   shape?: ButtonShape;
   size?: ButtonSize;
-  onClick?: React.FormEventHandler<any>;
-  onMouseUp?: React.FormEventHandler<any>;
-  onMouseDown?: React.FormEventHandler<any>;
-  onKeyPress?: React.KeyboardEventHandler<any>;
-  onKeyDown?: React.KeyboardEventHandler<any>;
-  tabIndex?: number;
   loading?: boolean | { delay?: number };
-  disabled?: boolean;
-  style?: React.CSSProperties;
   prefixCls?: string;
   className?: string;
   ghost?: boolean;
-  target?: string;
-  href?: string;
-  download?: string;
 }
+
+export interface AnchorButtonProps extends BaseButtonProps<HTMLAnchorElement> {
+  href: string;
+}
+
+export interface NativeButtonProps extends BaseButtonProps<HTMLButtonElement> {}
+
+export type ButtonProps = AnchorButtonProps | NativeButtonProps;
 
 export default class Button extends React.Component<ButtonProps, any> {
   static Group: typeof Group;
@@ -143,7 +141,7 @@ export default class Button extends React.Component<ButtonProps, any> {
     }
   }
 
-  handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+  handleClick = (e: React.MouseEvent<HTMLButtonElement | HTMLAnchorElement>) => {
     // Add click effect
     this.setState({ clicked: true });
     clearTimeout(this.timeout);
@@ -151,7 +149,7 @@ export default class Button extends React.Component<ButtonProps, any> {
 
     const onClick = this.props.onClick;
     if (onClick) {
-      onClick(e);
+      (onClick as (e: React.MouseEvent<HTMLButtonElement | HTMLAnchorElement>) => void)(e);
     }
   }
 
@@ -181,7 +179,7 @@ export default class Button extends React.Component<ButtonProps, any> {
         break;
     }
 
-    const ComponentProp = others.href ? 'a' : 'button';
+    const ComponentProp = (others as AnchorButtonProps).href ? 'a' : 'button';
 
     const classes = classNames(prefixCls, className, {
       [`${prefixCls}-${type}`]: type,
@@ -202,7 +200,7 @@ export default class Button extends React.Component<ButtonProps, any> {
     return (
       <ComponentProp
         {...omit(others, ['loading'])}
-        type={others.href ? undefined : (htmlType || 'button')}
+        type={(others as AnchorButtonProps).href ? undefined : (htmlType || 'button')}
         className={classes}
         onClick={this.handleClick}
       >

--- a/components/dropdown/dropdown-button.tsx
+++ b/components/dropdown/dropdown-button.tsx
@@ -9,7 +9,7 @@ const ButtonGroup = Button.Group;
 export interface DropdownButtonProps extends ButtonGroupProps, DropDownProps {
   type?: 'primary' | 'ghost' | 'dashed';
   disabled?: boolean;
-  onClick?: React.MouseEventHandler<any>;
+  onClick?: React.MouseEventHandler<HTMLButtonElement>;
   children?: any;
 }
 

--- a/components/transfer/operation.tsx
+++ b/components/transfer/operation.tsx
@@ -8,8 +8,8 @@ export interface TransferOperationProps {
   className?: string;
   leftArrowText?: string;
   rightArrowText?: string;
-  moveToLeft?: React.FormEventHandler<any>;
-  moveToRight?: React.FormEventHandler<any>;
+  moveToLeft?: React.FormEventHandler<HTMLButtonElement>;
+  moveToRight?: React.FormEventHandler<HTMLButtonElement>;
   leftActive?: boolean;
   rightActive?: boolean;
 }


### PR DESCRIPTION
First of all, thank you for your contribution! :-)

Please makes sure that these checkboxes are checked before submitting your PR, thank you!

* [x] Make sure that you propose PR to right branch: bugfix for `master`, feature for latest active branch `feature-x.x`.
* [x] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.


The old props of `Button` component lacks a lot of prop, like `onMouseOver` etc. 

Extra checklist:

**if** *isBugFix* **:**

  * [ ] Make sure that you add at least one unit test for the bug which you had fixed. ( Not possible since it's a typing fix and test are written in JavaScript )

