### PR TITLE
Migrate lifecycle method: Upload, CheckboxGroup, Layout.Sider, Tooltip, Popconfirm

### DIFF
--- a/components/checkbox/Group.tsx
+++ b/components/checkbox/Group.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
+import { polyfill } from 'react-lifecycles-compat';
 import classNames from 'classnames';
 import shallowEqual from 'shallowequal';
 import Checkbox from './Checkbox';
@@ -38,7 +39,7 @@ export interface CheckboxGroupContext {
   };
 }
 
-export default class CheckboxGroup extends React.Component<CheckboxGroupProps, CheckboxGroupState> {
+class CheckboxGroup extends React.Component<CheckboxGroupProps, CheckboxGroupState> {
   static defaultProps = {
     options: [],
     prefixCls: 'ant-checkbox',
@@ -54,6 +55,15 @@ export default class CheckboxGroup extends React.Component<CheckboxGroupProps, C
   static childContextTypes = {
     checkboxGroup: PropTypes.any,
   };
+
+  static getDerivedStateFromProps(nextProps: CheckboxGroupProps) {
+    if ('value' in nextProps) {
+      return {
+        value: nextProps.value || [],
+      };
+    }
+    return null;
+  }
 
   constructor(props: CheckboxGroupProps) {
     super(props);
@@ -72,13 +82,6 @@ export default class CheckboxGroup extends React.Component<CheckboxGroupProps, C
     };
   }
 
-  componentWillReceiveProps(nextProps: CheckboxGroupProps) {
-    if ('value' in nextProps) {
-      this.setState({
-        value: nextProps.value || [],
-      });
-    }
-  }
   shouldComponentUpdate(nextProps: CheckboxGroupProps, nextState: CheckboxGroupState) {
     return !shallowEqual(this.props, nextProps) ||
       !shallowEqual(this.state, nextState);
@@ -141,3 +144,7 @@ export default class CheckboxGroup extends React.Component<CheckboxGroupProps, C
     );
   }
 }
+
+polyfill(CheckboxGroup);
+
+export default CheckboxGroup;

--- a/components/checkbox/__tests__/group.test.js
+++ b/components/checkbox/__tests__/group.test.js
@@ -64,4 +64,19 @@ describe('CheckboxGroup', () => {
 
     expect(wrapper).toMatchSnapshot();
   });
+
+  it('should be controlled by value', () => {
+    const options = [
+      { label: 'Apple', value: 'Apple' },
+      { label: 'Orange', value: 'Orange' },
+    ];
+
+    const wrapper = mount(
+      <Checkbox.Group options={options} />
+    );
+
+    expect(wrapper.instance().state.value).toEqual([]);
+    wrapper.setProps({ value: ['Apple'] });
+    expect(wrapper.instance().state.value).toEqual(['Apple']);
+  });
 });

--- a/components/layout/Sider.tsx
+++ b/components/layout/Sider.tsx
@@ -15,6 +15,7 @@ if (typeof window !== 'undefined') {
 }
 
 import * as React from 'react';
+import { polyfill } from 'react-lifecycles-compat';
 import classNames from 'classnames';
 import omit from 'omit.js';
 import * as PropTypes from 'prop-types';
@@ -67,7 +68,7 @@ const generateId = (() => {
   };
 })();
 
