### PR TITLE
Use exact type for <Breadcrumb.Item />

### DIFF
--- a/components/breadcrumb/Breadcrumb.tsx
+++ b/components/breadcrumb/Breadcrumb.tsx
@@ -41,7 +41,7 @@ function defaultItemRender(route: Route, params: any, routes: Route[], paths: st
 }
 
 export default class Breadcrumb extends React.Component<BreadcrumbProps, any> {
-  static Item: any;
+  static Item: typeof BreadcrumbItem;
 
   static defaultProps = {
     prefixCls: 'ant-breadcrumb',


### PR DESCRIPTION
Using `any` as the type for `<Breadcrumb.Item />` component breaks the build for TSLint users having the [`no-unsafe-any`](https://palantir.github.io/tslint/rules/no-unsafe-any/) rule enabled.

Said rule marks all instances where entites of unknown shape are consumed, putting the consumer at risk of using a member that doesn't exist. In this situation, the type of `Item` is well defined (exactly the same as `BreadcrumbItem`), so there is no reason not to leverage it.

* [x] Make sure that you propose PR to right branch: bugfix for `master`, feature for latest active branch `feature-x.x`.
* [x] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.