### PR TITLE
Set menu mode to vertical by default

### DIFF
--- a/components/menu/index.tsx
+++ b/components/menu/index.tsx
@@ -220,26 +220,19 @@ export default class Menu extends React.Component<MenuProps, MenuState> {
     const { openAnimation, openTransitionName } = this.props;
     let menuOpenAnimation = openAnimation || openTransitionName;
     if (openAnimation === undefined && openTransitionName === undefined) {
-      switch (menuMode) {
-        case 'horizontal':
-          menuOpenAnimation = 'slide-up';
-          break;
-        case 'vertical':
-        case 'vertical-left':
-        case 'vertical-right':
-          // When mode switch from inline
-          // submenu should hide without animation
-          if (this.switchingModeFromInline) {
-            menuOpenAnimation = '';
-            this.switchingModeFromInline = false;
-          } else {
-            menuOpenAnimation = 'zoom-big';
-          }
-          break;
-        case 'inline':
-          menuOpenAnimation = animation;
-          break;
-        default:
+      if (menuMode === 'horizontal') {
+        menuOpenAnimation = 'slide-up';
+      } else if (menuMode === 'inline') {
+        menuOpenAnimation = animation;
+      } else {
+        // When mode switch from inline
+        // submenu should hide without animation
+        if (this.switchingModeFromInline) {
+          menuOpenAnimation = '';
+          this.switchingModeFromInline = false;
+        } else {
+          menuOpenAnimation = 'zoom-big';
+        }
       }
     }
     return menuOpenAnimation;


### PR DESCRIPTION
fix #13597
Keep behavior as same as `rc-menu`.


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#13597: Broken submenu hover animation in vertical mode](https://oss.issuehunt.io/repos/34526884/issues/13597)
---
</details>
<!-- /Issuehunt content-->