### PR TITLE
Hotfix/iconfont no display

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ components/**/*.jsx
 # Docs templates
 site/theme/template/IconDisplay/*.js
 site/theme/template/IconDisplay/*.jsx
+site/theme/template/IconDisplay/fields.js

--- a/components/icon/IconFont.tsx
+++ b/components/icon/IconFont.tsx
@@ -30,19 +30,19 @@ export default function create(options: CustomIconOptions = {}): React.SFC<IconP
   }
 
   const Iconfont: React.SFC<IconProps> = (props) => {
-    const { type } = props;
+    const { type, children, ...restProps } = props;
 
     // component > children > type
     let content = null;
     if (props.type) {
       content = <use xlinkHref={`#${type}`} />;
     }
-    if (props.children) {
-      content = props.children;
+    if (children) {
+      content = children;
     }
     return (
       <Icon
-        {...props}
+        {...restProps}
         {...extraCommonProps}
       >
         {content}

--- a/components/icon/__tests__/__snapshots__/index.test.js.snap
+++ b/components/icon/__tests__/__snapshots__/index.test.js.snap
@@ -331,13 +331,49 @@ exports[`Icon.createFromIconfontCN() should support iconfont.cn 1`] = `
   class="icons-list"
 >
   <i
-    class="anticon anticon-icon-tuichu"
-  />
+    class="anticon"
+  >
+    <svg
+      aria-hidden="true"
+      class=""
+      fill="currentColor"
+      height="1em"
+      width="1em"
+    >
+      <use
+        href="#icon-tuichu"
+      />
+    </svg>
+  </i>
   <i
-    class="anticon anticon-icon-facebook"
-  />
+    class="anticon"
+  >
+    <svg
+      aria-hidden="true"
+      class=""
+      fill="currentColor"
+      height="1em"
+      width="1em"
+    >
+      <use
+        href="#icon-facebook"
+      />
+    </svg>
+  </i>
   <i
-    class="anticon anticon-icon-twitter"
-  />
+    class="anticon"
+  >
+    <svg
+      aria-hidden="true"
+      class=""
+      fill="currentColor"
+      height="1em"
+      width="1em"
+    >
+      <use
+        href="#icon-twitter"
+      />
+    </svg>
+  </i>
 </div>
 `;


### PR DESCRIPTION
fix warning
```
console.error node_modules/_warning@4.0.2@warning/warning.js:34
    Warning: Icon should have `type` prop or `component` prop or `children`.

  console.error node_modules/_warning@4.0.2@warning/warning.js:34
    Warning: Make sure that you provide correct `viewBox` prop (default `0 0 1024 1024`) to the icon.

  console.error node_modules/_@ant-design_icons-react@1.0.0@@ant-design/icons-react/lib/utils.js:39
    [@ant-design/icons-react]: Could not find icon: icon-tuichu-o.

```

具体表现为走`createFromIconFontCN({...})` 也会创建 `Icon`。但是 `type` 属性传入 `Icon` 走了组件逻辑