### PR TITLE
Remove  useless function

### DIFF
--- a/components/_util/isNumeric.ts
+++ b/components/_util/isNumeric.ts
@@ -1,5 +1,0 @@
-const isNumeric = (value: any): boolean => {
-  return !isNaN(parseFloat(value)) && isFinite(value);
-};
-
-export default isNumeric;

--- a/components/layout/Sider.tsx
+++ b/components/layout/Sider.tsx
@@ -20,7 +20,6 @@ import classNames from 'classnames';
 import omit from 'omit.js';
 import * as PropTypes from 'prop-types';
 import Icon from '../icon';
-import isNumeric from '../_util/isNumeric';
 
 const dimensionMap = {
   xs: '480px',
@@ -194,7 +193,7 @@ class Sider extends React.Component<SiderProps, SiderState> {
       'defaultCollapsed', 'onCollapse', 'breakpoint', 'onBreakpoint']);
     const rawWidth = this.state.collapsed ? collapsedWidth : width;
     // use "px" as fallback unit for width
-    const siderWidth = isNumeric(rawWidth) ? `${rawWidth}px` : String(rawWidth);
+    const siderWidth = typeof rawWidth === 'number' ? `${rawWidth}px` : String(rawWidth);
     // special trigger when collapsedWidth == 0
     const zeroWidthTrigger = parseFloat(String(collapsedWidth || 0)) === 0 ? (
       <span onClick={this.toggle} className={`${prefixCls}-zero-width-trigger`}>

--- a/components/layout/__tests__/__snapshots__/index.test.js.snap
+++ b/components/layout/__tests__/__snapshots__/index.test.js.snap
@@ -3,7 +3,7 @@
 exports[`Layout renders string width correctly 1`] = `
 <div
   class="ant-layout-sider ant-layout-sider-dark"
-  style="flex:0 0 200px;max-width:200px;min-width:200px;width:200px"
+  style="flex:0 0 200;max-width:200;min-width:200;width:200"
 >
   <div
     class="ant-layout-sider-children"


### PR DESCRIPTION
`isNumeric` in `isNumeric.ts` only use for `Sider` and it seems useless. We should remove it for less mountaining of code.