### PR TITLE
<TreeSelect /> -- Export all `TreeNode` interfaces

### DIFF
--- a/components/tree-select/interface.tsx
+++ b/components/tree-select/interface.tsx
@@ -3,7 +3,7 @@ import { AbstractSelectProps } from '../select';
 
 export type TreeNode = TreeNodeNormal | TreeNodeSimpleMode;
 
-interface TreeNodeNormal {
+export interface TreeNodeNormal {
   value: string;
   /**
    * @deprecated Please use `title` instead.
@@ -18,12 +18,12 @@ interface TreeNodeNormal {
   children?: TreeNodeNormal[];
 }
 
-interface TreeNodeSimpleMode {
+export interface TreeNodeSimpleMode {
   /* It is possible to change `id` and `pId` prop keys using TreeDataSimpleMode so those keys can be anything */
   [key: string]: string | boolean | React.ReactNode;
 }
 
-interface TreeDataSimpleMode {
+export interface TreeDataSimpleMode {
   id?: string;
   pId?: string;
   rootPId?: string;


### PR DESCRIPTION
I would like to enforce `TreeNodeNormal` type since I know I am going to be using it specifically.