### PR TITLE
Fix #13413 - Set input border-right-width to @border-width-base on hover and focus state

### DIFF
--- a/components/input/style/mixin.less
+++ b/components/input/style/mixin.less
@@ -21,13 +21,13 @@
   border-color: ~`colorPalette("@{color}", 5)`;
   outline: 0;
   box-shadow: @input-outline-offset @outline-blur-size @outline-width fade(@color, 20%);
-  border-right-width: 1px !important;
+  border-right-width: @border-width-base !important;
 }
 
 // == when hoverd
 .hover(@color: @input-hover-border-color) {
   border-color: ~`colorPalette("@{color}", 5)`;
-  border-right-width: 1px !important;
+  border-right-width: @border-width-base !important;
 }
 
 .disabled() {


### PR DESCRIPTION
Fix #13413 
This issues caused by set `border-right-width` to `1px` on hover and focus state. Bug when you customize the @border-width-base variable to large than 1px, it can not display correctly. 

So I change  `border-right-width` property to `@border-width-base` on those state, and it works well.

please see the fix verison

![image](https://user-images.githubusercontent.com/15653996/49386575-d821a100-f75a-11e8-9aa2-ca2a43e60e1f.png)


First of all, thank you for your contribution! :-)

Please makes sure that these checkboxes are checked before submitting your pull request, thank you!

* [x] Make sure that you propose pull request to right branch: bugfix for `master`, feature for branch `feature`.
* [x] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a pull request to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you pull request.

Extra checklist:

**if** *isBugFix* **:**

  * [x] Make sure that you add at least one unit test for the bug which you had fixed.

**elif** *isNewFeature* **:**

  * [ ] Update API docs for the component.
  * [ ] Update/Add demo to demonstrate new feature.
  * [ ] Update TypeScript definition for the component.
  * [ ] Add unit tests for the feature.
