### PR TITLE
Fix Edge ignoring pointer-events:none on button's span

### DIFF
--- a/components/button/style/index.less
+++ b/components/button/style/index.less
@@ -21,6 +21,7 @@
   > i,
   > span {
     pointer-events: none;
+    display: inline-block;
   }
 
   &-primary {


### PR DESCRIPTION
Fix for [#12698](https://github.com/ant-design/ant-design/issues/12698)

Please makes sure that these checkboxes are checked before submitting your PR, thank you!

* [x] Make sure that you propose PR to right branch: bugfix for `master`, feature for branch `feature`.
* [x] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.

Extra checklist:

**if** *isBugFix* **:**

  * [x] Make sure that you add at least one unit test for the bug which you had fixed.

No test added, I don't know how to test that change.
Change was tested on my computer with the following browsers:
- Chrome 70.0.3538.67
- Firefox 62.0.3 ESR
- IE 11.0.9600.19155

> Would be nice, if some people could test/validate that change with Windows 10 and Edge to be sure there is no regression - I don't have the opportunity to access that kind of setup.