### PR TITLE
Fix issue #10635 Parent element set text-align break Spin

### DIFF
--- a/components/spin/style/index.less
+++ b/components/spin/style/index.less
@@ -23,12 +23,12 @@
   &-nested-loading {
     position: relative;
     > div > .@{spin-prefix-cls} {
+      display: block;
       position: absolute;
       height: 100%;
       max-height: 320px;
       width: 100%;
       z-index: 4;
-      display: block;
       .@{spin-prefix-cls}-dot {
         position: absolute;
         top: 50%;

--- a/components/spin/style/index.less
+++ b/components/spin/style/index.less
@@ -28,6 +28,7 @@
       max-height: 320px;
       width: 100%;
       z-index: 4;
+      display: block;
       .@{spin-prefix-cls}-dot {
         position: absolute;
         top: 50%;


### PR DESCRIPTION
Fix [#10635](https://github.com/ant-design/ant-design/issues/10635)

* [x] Make sure that you propose PR to right branch: bugfix for `master`, feature for latest active branch `feature-x.x`.
* [x] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.

Extra checklist:

*isBugFix* **:**

  * [ ] Make sure that you add at least one unit test for the bug which you had fixed..

No need to add the unit test since it's a CSS style issue.
