### PR TITLE
fix Tabs renderTabBar

### DIFF
--- a/components/tabs/index.tsx
+++ b/components/tabs/index.tsx
@@ -171,10 +171,10 @@ export default class Tabs extends React.Component<TabsProps, any> {
 
     return (
       <RcTabs
+        renderTabBar={() => <TabBar {...tabBarProps} tabBarExtraContent={tabBarExtraContent} />}
         {...this.props}
         className={cls}
         tabBarPosition={tabPosition}
-        renderTabBar={() => <TabBar {...tabBarProps} tabBarExtraContent={tabBarExtraContent} />}
         renderTabContent={() => (
           <TabContent className={contentCls} animated={tabPaneAnimated} animatedWithMargin />
         )}


### PR DESCRIPTION
`renderTabBar` would be overrided when it was behind of `...this.props`

First of all, thank you for your contribution! :-)

Please makes sure that these checkboxes are checked before submitting your pull request, thank you!

* [x] Make sure that you propose pull request to right branch: bugfix for `master`, feature for branch `feature`.
* [x] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a pull request to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you pull request.

Extra checklist:

**if** *isBugFix* **:**

  * [ ] Make sure that you add at least one unit test for the bug which you had fixed.

**elif** *isNewFeature* **:**

  * [ ] Update API docs for the component.
  * [ ] Update/Add demo to demonstrate new feature.
  * [ ] Update TypeScript definition for the component.
  * [ ] Add unit tests for the feature.
