### PR TITLE
Fixed a typo

### DIFF
--- a/components/tree-select/demo/treeData.md
+++ b/components/tree-select/demo/treeData.md
@@ -2,7 +2,7 @@
 order: 2
 title:
   zh-CN: 从数据直接生成
-  en-US: Generate form tree data
+  en-US: Generate from tree data
 ---
 
 ## zh-CN


### PR DESCRIPTION
Just a small typo I found while reading the docs.
from was misspelled as form
