### PR TITLE
Change label in TreeData interface to title, since label is deprecated

### DIFF
--- a/components/tree-select/interface.tsx
+++ b/components/tree-select/interface.tsx
@@ -4,7 +4,7 @@ import { AbstractSelectProps } from '../select';
 export interface TreeData {
   key: string;
   value: string;
-  label: React.ReactNode;
+  title: React.ReactNode;
   children?: TreeData[];
 }
 


### PR DESCRIPTION
Updating TreeData interface to fix this warning message (Warning: 'label' in treeData is deprecated. Please use 'title' instead.)
![image](https://user-images.githubusercontent.com/13233903/43160201-6c094dba-8f7c-11e8-9642-d9eb21997c72.png)
