### PR TITLE
fix bug in `DatePicker` demo `start-end`

### DIFF
--- a/components/date-picker/demo/start-end.md
+++ b/components/date-picker/demo/start-end.md
@@ -8,13 +8,13 @@ title:
 ## zh-CN
 
 当 `RangePicker` 无法满足业务需求时，可以使用两个 `DatePicker` 实现类似的功能。
-> * 通过设置 `disabledDate` 方法，来约束开始和结束日期。
+> * 通过设置 `disabledDate`和`disabledTime` 方法，来约束开始和结束日期。
 > * 通过 `open` `onOpenChange` 来优化交互。
 
 ## en-US
 
 When `RangePicker` does not satisfied your requirements, try to implement similar functionality with two `DatePicker`.
-> * Use the `disabledDate` property to limit the start and end dates.
+> * Use the `disabledDate` and `disabledTime` property to limit the start and end dates.
 > * Improve user experience with `open` and `onOpenChange`.
 
 ````jsx
@@ -27,12 +27,20 @@ class DateRange extends React.Component {
     endOpen: false,
   };
 
+  range = (start, end) => {
+    const result = [];
+    for (let i = start; i < end; i++) {
+      result.push(i);
+    }
+    return result;
+  }
+
   disabledStartDate = (startValue) => {
     const endValue = this.state.endValue;
     if (!startValue || !endValue) {
       return false;
     }
-    return startValue.valueOf() > endValue.valueOf();
+    return !startValue.isSame(endValue, 'day') && startValue.valueOf() > endValue.valueOf();
   }
 
   disabledEndDate = (endValue) => {
@@ -40,7 +48,76 @@ class DateRange extends React.Component {
     if (!endValue || !startValue) {
       return false;
     }
-    return endValue.valueOf() <= startValue.valueOf();
+    return !endValue.isSame(startValue, 'day') && endValue.valueOf() <= startValue.valueOf();
+  }
+
+  disabledStartTime = (startValue) => {
+    const disabledHours = () => {
+      const endValue = this.state.endValue;
+      if (!startValue || !endValue) return [];
+      return this.range(0, 24).filter(hour => startValue.isSame(endValue, 'day') && hour > endValue.hour());
+    }
+    const disabledMinutes = (hour) => {
+      const endValue = this.state.endValue;
+      if (!startValue || !endValue) return [];
+      return this.range(0, 60).filter(minute => (
+        startValue.isSame(endValue, 'day') &&
+        hour === endValue.hour() &&
+        minute > endValue.minute()
+      ));
+    }
+
+    const disabledSeconds = (hour, minute) => {
+      const endValue = this.state.endValue;
+      if (!startValue || !endValue) return [];
+      return this.range(0, 60).filter(second => (
+        startValue.isSame(endValue, 'day') &&
+        hour === endValue.hour() &&
+        minute === endValue.minute() &&
+        second > endValue.second()
+      ));
+    }
+
+    return {
+      disabledHours,
+      disabledMinutes,
+      disabledSeconds,
+    }
+  }
+
+  disabledEndTime = (endValue) => {
+    console.log(endValue);
+    const disabledHours = () => {
+      const startValue = this.state.startValue;
+      if (!startValue || !endValue) return [];
+      return this.range(0, 24).filter(hour => startValue.isSame(endValue, 'day') && hour < startValue.hour());
+    }
+    const disabledMinutes = (hour) => {
+      const startValue = this.state.startValue;
+      if (!startValue || !endValue) return [];
+      return this.range(0, 60).filter(minute => (
+        startValue.isSame(endValue, 'day') &&
+        hour === startValue.hour() &&
+        minute < startValue.minute()
+      ));
+    }
+
+    const disabledSeconds = (hour, minute) => {
+      const startValue = this.state.startValue;
+      if (!startValue || !endValue) return [];
+      return this.range(0, 60).filter(second => (
+        startValue.isSame(endValue, 'day') &&
+        hour === startValue.hour() &&
+        minute === startValue.minute() &&
+        second < startValue.second()
+      ));
+    }
+
+    return {
+      disabledHours,
+      disabledMinutes,
+      disabledSeconds,
+    }
   }
 
   onChange = (field, value) => {
@@ -73,6 +150,7 @@ class DateRange extends React.Component {
       <div>
         <DatePicker
           disabledDate={this.disabledStartDate}
+          disabledTime={this.disabledStartTime}
           showTime
           format="YYYY-MM-DD HH:mm:ss"
           value={startValue}
@@ -82,6 +160,7 @@ class DateRange extends React.Component {
         />
         <DatePicker
           disabledDate={this.disabledEndDate}
+          disabledTime={this.disabledEndTime}
           showTime
           format="YYYY-MM-DD HH:mm:ss"
           value={endValue}


### PR DESCRIPTION
fix #11528 

优化demo代码，添加disabledTime的逻辑，允许选择与开始时间同一天，在开始时间之后的时间段