### PR TITLE
fix Affix/index.tsx while offsetTop === 0 and offsetBottom is numberic

### DIFF
--- a/components/affix/index.tsx
+++ b/components/affix/index.tsx
@@ -126,7 +126,8 @@ export default class Affix extends React.Component<AffixProps, any> {
     const targetNode = target();
 
     // Backwards support
-    // Fix: if offsetTop === 0, it will get undefined, if offsetBottom is type of number, offsetMode will be { top: false, ... }
+    // Fix: if offsetTop === 0, it will get undefined,
+    //   if offsetBottom is type of number, offsetMode will be { top: false, ... }
     offsetTop = typeof offsetTop === 'undefined' ? offset : offsetTop;
     const scrollTop = getScroll(targetNode, true);
     const affixNode = ReactDOM.findDOMNode(this) as HTMLElement;

--- a/components/affix/index.tsx
+++ b/components/affix/index.tsx
@@ -126,7 +126,8 @@ export default class Affix extends React.Component<AffixProps, any> {
     const targetNode = target();
 
     // Backwards support
-    offsetTop = offsetTop || offset;
+    // Fix: if offsetTop === 0, it will get undefined, if offsetBottom is type of number, offsetMode will be { top: false, ... }
+    offsetTop = typeof offsetTop === 'undefined' ? offset : offsetTop;
     const scrollTop = getScroll(targetNode, true);
     const affixNode = ReactDOM.findDOMNode(this) as HTMLElement;
     const elemOffset = getOffset(affixNode, targetNode);


### PR DESCRIPTION
Fix: if offsetTop === 0, it will get undefined, if offsetBottom is type of number, offsetMode will be { top: false, ... }

First of all, thank you for your contribution! :-)

Please makes sure that these checkboxes are checked before submitting your PR, thank you!

* [x] Make sure that you propose PR to right branch: bugfix for `master`, feature for latest active branch `feature-x.x`.
* [x] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [ ] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.

Extra checklist:

**if** *isBugFix* **:**

  * [x] Make sure that you add at least one unit test for the bug which you had fixed.

**elif** *isNewFeature* **:**

  * [ ] Update API docs for the component.
  * [ ] Update/Add demo to demonstrate new feature.
  * [ ] Update TypeScript definition for the component.
  * [ ] Add unit tests for the feature.
