### PR TITLE
list padding and margin defaults added

### DIFF
--- a/components/list/style/index.less
+++ b/components/list/style/index.less
@@ -28,21 +28,20 @@
   &-empty-text {
     color: @text-color-secondary;
     font-size: @font-size-base;
-    padding: 16px;
+    padding: @list-empty-text-padding;
     text-align: center;
   }
   &-item {
     align-items: center;
     display: flex;
-    padding-top: 12px;
-    padding-bottom: 12px;
+    padding: @list-item-padding;
     &-meta {
       align-items: flex-start;
       display: flex;
       flex: 1;
       font-size: 0;
       &-avatar {
-        margin-right: 16px;
+        margin-right: @list-item-meta-avatar-margin-right;
       }
       &-content {
         flex: 1 0;
@@ -164,13 +163,13 @@
       margin-left: 58px;
     }
     &-meta {
-      margin-bottom: 16px;
+      margin-bottom: @list-item-meta-margin-bottom;
       &-avatar {
         display: none;
       }
       &-title {
         color: @heading-color;
-        margin-bottom: 12px;
+        margin-bottom: @list-item-meta-title-margin-bottom;
         font-size: @font-size-lg;
         line-height: 24px;
       }
@@ -179,7 +178,7 @@
       display: block;
       color: @text-color;
       font-size: @font-size-base;
-      margin-bottom: 16px;
+      margin: @list-item-content-margin;
     }
     &-action {
       margin-left: auto;

--- a/components/style/themes/default.less
+++ b/components/style/themes/default.less
@@ -486,4 +486,13 @@
 // ---
 @message-notice-content-padding:      10px 16px;
 
+// List
+// ---
+@list-empty-text-padding:                    @padding-md;
+@list-item-padding:                          @padding-sm 0;
+@list-item-content-margin:                   0 0 @padding-md 0;
+@list-item-meta-margin-bottom:               @padding-md;
+@list-item-meta-avatar-margin-right:         @padding-md;
+@list-item-meta-title-margin-bottom:         @padding-sm;
+
 @import "./default.deperated.less";


### PR DESCRIPTION
Description: Override access to margin settings for list items

Added options:

```
@list-empty-text-padding:           
@list-item-padding:                 
@list-item-content-margin:          
@list-item-meta-margin-bottom:      
@list-item-meta-avatar-margin-right:
@list-item-meta-title-margin-bottom:
```

* [x] Make sure that you propose PR to right branch: bugfix for `master`, feature for latest active branch `feature-x.x`.
* [x] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.

Extra checklist:

**elif** *isNewFeature* **:**

  * [ ] Update API docs for the component.
  * [ ] Update/Add demo to demonstrate new feature.
  * [ ] Update TypeScript definition for the component.
  * [ ] Add unit tests for the feature.
