### PR TITLE
fix(upload): preview can't show image when the image file use uppercase extension.

### DIFF
--- a/components/upload/UploadList.tsx
+++ b/components/upload/UploadList.tsx
@@ -19,13 +19,13 @@ const extname = (url: string) => {
   }
   const temp = url.split('/');
   const filename = temp[temp.length - 1];
-  const filenameWithoutSuffix = filename.split(/\#|\?/)[0];
+  const filenameWithoutSuffix = filename.split(/#|\?/)[0];
   return (/\.[^./\\]*$/.exec(filenameWithoutSuffix) || [''])[0];
 };
 
 const isImageUrl = (url: string): boolean => {
   const extension = extname(url);
-  if (/^data:image\//.test(url) || /(webp|svg|png|gif|jpg|jpeg|bmp)$/.test(extension)) {
+  if (/^data:image\//.test(url) || /(webp|svg|png|gif|jpg|jpeg|bmp)$/i.test(extension)) {
     return true;
   } else if (/^data:/.test(url)) { // other file types of base64
     return false;


### PR DESCRIPTION
First of all, thank you for your contribution! :-)

Please makes sure that these checkboxes are checked before submitting your PR, thank you!

* [x] Make sure that you propose PR to right branch: bugfix for `master`, feature for latest active branch `feature-x.x`.
* [x] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.

Upload preview can't show image when the image file use uppercase extension, like `.JPG`
This pr fix it, and remove unnecessary escape character in function `extname`.