### PR TITLE
Fix #11381 - Allow validator message as ReactChild

### DIFF
--- a/components/form/Form.tsx
+++ b/components/form/Form.tsx
@@ -40,7 +40,7 @@ export interface FormProps extends React.FormHTMLAttributes<HTMLFormElement> {
 
 export type ValidationRule = {
   /** validation error message */
-  message?: string;
+  message?: React.ReactChild;
   /** built-in validation type, available options: https://github.com/yiminghe/async-validator#type */
   type?: string;
   /** indicates whether field is required */

--- a/components/form/Form.tsx
+++ b/components/form/Form.tsx
@@ -40,7 +40,7 @@ export interface FormProps extends React.FormHTMLAttributes<HTMLFormElement> {
 
 export type ValidationRule = {
   /** validation error message */
-  message?: React.ReactChild;
+  message?: React.ReactNode;
   /** built-in validation type, available options: https://github.com/yiminghe/async-validator#type */
   type?: string;
   /** indicates whether field is required */


### PR DESCRIPTION
The validated message in getFieldDecorator should be any or ReactChild (type ReactChild = ReactElement<any> | ReactText) according to [async-validator](https://github.com/yiminghe/async-validator#messages), which indicated messages is allowed to use element.

