### PR TITLE
Correct type

### DIFF
--- a/components/mention/index.tsx
+++ b/components/mention/index.tsx
@@ -78,7 +78,7 @@ export default class Mention extends React.Component<MentionProps, MentionState>
     }
   }
 
-  defaultSearchChange(value: String): void {
+  defaultSearchChange(value: string): void {
     const searchValue = value.toLowerCase();
     const filteredSuggestions = (this.props.suggestions || []).filter(
       suggestion => {


### PR DESCRIPTION
In typescript, `String` is an interface. A bit difference between them.
For example:
``````
var str: String = new String("hello");
var str: string = "hello";
``````