### PR TITLE
Update rc-calendar to use new lifecycle methods & input auto focus

### DIFF
--- a/components/date-picker/__tests__/__snapshots__/DatePicker.test.js.snap
+++ b/components/date-picker/__tests__/__snapshots__/DatePicker.test.js.snap
@@ -115,6 +115,7 @@ exports[`DatePicker prop locale should works 1`] = `
           </div>
           <div
             class="ant-calendar-date-panel"
+            tabindex="0"
           >
             <div
               class="ant-calendar-header"

--- a/components/date-picker/__tests__/__snapshots__/WeekPicker.test.js.snap
+++ b/components/date-picker/__tests__/__snapshots__/WeekPicker.test.js.snap
@@ -14,6 +14,7 @@ exports[`WeekPicker should support dateRender 1`] = `
       >
         <div
           class="ant-calendar-date-panel"
+          tabindex="0"
         >
           <div
             class="ant-calendar-header"

--- a/components/date-picker/__tests__/__snapshots__/other.test.js.snap
+++ b/components/date-picker/__tests__/__snapshots__/other.test.js.snap
@@ -278,6 +278,7 @@ exports[`MonthPicker and WeekPicker render WeekPicker 1`] = `
       >
         <div
           class="ant-calendar-date-panel"
+          tabindex="0"
         >
           <div
             class="ant-calendar-header"

--- a/components/date-picker/__tests__/showTime.test.js
+++ b/components/date-picker/__tests__/showTime.test.js
@@ -99,41 +99,30 @@ describe('RangePicker with showTime', () => {
       <RangePicker showTime open onChange={onChangeFn} onOpenChange={onOpenChangeFn} />,
     );
 
-    const calendarWrapper = mount(
-      wrapper
-        .find('Trigger')
-        .instance()
-        .getComponent(),
-    );
+    function findNode(selector) {
+      return wrapper.find('Trigger').find(selector);
+    }
+
     expect(
-      calendarWrapper
-        .find('.ant-calendar-time-picker-btn')
-        .hasClass('ant-calendar-time-picker-btn-disabled'),
+      findNode('.ant-calendar-time-picker-btn').hasClass('ant-calendar-time-picker-btn-disabled'),
     ).toBe(true);
-    expect(
-      calendarWrapper.find('.ant-calendar-ok-btn').hasClass('ant-calendar-ok-btn-disabled'),
-    ).toBe(true);
-    calendarWrapper
-      .find('.ant-calendar-date')
+    expect(findNode('.ant-calendar-ok-btn').hasClass('ant-calendar-ok-btn-disabled')).toBe(true);
+    findNode('.ant-calendar-date')
       .at(10)
       .simulate('click');
-    calendarWrapper
-      .find('.ant-calendar-date')
+    findNode('.ant-calendar-date')
       .at(11)
       .simulate('click');
+
     expect(
-      calendarWrapper
-        .find('.ant-calendar-time-picker-btn')
-        .hasClass('ant-calendar-time-picker-btn-disabled'),
+      findNode('.ant-calendar-time-picker-btn').hasClass('ant-calendar-time-picker-btn-disabled'),
     ).toBe(false);
-    expect(
-      calendarWrapper.find('.ant-calendar-ok-btn').hasClass('ant-calendar-ok-btn-disabled'),
-    ).toBe(false);
+    expect(findNode('.ant-calendar-ok-btn').hasClass('ant-calendar-ok-btn-disabled')).toBe(false);
     expect(onChangeFn).toHaveBeenCalled();
     expect(onOpenChangeFn).not.toHaveBeenCalled();
   });
 
-  it('hould trigger onOk when press ok button', () => {
+  it('should trigger onOk when press ok button', () => {
     const onOkFn = jest.fn();
     const onChangeFn = jest.fn();
     const onOpenChangeFn = jest.fn();
@@ -147,22 +136,18 @@ describe('RangePicker with showTime', () => {
       />,
     );
 
-    const calendarWrapper = mount(
-      wrapper
-        .find('Trigger')
-        .instance()
-        .getComponent(),
-    );
-    calendarWrapper
-      .find('.ant-calendar-date')
+    function findNode(selector) {
+      return wrapper.find('Trigger').find(selector);
+    }
+
+    findNode('.ant-calendar-date')
       .at(10)
       .simulate('click');
-    calendarWrapper
-      .find('.ant-calendar-date')
+    findNode('.ant-calendar-date')
       .at(11)
       .simulate('click');
     onChangeFn.mockClear();
-    calendarWrapper.find('.ant-calendar-ok-btn').simulate('click');
+    findNode('.ant-calendar-ok-btn').simulate('click');
     expect(onOkFn).toHaveBeenCalled();
     expect(onOpenChangeFn).toHaveBeenCalledWith(false);
     expect(onChangeFn).not.toHaveBeenCalled();

--- a/components/date-picker/style/Calendar.less
+++ b/components/date-picker/style/Calendar.less
@@ -186,6 +186,7 @@
 
     &-panel {
       position: relative;
+      outline: none;
     }
 
     &:hover {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "prop-types": "^15.6.2",
     "raf": "^3.4.0",
     "rc-animate": "^2.5.4",
-    "rc-calendar": "~9.10.2",
+    "rc-calendar": "~9.10.3",
     "rc-cascader": "~0.17.0",
     "rc-checkbox": "~2.1.5",
     "rc-collapse": "~1.10.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "prop-types": "^15.6.2",
     "raf": "^3.4.0",
     "rc-animate": "^2.5.4",
-    "rc-calendar": "~9.9.2",
+    "rc-calendar": "~9.10.2",
     "rc-cascader": "~0.17.0",
     "rc-checkbox": "~2.1.5",
     "rc-collapse": "~1.10.0",


### PR DESCRIPTION
### This is a ...

- [x] New feature
- [ ] Other

### What's the background?

1. Migrate to new lifecycle methods: #9792
2. DatePicker support auto focus when opened: #11848
  
### API Realization
  
Internal added `focusablePanel` prop to let user disable tab active element to picker panel.
But we needn't export this function to antd user.
  
### What's the affect?

1. Input on DatePicker is now auto focused.
2. Add Picker panel `tab-index`.
3. Since it's from React mixin to new lifecycle methods, it may contains potential bug.

Changelog:
* DatePicker's input is now auto focus when open
* DatePicker 在打开后输入框会自动获得焦点

### Self Check before Merge

- [x] Doc is ready or not need
- [x] Demo is provided or not need
- [x] TypeScript definition is ready or not need
- [x] Changelog provided