-export default class Sider extends React.Component<SiderProps, SiderState> {
+class Sider extends React.Component<SiderProps, SiderState> {
   static __ANT_LAYOUT_SIDER: any = true;
 
   static defaultProps = {
@@ -89,6 +90,15 @@ export default class Sider extends React.Component<SiderProps, SiderState> {
   static contextTypes = {
     siderHook: PropTypes.object,
   };
+
+  static getDerivedStateFromProps(nextProps: SiderProps) {
+    if ('collapsed' in nextProps) {
+      return {
+        collapsed: nextProps.collapsed,
+      };
+    }
+    return null;
+  }
 
   private mql: MediaQueryList;
   private uniqueId: string;
@@ -120,14 +130,6 @@ export default class Sider extends React.Component<SiderProps, SiderState> {
       siderCollapsed: this.state.collapsed,
       collapsedWidth: this.props.collapsedWidth,
     };
-  }
-
-  componentWillReceiveProps(nextProps: SiderProps) {
-    if ('collapsed' in nextProps) {
-      this.setState({
-        collapsed: nextProps.collapsed,
-      });
-    }
   }
 
   componentDidMount() {
@@ -234,3 +236,7 @@ export default class Sider extends React.Component<SiderProps, SiderState> {
     );
   }
 }
+
+polyfill(Sider);
+
+export default Sider;

--- a/components/layout/__tests__/index.test.js
+++ b/components/layout/__tests__/index.test.js
@@ -76,6 +76,15 @@ describe('Layout', () => {
     );
     expect(wrapper).toMatchSnapshot();
   });
+
+  it('should be controlled by collapsed', () => {
+    const wrapper = mount(
+      <Sider>Sider</Sider>
+    );
+    expect(wrapper.instance().state.collapsed).toBe(false);
+    wrapper.setProps({ collapsed: true });
+    expect(wrapper.instance().state.collapsed).toBe(true);
+  });
 });
 
 describe('Sider onBreakpoint', () => {

--- a/components/popconfirm/index.tsx
+++ b/components/popconfirm/index.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { polyfill } from 'react-lifecycles-compat';
 import Tooltip, { AbstractTooltipProps }  from '../tooltip';
 import Icon from '../icon';
 import Button from '../button';
@@ -25,7 +26,7 @@ export interface PopconfirmLocale {
   cancelText: string;
 }
 
-export default class Popconfirm extends React.Component<PopconfirmProps, PopconfirmState> {
+class Popconfirm extends React.Component<PopconfirmProps, PopconfirmState> {
   static defaultProps = {
     prefixCls: 'ant-popover',
     transitionName: 'zoom-big',
@@ -35,6 +36,13 @@ export default class Popconfirm extends React.Component<PopconfirmProps, Popconf
     icon: <Icon type="exclamation-circle" />,
   };
 
+  static getDerivedStateFromProps(nextProps: PopconfirmProps) {
+    if ('visible' in nextProps) {
+      return { visible: nextProps.visible };
+    }
+    return null;
+  }
+
   private tooltip: any;
 
   constructor(props: PopconfirmProps) {
@@ -43,12 +51,6 @@ export default class Popconfirm extends React.Component<PopconfirmProps, Popconf
     this.state = {
       visible: props.visible,
     };
-  }
-
-  componentWillReceiveProps(nextProps: PopconfirmProps) {
-    if ('visible' in nextProps) {
-      this.setState({ visible: nextProps.visible });
-    }
   }
 
   getPopupDomNode() {
@@ -140,3 +142,7 @@ export default class Popconfirm extends React.Component<PopconfirmProps, Popconf
     );
   }
 }
+
+polyfill(Popconfirm);
+
+export default Popconfirm;

--- a/components/spin/__tests__/index.test.js
+++ b/components/spin/__tests__/index.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow, render } from 'enzyme';
+import { shallow, render, mount } from 'enzyme';
 import Spin from '..';
 
 describe('Spin', () => {
@@ -26,5 +26,14 @@ describe('Spin', () => {
       <Spin spinning delay={500} />
     );
     expect(wrapper.find('.ant-spin').at(0).hasClass('ant-spin-spinning')).toEqual(false);
+  });
+
+  it('should be controlled by spinning', () => {
+    const wrapper = mount(
+      <Spin spinning={false} />
+    );
+    expect(wrapper.instance().state.spinning).toBe(false);
+    wrapper.setProps({ spinning: true });
+    expect(wrapper.instance().state.spinning).toBe(true);
   });
 });

--- a/components/tooltip/index.tsx
+++ b/components/tooltip/index.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { cloneElement } from 'react';
+import { polyfill } from 'react-lifecycles-compat';
 import RcTooltip from 'rc-tooltip';
 import classNames from 'classnames';
 import getPlacements, { AdjustOverflow, PlacementsConfig } from './placements';
@@ -56,7 +57,7 @@ const splitObject = (obj: any, keys: string[]) => {
   return { picked, omitted };
 };
 
