### PR TITLE
add/fix tooltip align interface

### DIFF
--- a/components/tooltip/index.en-US.md
+++ b/components/tooltip/index.en-US.md
@@ -35,6 +35,7 @@ The following APIs are shared by Tooltip, Popconfirm, Popover.
 | trigger | Tooltip trigger mode | `hover` \| `focus` \| `click` \| `contextMenu` | `hover` |
 | visible | Whether the floating tooltip card is visible or not | boolean | `false` |
 | onVisibleChange | Callback executed when visibility of the tooltip card is changed | (visible) => void | - |
+| align | this value will be merged into placement's config, please refer to the settings [rc-tooltip](https://github.com/react-component/tooltip) | Object | - |
 
 ## Note
 

--- a/components/tooltip/index.tsx
+++ b/components/tooltip/index.tsx
@@ -15,6 +15,16 @@ export type TooltipPlacement =
 
 export type TooltipTrigger = 'hover' | 'focus' | 'click' | 'contextMenu';
 
+export interface TooltipAlignConfig {
+  points?: [string, string],
+  offset?: [number, number],
+  targetOffset?: [number, number],
+  overflow?: { adjustX: boolean, adjustY: boolean },
+  useCssRight?: boolean,
+  useCssBottom?: boolean,
+  useCssTransform?: boolean
+}
+
 export interface AbstractTooltipProps {
   prefixCls?: string;
   overlayClassName?: string;
@@ -36,6 +46,7 @@ export interface AbstractTooltipProps {
   getTooltipContainer?: (triggerNode: Element) => HTMLElement;
   getPopupContainer?: (triggerNode: Element) => HTMLElement;
   children?: React.ReactNode;
+  align?: TooltipAlignConfig;
 }
 
 export type RenderFunction = () => React.ReactNode;

--- a/components/tooltip/index.tsx
+++ b/components/tooltip/index.tsx
@@ -15,10 +15,12 @@ export type TooltipPlacement =
 
 export type TooltipTrigger = 'hover' | 'focus' | 'click' | 'contextMenu';
 
+// https://github.com/react-component/tooltip
+// https://github.com/yiminghe/dom-align
 export interface TooltipAlignConfig {
   points?: [string, string],
-  offset?: [number, number],
-  targetOffset?: [number, number],
+  offset?: [number | string, number | string],
+  targetOffset?: [number | string, number | string],
   overflow?: { adjustX: boolean, adjustY: boolean },
   useCssRight?: boolean,
   useCssBottom?: boolean,
@@ -46,6 +48,7 @@ export interface AbstractTooltipProps {
   getTooltipContainer?: (triggerNode: Element) => HTMLElement;
   getPopupContainer?: (triggerNode: Element) => HTMLElement;
   children?: React.ReactNode;
+  // align is a more higher api
   align?: TooltipAlignConfig;
 }
 

--- a/components/tooltip/index.zh-CN.md
+++ b/components/tooltip/index.zh-CN.md
@@ -37,6 +37,7 @@ title: Tooltip
 | trigger | 触发行为，可选 `hover/focus/click/contextMenu` | string | hover |
 | visible | 用于手动控制浮层显隐 | boolean | false |
 | onVisibleChange | 显示隐藏的回调 | (visible) => void | 无 |
+| align | 该值将合并到 placement 的配置中，设置参考 [rc-tooltip](https://github.com/react-component/tooltip) | Object | 无 |
 
 ## 注意
 


### PR DESCRIPTION
When use Typescript in app, a higher prop of rc-toolip 'align' isn't exposed in the Tooltip interface.
And the relative issues is [issues/12321](https://github.com/ant-design/ant-design/issues/12321)