### PR TITLE
fix(Table):fix arguments and type definition in TableRowSelection

### DIFF
--- a/components/table/interface.tsx
+++ b/components/table/interface.tsx
@@ -85,11 +85,11 @@ export type TableSelectWay = 'onSelect' | 'onSelectMultiple' | 'onSelectAll' | '
 export interface TableRowSelection<T> {
   type?: RowSelectionType;
   selectedRowKeys?: string[] | number[];
-  onChange?: (selectedRowKeys: string[] | number[], selectedRows: Array<T>) => void;
+  onChange?: (selectedRowKeys: string[] | number[], selectedRows: T[]) => void;
   getCheckboxProps?: (record: T) => Object;
   onSelect?: SelectionSelectFn<T>;
-  onSelectMultiple?: (selected: boolean, selectedRows: Array<T>, changeRows: Array<T>) => void;
-  onSelectAll?: (selected: boolean, selectedRows: Array<T>, changeRows: Array<T>) => void;
+  onSelectMultiple?: (selected: boolean, selectedRows: T[], changeRows: T[]) => void;
+  onSelectAll?: (selected: boolean, selectedRows: T[], changeRows: T[]) => void;
   onSelectInvert?: (selectedRowKeys: string[] | number[]) => void;
   selections?: SelectionItem[] | boolean;
   hideDefaultSelections?: boolean;

--- a/components/table/interface.tsx
+++ b/components/table/interface.tsx
@@ -85,12 +85,12 @@ export type TableSelectWay = 'onSelect' | 'onSelectMultiple' | 'onSelectAll' | '
 export interface TableRowSelection<T> {
   type?: RowSelectionType;
   selectedRowKeys?: string[] | number[];
-  onChange?: (selectedRowKeys: string[] | number[], selectedRows: Object[]) => void;
+  onChange?: (selectedRowKeys: string[] | number[], selectedRows: Array<T>) => void;
   getCheckboxProps?: (record: T) => Object;
   onSelect?: SelectionSelectFn<T>;
-  onSelectMultiple?: (selected: boolean, selectedRows: Object[], changeRows: Object[]) => void;
-  onSelectAll?: (selected: boolean, selectedRows: Object[], changeRows: Object[]) => void;
-  onSelectInvert?: (selectedRows: Object[]) => void;
+  onSelectMultiple?: (selected: boolean, selectedRows: Array<T>, changeRows: Array<T>) => void;
+  onSelectAll?: (selected: boolean, selectedRows: Array<T>, changeRows: Array<T>) => void;
+  onSelectInvert?: (selectedRowKeys: string[] | number[]) => void;
   selections?: SelectionItem[] | boolean;
   hideDefaultSelections?: boolean;
   fixed?: boolean;


### PR DESCRIPTION


* [x] Make sure that you propose pull request to right branch: bugfix for `master`, feature for branch `feature`.
* [x] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a pull request to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you pull request.

Extra checklist:

**if** *isBugFix* **:**
fix issue [13761](https://github.com/ant-design/ant-design/issues/13761)
1. since interface `TableRowSelection` has already used Generics `T`, we can use `T` to avoid type 
 assertion when we call member functions in `TableRowSelection`. 
2. Besides, I noticed that function `onSelectInvert` receives `selectedRowKeys` as an argument in [`table.tsx`](https://github.com/ant-design/ant-design/blob/master/components/table/Table.tsx), not `selectedRows`，so I fix it

  * [ ] Make sure that you add at least one unit test for the bug which you had fixed.


