### PR TITLE
Add missing showArrow option in types

### DIFF
--- a/components/select/index.tsx
+++ b/components/select/index.tsx
@@ -15,6 +15,7 @@ export interface AbstractSelectProps {
   showSearch?: boolean;
   allowClear?: boolean;
   disabled?: boolean;
+  showArrow?: boolean;
   style?: React.CSSProperties;
   tabIndex?: number;
   placeholder?: string | React.ReactNode;


### PR DESCRIPTION
Add missing `showArrow` option in types