### PR TITLE
fix form onFieldsChange param type

### DIFF
--- a/components/form/Form.tsx
+++ b/components/form/Form.tsx
@@ -19,7 +19,7 @@ interface FormCreateOptionMessages {
 }
 
 export interface FormCreateOption<T> {
-  onFieldsChange?: (props: T, fields: Array<any>, allFields: any, add: string) => void;
+  onFieldsChange?: (props: T, fields: object, allFields: any, add: string) => void;
   onValuesChange?: (props: T, changedValues: any, allValues: any) => void;
   mapPropsToFields?: (props: T) => void;
   validateMessages?: FormCreateOptionMessages;


### PR DESCRIPTION
The second param `fields` of `onFieldsChange` should be type `object` instead of `Array`.

currently, if you assign a more specific type(interface) to fields, you will get a type error:

[[reproduction link]](https://codesandbox.io/s/13moprz4n4)