### PR TITLE
Cascader support limit filtered item count

### DIFF
--- a/components/cascader/__tests__/index.test.js
+++ b/components/cascader/__tests__/index.test.js
@@ -272,4 +272,11 @@ describe('Cascader', () => {
     );
     errorSpy.mockReset();
   });
+
+  it('limit filtered item count', () => {
+    const wrapper = mount(<Cascader options={options} showSearch={{ filter, limit: 1 }} />);
+    wrapper.find('input').simulate('click');
+    wrapper.find('input').simulate('change', { target: { value: 'a' } });
+    expect(wrapper.find('.ant-cascader-menu-item').length).toBe(1);
+  });
 });

--- a/components/cascader/__tests__/index.test.js
+++ b/components/cascader/__tests__/index.test.js
@@ -273,10 +273,35 @@ describe('Cascader', () => {
     errorSpy.mockReset();
   });
 
-  it('limit filtered item count', () => {
-    const wrapper = mount(<Cascader options={options} showSearch={{ filter, limit: 1 }} />);
-    wrapper.find('input').simulate('click');
-    wrapper.find('input').simulate('change', { target: { value: 'a' } });
-    expect(wrapper.find('.ant-cascader-menu-item').length).toBe(1);
+  describe('limit filtered item count', () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    afterAll(() => {
+      errorSpy.mockRestore();
+    });
+
+    it('limit with positive number', () => {
+      const wrapper = mount(<Cascader options={options} showSearch={{ filter, limit: 1 }} />);
+      wrapper.find('input').simulate('click');
+      wrapper.find('input').simulate('change', { target: { value: 'a' } });
+      expect(wrapper.find('.ant-cascader-menu-item').length).toBe(1);
+    });
+
+    it('not limit', () => {
+      const wrapper = mount(<Cascader options={options} showSearch={{ filter, limit: false }} />);
+      wrapper.find('input').simulate('click');
+      wrapper.find('input').simulate('change', { target: { value: 'a' } });
+      expect(wrapper.find('.ant-cascader-menu-item').length).toBe(2);
+    });
+
+    it('negative limit', () => {
+      const wrapper = mount(<Cascader options={options} showSearch={{ filter, limit: -1 }} />);
+      wrapper.find('input').simulate('click');
+      wrapper.find('input').simulate('change', { target: { value: 'a' } });
+      expect(wrapper.find('.ant-cascader-menu-item').length).toBe(2);
+      expect(errorSpy).toBeCalledWith(
+        'Warning: \'limit\' of showSearch in Cascader should be positive number or false.'
+      );
+    });
   });
 });

--- a/components/cascader/index.en-US.md
+++ b/components/cascader/index.en-US.md
@@ -50,7 +50,7 @@ Fields in `showSearch`:
 | Property | Description | Type | Default |
 | -------- | ----------- | ---- | ------- |
 | filter | The function will receive two arguments, inputValue and option, if the function returns true, the option will be included in the filtered set; Otherwise, it will be excluded. | `function(inputValue, path): boolean` |  |
-| limit | Set the count of filtered items | number | 50 |
+| limit | Set the count of filtered items | number \| false | 50 |
 | matchInputWidth | Whether the width of result list equals to input's | boolean |  |
 | render | Used to render filtered options. | `function(inputValue, path): ReactNode` |  |
 | sort | Used to sort filtered options. | `function(a, b, inputValue)` |  |

--- a/components/cascader/index.en-US.md
+++ b/components/cascader/index.en-US.md
@@ -50,7 +50,7 @@ Fields in `showSearch`:
 | Property | Description | Type | Default |
 | -------- | ----------- | ---- | ------- |
 | filter | The function will receive two arguments, inputValue and option, if the function returns true, the option will be included in the filtered set; Otherwise, it will be excluded. | `function(inputValue, path): boolean` |  |
-| limit | Set the count of filtered items | boolean | 50 |
+| limit | Set the count of filtered items | number | 50 |
 | matchInputWidth | Whether the width of result list equals to input's | boolean |  |
 | render | Used to render filtered options. | `function(inputValue, path): ReactNode` |  |
 | sort | Used to sort filtered options. | `function(a, b, inputValue)` |  |

--- a/components/cascader/index.en-US.md
+++ b/components/cascader/index.en-US.md
@@ -50,6 +50,7 @@ Fields in `showSearch`:
 | Property | Description | Type | Default |
 | -------- | ----------- | ---- | ------- |
 | filter | The function will receive two arguments, inputValue and option, if the function returns true, the option will be included in the filtered set; Otherwise, it will be excluded. | `function(inputValue, path): boolean` |  |
