### PR TITLE
Popover的arrow顶部有阴影和上一个版本表现不一致

### DIFF
--- a/components/popover/style/index.less
+++ b/components/popover/style/index.less
@@ -113,7 +113,7 @@
   &-placement-top > &-content > &-arrow,
   &-placement-topLeft > &-content > &-arrow,
   &-placement-topRight > &-content > &-arrow {
-    bottom: @popover-distance - @popover-arrow-width + 1.5px;
+    bottom: @popover-distance - @popover-arrow-width + 2.2px;
     box-shadow: 3px 3px 7px rgba(0, 0, 0, 0.07);
     border-top-color: transparent;
     border-right-color: @popover-bg;

--- a/components/popover/style/index.less
+++ b/components/popover/style/index.less
@@ -100,15 +100,18 @@
   // .popover-arrow is outer, .popover-arrow:after is inner
 
   &-arrow {
-    background: @popover-bg;
-    background-color: inherit;
+    background: transparent;
     width: sqrt(@popover-arrow-width * @popover-arrow-width * 2);
     height: sqrt(@popover-arrow-width * @popover-arrow-width * 2);
     transform: rotate(45deg);
     position: absolute;
     display: block;
-    border-color: transparent;
+    border-width: sqrt(@popover-arrow-width * @popover-arrow-width * 2) / 2;
     border-style: solid;
+    border-top-color: transparent;
+    border-right-color: @popover-bg;
+    border-bottom-color: @popover-bg;
+    border-left-color: transparent;
   }
 
   &-placement-top > &-content > &-arrow,

--- a/components/popover/style/index.less
+++ b/components/popover/style/index.less
@@ -108,10 +108,6 @@
     display: block;
     border-width: sqrt(@popover-arrow-width * @popover-arrow-width * 2) / 2;
     border-style: solid;
-    border-top-color: transparent;
-    border-right-color: @popover-bg;
-    border-bottom-color: @popover-bg;
-    border-left-color: transparent;
   }
 
   &-placement-top > &-content > &-arrow,
@@ -119,6 +115,10 @@
   &-placement-topRight > &-content > &-arrow {
     bottom: @popover-distance - @popover-arrow-width + 1.5px;
     box-shadow: 3px 3px 7px rgba(0, 0, 0, 0.07);
+    border-top-color: transparent;
+    border-right-color: @popover-bg;
+    border-bottom-color: @popover-bg;
+    border-left-color: transparent;
   }
   &-placement-top > &-content > &-arrow {
     left: 50%;
@@ -136,6 +136,10 @@
   &-placement-rightBottom > &-content > &-arrow {
     left: @popover-distance - @popover-arrow-width + 2px;
     box-shadow: -3px 3px 7px rgba(0, 0, 0, 0.07);
+    border-top-color: transparent;
+    border-right-color: transparent;
+    border-bottom-color: @popover-bg;
+    border-left-color: @popover-bg;
   }
   &-placement-right > &-content > &-arrow {
     top: 50%;
@@ -153,6 +157,10 @@
   &-placement-bottomRight > &-content > &-arrow {
     top: @popover-distance - @popover-arrow-width + 2px;
     box-shadow: -2px -2px 5px rgba(0, 0, 0, 0.06);
+    border-top-color: @popover-bg;
+    border-right-color: transparent;
+    border-bottom-color: transparent;
+    border-left-color: @popover-bg;
   }
   &-placement-bottom > &-content > &-arrow {
     left: 50%;
@@ -170,6 +178,10 @@
   &-placement-leftBottom > &-content > &-arrow {
     right: @popover-distance - @popover-arrow-width + 2px;
     box-shadow: 3px -3px 7px rgba(0, 0, 0, 0.07);
+    border-top-color: @popover-bg;
+    border-right-color: @popover-bg;
+    border-bottom-color: transparent;
+    border-left-color: transparent;
   }
   &-placement-left > &-content > &-arrow {
     top: 50%;


### PR DESCRIPTION
3.11.3之后的版本Popover组件arrow上方会出现多余的阴影，不符合预期。
对比：
问题版本：https://deploy-preview-13731--ant-design.netlify.com/components/popover-cn/
之前版本：https://deploy-preview-11501--ant-design.netlify.com/components/popover-cn/
上下文是 [PR 13731](https://github.com/ant-design/ant-design/pull/13731) 为了解决 [Issue 13533 ](https://github.com/ant-design/ant-design/issues/13533)导致的
为了同时解决Issue 13533提到的用户自定义.ant-popover-inner时arrow遮盖的问题提交了这次PR
_BTW，通过修改 @popover-bg 自定义背景色更好些_

#13731 
#13533 

---
First of all, thank you for your contribution! :-)

Please makes sure that these checkboxes are checked before submitting your pull request, thank you!

* [x] Make sure that you propose pull request to right branch: bugfix for `master`, feature for branch `feature`.
* [x] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a pull request to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you pull request.

Extra checklist:

**if** *isBugFix* **:**

  * [x] Make sure that you add at least one unit test for the bug which you had fixed.

**elif** *isNewFeature* **:**

  * [ ] Update API docs for the component.
  * [ ] Update/Add demo to demonstrate new feature.
  * [ ] Update TypeScript definition for the component.
  * [ ] Add unit tests for the feature.
