### PR TITLE
Change default word-break to break-word

### DIFF
--- a/components/table/style/index.less
+++ b/components/table/style/index.less
@@ -168,7 +168,7 @@
   &-thead > tr > th,
   &-tbody > tr > td {
     padding: @table-padding-vertical @table-padding-horizontal;
-    word-break: break-all;
+    word-break: break-word;
   }
 
   &-thead > tr > th.@{table-prefix-cls}-selection-column-custom {


### PR DESCRIPTION
Can we change the default `word-break` to `break-word`? I think this can make english words looks better.