### PR TITLE
feat: support customizing Collapse expandIcon name

### DIFF
--- a/components/collapse/Collapse.tsx
+++ b/components/collapse/Collapse.tsx
@@ -16,6 +16,7 @@ export interface CollapseProps {
   className?: string;
   bordered?: boolean;
   prefixCls?: string;
+  arrowIcon?: string;
 }
 
 export default class Collapse extends React.Component<CollapseProps, any> {
@@ -25,11 +26,12 @@ export default class Collapse extends React.Component<CollapseProps, any> {
     prefixCls: 'ant-collapse',
     bordered: true,
     openAnimation: { ...animation, appear() { } },
+    arrowIcon: 'right',
   };
 
   renderExpandIcon = () => {
     return (
-      <Icon type="right" className={`arrow`} />
+      <Icon type={this.props.arrowIcon} className={`arrow`} />
     );
   }
 

--- a/components/collapse/Collapse.tsx
+++ b/components/collapse/Collapse.tsx
@@ -16,7 +16,7 @@ export interface CollapseProps {
   className?: string;
   bordered?: boolean;
   prefixCls?: string;
-  arrowIcon?: string;
+  switcherIcon?: string;
 }
 
 export default class Collapse extends React.Component<CollapseProps, any> {
@@ -26,12 +26,12 @@ export default class Collapse extends React.Component<CollapseProps, any> {
     prefixCls: 'ant-collapse',
     bordered: true,
     openAnimation: { ...animation, appear() { } },
-    arrowIcon: 'right',
+    switcherIcon: 'right',
   };
 
   renderExpandIcon = () => {
     return (
-      <Icon type={this.props.arrowIcon} className={`arrow`} />
+      <Icon type={this.props.switcherIcon} className={`arrow`} />
     );
   }
 

--- a/components/collapse/index.en-US.md
+++ b/components/collapse/index.en-US.md
@@ -24,7 +24,7 @@ A content area which can be collapsed and expanded.
 | defaultActiveKey | Key of the initial active panel | string | - |
 | onChange | Callback function executed when active panel is changed | Function | - |
 | destroyInactivePanel | Destroy Inactive Panel | boolean | `false` |
-| arrowIcon | Expand-icon name in Panel Header | string | `right` |
+| switcherIcon | Expand-icon name in Panel Header | string | `right` |
 
 ### Collapse.Panel
 

--- a/components/collapse/index.en-US.md
+++ b/components/collapse/index.en-US.md
@@ -24,6 +24,7 @@ A content area which can be collapsed and expanded.
 | defaultActiveKey | Key of the initial active panel | string | - |
 | onChange | Callback function executed when active panel is changed | Function | - |
 | destroyInactivePanel | Destroy Inactive Panel | boolean | `false` |
+| arrowIcon | Expand-icon name in Panel Header | string | `right` |
 
 ### Collapse.Panel
 

--- a/components/collapse/index.zh-CN.md
+++ b/components/collapse/index.zh-CN.md
@@ -22,7 +22,7 @@ cols: 1
 | activeKey | 当前激活 tab 面板的 key | string\[]\|string | 默认无，accordion模式下默认第一个元素 |
 | defaultActiveKey | 初始化选中面板的 key | string | 无 |
 | onChange | 切换面板的回调 | Function | 无 |
-| arrowIcon | 面板顶部箭头的 Icon 名称 | string | `right` |
+| switcherIcon | 面板顶部箭头的 Icon 名称 | string | `right` |
 
 ### Collapse.Panel
 

--- a/components/collapse/index.zh-CN.md
+++ b/components/collapse/index.zh-CN.md
@@ -22,6 +22,7 @@ cols: 1
 | activeKey | 当前激活 tab 面板的 key | string\[]\|string | 默认无，accordion模式下默认第一个元素 |
 | defaultActiveKey | 初始化选中面板的 key | string | 无 |
 | onChange | 切换面板的回调 | Function | 无 |
+| arrowIcon | 面板顶部箭头的 Icon 名称 | string | `right` |
 
 ### Collapse.Panel
 


### PR DESCRIPTION
Need to customize the icon in my case. If the API is ok, I will update the readme soon

#### code
```
<Collapse defaultActiveKey={['1']} onChange={callback} arrowIcon="caret-right">
...
</Collapse>
```

#### appearance
![image](https://user-images.githubusercontent.com/5318333/45417719-6b47bf00-b6b5-11e8-8be0-e00d60a5eb33.png)
