### PR TITLE
Updating of Rc-select version 

### DIFF
--- a/components/date-picker/__tests__/__snapshots__/DatePicker.test.js.snap
+++ b/components/date-picker/__tests__/__snapshots__/DatePicker.test.js.snap
@@ -810,7 +810,7 @@ exports[`DatePicker prop locale should works 1`] = `
                 <a
                   class="ant-calendar-today-btn "
                   role="button"
-                  title="November 21, 2016"
+                  title="November 22, 2016"
                 >
                   Днес
                 </a>

--- a/components/date-picker/__tests__/__snapshots__/DatePicker.test.js.snap
+++ b/components/date-picker/__tests__/__snapshots__/DatePicker.test.js.snap
@@ -810,7 +810,7 @@ exports[`DatePicker prop locale should works 1`] = `
                 <a
                   class="ant-calendar-today-btn "
                   role="button"
-                  title="November 22, 2016"
+                  title="November 21, 2016"
                 >
                   Днес
                 </a>

--- a/components/date-picker/createPicker.tsx
+++ b/components/date-picker/createPicker.tsx
@@ -216,6 +216,7 @@ export default function createPicker(TheCalendar: React.ComponentClass): any {
             value={(inputValue && inputValue.format(props.format)) || ''}
             placeholder={placeholder}
             className={props.pickerInputClass}
+            tabIndex={props.tabIndex}
             {...dataOrAriaProps}
           />
           {clearIcon}

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "rc-pagination": "~1.17.3",
     "rc-progress": "~2.2.6",
     "rc-rate": "~2.4.2",
-    "rc-select": "~8.4.0",
+    "rc-select": "~8.6.0",
     "rc-slider": "~8.6.3",
     "rc-steps": "~3.3.0",
     "rc-switch": "~1.8.0",


### PR DESCRIPTION
Hey there,

I added also to "rc-select" for "Select" component of Ant Design. So they merged my pull request. Now my changes are available in "8.6.0" version. Could you update version of "rc-select" which is used by antd?