### PR TITLE
add onClick prop for MenuItem

### DIFF
--- a/components/menu/MenuItem.tsx
+++ b/components/menu/MenuItem.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { Item } from 'rc-menu';
 import * as PropTypes from 'prop-types';
 import Tooltip from '../tooltip';
+import { ClickParam } from './index'
 
 interface MenuItemProps {
   rootPrefixCls?: string;
@@ -10,6 +11,7 @@ interface MenuItemProps {
   title?: React.ReactNode;
   children?: React.ReactNode;
   className?: string;
+  onClick?: (param: ClickParam) => void;
 }
 
 class MenuItem extends React.Component<MenuItemProps, any> {


### PR DESCRIPTION
First of all, thank you for your contribution! :-)

Please makes sure that these checkboxes are checked before submitting your pull request, thank you!

* [x] Make sure that you propose pull request to right branch: bugfix for `master`, feature for branch `feature`.
* [x] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a pull request to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you pull request.

Extra checklist:

**if** *isBugFix* **:**

  * [ ] Make sure that you add at least one unit test for the bug which you had fixed.

**elif** *isNewFeature* **:**

  * [ ] Update API docs for the component.
  * [ ] Update/Add demo to demonstrate new feature.
  * [ ] Update TypeScript definition for the component.
  * [ ] Add unit tests for the feature.

In the latest version, menuItem starts to have a specific definition for props, which means I will get a warning if I use onClick function on MenuItem. So I add the prop to make it match the  performance.