### PR TITLE
fix(module:alert): padding for overlapping close button

### DIFF
--- a/components/alert/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/alert/__tests__/__snapshots__/demo.test.js.snap
@@ -37,6 +37,27 @@ exports[`renders ./components/alert/demo/banner.md correctly 1`] = `
     class="ant-alert ant-alert-warning ant-alert-banner"
     data-show="true"
   >
+    <a
+      class="ant-alert-close-icon"
+    >
+      <i
+        class="anticon anticon-close"
+      >
+        <svg
+          aria-hidden="true"
+          class=""
+          data-icon="close"
+          fill="currentColor"
+          height="1em"
+          viewBox="64 64 896 896"
+          width="1em"
+        >
+          <path
+            d="M563.8 512l262.5-312.9c4.4-5.2.7-13.1-6.1-13.1h-79.8c-4.7 0-9.2 2.1-12.3 5.7L511.6 449.8 295.1 191.7c-3-3.6-7.5-5.7-12.3-5.7H203c-6.8 0-10.5 7.9-6.1 13.1L459.4 512 196.9 824.9A7.95 7.95 0 0 0 203 838h79.8c4.7 0 9.2-2.1 12.3-5.7l216.5-258.1 216.5 258.1c3 3.6 7.5 5.7 12.3 5.7h79.8c6.8 0 10.5-7.9 6.1-13.1L563.8 512z"
+          />
+        </svg>
+      </i>
+    </a>
     <i
       class="anticon anticon-exclamation-circle ant-alert-icon"
     >
@@ -62,27 +83,6 @@ exports[`renders ./components/alert/demo/banner.md correctly 1`] = `
     <span
       class="ant-alert-description"
     />
-    <a
-      class="ant-alert-close-icon"
-    >
-      <i
-        class="anticon anticon-close"
-      >
-        <svg
-          aria-hidden="true"
-          class=""
-          data-icon="close"
-          fill="currentColor"
-          height="1em"
-          viewBox="64 64 896 896"
-          width="1em"
-        >
-          <path
-            d="M563.8 512l262.5-312.9c4.4-5.2.7-13.1-6.1-13.1h-79.8c-4.7 0-9.2 2.1-12.3 5.7L511.6 449.8 295.1 191.7c-3-3.6-7.5-5.7-12.3-5.7H203c-6.8 0-10.5 7.9-6.1 13.1L459.4 512 196.9 824.9A7.95 7.95 0 0 0 203 838h79.8c4.7 0 9.2-2.1 12.3-5.7l216.5-258.1 216.5 258.1c3 3.6 7.5 5.7 12.3 5.7h79.8c6.8 0 10.5-7.9 6.1-13.1L563.8 512z"
-          />
-        </svg>
-      </i>
-    </a>
   </div>
   <br />
   <div
@@ -154,14 +154,6 @@ exports[`renders ./components/alert/demo/closable.md correctly 1`] = `
     class="ant-alert ant-alert-warning ant-alert-no-icon"
     data-show="true"
   >
-    <span
-      class="ant-alert-message"
-    >
-      Warning Text Warning Text Warning TextW arning Text Warning Text Warning TextWarning Text
-    </span>
-    <span
-      class="ant-alert-description"
-    />
     <a
       class="ant-alert-close-icon"
     >
@@ -183,11 +175,40 @@ exports[`renders ./components/alert/demo/closable.md correctly 1`] = `
         </svg>
       </i>
     </a>
+    <span
+      class="ant-alert-message"
+    >
+      Warning Text Warning Text Warning TextW arning Text Warning Text Warning TextWarning Text
+    </span>
+    <span
+      class="ant-alert-description"
+    />
   </div>
   <div
     class="ant-alert ant-alert-error ant-alert-with-description ant-alert-no-icon"
     data-show="true"
   >
+    <a
+      class="ant-alert-close-icon"
+    >
+      <i
+        class="anticon anticon-close"
+      >
+        <svg
+          aria-hidden="true"
+          class=""
+          data-icon="close"
+          fill="currentColor"
+          height="1em"
+          viewBox="64 64 896 896"
+          width="1em"
+        >
+          <path
+            d="M563.8 512l262.5-312.9c4.4-5.2.7-13.1-6.1-13.1h-79.8c-4.7 0-9.2 2.1-12.3 5.7L511.6 449.8 295.1 191.7c-3-3.6-7.5-5.7-12.3-5.7H203c-6.8 0-10.5 7.9-6.1 13.1L459.4 512 196.9 824.9A7.95 7.95 0 0 0 203 838h79.8c4.7 0 9.2-2.1 12.3-5.7l216.5-258.1 216.5 258.1c3 3.6 7.5 5.7 12.3 5.7h79.8c6.8 0 10.5-7.9 6.1-13.1L563.8 512z"
+          />
+        </svg>
+      </i>
+    </a>
     <span
       class="ant-alert-message"
     >
