### PR TITLE
Move colors definitions from the components less files to default.less

### DIFF
--- a/components/alert/style/index.less
+++ b/components/alert/style/index.less
@@ -74,7 +74,7 @@
       color: @alert-close-color;
       transition: color .3s;
       &:hover {
-        color: #404040;
+        color: @icon-color;
       }
     }
   }

--- a/components/alert/style/index.less
+++ b/components/alert/style/index.less
@@ -74,7 +74,7 @@
       color: @alert-close-color;
       transition: color .3s;
       &:hover {
-        color: @icon-color;
+        color: @icon-color-hover;
       }
     }
   }

--- a/components/badge/style/index.less
+++ b/components/badge/style/index.less
@@ -27,7 +27,7 @@
     font-weight: @badge-font-weight;
     white-space: nowrap;
     transform-origin: -10% center;
-    box-shadow: 0 0 0 1px @alternate-shadow-color;
+    box-shadow: 0 0 0 1px @shadow-color-inverse;
     a,
     a:hover {
       color: @badge-text-color;
@@ -48,7 +48,7 @@
     border-radius: 100%;
     background: @highlight-color;
     z-index: 10;
-    box-shadow: 0 0 0 1px @alternate-shadow-color;
+    box-shadow: 0 0 0 1px @shadow-color-inverse;
   }
 
   &-status {

--- a/components/badge/style/index.less
+++ b/components/badge/style/index.less
@@ -19,7 +19,7 @@
     border-radius: @badge-height / 2;
     min-width: @badge-height;
     background: @highlight-color;
-    color: #fff;
+    color: @badge-color;
     line-height: @badge-height;
     text-align: center;
     padding: 0 6px;
@@ -27,10 +27,10 @@
     font-weight: @badge-font-weight;
     white-space: nowrap;
     transform-origin: -10% center;
-    box-shadow: 0 0 0 1px #fff;
+    box-shadow: 0 0 0 1px @alternate-shadow-color;
     a,
     a:hover {
-      color: #fff;
+      color: @badge-color;
     }
   }
 
@@ -48,7 +48,7 @@
     border-radius: 100%;
     background: @highlight-color;
     z-index: 10;
-    box-shadow: 0 0 0 1px #fff;
+    box-shadow: 0 0 0 1px @alternate-shadow-color;
   }
 
   &-status {

--- a/components/badge/style/index.less
+++ b/components/badge/style/index.less
@@ -19,7 +19,7 @@
     border-radius: @badge-height / 2;
     min-width: @badge-height;
     background: @highlight-color;
-    color: @badge-color;
+    color: @badge-text-color;
     line-height: @badge-height;
     text-align: center;
     padding: 0 6px;
@@ -30,7 +30,7 @@
     box-shadow: 0 0 0 1px @alternate-shadow-color;
     a,
     a:hover {
-      color: @badge-color;
+      color: @badge-text-color;
     }
   }
 

--- a/components/button/style/index.less
+++ b/components/button/style/index.less
@@ -76,7 +76,7 @@
     left: -1px;
     bottom: -1px;
     right: -1px;
-    background: #fff;
+    background: @component-background;
     opacity: 0.35;
     content: '';
     border-radius: inherit;
@@ -151,8 +151,8 @@
 
   &-background-ghost {
     background: transparent !important;
-    border-color: #fff;
-    color: #fff;
+    border-color: @component-background;
+    color: @component-background;
   }
 
   &-background-ghost&-primary {

--- a/components/button/style/mixin.less
+++ b/components/button/style/mixin.less
@@ -59,7 +59,7 @@
   }
 
   &:focus {
-    .button-color(~`colorPalette("@{color}", 5)`; #fff; ~`colorPalette("@{color}", 5)`);
+    .button-color(~`colorPalette("@{color}", 5)`; transparent; ~`colorPalette("@{color}", 5)`);
   }
 
   &:active,

--- a/components/button/style/mixin.less
+++ b/components/button/style/mixin.less
@@ -59,7 +59,7 @@
   }
 
   &:focus {
-    .button-color(~`colorPalette("@{color}", 5)`; transparent; ~`colorPalette("@{color}", 5)`);
+    .button-color(~`colorPalette("@{color}", 5)`; @component-background; ~`colorPalette("@{color}", 5)`);
   }
 
   &:active,

--- a/components/calendar/style/index.less
+++ b/components/calendar/style/index.less
@@ -106,7 +106,7 @@
 
     &:active {
       background: @primary-color;
-      color: @alternate-text-color;
+      color: @text-color-inverse;
     }
   }
 
@@ -122,7 +122,7 @@
   &-selected-day &-value,
   &-month-panel-selected-cell &-value {
     background: @primary-color;
-    color: @alternate-text-color;
+    color: @text-color-inverse;
   }
 
   &-disabled-cell-first-of-row &-value {

--- a/components/calendar/style/index.less
+++ b/components/calendar/style/index.less
@@ -106,7 +106,7 @@
 
     &:active {
       background: @primary-color;
-      color: #fff;
+      color: @alternate-text-color;
     }
   }
 
