### PR TITLE
[wip]fix: layout demo page of overflowed menu

### DIFF
--- a/components/layout/demo/fixed.md
+++ b/components/layout/demo/fixed.md
@@ -27,7 +27,7 @@ ReactDOM.render(
         theme="dark"
         mode="horizontal"
         defaultSelectedKeys={['2']}
-        style={{ lineHeight: '64px' }}
+        style={{ lineHeight: '64px', width: 'calc(100% - 120px)' }}
       >
         <Menu.Item key="1">nav 1</Menu.Item>
         <Menu.Item key="2">nav 2</Menu.Item>

--- a/components/layout/demo/top-side-2.md
+++ b/components/layout/demo/top-side-2.md
@@ -27,7 +27,7 @@ ReactDOM.render(
         theme="dark"
         mode="horizontal"
         defaultSelectedKeys={['2']}
-        style={{ lineHeight: '64px' }}
+        style={{ lineHeight: '64px', width: 'calc(100% - 120px)' }}
       >
         <Menu.Item key="1">nav 1</Menu.Item>
         <Menu.Item key="2">nav 2</Menu.Item>

--- a/components/layout/demo/top-side.md
+++ b/components/layout/demo/top-side.md
@@ -27,7 +27,7 @@ ReactDOM.render(
         theme="dark"
         mode="horizontal"
         defaultSelectedKeys={['2']}
-        style={{ lineHeight: '64px' }}
+        style={{ lineHeight: '64px', width: 'calc(100% - 120px)' }}
       >
         <Menu.Item key="1">nav 1</Menu.Item>
         <Menu.Item key="2">nav 2</Menu.Item>

--- a/components/layout/demo/top.md
+++ b/components/layout/demo/top.md
@@ -33,7 +33,7 @@ ReactDOM.render(
         theme="dark"
         mode="horizontal"
         defaultSelectedKeys={['2']}
-        style={{ lineHeight: '64px' }}
+        style={{ lineHeight: '64px', width: 'calc(100% - 120px)' }}
       >
         <Menu.Item key="1">nav 1</Menu.Item>
         <Menu.Item key="2">nav 2</Menu.Item>


### PR DESCRIPTION
ref: https://github.com/react-component/menu/issues/200

最后一个 fixed header demo ... 的时候出不来 submenu, 还没找出原因，先开着。

可能的区别是在 iframe 里。 