-export default class Tooltip extends React.Component<TooltipProps, any> {
+class Tooltip extends React.Component<TooltipProps, any> {
   static defaultProps = {
     prefixCls: 'ant-tooltip',
     placement: 'top' as TooltipPlacement,
@@ -67,6 +68,13 @@ export default class Tooltip extends React.Component<TooltipProps, any> {
     autoAdjustOverflow: true,
   };
 
+  static getDerivedStateFromProps(nextProps: TooltipProps) {
+    if ('visible' in nextProps) {
+      return { visible: nextProps.visible };
+    }
+    return null;
+  }
+
   private tooltip: typeof RcTooltip;
 
   constructor(props: TooltipProps) {
@@ -75,12 +83,6 @@ export default class Tooltip extends React.Component<TooltipProps, any> {
     this.state = {
       visible: !!props.visible || !!props.defaultVisible,
     };
-  }
-
-  componentWillReceiveProps(nextProps: TooltipProps) {
-    if ('visible' in nextProps) {
-      this.setState({ visible: nextProps.visible });
-    }
   }
 
   onVisibleChange = (visible: boolean) => {
@@ -226,3 +228,7 @@ export default class Tooltip extends React.Component<TooltipProps, any> {
     );
   }
 }
+
+polyfill(Tooltip);
+
+export default Tooltip;

--- a/components/upload/Upload.tsx
+++ b/components/upload/Upload.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { polyfill } from 'react-lifecycles-compat';
 import RcUpload from 'rc-upload';
 import classNames from 'classnames';
 import uniqBy from 'lodash/uniqBy';
@@ -20,7 +21,7 @@ import { T, fileToObject, genPercentAdd, getFileItem, removeFileItem } from './u
 
 export { UploadProps };
 
-export default class Upload extends React.Component<UploadProps, UploadState> {
+class Upload extends React.Component<UploadProps, UploadState> {
   static Dragger: typeof Dragger;
 
   static defaultProps = {
@@ -37,6 +38,15 @@ export default class Upload extends React.Component<UploadProps, UploadState> {
     disabled: false,
     supportServerRender: true,
   };
+
+  static getDerivedStateFromProps(nextProps: UploadProps) {
+    if ('fileList' in nextProps) {
+      return {
+        fileList: nextProps.fileList || [],
+      };
+    }
+    return null;
+  }
 
   recentUploadStatus: boolean | PromiseLike<any>;
   progressTimer: any;
@@ -171,14 +181,6 @@ export default class Upload extends React.Component<UploadProps, UploadState> {
     const { onChange } = this.props;
     if (onChange) {
       onChange(info);
-    }
-  }
-
-  componentWillReceiveProps(nextProps: UploadProps) {
-    if ('fileList' in nextProps) {
-      this.setState({
-        fileList: nextProps.fileList || [],
-      });
     }
   }
 
@@ -317,3 +319,7 @@ export default class Upload extends React.Component<UploadProps, UploadState> {
     );
   }
 }
+
+polyfill(Upload);
+
+export default Upload;

--- a/components/upload/__tests__/upload.test.js
+++ b/components/upload/__tests__/upload.test.js
@@ -161,6 +161,21 @@ describe('Upload', () => {
     });
   });
 
+  it('should be controlled by fileList', () => {
+    const fileList = [{
+      uid: '-1',
+      name: 'foo.png',
+      status: 'done',
+      url: 'http://www.baidu.com/xxx.png',
+    }];
+    const wrapper = mount(
+      <Upload />
+    );
+    expect(wrapper.instance().state.fileList).toEqual([]);
+    wrapper.setProps({ fileList });
+    expect(wrapper.instance().state.fileList).toEqual(fileList);
+  });
+
   describe('util', () => {
     it('should be able to copy file instance', () => {
       const file = new File([], 'aaa.zip');


### PR DESCRIPTION
### what is done

- replace legacy `componentWillReceiveProps` with `static getDerivedStateFromProps`

- add test to ensure controlled component

- peer with react@15

### checklist

* [x] Make sure that you propose PR to right branch: bugfix for `master`, feature for latest active branch `feature-x.x`.
* [x] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.

### Extra checklist:

**if** *isBugFix* **:**

no

**elif** *isNewFeature* **:**

#9792 

  * [x] Add unit tests for the feature.
