### PR TITLE
feat(Avatar): expose onError

### DIFF
--- a/components/avatar/index.en-US.md
+++ b/components/avatar/index.en-US.md
@@ -15,3 +15,4 @@ Avatars can be used to represent people or objects. It supports images, `Icon`s,
 | size | the size of the avatar | `large` \| `small` \| `default` | `default` |
 | src | the address of the image for an image avatar | string | - |
 | alt | This attribute defines the alternative text describing the image | string | - |
+| onError | handler when img load error，return false to prevent default fallback behavior | () => boolean | - |

--- a/components/avatar/index.tsx
+++ b/components/avatar/index.tsx
@@ -18,7 +18,7 @@ export interface AvatarProps {
   children?: any;
   alt?: string;
   /* callback when img load error */
-  /* return true to prevent Avatar show default fallback behavior, then you can do fallback by your self*/
+  /* return false to prevent Avatar show default fallback behavior, then you can do fallback by your self*/
   onError?: () => boolean;
 }
 

--- a/components/avatar/index.tsx
+++ b/components/avatar/index.tsx
@@ -17,6 +17,9 @@ export interface AvatarProps {
   className?: string;
   children?: any;
   alt?: string;
+  /* callback when img load error */
+  /* return true to prevent Avatar show default fallback behavior, then you can do fallback by your self*/
+  onError?: () => boolean;
 }
 
 export interface AvatarState {
@@ -72,7 +75,13 @@ export default class Avatar extends React.Component<AvatarProps, AvatarState> {
     }
   }
 
-  handleImgLoadError = () => this.setState({ isImgExist: false });
+  handleImgLoadError = () => {
+    const { onError } = this.props;
+    const preventFallback =  onError && onError();
+    if (preventFallback !== false) {
+      this.setState({ isImgExist: false });
+    }
+  }
 
   render() {
     const {

--- a/components/avatar/index.zh-CN.md
+++ b/components/avatar/index.zh-CN.md
@@ -16,3 +16,4 @@ title: Avatar
 | size | 设置头像的大小 | Enum{ 'large', 'small', 'default' } | `default` |
 | src | 图片类头像的资源地址 | string | - |
 | alt | 图像无法显示时的替代文本 | string | - |
+| onError | 图片加载失败的事件，返回 false 会关闭组件默认的 fallback 行为 | () => boolean | - |


### PR DESCRIPTION
## Example


```js
class Foo extends React.Component {
  state = {
   src: "https://cdn.com/foo.png@100h.src", // `@100h.src` is a cdn scale param, but it may fail 
 }
  handleImgError = () => {
    this.setState({
      src: "https://cdn.com//foo.png", // fallback to original big image
   });
 }
  render() {
     return <Avatar src={this.state.src} onError={this.handleImgError}/>
  }
}
```




First of all, thank you for your contribution! :-)

Please makes sure that these checkboxes are checked before submitting your PR, thank you!

* [ ] Make sure that you propose PR to right branch: bugfix for `master`, feature for latest active branch `feature-x.x`.
* [ ] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [ ] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [ ] Rebase before creating a PR to keep commit history clear.
* [ ] Add some descriptions and refer relative issues for you PR.

Extra checklist:

**if** *isBugFix* **:**

  * [ ] Make sure that you add at least one unit test for the bug which you had fixed.

**elif** *isNewFeature* **:**

  * [ ] Update API docs for the component.
  * [ ] Update/Add demo to demonstrate new feature.
  * [ ] Update TypeScript definition for the component.
  * [ ] Add unit tests for the feature.
