### PR TITLE
Fix rowSelection columnWidth  doesn't work

### DIFF
--- a/components/table/Table.tsx
+++ b/components/table/Table.tsx
@@ -58,6 +58,8 @@ const defaultPagination = {
   onShowSizeChange: noop,
 };
 
+const ROW_SELECTION_COLUMN_WIDTH = '62px';
+
 /**
  * Avoid creating new object, so that parent component's shouldComponentUpdate
  * can works appropriately。
@@ -738,7 +740,7 @@ export default class Table<T> extends React.Component<TableProps<T>, TableState<
         render: this.renderSelectionBox(rowSelection.type),
         className: selectionColumnClass,
         fixed: rowSelection.fixed,
-        width: rowSelection.columnWidth,
+        width: rowSelection.columnWidth || ROW_SELECTION_COLUMN_WIDTH,
         title: rowSelection.columnTitle,
       };
       if (rowSelection.type !== 'radio') {

--- a/components/table/style/index.less
+++ b/components/table/style/index.less
@@ -294,8 +294,6 @@
   &-thead > tr > th.@{table-prefix-cls}-selection-column,
   &-tbody > tr > td.@{table-prefix-cls}-selection-column {
     text-align: center;
-    min-width: 62px;
-    width: 62px;
     .@{ant-prefix}-radio-wrapper {
       margin-right: 0;
     }


### PR DESCRIPTION
Fix the Table rowSelection columnWidth  doesn't work
修复 Table 组件自定义列表选择框宽度无效的情况

First of all, thank you for your contribution! :-)

Please makes sure that these checkboxes are checked before submitting your pull request, thank you!

* [ ] Make sure that you propose pull request to right branch: bugfix for `master`, feature for branch `feature`.
* [x] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [ ] Rebase before creating a pull request to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you pull request.

Extra checklist:

**if** *isBugFix* **:**

  * [x] Make sure that you add at least one unit test for the bug which you had fixed.

**elif** *isNewFeature* **:**

  * [ ] Update API docs for the component.
  * [ ] Update/Add demo to demonstrate new feature.
  * [ ] Update TypeScript definition for the component.
  * [ ] Add unit tests for the feature.
