### PR TITLE
Fix primary color usage in .button-variant-other

### DIFF
--- a/components/button/style/mixin.less
+++ b/components/button/style/mixin.less
@@ -49,12 +49,18 @@
 
   &:hover,
   &:focus {
-    .button-color(@primary-5; @background; @primary-5);
+    .button-color(
+      ~`colorPalette('@{btn-primary-bg}', 5) `; @background; ~`colorPalette('@{btn-primary-bg}', 5)
+        `
+    );
   }
 
   &:active,
   &.active {
-    .button-color(@primary-7; @background; @primary-7);
+    .button-color(
+      ~`colorPalette('@{btn-primary-bg}', 7) `; @background; ~`colorPalette('@{btn-primary-bg}', 7)
+        `
+    );
   }
 
   .button-disabled();


### PR DESCRIPTION
Instead of using `@primary-5` and `@primary-7`, use `colorPalette` mixin to modify `@btn-primary-bg`, which might differ from `@primary-color`.

Reopening #13671 but pointing to `feature` branch.