### PR TITLE
add listener for start transition

### DIFF
--- a/components/_util/__tests__/util.test.js
+++ b/components/_util/__tests__/util.test.js
@@ -1,3 +1,5 @@
+import raf from 'raf';
+import delayRaf from '../raf';
 import throttleByAnimationFrame from '../throttleByAnimationFrame';
 import getDataOrAriaProps from '../getDataOrAriaProps';
 
@@ -82,6 +84,34 @@ describe('Test utils function', () => {
       };
       const results = getDataOrAriaProps(props);
       expect(results).toEqual({ role: 'search' });
+    });
+  });
+
+  it('delayRaf', (done) => {
+    jest.useRealTimers();
+
+    let bamboo = false;
+    delayRaf(() => {
+      bamboo = true;
+    }, 3);
+
+    // Variable bamboo should be false in frame 2 but true in frame 4
+    raf(() => {
+      expect(bamboo).toBe(false);
+
+      // Frame 2
+      raf(() => {
+        expect(bamboo).toBe(false);
+
+        // Frame 3
+        raf(() => {
+          // Frame 4
+          raf(() => {
+            expect(bamboo).toBe(true);
+            done();
+          });
+        });
+      });
     });
   });
 });

--- a/components/_util/raf.ts
+++ b/components/_util/raf.ts
@@ -1,0 +1,34 @@
+import raf from 'raf';
+
+interface RafMap {
+  [id: number]: number,
+}
+
+let id: number = 0;
+const ids: RafMap = {};
+
+// Support call raf with delay specified frame
+export default function wrapperRaf(callback: () => void, delayFrames: number = 1): number {
+  const myId: number = id++;
+  let restFrames: number = delayFrames;
+
+  function internalCallback() {
+    restFrames -= 1;
+
+    if (restFrames <= 0) {
+      callback();
+      delete ids[id];
+    } else {
+      ids[id] = raf(internalCallback);
+    }
+  }
+
+  ids[id] = raf(internalCallback);
+
+  return myId;
+}
+
+wrapperRaf.cancel = function(id: number) {
+  raf.cancel(ids[id]);
+  delete ids[id];
+}

--- a/components/_util/wave.tsx
+++ b/components/_util/wave.tsx
@@ -22,6 +22,7 @@ export default class Wave extends React.Component<{insertExtraNode?: boolean}> {
   private clickWaveTimeoutId: number;
   private animationStartId: number;
   private animationStart: boolean = false;
+  private destroy: boolean = false
 
   isNotGrey(color: string) {
     const match = (color || '').match(/rgba?\((\d*), (\d*), (\d*)(, [\.\d]*)?\)/);
@@ -121,6 +122,8 @@ export default class Wave extends React.Component<{insertExtraNode?: boolean}> {
   }
 
   onTransitionStart = (e: AnimationEvent) => {
+    if (this.destroy) return;
+
     const node = findDOMNode(this) as HTMLElement;
     if (!e || e.target !== node) {
       return;
@@ -159,6 +162,8 @@ export default class Wave extends React.Component<{insertExtraNode?: boolean}> {
     if (this.clickWaveTimeoutId) {
       clearTimeout(this.clickWaveTimeoutId);
     }
+
+    this.destroy = true;
   }
 
   render() {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "classnames": "~2.2.6",
     "create-react-class": "^15.6.3",
     "create-react-context": "0.2.3",
-    "css-animation": "^1.4.1",
+    "css-animation": "^1.5.0",
     "dom-closest": "^0.2.0",
     "enquire.js": "^2.1.6",
     "intersperse": "^1.0.0",


### PR DESCRIPTION
Since test can't handle animation event, create a PR for double confirm.

ref: #12942

![kapture 2018-11-12 at 18 44 15](https://user-images.githubusercontent.com/5378891/48343463-6b603d00-e6ad-11e8-8e68-33b08fe98cce.gif)
