### PR TITLE
[Modal] Fix breakpoint for mobile view

### DIFF
--- a/components/modal/style/modal.less
+++ b/components/modal/style/modal.less
@@ -134,7 +134,7 @@
   }
 }
 
-@media (max-width: @screen-md) {
+@media (max-width: @screen-sm-max) {
   .@{dialog-prefix-cls} {
     width: auto !important;
     margin: 10px;


### PR DESCRIPTION
I think for `max-width` breakpoint, it will be more correct to use `@screen-sm-max` instead of `@screen-md`. 

_p.s. Don't forget that iPad has 768px_  😅