### PR TITLE
Change order of loader option in docs

### DIFF
--- a/docs/react/use-in-typescript.en-US.md
+++ b/docs/react/use-in-typescript.en-US.md
@@ -133,8 +133,8 @@ module.exports = function override(config, env) {
   tsLoader.options = {
     getCustomTransformers: () => ({
       before: [ tsImportPluginFactory({
-        libraryName: 'antd',
         libraryDirectory: 'es',
+        libraryName: 'antd',
         style: 'css',
       }) ]
     })

--- a/docs/react/use-in-typescript.zh-CN.md
+++ b/docs/react/use-in-typescript.zh-CN.md
@@ -132,8 +132,8 @@ module.exports = function override(config, env) {
   tsLoader.options = {
     getCustomTransformers: () => ({
       before: [ tsImportPluginFactory({
-        libraryName: 'antd',
         libraryDirectory: 'es',
+        libraryName: 'antd',
         style: 'css',
       }) ]
     })


### PR DESCRIPTION
Hi, I'm following this [doc](https://ant.design/docs/react/use-in-typescript).
Just realized  `libraryName` should come first otherwise it throw a compile error.

> The key 'libraryDirectory' is not sorted alphabetically

```
"react": "^16.3.2",
"typescript": "^2.8.3",
```

Thanks!