### PR TITLE
fix(module:timepicker): incorrect invalid border color

### DIFF
--- a/components/time-picker/style/index.less
+++ b/components/time-picker/style/index.less
@@ -43,7 +43,7 @@
     }
 
     &-invalid {
-      border-color: red;
+      border-color: @error-color;
     }
   }
 


### PR DESCRIPTION
* [x] Make sure that you propose PR to right branch: bugfix for `master`, feature for branch `feature`.
* [x] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a PR to keep commit history clear.
* [ ] Add some descriptions and refer relative issues for you PR.

Extra checklist:

**if** *isBugFix* **:**

  * [ ] Make sure that you add at least one unit test for the bug which you had fixed.

I see it is not applicable

**elif** *isNewFeature* **:**

  * [ ] Update API docs for the component.
  * [ ] Update/Add demo to demonstrate new feature.
  * [ ] Update TypeScript definition for the component.
  * [ ] Add unit tests for the feature.

## rationale
There should not be hardcoded color in such a system of stylesheets. Changed `red` to `@error-color`. Haven't field tested yet but my IDE is happy without syntax error.