### PR TITLE
Input: new method select(), passed to underlying input

### DIFF
--- a/components/input/Input.tsx
+++ b/components/input/Input.tsx
@@ -82,6 +82,10 @@ export default class Input extends React.Component<InputProps, any> {
     this.input.blur();
   }
 
+  select() {
+    this.input.select();
+  }
+
   getInputClassName() {
     const { prefixCls, size, disabled } = this.props;
     return classNames(prefixCls, {

--- a/components/input/__tests__/index.test.js
+++ b/components/input/__tests__/index.test.js
@@ -15,6 +15,13 @@ describe('Input', () => {
     );
     expect(wrapper).toMatchSnapshot();
   });
+
+  it('select()', () => {
+    const wrapper = mount(
+      <Input />
+    );
+    wrapper.instance().select();
+  });
 });
 
 focusTest(TextArea);


### PR DESCRIPTION
New method `select` which is passed on to the underlying input element. Similar to `focus` and `blur`.

Added no documentation and no demo because `focus` and `blur` weren't documented/demoed.

Side question: the underlying input is stored in `input` member variable. This variable isn't officially documented, but defined in TypeScript interface. So is accessing it *from outside* officially supported and safe, or is this an unsupported feature?

----

* [x] Make sure that you propose PR to right branch: bugfix for `master`, feature for latest active branch `feature-x.x`.
* [x] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.
* Extra checklist for *isNewFeature* **:**
  * [ ] ~Update API docs for the component.~
  * [ ] ~Update/Add demo to demonstrate new feature.~
  * [x] Update TypeScript definition for the component.
  * [ ] ~Add unit tests for the feature.~
