### PR TITLE
Fixed component demos can‘t be opened correctly in CodeSandbox

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -53,6 +53,7 @@ if (process.env.RUN_ENV === 'DEMO') {
     'no-return-assign': 0, // TODO: remove later
     'no-param-reassign': 0, // TODO: remove later
     'import/no-extraneous-dependencies': 0,
+    'object-curly-newline': ['error', { ImportDeclaration: 'never' }],
   });
 }
 

--- a/components/auto-complete/demo/uncertain-category.md
+++ b/components/auto-complete/demo/uncertain-category.md
@@ -15,9 +15,7 @@ Demonstration of [Lookup Patterns: Uncertain Category](https://ant.design/docs/s
 Basic Usage, set datasource of autocomplete with `dataSource` property.
 
 ````jsx
-import {
-  Icon, Button, Input, AutoComplete,
-} from 'antd';
+import { Icon, Button, Input, AutoComplete } from 'antd';
 
 const Option = AutoComplete.Option;
 

--- a/components/badge/demo/change.md
+++ b/components/badge/demo/change.md
@@ -14,9 +14,7 @@ title:
 The count will be animated as it changes.
 
 ````jsx
-import {
-  Badge, Button, Icon, Switch,
-} from 'antd';
+import { Badge, Button, Icon, Switch } from 'antd';
 
 const ButtonGroup = Button.Group;
 

--- a/components/breadcrumb/demo/router-4.md
+++ b/components/breadcrumb/demo/router-4.md
@@ -16,9 +16,7 @@ title:
 Used together with `react-router@4` or other router.
 
 ````jsx
-import {
-  HashRouter as Router, Route, Switch, Link, withRouter,
-} from 'react-router-dom';
+import { HashRouter as Router, Route, Switch, Link, withRouter } from 'react-router-dom';
 import { Breadcrumb, Alert } from 'antd';
 
 const Apps = () => (

--- a/components/breadcrumb/demo/router.md
+++ b/components/breadcrumb/demo/router.md
@@ -16,9 +16,7 @@ title:
 Used together with `react-router@2` `react-router@3`.
 
 ````jsx
-import {
-  Router, Route, Link, hashHistory,
-} from 'react-router';
+import { Router, Route, Link, hashHistory } from 'react-router';
 import { Breadcrumb, Alert } from 'antd';
 
 const Apps = () => (

--- a/components/button/demo/multiple.md
+++ b/components/button/demo/multiple.md
@@ -15,9 +15,7 @@ If you need several buttons, we recommend that you use 1 primary button + n seco
 
 
 ````jsx
-import {
-  Button, Menu, Dropdown, Icon,
-} from 'antd';
+import { Button, Menu, Dropdown, Icon } from 'antd';
 
 function handleMenuClick(e) {
   console.log('click', e);

--- a/components/card/demo/loading.md
+++ b/components/card/demo/loading.md
@@ -14,9 +14,7 @@ title:
 Shows a loading indicator while the contents of the card is being fetched.
 
 ````jsx
-import {
-  Skeleton, Switch, Card, Icon, Avatar,
-} from 'antd';
+import { Skeleton, Switch, Card, Icon, Avatar } from 'antd';
 
 const { Meta } = Card;
 

--- a/components/comment/demo/basic.md
+++ b/components/comment/demo/basic.md
@@ -14,9 +14,7 @@ title:
 A basic comment with author, avatar, time and actions.
 
 ````jsx
-import {
-  Comment, Icon, Tooltip, Avatar,
-} from 'antd';
+import { Comment, Icon, Tooltip, Avatar } from 'antd';
 import moment from 'moment';
 
 class App extends React.Component {

--- a/components/comment/demo/editor.md
+++ b/components/comment/demo/editor.md
@@ -14,9 +14,7 @@ title:
 Comment can be used as editor, user can customize the editor component.
 
 ````jsx
-import {
-  Comment, Avatar, Form, Button, List, Input,
-} from 'antd';
+import { Comment, Avatar, Form, Button, List, Input } from 'antd';
 import moment from 'moment';
 
 const FormItem = Form.Item;

--- a/components/drawer/demo/from-drawer.md
+++ b/components/drawer/demo/from-drawer.md
@@ -14,9 +14,7 @@ title:
 A drawer containing an editable form which needs to be collapsed by clicking the close button.
 
 ```jsx
-import {
-  Drawer, Form, Button, Col, Row, Input, Select, DatePicker,
-} from 'antd';
+import { Drawer, Form, Button, Col, Row, Input, Select, DatePicker } from 'antd';
 
 const { Option } = Select;
 

--- a/components/drawer/demo/user-profile.md
+++ b/components/drawer/demo/user-profile.md
@@ -14,9 +14,7 @@ title:
 Use when you need to quickly preview the outline of the object. Such as list item preview.
 
 ```jsx
-import {
-  Drawer, List, Avatar, Divider, Col, Row,
-} from 'antd';
+import { Drawer, List, Avatar, Divider, Col, Row } from 'antd';
 
 const pStyle = {
   fontSize: 16,

--- a/components/dropdown/demo/dropdown-button.md
+++ b/components/dropdown/demo/dropdown-button.md
@@ -14,9 +14,7 @@ title:
 A button is on the left, and a related functional menu is on the right.
 
 ````jsx
-import {
-  Menu, Dropdown, Button, Icon, message,
-} from 'antd';
+import { Menu, Dropdown, Button, Icon, message } from 'antd';
 
 function handleButtonClick(e) {
   message.info('Click on left button.');

--- a/components/dropdown/demo/event.md
+++ b/components/dropdown/demo/event.md
@@ -14,9 +14,7 @@ title:
 An event will be triggered when you click menu items, in which you can make different operations according to item's key.
 
 ````jsx
-import {
-  Menu, Dropdown, Icon, message,
-} from 'antd';
+import { Menu, Dropdown, Icon, message } from 'antd';
 
 const onClick = ({ key }) => {
   message.info(`Click on item ${key}`);

--- a/components/form/demo/advanced-search.md
+++ b/components/form/demo/advanced-search.md
@@ -19,9 +19,7 @@ Because the width of label is not fixed, you may need to adjust it by customizin
 
 
 ````jsx
-import {
-  Form, Row, Col, Input, Button, Icon,
-} from 'antd';
+import { Form, Row, Col, Input, Button, Icon } from 'antd';
 
 const FormItem = Form.Item;
 

--- a/components/form/demo/coordinated.md
+++ b/components/form/demo/coordinated.md
@@ -14,9 +14,7 @@ title:
 Use `setFieldsValue` to set other control's value programmaticly.
 
 ````jsx
-import {
-  Form, Select, Input, Button,
-} from 'antd';
+import { Form, Select, Input, Button } from 'antd';
 
 const FormItem = Form.Item;
 const Option = Select.Option;

--- a/components/form/demo/customized-form-controls.md
+++ b/components/form/demo/customized-form-controls.md
@@ -20,9 +20,7 @@ Customized or third-party form controls can be used in Form, too. Controls must 
 > * It must be a class component.
 
 ````jsx
-import {
-  Form, Input, Select, Button,
-} from 'antd';
+import { Form, Input, Select, Button } from 'antd';
 
 const FormItem = Form.Item;
 const Option = Select.Option;

--- a/components/form/demo/dynamic-form-item.md
+++ b/components/form/demo/dynamic-form-item.md
@@ -14,9 +14,7 @@ title:
 Add or remove form items dynamically.
 
 ````jsx
-import {
-  Form, Input, Icon, Button,
-} from 'antd';
+import { Form, Input, Icon, Button } from 'antd';
 
 const FormItem = Form.Item;
 

--- a/components/form/demo/dynamic-rule.md
+++ b/components/form/demo/dynamic-rule.md
@@ -14,9 +14,7 @@ title:
 Perform different check rules according to different situations.
 
 ````jsx
-import {
-  Form, Input, Button, Checkbox,
-} from 'antd';
+import { Form, Input, Button, Checkbox } from 'antd';
 
 const FormItem = Form.Item;
 

--- a/components/form/demo/form-in-modal.md
+++ b/components/form/demo/form-in-modal.md
@@ -14,9 +14,7 @@ title:
 When user visit a page with a list of items, and want to create a new item. The page can popup a form in Modal, then let user fill in the form to create an item.
 
 ````jsx
-import {
-  Button, Modal, Form, Input, Radio,
-} from 'antd';
+import { Button, Modal, Form, Input, Radio } from 'antd';
 
 const FormItem = Form.Item;
 

--- a/components/form/demo/horizontal-login.md
+++ b/components/form/demo/horizontal-login.md
@@ -14,9 +14,7 @@ title:
 Horizontal login form is often used in navigation bar.
 
 ````jsx
-import {
-  Form, Icon, Input, Button,
-} from 'antd';
+import { Form, Icon, Input, Button } from 'antd';
 
 const FormItem = Form.Item;
 

--- a/components/form/demo/layout.md
+++ b/components/form/demo/layout.md
@@ -14,9 +14,7 @@ title:
 There are three layout for form: `horizontal`, `vertical`, `inline`.
 
 ````jsx
-import {
-  Form, Input, Button, Radio,
-} from 'antd';
+import { Form, Input, Button, Radio } from 'antd';
 
 const FormItem = Form.Item;
 

--- a/components/form/demo/normal-login.md
+++ b/components/form/demo/normal-login.md
@@ -14,9 +14,7 @@ title:
 Normal login form which can contain more elements.
 
 ````jsx
-import {
-  Form, Icon, Input, Button, Checkbox,
-} from 'antd';
+import { Form, Icon, Input, Button, Checkbox } from 'antd';
 
 const FormItem = Form.Item;
 

--- a/components/form/demo/register.md
+++ b/components/form/demo/register.md
@@ -14,9 +14,7 @@ title:
 Fill in this form to create a new account for you.
 
 ````jsx
-import {
-  Form, Input, Tooltip, Icon, Cascader, Select, Row, Col, Checkbox, Button, AutoComplete,
-} from 'antd';
+import { Form, Input, Tooltip, Icon, Cascader, Select, Row, Col, Checkbox, Button, AutoComplete } from 'antd';
 
 const FormItem = Form.Item;
 const Option = Select.Option;

--- a/components/form/demo/time-related-controls.md
+++ b/components/form/demo/time-related-controls.md
@@ -14,9 +14,7 @@ title:
 The `value` of time-related components is a `moment` object, which we need to pre-process it before we submit to server.
 
 ````jsx
-import {
-  Form, DatePicker, TimePicker, Button,
-} from 'antd';
+import { Form, DatePicker, TimePicker, Button } from 'antd';
 
 const FormItem = Form.Item;
 const { MonthPicker, RangePicker } = DatePicker;

--- a/components/form/demo/validate-other.md
+++ b/components/form/demo/validate-other.md
@@ -14,10 +14,8 @@ title:
 Demostration for validataion configuration for form controls which are not show in the above demos.
 
 ````jsx
-import {
-  Form, Select, InputNumber, Switch, Radio,
-  Slider, Button, Upload, Icon, Rate,
-} from 'antd';
+import { Form, Select, InputNumber, Switch, Radio,
+  Slider, Button, Upload, Icon, Rate } from 'antd';
 
 const FormItem = Form.Item;
 const Option = Select.Option;

--- a/components/form/demo/validate-static.md
+++ b/components/form/demo/validate-static.md
@@ -22,9 +22,7 @@ We provide properties like `validateStatus` `help` `hasFeedback` to customize yo
 3. `help`: display validate message.
 
 ````jsx
-import {
-  Form, Input, DatePicker, Col, TimePicker, Select, Cascader, InputNumber,
-} from 'antd';
+import { Form, Input, DatePicker, Col, TimePicker, Select, Cascader, InputNumber } from 'antd';
 
 const FormItem = Form.Item;
 const Option = Select.Option;

--- a/components/input/demo/group.md
+++ b/components/input/demo/group.md
@@ -18,9 +18,7 @@ Input.Group example
 Note: You don't need `Col` to control the width in the `compact` mode.
 
 ````jsx
-import {
-  Input, Col, Select, InputNumber, DatePicker, AutoComplete, Cascader,
-} from 'antd';
+import { Input, Col, Select, InputNumber, DatePicker, AutoComplete, Cascader } from 'antd';
 
 const InputGroup = Input.Group;
 const Option = Select.Option;

--- a/components/layout/demo/side.md
+++ b/components/layout/demo/side.md
@@ -21,9 +21,7 @@ Generally, the mainnav is placed on the left side of the page, and the secondary
 The level of the aside navigation is scalable. The first, second, and third level navigations could be present more fluently and relevantly, and aside navigation can be fixed, allowing the user to quickly switch and spot the current position, improving the user experience. However, this navigation occupies some horizontal space of the contents
 
 ````jsx
-import {
-  Layout, Menu, Breadcrumb, Icon,
-} from 'antd';
+import { Layout, Menu, Breadcrumb, Icon } from 'antd';
 
 const {
   Header, Content, Footer, Sider,

--- a/components/layout/demo/top-side-2.md
+++ b/components/layout/demo/top-side-2.md
@@ -14,9 +14,7 @@ title:
 Both the top navigation and the sidebar, commonly used in application site.
 
 ````jsx
-import {
-  Layout, Menu, Breadcrumb, Icon,
-} from 'antd';
+import { Layout, Menu, Breadcrumb, Icon } from 'antd';
 
 const { SubMenu } = Menu;
 const { Header, Content, Sider } = Layout;

--- a/components/layout/demo/top-side.md
+++ b/components/layout/demo/top-side.md
@@ -14,9 +14,7 @@ title:
 Both the top navigation and the sidebar, commonly used in documentation site.
 
 ````jsx
-import {
-  Layout, Menu, Breadcrumb, Icon,
-} from 'antd';
+import { Layout, Menu, Breadcrumb, Icon } from 'antd';
 
 const { SubMenu } = Menu;
 const {

--- a/components/list/demo/infinite-load.md
+++ b/components/list/demo/infinite-load.md
@@ -14,9 +14,7 @@ title:
 The example of infinite load with [react-infinite-scroller](https://github.com/CassetteRocks/react-infinite-scroller).
 
 ````jsx
-import {
-  List, message, Avatar, Spin,
-} from 'antd';
+import { List, message, Avatar, Spin } from 'antd';
 import reqwest from 'reqwest';
 
 import InfiniteScroll from 'react-infinite-scroller';

--- a/components/list/demo/infinite-virtualized-load.md
+++ b/components/list/demo/infinite-virtualized-load.md
@@ -18,9 +18,7 @@ An example of infinite list & virtualized loading using [react-virtualized](http
 `Virtualized` rendering is a technique to mount big sets of data. It reduces the amount of rendered DOM nodes by tracking and hiding whatever isn't currently visible.
 
 ````jsx
-import {
-  List, message, Avatar, Spin,
-} from 'antd';
+import { List, message, Avatar, Spin } from 'antd';
 
 import reqwest from 'reqwest';
 

--- a/components/list/demo/loadmore.md
+++ b/components/list/demo/loadmore.md
@@ -14,9 +14,7 @@ title:
 Load more list with `loadMore` property.
 
 ````jsx
-import {
-  List, Avatar, Button, Skeleton,
-} from 'antd';
+import { List, Avatar, Button, Skeleton } from 'antd';
 
 import reqwest from 'reqwest';
 

--- a/components/locale-provider/demo/all.md
+++ b/components/locale-provider/demo/all.md
@@ -14,10 +14,8 @@ title:
 Components which need localization support are listed here, you can toggle the language in the demo.
 
 ````jsx
-import {
-  LocaleProvider, Pagination, DatePicker, TimePicker, Calendar,
-  Popconfirm, Table, Modal, Button, Select, Transfer, Radio,
-} from 'antd';
+import { LocaleProvider, Pagination, DatePicker, TimePicker, Calendar,
+  Popconfirm, Table, Modal, Button, Select, Transfer, Radio } from 'antd';
 import zhCN from 'antd/lib/locale-provider/zh_CN';
 import moment from 'moment';
 import 'moment/locale/zh-cn';

--- a/components/skeleton/demo/list.md
+++ b/components/skeleton/demo/list.md
@@ -14,9 +14,7 @@ title:
 Use skeleton in list component.
 
 ````jsx
-import {
-  Skeleton, Switch, List, Avatar, Icon,
-} from 'antd';
+import { Skeleton, Switch, List, Avatar, Icon } from 'antd';
 
 const listData = [];
 for (let i = 0; i < 3; i++) {

--- a/components/slider/demo/input-number.md
+++ b/components/slider/demo/input-number.md
@@ -14,9 +14,7 @@ title:
 Synchronize with [InputNumber](/components/input-number/) component.
 
 ````jsx
-import {
-  Slider, InputNumber, Row, Col,
-} from 'antd';
+import { Slider, InputNumber, Row, Col } from 'antd';
 
 class IntegerStep extends React.Component {
   state = {

--- a/components/table/demo/custom-filter-panel.md
+++ b/components/table/demo/custom-filter-panel.md
@@ -14,9 +14,7 @@ title:
 Implement a customized column search example via `filterDropdown`.
 
 ````jsx
-import {
-  Table, Input, Button, Icon,
-} from 'antd';
+import { Table, Input, Button, Icon } from 'antd';
 
 const data = [{
   key: '1',

--- a/components/table/demo/dynamic-settings.md
+++ b/components/table/demo/dynamic-settings.md
@@ -14,9 +14,7 @@ title:
 Select different settings to see the result.
 
 ````jsx
-import {
-  Table, Icon, Switch, Radio, Form, Divider,
-} from 'antd';
+import { Table, Icon, Switch, Radio, Form, Divider } from 'antd';
 
 const FormItem = Form.Item;
 

--- a/components/table/demo/edit-cell.md
+++ b/components/table/demo/edit-cell.md
@@ -14,9 +14,7 @@ title:
 Table with editable cells.
 
 ````jsx
-import {
-  Table, Input, Button, Popconfirm, Form,
-} from 'antd';
+import { Table, Input, Button, Popconfirm, Form } from 'antd';
 
 const FormItem = Form.Item;
 const EditableContext = React.createContext();

--- a/components/table/demo/edit-row.md
+++ b/components/table/demo/edit-row.md
@@ -14,9 +14,7 @@ title:
 Table with editable rows.
 
 ```jsx
-import {
-  Table, Input, InputNumber, Popconfirm, Form,
-} from 'antd';
+import { Table, Input, InputNumber, Popconfirm, Form } from 'antd';
 
 const data = [];
 for (let i = 0; i < 100; i++) {

--- a/components/table/demo/nested-table.md
+++ b/components/table/demo/nested-table.md
@@ -15,9 +15,7 @@ Showing more detailed info of every row.
 
 ````jsx
 
-import {
-  Table, Badge, Menu, Dropdown, Icon,
-} from 'antd';
+import { Table, Badge, Menu, Dropdown, Icon } from 'antd';
 
 const menu = (
   <Menu>

--- a/components/tag/demo/control.md
+++ b/components/tag/demo/control.md
@@ -15,9 +15,7 @@ Generating a set of Tags by array, you can add and remove dynamically.
 It's based on `afterClose` event, which will be triggered while the close animation end.
 
 ````jsx
-import {
-  Tag, Input, Tooltip, Icon,
-} from 'antd';
+import { Tag, Input, Tooltip, Icon } from 'antd';
 
 class EditableTagGroup extends React.Component {
   state = {

--- a/components/upload/demo/basic.md
+++ b/components/upload/demo/basic.md
@@ -14,9 +14,7 @@ title:
 Classic mode. File selection dialog pops up when upload button is clicked.
 
 ````jsx
-import {
-  Upload, message, Button, Icon,
-} from 'antd';
+import { Upload, message, Button, Icon } from 'antd';
 
 const props = {
   name: 'file',

--- a/components/upload/demo/upload-manually.md
+++ b/components/upload/demo/upload-manually.md
@@ -14,9 +14,7 @@ title:
 Upload files manually after `beforeUpload` returns `false`.
 
 ````jsx
-import {
-  Upload, Button, Icon, message,
-} from 'antd';
+import { Upload, Button, Icon, message } from 'antd';
 import reqwest from 'reqwest';
 
 class Demo extends React.Component {

--- a/package.json
+++ b/package.json
@@ -187,7 +187,7 @@
     "lint-fix:ts": "npm run tsc && antd-tools run ts-lint-fix",
     "lint-fix": "npm run lint-fix:code && npm run lint-fix:demo",
     "lint-fix:code": "eslint --fix tests site scripts components ./.*.js ./webpack.config.js --ext '.js,.jsx'",
-    "lint-fix:demo": "eslint-tinker ./components/*/demo/*.md",
+    "lint-fix:demo": "cross-env RUN_ENV=DEMO eslint-tinker ./components/*/demo/*.md",
     "sort-api": "node ./scripts/sort-api-table.js",
     "dist": "antd-tools run dist",
     "compile": "antd-tools run compile",


### PR DESCRIPTION
## Problem
When the `import` statement has multiple lines, the arguments submitted to CodeSandbox are missing an `antd` dependency, causing an error in opening the component demos in CodeSandbox.
```js
import {
  Menu, Dropdown, Button, Icon, message,
} from 'antd';
```
## Reason
In the `site/theme/template/Content/Demo.jsx` file, only one line is matched, so the parameters submitted to CodeSandbox are missing the `antd` dependency.
```js
const dependencies = sourceCode.split('\n').reduce((acc, line) => {
  const matches = line.match(/import .+? from '(.+)';$/);
  if (matches && matches[1]) {
    acc[matches[1]] = 'latest';
  }
  return acc;
}, { react: 'latest', 'react-dom': 'latest' });
```
## Solution
1. Add `'object-curly-newline': ['error', { ImportDeclaration: 'never' }],` to the `eslintrc.js` file, and then run `npm run lint-fix:demo`  to rewrite `import` to one line.
2. Change the regular matching rule to support multiple rows.

**Here I used the first option.**

## Other
* [x] Make sure that you propose pull request to right branch: bugfix for `master`, feature for branch `feature`.
* [x] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a pull request to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you pull request.
* [x] Make sure that you add at least one unit test for the bug which you had fixed.
