### PR TITLE
fix bug: If ItemGroup wraps the first menu, a style error is displayed when the menu is collapsed

### DIFF
--- a/components/menu/style/index.less
+++ b/components/menu/style/index.less
@@ -375,6 +375,7 @@
     width: @menu-collapsed-width;
     > .@{menu-prefix-cls}-item,
     > .@{menu-prefix-cls}-item-group > .@{menu-prefix-cls}-item-group-list > .@{menu-prefix-cls}-item,
+    > .@{menu-prefix-cls}-item-group > .@{menu-prefix-cls}-item-group-list > .@{menu-prefix-cls}-submenu > .@{menu-prefix-cls}-submenu-title,
     > .@{menu-prefix-cls}-submenu > .@{menu-prefix-cls}-submenu-title {
       left: 0;
       text-overflow: clip;


### PR DESCRIPTION
online demo:[https://codepen.io/cnjs/pen/qMEoZG](https://codepen.io/cnjs/pen/qMEoZG)