### PR TITLE
fix less mixin clearfix

### DIFF
--- a/components/style/mixins/clearfix.less
+++ b/components/style/mixins/clearfix.less
@@ -4,13 +4,10 @@
   zoom: 1;
   &:before,
   &:after {
-    content: " ";
+    content: "";
     display: table;
   }
   &:after {
     clear: both;
-    visibility: hidden;
-    font-size: 0;
-    height: 0;
   }
 }


### PR DESCRIPTION
# Description
The less mixin clearfix has a small bug and could be more simplified.
Both before and after pseudo class is set the content property with a space value, 
but only the after pseudo is set extra properties to prevent some side effects.
As a result, if the parent element is set the property white-space to be 'pre', the before pseudo will break the layout.
Besides, the content property can be just set empty string, so that there's no need to set extra properties in after pseudo.

# Reproduction link
https://codesandbox.io/s/oo840q1wx5

# Check List
* [x] Make sure that you propose PR to right branch: bugfix for `master`, feature for latest active branch `feature-x.x`.
* [x] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.
