### PR TITLE
fix: Enable maskStyle on Drawer

### DIFF
--- a/components/drawer/index.tsx
+++ b/components/drawer/index.tsx
@@ -200,13 +200,17 @@ export default class Drawer extends React.Component<DrawerProps, IDrawerState> {
   }
 
   getRcDrawerStyle = () => {
-    const { zIndex, placement } = this.props;
+    const { zIndex, placement, maskStyle } = this.props;
     return this.state.push
     ? {
+      ...maskStyle,
       zIndex,
       transform: this.getPushTransform(placement),
     }
-    : { zIndex };
+    : {
+      ...maskStyle,
+      zIndex,
+    };
   }
 
   // render Provider for Multi-level drawe


### PR DESCRIPTION
This is a bugfix.

Bug description: The `maskStyle` prop of `Drawer` is documented in website, and declared in source file, but never used.