### PR TITLE
remove less vars @icon-url

### DIFF
--- a/components/style/themes/default.less
+++ b/components/style/themes/default.less
@@ -67,7 +67,6 @@
 
 // ICONFONT
 @iconfont-css-prefix    : anticon;
-@icon-url               : "https://at.alicdn.com/t/font_148784_v4ggb6wrjmkotj4i";
 
 // LINK
 @link-color             : @primary-color;

--- a/docs/react/customize-theme.en-US.md
+++ b/docs/react/customize-theme.en-US.md
@@ -100,10 +100,10 @@ Note: This way will load the styles of all components, regardless of your demand
 
 ## How to avoid modifying global styles ?
 
-Currently ant-design is designed as a whole experience and modify global styles (eg `body` etc).  
-If you need to integrate ant-design as a part of an existing website, it's likely you want to prevent ant-design to override global styles.  
+Currently ant-design is designed as a whole experience and modify global styles (eg `body` etc).
+If you need to integrate ant-design as a part of an existing website, it's likely you want to prevent ant-design to override global styles.
 
-While there's no canonical way to do it, you can take one of the following paths : 
+While there's no canonical way to do it, you can take one of the following paths :
 
 ### Configure webpack to load an alternale less file and scope global styles
 
@@ -127,8 +127,6 @@ You must import styles as less format. A common mistake would be importing multi
 
 - If you import styles by specifying the `style` option of [babel-plugin-import](https://github.com/ant-design/babel-plugin-import), change it from `'css'` to `true`, which will import the `less` version of antd.
 - If you import styles from `'antd/dist/antd.css'`, change it to `antd/dist/antd.less`.
-
-If you want to override `@icon-url`, the value must be contained in quotes like `"@icon-url": "'your-icon-font-path'"` ([A fix sample](https://github.com/visvadw/dvajs-user-dashboard/pull/2)).
 
 ## Related Articles
 

--- a/docs/react/customize-theme.zh-CN.md
+++ b/docs/react/customize-theme.zh-CN.md
@@ -105,8 +105,6 @@ module.exports = {
 - 如果你在使用 [babel-plugin-import](https://github.com/ant-design/babel-plugin-import) 的 `style` 配置来引入样式，需要将配置值从 `'css'` 改为 `true`，这样会引入 less 文件。
 - 如果你是通过 `'antd/dist/antd.css'` 引入样式的，改为 `antd/dist/antd.less`。
 
-如果要覆盖 `@icon-url` 变量，内容需要包括引号 `"@icon-url": "'your-icon-font-path'"`（[修正示例](https://github.com/visvadw/dvajs-user-dashboard/pull/2)）。
-
 ## 社区教程
 
 - [Using Ant Design in Sass-Styled Webpack Projects with `antd-scss-theme-plugin`](https://intoli.com/blog/antd-scss-theme-plugin/)


### PR DESCRIPTION
We don't need to use the less variable `@icon-url` any more, 'cause the icons have been downloaded as npm package.
