### PR TITLE
Remove scrollbar on confirm Modal title

### DIFF
--- a/components/modal/style/confirm.less
+++ b/components/modal/style/confirm.less
@@ -24,7 +24,7 @@
       color: @heading-color;
       font-weight: 500;
       font-size: @font-size-lg;
-      line-height: 22px;
+      line-height: 1.375;
       display: block;
       // create BFC to avoid
       // https://user-images.githubusercontent.com/507615/37702510-ba844e06-2d2d-11e8-9b67-8e19be57f445.png


### PR DESCRIPTION
Environment: Windows 10 Chrome 67.0.3396.99 (Official Build) (64-bit),

There's a scrollbar on confirm Modal title.
This happened to me because I set `@font-size-base` to `16px` (Default is `14px`).
It will cause `@font-size-lg` to be `18px` (Default is `16px`).

![image](https://user-images.githubusercontent.com/9879279/42739076-93abbdb0-8844-11e8-97f8-7c97ec3d79ec.png)
![image](https://user-images.githubusercontent.com/9879279/42739091-d32dbf74-8844-11e8-9304-f47293d0e03a.png)

The current `line-height` of tittle is fixed to `22px`. However it should be a ratio related to the font size.
The default `@font-size-lg` is `16px`, so the `line-height` should be 22 / 16 = 1.375.

![image](https://user-images.githubusercontent.com/9879279/42739372-09933728-884b-11e8-9fcd-d97ca4ce9f77.png)

After `height-line` is changed to `1.375`, no matter what `font-size` is, the scrollbar is no longer there.

![image](https://user-images.githubusercontent.com/9879279/42739421-f2a1fecc-884b-11e8-91c1-c7ea121c34e3.png)
