### PR TITLE
Fix spin delay issue if mounts with spinning=true

### DIFF
--- a/components/spin/__tests__/index.test.js
+++ b/components/spin/__tests__/index.test.js
@@ -20,4 +20,11 @@ describe('Spin', () => {
     );
     expect(wrapper).toMatchSnapshot();
   });
+
+  it('should render with delay when it\'s mounted with spinning=true and delay', () => {
+    const wrapper = shallow(
+      <Spin spinning delay={500} />
+    );
+    expect(wrapper.find('.ant-spin').at(0).hasClass('ant-spin-spinning')).toEqual(false);
+  });
 });

--- a/components/spin/index.tsx
+++ b/components/spin/index.tsx
@@ -56,7 +56,7 @@ export default class Spin extends React.Component<SpinProps, SpinState> {
     return !!(this.props && this.props.children);
   }
 
-  componentWillMount() {
+  componentDidMount() {
     const { spinning, delay } = this.props;
     if (spinning && delay && !isNaN(Number(delay))) {
       this.setState({ spinning: false });

--- a/components/spin/index.tsx
+++ b/components/spin/index.tsx
@@ -56,6 +56,14 @@ export default class Spin extends React.Component<SpinProps, SpinState> {
     return !!(this.props && this.props.children);
   }
 
+  componentWillMount() {
+    const { spinning, delay } = this.props;
+    if (spinning && delay && !isNaN(Number(delay))) {
+      this.setState({ spinning: false });
+      this.delayTimeout = window.setTimeout(() => this.setState({ spinning }), delay);
+    }
+  }
+
   componentWillUnmount() {
     if (this.debounceTimeout) {
       clearTimeout(this.debounceTimeout);


### PR DESCRIPTION
* [x] Make sure that you propose PR to right branch: bugfix for `master`, feature for latest active branch `feature-x.x`.
* [x] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.

Extra checklist:

**if** *isBugFix* **:**

  * [x] Make sure that you add at least one unit test for the bug which you had fixed.

If a spin component mounts with spinning=true and delay (e.g. in case of rendering a component with data loading initially), it won't be delayed. This PR just fix for it.
