### PR TITLE
feat: prevent horizontal menu items wrapping

### DIFF
--- a/components/menu/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/menu/__tests__/__snapshots__/demo.test.js.snap
@@ -33,7 +33,9 @@ exports[`renders ./components/menu/demo/horizontal.md correctly 1`] = `
       aria-haspopup="true"
       class="ant-menu-submenu-title"
     >
-      <span>
+      <span
+        class="submenu-title-wrapper"
+      >
         <i
           class="anticon anticon-setting"
         />

--- a/components/menu/__tests__/index.test.js
+++ b/components/menu/__tests__/index.test.js
@@ -85,6 +85,7 @@ describe('Menu', () => {
     wrapper.update();
     expect(wrapper.find('.ant-menu-sub').hostNodes().at(0).hasClass('ant-menu-hidden')).toBe(true);
     wrapper.setProps({ openKeys: ['1'] });
+    wrapper.update();
     expect(wrapper.find('.ant-menu-sub').hostNodes().at(0).hasClass('ant-menu-hidden')).not.toBe(true);
   });
 
@@ -103,6 +104,7 @@ describe('Menu', () => {
     wrapper.update();
     expect(wrapper.find('.ant-menu-sub').hostNodes().at(0).hasClass('ant-menu-hidden')).toBe(true);
     wrapper.setProps({ openKeys: ['1'] });
+    wrapper.update();
     expect(wrapper.find('.ant-menu-sub').hostNodes().at(0).hasClass('ant-menu-hidden')).not.toBe(true);
   });
 
@@ -121,6 +123,7 @@ describe('Menu', () => {
     wrapper.update();
     expect(wrapper.find('.ant-menu-sub').hostNodes().at(0).hasClass('ant-menu-hidden')).toBe(true);
     wrapper.setProps({ openKeys: ['1'] });
+    wrapper.update();
     expect(wrapper.find('.ant-menu-sub').hostNodes().at(0).hasClass('ant-menu-hidden')).not.toBe(true);
   });
 

--- a/components/menu/demo/horizontal.md
+++ b/components/menu/demo/horizontal.md
@@ -37,6 +37,7 @@ class App extends React.Component {
         onClick={this.handleClick}
         selectedKeys={[this.state.current]}
         mode="horizontal"
+        triggerSubMenuAction="click"
       >
         <Menu.Item key="mail">
           <Icon type="mail" />Navigation One
@@ -44,7 +45,7 @@ class App extends React.Component {
         <Menu.Item key="app" disabled>
           <Icon type="appstore" />Navigation Two
         </Menu.Item>
-        <SubMenu title={<span><Icon type="setting" />Navigation Three - Submenu</span>}>
+        <SubMenu title={<span className="submenu-title-wrapper"><Icon type="setting" />Navigation Three - Submenu</span>}>
           <MenuItemGroup title="Item 1">
             <Menu.Item key="setting:1">Option 1</Menu.Item>
             <Menu.Item key="setting:2">Option 2</Menu.Item>

--- a/components/menu/style/index.less
+++ b/components/menu/style/index.less
@@ -179,6 +179,10 @@
       position: absolute;
       border-radius: @border-radius-base;
       z-index: @zindex-dropdown;
+
+      .submenu-title-wrapper {
+        padding-right: 20px;
+      }
     }
 
     > .@{menu-prefix-cls} {
@@ -262,12 +266,13 @@
     border-bottom: @border-width-base @border-style-base @border-color-split;
     box-shadow: none;
     line-height: 46px;
+    white-space: nowrap;
 
     > .@{menu-prefix-cls}-item,
     > .@{menu-prefix-cls}-submenu {
       position: relative;
       top: 1px;
-      float: left;
+      display: inline-block;
       border-bottom: 2px solid transparent;
 
       &:hover,


### PR DESCRIPTION
prepare to support for menu overflow ux improvement. see: https://github.com/react-component/menu/issues/148

should go after we have we merged https://github.com/react-component/menu/pull/159 and used it as a dependency.

![wrapping](https://user-images.githubusercontent.com/1731837/42550555-0fef7878-8505-11e8-9d2f-f708fec66b44.gif)
