### PR TITLE
Added missing prop firstActiveValue in Select component

### DIFF
--- a/components/select/index.tsx
+++ b/components/select/index.tsx
@@ -38,6 +38,7 @@ export interface SelectProps extends AbstractSelectProps {
   defaultValue?: SelectValue;
   mode?: 'default' | 'multiple' | 'tags' | 'combobox';
   optionLabelProp?: string;
+  firstActiveValue?: string | string[];
   onChange?: (value: SelectValue, option: React.ReactElement<any> | React.ReactElement<any>[]) => void;
   onSelect?: (value: SelectValue, option: React.ReactElement<any>) => any;
   onDeselect?: (value: SelectValue) => any;


### PR DESCRIPTION
In documentation we have `firstActiveValue` and it works when we use it, but not in `SelectProps` interface.
