### PR TITLE
Allow to use any CSS units for layout width

### DIFF
--- a/components/layout/Sider.tsx
+++ b/components/layout/Sider.tsx
@@ -184,7 +184,7 @@ export default class Sider extends React.Component<SiderProps, SiderState> {
     // use "px" as fallback unit for width
     const siderWidth = typeof rawWidth === 'number' ? `${rawWidth}px` : rawWidth;
     // special trigger when collapsedWidth == 0
-    const zeroWidthTrigger = parseFloat(collapsedWidth) === 0 ? (
+    const zeroWidthTrigger = parseFloat(collapsedWidth || 0) === 0 ? (
       <span onClick={this.toggle} className={`${prefixCls}-zero-width-trigger`}>
         <Icon type="bars" />
       </span>
@@ -214,7 +214,7 @@ export default class Sider extends React.Component<SiderProps, SiderState> {
       [`${prefixCls}-collapsed`]: !!this.state.collapsed,
       [`${prefixCls}-has-trigger`]: collapsible && trigger !== null && !zeroWidthTrigger,
       [`${prefixCls}-below`]: !!this.state.below,
-      [`${prefixCls}-zero-width`]: parseFloat(siderWidth) === 0,
+      [`${prefixCls}-zero-width`]: parseFloat(siderWidth || 0) === 0,
     });
     return (
       <div className={siderCls} {...divProps} style={divStyle}>

--- a/components/layout/Sider.tsx
+++ b/components/layout/Sider.tsx
@@ -180,9 +180,11 @@ export default class Sider extends React.Component<SiderProps, SiderState> {
     } = this.props;
     const divProps = omit(others, ['collapsed',
       'defaultCollapsed', 'onCollapse', 'breakpoint']);
-    const siderWidth = this.state.collapsed ? collapsedWidth : width;
+    const rawWidth = this.state.collapsed ? collapsedWidth : width;
+    // use "px" as fallback unit for width
+    const siderWidth = typeof rawWidth === 'number' ? `${rawWidth}px` : rawWidth;
     // special trigger when collapsedWidth == 0
-    const zeroWidthTrigger = collapsedWidth === 0 || collapsedWidth === '0' || collapsedWidth === '0px' ? (
+    const zeroWidthTrigger = parseFloat(collapsedWidth) === 0 ? (
       <span onClick={this.toggle} className={`${prefixCls}-zero-width-trigger`}>
         <Icon type="bars" />
       </span>
@@ -201,21 +203,18 @@ export default class Sider extends React.Component<SiderProps, SiderState> {
         </div>
       ) : null
     );
-    // For collapsedWidth="40px"
-    // https://github.com/ant-design/ant-design/issues/10140
-    const siderWidthNumber = (siderWidth || 0).toString().replace(/px$/, '');
     const divStyle = {
       ...style,
-      flex: `0 0 ${siderWidthNumber}px`,
-      maxWidth: `${siderWidthNumber}px`, // Fix width transition bug in IE11
-      minWidth: `${siderWidthNumber}px`, // https://github.com/ant-design/ant-design/issues/6349
-      width: `${siderWidthNumber}px`,
+      flex: `0 0 ${siderWidth}`,
+      maxWidth: siderWidth, // Fix width transition bug in IE11
+      minWidth: siderWidth, // https://github.com/ant-design/ant-design/issues/6349
+      width: siderWidth,
     };
     const siderCls = classNames(className, prefixCls, {
       [`${prefixCls}-collapsed`]: !!this.state.collapsed,
       [`${prefixCls}-has-trigger`]: collapsible && trigger !== null && !zeroWidthTrigger,
       [`${prefixCls}-below`]: !!this.state.below,
-      [`${prefixCls}-zero-width`]: siderWidth === 0 || siderWidth === '0' || siderWidth === '0px',
+      [`${prefixCls}-zero-width`]: parseFloat(siderWidth) === 0,
     });
     return (
       <div className={siderCls} {...divProps} style={divStyle}>

--- a/components/layout/Sider.tsx
+++ b/components/layout/Sider.tsx
@@ -182,9 +182,9 @@ export default class Sider extends React.Component<SiderProps, SiderState> {
       'defaultCollapsed', 'onCollapse', 'breakpoint']);
     const rawWidth = this.state.collapsed ? collapsedWidth : width;
     // use "px" as fallback unit for width
-    const siderWidth = typeof rawWidth === 'number' ? `${rawWidth}px` : rawWidth;
+    const siderWidth = typeof rawWidth === 'number' ? `${rawWidth}px` : String(rawWidth || 0);
     // special trigger when collapsedWidth == 0
-    const zeroWidthTrigger = parseFloat(collapsedWidth || 0) === 0 ? (
+    const zeroWidthTrigger = parseFloat(String(collapsedWidth || 0)) === 0 ? (
       <span onClick={this.toggle} className={`${prefixCls}-zero-width-trigger`}>
         <Icon type="bars" />
       </span>
@@ -214,7 +214,7 @@ export default class Sider extends React.Component<SiderProps, SiderState> {
       [`${prefixCls}-collapsed`]: !!this.state.collapsed,
       [`${prefixCls}-has-trigger`]: collapsible && trigger !== null && !zeroWidthTrigger,
       [`${prefixCls}-below`]: !!this.state.below,
-      [`${prefixCls}-zero-width`]: parseFloat(siderWidth || 0) === 0,
+      [`${prefixCls}-zero-width`]: parseFloat(siderWidth) === 0,
     });
     return (
       <div className={siderCls} {...divProps} style={divStyle}>

--- a/components/layout/__tests__/index.test.js
+++ b/components/layout/__tests__/index.test.js
@@ -45,7 +45,7 @@ describe('Layout', () => {
     expect(wrapper.find('.ant-layout-sider').at(0).prop('style').width).toBe('50%');
     expect(wrapper.find('.ant-layout-sider').at(0).prop('style').flex).toBe('0 0 50%');
   });
-  
+
   it('detect ant-layout-sider-zero-width class in sider when its width is 0%', async () => {
     const wrapper = mount(
       <Layout>

--- a/components/layout/__tests__/index.test.js
+++ b/components/layout/__tests__/index.test.js
@@ -34,4 +34,25 @@ describe('Layout', () => {
     );
     expect(wrapper.find('.ant-layout-sider').hasClass('ant-layout-sider-has-trigger')).toBe(true);
   });
+
+  it('should have 50% width of sidebar', async () => {
+    const wrapper = mount(
+      <Layout>
+        <div><Sider width="50%">Sider</Sider></div>
+        <Content>Content</Content>
+      </Layout>
+    );
+    expect(wrapper.find('.ant-layout-sider').at(0).prop('style').width).toBe('50%');
+    expect(wrapper.find('.ant-layout-sider').at(0).prop('style').flex).toBe('0 0 50%');
+  });
+  
+  it('detect ant-layout-sider-zero-width class in sider when its width is 0%', async () => {
+    const wrapper = mount(
+      <Layout>
+        <div><Sider width="0%">Sider</Sider></div>
+        <Content>Content</Content>
+      </Layout>
+    );
+    expect(wrapper.find('.ant-layout-sider').hasClass('ant-layout-sider-zero-width')).toBe(true);
+  });
 });


### PR DESCRIPTION
👋 
From [docs](https://ant.design/components/layout/) we can see that `width` of layout can be number or string. For me it means I can use `50%`, `20em` and so on. Currently, only pixels are supported. 

This PR is going to fix it. It will allow to use any CSS units for layout width.

Resolves #9719 💯 