### PR TITLE
Fix incompatible type error for Table[size] prop

### DIFF
--- a/components/table/Table.tsx
+++ b/components/table/Table.tsx
@@ -20,6 +20,7 @@ import { flatArray, treeMap, flatFilter, normalizeColumns } from './util';
 import { SpinProps } from '../spin';
 import {
   TableProps,
+  TableSize,
   TableState,
   TableComponents,
   RowSelectionType,
@@ -88,7 +89,7 @@ export default class Table<T> extends React.Component<TableProps<T>, TableState<
     prefixCls: 'ant-table',
     useFixedHeader: false,
     className: '',
-    size: 'large',
+    size: 'default' as TableSize,
     loading: false,
     bordered: false,
     indentSize: 20,

--- a/components/table/interface.tsx
+++ b/components/table/interface.tsx
@@ -84,12 +84,13 @@ export interface SorterResult<T> {
   field: string;
   columnKey: string;
 }
+export type TableSize = 'default' | 'middle' | 'small';
 export interface TableProps<T> {
   prefixCls?: string;
   dropdownPrefixCls?: string;
   rowSelection?: TableRowSelection<T>;
   pagination?: PaginationConfig | false;
-  size?: 'default' | 'middle' | 'small';
+  size?: TableSize;
   dataSource?: T[];
   components?: TableComponents;
   columns?: ColumnProps<T>[];


### PR DESCRIPTION
The same as https://github.com/ant-design/ant-design/pull/10055 but for Table.

Also, a default table size was *large* instead of *default*. There is no information about *large* in docs so I've change it to *default* as I'm assuming that it is a mistake.