### PR TITLE
fix inconsistent component state updates

### DIFF
--- a/components/cascader/index.tsx
+++ b/components/cascader/index.tsx
@@ -236,11 +236,11 @@ export default class Cascader extends React.Component<CascaderProps, CascaderSta
 
   handlePopupVisibleChange = (popupVisible: boolean) => {
     if (!('popupVisible' in this.props)) {
-      this.setState({
+      this.setState(state => ({
         popupVisible,
         inputFocused: popupVisible,
-        inputValue: popupVisible ? this.state.inputValue : '',
-      });
+        inputValue: popupVisible ? state.inputValue : '',
+      }));
     }
 
     const onPopupVisibleChange = this.props.onPopupVisibleChange;

--- a/components/layout/layout.tsx
+++ b/components/layout/layout.tsx
@@ -35,7 +35,11 @@ class Basic extends React.Component<BasicProps, any> {
   }
 }
 
-class BasicLayout extends React.Component<BasicProps, any> {
+interface BasicLayoutState {
+  siders: string[];
+}
+
+class BasicLayout extends React.Component<BasicProps, BasicLayoutState> {
   static childContextTypes = {
     siderHook: PropTypes.object,
   };
@@ -45,14 +49,14 @@ class BasicLayout extends React.Component<BasicProps, any> {
     return {
       siderHook: {
         addSider: (id: string) => {
-          this.setState({
-            siders: [...this.state.siders, id],
-          });
+          this.setState(state => ({
+            siders: [...state.siders, id],
+          }));
         },
         removeSider: (id: string) => {
-          this.setState({
-            siders: this.state.siders.filter(currentId => currentId !== id),
-          });
+          this.setState(state => ({
+            siders: state.siders.filter(currentId => currentId !== id),
+          }));
         },
       },
     };


### PR DESCRIPTION
This isn't a normal feature/bugfix PR, just fixing LGTM.com alerts.

React component state updates using `setState` may asynchronously update `this.props` and `this.state`, thus it is not safe to use either of the two when calculating the new state passed to `setState`, and instead the callback-based variant should be used instead. ([details here](https://lgtm.com/rules/1819283066/)).

*(Full disclosure: I'm part of the team behind LGTM.com)*
