### PR TITLE
docs: explain how to prevent global styles pollution

### DIFF
--- a/docs/react/customize-theme.en-US.md
+++ b/docs/react/customize-theme.en-US.md
@@ -111,11 +111,10 @@ It's possible to configure webpack to load an alternate less file:
 
 ```ts
 new webpack.NormalModuleReplacementPlugin( /node_modules\/antd\/lib\/style\/index\.less/, path.resolve(rootDir, 'src/myStylesReplacement.less') ),
-
-Where the src/myStylesReplacement.less file loads the same files as the index.less file, but loads them within the scope of a top-level selector:
-
 #antd { @import '~antd/lib/style/core/index.less'; @import '~antd/lib/style/themes/default.less'; }
 ```
+
+Where the src/myStylesReplacement.less file loads the same files as the index.less file, but loads them within the scope of a top-level selector:
 
 The result is that all of the "global" styles are being applied with the #antd scope.
 

--- a/docs/react/customize-theme.en-US.md
+++ b/docs/react/customize-theme.en-US.md
@@ -120,7 +120,7 @@ The result is that all of the "global" styles are being applied with the #antd s
 
 ### Use a postcss processor to scope all styles
 
-See eg https://gist.github.com/sbusch/a90eafaf5a5b61c6d6172da6ff76ddaa
+See an example of usage with gulp and [postcss-prefixwrap](https://github.com/dbtedman/postcss-prefixwrap) : https://gist.github.com/sbusch/a90eafaf5a5b61c6d6172da6ff76ddaa
 
 ## Not working?
 

--- a/docs/react/customize-theme.en-US.md
+++ b/docs/react/customize-theme.en-US.md
@@ -110,7 +110,8 @@ While there's no canonical way to do it, you can take one of the following paths
 It's possible to configure webpack to load an alternate less file:
 
 ```ts
-new webpack.NormalModuleReplacementPlugin( /node_modules\/antd\/lib\/style\/index\.less/, path.resolve(rootDir, 'src/myStylesReplacement.less') ),
+new webpack.NormalModuleReplacementPlugin( /node_modules\/antd\/lib\/style\/index\.less/, path.resolve(rootDir, 'src/myStylesReplacement.less') )
+
 #antd { @import '~antd/lib/style/core/index.less'; @import '~antd/lib/style/themes/default.less'; }
 ```
 

--- a/docs/react/customize-theme.en-US.md
+++ b/docs/react/customize-theme.en-US.md
@@ -100,8 +100,8 @@ Note: This way will load the styles of all components, regardless of your demand
 
 ## How to avoid modifying global styles ?
 
-Currently ant-design modify is designed as a whole experience and modify global styles (eg `body` etc).  
-If you need to integrate ant-design as a part of an existing website, it's likely you would want to prevent ant-design to override global styles.  
+Currently ant-design is designed as a whole experience and modify global styles (eg `body` etc).  
+If you need to integrate ant-design as a part of an existing website, it's likely you want to prevent ant-design to override global styles.  
 
 While there's no canonical way to do it, you can take one of the following paths : 
 
@@ -115,9 +115,7 @@ new webpack.NormalModuleReplacementPlugin( /node_modules\/antd\/lib\/style\/inde
 #antd { @import '~antd/lib/style/core/index.less'; @import '~antd/lib/style/themes/default.less'; }
 ```
 
-Where the src/myStylesReplacement.less file loads the same files as the index.less file, but loads them within the scope of a top-level selector:
-
-The result is that all of the "global" styles are being applied with the #antd scope.
+Where the src/myStylesReplacement.less file loads the same files as the index.less file, but loads them within the scope of a top-level selector : the result is that all of the "global" styles are being applied with the #antd scope.
 
 ### Use a postcss processor to scope all styles
 

--- a/docs/react/customize-theme.en-US.md
+++ b/docs/react/customize-theme.en-US.md
@@ -98,6 +98,27 @@ Another approach to customize theme is creating a `less` file within variables t
 
 Note: This way will load the styles of all components, regardless of your demand, which cause `style` option of `babel-plugin-import` not working.
 
+## How to avoid modifying global styles ?
+
+Currently ant-design modify is designed as a whole experience and modify global styles (eg `body` etc).  
+If you need to integrate ant-design as a part of a website, perhaps you would want to prevent ant-design to override global styles.  
+
+While there's no canonical way to do it, you can take one of the following paths : 
+
+### Configuring webpack to scope less files
+
+It's possible to configure webpack to load an alternate less file:
+
+```ts
+new webpack.NormalModuleReplacementPlugin( /node_modules\/antd\/lib\/style\/index\.less/, path.resolve(rootDir, 'src/myStylesReplacement.less') ),
+
+Where the src/myStylesReplacement.less file loads the same files as the index.less file, but loads them within the scope of a top-level selector:
+
+#antd { @import '~antd/lib/style/core/index.less'; @import '~antd/lib/style/themes/default.less'; }
+```
+
+The result is that all of the "global" styles are being applied with the #antd scope:
+
 ## Not working?
 
 You must import styles as less format. A common mistake would be importing multiple copied of styles that some of them are css format to override the less styles.

--- a/docs/react/customize-theme.en-US.md
+++ b/docs/react/customize-theme.en-US.md
@@ -101,11 +101,11 @@ Note: This way will load the styles of all components, regardless of your demand
 ## How to avoid modifying global styles ?
 
 Currently ant-design modify is designed as a whole experience and modify global styles (eg `body` etc).  
-If you need to integrate ant-design as a part of a website, perhaps you would want to prevent ant-design to override global styles.  
+If you need to integrate ant-design as a part of an existing website, it's likely you would want to prevent ant-design to override global styles.  
 
 While there's no canonical way to do it, you can take one of the following paths : 
 
-### Configuring webpack to scope less files
+### Configure webpack to load an alternale less file and scope global styles
 
 It's possible to configure webpack to load an alternate less file:
 
@@ -117,7 +117,11 @@ Where the src/myStylesReplacement.less file loads the same files as the index.le
 #antd { @import '~antd/lib/style/core/index.less'; @import '~antd/lib/style/themes/default.less'; }
 ```
 
-The result is that all of the "global" styles are being applied with the #antd scope:
+The result is that all of the "global" styles are being applied with the #antd scope.
+
+### Use a postcss processor to scope all styles
+
+See eg https://gist.github.com/sbusch/a90eafaf5a5b61c6d6172da6ff76ddaa
 
 ## Not working?
 


### PR DESCRIPTION
Add explanation in docs (customize-theme) to how to prevent global styles pollution by configuring webpack.
Based on https://github.com/ant-design/ant-design/issues/4331#issuecomment-391066131
This solution looks the best for people using webpack.

Add also another solution based on  https://github.com/ant-design/ant-design/issues/4331#issuecomment-396000599

Should help to decrease noise in https://github.com/ant-design/ant-design/issues/4331 ;)

First of all, thank you for your contribution! :-)

Please makes sure that these checkboxes are checked before submitting your PR, thank you!

* [x] Make sure that you propose PR to right branch: bugfix for `master`, feature for latest active branch `feature-x.x`.
* [x] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.

Extra checklist:

**if** *isBugFix* **:**

  * [ ] Make sure that you add at least one unit test for the bug which you had fixed.

**elif** *isNewFeature* **:**

  * [ ] Update API docs for the component.
  * [ ] Update/Add demo to demonstrate new feature.
  * [ ] Update TypeScript definition for the component.
  * [ ] Add unit tests for the feature.
