### PR TITLE
The <Affix> run update-position when first mounted

### DIFF
--- a/components/affix/index.tsx
+++ b/components/affix/index.tsx
@@ -218,6 +218,8 @@ export default class Affix extends React.Component<AffixProps, AffixState> {
     // Wait for parent component ref has its value
     this.timeout = setTimeout(() => {
       this.setTargetEventListeners(target);
+      // Mock Event object.
+      this.updatePosition({} as Event);
     });
   }
 


### PR DESCRIPTION
Affix would have the correct styles, even when its first render.

Consider the following code:
```js
  render () {
      return this.state.show ? (  // default to be false
        <Affix offsetTop={75}>
          <Alert />
        </Affix>
      ) : null;
  }
```

Now execute:
```js
this.setState({ show: true });
```

The `<Affix>` is expected to be fixed on the top of the view, once `state.show` is set to be `true`.


