### PR TITLE
Update Pagination Typescript definition to include "role"

### DIFF
--- a/components/pagination/Pagination.tsx
+++ b/components/pagination/Pagination.tsx
@@ -27,6 +27,9 @@ export interface PaginationProps {
   prefixCls?: string;
   selectPrefixCls?: string;
   itemRender?: (page: number, type: 'page' | 'prev' | 'next' | 'jump-prev' | 'jump-next') => React.ReactNode;
+  'data-*'?: string | number | boolean;
+  'aria-*'?: string | number | boolean;
+  role?: string;
 }
 
 export interface PaginationConfig extends PaginationProps {

--- a/components/pagination/Pagination.tsx
+++ b/components/pagination/Pagination.tsx
@@ -27,8 +27,6 @@ export interface PaginationProps {
   prefixCls?: string;
   selectPrefixCls?: string;
   itemRender?: (page: number, type: 'page' | 'prev' | 'next' | 'jump-prev' | 'jump-next') => React.ReactNode;
-  'data-*'?: string | number | boolean;
-  'aria-*'?: string | number | boolean;
   role?: string;
 }
 


### PR DESCRIPTION
A [PR on rc-pagination](https://github.com/react-component/pagination/pull/135/files) added the ability to define `data-`, `aria-` and `role` attributes. This PR is just adding the `role` attribute to the definition.

Definitions for `data-` and `aria-` are not required since they are already allowed as props on Pagination.