### PR TITLE
Add strokeLinecap attribute to progress component

### DIFF
--- a/components/progress/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/progress/__tests__/__snapshots__/demo.test.js.snap
@@ -380,7 +380,7 @@ exports[`renders ./components/progress/demo/dynamic.md correctly 1`] = `
         >
           <div
             class="ant-progress-bg"
-            style="width:0%;height:8px"
+            style="width:0%;height:8px;border-radius:100px"
           />
         </div>
       </div>
@@ -513,7 +513,7 @@ exports[`renders ./components/progress/demo/line.md correctly 1`] = `
         >
           <div
             class="ant-progress-bg"
-            style="width:30%;height:8px"
+            style="width:30%;height:8px;border-radius:100px"
           />
         </div>
       </div>
@@ -536,7 +536,7 @@ exports[`renders ./components/progress/demo/line.md correctly 1`] = `
         >
           <div
             class="ant-progress-bg"
-            style="width:50%;height:8px"
+            style="width:50%;height:8px;border-radius:100px"
           />
         </div>
       </div>
@@ -559,7 +559,7 @@ exports[`renders ./components/progress/demo/line.md correctly 1`] = `
         >
           <div
             class="ant-progress-bg"
-            style="width:70%;height:8px"
+            style="width:70%;height:8px;border-radius:100px"
           />
         </div>
       </div>
@@ -584,7 +584,7 @@ exports[`renders ./components/progress/demo/line.md correctly 1`] = `
         >
           <div
             class="ant-progress-bg"
-            style="width:100%;height:8px"
+            style="width:100%;height:8px;border-radius:100px"
           />
         </div>
       </div>
@@ -609,7 +609,7 @@ exports[`renders ./components/progress/demo/line.md correctly 1`] = `
         >
           <div
             class="ant-progress-bg"
-            style="width:50%;height:8px"
+            style="width:50%;height:8px;border-radius:100px"
           />
         </div>
       </div>
@@ -634,7 +634,7 @@ exports[`renders ./components/progress/demo/line-mini.md correctly 1`] = `
         >
           <div
             class="ant-progress-bg"
-            style="width:30%;height:6px"
+            style="width:30%;height:6px;border-radius:100px"
           />
         </div>
       </div>
@@ -657,7 +657,7 @@ exports[`renders ./components/progress/demo/line-mini.md correctly 1`] = `
         >
           <div
             class="ant-progress-bg"
-            style="width:50%;height:6px"
+            style="width:50%;height:6px;border-radius:100px"
           />
         </div>
       </div>
@@ -680,7 +680,7 @@ exports[`renders ./components/progress/demo/line-mini.md correctly 1`] = `
         >
           <div
             class="ant-progress-bg"
-            style="width:70%;height:6px"
+            style="width:70%;height:6px;border-radius:100px"
           />
         </div>
       </div>
@@ -705,7 +705,7 @@ exports[`renders ./components/progress/demo/line-mini.md correctly 1`] = `
         >
           <div
             class="ant-progress-bg"
-            style="width:100%;height:6px"
+            style="width:100%;height:6px;border-radius:100px"
           />
         </div>
       </div>
@@ -715,6 +715,114 @@ exports[`renders ./components/progress/demo/line-mini.md correctly 1`] = `
         <i
           class="anticon anticon-check-circle"
         />
+      </span>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`renders ./components/progress/demo/linecap.md correctly 1`] = `
+<div>
+  <div
+    class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default"
+  >
+    <div>
+      <div
+        class="ant-progress-outer"
+      >
+        <div
+          class="ant-progress-inner"
+        >
+          <div
+            class="ant-progress-bg"
+            style="width:75%;height:8px;border-radius:0"
+          />
+        </div>
+      </div>
+      <span
+        class="ant-progress-text"
+      >
+        75%
+      </span>
+    </div>
+  </div>
+  <div
+    class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default"
+  >
+    <div
+      class="ant-progress-inner"
+      style="width:120px;height:120px;font-size:24px"
+    >
+      <svg
+        class="ant-progress-circle "
+        viewBox="0 0 100 100"
+      >
+        <path
+          class="ant-progress-circle-trail"
+          d="M 50,50 m 0,-47
+     a 47,47 0 1 1 0,94
+     a 47,47 0 1 1 0,-94"
+          fill-opacity="0"
+          stroke="#f3f3f3"
+          stroke-width="6"
+          style="stroke-dasharray:295.3097094374406px 295.3097094374406px;stroke-dashoffset:-0px;transition:stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s"
+        />
+        <path
+          class="ant-progress-circle-path"
+          d="M 50,50 m 0,-47
+     a 47,47 0 1 1 0,94
+     a 47,47 0 1 1 0,-94"
+          fill-opacity="0"
+          stroke="#108ee9"
+          stroke-linecap="square"
+          stroke-width="6"
+          style="stroke-dasharray:221.48228207808043px 295.3097094374406px;stroke-dashoffset:-0px;transition:stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s"
+        />
+      </svg>
+      <span
+        class="ant-progress-text"
+      >
+        75%
+      </span>
+    </div>
+  </div>
+  <div
+    class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default"
+  >
+    <div
+      class="ant-progress-inner"
+      style="width:120px;height:120px;font-size:24px"
+    >
+      <svg
+        class="ant-progress-circle "
+        viewBox="0 0 100 100"
+      >
+        <path
+          class="ant-progress-circle-trail"
+          d="M 50,50 m 0,47
+     a 47,47 0 1 1 0,-94
+     a 47,47 0 1 1 0,94"
+          fill-opacity="0"
+          stroke="#f3f3f3"
+          stroke-width="6"
+          style="stroke-dasharray:220.30970943744057px 295.3097094374406px;stroke-dashoffset:-37.5px;transition:stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s"
+        />
+        <path
+          class="ant-progress-circle-path"
+          d="M 50,50 m 0,47
+     a 47,47 0 1 1 0,-94
+     a 47,47 0 1 1 0,94"
+          fill-opacity="0"
+          stroke="#108ee9"
+          stroke-linecap="square"
+          stroke-width="6"
+          style="stroke-dasharray:165.23228207808043px 295.3097094374406px;stroke-dashoffset:-37.5px;transition:stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s"
+        />
+      </svg>
+      <span
+        class="ant-progress-text"
+      >
+        75%
       </span>
     </div>
   </div>
