### PR TITLE
Transfer: fix search-not-found block sometimes not show in edge

### DIFF
--- a/components/transfer/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/transfer/__tests__/__snapshots__/demo.test.js.snap
@@ -349,11 +349,6 @@ exports[`renders ./components/transfer/demo/basic.md correctly 1`] = `
             style="height:32px"
           />
         </ul>
-        <div
-          class="ant-transfer-list-body-not-found"
-        >
-          Not Found
-        </div>
       </div>
     </div>
     <div
@@ -471,11 +466,6 @@ exports[`renders ./components/transfer/demo/basic.md correctly 1`] = `
             style="height:32px"
           />
         </ul>
-        <div
-          class="ant-transfer-list-body-not-found"
-        >
-          Not Found
-        </div>
       </div>
     </div>
   </div>

--- a/components/transfer/__tests__/__snapshots__/index.test.js.snap
+++ b/components/transfer/__tests__/__snapshots__/index.test.js.snap
@@ -86,11 +86,6 @@ exports[`Transfer should render correctly 1`] = `
           <span />
         </li>
       </ul>
-      <div
-        class="ant-transfer-list-body-not-found"
-      >
-        Not Found
-      </div>
     </div>
   </div>
   <div
@@ -201,11 +196,6 @@ exports[`Transfer should render correctly 1`] = `
           <span />
         </li>
       </ul>
-      <div
-        class="ant-transfer-list-body-not-found"
-      >
-        Not Found
-      </div>
     </div>
   </div>
 </div>
@@ -277,11 +267,6 @@ exports[`Transfer should show sorted targetkey 1`] = `
           </span>
         </li>
       </ul>
-      <div
-        class="ant-transfer-list-body-not-found"
-      >
-        Not Found
-      </div>
     </div>
   </div>
   <div
@@ -419,11 +404,6 @@ exports[`Transfer should show sorted targetkey 1`] = `
           </span>
         </li>
       </ul>
-      <div
-        class="ant-transfer-list-body-not-found"
-      >
-        Not Found
-      </div>
     </div>
   </div>
 </div>

--- a/components/transfer/__tests__/__snapshots__/list.test.js.snap
+++ b/components/transfer/__tests__/__snapshots__/list.test.js.snap
@@ -102,11 +102,6 @@ exports[`List should render correctly 1`] = `
         <span />
       </li>
     </ul>
-    <div
-      class="ant-transfer-list-body-not-found"
-    >
-      Not Found
-    </div>
   </div>
 </div>
 `;

--- a/components/transfer/list.tsx
+++ b/components/transfer/list.tsx
@@ -9,10 +9,6 @@ import Search from './search';
 import Item from './item';
 import triggerEvent from '../_util/triggerEvent';
 
-function isIEorEDGE() {
-  return (document as any).documentMode || /Edge/.test(navigator.userAgent);
-}
-
 function noop() {}
 
 function isRenderResultPlainObject(result: any) {
@@ -59,7 +55,6 @@ export default class TransferList extends React.Component<TransferListProps, any
 
   timer: number;
   triggerScrollTimer: number;
-  fixIERepaintTimer: number;
   notFoundNode: HTMLDivElement;
 
   constructor(props: TransferListProps) {
@@ -80,7 +75,6 @@ export default class TransferList extends React.Component<TransferListProps, any
   componentWillUnmount() {
     clearTimeout(this.timer);
     clearTimeout(this.triggerScrollTimer);
-    clearTimeout(this.fixIERepaintTimer);
   }
 
   shouldComponentUpdate(...args: any[]) {
@@ -117,12 +111,10 @@ export default class TransferList extends React.Component<TransferListProps, any
         triggerEvent(listNode, 'scroll');
       }
     }, 0);
-    this.fixIERepaint();
   };
 
   handleClear = () => {
     this.props.handleClear();
-    this.fixIERepaint();
   };
 
   matchFilter = (text: string, item: TransferItem) => {
@@ -142,24 +134,6 @@ export default class TransferList extends React.Component<TransferListProps, any
       renderedEl: isRenderResultPlain ? renderResult.label : renderResult,
     };
   };
-
-  saveNotFoundRef = (node: HTMLDivElement) => {
-    this.notFoundNode = node;
-  };
-
-  // Fix IE/Edge repaint
-  // https://github.com/ant-design/ant-design/issues/9697
-  // https://stackoverflow.com/q/27947912/3040605
-  fixIERepaint() {
-    if (!isIEorEDGE()) {
-      return;
-    }
-    this.fixIERepaintTimer = window.setTimeout(() => {
-      if (this.notFoundNode) {
-        this.notFoundNode.className = this.notFoundNode.className;
-      }
-    }, 0);
-  }
 
   render() {
     const {
@@ -236,6 +210,10 @@ export default class TransferList extends React.Component<TransferListProps, any
       </div>
     ) : null;
 
+    const searchNotFound = showItems.every(item => item === null) && (
+      <div className={`${prefixCls}-body-not-found`}>{notFoundContent}</div>
+    );
+
     const listBody = bodyDom || (
       <div
         className={classNames(
@@ -252,9 +230,7 @@ export default class TransferList extends React.Component<TransferListProps, any
         >
           {showItems}
         </Animate>
-        <div className={`${prefixCls}-body-not-found`} ref={this.saveNotFoundRef}>
-          {notFoundContent}
-        </div>
+        {searchNotFound}
       </div>
     );
 

--- a/components/transfer/style/index.less
+++ b/components/transfer/style/index.less
@@ -125,15 +125,10 @@
       padding-top: 0;
       color: @disabled-color;
       text-align: center;
-      display: none;
       position: absolute;
       top: 50%;
       width: 100%;
       margin-top: -10px;
-    }
-
-    &-content:empty + &-body-not-found {
-      display: block;
     }
 
     &-footer {


### PR DESCRIPTION
Fix #13491 
edge里`:empty`有重绘问题，之前的walkaround在edge里无效了。现在去掉`:empty`，通过js来判断是否显示无匹配结果