### PR TITLE
Hotfix(Upload & Icon): upload close icon style error

### DIFF
--- a/components/upload/style/index.less
+++ b/components/upload/style/index.less
@@ -166,7 +166,7 @@
       top: 6px;
       right: 4px;
       color: @text-color-secondary;
-      line-height: 22px;
+      line-height: 0;
       &:hover {
         color: @text-color;
       }


### PR DESCRIPTION
## Upload

| Before | After |
|:-------:|:-----:|
|![before](https://user-images.githubusercontent.com/15819224/45802098-6b187680-bce8-11e8-9d24-8152f3f5cb25.png)|![after](https://user-images.githubusercontent.com/15819224/45802106-6fdd2a80-bce8-11e8-86af-03ee0efaa443.png)|