### PR TITLE
[chore] Fix LGTM alerts for unused code

### DIFF
--- a/components/icon/index.tsx
+++ b/components/icon/index.tsx
@@ -138,7 +138,7 @@ const Icon: IconComponent<IconProps> = props => {
       );
     }
     computedType = withThemeSuffix(
-      removeTypeTheme(alias(type)),
+      removeTypeTheme(alias(computedType)),
       dangerousTheme || theme || defaultTheme,
     );
     innerNode = (

--- a/components/modal/confirm.tsx
+++ b/components/modal/confirm.tsx
@@ -136,7 +136,7 @@ export default function confirm(config: ModalFuncProps) {
     if (unmountResult && div.parentNode) {
       div.parentNode.removeChild(div);
     }
-    const triggerCancel = args && args.length && args.some(param => param && param.triggerCancel);
+    const triggerCancel = args.some(param => param && param.triggerCancel);
     if (config.onCancel && triggerCancel) {
       config.onCancel(...args);
     }

--- a/components/slider/index.tsx
+++ b/components/slider/index.tsx
@@ -81,12 +81,7 @@ export default class Slider extends React.Component<SliderProps, SliderState> {
     const { tooltipPrefixCls, tipFormatter, tooltipVisible } = this.props;
     const { visibles } = this.state;
     const isTipFormatter = tipFormatter ? visibles[index] || dragging : false;
-    let visible;
-    if (tooltipVisible) {
-      visible = tooltipVisible || isTipFormatter;
-    } else if (tooltipVisible === undefined) {
-      visible = isTipFormatter;
-    }
+    const visible = tooltipVisible || (tooltipVisible === undefined && isTipFormatter);
     return (
       <Tooltip
         prefixCls={tooltipPrefixCls}

--- a/components/table/Table.tsx
+++ b/components/table/Table.tsx
@@ -553,10 +553,8 @@ export default class Table<T> extends React.Component<TableProps<T>, TableState<
   handleRadioSelect = (record: T, rowIndex: number, e: RadioChangeEvent) => {
     const checked = e.target.checked;
     const nativeEvent = e.nativeEvent;
-    const defaultSelection = this.store.getState().selectionDirty ? [] : this.getDefaultSelection();
-    let selectedRowKeys = this.store.getState().selectedRowKeys.concat(defaultSelection);
     const key = this.getRecordKey(record, rowIndex);
-    selectedRowKeys = [key];
+    const selectedRowKeys = [key];
     this.store.setState({
       selectionDirty: true,
     });

--- a/components/tree/DirectoryTree.tsx
+++ b/components/tree/DirectoryTree.tsx
@@ -143,7 +143,7 @@ export default class DirectoryTree extends React.Component<DirectoryTreeProps, D
     const shiftPick: boolean = nativeEvent.shiftKey;
 
     // Generate new selected keys
-    let newSelectedKeys = selectedKeys.slice();
+    let newSelectedKeys: string[];
     if (multiple && ctrlPick) {
       // Control click
       newSelectedKeys = keys;

--- a/components/tree/DirectoryTree.tsx
+++ b/components/tree/DirectoryTree.tsx
@@ -132,7 +132,7 @@ export default class DirectoryTree extends React.Component<DirectoryTreeProps, D
 
   onSelect = (keys: string[], event: AntTreeNodeSelectedEvent) => {
     const { onSelect, multiple, children } = this.props;
-    const { expandedKeys = [], selectedKeys = [] } = this.state;
+    const { expandedKeys = [] } = this.state;
     const { node, nativeEvent } = event;
     const { eventKey = '' } = node.props;
 


### PR DESCRIPTION
This isn't a normal feature/bugfix PR, just fixing a number of LGTM alerts around unused / unneeded code.

The [one remaining alert](https://lgtm.com/projects/g/ant-design/ant-design/alerts?mode=tree&ruleFocus=1506221406550) around unused / dead code is because of a false positive that I've already reported here: https://github.com/Semmle/ql/issues/670

*(Full disclosure: I'm part of the team behind LGTM.com)*