### PR TITLE
bugfix:添加在线编辑对react-router3/4的支持

### DIFF
--- a/site/theme/template/Content/Demo.jsx
+++ b/site/theme/template/Content/Demo.jsx
@@ -135,7 +135,10 @@ export default class Demo extends React.Component {
       html,
       js: state.sourceCode
         .replace(/import\s+\{\s+(.*)\s+\}\s+from\s+'antd';/, 'const { $1 } = antd;')
-        .replace("import moment from 'moment';", ''),
+        .replace("import moment from 'moment';", '')
+        .replace(/import\s+\{\s+(.*)\s+\}\s+from\s+'react-router';/, 'const { $1 } = ReactRouter;')
+        .replace(/import\s+\{\s+(.*)\s+\}\s+from\s+'react-router-dom';/, 'const { $1 } = ReactRouterDOM;')
+        .replace(/([a-zA-Z]*)\s+as\s+([a-zA-Z]*)/, '$1:$2'),
       css: prefillStyle,
       editors: '001',
       css_external: 'https://unpkg.com/antd/dist/antd.css',
@@ -144,6 +147,8 @@ export default class Demo extends React.Component {
         'react-dom@16.x/umd/react-dom.development.js',
         'moment/min/moment-with-locales.js',
         'antd/dist/antd-with-locales.js',
+        'react-router-dom/umd/react-router-dom.min.js',
+        'react-router@3.x/umd/ReactRouter.min.js',
       ].map(url => `https://unpkg.com/${url}`).join(';'),
       js_pre_processor: 'typescript',
     };


### PR DESCRIPTION
Breadcrumb面包屑组件的代码演示中有react-router@3/4的demo,但该代码只能在网站上正确展示，无法在打开的在线编辑页（CodePen）中编辑，因为缺少必要的依赖和处理。