@@ -734,11 +842,11 @@ exports[`renders ./components/progress/demo/segment.md correctly 1`] = `
       >
         <div
           class="ant-progress-bg"
-          style="width:60%;height:8px"
+          style="width:60%;height:8px;border-radius:100px"
         />
         <div
           class="ant-progress-success-bg"
-          style="width:30%;height:8px"
+          style="width:30%;height:8px;border-radius:100px"
         />
       </div>
     </div>

--- a/components/progress/__tests__/__snapshots__/index.test.js.snap
+++ b/components/progress/__tests__/__snapshots__/index.test.js.snap
@@ -13,11 +13,11 @@ exports[`Progress render format 1`] = `
       >
         <div
           class="ant-progress-bg"
-          style="width: 50%; height: 8px;"
+          style="width: 50%; height: 8px; border-radius: 100px;"
         />
         <div
           class="ant-progress-success-bg"
-          style="width: 10%; height: 8px;"
+          style="width: 10%; height: 8px; border-radius: 100px;"
         />
       </div>
     </div>
@@ -43,7 +43,7 @@ exports[`Progress render negetive progress 1`] = `
       >
         <div
           class="ant-progress-bg"
-          style="width: 0%; height: 8px;"
+          style="width: 0%; height: 8px; border-radius: 100px;"
         />
       </div>
     </div>
@@ -69,11 +69,11 @@ exports[`Progress render negetive successPercent 1`] = `
       >
         <div
           class="ant-progress-bg"
-          style="width: 50%; height: 8px;"
+          style="width: 50%; height: 8px; border-radius: 100px;"
         />
         <div
           class="ant-progress-success-bg"
-          style="width: 0%; height: 8px;"
+          style="width: 0%; height: 8px; border-radius: 100px;"
         />
       </div>
     </div>
@@ -99,7 +99,7 @@ exports[`Progress render out-of-range progress 1`] = `
       >
         <div
           class="ant-progress-bg"
-          style="width: 100%; height: 8px;"
+          style="width: 100%; height: 8px; border-radius: 100px;"
         />
       </div>
     </div>
@@ -127,7 +127,7 @@ exports[`Progress render out-of-range progress with info 1`] = `
       >
         <div
           class="ant-progress-bg"
-          style="width: 100%; height: 8px;"
+          style="width: 100%; height: 8px; border-radius: 100px;"
         />
       </div>
     </div>

--- a/components/progress/demo/linecap.md
+++ b/components/progress/demo/linecap.md
@@ -1,0 +1,26 @@
+---
+order: 10
+title:
+  zh-CN:
+  en-US: Square linecaps
+---
+
+## zh-CN
+
+`strokeLinecap="square"`
+
+## en-US
+
+By setting `strokeLinecap="square`, you can change the linecaps from round to square.
+
+````jsx
+import { Progress } from 'antd';
+
+ReactDOM.render(
+  <div>
+    <Progress strokeLinecap="square" percent={75} />
+    <Progress strokeLinecap="square" type="circle" percent={75} />
+    <Progress strokeLinecap="square" type="dashboard" percent={75} />
+  </div>,
+  mountNode);
+````

--- a/components/progress/index.en-US.md
+++ b/components/progress/index.en-US.md
@@ -25,6 +25,7 @@ If it will take a long time to complete an operation, you can use `Progress` to 
 | status | to set the status of the Progress, options: `success` `exception` `active` | string | - |
 | strokeWidth `(type=line)` | to set the width of the progress bar, unit: `px` | number | 10 |
 | strokeWidth `(type=circle)` | to set the width of the circular progress bar, unit: percentage of the canvas width | number | 6 |
+| strokeLinecap | to set the style of the progress linecap | Enum{ 'round', 'square' } | `round` |
 | strokeColor | color of progress bar | string | - |
 | successPercent | segmented success percent, works when `type="line"` | number | 0 |
 | type | to set the type, options: `line` `circle` `dashboard` | string | `line` |

