### PR TITLE
Starting sort order with 'ascend', then 'descend', then undefined.

### DIFF
--- a/components/table/Table.tsx
+++ b/components/table/Table.tsx
@@ -380,9 +380,9 @@ export default class Table<T> extends React.Component<TableProps<T>, TableState<
     const oldSortOrder = this.isSameColumn(sortColumn, column) ? sortOrder : undefined;
     // 切换排序状态，按照降序/升序/不排序的顺序
     if (!oldSortOrder) {
-      newSortOrder = 'descend';
-    } else if (oldSortOrder === 'descend') {
       newSortOrder = 'ascend';
+    } else if (oldSortOrder === 'ascend') {
+      newSortOrder = 'descend';
     } else {
       newSortOrder = undefined;
     }

--- a/components/table/__tests__/Table.sorter.test.js
+++ b/components/table/__tests__/Table.sorter.test.js
@@ -61,13 +61,13 @@ describe('Table.sorter', () => {
   it('sort records', () => {
     const wrapper = mount(createTable());
 
-    // descent
-    wrapper.find('.ant-table-column-sorters').simulate('click');
-    expect(renderedNames(wrapper)).toEqual(['Tom', 'Lucy', 'Jack', 'Jerry']);
-
-    // ascent
+    // ascend
     wrapper.find('.ant-table-column-sorters').simulate('click');
     expect(renderedNames(wrapper)).toEqual(['Jack', 'Jerry', 'Lucy', 'Tom']);
+
+    // descend
+    wrapper.find('.ant-table-column-sorters').simulate('click');
+    expect(renderedNames(wrapper)).toEqual(['Tom', 'Lucy', 'Jack', 'Jerry']);
   });
 
   it('can be controlled by sortOrder', () => {
@@ -99,14 +99,14 @@ describe('Table.sorter', () => {
     wrapper.find('.ant-table-column-sorters').simulate('click');
     const sorter1 = handleChange.mock.calls[0][2];
     expect(sorter1.column.dataIndex).toBe('name');
-    expect(sorter1.order).toBe('descend');
+    expect(sorter1.order).toBe('ascend');
     expect(sorter1.field).toBe('name');
     expect(sorter1.columnKey).toBe('name');
 
     wrapper.find('.ant-table-column-sorters').simulate('click');
     const sorter2 = handleChange.mock.calls[1][2];
     expect(sorter2.column.dataIndex).toBe('name');
-    expect(sorter2.order).toBe('ascend');
+    expect(sorter2.order).toBe('descend');
     expect(sorter2.field).toBe('name');
     expect(sorter2.columnKey).toBe('name');
 
@@ -172,9 +172,9 @@ describe('Table.sorter', () => {
     );
     expect(wrapper.find('.custom-title').text()).toEqual('');
     wrapper.find('.ant-table-column-sorters').simulate('click');
-    expect(wrapper.find('.custom-title').text()).toEqual('descend');
-    wrapper.find('.ant-table-column-sorters').simulate('click');
     expect(wrapper.find('.custom-title').text()).toEqual('ascend');
+    wrapper.find('.ant-table-column-sorters').simulate('click');
+    expect(wrapper.find('.custom-title').text()).toEqual('descend');
   });
 
   // https://github.com/ant-design/ant-design/pull/12264#discussion_r218053034
@@ -204,12 +204,12 @@ describe('Table.sorter', () => {
     const ageColumn = wrapper.find('.ant-table-column-sorters').at(1);
     // sort name
     nameColumn.simulate('click');
-    expect(nameColumn.find('.ant-table-column-sorter-down').at(0).getDOMNode().className).toContain(' on');
-    expect(ageColumn.find('.ant-table-column-sorter-down').at(0).getDOMNode().className).toContain(' off');
+    expect(nameColumn.find('.ant-table-column-sorter-up').at(0).getDOMNode().className).toContain(' on');
+    expect(ageColumn.find('.ant-table-column-sorter-up').at(0).getDOMNode().className).toContain(' off');
     // sort age
     ageColumn.simulate('click');
-    expect(nameColumn.find('.ant-table-column-sorter-down').at(0).getDOMNode().className).toContain(' off');
-    expect(ageColumn.find('.ant-table-column-sorter-down').at(0).getDOMNode().className).toContain(' on');
+    expect(nameColumn.find('.ant-table-column-sorter-up').at(0).getDOMNode().className).toContain(' off');
+    expect(ageColumn.find('.ant-table-column-sorter-up').at(0).getDOMNode().className).toContain(' on');
   });
 
   // https://github.com/ant-design/ant-design/issues/12571
@@ -249,20 +249,20 @@ describe('Table.sorter', () => {
 
     const wrapper = mount(<TableTest />);
     const nameColumn = wrapper.find('.ant-table-column-sorters').at(0);
-    expect(nameColumn.find('.ant-table-column-sorter-down').at(0).getDOMNode().className).toContain(' off');
     expect(nameColumn.find('.ant-table-column-sorter-up').at(0).getDOMNode().className).toContain(' off');
+    expect(nameColumn.find('.ant-table-column-sorter-down').at(0).getDOMNode().className).toContain(' off');
     // sort name
     nameColumn.simulate('click');
-    expect(nameColumn.find('.ant-table-column-sorter-down').at(0).getDOMNode().className).toContain(' on');
-    expect(nameColumn.find('.ant-table-column-sorter-up').at(0).getDOMNode().className).toContain(' off');
-    // sort name
-    nameColumn.simulate('click');
-    expect(nameColumn.find('.ant-table-column-sorter-down').at(0).getDOMNode().className).toContain(' off');
     expect(nameColumn.find('.ant-table-column-sorter-up').at(0).getDOMNode().className).toContain(' on');
+    expect(nameColumn.find('.ant-table-column-sorter-down').at(0).getDOMNode().className).toContain(' off');
     // sort name
     nameColumn.simulate('click');
-    expect(nameColumn.find('.ant-table-column-sorter-down').at(0).getDOMNode().className).toContain(' off');
     expect(nameColumn.find('.ant-table-column-sorter-up').at(0).getDOMNode().className).toContain(' off');
+    expect(nameColumn.find('.ant-table-column-sorter-down').at(0).getDOMNode().className).toContain(' on');
+    // sort name
+    nameColumn.simulate('click');
+    expect(nameColumn.find('.ant-table-column-sorter-up').at(0).getDOMNode().className).toContain(' off');
+    expect(nameColumn.find('.ant-table-column-sorter-down').at(0).getDOMNode().className).toContain(' off');
   });
 
   // https://github.com/ant-design/ant-design/issues/12737
@@ -303,20 +303,20 @@ describe('Table.sorter', () => {
 
     const wrapper = mount(<TableTest />);
     const nameColumn = wrapper.find('.ant-table-column-sorters').at(0);
-    expect(nameColumn.find('.ant-table-column-sorter-down').at(0).getDOMNode().className).toContain(' off');
     expect(nameColumn.find('.ant-table-column-sorter-up').at(0).getDOMNode().className).toContain(' off');
+    expect(nameColumn.find('.ant-table-column-sorter-down').at(0).getDOMNode().className).toContain(' off');
     // sort name
     nameColumn.simulate('click');
-    expect(nameColumn.find('.ant-table-column-sorter-down').at(0).getDOMNode().className).toContain(' on');
-    expect(nameColumn.find('.ant-table-column-sorter-up').at(0).getDOMNode().className).toContain(' off');
-    // sort name
-    nameColumn.simulate('click');
-    expect(nameColumn.find('.ant-table-column-sorter-down').at(0).getDOMNode().className).toContain(' off');
     expect(nameColumn.find('.ant-table-column-sorter-up').at(0).getDOMNode().className).toContain(' on');
+    expect(nameColumn.find('.ant-table-column-sorter-down').at(0).getDOMNode().className).toContain(' off');
     // sort name
     nameColumn.simulate('click');
-    expect(nameColumn.find('.ant-table-column-sorter-down').at(0).getDOMNode().className).toContain(' off');
     expect(nameColumn.find('.ant-table-column-sorter-up').at(0).getDOMNode().className).toContain(' off');
+    expect(nameColumn.find('.ant-table-column-sorter-down').at(0).getDOMNode().className).toContain(' on');
+    // sort name
+    nameColumn.simulate('click');
+    expect(nameColumn.find('.ant-table-column-sorter-up').at(0).getDOMNode().className).toContain(' off');
+    expect(nameColumn.find('.ant-table-column-sorter-down').at(0).getDOMNode().className).toContain(' off');
   });
 
   // https://github.com/ant-design/ant-design/issues/12870
@@ -360,19 +360,19 @@ describe('Table.sorter', () => {
 
     const wrapper = mount(<TableTest />);
     const nameColumn = wrapper.find('.ant-table-column-sorters').at(0);
-    expect(nameColumn.find('.ant-table-column-sorter-down').at(0).getDOMNode().className).toContain(' off');
     expect(nameColumn.find('.ant-table-column-sorter-up').at(0).getDOMNode().className).toContain(' off');
+    expect(nameColumn.find('.ant-table-column-sorter-down').at(0).getDOMNode().className).toContain(' off');
     // sort name
     nameColumn.simulate('click');
-    expect(nameColumn.find('.ant-table-column-sorter-down').at(0).getDOMNode().className).toContain(' on');
-    expect(nameColumn.find('.ant-table-column-sorter-up').at(0).getDOMNode().className).toContain(' off');
-    // sort name
-    nameColumn.simulate('click');
-    expect(nameColumn.find('.ant-table-column-sorter-down').at(0).getDOMNode().className).toContain(' off');
     expect(nameColumn.find('.ant-table-column-sorter-up').at(0).getDOMNode().className).toContain(' on');
+    expect(nameColumn.find('.ant-table-column-sorter-down').at(0).getDOMNode().className).toContain(' off');
     // sort name
     nameColumn.simulate('click');
-    expect(nameColumn.find('.ant-table-column-sorter-down').at(0).getDOMNode().className).toContain(' off');
     expect(nameColumn.find('.ant-table-column-sorter-up').at(0).getDOMNode().className).toContain(' off');
+    expect(nameColumn.find('.ant-table-column-sorter-down').at(0).getDOMNode().className).toContain(' on');
+    // sort name
+    nameColumn.simulate('click');
+    expect(nameColumn.find('.ant-table-column-sorter-up').at(0).getDOMNode().className).toContain(' off');
+    expect(nameColumn.find('.ant-table-column-sorter-down').at(0).getDOMNode().className).toContain(' off');
   });
 });


### PR DESCRIPTION
When using a `Table` component, the sort order is always jumping to descending on the first click. This pull request modifies this to ensure the first click is ascending.

Column 1st click: `undefined` => `'ascend'`
Column 2nd click: `'ascend'` => `'descend'`
Column 3rd click: `'descend'` => `undefined`
...

I have never seen table sorting that starts with descending order. So, it's fair to claim this as a standard (none => ascend => descend => none)

**Note:** lint was broken on master. You will find several `let` => `const` changes to appease the hook.