### PR TITLE
Modal: Add the update function type definition

### DIFF
--- a/components/modal/Modal.tsx
+++ b/components/modal/Modal.tsx
@@ -84,6 +84,7 @@ export interface ModalFuncProps {
 
 export type ModalFunc = (props: ModalFuncProps) => {
   destroy: () => void,
+  update: (newConfig: ModalFuncProps) => void,
 };
 
 export interface ModalLocale {


### PR DESCRIPTION
#11884 added the update function: https://github.com/ant-design/ant-design/blame/46f1d3e97952e216e60ab7c737956bc3db8d9725/components/modal/confirm.tsx#L98

But it wasn't added to the ModalFunc type, so TypeScript wouldn't let me use it. This PR adds the method to that type.