### PR TITLE
:bug: fix status normal

### DIFF
--- a/components/progress/__tests__/__snapshots__/index.test.js.snap
+++ b/components/progress/__tests__/__snapshots__/index.test.js.snap
@@ -89,6 +89,33 @@ exports[`Progress render negetive successPercent 1`] = `
 </div>
 `;
 
+exports[`Progress render normal progress 1`] = `
+<div
+  class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default"
+>
+  <div>
+    <div
+      class="ant-progress-outer"
+    >
+      <div
+        class="ant-progress-inner"
+      >
+        <div
+          class="ant-progress-bg"
+          style="width: 0%; height: 8px; border-radius: 100px;"
+        />
+      </div>
+    </div>
+    <span
+      class="ant-progress-text"
+      title="0%"
+    >
+      0%
+    </span>
+  </div>
+</div>
+`;
+
 exports[`Progress render out-of-range progress 1`] = `
 <div
   class="ant-progress ant-progress-line ant-progress-status-success ant-progress-show-info ant-progress-default"

--- a/components/progress/__tests__/index.test.js
+++ b/components/progress/__tests__/index.test.js
@@ -46,4 +46,9 @@ describe('Progress', () => {
     const wrapper = mount(<Progress type="circle" percent={50} strokeColor="red" />);
     expect(wrapper.render()).toMatchSnapshot();
   });
+
+  it('render normal progress', () => {
+    const wrapper = mount(<Progress status="normal" />);
+    expect(wrapper.render()).toMatchSnapshot();
+  });
 });

--- a/components/progress/index.en-US.md
+++ b/components/progress/index.en-US.md
@@ -22,7 +22,7 @@ If it will take a long time to complete an operation, you can use `Progress` to 
 | gapPosition `(type=circle)` | the gap position, options: `top` `bottom` `left` `right` | string | `top` |
 | percent | to set the completion percentage | number | 0 |
 | showInfo | whether to display the progress value and the status icon | boolean | true |
-| status | to set the status of the Progress, options: `success` `exception` `active` | string | - |
+| status | to set the status of the Progress, options: `success` `exception` `active` `normal` | string | - |
 | strokeWidth `(type=line)` | to set the width of the progress bar, unit: `px` | number | 10 |
 | strokeWidth `(type=circle)` | to set the width of the circular progress bar, unit: percentage of the canvas width | number | 6 |
 | strokeLinecap | to set the style of the progress linecap | Enum{ 'round', 'square' } | `round` |

--- a/components/progress/index.zh-CN.md
+++ b/components/progress/index.zh-CN.md
@@ -23,7 +23,7 @@ title: Progress
 | gapPosition `(type=circle)` | 圆形进度条缺口位置 | Enum{ 'top', 'bottom', 'left', 'right' } | `top` |
 | percent | 百分比 | number | 0 |
 | showInfo | 是否显示进度数值或状态图标 | boolean | true |
-| status | 状态，可选：`success` `exception` `active` | string | - |
+| status | 状态，可选：`success` `exception` `active` `normal` | string | - |
 | strokeWidth `(type=line)` | 进度条线的宽度，单位 px | number | 10 |
 | strokeWidth `(type=circle)` | 圆形进度条线的宽度，单位是进度条画布宽度的百分比 | number | 6 |
 | strokeLinecap | | Enum{ 'round', 'square' } | `round` |

--- a/components/progress/progress.tsx
+++ b/components/progress/progress.tsx
@@ -20,7 +20,7 @@ export interface ProgressProps {
   percent?: number;
   successPercent?: number;
   format?: (percent?: number, successPercent?: number) => React.ReactNode;
-  status?: 'success' | 'active' | 'exception';
+  status?: 'success' | 'active' | 'exception' | 'normal';
   showInfo?: boolean;
   strokeWidth?: number;
   strokeLinecap?: string;


### PR DESCRIPTION
First of all, thank you for your contribution! :-)

Please makes sure that these checkboxes are checked before submitting your pull request, thank you!

* [x] Make sure that you propose pull request to right branch: bugfix for `master`, feature for branch `feature`.
* [x] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a pull request to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you pull request.

Extra checklist:

**if** *isBugFix* **:**

  * [x] Make sure that you add at least one unit test for the bug which you had fixed.

**elif** *isNewFeature* **:**

  * [ ] Update API docs for the component.
  * [ ] Update/Add demo to demonstrate new feature.
  * [ ] Update TypeScript definition for the component.
  * [ ] Add unit tests for the feature.

this happens in when I need to keep progress 100% as normal status

![image](https://user-images.githubusercontent.com/11738111/49446016-2ba0f700-f80e-11e8-8b69-4232b4f3cca6.png)

progress component should be able to use status `normal` with correct type definition, otherwise i have to use `status={'normal' as any}`  as a workaround.