### PR TITLE
Enhanced InputNumber props with HTMLInputElement attributes.

### DIFF
--- a/components/input-number/index.tsx
+++ b/components/input-number/index.tsx
@@ -4,9 +4,9 @@ import RcInputNumber from 'rc-input-number';
 
 import { Omit } from '../_util/type';
 
-type OmitAttributes = 'defaultValue' | 'onChange' | 'size';
+type OmitAttrs = 'defaultValue' | 'onChange' | 'size';
 
-export interface InputNumberProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>, OmitAttributes> {
+export interface InputNumberProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>, OmitAttrs> {
   prefixCls?: string;
   min?: number;
   max?: number;

--- a/components/input-number/index.tsx
+++ b/components/input-number/index.tsx
@@ -2,7 +2,11 @@ import * as React from 'react';
 import classNames from 'classnames';
 import RcInputNumber from 'rc-input-number';
 
-export interface InputNumberProps {
+import { Omit } from '../_util/type';
+
+type OmitAttributes = 'defaultValue' | 'onChange' | 'size';
+
+export interface InputNumberProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>, OmitAttributes> {
   prefixCls?: string;
   min?: number;
   max?: number;

--- a/components/input-number/index.tsx
+++ b/components/input-number/index.tsx
@@ -14,7 +14,6 @@ export interface InputNumberProps extends Omit<React.InputHTMLAttributes<HTMLInp
   step?: number | string;
   defaultValue?: number;
   tabIndex?: number;
-  onKeyDown?: React.FormEventHandler<any>;
   onChange?: (value: number | string | undefined) => void;
   disabled?: boolean;
   size?: 'large' | 'small' | 'default';

--- a/components/input-number/index.tsx
+++ b/components/input-number/index.tsx
@@ -4,7 +4,8 @@ import RcInputNumber from 'rc-input-number';
 
 import { Omit } from '../_util/type';
 
-type OmitAttrs = 'defaultValue' | 'onChange' | 'size';
+// omitting this attrs because they conflicts with the ones defined in InputNumberProps
+export type OmitAttrs = 'defaultValue' | 'onChange' | 'size';
 
 export interface InputNumberProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>, OmitAttrs> {
   prefixCls?: string;


### PR DESCRIPTION
It is possibile to use additional props supported by the inner input
element:

```
const inputEl = <InputNumber autoFocus />
```

Before this commit the type checker did not recognize the `autoFocus`
prop.

Some attributes must be omitted because they conflict with props
defined on `InputNumberProps` interface