### PR TITLE
Fix a regular expression

### DIFF
--- a/site/theme/template/Home/Page1.jsx
+++ b/site/theme/template/Home/Page1.jsx
@@ -220,7 +220,7 @@ const page1Data = [
 ];
 
 const getTransformXY = t => {
-  const s = t.replace(/[a-z|(|)]/g, '').split(',');
+  const s = t.replace(/[a-z()]/g, '').split(',');
   return {
     x: s[0],
     y: s[1],


### PR DESCRIPTION
Pipe (`|`) is not supposed to be used as a delimiter in character classes, though
it seems like that's what someone's trying to do here, given it's trying to
extract numbers from a css transform property.

To test, I made sure that the results of these two expressions was the same:

```ts
"translate (123px, 2px)".replace(/[a-z()]/g, '').split(',') // [" 123", " 2"]
"translate (123px, 2px)".replace(/[a-z|(|)]/g, '').split(',') // [" 123", " 2"]
```
