### PR TITLE
setting initialValue in select inside form

### DIFF
--- a/components/select/index.en-US.md
+++ b/components/select/index.en-US.md
@@ -26,7 +26,7 @@ Select component to select value from options.
 | allowClear | Show clear button. | boolean | false |
 | autoFocus | Get focus by default | boolean | false |
 | defaultActiveFirstOption | Whether active first option by default | boolean | true |
-| defaultValue | Initial selected option. | string\|number\|string\[]\|number\[] | - |
+| defaultValue | Initial selected option.Note:while setting default value in select inside form use [initialValue prop inside getFieldDecorator](http://ant.design/components/form/#components-form-demo-register) | string\|number\|string\[]\|number\[] | - |
 | disabled | Whether disabled select | boolean | false |
 | dropdownClassName | className of dropdown menu | string | - |
 | dropdownMatchSelectWidth | Whether dropdown's with is same with select. | boolean | true |


### PR DESCRIPTION
**Adding Documentation**

when we set `defaultValue` in simple select it nicely works
but but
[When we put select inside form and set defaultValue it doesn't work](https://codesandbox.io/s/oqwq8wk786)

then after 5 hours, I found [the `initialValue` prop in `getFieldDecorator`](http://ant.design/components/form/#components-form-demo-register)

so, i thought i should Document this :)

First of all, thank you for your contribution! :-)

Please makes sure that these checkboxes are checked before submitting your PR, thank you!

* [ ] Make sure that you propose PR to right branch: bugfix for `master`, feature for latest active branch `feature-x.x`.
* [ ] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [ ] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [ ] Rebase before creating a PR to keep commit history clear.
* [ ] Add some descriptions and refer relative issues for you PR.

Extra checklist:

**if** *isBugFix* **:**

  * [ ] Make sure that you add at least one unit test for the bug which you had fixed.

**elif** *isNewFeature* **:**

  * [ ] Update API docs for the component.
  * [ ] Update/Add demo to demonstrate new feature.
  * [ ] Update TypeScript definition for the component.
  * [ ] Add unit tests for the feature.
