### PR TITLE
Fix the bug when the children is 0 and < Button > has icon prop , the width of component is wrong.

### DIFF
--- a/components/button/button.tsx
+++ b/components/button/button.tsx
@@ -207,7 +207,7 @@ export default class Button extends React.Component<ButtonProps, any> {
       [`${prefixCls}-${type}`]: type,
       [`${prefixCls}-${shape}`]: shape,
       [`${prefixCls}-${sizeCls}`]: sizeCls,
-      [`${prefixCls}-icon-only`]: !children && icon,
+      [`${prefixCls}-icon-only`]: (!children && children!==0) && icon,
       [`${prefixCls}-loading`]: loading,
       [`${prefixCls}-background-ghost`]: ghost,
       [`${prefixCls}-two-chinese-chars`]: hasTwoCNChar,


### PR DESCRIPTION
Fix the bug when the children is 0 and `< Button >` has `icon` prop , the width of component is wrong.

![image](https://user-images.githubusercontent.com/22285404/49878238-0a6d8580-fe62-11e8-8934-fcfda93ff5df.png)

bug demo: https://codesandbox.io/s/0146v1lxkl

First of all, thank you for your contribution! :-)

Please makes sure that these checkboxes are checked before submitting your pull request, thank you!

* [x] Make sure that you propose pull request to right branch: bugfix for `master`, feature for branch `feature`.
* [x] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a pull request to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you pull request.

Extra checklist:

**if** *isBugFix* **:**

  * [ ] Make sure that you add at least one unit test for the bug which you had fixed.

I am sorry that I have not been able to add a unit test because the enzyme cannot get the width of the component https://github.com/airbnb/enzyme/issues/1940