### PR TITLE
Update ru_RU.tsx

### DIFF
--- a/components/locale-provider/ru_RU.tsx
+++ b/components/locale-provider/ru_RU.tsx
@@ -29,8 +29,8 @@ export default {
   Transfer: {
     notFoundContent: 'Ничего не найдено',
     searchPlaceholder: 'Введите название для поиска',
-    itemUnit: 'item',
-    itemsUnit: 'items',
+    itemUnit: 'элемент',
+    itemsUnit: 'элем.',
   },
   Select: {
     notFoundContent: 'Ничего не найдено',


### PR DESCRIPTION
Russian orthography not easy for plural forms:
1 элемент
2 элемента (элем.)
...
5 элементов (элем.)
...
21 элемент (элем.)
22 элемента (элем.)

Therefore, I suggest using a shortened form: элем[dot]