### PR TITLE
Inherit @form-feedback-icon-size from @font-size-base;

### DIFF
--- a/components/form/style/index.less
+++ b/components/form/style/index.less
@@ -8,7 +8,7 @@
 @form-prefix-cls: ~"@{ant-prefix}-form";
 @form-component-height: @input-height-base;
 @form-component-max-height: @input-height-lg;
-@form-feedback-icon-size: 14px;
+@form-feedback-icon-size: @font-size-base;
 @form-help-margin-top: (@form-component-height - @form-component-max-height) / 2 + 2px;
 
 .@{form-prefix-cls} {


### PR DESCRIPTION
I redefined the `@font-size-base` in my application. I noticed the green checkmark for the form feedback did not adapt in size. This fix makes it so the `@form-feedback-icon-size` is set dynamically from the `@font-size-base`

Before it was hardcoded to 14px (the default base font size)

![image](https://user-images.githubusercontent.com/12158000/44991678-21fcbe80-af95-11e8-8c73-fcccfd82f6dc.png)

Now it adapts, based on the font-size the whole app uses

![image](https://user-images.githubusercontent.com/12158000/44991908-faf2bc80-af95-11e8-8cc4-f13c64a3c134.png)

Further idea: It may be even better to adapt the size of the checkmark depending on the size of the parent input.