### PR TITLE
fix(calendar): fix fullcalendar content 2px overflow

### DIFF
--- a/components/calendar/style/index.less
+++ b/components/calendar/style/index.less
@@ -235,7 +235,7 @@
   }
 
   &-fullscreen &-content {
-    height: 90px;
+    height: 88px;
     overflow-y: auto;
     position: static;
     width: auto;


### PR DESCRIPTION
![fullcalendar](http://cdn.yangzhedi.com/antd.png)

there is a 2px overflow in fullcalendar-content, 

[https://ant.design/components/calendar-cn/](https://ant.design/components/calendar-cn/)

First of all, thank you for your contribution! :-)

Please makes sure that these checkboxes are checked before submitting your PR, thank you!

* [x] Make sure that you propose PR to right branch: bugfix for `master`, feature for latest active branch `feature-x.x`.
* [ ] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [ ] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [ ] Rebase before creating a PR to keep commit history clear.
* [ ] Add some descriptions and refer relative issues for you PR.
