### PR TITLE
IE11 & 低于版本14的Edge浏览器, Tab键焦点落在图标上

### DIFF
--- a/components/icon/utils.ts
+++ b/components/icon/utils.ts
@@ -8,6 +8,7 @@ export const svgBaseProps = {
   height: "1em",
   fill: "currentColor",
   ["aria-hidden"]: "true",
+  focusable: "false",
 };
 
 const fillTester = /-fill$/;


### PR DESCRIPTION
浏览器: IE 11, Edge
重现步骤: FormItem设置hasFeedback属性, 校验错误时显示图标. 在表单区域内使用tab键切换焦点.
预期: 焦点从一个输入框切换到下一个输入框
实际: 焦点从输入框切换到图标, 再切换到下一个输入框

参考: https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/8090208/