### PR TITLE
Fix less config in documentation

### DIFF
--- a/docs/react/use-in-typescript.en-US.md
+++ b/docs/react/use-in-typescript.en-US.md
@@ -200,6 +200,7 @@ $ yarn add react-app-rewire-less --dev
     };
 
 +   config = rewireLess.withLoaderOptions({
++     javascriptEnabled: true,
 +     modifyVars: { "@primary-color": "#1DA57A" },
 +   })(config, env);
 


### PR DESCRIPTION
There is a bug in documentation which produces an error:

```
Failed to compile.

./node_modules/antd/es/button/style/index.lessModule build failed:

// https://github.com/ant-design/ant-motion/issues/44
.bezierEasingMixin();^
Inline JavaScript is not enabled. Is it set in your options?
      in /.../node_modules/antd/es/style/color/bezierEasing.less (line 110, column 0)
```

Solution found here:
https://github.com/ant-design/ant-design/issues/7927#issuecomment-400368810