### PR TITLE
Improved Form component typings

### DIFF
--- a/components/form/Form.tsx
+++ b/components/form/Form.tsx
@@ -18,7 +18,7 @@ export interface FormCreateOption<T> {
 
 export type FormLayout = 'horizontal' | 'inline' | 'vertical';
 
-export interface FormProps {
+export interface FormProps extends React.FormHTMLAttributes<HTMLFormElement> {
   layout?: FormLayout;
   form?: WrappedFormUtils;
   onSubmit?: React.FormEventHandler<any>;

--- a/components/input/Input.tsx
+++ b/components/input/Input.tsx
@@ -38,8 +38,8 @@ export interface InputProps extends AbstractInputProps {
   onKeyUp?: React.FormEventHandler<HTMLInputElement>;
   onChange?: React.ChangeEventHandler<HTMLInputElement>;
   onClick?: React.FormEventHandler<HTMLInputElement>;
-  onFocus?: React.FormEventHandler<HTMLInputElement>;
-  onBlur?: React.FormEventHandler<HTMLInputElement>;
+  onFocus?: React.FocusEventHandler<HTMLInputElement>;
+  onBlur?: React.FocusEventHandler<HTMLInputElement>;
   autoComplete?: string;
   prefix?: React.ReactNode;
   suffix?: React.ReactNode;


### PR DESCRIPTION
With this fix you can use HTMLFormElement attributes on Form component
without getting TypeScript errors.

For example this code does not longer produce error for the additional
`autoComplete` prop:

```
const myForm = (
  <Form autoComplete="off">
    ...
  </Form>
)
```

also it includes a better typing with the Input component regarding the `onFocus` and `onBlur` handler