### PR TITLE
fix calendar month range display

### DIFF
--- a/components/calendar/Header.tsx
+++ b/components/calendar/Header.tsx
@@ -83,7 +83,8 @@ export default class Header extends React.Component<HeaderProps, any> {
       const currentYear = value.get('year');
       if (rangeEnd.get('year') === currentYear) {
         end = rangeEnd.get('month') + 1;
-      } else if (rangeStart.get('year') === currentYear) {
+      }
+      if (rangeStart.get('year') === currentYear) {
         start = rangeStart.get('month');
       }
     }


### PR DESCRIPTION
if year of start equals year of end，then just one judgement will use.