### PR TITLE
Remove classNames from custom-typing file

### DIFF
--- a/typings/custom-typings.d.ts
+++ b/typings/custom-typings.d.ts
@@ -1,5 +1,3 @@
-declare module 'classnames';
-
 declare module 'rc-calendar*';
 
 declare module 'rc-time-picker*';


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/17755202/50481269-87306000-0a1b-11e9-8c1e-3fcd7402dc0d.png)

We have added the classNames type to the project, why add a custom type to it? Custom types cover the types we add.
![image](https://user-images.githubusercontent.com/17755202/50481300-b8a92b80-0a1b-11e9-86b3-0c15ac0e2707.png)
