### PR TITLE
Improve input-number handler style

### DIFF
--- a/components/input-number/style/index.less
+++ b/components/input-number/style/index.less
@@ -123,7 +123,7 @@
     cursor: pointer;
     &-inner {
       top: 50%;
-      margin-top: -6px;
+      margin-top: -5px;
       &:before {
         text-align: center;
         content: "\e61e";
@@ -136,7 +136,7 @@
 
   &-handler-down {
     border-top: @border-width-base @border-style-base @border-color-base;
-    top: -1px;
+    top: 0;
     cursor: pointer;
     &-inner {
       top: 50%;


### PR DESCRIPTION
Just make handler look better.

![ant design-input-number](https://user-images.githubusercontent.com/1730277/44385508-329f4480-a552-11e8-8ff3-2a87e0e8ccaa.png)

Left is old style.
Right is new style.
