### PR TITLE
fixed: dist files dropped in production mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -228,6 +228,7 @@
     "lint-staged"
   ],
   "sideEffects": [
+    "dist/*",
     "es/**/style/*",
     "lib/**/style/*"
   ]


### PR DESCRIPTION
First of all, thank you for your contribution! :-)

Please makes sure that these checkboxes are checked before submitting your PR, thank you!

* [x] Make sure that you propose PR to right branch: bugfix for `master`, feature for latest active branch `feature-x.x`.
* [ ] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [ ] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [ ] Rebase before creating a PR to keep commit history clear.
* [ ] Add some descriptions and refer relative issues for you PR.

Extra checklist:

**if** *isBugFix* **:**

  * [ ] Make sure that you add at least one unit test for the bug which you had fixed.

**elif** *isNewFeature* **:**

  * [ ] Update API docs for the component.
  * [ ] Update/Add demo to demonstrate new feature.
  * [ ] Update TypeScript definition for the component.
  * [ ] Add unit tests for the feature.

------

按照文档上的使用办法：

示例#
```
import { DatePicker } from 'antd';
ReactDOM.render(<DatePicker />, mountNode);
```
引入样式：

```
import 'antd/dist/antd.css';  // or 'antd/dist/antd.less'
```


`import 'antd/dist/antd.css';  // or 'antd/dist/antd.less'` 在 production 模式下会被移除。

webpack4 说明：

> Note that any imported file is subject to tree shaking. This means if you use something like css-loader in your project and import a CSS file, it needs to be added to the side effect list so it will not be unintentionally dropped in production mode:

https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free