--- a/components/progress/index.zh-CN.md
+++ b/components/progress/index.zh-CN.md
@@ -26,6 +26,7 @@ title: Progress
 | status | 状态，可选：`success` `exception` `active` | string | - |
 | strokeWidth `(type=line)` | 进度条线的宽度，单位 px | number | 10 |
 | strokeWidth `(type=circle)` | 圆形进度条线的宽度，单位是进度条画布宽度的百分比 | number | 6 |
+| strokeLinecap | | Enum{ 'round', 'square' } | `round` |
 | strokeColor | 进度条的色彩 | string | - |
 | successPercent | 已完成的分段百分比，`type="line"` 时有效 | number | 0 |
 | type | 类型，可选 `line` `circle` `dashboard` | string | line |

--- a/components/progress/progress.tsx
+++ b/components/progress/progress.tsx
@@ -23,6 +23,7 @@ export interface ProgressProps {
   status?: 'success' | 'active' | 'exception';
   showInfo?: boolean;
   strokeWidth?: number;
+  strokeLinecap?: string;
   strokeColor?: string;
   trailColor?: string;
   width?: number;
@@ -61,6 +62,7 @@ export default class Progress extends React.Component<ProgressProps, {}> {
     percent: PropTypes.number,
     width: PropTypes.number,
     strokeWidth: PropTypes.number,
+    strokeLinecap: PropTypes.oneOf(['round', 'square']),
     strokeColor: PropTypes.string,
     trailColor: PropTypes.string,
     format: PropTypes.func,
@@ -72,7 +74,7 @@ export default class Progress extends React.Component<ProgressProps, {}> {
     const props = this.props;
     const {
       prefixCls, className, percent = 0, status, format, trailColor, size, successPercent,
-      type, strokeWidth, width, showInfo, gapDegree = 0, gapPosition, strokeColor,
+      type, strokeWidth, width, showInfo, gapDegree = 0, gapPosition, strokeColor, strokeLinecap = 'round',
       ...restProps
     } = props;
     const progressStatus = parseInt((successPercent ? successPercent.toString() : percent.toString()), 10) >= 100 &&
@@ -99,10 +101,12 @@ export default class Progress extends React.Component<ProgressProps, {}> {
         width: `${validProgress(percent)}%`,
         height: strokeWidth || (size === 'small' ? 6 : 8),
         background: strokeColor,
+        borderRadius: strokeLinecap === 'square' ? 0 : '100px',
       };
       const successPercentStyle = {
         width: `${validProgress(successPercent)}%`,
         height: strokeWidth || (size === 'small' ? 6 : 8),
+        borderRadius: strokeLinecap === 'square' ? 0 : '100px',
       };
       const successSegment = successPercent !== undefined
         ? <div className={`${prefixCls}-success-bg`} style={successPercentStyle} />
@@ -135,6 +139,7 @@ export default class Progress extends React.Component<ProgressProps, {}> {
             strokeWidth={circleWidth}
             trailWidth={circleWidth}
             strokeColor={(statusColorMap as any)[progressStatus]}
+            strokeLinecap={strokeLinecap}
             trailColor={trailColor}
             prefixCls={prefixCls}
             gapDegree={gapDeg}

--- a/components/progress/style/index.less
+++ b/components/progress/style/index.less
@@ -49,7 +49,6 @@
 
   &-success-bg,
   &-bg {
-    border-radius: 100px;
     background-color: @progress-default-color;
     transition: all .4s @ease-out-circ 0s;
     position: relative;

--- a/components/upload/__tests__/__snapshots__/uploadlist.test.js.snap
+++ b/components/upload/__tests__/__snapshots__/uploadlist.test.js.snap
@@ -64,7 +64,7 @@ exports[`Upload List handle error 1`] = `
               >
                 <div
                   class="ant-progress-bg"
-                  style="width: 0%; height: 2px;"
+                  style="width: 0%; height: 2px; border-radius: 100px;"
                 />
               </div>
             </div>
@@ -140,7 +140,7 @@ exports[`Upload List should be uploading when upload a file 1`] = `
               >
                 <div
                   class="ant-progress-bg"
-                  style="width: 0%; height: 2px;"
+                  style="width: 0%; height: 2px; border-radius: 100px;"
                 />
               </div>
             </div>
@@ -216,7 +216,7 @@ exports[`Upload List should be uploading when upload a file 2`] = `
               >
                 <div
                   class="ant-progress-bg"
-                  style="width: 0%; height: 2px;"
+                  style="width: 0%; height: 2px; border-radius: 100px;"
                 />
               </div>
             </div>


### PR DESCRIPTION
### Description:
Allow to control `strokeLinecap` of progress bar (`square` or `round`). `round` stays the default.

### PR Checklist:

* [x] Make sure that you propose PR to right branch: bugfix for `master`, feature for latest active branch `feature-x.x`.
* [x] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.

Extra checklist **NewFeature**:

  * [x] Update API docs for the component.
  * [x] Update/Add demo to demonstrate new feature.
  * [x] Update TypeScript definition for the component.
  * [ ] Add unit tests for the feature.
