### PR TITLE
Fix regular error in firefox and safri

### DIFF
--- a/components/table/demo/custom-filter-panel.md
+++ b/components/table/demo/custom-filter-panel.md
@@ -84,7 +84,7 @@ class App extends React.Component {
         const { searchText } = this.state;
         return searchText ? (
           <span>
-            {text.split(new RegExp(`(?<=${searchText})|(?=${searchText})`, 'i')).map((fragment, i) => (
+            {text.split(new RegExp(`(${searchText})`, 'gi')).map((fragment, i) => (
               fragment.toLowerCase() === searchText.toLowerCase()
                 ? <span key={i} className="highlight">{fragment}</span> : fragment // eslint-disable-line
             ))}


### PR DESCRIPTION
Fix #13268 and #13187 
Only `Chrome` supports `lookbehind assertions` for now,  so use a common regex instead of it.
ref: [highlight-text-using-reactjs](https://stackoverflow.com/questions/29652862/highlight-text-using-reactjs)
It works fine in `Chrome`,  `Safri` and `FireFox`, not tested in `IE`.