@@ -122,7 +122,7 @@
   &-selected-day &-value,
   &-month-panel-selected-cell &-value {
     background: @primary-color;
-    color: #fff;
+    color: @alternate-text-color;
   }
 
   &-disabled-cell-first-of-row &-value {

--- a/components/card/style/index.less
+++ b/components/card/style/index.less
@@ -3,7 +3,10 @@
 
 @card-prefix-cls: ~"@{ant-prefix}-card";
 @card-head-height: 48px;
-@card-hover-border: rgba(0, 0, 0, 0.09);
+@card-hover-border: fade(@alternate-color, 9%);
+
+@gradient-min: fade(@card-background, 20%);
+@gradient-max: fade(@card-background, 40%);
 
 .@{card-prefix-cls} {
   .reset-component;
@@ -233,7 +236,7 @@
     height: 14px;
     margin: 4px 0;
     border-radius: @border-radius-sm;
-    background: linear-gradient(90deg, rgba(207, 216, 220, .2), rgba(207, 216, 220, .4), rgba(207, 216, 220, .2));
+    background: linear-gradient(90deg, @gradient-min, @gradient-max, @gradient-min);
     animation: card-loading 1.4s ease infinite;
     background-size: 600% 600%;
   }

--- a/components/card/style/index.less
+++ b/components/card/style/index.less
@@ -3,7 +3,7 @@
 
 @card-prefix-cls: ~"@{ant-prefix}-card";
 @card-head-height: 48px;
-@card-hover-border: fade(@alternate-color, 9%);
+@card-hover-border: fade(@black, 9%);
 
 @gradient-min: fade(@card-background, 20%);
 @gradient-max: fade(@card-background, 40%);

--- a/components/carousel/style/index.less
+++ b/components/carousel/style/index.less
@@ -157,7 +157,7 @@
       button {
         border: 0;
         cursor: pointer;
-        background: #fff;
+        background: @component-background;
         opacity: 0.3;
         display: block;
         width: @carousel-dot-width;
@@ -174,7 +174,7 @@
         }
       }
       &.slick-active button {
-        background: #fff;
+        background: @component-background;
         opacity: 1;
         width: @carousel-dot-active-width;
         &:hover,

--- a/components/date-picker/style/Calendar.less
+++ b/components/date-picker/style/Calendar.less
@@ -86,7 +86,7 @@
   position: relative;
   outline: none;
   width: 280px;
-  border: @border-width-base @border-style-base #fff;
+  border: @border-width-base @border-style-base @alternate-border-color;
   list-style: none;
   font-size: @font-size-base;
   text-align: left;
@@ -194,7 +194,7 @@
     }
 
     &:active {
-      color: #fff;
+      color: @alternate-text-color;
       background: @primary-5;
     }
   }
@@ -217,7 +217,7 @@
   &-selected-date, &-selected-start-date, &-selected-end-date {
     .@{calendar-prefix-cls}-date {
       background: @primary-color;
-      color: #fff;
+      color: @alternate-text-color;
       border: @border-width-base @border-style-base transparent;
 
       &:hover {
@@ -228,7 +228,7 @@
 
   &-disabled-cell &-date {
     cursor: not-allowed;
-    color: #bcbcbc;
+    color: @disabled-color;
     background: @disabled-bg;
     border-radius: 0;
     width: auto;
@@ -249,7 +249,7 @@
       left: 5px;
       width: 24px;
       height: 24px;
-      border: @border-width-base @border-style-base #bcbcbc;
+      border: @border-width-base @border-style-base @disabled-color;
       border-radius: @border-radius-sm;
     }
   }

--- a/components/date-picker/style/Calendar.less
+++ b/components/date-picker/style/Calendar.less
@@ -86,7 +86,7 @@
   position: relative;
   outline: none;
   width: 280px;
-  border: @border-width-base @border-style-base @alternate-border-color;
+  border: @border-width-base @border-style-base @border-color-inverse;
   list-style: none;
   font-size: @font-size-base;
   text-align: left;

--- a/components/date-picker/style/Calendar.less
+++ b/components/date-picker/style/Calendar.less
@@ -194,7 +194,7 @@
     }
 
     &:active {
-      color: @alternate-text-color;
+      color: @text-color-inverse;
       background: @primary-5;
     }
   }
@@ -217,7 +217,7 @@
   &-selected-date, &-selected-start-date, &-selected-end-date {
     .@{calendar-prefix-cls}-date {
       background: @primary-color;
-      color: @alternate-text-color;
+      color: @text-color-inverse;
       border: @border-width-base @border-style-base transparent;
 
       &:hover {

--- a/components/date-picker/style/DecadePanel.less
+++ b/components/date-picker/style/DecadePanel.less
@@ -54,11 +54,11 @@
 
 .@{calendar-prefix-cls}-decade-panel-selected-cell .@{calendar-prefix-cls}-decade-panel-decade {
   background: @primary-color;
-  color: @alternate-text-color;
+  color: @text-color-inverse;
 
   &:hover {
     background: @primary-color;
-    color: @alternate-text-color;
+    color: @text-color-inverse;
   }
 }
 

--- a/components/date-picker/style/DecadePanel.less
+++ b/components/date-picker/style/DecadePanel.less
@@ -54,11 +54,11 @@
 
 .@{calendar-prefix-cls}-decade-panel-selected-cell .@{calendar-prefix-cls}-decade-panel-decade {
   background: @primary-color;
-  color: #fff;
+  color: @alternate-text-color;
 
   &:hover {
     background: @primary-color;
-    color: #fff;
+    color: @alternate-text-color;
   }
 }
 

--- a/components/date-picker/style/MonthPanel.less
+++ b/components/date-picker/style/MonthPanel.less
@@ -35,11 +35,11 @@
 
 .@{calendar-prefix-cls}-month-panel-selected-cell .@{calendar-prefix-cls}-month-panel-month {
   background: @primary-color;
-  color: #fff;
+  color: @alternate-text-color;
 
   &:hover {
     background: @primary-color;
-    color: #fff;
+    color: @alternate-text-color;
   }
 }
 
@@ -50,7 +50,7 @@
     &,
     &:hover {
       cursor: not-allowed;
-      color: #bcbcbc;
+      color: @disabled-color;
       background: @disabled-bg;
     }
   }

--- a/components/date-picker/style/MonthPanel.less
+++ b/components/date-picker/style/MonthPanel.less
@@ -35,11 +35,11 @@
 
 .@{calendar-prefix-cls}-month-panel-selected-cell .@{calendar-prefix-cls}-month-panel-month {
   background: @primary-color;
-  color: @alternate-text-color;
+  color: @text-color-inverse;
 
   &:hover {
     background: @primary-color;
-    color: @alternate-text-color;
+    color: @text-color-inverse;
   }
 }
 

--- a/components/date-picker/style/YearPanel.less
+++ b/components/date-picker/style/YearPanel.less
@@ -57,11 +57,11 @@
 
 .@{calendar-prefix-cls}-year-panel-selected-cell .@{calendar-prefix-cls}-year-panel-year {
   background: @primary-color;
-  color: #fff;
+  color: @alternate-text-color;
 
   &:hover {
     background: @primary-color;
-    color: #fff;
+    color: @alternate-text-color;
   }
 }
 

--- a/components/date-picker/style/YearPanel.less
+++ b/components/date-picker/style/YearPanel.less
@@ -57,11 +57,11 @@
 
 .@{calendar-prefix-cls}-year-panel-selected-cell .@{calendar-prefix-cls}-year-panel-year {
   background: @primary-color;
-  color: @alternate-text-color;
+  color: @text-color-inverse;
 
   &:hover {
     background: @primary-color;
-    color: @alternate-text-color;
+    color: @text-color-inverse;
   }
 }
 

--- a/components/drawer/style/drawer.less
+++ b/components/drawer/style/drawer.less
@@ -107,7 +107,7 @@
 
     &:focus,
     &:hover {
-      color: @icon-color;
+      color: @icon-color-hover;
       text-decoration: none;
     }
   }

--- a/components/drawer/style/drawer.less
+++ b/components/drawer/style/drawer.less
@@ -107,7 +107,7 @@
 
     &:focus,
     &:hover {
-      color: #444;
+      color: @icon-color;
       text-decoration: none;
     }
   }

