### PR TITLE
Add @menu-item-active-border-width var to Menu.Item

### DIFF
--- a/components/menu/style/index.less
+++ b/components/menu/style/index.less
@@ -325,7 +325,7 @@
         right: 0;
         top: 0;
         bottom: 0;
-        border-right: 3px solid @menu-highlight-color;
+        border-right: @menu-item-active-border-width solid @menu-highlight-color;
         transform: scaleY(.0001);
         opacity: 0;
         transition: transform .15s @ease-out, opacity .15s @ease-out;

--- a/components/style/themes/default.less
+++ b/components/style/themes/default.less
@@ -324,6 +324,7 @@
 @menu-item-color: @text-color;
 @menu-highlight-color: @primary-color;
 @menu-item-active-bg: @item-active-bg;
+@menu-item-active-border-width: 3px;
 @menu-item-group-title-color: @text-color-secondary;
 // dark theme
 @menu-dark-color: @text-color-secondary-dark;


### PR DESCRIPTION
Adds a variable, `@menu-item-active-border-width`, to modify the `border-width` of the `.ant-menu-item-selected::after` in the `Menu.Item` component. This allows you to adjust the width to match your design principles/values.

![image](https://user-images.githubusercontent.com/4118615/44744048-25de9b80-aad2-11e8-8748-93fd2a3ab284.png)

* [x] Make sure that you propose PR to right branch: bugfix for `master`, feature for latest active branch `feature-x.x`.
* [x] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.