+| limit | Set the count of filtered items | boolean | 50 |
 | matchInputWidth | Whether the width of result list equals to input's | boolean |  |
 | render | Used to render filtered options. | `function(inputValue, path): ReactNode` |  |
 | sort | Used to sort filtered options. | `function(a, b, inputValue)` |  |

--- a/components/cascader/index.tsx
+++ b/components/cascader/index.tsx
@@ -6,6 +6,7 @@ import omit from 'omit.js';
 import KeyCode from 'rc-util/lib/KeyCode';
 import Input from '../input';
 import Icon from '../icon';
+import warning from '../_util/warning';
 
 export interface CascaderOptionType {
   value?: string;
@@ -40,7 +41,7 @@ export interface ShowSearchType {
   ) => React.ReactNode;
   sort?: (a: CascaderOptionType[], b: CascaderOptionType[], inputValue: string, names: FilledFieldNamesType) => number;
   matchInputWidth?: boolean;
-  limit?: number;
+  limit?: number | false;
 }
 
 export interface CascaderProps {
@@ -341,6 +342,10 @@ export default class Cascader extends React.Component<CascaderProps, CascaderSta
         return matchCount >= limit;
       });
     } else {
+      warning(
+        typeof limit !== 'number',
+        '\'limit\' of showSearch in Cascader should be positive number or false.',
+      );
       filtered = flattenOptions.filter((path) => filter(this.state.inputValue, path, names));
     }
 

--- a/components/cascader/index.tsx
+++ b/components/cascader/index.tsx
@@ -98,6 +98,7 @@ export interface CascaderState {
   flattenOptions: CascaderOptionType[][] | undefined;
 }
 
+// We limit the filtered item count by default
 const defaultLimit = 50;
 
 function highlightKeyword(str: string, keyword: string, prefixCls: string | undefined) {

--- a/components/cascader/index.zh-CN.md
+++ b/components/cascader/index.zh-CN.md
@@ -51,7 +51,7 @@ subtitle: 级联选择
 | 参数 | 说明 | 类型 | 默认值 |
 | --- | --- | --- | --- |
 | filter | 接收 `inputValue` `path` 两个参数，当 `path` 符合筛选条件时，应返回 true，反之则返回 false。 | `function(inputValue, path): boolean` |  |
-| limit | 搜索结果展示数量 | boolean | 50 |
+| limit | 搜索结果展示数量 | number | 50 |
 | matchInputWidth | 搜索结果列表是否与输入框同宽 | boolean |  |
 | render | 用于渲染 filter 后的选项 | `function(inputValue, path): ReactNode` |  |
 | sort | 用于排序 filter 后的选项 | `function(a, b, inputValue)` |  |

--- a/components/cascader/index.zh-CN.md
+++ b/components/cascader/index.zh-CN.md
@@ -51,7 +51,7 @@ subtitle: 级联选择
 | 参数 | 说明 | 类型 | 默认值 |
 | --- | --- | --- | --- |
 | filter | 接收 `inputValue` `path` 两个参数，当 `path` 符合筛选条件时，应返回 true，反之则返回 false。 | `function(inputValue, path): boolean` |  |
-| limit | 搜索结果展示数量 | number | 50 |
+| limit | 搜索结果展示数量 | number \| false | 50 |
 | matchInputWidth | 搜索结果列表是否与输入框同宽 | boolean |  |
 | render | 用于渲染 filter 后的选项 | `function(inputValue, path): ReactNode` |  |
 | sort | 用于排序 filter 后的选项 | `function(a, b, inputValue)` |  |

--- a/components/cascader/index.zh-CN.md
+++ b/components/cascader/index.zh-CN.md
@@ -51,6 +51,7 @@ subtitle: 级联选择
 | 参数 | 说明 | 类型 | 默认值 |
 | --- | --- | --- | --- |
 | filter | 接收 `inputValue` `path` 两个参数，当 `path` 符合筛选条件时，应返回 true，反之则返回 false。 | `function(inputValue, path): boolean` |  |
+| limit | 搜索结果展示数量 | boolean | 50 |
 | matchInputWidth | 搜索结果列表是否与输入框同宽 | boolean |  |
 | render | 用于渲染 filter 后的选项 | `function(inputValue, path): ReactNode` |  |
 | sort | 用于排序 filter 后的选项 | `function(a, b, inputValue)` |  |


### PR DESCRIPTION
Add `limit` prop in `showSearch`. Default value: 50:
```jsx
<Cascader
  {...props}
  showSearch={{ limit: 30 }}
/>
```

ref: #13097 