--- a/components/dropdown/style/index.less
+++ b/components/dropdown/style/index.less
@@ -219,7 +219,7 @@
       color: @text-color-secondary-dark;
     }
     &:hover {
-      color: #fff;
+      color: @alternate-text-color;
       background: transparent;
     }
   }
@@ -228,7 +228,7 @@
     &:hover,
     > a {
       background: @primary-color;
-      color: #fff;
+      color: @alternate-text-color;
     }
   }
 }

--- a/components/dropdown/style/index.less
+++ b/components/dropdown/style/index.less
@@ -219,7 +219,7 @@
       color: @text-color-secondary-dark;
     }
     &:hover {
-      color: @alternate-text-color;
+      color: @text-color-inverse;
       background: transparent;
     }
   }
@@ -228,7 +228,7 @@
     &:hover,
     > a {
       background: @primary-color;
-      color: @alternate-text-color;
+      color: @text-color-inverse;
     }
   }
 }

--- a/components/form/style/index.less
+++ b/components/form/style/index.less
@@ -279,7 +279,7 @@ form {
   .@{ant-prefix}-select-selection--single {
     margin-left: -1px;
     height: @input-height-lg;
-    background-color: fade(@alternate-color, 7%);
+    background-color: fade(@black, 7%);
     .@{ant-prefix}-select-selection__rendered {
       padding-left: 8px;
       padding-right: 25px;

--- a/components/form/style/index.less
+++ b/components/form/style/index.less
@@ -279,7 +279,7 @@ form {
   .@{ant-prefix}-select-selection--single {
     margin-left: -1px;
     height: @input-height-lg;
-    background-color: #eee;
+    background-color: fade(@alternate-color, 7%);
     .@{ant-prefix}-select-selection__rendered {
       padding-left: 8px;
       padding-right: 25px;

--- a/components/input-number/style/index.less
+++ b/components/input-number/style/index.less
@@ -26,7 +26,7 @@
     width: 100%;
     font-weight: bold;
     &:active {
-      background: #f4f4f4;
+      background: @input-active-bg;
     }
     &:hover &-up-inner,
     &:hover &-down-inner {

--- a/components/input-number/style/index.less
+++ b/components/input-number/style/index.less
@@ -26,7 +26,7 @@
     width: 100%;
     font-weight: bold;
     &:active {
-      background: @input-active-bg;
+      background: @input-number-handler-active-bg;
     }
     &:hover &-up-inner,
     &:hover &-down-inner {

--- a/components/input/style/search-input.less
+++ b/components/input/style/search-input.less
@@ -11,7 +11,7 @@
     cursor: pointer;
     transition: all .3s;
     &:hover {
-      color: fade(@alternate-color, 80%);
+      color: fade(@black, 80%);
     }
   }
 

--- a/components/input/style/search-input.less
+++ b/components/input/style/search-input.less
@@ -11,7 +11,7 @@
     cursor: pointer;
     transition: all .3s;
     &:hover {
-      color: #333;
+      color: fade(@alternate-color, 80%);
     }
   }
 

--- a/components/menu/style/dark.less
+++ b/components/menu/style/dark.less
@@ -20,7 +20,7 @@
 
   &-dark &-inline&-sub {
     background: @menu-dark-submenu-bg;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, .45) inset;
+    box-shadow: 0 2px 8px fade(@alternate-color, 45%) inset;
   }
 
   &-dark&-horizontal {

--- a/components/menu/style/dark.less
+++ b/components/menu/style/dark.less
@@ -20,7 +20,7 @@
 
   &-dark &-inline&-sub {
     background: @menu-dark-submenu-bg;
-    box-shadow: 0 2px 8px fade(@alternate-color, 45%) inset;
+    box-shadow: 0 2px 8px fade(@black, 45%) inset;
   }
 
   &-dark&-horizontal {

--- a/components/menu/style/index.less
+++ b/components/menu/style/index.less
@@ -204,7 +204,7 @@
           content: '';
           position: absolute;
           vertical-align: baseline;
-          background: #fff;
+          background: @menu-bg;
           background-image: linear-gradient(to right, @menu-item-color, @menu-item-color);
           width: 6px;
           height: 1.5px;

--- a/components/modal/style/modal.less
+++ b/components/modal/style/modal.less
@@ -75,7 +75,7 @@
 
     &:focus,
     &:hover {
-      color: @icon-color;
+      color: @icon-color-hover;
       text-decoration: none;
     }
   }

--- a/components/modal/style/modal.less
+++ b/components/modal/style/modal.less
@@ -75,7 +75,7 @@
 
     &:focus,
     &:hover {
-      color: #444;
+      color: @icon-color;
       text-decoration: none;
     }
   }

--- a/components/popover/style/index.less
+++ b/components/popover/style/index.less
@@ -18,7 +18,7 @@
   &:after {
     content: "";
     position: absolute;
-    background: rgba(255, 255, 255, 0.01);
+    background: fade(@default-color, 1%);
   }
 
   &-hidden {
@@ -112,7 +112,7 @@
   &-placement-topLeft > &-content >  &-arrow,
   &-placement-topRight > &-content >  &-arrow {
     bottom: @popover-distance - @popover-arrow-width + 1.5px;
-    box-shadow: 3px 3px 7px rgba(0, 0, 0, 0.07);
+    box-shadow: 3px 3px 7px fade(@alternate-color, 7%);
   }
   &-placement-top > &-content >  &-arrow {
     left: 50%;
@@ -129,7 +129,7 @@
   &-placement-rightTop > &-content >  &-arrow,
   &-placement-rightBottom > &-content >  &-arrow {
     left: @popover-distance - @popover-arrow-width + 2px;
-    box-shadow: -3px 3px 7px rgba(0, 0, 0, 0.07);
+    box-shadow: -3px 3px 7px fade(@alternate-color, 7%);
   }
   &-placement-right > &-content >  &-arrow {
     top: 50%;
@@ -146,7 +146,7 @@
   &-placement-bottomLeft > &-content >  &-arrow,
   &-placement-bottomRight > &-content >  &-arrow {
     top: @popover-distance - @popover-arrow-width + 2px;
-    box-shadow: -2px -2px 5px rgba(0, 0, 0, 0.06);
+    box-shadow: -2px -2px 5px fade(@alternate-color, 6%);
   }
   &-placement-bottom > &-content >  &-arrow {
     left: 50%;
@@ -163,7 +163,7 @@
   &-placement-leftTop > &-content >  &-arrow,
   &-placement-leftBottom > &-content >  &-arrow {
     right: @popover-distance - @popover-arrow-width + 2px;
-    box-shadow: 3px -3px 7px rgba(0, 0, 0, 0.07);
+    box-shadow: 3px -3px 7px fade(@alternate-color, 7%);
   }
   &-placement-left > &-content >  &-arrow {
     top: 50%;

--- a/components/popover/style/index.less
+++ b/components/popover/style/index.less
@@ -18,7 +18,7 @@
   &:after {
     content: "";
     position: absolute;
-    background: fade(@default-color, 1%);
+    background: fade(@white, 1%);
   }
 
   &-hidden {
@@ -112,7 +112,7 @@
   &-placement-topLeft > &-content >  &-arrow,
   &-placement-topRight > &-content >  &-arrow {
     bottom: @popover-distance - @popover-arrow-width + 1.5px;
-    box-shadow: 3px 3px 7px fade(@alternate-color, 7%);
+    box-shadow: 3px 3px 7px fade(@black, 7%);
   }
   &-placement-top > &-content >  &-arrow {
     left: 50%;
@@ -129,7 +129,7 @@
   &-placement-rightTop > &-content >  &-arrow,
   &-placement-rightBottom > &-content >  &-arrow {
     left: @popover-distance - @popover-arrow-width + 2px;
-    box-shadow: -3px 3px 7px fade(@alternate-color, 7%);
+    box-shadow: -3px 3px 7px fade(@black, 7%);
   }
   &-placement-right > &-content >  &-arrow {
     top: 50%;
@@ -146,7 +146,7 @@
   &-placement-bottomLeft > &-content >  &-arrow,
   &-placement-bottomRight > &-content >  &-arrow {
     top: @popover-distance - @popover-arrow-width + 2px;
-    box-shadow: -2px -2px 5px fade(@alternate-color, 6%);
+    box-shadow: -2px -2px 5px fade(@black, 6%);
   }
   &-placement-bottom > &-content >  &-arrow {
     left: 50%;
@@ -163,7 +163,7 @@
   &-placement-leftTop > &-content >  &-arrow,
   &-placement-leftBottom > &-content >  &-arrow {
     right: @popover-distance - @popover-arrow-width + 2px;
-    box-shadow: 3px -3px 7px fade(@alternate-color, 7%);
+    box-shadow: 3px -3px 7px fade(@black, 7%);
   }
   &-placement-left > &-content >  &-arrow {
     top: 50%;

--- a/components/radio/style/index.less
+++ b/components/radio/style/index.less
@@ -118,7 +118,7 @@
     border-color: @border-color-base !important;
     background-color: @input-disabled-bg;
     &:after {
-      background-color: fade(@alternate-color, 20%);
+      background-color: fade(@black, 20%);
     }
   }
 
@@ -279,7 +279,7 @@ span.@{radio-prefix-cls} + * {
 
   &-disabled&-checked {
     color: @text-color-inverse;
-    background-color: fade(@alternate-color, 90%);
+    background-color: fade(@black, 90%);
     border-color: @border-color-base;
     box-shadow: none;
   }

--- a/components/radio/style/index.less
+++ b/components/radio/style/index.less
@@ -278,7 +278,7 @@ span.@{radio-prefix-cls} + * {
   }
 
   &-disabled&-checked {
-    color: @alternate-text-color;
+    color: @text-color-inverse;
     background-color: fade(@alternate-color, 90%);
     border-color: @border-color-base;
     box-shadow: none;

--- a/components/radio/style/index.less
+++ b/components/radio/style/index.less
@@ -118,7 +118,7 @@
     border-color: @border-color-base !important;
     background-color: @input-disabled-bg;
     &:after {
-      background-color: #ccc;
+      background-color: fade(@alternate-color, 20%);
     }
   }
 
@@ -247,16 +247,16 @@ span.@{radio-prefix-cls} + * {
   .@{radio-group-prefix-cls}-solid &-checked:not(&-disabled) {
     background: @radio-dot-color;
     border-color: @radio-dot-color;
-    color: #fff;
+    color: @component-background;
     &:hover {
       border-color: @radio-button-hover-color;
       background: @radio-button-hover-color;
-      color: #fff;
+      color: @component-background;
     }
     &:active {
       border-color: @radio-button-active-color;
       background: @radio-button-active-color;
-      color: #fff;
+      color: @component-background;
     }
   }
 
@@ -278,8 +278,8 @@ span.@{radio-prefix-cls} + * {
   }
 
   &-disabled&-checked {
-    color: #fff;
-    background-color: #e6e6e6;
+    color: @alternate-text-color;
+    background-color: fade(@alternate-color, 90%);
     border-color: @border-color-base;
     box-shadow: none;
   }

--- a/components/select/style/index.less
+++ b/components/select/style/index.less
@@ -144,7 +144,7 @@
 
   &-disabled &-selection--multiple &-selection__choice {
     background: @background-color-base;
-    color: #aaa;
+    color: fade(@alternate-color, 33%);
     padding-right: 10px;
     &__remove {
       display: none;
@@ -364,7 +364,7 @@
       position: absolute;
       right: 4px;
       &:hover {
-        color: #404040;
+        color: @icon-color;
       }
       &:before {
         content: "\e633";
@@ -561,7 +561,7 @@
       }
 
       &:hover:after {
-        color: #ddd;
+        color: fade(@alternate-color, 87%);
       }
 
       &-disabled:after {

--- a/components/select/style/index.less
+++ b/components/select/style/index.less
@@ -144,7 +144,7 @@
 
   &-disabled &-selection--multiple &-selection__choice {
     background: @background-color-base;
-    color: fade(@alternate-color, 33%);
+    color: fade(@black, 33%);
     padding-right: 10px;
     &__remove {
       display: none;
@@ -364,7 +364,7 @@
       position: absolute;
       right: 4px;
       &:hover {
-        color: @icon-color;
+        color: @icon-color-hover;
       }
       &:before {
         content: "\e633";
@@ -561,7 +561,7 @@
       }
 
       &:hover:after {
-        color: fade(@alternate-color, 87%);
+        color: fade(@black, 87%);
       }
 
       &-disabled:after {

--- a/components/spin/style/index.less
+++ b/components/spin/style/index.less
@@ -40,7 +40,7 @@
         top: 50%;
         width: 100%;
         padding-top: (@spin-dot-size - @font-size-base) / 2 + 2px;
-        text-shadow: 0 1px 2px @alternate-shadow-color;
+        text-shadow: 0 1px 2px @shadow-color-inverse;
       }
       &.@{spin-prefix-cls}-show-text .@{spin-prefix-cls}-dot {
         margin-top: -@spin-dot-size / 2 - 10px;

--- a/components/spin/style/index.less
+++ b/components/spin/style/index.less
@@ -40,7 +40,7 @@
         top: 50%;
         width: 100%;
         padding-top: (@spin-dot-size - @font-size-base) / 2 + 2px;
-        text-shadow: 0 1px 2px #fff;
+        text-shadow: 0 1px 2px @alternate-shadow-color;
       }
       &.@{spin-prefix-cls}-show-text .@{spin-prefix-cls}-dot {
         margin-top: -@spin-dot-size / 2 - 10px;
@@ -95,7 +95,7 @@
       right: 0;
       top: 0;
       bottom: 0;
-      background: #fff;
+      background: @component-background;
       opacity: 0.3;
       transition: all .3s;
       z-index: 10;

--- a/components/steps/style/index.less
+++ b/components/steps/style/index.less
@@ -6,7 +6,7 @@
 @process-title-color: @heading-color;
 @process-description-color: @text-color;
 @process-tail-color: @border-color-split;
-@process-icon-text-color: #fff;
+@process-icon-text-color: @alternate-text-color;
 @wait-icon-color: @disabled-color;
 @wait-title-color: @text-color-secondary;
 @wait-description-color: @wait-title-color;

--- a/components/steps/style/index.less
+++ b/components/steps/style/index.less
@@ -6,7 +6,7 @@
 @process-title-color: @heading-color;
 @process-description-color: @text-color;
 @process-tail-color: @border-color-split;
-@process-icon-text-color: @alternate-text-color;
+@process-icon-text-color: @text-color-inverse;
 @wait-icon-color: @disabled-color;
 @wait-title-color: @text-color-secondary;
 @wait-description-color: @wait-title-color;

--- a/components/steps/style/progress-dot.less
+++ b/components/steps/style/progress-dot.less
@@ -35,7 +35,7 @@
         /* expand hover area */
         &:after {
           content: "";
-          background: fade(@alternate-color, 0.1%);
+          background: fade(@black, 0.1%);
           width: 60px;
           height: 32px;
           position: absolute;

--- a/components/steps/style/progress-dot.less
+++ b/components/steps/style/progress-dot.less
@@ -35,7 +35,7 @@
         /* expand hover area */
         &:after {
           content: "";
-          background: rgba(0, 0, 0, .001);
+          background: fade(@alternate-color, 0.1%);
           width: 60px;
           height: 32px;
           position: absolute;

--- a/components/style/core/base.less
+++ b/components/style/core/base.less
@@ -500,7 +500,7 @@ mark {
 
 ::selection {
   background: @primary-color;
-  color: @alternate-text-color;
+  color: @text-color-inverse;
 }
 
 // Utility classes

--- a/components/style/core/base.less
+++ b/components/style/core/base.less
@@ -59,7 +59,7 @@ html {
   -webkit-text-size-adjust: 100%; // 4
   -ms-text-size-adjust: 100%; // 4
   -ms-overflow-style: scrollbar; // 5
-  -webkit-tap-highlight-color: fade(@alternate-color, 0%); // 6
+  -webkit-tap-highlight-color: fade(@black, 0%); // 6
 }
 
 // IE10+ doesn't honor `<meta name="viewport">` in some cases.

--- a/components/style/core/base.less
+++ b/components/style/core/base.less
@@ -59,7 +59,7 @@ html {
   -webkit-text-size-adjust: 100%; // 4
   -ms-text-size-adjust: 100%; // 4
   -ms-overflow-style: scrollbar; // 5
-  -webkit-tap-highlight-color: rgba(0, 0, 0, 0); // 6
+  -webkit-tap-highlight-color: fade(@alternate-color, 0%); // 6
 }
 
 // IE10+ doesn't honor `<meta name="viewport">` in some cases.
@@ -500,7 +500,7 @@ mark {
 
 ::selection {
   background: @primary-color;
-  color: #fff;
+  color: @alternate-text-color;
 }
 
 // Utility classes

--- a/components/style/themes/default.less
+++ b/components/style/themes/default.less
@@ -12,8 +12,8 @@
 @error-color            : @red-6;
 @highlight-color        : @red-6;
 @warning-color          : @gold-6;
-@default-color          : #fff;
-@alternate-color        : #000;
+@white                  : #fff;
+@black                  : #000;
 @normal-color           : #d9d9d9;
 
 // Color used by default to control hover and active backgrounds and for
@@ -39,14 +39,14 @@
 @font-family-no-number  : "Chinese Quote", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "Helvetica Neue", Helvetica, Arial, sans-serif;
 @font-family            : "Monospaced Number", @font-family-no-number;
 @code-family            : Consolas, Menlo, Courier, monospace;
-@heading-color          : fade(@alternate-color, 85%);
-@text-color             : fade(@alternate-color, 65%);
-@text-color-secondary   : fade(@alternate-color, 45%);
-@text-color-inverse   : #fff;
-@icon-color             : fade(@alternate-color, 75%);
-@heading-color-dark     : fade(@default-color, 100%);
-@text-color-dark        : fade(@default-color, 85%);
-@text-color-secondary-dark: fade(@default-color, 65%);
+@heading-color          : fade(@black, 85%);
+@text-color             : fade(@black, 65%);
+@text-color-secondary   : fade(@black, 45%);
+@text-color-inverse     : #fff;
+@icon-color-hover       : fade(@black, 75%);
+@heading-color-dark     : fade(@white, 100%);
+@text-color-dark        : fade(@white, 85%);
+@text-color-secondary-dark: fade(@white, 65%);
 @font-size-base         : 14px;
 @font-size-lg           : @font-size-base + 2px;
 @font-size-sm           : 12px;
@@ -97,7 +97,7 @@
 // Border color
 @border-color-base      : hsv(0, 0, 85%);  // base border outline a component
 @border-color-split     : hsv(0, 0, 91%);  // split border inside a component
-@alternate-border-color : @default-color;
+@alternate-border-color : @white;
 @border-width-base      : 1px;            // width of the border for a component
 @border-style-base      : solid;          // style of a components border
 
@@ -115,8 +115,8 @@
 @disabled-color-dark    : fade(#fff, 35%);
 
 // Shadow
-@shadow-color           : fade(@alternate-color, 15%);
-@alternate-shadow-color : @component-background;
+@shadow-color           : fade(@black, 15%);
+@shadow-color-inverse : @component-background;
 @box-shadow-base        : @shadow-1-down;
 @shadow-1-up            : 0 2px 8px @shadow-color;
 @shadow-1-down          : 0 2px 8px @shadow-color;
@@ -284,7 +284,7 @@
 //** Tooltip text color
 @tooltip-color: #fff;
 //** Tooltip background color
-@tooltip-bg: fade(@alternate-color, 75%);
+@tooltip-bg: fade(@black, 75%);
 //** Tooltip arrow width
 @tooltip-arrow-width: 5px;
 //** Tooltip distance with trigger
@@ -312,7 +312,7 @@
 
 // Modal
 // --
-@modal-mask-bg: fade(@alternate-color, 65%);
+@modal-mask-bg: fade(@black, 65%);
 
 // Progress
 // --
@@ -394,7 +394,7 @@
 @card-padding-base: 24px;
 @card-padding-wider: 32px;
 @card-actions-background: @background-color-light;
-@card-shadow: 0 2px 8px fade(@alternate-color, 9%);
+@card-shadow: 0 2px 8px fade(@black, 9%);
 @card-background: #cfd8dc;
 
 // Tabs

--- a/components/style/themes/default.less
+++ b/components/style/themes/default.less
@@ -97,7 +97,7 @@
 // Border color
 @border-color-base      : hsv(0, 0, 85%);  // base border outline a component
 @border-color-split     : hsv(0, 0, 91%);  // split border inside a component
-@alternate-border-color : @white;
+@border-color-inverse   : @white;
 @border-width-base      : 1px;            // width of the border for a component
 @border-style-base      : solid;          // style of a components border
 
@@ -116,7 +116,7 @@
 
 // Shadow
 @shadow-color           : fade(@black, 15%);
-@shadow-color-inverse : @component-background;
+@shadow-color-inverse   : @component-background;
 @box-shadow-base        : @shadow-1-down;
 @shadow-1-up            : 0 2px 8px @shadow-color;
 @shadow-1-down          : 0 2px 8px @shadow-color;
@@ -257,25 +257,25 @@
 
 // Input
 // ---
-@input-height-base           : 32px;
-@input-height-lg             : 40px;
-@input-height-sm             : 24px;
-@input-padding-horizontal    : @control-padding-horizontal - 1px;
-@input-padding-horizontal-base: @input-padding-horizontal;
-@input-padding-horizontal-sm : @control-padding-horizontal-sm - 1px;
-@input-padding-horizontal-lg : @input-padding-horizontal;
-@input-padding-vertical-base : 4px;
-@input-padding-vertical-sm   : 1px;
-@input-padding-vertical-lg   : 6px;
-@input-placeholder-color     : hsv(0, 0, 75%);
-@input-color                 : @text-color;
-@input-border-color          : @border-color-base;
-@input-bg                    : #fff;
-@input-active-bg             : #f4f4f4;
-@input-addon-bg              : @background-color-light;
-@input-hover-border-color    : @primary-color;
-@input-disabled-bg           : @disabled-bg;
-@input-outline-offset        : 0 0;
+@input-height-base              : 32px;
+@input-height-lg                : 40px;
+@input-height-sm                : 24px;
+@input-padding-horizontal       : @control-padding-horizontal - 1px;
+@input-padding-horizontal-base  : @input-padding-horizontal;
+@input-padding-horizontal-sm    : @control-padding-horizontal-sm - 1px;
+@input-padding-horizontal-lg    : @input-padding-horizontal;
+@input-padding-vertical-base    : 4px;
+@input-padding-vertical-sm      : 1px;
+@input-padding-vertical-lg      : 6px;
+@input-placeholder-color        : hsv(0, 0, 75%);
+@input-color                    : @text-color;
+@input-border-color             : @border-color-base;
+@input-bg                       : #fff;
+@input-number-handler-active-bg : #f4f4f4;
+@input-addon-bg                 : @background-color-light;
+@input-hover-border-color       : @primary-color;
+@input-disabled-bg              : @disabled-bg;
+@input-outline-offset           : 0 0;
 
 // Tooltip
 // ---

--- a/components/style/themes/default.less
+++ b/components/style/themes/default.less
@@ -42,7 +42,7 @@
 @heading-color          : fade(@alternate-color, 85%);
 @text-color             : fade(@alternate-color, 65%);
 @text-color-secondary   : fade(@alternate-color, 45%);
-@alternate-text-color   : #fff;
+@text-color-inverse   : #fff;
 @icon-color             : fade(@alternate-color, 75%);
 @heading-color-dark     : fade(@default-color, 100%);
 @text-color-dark        : fade(@default-color, 85%);
@@ -378,7 +378,7 @@
 @badge-font-size: @font-size-sm;
 @badge-font-weight: normal;
 @badge-status-size: 6px;
-@badge-color: @component-background;
+@badge-text-color: @component-background;
 
 // Rate
 // ---

--- a/components/style/themes/default.less
+++ b/components/style/themes/default.less
@@ -12,6 +12,8 @@
 @error-color            : @red-6;
 @highlight-color        : @red-6;
 @warning-color          : @gold-6;
+@default-color          : #fff;
+@alternate-color        : #000;
 @normal-color           : #d9d9d9;
 
 // Color used by default to control hover and active backgrounds and for
@@ -37,12 +39,14 @@
 @font-family-no-number  : "Chinese Quote", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "Helvetica Neue", Helvetica, Arial, sans-serif;
 @font-family            : "Monospaced Number", @font-family-no-number;
 @code-family            : Consolas, Menlo, Courier, monospace;
-@heading-color          : fade(#000, 85%);
-@text-color             : fade(#000, 65%);
-@text-color-secondary   : fade(#000, 45%);
-@heading-color-dark     : fade(#fff, 100%);
-@text-color-dark        : fade(#fff, 85%);
-@text-color-secondary-dark: fade(#fff, 65%);
+@heading-color          : fade(@alternate-color, 85%);
+@text-color             : fade(@alternate-color, 65%);
+@text-color-secondary   : fade(@alternate-color, 45%);
+@alternate-text-color   : #fff;
+@icon-color             : fade(@alternate-color, 75%);
+@heading-color-dark     : fade(@default-color, 100%);
+@text-color-dark        : fade(@default-color, 85%);
+@text-color-secondary-dark: fade(@default-color, 65%);
 @font-size-base         : 14px;
 @font-size-lg           : @font-size-base + 2px;
 @font-size-sm           : 12px;
@@ -93,6 +97,7 @@
 // Border color
 @border-color-base      : hsv(0, 0, 85%);  // base border outline a component
 @border-color-split     : hsv(0, 0, 91%);  // split border inside a component
+@alternate-border-color : @default-color;
 @border-width-base      : 1px;            // width of the border for a component
 @border-style-base      : solid;          // style of a components border
 
@@ -110,7 +115,8 @@
 @disabled-color-dark    : fade(#fff, 35%);
 
 // Shadow
-@shadow-color           : rgba(0, 0, 0, .15);
+@shadow-color           : fade(@alternate-color, 15%);
+@alternate-shadow-color : @component-background;
 @box-shadow-base        : @shadow-1-down;
 @shadow-1-up            : 0 2px 8px @shadow-color;
 @shadow-1-down          : 0 2px 8px @shadow-color;
@@ -265,6 +271,7 @@
 @input-color                 : @text-color;
 @input-border-color          : @border-color-base;
 @input-bg                    : #fff;
+@input-active-bg             : #f4f4f4;
 @input-addon-bg              : @background-color-light;
 @input-hover-border-color    : @primary-color;
 @input-disabled-bg           : @disabled-bg;
@@ -277,7 +284,7 @@
 //** Tooltip text color
 @tooltip-color: #fff;
 //** Tooltip background color
-@tooltip-bg: rgba(0, 0, 0, .75);
+@tooltip-bg: fade(@alternate-color, 75%);
 //** Tooltip arrow width
 @tooltip-arrow-width: 5px;
 //** Tooltip distance with trigger
@@ -305,7 +312,7 @@
 
 // Modal
 // --
-@modal-mask-bg: rgba(0, 0, 0, 0.65);
+@modal-mask-bg: fade(@alternate-color, 65%);
 
 // Progress
 // --
@@ -371,6 +378,7 @@
 @badge-font-size: @font-size-sm;
 @badge-font-weight: normal;
 @badge-status-size: 6px;
+@badge-color: @component-background;
 
 // Rate
 // ---
@@ -386,7 +394,8 @@
 @card-padding-base: 24px;
 @card-padding-wider: 32px;
 @card-actions-background: @background-color-light;
-@card-shadow: 0 2px 8px rgba(0, 0, 0, .09);
+@card-shadow: 0 2px 8px fade(@alternate-color, 9%);
+@card-background: #cfd8dc;
 
 // Tabs
 // ---
@@ -432,6 +441,7 @@
 @switch-sm-checked-margin-left: -(@switch-sm-height - 3px);
 @switch-disabled-opacity: 0.4;
 @switch-color: @primary-color;
+@switch-shadow-color: fade(#00230b, 20%);
 
 // Pagination
 // ---

--- a/components/switch/style/index.less
+++ b/components/switch/style/index.less
@@ -21,7 +21,7 @@
   user-select: none;
 
   &-inner {
-    color: #fff;
+    color: @alternate-text-color;
     font-size: @font-size-sm;
     margin-left: 24px;
     margin-right: 6px;
@@ -43,7 +43,7 @@
   }
 
   &:after {
-    box-shadow: 0 2px 4px 0 rgba(0, 35, 11, .2);
+    box-shadow: 0 2px 4px 0 @switch-shadow-color;
   }
 
   &:active:before,

--- a/components/switch/style/index.less
+++ b/components/switch/style/index.less
@@ -21,7 +21,7 @@
   user-select: none;
 
   &-inner {
-    color: @alternate-text-color;
+    color: @text-color-inverse;
     font-size: @font-size-sm;
     margin-left: 24px;
     margin-right: 6px;

--- a/components/table/style/index.less
+++ b/components/table/style/index.less
@@ -456,7 +456,7 @@
       display: inline-block;
       line-height: 1;
       &:hover .@{iconfont-css-prefix}-down {
-        color: fade(@alternate-color, 60%);
+        color: fade(@black, 60%);
       }
     }
   }

--- a/components/table/style/index.less
+++ b/components/table/style/index.less
@@ -456,7 +456,7 @@
       display: inline-block;
       line-height: 1;
       &:hover .@{iconfont-css-prefix}-down {
-        color: #666;
+        color: fade(@alternate-color, 60%);
       }
     }
   }

--- a/components/tag/style/index.less
+++ b/components/tag/style/index.less
@@ -55,7 +55,7 @@
     a:hover,
     .@{iconfont-css-prefix}-cross,
     .@{iconfont-css-prefix}-cross:hover {
-      color: @alternate-text-color;
+      color: @text-color-inverse;
     }
   }
 
@@ -67,7 +67,7 @@
     }
     &:active,
     &-checked {
-      color: @alternate-text-color;
+      color: @text-color-inverse;
     }
     &-checked {
       background-color: @primary-6;
@@ -111,7 +111,7 @@
     &-@{color}-inverse {
       background: @@darkColor;
       border-color: @@darkColor;
-      color: @alternate-text-color;
+      color: @text-color-inverse;
     }
   }
 

--- a/components/tag/style/index.less
+++ b/components/tag/style/index.less
@@ -55,7 +55,7 @@
     a:hover,
     .@{iconfont-css-prefix}-cross,
     .@{iconfont-css-prefix}-cross:hover {
-      color: #fff;
+      color: @alternate-text-color;
     }
   }
 
@@ -67,7 +67,7 @@
     }
     &:active,
     &-checked {
-      color: #fff;
+      color: @alternate-text-color;
     }
     &-checked {
       background-color: @primary-6;
@@ -111,7 +111,7 @@
     &-@{color}-inverse {
       background: @@darkColor;
       border-color: @@darkColor;
-      color: #fff;
+      color: @alternate-text-color;
     }
   }
 

--- a/components/upload/style/index.less
+++ b/components/upload/style/index.less
@@ -313,7 +313,7 @@
         content: ' ';
         position: absolute;
         z-index: 1;
-        background-color: fade(@alternate-color, 50%);
+        background-color: fade(@black, 50%);
         transition: all .3s;
         width: 100%;
         height: 100%;

--- a/components/upload/style/index.less
+++ b/components/upload/style/index.less
@@ -345,7 +345,7 @@
         color: @text-color-dark;
         margin: 0 4px;
         &:hover {
-          color: @alternate-text-color;
+          color: @text-color-inverse;
         }
       }
     }

--- a/components/upload/style/index.less
+++ b/components/upload/style/index.less
@@ -313,7 +313,7 @@
         content: ' ';
         position: absolute;
         z-index: 1;
-        background-color: rgba(0, 0, 0, 0.5);
+        background-color: fade(@alternate-color, 50%);
         transition: all .3s;
         width: 100%;
         height: 100%;
@@ -345,7 +345,7 @@
         color: @text-color-dark;
         margin: 0 4px;
         &:hover {
-          color: #fff;
+          color: @alternate-text-color;
         }
       }
     }


### PR DESCRIPTION
First of all, thank you for your contribution! :-)

Please makes sure that these checkboxes are checked before submitting your PR, thank you!

* [x] Make sure that you propose PR to right branch: bugfix for `master`, feature for latest active branch `feature-x.x`.
* [x] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [ ] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
^ I did not manage to get the Linter to work :/
* [x] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.

Extra checklist:

**if** *isBugFix* **:**

  * [ ] Make sure that you add at least one unit test for the bug which you had fixed.

**elif** *isNewFeature* **:**

  * [ ] Update API docs for the component.
  * [ ] Update/Add demo to demonstrate new feature.
  * [ ] Update TypeScript definition for the component.
  * [ ] Add unit tests for the feature.

----

**Related issue**: #11519 

**Goal**: Move all colors definitions from the components less indexes into `default.less` so that the whole style can be controlled with less variables. Specifically, it makes it easier (and less hacky) to create dark themed applications using Ant Design.

**Note**: New variables were introduced. This is just a proposal and the way I factorized colors and named variables can be discussed.

**Possible next step**: Adding a custom Lint rule to check that colors are not added to components less indexes in the future would make this more robust.