@@ -198,27 +219,6 @@ exports[`renders ./components/alert/demo/closable.md correctly 1`] = `
     >
       Error Description Error Description Error Description Error Description Error Description Error Description
     </span>
-    <a
-      class="ant-alert-close-icon"
-    >
-      <i
-        class="anticon anticon-close"
-      >
-        <svg
-          aria-hidden="true"
-          class=""
-          data-icon="close"
-          fill="currentColor"
-          height="1em"
-          viewBox="64 64 896 896"
-          width="1em"
-        >
-          <path
-            d="M563.8 512l262.5-312.9c4.4-5.2.7-13.1-6.1-13.1h-79.8c-4.7 0-9.2 2.1-12.3 5.7L511.6 449.8 295.1 191.7c-3-3.6-7.5-5.7-12.3-5.7H203c-6.8 0-10.5 7.9-6.1 13.1L459.4 512 196.9 824.9A7.95 7.95 0 0 0 203 838h79.8c4.7 0 9.2-2.1 12.3-5.7l216.5-258.1 216.5 258.1c3 3.6 7.5 5.7 12.3 5.7h79.8c6.8 0 10.5-7.9 6.1-13.1L563.8 512z"
-          />
-        </svg>
-      </i>
-    </a>
   </div>
 </div>
 `;
@@ -228,6 +228,11 @@ exports[`renders ./components/alert/demo/close-text.md correctly 1`] = `
   class="ant-alert ant-alert-info ant-alert-no-icon"
   data-show="true"
 >
+  <a
+    class="ant-alert-close-icon"
+  >
+    Close Now
+  </a>
   <span
     class="ant-alert-message"
   >
@@ -236,11 +241,6 @@ exports[`renders ./components/alert/demo/close-text.md correctly 1`] = `
   <span
     class="ant-alert-description"
   />
-  <a
-    class="ant-alert-close-icon"
-  >
-    Close Now
-  </a>
 </div>
 `;
 
@@ -846,14 +846,6 @@ exports[`renders ./components/alert/demo/smooth-closed.md correctly 1`] = `
     class="ant-alert ant-alert-success ant-alert-no-icon"
     data-show="true"
   >
-    <span
-      class="ant-alert-message"
-    >
-      Alert Message Text
-    </span>
-    <span
-      class="ant-alert-description"
-    />
     <a
       class="ant-alert-close-icon"
     >
@@ -875,6 +867,14 @@ exports[`renders ./components/alert/demo/smooth-closed.md correctly 1`] = `
         </svg>
       </i>
     </a>
+    <span
+      class="ant-alert-message"
+    >
+      Alert Message Text
+    </span>
+    <span
+      class="ant-alert-description"
+    />
   </div>
   <p>
     placeholder text here

--- a/components/alert/index.tsx
+++ b/components/alert/index.tsx
@@ -148,10 +148,10 @@ export default class Alert extends React.Component<AlertProps, AlertState> {
         onEnd={this.animationEnd}
       >
         <div data-show={this.state.closing} className={alertCls} style={style} {...dataOrAriaProps}>
+          {closeIcon}
           {showIcon ? iconNode : null}
           <span className={`${prefixCls}-message`}>{message}</span>
           <span className={`${prefixCls}-description`}>{description}</span>
-          {closeIcon}
         </div>
       </Animate>
     );

--- a/components/alert/style/index.less
+++ b/components/alert/style/index.less
@@ -15,6 +15,7 @@
 
   &&-no-icon {
     padding: 8px 15px;
+    .clearfix;
   }
 
   &-icon {
@@ -63,11 +64,9 @@
 
   &-close-icon {
     font-size: @font-size-sm;
-    position: absolute;
-    right: 16px;
-    top: 8px;
-    line-height: 22px;
+    line-height: 21px;
     overflow: hidden;
+    float: right;
     cursor: pointer;
 
     .@{iconfont-css-prefix}-close {
@@ -82,6 +81,11 @@
   &-close-text {
     position: absolute;
     right: 16px;
+  }
+
+  &-message {
+    display: block;
+    padding-right: 16px;
   }
 
   &-with-description {
@@ -104,9 +108,6 @@
   }
 
   &-with-description &-close-icon {
-    position: absolute;
-    top: 16px;
-    right: 16px;
     cursor: pointer;
     font-size: @font-size-base;
   }


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

```
[x] Code style update (formatting, local variables)
```

## What is the current behavior?

Issue Number: [#1668](https://github.com/NG-ZORRO/ng-zorro-antd/issues/1668)

## What is the new behavior?

Close button doesn't overlap alert's content anymore.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```