### PR TITLE
Clean up TextAreaProps type

### DIFF
--- a/components/input/TextArea.tsx
+++ b/components/input/TextArea.tsx
@@ -23,7 +23,6 @@ export interface AutoSizeType {
   maxRows?: number;
 }
 
-
 export type HTMLTextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
 
 export interface TextAreaProps extends HTMLTextareaProps {

--- a/components/input/TextArea.tsx
+++ b/components/input/TextArea.tsx
@@ -23,7 +23,10 @@ export interface AutoSizeType {
   maxRows?: number;
 }
 
-export interface TextAreaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {
+
+export type HTMLTextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
+
+export interface TextAreaProps extends HTMLTextareaProps {
   prefixCls?: string;
   autosize?: boolean | AutoSizeType;
   onPressEnter?: React.KeyboardEventHandler<HTMLTextAreaElement>;
@@ -33,9 +36,7 @@ export interface TextAreaState {
   textareaStyles?: React.CSSProperties;
 }
 
-export type HTMLTextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
-
-export default class TextArea extends React.Component<TextAreaProps & HTMLTextareaProps, TextAreaState> {
+export default class TextArea extends React.Component<TextAreaProps, TextAreaState> {
   static defaultProps = {
     prefixCls: 'ant-input',
   };


### PR DESCRIPTION
The props for TextArea included React.TextareaHTMLAttributes twice
