### PR TITLE
change autoComplete optionLabelProp

### DIFF
--- a/components/auto-complete/index.tsx
+++ b/components/auto-complete/index.tsx
@@ -47,7 +47,7 @@ export default class AutoComplete extends React.Component<AutoCompleteProps, {}>
   static defaultProps = {
     prefixCls: 'ant-select',
     transitionName: 'slide-up',
-    optionLabelProp: 'children',
+    optionLabelProp: 'value',
     choiceTransitionName: 'zoom',
     showSearch: false,
     filterOption: false,


### PR DESCRIPTION
issue: https://github.com/ant-design/ant-design/issues/11851

看了一下就是 optionLabelProp 默认值的问题，但是鉴于这个属性已经存在 2 年了，如果改了担心会导致诸如：
```jsx
<Option key={index}>
  {`id_${index}`}
</Option>
```
这种代码 break 掉。意下如何？