### PR TITLE
Add Radio.Group props `optionType` to choose item type

### DIFF
--- a/components/radio/demo/radiogroup-options.md
+++ b/components/radio/demo/radiogroup-options.md
@@ -8,10 +8,12 @@ title:
 ## zh-CN
 
 通过配置 `options` 参数来渲染单选框。
+使用 `options` 时还可以通过 `optionType` 来配置选项的类型。
 
 ## en-US
 
 Render radios by configuring `options`.
+`optionType` can also used, along with `options`, to choose the item type.
 
 ```jsx
 import { Radio } from 'antd';
@@ -63,7 +65,7 @@ class App extends React.Component {
       <div>
         <RadioGroup options={plainOptions} onChange={this.onChange1} value={this.state.value1} />
         <RadioGroup options={options} onChange={this.onChange2} value={this.state.value2} />
-        <RadioGroup options={optionsWithDisabled} onChange={this.onChange3} value={this.state.value3} />
+        <RadioGroup optionType="button" options={optionsWithDisabled} onChange={this.onChange3} value={this.state.value3} />
       </div>
     );
   }

--- a/components/radio/group.tsx
+++ b/components/radio/group.tsx
@@ -3,6 +3,7 @@ import * as PropTypes from 'prop-types';
 import classNames from 'classnames';
 import shallowEqual from 'shallowequal';
 import Radio from './radio';
+import RadioButton from './radioButton';
 import { RadioGroupProps, RadioGroupState, RadioChangeEvent, RadioGroupButtonStyle } from './interface';
 
 function getCheckedValue(children: React.ReactNode) {
@@ -101,10 +102,11 @@ export default class RadioGroup extends React.Component<RadioGroupProps, RadioGr
 
     // 如果存在 options, 优先使用
     if (options && options.length > 0) {
+      const Option = props.optionType === 'button' ? RadioButton : Radio;
       children = options.map((option, index) => {
         if (typeof option === 'string') { // 此处类型自动推导为 string
           return (
-            <Radio
+            <Option
               key={index}
               prefixCls={prefixCls}
               disabled={this.props.disabled}
@@ -113,11 +115,11 @@ export default class RadioGroup extends React.Component<RadioGroupProps, RadioGr
               checked={this.state.value === option}
             >
               {option}
-            </Radio>
+            </Option>
           );
         } else { // 此处类型自动推导为 { label: string value: string }
           return (
-            <Radio
+            <Option
               key={index}
               prefixCls={prefixCls}
               disabled={option.disabled || this.props.disabled}
@@ -126,7 +128,7 @@ export default class RadioGroup extends React.Component<RadioGroupProps, RadioGr
               checked={this.state.value === option.value}
             >
               {option.label}
-            </Radio>
+            </Option>
           );
         }
       });

--- a/components/radio/index.en-US.md
+++ b/components/radio/index.en-US.md
@@ -36,6 +36,7 @@ Radio group can wrap a group of `Radio`。
 | size | size for radio button style | `large` \| `default` \| `small` | `default` |
 | value | Used for setting the currently selected value. | any | - |
 | onChange | The callback function that is triggered when the state changes. | Function(e:Event) | - |
+| optionType | type of radio option | `radio` for `Radio` \| `button` for `Radio.Button` | `radio` |
 | buttonStyle | style type of radio button | `outline` \| `solid` | `outline` |
 
 ## Methods

--- a/components/radio/index.zh-CN.md
+++ b/components/radio/index.zh-CN.md
@@ -36,6 +36,7 @@ title: Radio
 | size | 大小，只对按钮样式生效 | `large` \| `default` \| `small` | `default` |
 | value | 用于设置当前选中的值 | any | - |
 | onChange | 选项变化时的回调函数 | Function(e:Event) | - |
+| optionType | Group下面的选型类型 | `radio` 对应 `Radio` \| `button` 对应 `Radio.Button` | `radio` |
 | buttonStyle | RadioButton 的风格样式，目前有描边和填色两种风格 | `outline` \| `solid` | `outline` |
 
 ## 方法

--- a/components/radio/interface.tsx
+++ b/components/radio/interface.tsx
@@ -3,6 +3,7 @@ import { AbstractCheckboxGroupProps } from '../checkbox/Group';
 import { AbstractCheckboxProps } from '../checkbox/Checkbox';
 
 export type RadioGroupButtonStyle = 'outline' | 'solid';
+export type RadioGroupOptionType = 'radio' | 'button';
 
 export interface RadioGroupProps extends AbstractCheckboxGroupProps {
   defaultValue?: any;
@@ -15,6 +16,7 @@ export interface RadioGroupProps extends AbstractCheckboxGroupProps {
   children?: React.ReactNode;
   id?: string;
   buttonStyle?: RadioGroupButtonStyle;
+  optionType?: RadioGroupOptionType;
 }
 
 export interface RadioGroupState {


### PR DESCRIPTION
Add Radio.Group props `optionType` to choose item type (Radio or Radio.Button) when `options` is used.

`optionType` 
- radio` for `Radio` (default, current behavior)
- `button` for `Radio.Button`

First of all, thank you for your contribution! :-)

Please makes sure that these checkboxes are checked before submitting your PR, thank you!

* [x] Make sure that you propose PR to right branch: bugfix for `master`, feature for branch `feature`.
* [x] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [ ] Rebase before creating a PR to keep commit history clear.
* [ ] Add some descriptions and refer relative issues for you PR.

* [x] Update API docs for the component.
* [x] Update/Add demo to demonstrate new feature.
* [x] Update TypeScript definition for the component.
* [ ] Add unit tests for the feature.
