### PR TITLE
Fix Message style when text is too long

### DIFF
--- a/components/message/index.tsx
+++ b/components/message/index.tsx
@@ -89,7 +89,7 @@ function notice(args: ArgsProps): MessageType {
             }`}
           >
             {args.icon ? args.icon : iconType ? iconNode : ''}
-            <span>{args.content}</span>
+            <span className={`${prefixCls}-notice-content-text`}>{args.content}</span>
           </div>
         ),
         onClose: callback,

--- a/components/message/style/index.less
+++ b/components/message/style/index.less
@@ -29,6 +29,10 @@
     pointer-events: all;
   }
 
+  &-notice-content-text {
+    word-break: break-word;
+  }
+
   &-success .@{iconfont-css-prefix} {
     color: @success-color;
   }


### PR DESCRIPTION
First of all, thank you for your contribution! :-)

Please makes sure that these checkboxes are checked before submitting your pull request, thank you!

* [x] Make sure that you propose pull request to right branch: bugfix for `master`, feature for branch `feature`.
* [x] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a pull request to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you pull request.

Extra checklist:

**if** *isBugFix* **:**

  * [ ] Make sure that you add at least one unit test for the bug which you had fixed.

**elif** *isNewFeature* **:**

  * [ ] Update API docs for the component.
  * [ ] Update/Add demo to demonstrate new feature.
  * [ ] Update TypeScript definition for the component.
  * [ ] Add unit tests for the feature.

Currently, if message text is too long, the message instance will  beyond viewport, add a word-break is better, it keep style in current position.