### PR TITLE
Calendar: show `extraFooter` in all mode 

### DIFF
--- a/components/date-picker/WeekPicker.tsx
+++ b/components/date-picker/WeekPicker.tsx
@@ -100,6 +100,13 @@ class WeekPicker extends React.Component<any, WeekPickerState> {
     this.handleChange(null);
   };
 
+  renderFooter = (...args: any[]) => {
+    const { prefixCls, renderExtraFooter } = this.props;
+    return renderExtraFooter ? (
+      <div className={`${prefixCls}-footer-extra`}>{renderExtraFooter(...args)}</div>
+    ) : null;
+  };
+
   focus() {
     this.input.focus();
   }
@@ -157,6 +164,7 @@ class WeekPicker extends React.Component<any, WeekPickerState> {
         showDateInput={false}
         showToday={false}
         disabledDate={disabledDate}
+        renderFooter={this.renderFooter}
       />
     );
     const clearIcon =

--- a/components/date-picker/__tests__/DatePicker.test.js
+++ b/components/date-picker/__tests__/DatePicker.test.js
@@ -163,4 +163,39 @@ describe('DatePicker', () => {
 
     expect(wrapper.render()).toMatchSnapshot();
   });
+
+  it('extra footer works', () => {
+    const wrapper = mount(
+      <DatePicker renderExtraFooter={mode => <span className="extra-node">{mode}</span>} />,
+    );
+    openPanel(wrapper);
+
+    let extraNode = wrapper.find('.extra-node');
+    expect(extraNode.length).toBe(1);
+    expect(extraNode.text()).toBe('date');
+
+    wrapper
+      .find('.ant-calendar-month-select')
+      .hostNodes()
+      .simulate('click');
+    extraNode = wrapper.find('.ant-calendar-month-panel .extra-node');
+    expect(extraNode.length).toBe(1);
+    expect(extraNode.text()).toBe('month');
+
+    wrapper
+      .find('.ant-calendar-year-select')
+      .hostNodes()
+      .simulate('click');
+    extraNode = wrapper.find('.ant-calendar-year-panel .extra-node');
+    expect(extraNode.length).toBe(1);
+    expect(extraNode.text()).toBe('year');
+
+    wrapper
+      .find('.ant-calendar-year-panel-decade-select')
+      .hostNodes()
+      .simulate('click');
+    extraNode = wrapper.find('.ant-calendar-decade-panel .extra-node');
+    expect(extraNode.length).toBe(1);
+    expect(extraNode.text()).toBe('decade');
+  });
 });

--- a/components/date-picker/__tests__/WeekPicker.test.js
+++ b/components/date-picker/__tests__/WeekPicker.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { mount } from 'enzyme';
 import DatePicker from '..';
 import focusTest from '../../../tests/shared/focusTest';
+import { openPanel } from './utils';
 
 const { WeekPicker } = DatePicker;
 
@@ -11,5 +12,40 @@ describe('WeekPicker', () => {
   it('should support style prop', () => {
     const wrapper = mount(<WeekPicker style={{ width: 400 }} />);
     expect(wrapper.render()).toMatchSnapshot();
+  });
+
+  it('extra footer works', () => {
+    const wrapper = mount(
+      <WeekPicker renderExtraFooter={mode => <span className="extra-node">{mode}</span>} />,
+    );
+    openPanel(wrapper);
+
+    let extraNode = wrapper.find('.extra-node');
+    expect(extraNode.length).toBe(1);
+    expect(extraNode.text()).toBe('date');
+
+    wrapper
+      .find('.ant-calendar-month-select')
+      .hostNodes()
+      .simulate('click');
+    extraNode = wrapper.find('.ant-calendar-month-panel .extra-node');
+    expect(extraNode.length).toBe(1);
+    expect(extraNode.text()).toBe('month');
+
+    wrapper
+      .find('.ant-calendar-year-select')
+      .hostNodes()
+      .simulate('click');
+    extraNode = wrapper.find('.ant-calendar-year-panel .extra-node');
+    expect(extraNode.length).toBe(1);
+    expect(extraNode.text()).toBe('year');
+
+    wrapper
+      .find('.ant-calendar-year-panel-decade-select')
+      .hostNodes()
+      .simulate('click');
+    extraNode = wrapper.find('.ant-calendar-decade-panel .extra-node');
+    expect(extraNode.length).toBe(1);
+    expect(extraNode.text()).toBe('decade');
   });
 });

