### PR TITLE
Makes defaultProps types more specific to fix type error

### DIFF
--- a/components/anchor/Anchor.tsx
+++ b/components/anchor/Anchor.tsx
@@ -117,10 +117,10 @@ export default class Anchor extends React.Component<AnchorProps, AnchorState> {
   static Link: typeof AnchorLink;
 
   static defaultProps = {
-    prefixCls: 'ant-anchor',
-    affix: true,
-    showInkInFixed: false,
-    getContainer: getDefaultContainer,
+    prefixCls: 'ant-anchor' as 'ant-anchor',
+    affix: true as true,
+    showInkInFixed: false as false,
+    getContainer: getDefaultContainer as typeof getDefaultContainer,
   };
 
   static childContextTypes = {

--- a/components/anchor/AnchorLink.tsx
+++ b/components/anchor/AnchorLink.tsx
@@ -12,8 +12,8 @@ export interface AnchorLinkProps {
 
 export default class AnchorLink extends React.Component<AnchorLinkProps, any> {
   static defaultProps = {
-    prefixCls: 'ant-anchor',
-    href: '#',
+    prefixCls: 'ant-anchor' as 'ant-anchor',
+    href: '#' as '#',
   };
 
   static contextTypes = {

--- a/components/auto-complete/index.tsx
+++ b/components/auto-complete/index.tsx
@@ -45,12 +45,12 @@ export default class AutoComplete extends React.Component<AutoCompleteProps, {}>
   static OptGroup = OptGroup as React.ClassicComponentClass<OptGroupProps>;
 
   static defaultProps = {
-    prefixCls: 'ant-select',
-    transitionName: 'slide-up',
-    optionLabelProp: 'children',
-    choiceTransitionName: 'zoom',
-    showSearch: false,
-    filterOption: false,
+    prefixCls: 'ant-select' as 'ant-select',
+    transitionName: 'slide-up' as 'slide-up',
+    optionLabelProp: 'children' as 'children',
+    choiceTransitionName: 'zoom' as 'zoom',
+    showSearch: false as false,
+    filterOption: false as false,
   };
 
   private select: any;

--- a/components/avatar/index.tsx
+++ b/components/avatar/index.tsx
@@ -32,9 +32,9 @@ export interface AvatarState {
 
 export default class Avatar extends React.Component<AvatarProps, AvatarState> {
   static defaultProps = {
-    prefixCls: 'ant-avatar',
-    shape: 'circle',
-    size: 'default',
+    prefixCls: 'ant-avatar' as 'ant-avatar',
+    shape: 'circle' as 'circle',
+    size: 'default' as 'default',
   };
 
   private avatarChildren: any;

--- a/components/back-top/index.tsx
+++ b/components/back-top/index.tsx
@@ -33,7 +33,7 @@ export interface BackTopProps {
 
 export default class BackTop extends React.Component<BackTopProps, any> {
   static defaultProps = {
-    visibilityHeight: 400,
+    visibilityHeight: 400 as 400,
   };
 
   scrollEvent: any;

--- a/components/badge/ScrollNumber.tsx
+++ b/components/badge/ScrollNumber.tsx
@@ -28,8 +28,8 @@ export interface ScrollNumberState {
 
 export default class ScrollNumber extends Component<ScrollNumberProps, ScrollNumberState> {
   static defaultProps = {
-    prefixCls: 'ant-scroll-number',
-    count: null,
+    prefixCls: 'ant-scroll-number' as 'ant-scroll-number',
+    count: null as null,
     onAnimated() {
     },
   };

--- a/components/badge/index.tsx
+++ b/components/badge/index.tsx
@@ -26,12 +26,12 @@ export interface BadgeProps {
 
 export default class Badge extends React.Component<BadgeProps, any> {
   static defaultProps = {
-    prefixCls: 'ant-badge',
-    scrollNumberPrefixCls: 'ant-scroll-number',
-    count: null,
-    showZero: false,
-    dot: false,
-    overflowCount: 99,
+    prefixCls: 'ant-badge' as 'ant-badge',
+    scrollNumberPrefixCls: 'ant-scroll-number' as 'ant-scroll-number',
+    count: null as null,
+    showZero: false as false,
+    dot: false as false,
+    overflowCount: 99 as 99,
   };
 
   static propTypes = {

--- a/components/breadcrumb/Breadcrumb.tsx
+++ b/components/breadcrumb/Breadcrumb.tsx
@@ -44,8 +44,8 @@ export default class Breadcrumb extends React.Component<BreadcrumbProps, any> {
   static Item: typeof BreadcrumbItem;
 
   static defaultProps = {
-    prefixCls: 'ant-breadcrumb',
-    separator: '/',
+    prefixCls: 'ant-breadcrumb' as 'ant-breadcrumb',
+    separator: '/' as '/',
   };
 
   static propTypes = {

--- a/components/breadcrumb/BreadcrumbItem.tsx
+++ b/components/breadcrumb/BreadcrumbItem.tsx
@@ -11,8 +11,8 @@ export default class BreadcrumbItem extends React.Component<BreadcrumbItemProps,
   static __ANT_BREADCRUMB_ITEM = true;
 
   static defaultProps = {
-    prefixCls: 'ant-breadcrumb',
-    separator: '/',
+    prefixCls: 'ant-breadcrumb' as 'ant-breadcrumb',
+    separator: '/' as '/',
   };
 
   static propTypes = {

--- a/components/button/button.tsx
+++ b/components/button/button.tsx
@@ -70,10 +70,10 @@ export default class Button extends React.Component<ButtonProps, any> {
   static __ANT_BUTTON = true;
 
   static defaultProps = {
-    prefixCls: 'ant-btn',
-    loading: false,
-    ghost: false,
-    block: false,
+    prefixCls: 'ant-btn' as 'ant-btn',
+    loading: false as false,
+    ghost: false as false,
+    block: false as false,
   };
 
   static propTypes = {

--- a/components/calendar/Constants.tsx
+++ b/components/calendar/Constants.tsx
@@ -1,1 +1,1 @@
-export const PREFIX_CLS = 'ant-fullcalendar';
+export const PREFIX_CLS = 'ant-fullcalendar' as 'ant-fullcalendar';

--- a/components/calendar/Header.tsx
+++ b/components/calendar/Header.tsx
@@ -21,8 +21,8 @@ export interface HeaderProps {
 export default class Header extends React.Component<HeaderProps, any> {
   static defaultProps = {
     prefixCls: `${PREFIX_CLS}-header`,
-    yearSelectOffset: 10,
-    yearSelectTotal: 20,
+    yearSelectOffset: 10 as 10,
+    yearSelectTotal: 20 as 20,
   };
 
   private calenderHeaderNode: HTMLDivElement;

--- a/components/calendar/index.tsx
+++ b/components/calendar/index.tsx
@@ -49,9 +49,9 @@ export interface CalendarState {
 export default class Calendar extends React.Component<CalendarProps, CalendarState> {
   static defaultProps = {
     locale: {},
-    fullscreen: true,
+    fullscreen: true as true,
     prefixCls: PREFIX_CLS,
-    mode: 'month',
+    mode: 'month' as 'month',
     onSelect: noop,
     onPanelChange: noop,
     onChange: noop,

--- a/components/carousel/index.tsx
+++ b/components/carousel/index.tsx
@@ -68,10 +68,10 @@ export interface CarouselProps {
 
 export default class Carousel extends React.Component<CarouselProps, {}> {
   static defaultProps = {
-    dots: true,
-    arrows: false,
-    prefixCls: 'ant-carousel',
-    draggable: false,
+    dots: true as true,
+    arrows: false as false,
+    prefixCls: 'ant-carousel' as 'ant-carousel',
+    draggable: false as false,
   };
 
   innerSlider: any;

--- a/components/cascader/index.tsx
+++ b/components/cascader/index.tsx
@@ -142,15 +142,15 @@ const defaultDisplayRender = (label: string[]) => label.join(' / ');
 
 export default class Cascader extends React.Component<CascaderProps, CascaderState> {
   static defaultProps = {
-    prefixCls: 'ant-cascader',
-    inputPrefixCls: 'ant-input',
-    placeholder: 'Please select',
-    transitionName: 'slide-up',
-    popupPlacement: 'bottomLeft',
+    prefixCls: 'ant-cascader' as 'ant-cascader',
+    inputPrefixCls: 'ant-input' as 'ant-input',
+    placeholder: 'Please select' as 'Please select',
+    transitionName: 'slide-up' as 'slide-up',
+    popupPlacement: 'bottomLeft' as 'bottomLeft',
     options: [],
-    disabled: false,
-    allowClear: true,
-    notFoundContent: 'Not Found',
+    disabled: false as false,
+    allowClear: true as true,
+    notFoundContent: 'Not Found' as 'Not Found',
   };
 
   cachedOptions: CascaderOptionType[];

--- a/components/checkbox/Checkbox.tsx
+++ b/components/checkbox/Checkbox.tsx
@@ -41,8 +41,8 @@ export interface CheckboxChangeEvent {
 export default class Checkbox extends React.Component<CheckboxProps, {}> {
   static Group: typeof CheckboxGroup;
   static defaultProps = {
-    prefixCls: 'ant-checkbox',
-    indeterminate: false,
+    prefixCls: 'ant-checkbox' as 'ant-checkbox',
+    indeterminate: false as false,
   };
 
   static contextTypes = {

--- a/components/checkbox/Group.tsx
+++ b/components/checkbox/Group.tsx
@@ -42,7 +42,7 @@ export interface CheckboxGroupContext {
 class CheckboxGroup extends React.Component<CheckboxGroupProps, CheckboxGroupState> {
   static defaultProps = {
     options: [],
-    prefixCls: 'ant-checkbox',
+    prefixCls: 'ant-checkbox' as 'ant-checkbox',
   };
 
   static propTypes = {

--- a/components/collapse/Collapse.tsx
+++ b/components/collapse/Collapse.tsx
@@ -22,8 +22,8 @@ export default class Collapse extends React.Component<CollapseProps, any> {
   static Panel = CollapsePanel;
 
   static defaultProps = {
-    prefixCls: 'ant-collapse',
-    bordered: true,
+    prefixCls: 'ant-collapse' as 'ant-collapse',
+    bordered: true as true,
     openAnimation: { ...animation, appear() { } },
   };
 

--- a/components/date-picker/RangePicker.tsx
+++ b/components/date-picker/RangePicker.tsx
@@ -67,10 +67,10 @@ function fixLocale(value: RangePickerValue | undefined, localeCode: string) {
 
 class RangePicker extends React.Component<any, RangePickerState> {
   static defaultProps = {
-    prefixCls: 'ant-calendar',
-    tagPrefixCls: 'ant-tag',
-    allowClear: true,
-    showToday: false,
+    prefixCls: 'ant-calendar' as 'ant-calendar',
+    tagPrefixCls: 'ant-tag' as 'ant-tag',
+    allowClear: true as true,
+    showToday: false as false,
   };
 
   static getDerivedStateFromProps(nextProps: any, prevState: any) {

--- a/components/date-picker/WeekPicker.tsx
+++ b/components/date-picker/WeekPicker.tsx
@@ -13,8 +13,8 @@ function formatValue(value: moment.Moment | null, format: string): string {
 
 class WeekPicker extends React.Component<any, any> {
   static defaultProps = {
-    format: 'gggg-wo',
-    allowClear: true,
+    format: 'gggg-wo' as 'gggg-wo',
+    allowClear: true as true,
   };
 
   static getDerivedStateFromProps(nextProps: any) {

--- a/components/date-picker/createPicker.tsx
+++ b/components/date-picker/createPicker.tsx
@@ -18,9 +18,9 @@ export interface PickerProps {
 export default function createPicker(TheCalendar: React.ComponentClass): any {
   class CalenderWrapper extends React.Component<any, any> {
     static defaultProps = {
-      prefixCls: 'ant-calendar',
-      allowClear: true,
-      showToday: true,
+      prefixCls: 'ant-calendar' as 'ant-calendar',
+      allowClear: true as true,
+      showToday: true as true,
     };
 
     static getDerivedStateFromProps(nextProps: PickerProps, prevState: any) {

--- a/components/date-picker/wrapPicker.tsx
+++ b/components/date-picker/wrapPicker.tsx
@@ -26,7 +26,7 @@ export default function wrapPicker(Picker: React.ComponentClass<any>, defaultFor
   return class PickerWrapper extends React.Component<any, any> {
     static defaultProps = {
       format: defaultFormat || 'YYYY-MM-DD',
-      transitionName: 'slide-up',
+      transitionName: 'slide-up' as 'slide-up',
       popupStyle: {},
       onChange() {
       },
@@ -35,8 +35,8 @@ export default function wrapPicker(Picker: React.ComponentClass<any>, defaultFor
       onOpenChange() {
       },
       locale: {},
-      prefixCls: 'ant-calendar',
-      inputPrefixCls: 'ant-input',
+      prefixCls: 'ant-calendar' as 'ant-calendar',
+      inputPrefixCls: 'ant-input' as 'ant-input',
     };
 
     private picker: any;

--- a/components/drawer/index.tsx
+++ b/components/drawer/index.tsx
@@ -66,13 +66,13 @@ export default class Drawer extends React.Component<DrawerProps, IDrawerState> {
   };
 
   static defaultProps = {
-    prefixCls: 'ant-drawer',
-    width: 256,
-    height: 256,
-    closable: true,
-    placement: 'right',
-    maskClosable: true,
-    level: null,
+    prefixCls: 'ant-drawer' as 'ant-drawer',
+    width: 256 as 256,
+    height: 256 as 256,
+    closable: true as true,
+    placement: 'right' as 'right',
+    maskClosable: true as true,
+    level: null as null,
   };
 
   readonly state = {

--- a/components/dropdown/dropdown-button.tsx
+++ b/components/dropdown/dropdown-button.tsx
@@ -7,7 +7,7 @@ import classNames from 'classnames';
 const ButtonGroup = Button.Group;
 
 export interface DropdownButtonProps extends ButtonGroupProps, DropDownProps {
-  type?: 'primary' | 'ghost' | 'dashed';
+  type?: 'default' | 'primary' | 'ghost' | 'dashed';
   htmlType?: ButtonHTMLType;
   disabled?: boolean;
   onClick?: React.MouseEventHandler<HTMLButtonElement>;
@@ -16,9 +16,9 @@ export interface DropdownButtonProps extends ButtonGroupProps, DropDownProps {
 
 export default class DropdownButton extends React.Component<DropdownButtonProps, any> {
   static defaultProps = {
-    placement: 'bottomRight',
-    type: 'default',
-    prefixCls: 'ant-dropdown-button',
+    placement: 'bottomRight' as 'bottomRight',
+    type: 'default' as 'default',
+    prefixCls: 'ant-dropdown-button' as 'ant-dropdown-button',
   };
 
   render() {

--- a/components/dropdown/dropdown.tsx
+++ b/components/dropdown/dropdown.tsx
@@ -23,10 +23,10 @@ export interface DropDownProps {
 export default class Dropdown extends React.Component<DropDownProps, any> {
   static Button: typeof DropdownButton;
   static defaultProps = {
-    prefixCls: 'ant-dropdown',
-    mouseEnterDelay: 0.15,
-    mouseLeaveDelay: 0.1,
-    placement: 'bottomLeft',
+    prefixCls: 'ant-dropdown' as 'ant-dropdown',
+    mouseEnterDelay: 0.15 as 0.15,
+    mouseLeaveDelay: 0.1 as 0.1,
+    placement: 'bottomLeft' as 'bottomLeft',
   };
 
   getTransitionName() {

--- a/components/form/Form.tsx
+++ b/components/form/Form.tsx
@@ -145,9 +145,9 @@ export interface ComponentDecorator {
 
 export default class Form extends React.Component<FormProps, any> {
   static defaultProps = {
-    prefixCls: 'ant-form',
-    layout: 'horizontal' as FormLayout,
-    hideRequiredMark: false,
+    prefixCls: 'ant-form' as 'ant-form',
+    layout: 'horizontal' as 'horizontal',
+    hideRequiredMark: false as false,
     onSubmit(e: React.FormEvent<HTMLFormElement>) {
       e.preventDefault();
     },

--- a/components/form/FormItem.tsx
+++ b/components/form/FormItem.tsx
@@ -32,9 +32,9 @@ export interface FormItemContext {
 
 export default class FormItem extends React.Component<FormItemProps, any> {
   static defaultProps = {
-    hasFeedback: false,
-    prefixCls: 'ant-form',
-    colon: true,
+    hasFeedback: false as false,
+    prefixCls: 'ant-form' as 'ant-form',
+    colon: true as true,
   };
 
   static propTypes = {

--- a/components/grid/row.tsx
+++ b/components/grid/row.tsx
@@ -49,7 +49,7 @@ const responsiveMap: BreakpointMap = {
 
 export default class Row extends React.Component<RowProps, RowState> {
   static defaultProps = {
-    gutter: 0,
+    gutter: 0 as 0,
   };
 
   static propTypes = {

--- a/components/input-number/index.tsx
+++ b/components/input-number/index.tsx
@@ -30,8 +30,8 @@ export interface InputNumberProps extends Omit<React.InputHTMLAttributes<HTMLInp
 
 export default class InputNumber extends React.Component<InputNumberProps, any> {
   static defaultProps = {
-    prefixCls: 'ant-input-number',
-    step: 1,
+    prefixCls: 'ant-input-number' as 'ant-input-number',
+    step: 1 as 1,
   };
 
   private inputNumberRef: any;

--- a/components/input/Input.tsx
+++ b/components/input/Input.tsx
@@ -30,9 +30,9 @@ export default class Input extends React.Component<InputProps, any> {
   static TextArea: typeof TextArea;
 
   static defaultProps = {
-    prefixCls: 'ant-input',
-    type: 'text',
-    disabled: false,
+    prefixCls: 'ant-input' as 'ant-input',
+    type: 'text' as 'text',
+    disabled: false as false,
   };
 
   static propTypes = {

--- a/components/input/Search.tsx
+++ b/components/input/Search.tsx
@@ -12,9 +12,9 @@ export interface SearchProps extends InputProps {
 
 export default class Search extends React.Component<SearchProps, any> {
   static defaultProps = {
-    inputPrefixCls: 'ant-input',
-    prefixCls: 'ant-input-search',
-    enterButton: false,
+    inputPrefixCls: 'ant-input' as 'ant-input',
+    prefixCls: 'ant-input-search' as 'ant-input-search',
+    enterButton: false as false,
   };
 
   private input: Input;

--- a/components/input/TextArea.tsx
+++ b/components/input/TextArea.tsx
@@ -37,7 +37,7 @@ export interface TextAreaState {
 
 export default class TextArea extends React.Component<TextAreaProps, TextAreaState> {
   static defaultProps = {
-    prefixCls: 'ant-input',
+    prefixCls: 'ant-input' as 'ant-input',
   };
 
   nextFrameActionId: number;

--- a/components/layout/Sider.tsx
+++ b/components/layout/Sider.tsx
@@ -72,14 +72,14 @@ class Sider extends React.Component<SiderProps, SiderState> {
   static __ANT_LAYOUT_SIDER: any = true;
 
   static defaultProps = {
-    prefixCls: 'ant-layout-sider',
-    collapsible: false,
-    defaultCollapsed: false,
-    reverseArrow: false,
-    width: 200,
-    collapsedWidth: 80,
+    prefixCls: 'ant-layout-sider' as 'ant-layout-sider',
+    collapsible: false as false,
+    defaultCollapsed: false as false,
+    reverseArrow: false as false,
+    width: 200 as 200,
+    collapsedWidth: 80 as 80,
     style: {},
-    theme: 'dark' as SiderTheme,
+    theme: 'dark' as 'dark',
   };
 
   static childContextTypes = {

--- a/components/list/index.tsx
+++ b/components/list/index.tsx
@@ -73,11 +73,11 @@ export default class List extends React.Component<ListProps> {
 
   static defaultProps = {
     dataSource: [],
-    prefixCls: 'ant-list',
-    bordered: false,
-    split: true,
-    loading: false,
-    pagination: false,
+    prefixCls: 'ant-list' as 'ant-list',
+    bordered: false as false,
+    split: true as true,
+    loading: false as false,
+    pagination: false as false,
   };
 
   state = {

--- a/components/mention/index.tsx
+++ b/components/mention/index.tsx
@@ -38,11 +38,11 @@ export interface MentionState {
 export default class Mention extends React.Component<MentionProps, MentionState> {
   static getMentions = getMentions;
   static defaultProps = {
-    prefixCls: 'ant-mention',
-    notFoundContent: '无匹配结果，轻敲空格完成输入',
-    loading: false,
-    multiLines: false,
-    placement: 'bottom',
+    prefixCls: 'ant-mention' as 'ant-mention',
+    notFoundContent: '无匹配结果，轻敲空格完成输入' as '无匹配结果，轻敲空格完成输入',
+    loading: false as false,
+    multiLines: false as false,
+    placement: 'bottom' as 'bottom',
   };
   static Nav = Nav;
   static toString = toString;

--- a/components/modal/Modal.tsx
+++ b/components/modal/Modal.tsx
@@ -102,15 +102,15 @@ export default class Modal extends React.Component<ModalProps, {}> {
   static confirm: ModalFunc;
 
   static defaultProps = {
-    prefixCls: 'ant-modal',
-    width: 520,
-    transitionName: 'zoom',
-    maskTransitionName: 'fade',
-    confirmLoading: false,
-    visible: false,
-    okType: 'primary' as ButtonType,
-    okButtonDisabled: false,
-    cancelButtonDisabled: false,
+    prefixCls: 'ant-modal' as 'ant-modal',
+    width: 520 as 520,
+    transitionName: 'zoom' as 'zoom',
+    maskTransitionName: 'fade' as 'fade',
+    confirmLoading: false as false,
+    visible: false as false,
+    okType: 'primary' as 'primary',
+    okButtonDisabled: false as false,
+    cancelButtonDisabled: false as false,
   };
 
   static propTypes = {

--- a/components/pagination/Pagination.tsx
+++ b/components/pagination/Pagination.tsx
@@ -39,8 +39,8 @@ export type PaginationLocale = any;
 
 export default class Pagination extends React.Component<PaginationProps, {}> {
   static defaultProps = {
-    prefixCls: 'ant-pagination',
-    selectPrefixCls: 'ant-select',
+    prefixCls: 'ant-pagination' as 'ant-pagination',
+    selectPrefixCls: 'ant-select' as 'ant-select',
   };
 
   getIconsProps = () => {

--- a/components/popconfirm/index.tsx
+++ b/components/popconfirm/index.tsx
@@ -29,11 +29,11 @@ export interface PopconfirmLocale {
 
 class Popconfirm extends React.Component<PopconfirmProps, PopconfirmState> {
   static defaultProps = {
-    prefixCls: 'ant-popover',
-    transitionName: 'zoom-big',
-    placement: 'top',
-    trigger: 'click',
-    okType: 'primary',
+    prefixCls: 'ant-popover' as 'ant-popover',
+    transitionName: 'zoom-big' as 'zoom-big',
+    placement: 'top' as 'top',
+    trigger: 'click' as 'click',
+    okType: 'primary' as 'primary',
     icon: <Icon type="exclamation-circle" theme="filled" />,
   };
 

--- a/components/popover/index.tsx
+++ b/components/popover/index.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import Tooltip, { AbstractTooltipProps, TooltipPlacement, TooltipTrigger } from '../tooltip';
+import Tooltip, { AbstractTooltipProps } from '../tooltip';
 import warning from '../_util/warning';
 
 export interface PopoverProps extends AbstractTooltipProps {
@@ -9,12 +9,12 @@ export interface PopoverProps extends AbstractTooltipProps {
 
 export default class Popover extends React.Component<PopoverProps, {}> {
   static defaultProps = {
-    prefixCls: 'ant-popover',
-    placement: 'top' as TooltipPlacement,
-    transitionName: 'zoom-big',
-    trigger: 'hover' as TooltipTrigger,
-    mouseEnterDelay: 0.1,
-    mouseLeaveDelay: 0.1,
+    prefixCls: 'ant-popover' as 'ant-popover',
+    placement: 'top' as 'top',
+    transitionName: 'zoom-big' as 'zoom-big',
+    trigger: 'hover' as 'hover',
+    mouseEnterDelay: 0.1 as 0.1,
+    mouseLeaveDelay: 0.1 as 0.1,
     overlayStyle: {},
   };
 

--- a/components/progress/progress.tsx
+++ b/components/progress/progress.tsx
@@ -47,12 +47,12 @@ export default class Progress extends React.Component<ProgressProps, {}> {
   static Circle: any;
 
   static defaultProps = {
-    type: 'line' as ProgressType,
-    percent: 0,
-    showInfo: true,
-    trailColor: '#f3f3f3',
-    prefixCls: 'ant-progress',
-    size: 'default' as ProgressSize,
+    type: 'line' as 'line',
+    percent: 0 as 0,
+    showInfo: true as true,
+    trailColor: '#f3f3f3' as '#f3f3f3',
+    prefixCls: 'ant-progress' as 'ant-progress',
+    size: 'default' as 'default',
   };
 
   static propTypes = {

--- a/components/radio/group.tsx
+++ b/components/radio/group.tsx
@@ -3,7 +3,7 @@ import * as PropTypes from 'prop-types';
 import classNames from 'classnames';
 import shallowEqual from 'shallowequal';
 import Radio from './radio';
-import { RadioGroupProps, RadioGroupState, RadioChangeEvent, RadioGroupButtonStyle } from './interface';
+import { RadioGroupProps, RadioGroupState, RadioChangeEvent } from './interface';
 
 function getCheckedValue(children: React.ReactNode) {
   let value = null;
@@ -19,9 +19,9 @@ function getCheckedValue(children: React.ReactNode) {
 
 export default class RadioGroup extends React.Component<RadioGroupProps, RadioGroupState> {
   static defaultProps = {
-    disabled: false,
-    prefixCls: 'ant-radio',
-    buttonStyle: 'outline' as RadioGroupButtonStyle,
+    disabled: false as false,
+    prefixCls: 'ant-radio' as 'ant-radio',
+    buttonStyle: 'outline' as 'outline',
   };
 
   static childContextTypes = {

--- a/components/radio/radio.tsx
+++ b/components/radio/radio.tsx
@@ -12,8 +12,8 @@ export default class Radio extends React.Component<RadioProps, {}> {
   static Button: typeof RadioButton;
 
   static defaultProps = {
-    prefixCls: 'ant-radio',
-    type: 'radio',
+    prefixCls: 'ant-radio' as 'ant-radio',
+    type: 'radio' as 'radio',
   };
 
   static contextTypes = {

--- a/components/radio/radioButton.tsx
+++ b/components/radio/radioButton.tsx
@@ -9,7 +9,7 @@ export type RadioButtonProps = AbstractCheckboxProps<RadioChangeEvent>;
 
 export default class RadioButton extends React.Component<RadioButtonProps, any> {
   static defaultProps = {
-    prefixCls: 'ant-radio-button',
+    prefixCls: 'ant-radio-button' as 'ant-radio-button',
   };
 
   static contextTypes = {

--- a/components/rate/index.tsx
+++ b/components/rate/index.tsx
@@ -25,7 +25,7 @@ export default class Rate extends React.Component<RateProps, any> {
   };
 
   static defaultProps = {
-    prefixCls: 'ant-rate',
+    prefixCls: 'ant-rate' as 'ant-rate',
     character: <Icon type="star" theme="filled" />,
   };
 

--- a/components/select/index.tsx
+++ b/components/select/index.tsx
@@ -103,10 +103,10 @@ export default class Select extends React.Component<SelectProps, {}> {
   static SECRET_COMBOBOX_MODE_DO_NOT_USE = 'SECRET_COMBOBOX_MODE_DO_NOT_USE';
 
   static defaultProps = {
-    prefixCls: 'ant-select',
-    showSearch: false,
-    transitionName: 'slide-up',
-    choiceTransitionName: 'zoom',
+    prefixCls: 'ant-select' as 'ant-select',
+    showSearch: false as false,
+    transitionName: 'slide-up' as 'slide-up',
+    choiceTransitionName: 'zoom' as 'zoom',
   };
 
   static propTypes = SelectPropTypes;

--- a/components/slider/index.tsx
+++ b/components/slider/index.tsx
@@ -47,8 +47,8 @@ export interface SliderState {
 
 export default class Slider extends React.Component<SliderProps, SliderState> {
   static defaultProps = {
-    prefixCls: 'ant-slider',
-    tooltipPrefixCls: 'ant-tooltip',
+    prefixCls: 'ant-slider' as 'ant-slider',
+    tooltipPrefixCls: 'ant-tooltip' as 'ant-tooltip',
     tipFormatter(value: number) {
       return value.toString();
     },

--- a/components/spin/index.tsx
+++ b/components/spin/index.tsx
@@ -58,10 +58,10 @@ function shouldDelay(spinning?: boolean, delay?: number): boolean {
 
 class Spin extends React.Component<SpinProps, SpinState> {
   static defaultProps = {
-    prefixCls: 'ant-spin',
-    spinning: true,
-    size: 'default' as SpinSize,
-    wrapperClassName: '',
+    prefixCls: 'ant-spin' as 'ant-spin',
+    spinning: true as true,
+    size: 'default' as 'default',
+    wrapperClassName: '' as '',
   };
 
   static propTypes = {

--- a/components/steps/index.tsx
+++ b/components/steps/index.tsx
@@ -19,9 +19,9 @@ export default class Steps extends React.Component<StepsProps, any> {
   static Step = RcSteps.Step;
 
   static defaultProps = {
-    prefixCls: 'ant-steps',
-    iconPrefix: 'ant',
-    current: 0,
+    prefixCls: 'ant-steps' as 'ant-steps',
+    iconPrefix: 'ant' as 'ant',
+    current: 0 as 0,
   };
 
   static propTypes = {

--- a/components/switch/index.tsx
+++ b/components/switch/index.tsx
@@ -21,7 +21,7 @@ export interface SwitchProps {
 
 export default class Switch extends React.Component<SwitchProps, {}> {
   static defaultProps = {
-    prefixCls: 'ant-switch',
+    prefixCls: 'ant-switch' as 'ant-switch',
   };
 
   static propTypes = {

--- a/components/table/Table.tsx
+++ b/components/table/Table.tsx
@@ -20,7 +20,6 @@ import { flatArray, treeMap, flatFilter, normalizeColumns } from './util';
 import { SpinProps } from '../spin';
 import {
   TableProps,
-  TableSize,
   TableState,
   TableComponents,
   RowSelectionType,
@@ -86,16 +85,16 @@ export default class Table<T> extends React.Component<TableProps<T>, TableState<
 
   static defaultProps = {
     dataSource: [],
-    prefixCls: 'ant-table',
-    useFixedHeader: false,
-    className: '',
-    size: 'default' as TableSize,
-    loading: false,
-    bordered: false,
-    indentSize: 20,
+    prefixCls: 'ant-table' as 'ant-table',
+    useFixedHeader: false as false,
+    className: '' as '',
+    size: 'default' as 'default',
+    loading: false as false,
+    bordered: false as false,
+    indentSize: 20 as 20,
     locale: {},
-    rowKey: 'key',
-    showHeader: true,
+    rowKey: 'key' as 'key',
+    showHeader: true as true,
   };
 
   CheckboxPropsCache: {

--- a/components/tabs/index.tsx
+++ b/components/tabs/index.tsx
@@ -48,8 +48,8 @@ export default class Tabs extends React.Component<TabsProps, any> {
   static TabPane = TabPane as React.ClassicComponentClass<TabPaneProps>;
 
   static defaultProps = {
-    prefixCls: 'ant-tabs',
-    hideAdd: false,
+    prefixCls: 'ant-tabs' as 'ant-tabs',
+    hideAdd: false as false,
   };
 
   removeTab = (targetKey: string, e: React.MouseEvent<HTMLElement>) => {

--- a/components/tag/index.tsx
+++ b/components/tag/index.tsx
@@ -34,8 +34,8 @@ export interface TagState {
 class Tag extends React.Component<TagProps, TagState> {
   static CheckableTag = CheckableTag;
   static defaultProps = {
-    prefixCls: 'ant-tag',
-    closable: false,
+    prefixCls: 'ant-tag' as 'ant-tag',
+    closable: false as false,
   };
 
   static getDerivedStateFromProps(nextProps: TagProps, state: TagState) {

--- a/components/time-picker/index.tsx
+++ b/components/time-picker/index.tsx
@@ -58,18 +58,18 @@ export interface TimePickerLocale {
 
 class TimePicker extends React.Component<TimePickerProps, any> {
   static defaultProps = {
-    prefixCls: 'ant-time-picker',
+    prefixCls: 'ant-time-picker' as 'ant-time-picker',
     align: {
-      offset: [0, -2],
+      offset: [0, -2] as [0, -2],
     },
-    disabled: false,
+    disabled: false as false,
     disabledHours: undefined,
     disabledMinutes: undefined,
     disabledSeconds: undefined,
-    hideDisabledOptions: false,
-    placement: 'bottomLeft',
-    transitionName: 'slide-up',
-    focusOnOpen: true,
+    hideDisabledOptions: false as false,
+    placement: 'bottomLeft' as 'bottomLeft',
+    transitionName: 'slide-up' as 'slide-up',
+    focusOnOpen: true as true,
   };
 
   static getDerivedStateFromProps(nextProps: TimePickerProps) {

--- a/components/timeline/Timeline.tsx
+++ b/components/timeline/Timeline.tsx
@@ -17,9 +17,9 @@ export interface TimelineProps {
 export default class Timeline extends React.Component<TimelineProps, any> {
   static Item = TimelineItem as React.ClassicComponentClass<TimeLineItemProps>;
   static defaultProps = {
-    prefixCls: 'ant-timeline',
-    reverse: false,
-    mode: '',
+    prefixCls: 'ant-timeline' as 'ant-timeline',
+    reverse: false as false,
+    mode: '' as '',
   };
 
   render() {

--- a/components/timeline/TimelineItem.tsx
+++ b/components/timeline/TimelineItem.tsx
@@ -12,9 +12,9 @@ export interface TimeLineItemProps {
 
 export default class TimelineItem extends React.Component<TimeLineItemProps, any> {
   static defaultProps = {
-    prefixCls: 'ant-timeline',
-    color: 'blue',
-    pending: false,
+    prefixCls: 'ant-timeline' as 'ant-timeline',
+    color: 'blue' as 'blue',
+    pending: false as false,
   };
 
   render() {

--- a/components/tooltip/index.tsx
+++ b/components/tooltip/index.tsx
@@ -73,13 +73,13 @@ const splitObject = (obj: any, keys: string[]) => {
 
 class Tooltip extends React.Component<TooltipProps, any> {
   static defaultProps = {
-    prefixCls: 'ant-tooltip',
-    placement: 'top' as TooltipPlacement,
-    transitionName: 'zoom-big-fast',
-    mouseEnterDelay: 0.1,
-    mouseLeaveDelay: 0.1,
-    arrowPointAtCenter: false,
-    autoAdjustOverflow: true,
+    prefixCls: 'ant-tooltip' as 'ant-tooltip',
+    placement: 'top' as 'top',
+    transitionName: 'zoom-big-fast' as 'zoom-big-fast',
+    mouseEnterDelay: 0.1 as 0.1,
+    mouseLeaveDelay: 0.1 as 0.1,
+    arrowPointAtCenter: false as false,
+    autoAdjustOverflow: true as true,
   };
 
   static getDerivedStateFromProps(nextProps: TooltipProps) {

--- a/components/transfer/index.tsx
+++ b/components/transfer/index.tsx
@@ -69,7 +69,7 @@ export default class Transfer extends React.Component<TransferProps, any> {
     dataSource: [],
     render: noop,
     locale: {},
-    showSearch: false,
+    showSearch: false as false,
   };
 
   static propTypes = {

--- a/components/transfer/list.tsx
+++ b/components/transfer/list.tsx
@@ -48,8 +48,8 @@ export interface TransferListProps {
 export default class TransferList extends React.Component<TransferListProps, any> {
   static defaultProps = {
     dataSource: [],
-    titleText: '',
-    showSearch: false,
+    titleText: '' as '',
+    showSearch: false as false,
     render: noop,
     lazy: {},
   };

--- a/components/transfer/search.tsx
+++ b/components/transfer/search.tsx
@@ -12,7 +12,7 @@ export interface TransferSearchProps {
 
 export default class Search extends React.Component<TransferSearchProps, any> {
   static defaultProps = {
-    placeholder: '',
+    placeholder: '' as '',
   };
 
   handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/components/tree-select/index.tsx
+++ b/components/tree-select/index.tsx
@@ -17,10 +17,10 @@ export default class TreeSelect extends React.Component<TreeSelectProps, any> {
   static SHOW_CHILD = SHOW_CHILD;
 
   static defaultProps = {
-    prefixCls: 'ant-select',
-    transitionName: 'slide-up',
-    choiceTransitionName: 'zoom',
-    showSearch: false,
+    prefixCls: 'ant-select' as 'ant-select',
+    transitionName: 'slide-up' as 'slide-up',
+    choiceTransitionName: 'zoom' as 'zoom',
+    showSearch: false as false,
   };
 
   private rcTreeSelect: any;

--- a/components/tree/DirectoryTree.tsx
+++ b/components/tree/DirectoryTree.tsx
@@ -32,9 +32,9 @@ function getIcon(props: AntdTreeNodeAttribute): React.ReactNode {
 
 export default class DirectoryTree extends React.Component<DirectoryTreeProps, DirectoryTreeState> {
   static defaultProps = {
-    prefixCls: 'ant-tree',
-    showIcon: true,
-    expandAction: 'click',
+    prefixCls: 'ant-tree' as 'ant-tree',
+    showIcon: true as true,
+    expandAction: 'click' as 'click',
   };
 
   state: DirectoryTreeState;

--- a/components/tree/Tree.tsx
+++ b/components/tree/Tree.tsx
@@ -151,9 +151,9 @@ export default class Tree extends React.Component<TreeProps, any> {
   static DirectoryTree = DirectoryTree;
 
   static defaultProps = {
-    prefixCls: 'ant-tree',
-    checkable: false,
-    showIcon: false,
+    prefixCls: 'ant-tree' as 'ant-tree',
+    checkable: false as false,
+    showIcon: false as false,
     openAnimation: {
       ...animation,
       appear: null,

--- a/components/upload/Upload.tsx
+++ b/components/upload/Upload.tsx
@@ -14,8 +14,6 @@ import {
   UploadFile,
   UploadLocale,
   UploadChangeParam,
-  UploadType,
-  UploadListType,
 } from './interface';
 import { T, fileToObject, genPercentAdd, getFileItem, removeFileItem } from './utils';
 
@@ -25,18 +23,18 @@ class Upload extends React.Component<UploadProps, UploadState> {
   static Dragger: typeof Dragger;
 
   static defaultProps = {
-    prefixCls: 'ant-upload',
-    type: 'select' as UploadType,
-    multiple: false,
-    action: '',
+    prefixCls: 'ant-upload' as 'ant-upload',
+    type: 'select' as 'select',
+    multiple: false as false,
+    action: '' as '',
     data: {},
-    accept: '',
+    accept: '' as '',
     beforeUpload: T,
-    showUploadList: true,
-    listType: 'text' as UploadListType, // or pictrue
-    className: '',
-    disabled: false,
-    supportServerRender: true,
+    showUploadList: true as true,
+    listType: 'text' as 'text', // or picture
+    className: '' as '',
+    disabled: false as false,
+    supportServerRender: true as true,
   };
 
   static getDerivedStateFromProps(nextProps: UploadProps) {

--- a/components/upload/UploadList.tsx
+++ b/components/upload/UploadList.tsx
@@ -4,7 +4,7 @@ import Icon from '../icon';
 import Tooltip from '../tooltip';
 import Progress from '../progress';
 import classNames from 'classnames';
-import { UploadListProps, UploadFile, UploadListType } from './interface';
+import { UploadListProps, UploadFile } from './interface';
 
 // https://developer.mozilla.org/en-US/docs/Web/API/FileReader/readAsDataURL
 const previewFile = (file: File, callback: Function) => {
@@ -41,14 +41,14 @@ const isImageUrl = (file: UploadFile): boolean => {
 
 export default class UploadList extends React.Component<UploadListProps, any> {
   static defaultProps = {
-    listType: 'text' as UploadListType,  // or picture
+    listType: 'text' as 'text',  // or picture
     progressAttr: {
-      strokeWidth: 2,
-      showInfo: false,
+      strokeWidth: 2 as 2,
+      showInfo: false as false,
     },
-    prefixCls: 'ant-upload',
-    showRemoveIcon: true,
-    showPreviewIcon: true,
+    prefixCls: 'ant-upload' as 'ant-upload',
+    showRemoveIcon: true as true,
+    showPreviewIcon: true as true,
   };
 
   handleClose = (file: UploadFile) => {


### PR DESCRIPTION
Created to fix this error in project:

```
Argument of type 'typeof Dropdown' is not assignable to parameter of type 'ComponentType<DropDownProps>'.
  Type 'typeof Dropdown' is not assignable to type 'StatelessComponent<DropDownProps>'.
    Types of property 'defaultProps' are incompatible.
      Type '{ prefixCls: string; mouseEnterDelay: number; mouseLeaveDelay: number; placement: string; }' is not assignable to type 'Partial<DropDownProps> | undefined'.
        Type '{ prefixCls: string; mouseEnterDelay: number; mouseLeaveDelay: number; placement: string; }' is not assignable to type 'Partial<DropDownProps>'.
          Types of property 'placement' are incompatible.
            Type 'string' is not assignable to type '"topLeft" | "topCenter" | "topRight" | "bottomLeft" | "bottomCenter" | "bottomRight" | undefined'.
```

In Typescript, when not casting to a specific value, the type of a variable is inferred as the larger data type. e.g. `false` is inferred as `boolean`, `"hello"` is inferred as `string`. This causes type errors when defaultProps has a string default for a prop that the Props interface has defined as a union of specific strings. Default props thus need to be cast to their specific value to avoid running into this type error. Doing so also has the helpful benefit of making the typescript-generated types more helpful when developing, instead of needing to look up the default values on the website.

`Dropdown.defaultProps.placement` in the generated types is of type `string`, when it should be `"bottomLeft"` to comply with the placement union. Here's the previous generated types:

```
export default class Dropdown extends React.Component<DropDownProps, any> {
    static Button: typeof DropdownButton;
    static defaultProps: {
        prefixCls: string;
        mouseEnterDelay: number;
        mouseLeaveDelay: number;
        placement: string;
    };
    getTransitionName(): string;
    componentDidMount(): void;
    render(): JSX.Element;
}
```

new generated types:

```
export default class Dropdown extends React.Component<DropDownProps, any> {
    static Button: typeof DropdownButton;
    static defaultProps: {
        prefixCls: "ant-dropdown";
        mouseEnterDelay: 0.15;
        mouseLeaveDelay: 0.1;
        placement: "bottomLeft";
    };
    getTransitionName(): string;
    componentDidMount(): void;
    render(): JSX.Element;
}
```

I figured it would be not very useful to only fix this for Dropdown, so I went ahead and changed it for all the places I searched for `defaultProps`.

---
First of all, thank you for your contribution! :-)

Please makes sure that these checkboxes are checked before submitting your PR, thank you!

* [x] Make sure that you propose PR to right branch: bugfix for `master`, feature for branch `feature`.
* [x] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [ ] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.

Extra checklist:

**if** *isBugFix* **:**

  * [ ] Make sure that you add at least one unit test for the bug which you had fixed.

**elif** *isNewFeature* **:**

  * [ ] Update API docs for the component.
  * [ ] Update/Add demo to demonstrate new feature.
  * [ ] Update TypeScript definition for the component.
  * [ ] Add unit tests for the feature.
