### PR TITLE
should add moment to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
   "license": "MIT",
   "peerDependencies": {
     "react": ">=16.0.0",
-    "react-dom": ">=16.0.0"
+    "react-dom": ">=16.0.0",
+    "moment": "^2.22.2"
   },
   "dependencies": {
     "@ant-design/icons": "~1.1.15",


### PR DESCRIPTION
dist/antd.min.js did not contain moment's source.   
```html
<script
      src="https://unpkg.com/react@16.0.0/umd/react.production.min.js"
      async=""
    ></script>
    <script
      src="https://unpkg.com/react-dom@16.0.0/umd/react-dom.production.min.js"
      async=""></script>
    <!-- <script
      src="https://unpkg.com/moment@2.22.2/min/moment.min.js"
      async=""></script> -->
    <script
      src="https://unpkg.com/antd@3.0.1/dist/antd.min.js"
      async=""
    ></script>
```
it can't be runing without moment, so we should note in peerDependencies specially