--- a/components/date-picker/index.en-US.md
+++ b/components/date-picker/index.en-US.md
@@ -111,6 +111,7 @@ The following APIs are shared by DatePicker, MonthPicker, RangePicker, WeekPicke
 | format | to set the date format, refer to [moment.js](http://momentjs.com/) | string | "YYYY-wo" |
 | value | to set date | [moment](http://momentjs.com/) | - |
 | onChange | a callback function, can be executed when the selected time is changing | function(date: moment, dateString: string) | - |
+| renderExtraFooter | render extra footer in panel | (mode) => React.ReactNode | - |
 
 ### RangePicker
 

--- a/components/date-picker/index.en-US.md
+++ b/components/date-picker/index.en-US.md
@@ -82,7 +82,7 @@ The following APIs are shared by DatePicker, MonthPicker, RangePicker, WeekPicke
 | defaultPickerValue | to set default picker date | [moment](http://momentjs.com/) | - |
 | disabledTime | to specify the time that cannot be selected | function(date) | - |
 | format | to set the date format, refer to [moment.js](http://momentjs.com/) | string | "YYYY-MM-DD" |
-| renderExtraFooter | render extra footer in panel | () => React.ReactNode | - |
+| renderExtraFooter | render extra footer in panel | (mode) => React.ReactNode | - |
 | showTime | to provide an additional time selection | object\|boolean | [TimePicker Options](/components/time-picker/#API) |
 | showTime.defaultValue | to set default time of selected date, [demo](#components-date-picker-demo-disabled-date) | [moment](http://momentjs.com/) | moment() |
 | showToday | whether to show "Today" button | boolean | true |

--- a/components/date-picker/index.en-US.md
+++ b/components/date-picker/index.en-US.md
@@ -65,7 +65,6 @@ The following APIs are shared by DatePicker, MonthPicker, RangePicker, WeekPicke
 | style | to customize the style of the input box | object | {} |
 | onOpenChange | a callback function, can be executed whether the popup calendar is popped up or closed | function(status) | - |
 | onPanelChange | callback when picker panel mode is changed | function(value, mode) | - |
-| renderFooter | renderer of picker panel footer | (mode) => ReactNode | - |
 
 ### Common Methods
 

--- a/components/date-picker/index.zh-CN.md
+++ b/components/date-picker/index.zh-CN.md
@@ -114,6 +114,7 @@ moment.locale('zh-cn');
 | format | 展示的日期格式，配置参考 [moment.js](http://momentjs.com/) | string | "YYYY-wo" |
 | value | 日期 | [moment](http://momentjs.com/) | - |
 | onChange | 时间发生变化的回调，发生在用户选择时间时 | function(date: moment, dateString: string) | - |
+| renderExtraFooter | 在面板中添加额外的页脚 | (mode) => React.ReactNode | - |
 
 ### RangePicker
 

--- a/components/date-picker/index.zh-CN.md
+++ b/components/date-picker/index.zh-CN.md
@@ -66,7 +66,6 @@ moment.locale('zh-cn');
 | style | 自定义输入框样式 | object | {} |
 | onOpenChange | 弹出日历和关闭日历的回调 | function(status) | 无 |
 | onPanelChange | 日历面板切换的回调 | function(value, mode) | - |
-| renderFooter | 渲染弹出层的页脚 | (mode) => ReactNode | - |
 
 ### 共同的方法
 

--- a/components/date-picker/index.zh-CN.md
+++ b/components/date-picker/index.zh-CN.md
@@ -84,7 +84,7 @@ moment.locale('zh-cn');
 | disabledTime | 不可选择的时间 | function(date) | 无 |
 | format | 设置日期格式，为数组时支持多格式匹配，展示以第一个为准。配置参考 [moment.js](http://momentjs.com/) | string \| string[] | "YYYY-MM-DD" |
 | mode | 日期面板的状态 | `time|date|month|year` | 'date' |
-| renderExtraFooter | 在面板中添加额外的页脚 | () => React.ReactNode | - |
+| renderExtraFooter | 在面板中添加额外的页脚 | (mode) => React.ReactNode | - |
 | showTime | 增加时间选择功能 | Object\|boolean | [TimePicker Options](/components/time-picker/#API) |
 | showTime.defaultValue | 设置用户选择日期时默认的时分秒，[例子](#components-date-picker-demo-disabled-date) | [moment](http://momentjs.com/) | moment() |
 | showToday | 是否展示“今天”按钮 | boolean | true |

--- a/components/date-picker/style/DecadePanel.less
+++ b/components/date-picker/style/DecadePanel.less
@@ -1,5 +1,7 @@
 .@{calendar-prefix-cls}-decade-panel {
   position: absolute;
+  display: flex;
+  flex-direction: column;
   top: 0;
   right: 0;
   bottom: 0;
@@ -19,7 +21,14 @@
 }
 
 .@{calendar-prefix-cls}-decade-panel-body {
-  height: ~'calc(100% - 40px)';
+  flex: 1;
+}
+
+.@{calendar-prefix-cls}-decade-panel-footer {
+  border-top: @border-width-base @border-style-base @border-color-split;
+  .@{calendar-prefix-cls}-footer-extra {
+    padding: 0 12px;
+  }
 }
 
 .@{calendar-prefix-cls}-decade-panel-table {

--- a/components/date-picker/style/MonthPanel.less
+++ b/components/date-picker/style/MonthPanel.less
@@ -12,6 +12,8 @@
   > div {
     // TODO: this is a useless wrapper, and we need to remove it in rc-calendar
     height: 100%;
+    display: flex;
+    flex-direction: column;
   }
 }
 
@@ -24,7 +26,14 @@
 }
 
 .@{calendar-prefix-cls}-month-panel-body {
-  height: ~'calc(100% - 40px)';
+  flex: 1;
+}
+
+.@{calendar-prefix-cls}-month-panel-footer {
+  border-top: @border-width-base @border-style-base @border-color-split;
+  .@{calendar-prefix-cls}-footer-extra {
+    padding: 0 12px;
+  }
 }
 
 .@{calendar-prefix-cls}-month-panel-table {

--- a/components/date-picker/style/YearPanel.less
+++ b/components/date-picker/style/YearPanel.less
@@ -12,6 +12,8 @@
   > div {
     // TODO: this is a useless wrapper, and we need to remove it in rc-calendar
     height: 100%;
+    display: flex;
+    flex-direction: column;
   }
 }
 
@@ -24,7 +26,14 @@
 }
 
 .@{calendar-prefix-cls}-year-panel-body {
-  height: ~'calc(100% - 40px)';
+  flex: 1;
+}
+
+.@{calendar-prefix-cls}-year-panel-footer {
+  border-top: @border-width-base @border-style-base @border-color-split;
+  .@{calendar-prefix-cls}-footer-extra {
+    padding: 0 12px;
+  }
 }
 
 .@{calendar-prefix-cls}-year-panel-table {


### PR DESCRIPTION
fix #11618

1. show extraFooter in all mode of `DatePicker`.
2. add support for `renderExtraFooter` in `WeekPicker`