### PR TITLE
fix #11312: add autoClearSearchValue to AbstractSelectProps

### DIFF
--- a/components/select/index.en-US.md
+++ b/components/select/index.en-US.md
@@ -24,6 +24,7 @@ Select component to select value from options.
 | Property | Description | Type | Default |
 | -------- | ----------- | ---- | ------- |
 | allowClear | Show clear button. | boolean | false |
+| autoClearSearchValue | Whether the current search will be cleared on selecting an item. Only applies when `mode` is set to `multiple` or `tags`. | boolean | true |
 | autoFocus | Get focus by default | boolean | false |
 | defaultActiveFirstOption | Whether active first option by default | boolean | true |
 | defaultValue | Initial selected option. | string\|string\[]<br />number\|number\[] | - |

--- a/components/select/index.tsx
+++ b/components/select/index.tsx
@@ -33,6 +33,7 @@ export interface AbstractSelectProps {
   defaultOpen?: boolean;
   open?: boolean;
   onDropdownVisibleChange?: (open: boolean) => void;
+  autoClearSearchValue?: boolean;
 }
 
 export interface LabeledValue {

--- a/components/select/index.zh-CN.md
+++ b/components/select/index.zh-CN.md
@@ -25,6 +25,7 @@ title: Select
 | 参数 | 说明 | 类型 | 默认值 |
 | --- | --- | --- | --- |
 | allowClear | 支持清除 | boolean | false |
+| autoClearSearchValue | 是否在选中项后清空搜索框，只在 `mode` 为 `multiple` 或 `tags` 时有效。 | boolean | true |
 | autoFocus | 默认获取焦点 | boolean | false |
 | defaultActiveFirstOption | 是否默认高亮第一个选项。 | boolean | true |
 | defaultValue | 指定默认选中的条目 | string\|string\[]<br />number\|number\[] | - |


### PR DESCRIPTION
- extends the interface with an optional prop that can be provided to the RcSelect

First of all, thank you for your contribution! :-)

Please makes sure that these checkboxes are checked before submitting your PR, thank you!

* [ x ] Make sure that you propose PR to right branch: bugfix for `master`, feature for branch `feature`.
* [ x ] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [ x ] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [ x ] Rebase before creating a PR to keep commit history clear.
* [ x ] Add some descriptions and refer relative issues for you PR.

Extra checklist:

**if** *isBugFix* **:**

  * [ ] Make sure that you add at least one unit test for the bug which you had fixed.

**elif** *isNewFeature* **:**

  * [ ] Update API docs for the component.
  * [ ] Update/Add demo to demonstrate new feature.
  * [ ] Update TypeScript definition for the component.
  * [ ] Add unit tests for the feature.

This fix is related to Issue #11312 and adds the optional `autoClearSearchValue` prop which can be supplied to `RcSelect` to the Select´s props. This is not really a new feature and a relatively unsubstantial one a that, so I didn´t add a demo for it, but I could do so if that´s desirable.

I updated the English API docs, but I´m not a Chinese speaker so there is no addition to the Chinese documentation. Maybe someone speaking Chinese would be willing to help out.