### PR TITLE
Add onFilter property to Table that gives access to the filtered dataSource

### DIFF
--- a/components/popover/style/index.less
+++ b/components/popover/style/index.less
@@ -111,7 +111,7 @@
   &-placement-top > &-content > &-arrow,
   &-placement-topLeft > &-content >  &-arrow,
   &-placement-topRight > &-content >  &-arrow {
-    bottom: @popover-distance - @popover-arrow-width + 1px;
+    bottom: @popover-distance - @popover-arrow-width + 1.5px;
     box-shadow: 3px 3px 7px rgba(0, 0, 0, 0.07);
   }
   &-placement-top > &-content >  &-arrow {

--- a/components/table/Table.tsx
+++ b/components/table/Table.tsx
@@ -212,7 +212,12 @@ export default class Table<T> extends React.Component<TableProps<T>, TableState<
         newFilters[key] = filtersFromColumns[key];
       });
       if (this.isFiltersChanged(newFilters)) {
-        this.setState({ filters: newFilters });
+        this.setState({ filters: newFilters }, () => {
+          const onFilter = this.props.onFilter;
+          if (onFilter) {
+            onFilter.apply(null, [this.getLocalData(), this.state.filters]);
+          }
+        });
       }
     }
 

--- a/components/table/__tests__/Table.filter.test.js
+++ b/components/table/__tests__/Table.filter.test.js
@@ -183,6 +183,41 @@ describe('Table.filter', () => {
     expect(handleChange).toBeCalledWith({}, { name: ['boy'] }, {});
   });
 
