### PR TITLE
Adding rcselect 'showAction' to AbstractSelectProps to avoid linting …

### DIFF
--- a/components/select/index.tsx
+++ b/components/select/index.tsx
@@ -11,6 +11,7 @@ import Icon from '../icon';
 export interface AbstractSelectProps {
   prefixCls?: string;
   className?: string;
+  showAction?: string | string[];
   size?: 'default' | 'large' | 'small';
   notFoundContent?: React.ReactNode | null;
   transitionName?: string;


### PR DESCRIPTION
…errors when used through antd Select component

The usage of this prop was discussed over #6873

There's a few things I haven't checked out as I need your input and thoughts about that. This is just a prop setting being added and there's no tests over this area. Should I create them anyways? How's the procedure in those cases? Is that correct to be pointing at a feature?

This is due to linting issues when the prop `showAction` is set

Here's my checklist below: 

* [x] Make sure that you propose PR to right branch: bugfix for `master`, feature for branch `feature`.
* [x] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.

Extra checklist:

  * [ ] Update API docs for the component.
  * [ ] Update/Add demo to demonstrate new feature.
  * [ ] Update TypeScript definition for the component.
  * [ ] Add unit tests for the feature.
