### PR TITLE
Table: add prop `sortDirections` for table and column

### DIFF
--- a/components/table/Table.tsx
+++ b/components/table/Table.tsx
@@ -81,7 +81,7 @@ export default class Table<T> extends React.Component<TableProps<T>, TableState<
     onChange: PropTypes.func,
     locale: PropTypes.object,
     dropdownPrefixCls: PropTypes.string,
-    sortMethods: PropTypes.array,
+    sortDirections: PropTypes.array,
   };
 
   static defaultProps = {
@@ -96,7 +96,7 @@ export default class Table<T> extends React.Component<TableProps<T>, TableState<
     locale: {},
     rowKey: 'key',
     showHeader: true,
-    sortMethods: ['ascend', 'descend'],
+    sortDirections: ['ascend', 'descend'],
   };
 
   CheckboxPropsCache: {
@@ -379,17 +379,18 @@ export default class Table<T> extends React.Component<TableProps<T>, TableState<
     if (!column.sorter) {
       return;
     }
-    const sortMethods = column.sortMethods || this.props.sortMethods;
+    const sortDirections = column.sortDirections || this.props.sortDirections;
     const { sortOrder, sortColumn } = this.state;
     // 只同时允许一列进行排序，否则会导致排序顺序的逻辑问题
     let newSortOrder: 'descend' | 'ascend' | undefined;
     // 切换另一列时，丢弃 sortOrder 的状态
     if (this.isSameColumn(sortColumn, column) && sortOrder !== undefined) {
-      // 按照sortMethods的内容依次切换排序状态
-      const methodIndex = sortMethods.indexOf(sortOrder) + 1;
-      newSortOrder = methodIndex === sortMethods.length ? undefined : sortMethods[methodIndex];
+      // 按照sortDirections的内容依次切换排序状态
+      const methodIndex = sortDirections.indexOf(sortOrder) + 1;
+      newSortOrder =
+        methodIndex === sortDirections.length ? undefined : sortDirections[methodIndex];
     } else {
-      newSortOrder = sortMethods[0];
+      newSortOrder = sortDirections[0];
     }
 
     const newState = {
@@ -824,11 +825,11 @@ export default class Table<T> extends React.Component<TableProps<T>, TableState<
         );
       }
       if (column.sorter) {
-        const sortMethods = column.sortMethods || this.props.sortMethods;
+        const sortDirections = column.sortDirections || this.props.sortDirections;
         const isAscend = isSortColumn && sortOrder === 'ascend';
         const isDescend = isSortColumn && sortOrder === 'descend';
 
-        const ascend = sortMethods.indexOf('ascend') !== -1 && (
+        const ascend = sortDirections.indexOf('ascend') !== -1 && (
           <Icon
             className={`${prefixCls}-column-sorter-up ${isAscend ? 'on' : 'off'}`}
             type="caret-up"
@@ -836,7 +837,7 @@ export default class Table<T> extends React.Component<TableProps<T>, TableState<
           />
         );
 
-        const descend = sortMethods.indexOf('descend') !== -1 && (
+        const descend = sortDirections.indexOf('descend') !== -1 && (
           <Icon
             className={`${prefixCls}-column-sorter-down ${isDescend ? 'on' : 'off'}`}
             type="caret-down"

--- a/components/table/Table.tsx
+++ b/components/table/Table.tsx
@@ -379,13 +379,13 @@ export default class Table<T> extends React.Component<TableProps<T>, TableState<
     if (!column.sorter) {
       return;
     }
-    const { sortMethods } = this.props;
+    const sortMethods = column.sortMethods || this.props.sortMethods;
     const { sortOrder, sortColumn } = this.state;
     // 只同时允许一列进行排序，否则会导致排序顺序的逻辑问题
     let newSortOrder: 'descend' | 'ascend' | undefined;
     // 切换另一列时，丢弃 sortOrder 的状态
     if (this.isSameColumn(sortColumn, column) && sortOrder !== undefined) {
-      // 切换排序状态，按照降序/升序/不排序的顺序
+      // 按照sortMethods的内容依次切换排序状态
       const methodIndex = sortMethods.indexOf(sortOrder) + 1;
       newSortOrder = methodIndex === sortMethods.length ? undefined : sortMethods[methodIndex];
     } else {
@@ -799,7 +799,7 @@ export default class Table<T> extends React.Component<TableProps<T>, TableState<
   }
 
   renderColumnsDropdown(columns: ColumnProps<T>[], locale: TableLocale) {
-    const { prefixCls, dropdownPrefixCls, sortMethods } = this.props;
+    const { prefixCls, dropdownPrefixCls } = this.props;
     const { sortOrder, filters } = this.state;
     return treeMap(columns, (column, i) => {
       const key = this.getColumnKey(column, i) as string;
@@ -824,6 +824,7 @@ export default class Table<T> extends React.Component<TableProps<T>, TableState<
         );
       }
       if (column.sorter) {
+        const sortMethods = column.sortMethods || this.props.sortMethods;
         const isAscend = isSortColumn && sortOrder === 'ascend';
         const isDescend = isSortColumn && sortOrder === 'descend';
 

--- a/components/table/__tests__/Table.sorter.test.js
+++ b/components/table/__tests__/Table.sorter.test.js
@@ -536,7 +536,7 @@ describe('Table.sorter', () => {
   it('should first sort by descend, then ascend, then cancel sort', () => {
     const wrapper = mount(
       createTable({
-        sortMethods: ['descend', 'ascend'],
+        sortDirections: ['descend', 'ascend'],
       }),
     );
 
@@ -556,7 +556,7 @@ describe('Table.sorter', () => {
   it('should first sort by descend, then cancel sort', () => {
     const wrapper = mount(
       createTable({
-        sortMethods: ['descend'],
+        sortDirections: ['descend'],
       }),
     );
 
@@ -574,7 +574,7 @@ describe('Table.sorter', () => {
       createTable(
         {},
         {
-          sortMethods: ['descend'],
+          sortDirections: ['descend'],
         },
       ),
     );

--- a/components/table/__tests__/Table.sorter.test.js
+++ b/components/table/__tests__/Table.sorter.test.js
@@ -568,4 +568,23 @@ describe('Table.sorter', () => {
     wrapper.find('.ant-table-column-sorters').simulate('click');
     expect(renderedNames(wrapper)).toEqual(['Jack', 'Lucy', 'Tom', 'Jerry']);
   });
+
+  it('should first sort by descend, then cancel sort. (column prop)', () => {
+    const wrapper = mount(
+      createTable(
+        {},
+        {
+          sortMethods: ['descend'],
+        },
+      ),
+    );
+
+    // descend
+    wrapper.find('.ant-table-column-sorters').simulate('click');
+    expect(renderedNames(wrapper)).toEqual(['Tom', 'Lucy', 'Jack', 'Jerry']);
+
+    // cancel sort
+    wrapper.find('.ant-table-column-sorters').simulate('click');
+    expect(renderedNames(wrapper)).toEqual(['Jack', 'Lucy', 'Tom', 'Jerry']);
+  });
 });

--- a/components/table/__tests__/Table.sorter.test.js
+++ b/components/table/__tests__/Table.sorter.test.js
@@ -532,4 +532,40 @@ describe('Table.sorter', () => {
         .getDOMNode().className,
     ).toContain(' off');
   });
+
+  it('should first sort by descend, then ascend, then cancel sort', () => {
+    const wrapper = mount(
+      createTable({
+        sortMethods: ['descend', 'ascend'],
+      }),
+    );
+
+    // descend
+    wrapper.find('.ant-table-column-sorters').simulate('click');
+    expect(renderedNames(wrapper)).toEqual(['Tom', 'Lucy', 'Jack', 'Jerry']);
+
+    // ascend
+    wrapper.find('.ant-table-column-sorters').simulate('click');
+    expect(renderedNames(wrapper)).toEqual(['Jack', 'Jerry', 'Lucy', 'Tom']);
+
+    // cancel sort
+    wrapper.find('.ant-table-column-sorters').simulate('click');
+    expect(renderedNames(wrapper)).toEqual(['Jack', 'Lucy', 'Tom', 'Jerry']);
+  });
+
+  it('should first sort by descend, then cancel sort', () => {
+    const wrapper = mount(
+      createTable({
+        sortMethods: ['descend'],
+      }),
+    );
+
+    // descend
+    wrapper.find('.ant-table-column-sorters').simulate('click');
+    expect(renderedNames(wrapper)).toEqual(['Tom', 'Lucy', 'Jack', 'Jerry']);
+
+    // cancel sort
+    wrapper.find('.ant-table-column-sorters').simulate('click');
+    expect(renderedNames(wrapper)).toEqual(['Jack', 'Lucy', 'Tom', 'Jerry']);
+  });
 });

--- a/components/table/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/table/__tests__/__snapshots__/demo.test.js.snap
@@ -9173,23 +9173,6 @@ exports[`renders ./components/table/demo/head.md correctly 1`] = `
                         class="ant-table-column-sorter"
                       >
                         <i
-                          class="anticon anticon-caret-up ant-table-column-sorter-up off"
-                        >
-                          <svg
-                            aria-hidden="true"
-                            class=""
-                            data-icon="caret-up"
-                            fill="currentColor"
-                            height="1em"
-                            viewBox="0 0 1024 1024"
-                            width="1em"
-                          >
-                            <path
-                              d="M858.9 689L530.5 308.2c-9.4-10.9-27.5-10.9-37 0L165.1 689c-12.2 14.2-1.2 35 18.5 35h656.8c19.7 0 30.7-20.8 18.5-35z"
-                            />
-                          </svg>
-                        </i>
-                        <i
                           class="anticon anticon-caret-down ant-table-column-sorter-down off"
                         >
                           <svg

--- a/components/table/demo/head.md
+++ b/components/table/demo/head.md
@@ -11,7 +11,7 @@ title:
 
 对某一列数据进行排序，通过指定列的 `sorter` 函数即可启动排序按钮。`sorter: function(rowA, rowB) { ... }`， rowA、rowB 为比较的两个行数据。
 
-`sortMethods: ['ascend' | 'descend']`改变每列可用的排序方式，切换排序时按数组内容依次切换，设置在table props上时对所有列生效。
+`sortDirections: ['ascend' | 'descend']`改变每列可用的排序方式，切换排序时按数组内容依次切换，设置在table props上时对所有列生效。
 
 使用 `defaultSortOrder` 属性，设置列的默认排序顺序。
 
@@ -21,7 +21,7 @@ Use `filters` to generate filter menu in columns, `onFilter` to determine filter
 
 Use `sorter` to make a column sortable. `sorter` can be a function of the type `function(a, b) { ... }` for sorting data locally.
 
-`sortMethods: ['ascend' | 'descend']` defines available sort methods for each columns, effective for all columns when set on table props.
+`sortDirections: ['ascend' | 'descend']` defines available sort methods for each columns, effective for all columns when set on table props.
 
 Uses `defaultSortOrder` to make a column sorted by default.
 
@@ -54,7 +54,7 @@ const columns = [{
   // here is that finding the name started with `value`
   onFilter: (value, record) => record.name.indexOf(value) === 0,
   sorter: (a, b) => a.name.length - b.name.length,
-  sortMethods: ['descend'],
+  sortDirections: ['descend'],
 }, {
   title: 'Age',
   dataIndex: 'age',
@@ -73,7 +73,7 @@ const columns = [{
   filterMultiple: false,
   onFilter: (value, record) => record.address.indexOf(value) === 0,
   sorter: (a, b) => a.address.length - b.address.length,
-  sortMethods: ['descend', 'ascend'],
+  sortDirections: ['descend', 'ascend'],
 }];
 
 const data = [{

--- a/components/table/demo/head.md
+++ b/components/table/demo/head.md
@@ -11,6 +11,8 @@ title:
 
 对某一列数据进行排序，通过指定列的 `sorter` 函数即可启动排序按钮。`sorter: function(rowA, rowB) { ... }`， rowA、rowB 为比较的两个行数据。
 
+`sortMethods: ['ascend' | 'descend']`改变每列可用的排序方式，切换排序时按数组内容依次切换，设置在table props上时对所有列生效。
+
 使用 `defaultSortOrder` 属性，设置列的默认排序顺序。
 
 ## en-US
@@ -18,6 +20,8 @@ title:
 Use `filters` to generate filter menu in columns, `onFilter` to determine filtered result, and `filterMultiple` to indicate whether it's multiple or single selection.
 
 Use `sorter` to make a column sortable. `sorter` can be a function of the type `function(a, b) { ... }` for sorting data locally.
+
+`sortMethods: ['ascend' | 'descend']` defines available sort methods for each columns, effective for all columns when set on table props.
 
 Uses `defaultSortOrder` to make a column sorted by default.
 
@@ -50,6 +54,7 @@ const columns = [{
   // here is that finding the name started with `value`
   onFilter: (value, record) => record.name.indexOf(value) === 0,
   sorter: (a, b) => a.name.length - b.name.length,
+  sortMethods: ['descend'],
 }, {
   title: 'Age',
   dataIndex: 'age',
@@ -68,6 +73,7 @@ const columns = [{
   filterMultiple: false,
   onFilter: (value, record) => record.address.indexOf(value) === 0,
   sorter: (a, b) => a.address.length - b.address.length,
+  sortMethods: ['descend', 'ascend'],
 }];
 
 const data = [{

--- a/components/table/interface.tsx
+++ b/components/table/interface.tsx
@@ -41,7 +41,7 @@ export interface ColumnProps<T> {
   onCellClick?: (record: T, event: any) => void;
   onCell?: (record: T, rowIndex: number) => any;
   onHeaderCell?: (props: ColumnProps<T>) => any;
-  sortMethods?: SortOrder[];
+  sortDirections?: SortOrder[];
 }
 
 export interface AdditionalCellProps {
@@ -163,7 +163,7 @@ export interface TableProps<T> {
   className?: string;
   style?: React.CSSProperties;
   children?: React.ReactNode;
-  sortMethods: SortOrder[];
+  sortDirections: SortOrder[];
 }
 
 export interface TableStateFilters {

--- a/components/table/interface.tsx
+++ b/components/table/interface.tsx
@@ -162,6 +162,7 @@ export interface TableProps<T> {
   className?: string;
   style?: React.CSSProperties;
   children?: React.ReactNode;
+  sortMethods: SortOrder[];
 }
 
 export interface TableStateFilters {

--- a/components/table/interface.tsx
+++ b/components/table/interface.tsx
@@ -41,6 +41,7 @@ export interface ColumnProps<T> {
   onCellClick?: (record: T, event: any) => void;
   onCell?: (record: T, rowIndex: number) => any;
   onHeaderCell?: (props: ColumnProps<T>) => any;
+  sortMethods?: SortOrder[];
 }
 
 export interface AdditionalCellProps {


### PR DESCRIPTION
Fix #13562 
Table可以通过`sortMethods`调整排序方法的切换顺序，也可设置为只有一种排序方法