### PR TITLE
Remove redundant icons

### DIFF
--- a/components/style/core/iconfont.less
+++ b/components/style/core/iconfont.less
@@ -177,8 +177,6 @@
 .@{iconfont-css-prefix}-aliwangwang-o:before { content: "\e68f"; }
 .@{iconfont-css-prefix}-export:before { content: "\e691"; }
 .@{iconfont-css-prefix}-edit:before { content: "\e692"; }
-.@{iconfont-css-prefix}-circle-down-o:before { content: "\e693"; }
-.@{iconfont-css-prefix}-circle-down-:before { content: "\e694"; }
 .@{iconfont-css-prefix}-appstore-o:before { content: "\e695"; }
 .@{iconfont-css-prefix}-appstore:before { content: "\e696"; }
 .@{iconfont-css-prefix}-scan:before { content: "\e697"; }


### PR DESCRIPTION
我在把 antd 的 icons 拆分出来，发现了一些多余或者命名有问题的 icons。

但我不知道他们是否在其他地方被使用，或是有兼容性考虑，仅供参考。