### PR TITLE
add strict mode for submit object property names

### DIFF
--- a/components/form/Form.tsx
+++ b/components/form/Form.tsx
@@ -118,7 +118,7 @@ export type WrappedFormUtils = {
   /** 重置一组输入控件的值与状态，如不传入参数，则重置所有组件 */
   resetFields(names?: Array<string>): void;
 
-  getFieldDecorator(id: string, options?: GetFieldDecoratorOptions): (node: React.ReactNode) => React.ReactNode;
+  getFieldDecorator<T extends Object = {}>(id: keyof T, options?: GetFieldDecoratorOptions): (node: React.ReactNode) => React.ReactNode;
 };
 
 export interface FormComponentProps {

--- a/components/form/Form.tsx
+++ b/components/form/Form.tsx
@@ -117,7 +117,7 @@ export type WrappedFormUtils = {
   isFieldsTouched(names?: Array<string>): boolean;
   /** 重置一组输入控件的值与状态，如不传入参数，则重置所有组件 */
   resetFields(names?: Array<string>): void;
-
+  // tslint:disable-next-line:max-line-length
   getFieldDecorator<T extends Object = {}>(id: keyof T, options?: GetFieldDecoratorOptions): (node: React.ReactNode) => React.ReactNode;
 };
 


### PR DESCRIPTION
This feature adds a posibility to validate property names in TypeScript by inserting required object interface.
