### PR TITLE
[WIP] Icon: use SVG instead of Font CSS

### DIFF
--- a/components/icon/__tests__/__snapshots__/index.test.js.snap
+++ b/components/icon/__tests__/__snapshots__/index.test.js.snap
@@ -5,3 +5,9 @@ exports[`Icon should render to a <i class="xxx"></i> 1`] = `
   class="anticon anticon-appstore my-icon-classname"
 />
 `;
+
+exports[`Icon should render to a <i class="xxx"><svg><use xlink:href="antd-icon-TYPENAME"/></svg></i> 1`] = `
+<i
+  class="anticon anticon-zhihu other-class-name"
+/>
+`;

--- a/components/icon/__tests__/index.test.js
+++ b/components/icon/__tests__/index.test.js
@@ -9,4 +9,11 @@ describe('Icon', () => {
     );
     expect(wrapper).toMatchSnapshot();
   });
+
+  it('should render to a <i class="xxx"><svg><use xlink:href="antd-icon-TYPENAME"/></svg></i>', () => {
+    const wrapper = render(
+      <Icon type="zhihu" className="other-class-name" />
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
 });

--- a/components/icon/index.tsx
+++ b/components/icon/index.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import classNames from 'classnames';
 import omit from 'omit.js';
+import { symbols, prefix } from 'antd-icons';
 
 export interface IconProps {
   type: string;
@@ -11,14 +12,68 @@ export interface IconProps {
   style?: React.CSSProperties;
 }
 
-const Icon = (props: IconProps) => {
-  const { type, className = '', spin } = props;
-  const classString = classNames({
-    anticon: true,
-    'anticon-spin': !!spin || type === 'loading',
-    [`anticon-${type}`]: true,
-  }, className);
-  return <i {...omit(props, ['type', 'spin'])} className={classString} />;
-};
+export interface SvgIconProps {
+  className?: string;
+  onClick?: React.MouseEventHandler<any>;
+  spin?: boolean;
+  style?: React.CSSProperties;
+  children?: React.ReactNode;
+}
+
+class Icon extends React.PureComponent<IconProps> {
+  componentDidMount() {
+    if (document) {
+      const idName = '__DO_NOT_MANUALLY_USE_ANTD_SVG_SPRITE_NODE__';
+      const spriteNode = document.getElementById(idName);
+      const mountNode = document.body;
+      if(!spriteNode && mountNode) {
+        console.log('!!!!!mounted');
+        mountNode.insertAdjacentHTML('afterbegin', `
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    id="${idName}"
+    style="position:absolute;width:0;height:0"
+  >
+    <defs>
+      ${symbols}
+    </defs>
+  </svg>
+`.trim());
+      }
+    }
+  }
+
+  render() {
+    const { type, className = '', spin } = this.props;
+    const classString = classNames({
+      anticon: true,
+      'anticon-spin': !!spin || type === 'loading'
+    }, className);
+
+    return (
+      <i {...omit(this.props, ['type', 'spin'])} className={classString}>
+        <svg width={'1em'} height={'1em'} fill={'currentColor'}>
+          <use xlinkHref={`#${prefix}${type}`}/>
+        </svg>
+      </i>
+    );
+  }
+
+  static SvgIcon(props: SvgIconProps) {
+    const { className = '', spin } = props;
+    const classString = classNames({
+      anticon: true,
+      'anticon-spin': !!spin
+    }, className);
+    return (
+      <i {...omit(props, ['spin'])} className={classString}>
+        <svg width={'1em'} height={'1em'} fill={'currentColor'}>
+          {props.children}
+        </svg>
+      </i>
+    );
+  }
+}
 
 export default Icon;

--- a/components/style/core/iconfont.less
+++ b/components/style/core/iconfont.less
@@ -299,6 +299,10 @@
   display: inline-block;
   animation: loadingCircle 1s infinite linear;
 }
+.@{iconfont-css-prefix}-spin {
+  display: inline-block;
+  animation: loadingCircle 1s infinite linear;
+}
 
 .@{iconfont-css-prefix}-weibo-square:before { content: "\e6f5"; }
 .@{iconfont-css-prefix}-weibo-circle:before { content: "\e6f4"; }

--- a/package.json
+++ b/package.json
@@ -39,12 +39,14 @@
     "react-dom": ">=16.0.0"
   },
   "dependencies": {
+    "antd-icons": "^0.0.1-alpha.9",
     "array-tree-filter": "^2.0.0",
     "babel-runtime": "6.x",
     "classnames": "~2.2.0",
     "create-react-class": "^15.6.0",
     "css-animation": "^1.2.5",
     "dom-closest": "^0.2.0",
+    "dynamic-icon": "^0.1.3",
     "enquire.js": "^2.1.1",
     "intersperse": "^1.0.0",
     "lodash": "^4.17.5",


### PR DESCRIPTION
  * [x] Update API docs for the component.
  * [ ] Update/Add demo to demonstrate new feature.
  * [ ] Update TypeScript definition for the component.
  * [ ] Add unit tests for the feature.

## current status: WIP

- import all [526 ant-design icon](http://www.iconfont.cn/collections/detail?cid=9402) as SVG symbols by default.

- support custom icons:
```jsx
// use SvgIcon
const SvgIcon = Icon.SvgIcon;
const MySpecificIcon = () => (
  <SvgIcon>
    <path d="M967 579q-37 88 -105.5 156.5t-157.5 ......"/>
  </SvgIcon>
);
render(<MySpecificIcon />, mountedNode);

// use SVG Sprite
// you need to import your SVG symbols at first
// for example, in some component
componentDidMount() {
  const symbols = '<symbol id="one">...</symbol><symbol id="two">...</symbol>';
  document.insertAdjacentHTML('afterbegin', `
  <svg
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
    id="${idName}"
    style="position:absolute;width:0;height:0"
  >
    <defs>
      ${symbols}
    </defs>
  </svg>
`.trim());
}

// usage
const CustomIcon = Icon.create({ prefix: 'icon-' });
render(<CustomIcon type="message" className="my-class"/>, mountedNode);
```

and it will render to
```html
<i class="anticon my-class">
  <svg width="1em" height="1em" fill="currentColor">
    <use xlink:href="#icon-message"/>
  </svg>
</i>
```

if you are using iconfont.cn
```jsx
// usage
const CustomIcon = Icon.create({
  prefix: 'icon-',
  namespace: 'iconfont',
  scriptLink: 'https://at.alicdn.com/t/font_8d5l8fzk5b87iudi.js' // url coming from: http://www.iconfont.cn/help/detail?spm=a313x.7781069.1998910419.d8cf4382a&helptype=code
});
render(<CustomIcon type="message" className="my-class"/>, mountedNode);
// you don't need to import svg symbols manually
```