+  it('fires onFilter event', () => {
+    const onFilter = jest.fn();
+    const wrapper = mount(createTable({ onFilter }));
+
+    expect(wrapper.find('tbody tr').length).toBe(4);
+    wrapper.setProps({
+      columns: [{
+        ...column,
+        filteredValue: ['Lucy'],
+      }],
+    });
+    expect(wrapper.find('tbody tr').length).toBe(1);
+    expect(onFilter).toBeCalledWith([{ key: 1, name: 'Lucy' }], { name: ['Lucy'] });
+  });
+
+  it('fires onFilter event and returns correct number of rows with pagination enabled', () => {
+    const onFilter = jest.fn();
+    const wrapper = mount(createTable({ onFilter, pagination: { pageSize: 2 } }));
+
+    expect(wrapper.find('tbody tr').length).toBe(2);
+    wrapper.setProps({
+      columns: [{
+        ...column,
+        filteredValue: ['Lucy', 'Tom', 'Jerry'],
+      }],
+    });
+    expect(wrapper.find('tbody tr').length).toBe(2);
+    expect(onFilter).toBeCalledWith(
+      [
+        { key: 1, name: 'Lucy' },
+        { key: 2, name: 'Tom' },
+        { key: 3, name: 'Jerry' },
+      ], { name: ['Lucy', 'Tom', 'Jerry'] });
+  });
+
   it('three levels menu', () => {
     const filters = [
       { text: 'Upper', value: 'Upper' },

--- a/components/table/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/table/__tests__/__snapshots__/demo.test.js.snap
@@ -8915,6 +8915,10 @@ exports[`renders ./components/table/demo/reset-filter.md correctly 1`] = `
   <div
     class="table-operations"
   >
+    <p>
+      This table has 4 row(s)
+    </p>
+    <br />
     <button
       class="ant-btn"
       type="button"

--- a/components/table/demo/reset-filter.md
+++ b/components/table/demo/reset-filter.md
@@ -48,6 +48,7 @@ const data = [{
 
 class App extends React.Component {
   state = {
+    dataSourceLength: data.length,
     filteredInfo: null,
     sortedInfo: null,
   };
@@ -57,6 +58,9 @@ class App extends React.Component {
       filteredInfo: filters,
       sortedInfo: sorter,
     });
+  }
+  onFilter = (filteredDataSource) => {
+    this.setState({ dataSourceLength: filteredDataSource.length });
   }
   clearFilters = () => {
     this.setState({ filteredInfo: null });
@@ -76,6 +80,7 @@ class App extends React.Component {
     });
   }
   render() {
+    const { dataSourceLength } = this.state;
     let { sortedInfo, filteredInfo } = this.state;
     sortedInfo = sortedInfo || {};
     filteredInfo = filteredInfo || {};
@@ -113,11 +118,17 @@ class App extends React.Component {
     return (
       <div>
         <div className="table-operations">
+          <p>This table has {dataSourceLength} row(s)</p><br />
           <Button onClick={this.setAgeSort}>Sort age</Button>
           <Button onClick={this.clearFilters}>Clear filters</Button>
           <Button onClick={this.clearAll}>Clear filters and sorters</Button>
         </div>
-        <Table columns={columns} dataSource={data} onChange={this.handleChange} />
+        <Table
+          columns={columns}
+          dataSource={data}
+          onChange={this.handleChange}
+          onFilter={this.onFilter}
+        />
       </div>
     );
   }

--- a/components/table/index.en-US.md
+++ b/components/table/index.en-US.md
@@ -75,6 +75,7 @@ const columns = [{
 | size | Size of table | `default` \| `middle` \| `small` | `default` |
 | title | Table title renderer | Function(currentPageData) |  |
 | onChange | Callback executed when pagination, filters or sorter is changed | Function(pagination, filters, sorter) |  |
+| onFilter | Callback executed when filters change | Function(filteredDataSource, filters) |  |
 | onExpand | Callback executed when the row expand icon is clicked | Function(expanded, record) |  |
 | onExpandedRowsChange | Callback executed when the expanded rows change | Function(expandedRows) |  |
 | onHeaderRow | Set props on per header row | Function(column, index) | - |

--- a/components/table/index.zh-CN.md
+++ b/components/table/index.zh-CN.md
@@ -76,6 +76,7 @@ const columns = [{
 | size | 正常或迷你类型，`default` or `small` | string | default |
 | title | 表格标题 | Function(currentPageData) |  |
 | onChange | 分页、排序、筛选变化时触发 | Function(pagination, filters, sorter) |  |
+| onFilter | 过滤器更改时执行回调 | Function(filteredDataSource, filters) |  |
 | onExpand | 点击展开图标时触发 | Function(expanded, record) |  |
 | onExpandedRowsChange | 展开的行变化时触发 | Function(expandedRows) |  |
 | onHeaderRow | 设置头部行属性 | Function(column, index) | - |

--- a/components/table/interface.tsx
+++ b/components/table/interface.tsx
@@ -109,6 +109,7 @@ export interface TableProps<T> {
     filters: Record<keyof T, string[]>,
     sorter: SorterResult<T>,
   ) => void;
+  onFilter?: (filteredDataSource: T[], filters: Record<keyof T, string[]>) => void;
   loading?: boolean | SpinProps;
   locale?: Object;
   indentSize?: number;

--- a/docs/spec/work-with-us.zh-CN.md
+++ b/docs/spec/work-with-us.zh-CN.md
@@ -8,14 +8,7 @@ title: 加入我们
 
 ## UI/UE 设计师
 
-```__react
-const emails = [
-  'lindong.lld#alipay.com',
-];
-ReactDOM.render(
-  <p>作品和简历请投递：{emails[parseInt(Math.random() * emails.length, 10)]}</p>
-, mountNode)
-```
+简历和作品集请投递：lindong.lld#alipay.com
 
 > 注明简历来自 ant.design 官网
 

--- a/docs/spec/work-with-us.zh-CN.md
+++ b/docs/spec/work-with-us.zh-CN.md
@@ -10,7 +10,6 @@ title: 加入我们
 
 ```__react
 const emails = [
-  'momo.zxy#alipay.com',
   'lindong.lld#alipay.com',
 ];
 ReactDOM.render(
@@ -28,12 +27,13 @@ ReactDOM.render(
   - 沟通能力佳，善于自我管理；
   - 有企业级设计实战经验，加分；
   - 有良好的英文能力和国际视眼，加分；
-  - 深度了解 SAP、Salesforce、Google 等设计体系，加分。
+  - 深度理解 SAP、Salesforce、Google 等设计体系，能提出自己见解并落实到实践中，加加加分。
   - 爱 🐱。
 - 岗位职责：
   - 参与金融云、数据服务、人工智能以及金融核心等业务领域的设计工作；
-  - 参与[语雀](https://yuque.com/)、[云凤蝶](http://www.yunfengdie.com/intro)等创新产品的设计工作；
   - 参与 Ant Design 的打磨，将其建设成全球卓越的设计体系。
+- One More Thing：
+  - 你们总是为世界带去美好，但总是忘却你们也需要美好。我们正在努力打造[Kitchen](https://kitchen.alipay.com/)、[语雀画板](https://yuque.com/)等专属设计师的产品，让设计真正变成财富。期待志同道合的你，一道给设计行业带来「微小而美好的改变」。
 
 ## 前端工程师
 


### PR DESCRIPTION
First of all, thank you for your contribution! :-)

Please makes sure that these checkboxes are checked before submitting your PR, thank you!

* [x] Make sure that you propose PR to right branch: bugfix for `master`, feature for latest active branch `feature-x.x`.
* [x] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.

Extra checklist:

  * [x] Update API docs for the component.
  * [x] Update/Add demo to demonstrate new feature.
  * [x] Update TypeScript definition for the component.
  * [x] Add unit tests for the feature.

Sometimes it's desirable to receive the filtered dataSource when the filters change in the `Table` component. For example when you want to display the number of rows in your table.

Issue for this feature #10298

This PR adds an `onFilter` prop to the `Table` component. When the filters change, the `onFilter` callback will be called with the `filteredDataSource` and `filters` properties.

````
<Table
  columns={columns}
  dataSource={data}

  onFilter={(filteredDataSource, activeFilters) => {

    // Now you can do whatever you want with the filtered dataSource

    this.setState({ numberOfRowsInTable: filteredDataSource.length });
  }}
/>
````