### PR TITLE
Added missing API documentation

### DIFF
--- a/components/divider/index.en-US.md
+++ b/components/divider/index.en-US.md
@@ -18,6 +18,8 @@ A divider line separates different content.
 
 | Property | Description | Type | Default |
 | -------- | ----------- | ---- | ------- |
-| dashed | whether line is dashed | Boolean | false |
+| dashed | whether line is dashed | boolean | false |
 | type | direction type of divider | enum: `horizontal` `vertical` | `horizontal` |
 | orientation | position of title inside divider | enum: `left` `right` `center` | `center` |
+| className | className of container | string | `-` |
+| style | style object of container | object | `-` |

--- a/components/divider/index.en-US.md
+++ b/components/divider/index.en-US.md
@@ -21,5 +21,5 @@ A divider line separates different content.
 | dashed | whether line is dashed | boolean | false |
 | type | direction type of divider | enum: `horizontal` `vertical` | `horizontal` |
 | orientation | position of title inside divider | enum: `left` `right` `center` | `center` |
-| className | className of container | string | `-` |
-| style | style object of container | object | `-` |
+| className | className of container | string | - |
+| style | style object of container | object | - |


### PR DESCRIPTION
Added missing Divider API documentation.

I only checked the two I felt were relevant for this minor update to docs, if more must be checked please let me know.

This was created due to looking for style option and locating PR #8504.

* [ ] Make sure that you propose PR to right branch: bugfix for `master`, feature for latest active branch `feature-x.x`.
* [ ] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [ ] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.

Extra checklist:

**if** *isBugFix* **:**

  * [ ] Make sure that you add at least one unit test for the bug which you had fixed.

**elif** *isNewFeature* **:**

  * [ ] Update API docs for the component.
  * [ ] Update/Add demo to demonstrate new feature.
  * [ ] Update TypeScript definition for the component.
  * [ ] Add unit tests for the feature.
