### PR TITLE
Add @progress-text-color var to <Progress />

### DIFF
--- a/components/progress/style/index.less
+++ b/components/progress/style/index.less
@@ -132,7 +132,7 @@
     transform: translateY(-50%);
     left: 0;
     margin: 0;
-    color: @text-color;
+    color: @progress-text-color;
 
     .@{iconfont-css-prefix} {
       font-size: 14 / 12em;

--- a/components/style/themes/default.less
+++ b/components/style/themes/default.less
@@ -313,6 +313,7 @@
 // --
 @progress-default-color: @processing-color;
 @progress-remaining-color: @background-color-base;
+@progress-text-color: @text-color;
 
 // Menu
 // ---


### PR DESCRIPTION
Adds a variable to modify the `color` of the `ant-progress-text` within the `<Progress />` component. This allows you to adjust the color to match your design principles/values.

![image](https://user-images.githubusercontent.com/4118615/44230503-4c631500-a169-11e8-8539-b68cdb696f84.png)

* [x] Make sure that you propose PR to right branch: bugfix for `master`, feature for latest active branch `feature-x.x`.
* [x] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.