### PR TITLE
Fix #13413 - fix customize border-width problem in input group compact mode

### DIFF
--- a/components/input/style/mixin.less
+++ b/components/input/style/mixin.less
@@ -304,7 +304,7 @@
     & > .@{ant-prefix}-mention-wrapper .@{ant-prefix}-mention-editor,
     & > .@{ant-prefix}-time-picker .@{ant-prefix}-time-picker-input {
       border-radius: 0;
-      border-right-width: 1px;
+      border-right-width: @border-width-base;
       border-right-color: transparent;
       &:hover {
         .hover();
@@ -335,7 +335,7 @@
     & > .@{ant-prefix}-time-picker:last-child .@{ant-prefix}-time-picker-input {
       border-top-right-radius: @border-radius-base;
       border-bottom-right-radius: @border-radius-base;
-      border-right-width: 1px;
+      border-right-width: @border-width-base;
       border-right-color: @input-border-color;
       &:hover {
         .hover();


### PR DESCRIPTION
Fix #13413 

This issues caused by set border-right-width to 1px in input-group-comcapt last-child and input-group-comcapt select component.

please see the fix verison

![image](https://user-images.githubusercontent.com/15653996/49707054-7c787b80-fc64-11e8-9be4-e490680908ec.png)

![image](https://user-images.githubusercontent.com/15653996/49707063-87cba700-fc64-11e8-9fb4-d10ec4647db0.png)

![image](https://user-images.githubusercontent.com/15653996/49707071-9023e200-fc64-11e8-910e-541558c0c995.png)




First of all, thank you for your contribution! :-)

Please makes sure that these checkboxes are checked before submitting your pull request, thank you!

* [x] Make sure that you propose pull request to right branch: bugfix for `master`, feature for branch `feature`.
* [x] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a pull request to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you pull request.

Extra checklist:

**if** *isBugFix* **:**

  * [x] Make sure that you add at least one unit test for the bug which you had fixed.

**elif** *isNewFeature* **:**

  * [ ] Update API docs for the component.
  * [ ] Update/Add demo to demonstrate new feature.
  * [ ] Update TypeScript definition for the component.
  * [ ] Add unit tests for the feature.
