### PR TITLE
dva 相关外链更新到 dva 官网

### DIFF
--- a/docs/react/practical-projects.en-US.md
+++ b/docs/react/practical-projects.en-US.md
@@ -268,9 +268,9 @@ We have completed a simple application, but you may still have lots of questions
 
 You can:
 
-- Visit [dva official website](https://github.com/dvajs/dva).
-- Be familiar with the [8 Concepts](https://github.com/dvajs/dva/blob/master/docs/Concepts.md), and understand how they are connected together
-- Know all [dva APIs](https://github.com/dvajs/dva/blob/master/docs/API.md)
-- Checkout [dva knowledgemap](https://github.com/dvajs/dva-knowledgemap), including all the basic knowledge with ES6, React, dva
+- Visit [dva official website](https://dvajs.com/).
+- Be familiar with the [8 Concepts](https://dvajs.com/guide/concepts.html), and understand how they are connected together
+- Know all [dva APIs](https://dvajs.com/api/)
+- Checkout [dva knowledgemap](https://dvajs.com/knowledgemap/), including all the basic knowledge with ES6, React, dva
 - Checkout [more FAQ](https://github.com/dvajs/dva/issues?q=is%3Aissue+is%3Aclosed+label%3Afaq)
 - If your project is created with [dva-cli](https://github.com/dvajs/dva-cli) , checkout how to [Configure it](https://github.com/sorrycc/roadhog#configuration)

--- a/docs/react/practical-projects.zh-CN.md
+++ b/docs/react/practical-projects.zh-CN.md
@@ -270,9 +270,9 @@ File sizes after gzip:
 
 你可以：
 
-- 访问 [dva 官网](https://github.com/dvajs/dva)
-- 理解 dva 的 [8 个概念](https://github.com/dvajs/dva/blob/master/docs/Concepts_zh-CN.md) ，以及他们是如何串起来的
-- 掌握 dva 的[所有 API](https://github.com/dvajs/dva/blob/master/docs/API_zh-CN.md)
-- 查看 [dva 知识地图](https://github.com/dvajs/dva-knowledgemap) ，包含 ES6, React, dva 等所有基础知识
+- 访问 [dva 官网](https://dvajs.com/)
+- 理解 dva 的 [8 个概念](https://dvajs.com/guide/concepts.html) ，以及他们是如何串起来的
+- 掌握 dva 的[所有 API](https://dvajs.com/api/)
+- 查看 [dva 知识地图](https://dvajs.com/knowledgemap/) ，包含 ES6, React, dva 等所有基础知识
 - 查看 [更多 FAQ](https://github.com/dvajs/dva/issues?q=is%3Aissue+is%3Aclosed+label%3Afaq)，看看别人通常会遇到什么问题
 - 如果你基于 dva-cli 创建项目，最好了解他的 [配置方式](https://github.com/sorrycc/roadhog/blob/master/README_zh-cn.md#配置)


### PR DESCRIPTION
理解 dva 的 [8 个概念]、查看 [dva 知识地图] 的链接都404了，顺便更新到 dva 官网去