### PR TITLE
fix:onOpenChange handler not being called in RangePicker for preset r…

### DIFF
--- a/components/date-picker/RangePicker.tsx
+++ b/components/date-picker/RangePicker.tsx
@@ -184,9 +184,13 @@ class RangePicker extends React.Component<any, RangePickerState> {
 
     this.setValue(value, true);
 
-    const { onOk } = this.props;
+    const { onOk,onOpenChange } = this.props;
     if (onOk) {
       onOk(value);
+    }
+
+    if (onOpenChange) {
+      onOpenChange(false);
     }
   }
 

--- a/components/date-picker/RangePicker.tsx
+++ b/components/date-picker/RangePicker.tsx
@@ -184,7 +184,7 @@ class RangePicker extends React.Component<any, RangePickerState> {
 
     this.setValue(value, true);
 
-    const { onOk,onOpenChange } = this.props;
+    const { onOk, onOpenChange } = this.props;
     if (onOk) {
       onOk(value);
     }

--- a/components/date-picker/__tests__/RangePicker.test.js
+++ b/components/date-picker/__tests__/RangePicker.test.js
@@ -224,4 +224,13 @@ describe('RangePicker', () => {
     wrapper.find('.ant-calendar-prev-month-btn').first().simulate('click');
     expect(wrapper.find('.ant-calendar-my-select').first().text()).toBe('Jun2017');
   });
+  // https://github.com/ant-design/ant-design/issues/11631
+  it('triggers onOpenChange when click on preset range', () => {
+    const handleOpenChange = jest.fn();
+    const range = [moment().subtract(2, 'd'), moment()];
+    const wrapper = mount(<RangePicker onOpenChange={handleOpenChange} ranges={{ 'recent two days': range }} />);
+    wrapper.find('.ant-calendar-picker-input').simulate('click');
+    wrapper.find('.ant-calendar-range-quick-selector Tag').simulate('click');
+    expect(handleOpenChange).toBeCalledWith(false);
+  });
 });


### PR DESCRIPTION
…anges(#11631)

First of all, thank you for your contribution! :-)

Please makes sure that these checkboxes are checked before submitting your PR, thank you!

* [x] Make sure that you propose PR to right branch: bugfix for `master`, feature for branch `feature`.
* [x] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.

Extra checklist:

**if** *isBugFix* **:**

  * [x] Make sure that you add at least one unit test for the bug which you had fixed.

**elif** *isNewFeature* **:**

  * [ ] Update API docs for the component.
  * [ ] Update/Add demo to demonstrate new feature.
  * [ ] Update TypeScript definition for the component.
  * [ ] Add unit tests for the feature.


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#11631: onOpenChange handler not being called in RangePicker for preset ranges (set via ranges prop to RangePicker)](https://issuehunt.io/repos/34526884/issues/11631)
---

IssueHunt has been backed by the following sponsors. [Become a sponsor](https://issuehunt.io/membership/members)
</details>
<!-- /Issuehunt content-->