### PR TITLE
docs(collapse): add accordion, add bordered

### DIFF
--- a/components/collapse/index.en-US.md
+++ b/components/collapse/index.en-US.md
@@ -18,7 +18,9 @@ A content area which can be collapsed and expanded.
 
 | Property | Description | Type | Default |
 | -------- | ----------- | ---- | ------- |
+| accordion | If `true`, `Collapse` renders as `Accordion` | boolean | `false` |
 | activeKey | Key of the active panel | string\[]\|string | No default value. In `accordion` mode, it's the key of the first panel. |
+| bordered | Toggles rendering of the border around the collapse block | boolean | `true` |
 | defaultActiveKey | Key of the initial active panel | string | - |
 | onChange | Callback function executed when active panel is changed | Function | - |
 


### PR DESCRIPTION
Adds missing Collapse component API, such as `accordion` and `bordered`. Both present in examples but not in API reference.

I assume Chinese version will require edits as well, but unfortunately, I can't work on that one.