### PR TITLE
Add expandIcon for Collapse

### DIFF
--- a/components/collapse/Collapse.tsx
+++ b/components/collapse/Collapse.tsx
@@ -17,6 +17,7 @@ export interface CollapseProps {
   className?: string;
   bordered?: boolean;
   prefixCls?: string;
+  expandIcon?: (panelProps: any) => React.ReactNode;
 }
 
 export default class Collapse extends React.Component<CollapseProps, any> {
@@ -27,9 +28,16 @@ export default class Collapse extends React.Component<CollapseProps, any> {
     openAnimation: { ...animation, appear() {} },
   };
 
-  renderExpandIcon = () => {
-    return <Icon type="right" className={`arrow`} />;
-  };
+  renderExpandIcon = (panelProps: any, prefixCls: string) => {
+    const { expandIcon } = this.props;
+    if (!expandIcon) {
+      return <Icon type="right" className={`${prefixCls}-arrow`} />;
+    }
+    const icon = expandIcon(panelProps);
+    return React.isValidElement(icon) ? React.cloneElement(icon as any, {
+      className: `${prefixCls}-arrow`,
+    }) : icon;
+  }
 
   renderCollapse = ({ getPrefixCls }: ConfigConsumerProps) => {
     const { prefixCls: customizePrefixCls, className = '', bordered } = this.props;
@@ -43,9 +51,9 @@ export default class Collapse extends React.Component<CollapseProps, any> {
     return (
       <RcCollapse
         {...this.props}
+        expandIcon={(panelProps: any) => this.renderExpandIcon(panelProps, prefixCls)}
         prefixCls={prefixCls}
         className={collapseClassName}
-        expandIcon={this.renderExpandIcon}
       />
     );
   };

--- a/components/collapse/Collapse.tsx
+++ b/components/collapse/Collapse.tsx
@@ -20,6 +20,16 @@ export interface CollapseProps {
   expandIcon?: (panelProps: any) => React.ReactNode;
 }
 
+interface PanelProps {
+  isActive?: boolean;
+  header?: React.ReactNode;
+  className?: string;
+  style?: React.CSSProperties;
+  showArrow?: boolean;
+  forceRender?: boolean;
+  disabled?: boolean;
+}
+
 export default class Collapse extends React.Component<CollapseProps, any> {
   static Panel = CollapsePanel;
 
@@ -28,16 +38,19 @@ export default class Collapse extends React.Component<CollapseProps, any> {
     openAnimation: { ...animation, appear() {} },
   };
 
-  renderExpandIcon = (panelProps: any, prefixCls: string) => {
+  renderExpandIcon = (panelProps: PanelProps = {}, prefixCls: string) => {
     const { expandIcon } = this.props;
-    if (!expandIcon) {
-      return <Icon type="right" className={`${prefixCls}-arrow`} />;
-    }
-    const icon = expandIcon(panelProps);
-    return React.isValidElement(icon) ? React.cloneElement(icon as any, {
-      className: `${prefixCls}-arrow`,
-    }) : icon;
-  }
+    const icon = expandIcon ? (
+      expandIcon(panelProps)
+    ) : (
+      <Icon type="right" rotate={panelProps.isActive ? 90 : undefined} />
+    );
+    return React.isValidElement(icon)
+      ? React.cloneElement(icon as any, {
+          className: `${prefixCls}-arrow`,
+        })
+      : icon;
+  };
 
   renderCollapse = ({ getPrefixCls }: ConfigConsumerProps) => {
     const { prefixCls: customizePrefixCls, className = '', bordered } = this.props;
@@ -51,7 +64,7 @@ export default class Collapse extends React.Component<CollapseProps, any> {
     return (
       <RcCollapse
         {...this.props}
-        expandIcon={(panelProps: any) => this.renderExpandIcon(panelProps, prefixCls)}
+        expandIcon={(panelProps: PanelProps) => this.renderExpandIcon(panelProps, prefixCls)}
         prefixCls={prefixCls}
         className={collapseClassName}
       />

--- a/components/collapse/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/collapse/__tests__/__snapshots__/demo.test.js.snap
@@ -16,7 +16,7 @@ exports[`renders ./components/collapse/demo/accordion.md correctly 1`] = `
     >
       <i
         aria-label="icon: right"
-        class="anticon anticon-right arrow"
+        class="anticon anticon-right ant-collapse-arrow"
       >
         <svg
           aria-hidden="true"
@@ -46,7 +46,7 @@ exports[`renders ./components/collapse/demo/accordion.md correctly 1`] = `
     >
       <i
         aria-label="icon: right"
-        class="anticon anticon-right arrow"
+        class="anticon anticon-right ant-collapse-arrow"
       >
         <svg
           aria-hidden="true"
@@ -76,7 +76,7 @@ exports[`renders ./components/collapse/demo/accordion.md correctly 1`] = `
     >
       <i
         aria-label="icon: right"
-        class="anticon anticon-right arrow"
+        class="anticon anticon-right ant-collapse-arrow"
       >
         <svg
           aria-hidden="true"
@@ -113,7 +113,7 @@ exports[`renders ./components/collapse/demo/basic.md correctly 1`] = `
     >
       <i
         aria-label="icon: right"
-        class="anticon anticon-right arrow"
+        class="anticon anticon-right ant-collapse-arrow"
       >
         <svg
           aria-hidden="true"
@@ -158,7 +158,7 @@ exports[`renders ./components/collapse/demo/basic.md correctly 1`] = `
     >
       <i
         aria-label="icon: right"
-        class="anticon anticon-right arrow"
+        class="anticon anticon-right ant-collapse-arrow"
       >
         <svg
           aria-hidden="true"
@@ -188,7 +188,7 @@ exports[`renders ./components/collapse/demo/basic.md correctly 1`] = `
     >
       <i
         aria-label="icon: right"
-        class="anticon anticon-right arrow"
+        class="anticon anticon-right ant-collapse-arrow"
       >
         <svg
           aria-hidden="true"
@@ -225,7 +225,7 @@ exports[`renders ./components/collapse/demo/borderless.md correctly 1`] = `
     >
       <i
         aria-label="icon: right"
-        class="anticon anticon-right arrow"
+        class="anticon anticon-right ant-collapse-arrow"
       >
         <svg
           aria-hidden="true"
@@ -268,7 +268,7 @@ exports[`renders ./components/collapse/demo/borderless.md correctly 1`] = `
     >
       <i
         aria-label="icon: right"
-        class="anticon anticon-right arrow"
+        class="anticon anticon-right ant-collapse-arrow"
       >
         <svg
           aria-hidden="true"
@@ -298,7 +298,7 @@ exports[`renders ./components/collapse/demo/borderless.md correctly 1`] = `
     >
       <i
         aria-label="icon: right"
-        class="anticon anticon-right arrow"
+        class="anticon anticon-right ant-collapse-arrow"
       >
         <svg
           aria-hidden="true"
@@ -335,20 +335,20 @@ exports[`renders ./components/collapse/demo/custom.md correctly 1`] = `
       tabindex="0"
     >
       <i
-        aria-label="icon: right"
-        class="anticon anticon-right arrow"
+        aria-label="icon: caret-right"
+        class="anticon anticon-caret-right ant-collapse-arrow"
       >
         <svg
           aria-hidden="true"
           class=""
-          data-icon="right"
+          data-icon="caret-right"
           fill="currentColor"
           height="1em"
-          viewBox="64 64 896 896"
+          viewBox="0 0 1024 1024"
           width="1em"
         >
           <path
-            d="M765.7 486.8L314.9 134.7A7.97 7.97 0 0 0 302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 0 0 0-50.4z"
+            d="M715.8 493.5L335 165.1c-14.2-12.2-35-1.2-35 18.5v656.8c0 19.7 20.8 30.7 35 18.5l380.8-328.4c10.9-9.4 10.9-27.6 0-37z"
           />
         </svg>
       </i>
@@ -381,20 +381,20 @@ exports[`renders ./components/collapse/demo/custom.md correctly 1`] = `
       tabindex="0"
     >
       <i
-        aria-label="icon: right"
-        class="anticon anticon-right arrow"
+        aria-label="icon: caret-right"
+        class="anticon anticon-caret-right ant-collapse-arrow"
       >
         <svg
           aria-hidden="true"
           class=""
-          data-icon="right"
+          data-icon="caret-right"
           fill="currentColor"
           height="1em"
-          viewBox="64 64 896 896"
+          viewBox="0 0 1024 1024"
           width="1em"
         >
           <path
-            d="M765.7 486.8L314.9 134.7A7.97 7.97 0 0 0 302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 0 0 0-50.4z"
+            d="M715.8 493.5L335 165.1c-14.2-12.2-35-1.2-35 18.5v656.8c0 19.7 20.8 30.7 35 18.5l380.8-328.4c10.9-9.4 10.9-27.6 0-37z"
           />
         </svg>
       </i>
@@ -412,20 +412,20 @@ exports[`renders ./components/collapse/demo/custom.md correctly 1`] = `
       tabindex="0"
     >
       <i
-        aria-label="icon: right"
-        class="anticon anticon-right arrow"
+        aria-label="icon: caret-right"
+        class="anticon anticon-caret-right ant-collapse-arrow"
       >
         <svg
           aria-hidden="true"
           class=""
-          data-icon="right"
+          data-icon="caret-right"
           fill="currentColor"
           height="1em"
-          viewBox="64 64 896 896"
+          viewBox="0 0 1024 1024"
           width="1em"
         >
           <path
-            d="M765.7 486.8L314.9 134.7A7.97 7.97 0 0 0 302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 0 0 0-50.4z"
+            d="M715.8 493.5L335 165.1c-14.2-12.2-35-1.2-35 18.5v656.8c0 19.7 20.8 30.7 35 18.5l380.8-328.4c10.9-9.4 10.9-27.6 0-37z"
           />
         </svg>
       </i>
@@ -450,7 +450,7 @@ exports[`renders ./components/collapse/demo/mix.md correctly 1`] = `
     >
       <i
         aria-label="icon: right"
-        class="anticon anticon-right arrow"
+        class="anticon anticon-right ant-collapse-arrow"
       >
         <svg
           aria-hidden="true"
@@ -480,7 +480,7 @@ exports[`renders ./components/collapse/demo/mix.md correctly 1`] = `
     >
       <i
         aria-label="icon: right"
-        class="anticon anticon-right arrow"
+        class="anticon anticon-right ant-collapse-arrow"
       >
         <svg
           aria-hidden="true"
@@ -510,7 +510,7 @@ exports[`renders ./components/collapse/demo/mix.md correctly 1`] = `
     >
       <i
         aria-label="icon: right"
-        class="anticon anticon-right arrow"
+        class="anticon anticon-right ant-collapse-arrow"
       >
         <svg
           aria-hidden="true"
@@ -547,7 +547,7 @@ exports[`renders ./components/collapse/demo/noarrow.md correctly 1`] = `
     >
       <i
         aria-label="icon: right"
-        class="anticon anticon-right arrow"
+        class="anticon anticon-right ant-collapse-arrow"
       >
         <svg
           aria-hidden="true"

--- a/components/collapse/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/collapse/__tests__/__snapshots__/demo.test.js.snap
@@ -121,6 +121,7 @@ exports[`renders ./components/collapse/demo/basic.md correctly 1`] = `
           data-icon="right"
           fill="currentColor"
           height="1em"
+          style="-ms-transform:rotate(90deg);transform:rotate(90deg)"
           viewBox="64 64 896 896"
           width="1em"
         >
@@ -233,6 +234,7 @@ exports[`renders ./components/collapse/demo/borderless.md correctly 1`] = `
           data-icon="right"
           fill="currentColor"
           height="1em"
+          style="-ms-transform:rotate(90deg);transform:rotate(90deg)"
           viewBox="64 64 896 896"
           width="1em"
         >
@@ -344,6 +346,7 @@ exports[`renders ./components/collapse/demo/custom.md correctly 1`] = `
           data-icon="caret-right"
           fill="currentColor"
           height="1em"
+          style="-ms-transform:rotate(90deg);transform:rotate(90deg)"
           viewBox="0 0 1024 1024"
           width="1em"
         >
@@ -555,6 +558,7 @@ exports[`renders ./components/collapse/demo/noarrow.md correctly 1`] = `
           data-icon="right"
           fill="currentColor"
           height="1em"
+          style="-ms-transform:rotate(90deg);transform:rotate(90deg)"
           viewBox="64 64 896 896"
           width="1em"
         >

--- a/components/collapse/__tests__/__snapshots__/index.test.js.snap
+++ b/components/collapse/__tests__/__snapshots__/index.test.js.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Collapse should support remove expandIcon 1`] = `
+<div
+  class="ant-collapse"
+>
+  <div
+    class="ant-collapse-item"
+  >
+    <div
+      aria-expanded="false"
+      class="ant-collapse-header"
+      role="button"
+      tabindex="0"
+    >
+      header
+    </div>
+  </div>
+</div>
+`;

--- a/components/collapse/__tests__/index.test.js
+++ b/components/collapse/__tests__/index.test.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import Collapse from '..';
+
+describe('Collapse', () => {
+  it('should support remove expandIcon', () => {
+    const wrapper = mount(
+      <Collapse expandIcon={() => null}>
+        <Collapse.Panel header="header" />
+      </Collapse>
+    );
+    expect(wrapper.render()).toMatchSnapshot();
+  });
+});

--- a/components/collapse/demo/custom.md
+++ b/components/collapse/demo/custom.md
@@ -7,14 +7,14 @@ title:
 
 ## zh-CN
 
-自定义各个面板的背景色、圆角和边距。
+自定义各个面板的背景色、圆角、边距和图标。
 
 ## en-US
 
-Customize the background, border and margin styles for each panel.
+Customize the background, border, margin styles and icon for each panel.
 
 ````jsx
-import { Collapse } from 'antd';
+import { Collapse, Icon } from 'antd';
 
 const Panel = Collapse.Panel;
 
@@ -33,7 +33,11 @@ const customPanelStyle = {
 };
 
 ReactDOM.render(
-  <Collapse bordered={false} defaultActiveKey={['1']}>
+  <Collapse
+    bordered={false}
+    defaultActiveKey={['1']}
+    expandIcon={() => <Icon type="caret-right" />}
+  >
     <Panel header="This is panel header 1" key="1" style={customPanelStyle}>
       <p>{text}</p>
     </Panel>

--- a/components/collapse/demo/custom.md
+++ b/components/collapse/demo/custom.md
@@ -36,7 +36,7 @@ ReactDOM.render(
   <Collapse
     bordered={false}
     defaultActiveKey={['1']}
-    expandIcon={() => <Icon type="caret-right" />}
+    expandIcon={({ isActive }) => <Icon type="caret-right" rotate={isActive ? 90 : 0} />}
   >
     <Panel header="This is panel header 1" key="1" style={customPanelStyle}>
       <p>{text}</p>

--- a/components/collapse/index.en-US.md
+++ b/components/collapse/index.en-US.md
@@ -18,11 +18,12 @@ A content area which can be collapsed and expanded.
 
 | Property | Description | Type | Default |
 | -------- | ----------- | ---- | ------- |
-| accordion | If `true`, `Collapse` renders as `Accordion` | boolean | `false` |
 | activeKey | Key of the active panel | string\[]\|string | No default value. In `accordion` mode, it's the key of the first panel. |
-| bordered | Toggles rendering of the border around the collapse block | boolean | `true` |
 | defaultActiveKey | Key of the initial active panel | string | - |
+| bordered | Toggles rendering of the border around the collapse block | boolean | `true` |
+| accordion | If `true`, `Collapse` renders as `Accordion` | boolean | `false` |
 | onChange | Callback function executed when active panel is changed | Function | - |
+| expandIcon | 自定义切换图标 | (panelProps) => ReactNode | - |
 | destroyInactivePanel | Destroy Inactive Panel | boolean | `false` |
 
 ### Collapse.Panel

--- a/components/collapse/index.en-US.md
+++ b/components/collapse/index.en-US.md
@@ -23,7 +23,7 @@ A content area which can be collapsed and expanded.
 | bordered | Toggles rendering of the border around the collapse block | boolean | `true` |
 | accordion | If `true`, `Collapse` renders as `Accordion` | boolean | `false` |
 | onChange | Callback function executed when active panel is changed | Function | - |
-| expandIcon | 自定义切换图标 | (panelProps) => ReactNode | - |
+| expandIcon | allow to customize collapse icon | (panelProps) => ReactNode | - |
 | destroyInactivePanel | Destroy Inactive Panel | boolean | `false` |
 
 ### Collapse.Panel

--- a/components/collapse/index.zh-CN.md
+++ b/components/collapse/index.zh-CN.md
@@ -21,7 +21,11 @@ cols: 1
 | --- | --- | --- | --- |
 | activeKey | 当前激活 tab 面板的 key | string\[]\|string | 默认无，accordion模式下默认第一个元素 |
 | defaultActiveKey | 初始化选中面板的 key | string | 无 |
+| bordered | 带边框风格的折叠面板 | boolean | `true` |
+| accordion | 手风琴模式 | boolean | `false` |
 | onChange | 切换面板的回调 | Function | 无 |
+| expandIcon | 自定义切换图标 | (panelProps) => ReactNode | - |
+| destroyInactivePanel | 销毁折叠隐藏的面板 | boolean | `false` |
 
 ### Collapse.Panel
 
@@ -31,6 +35,7 @@ cols: 1
 | forceRender | 被隐藏时是否渲染 DOM 结构 | boolean | false |
 | header | 面板头内容 | string\|ReactNode | 无 |
 | key | 对应 activeKey | string | 无 |
+| showArrow | 是否展示当前面板上的箭头 | boolean | `true` |
 
 ## FAQ
 

--- a/components/collapse/style/index.less
+++ b/components/collapse/style/index.less
@@ -35,7 +35,7 @@
       position: relative;
       transition: all 0.3s;
 
-      .arrow {
+      .@{collapse-prefix-cls}-arrow {
         .iconfont-mixin();
         font-size: @font-size-sm;
         position: absolute;
@@ -43,6 +43,7 @@
         line-height: 46px;
         vertical-align: top;
         top: 50%;
+        margin-top: 2px;
         transform: translateY(-50%);
         left: @padding-md;
         & svg {
@@ -89,7 +90,7 @@
   }
 
   & > &-item > &-header[aria-expanded='true'] {
-    .anticon-right svg {
+    .@{collapse-prefix-cls}-arrow svg {
       .collapse-open();
     }
   }

--- a/components/collapse/style/index.less
+++ b/components/collapse/style/index.less
@@ -3,13 +3,6 @@
 
 @collapse-prefix-cls: ~'@{ant-prefix}-collapse';
 
-.collapse-close() {
-  transform: rotate(0);
-}
-.collapse-open() {
-  transform: rotate(90deg);
-}
-
 .@{collapse-prefix-cls} {
   .reset-component;
   background-color: @collapse-header-bg;
@@ -46,8 +39,8 @@
         margin-top: 2px;
         transform: translateY(-50%);
         left: @padding-md;
+
         & svg {
-          .collapse-close();
           transition: transform 0.24s;
         }
       }
@@ -86,12 +79,6 @@
   &-item:last-child {
     > .@{collapse-prefix-cls}-content {
       border-radius: 0 0 @border-radius-base @border-radius-base;
-    }
-  }
-
-  & > &-item > &-header[aria-expanded='true'] {
-    .@{collapse-prefix-cls}-arrow svg {
-      .collapse-open();
     }
   }
 

--- a/components/config-provider/__tests__/__snapshots__/components.test.js.snap
+++ b/components/config-provider/__tests__/__snapshots__/components.test.js.snap
@@ -5985,7 +5985,7 @@ exports[`ConfigProvider components Collapse configProvider 1`] = `
     >
       <i
         aria-label="icon: right"
-        class="anticon anticon-right arrow"
+        class="anticon anticon-right config-collapse-arrow"
       >
         <svg
           aria-hidden="true"
@@ -6022,7 +6022,7 @@ exports[`ConfigProvider components Collapse normal 1`] = `
     >
       <i
         aria-label="icon: right"
-        class="anticon anticon-right arrow"
+        class="anticon anticon-right ant-collapse-arrow"
       >
         <svg
           aria-hidden="true"
@@ -6059,7 +6059,7 @@ exports[`ConfigProvider components Collapse prefixCls 1`] = `
     >
       <i
         aria-label="icon: right"
-        class="anticon anticon-right arrow"
+        class="anticon anticon-right prefix-Collapse-arrow"
       >
         <svg
           aria-hidden="true"

--- a/components/icon/demo/basic.md
+++ b/components/icon/demo/basic.md
@@ -22,6 +22,7 @@ ReactDOM.render(
     <Icon type="setting" theme="filled" />
     <Icon type="smile" theme="outlined" />
     <Icon type="sync" spin />
+    <Icon type="smile" rotate={180} />
     <Icon type="loading" />
   </div>,
   mountNode

--- a/components/icon/index.en-US.md
+++ b/components/icon/index.en-US.md
@@ -26,6 +26,7 @@ ReactDOM.render(<IconDisplay />, mountNode);
 | style | Style properties of icon, like `fontSize` and `color` | CSSProperties | - |
 | theme | Theme of the ant design icon  | 'filled' \| 'outlined' \| 'twoTone' | 'outlined' |
 | spin | Rotate icon with animation | boolean | false |
+| rotate | rateto degress (added in 3.13.0, not working in IE9) | number | - |
 | component | The component used for the root node. This will override the **`type`** property. | ComponentType<CustomIconComponentProps\> | - |
 | twoToneColor | Only support the two-tone icon. Specific the primary color. | string (hex color) | - |
 

--- a/components/icon/index.tsx
+++ b/components/icon/index.tsx
@@ -23,6 +23,7 @@ let dangerousTheme: ThemeType | undefined = undefined;
 export interface TransferLocale {
   icon: string;
 }
+
 export interface CustomIconComponentProps {
   width: string | number;
   height: string | number;
@@ -30,6 +31,8 @@ export interface CustomIconComponentProps {
   viewBox?: string;
   className?: string;
   style?: React.CSSProperties;
+  spin?: boolean;
+  rotate?: number;
   ['aria-hidden']?: string;
 }
 
@@ -46,6 +49,7 @@ export interface IconProps {
   twoToneColor?: string;
   viewBox?: string;
   spin?: boolean;
+  rotate?: number;
   style?: React.CSSProperties;
   prefixCls?: string;
   role?: string;
@@ -69,6 +73,7 @@ const Icon: IconComponent<IconProps> = props => {
     component: Component,
     viewBox,
     spin,
+    rotate,
 
     tabIndex,
     onClick,
@@ -102,17 +107,22 @@ const Icon: IconComponent<IconProps> = props => {
 
   let innerNode: React.ReactNode;
 
+  const svgStyle = rotate
+    ? {
+        msTransform: `rotate(${rotate}deg)`,
+        transform: `rotate(${rotate}deg)`,
+      }
+    : undefined;
+
+  const innerSvgProps: CustomIconComponentProps = {
+    ...svgBaseProps,
+    className: svgClassString,
+    style: svgStyle,
+    viewBox,
+  };
+
   // component > children > type
   if (Component) {
-    const innerSvgProps: CustomIconComponentProps = {
-      ...svgBaseProps,
-      className: svgClassString,
-      viewBox,
-    };
-    if (!viewBox) {
-      delete innerSvgProps.viewBox;
-    }
-
     innerNode = <Component {...innerSvgProps}>{children}</Component>;
   }
 
@@ -125,10 +135,6 @@ const Icon: IconComponent<IconProps> = props => {
       'Make sure that you provide correct `viewBox`' +
         ' prop (default `0 0 1024 1024`) to the icon.',
     );
-    const innerSvgProps: CustomIconComponentProps = {
-      ...svgBaseProps,
-      className: svgClassString,
-    };
     innerNode = (
       <svg {...innerSvgProps} viewBox={viewBox}>
         {children}
@@ -151,7 +157,12 @@ const Icon: IconComponent<IconProps> = props => {
       dangerousTheme || theme || defaultTheme,
     );
     innerNode = (
-      <ReactIcon className={svgClassString} type={computedType} primaryColor={twoToneColor} />
+      <ReactIcon
+        className={svgClassString}
+        type={computedType}
+        primaryColor={twoToneColor}
+        style={svgStyle}
+      />
     );
   }
 

--- a/components/icon/index.zh-CN.md
+++ b/components/icon/index.zh-CN.md
@@ -31,6 +31,7 @@ ReactDOM.render(<IconDisplay />, mountNode);
 | style | 设置图标的样式，例如 `fontSize` 和 `color` | CSSProperties | - |
 | theme | 图标主题风格。可选实心、描线、双色等主题风格，适用于官方图标 | 'filled' \| 'outlined' \| 'twoTone' | 'outlined' |
 | spin | 是否有旋转动画 | boolean | false |
+| rotate | 图标旋转角度（3.13.0 后新增，IE9 无效） | number | - |
 | component | 控制如何渲染图标，通常是一个渲染根标签为 `<svg>` 的 `React` 组件，**会使 `type` 属性失效** | ComponentType<CustomIconComponentProps\> | - |
 | twoToneColor | 仅适用双色图标。设置双色图标的主要颜色 | string (十六进制颜色) | - |
 


### PR DESCRIPTION
### This is a ...

- [x] New feature
- [ ] Other

### What's the background?
  
Developer need to customize `expand/collapse` Icon of Collapse.

The related issues: #14058  #12212
  
### API Realization

`rc-collapse` already has a [expandIcon](https://github.com/react-component/collapse/pull/89) for this, we need to expose it in antd's API.
  
```jsx
<Collapse expandIcon={() => <Icon type="caret-right" />}>
  ...
</Collapse>
```
  
### What's the affect?

- Developer can customize `expand/collapse` Icon of Collapse.
- Developer can use `<Icon rotate={90} />` to rotate icon.
- The API document and tweak some style of Collapse icon are also updated.
- The DOM structure of collapse icon will be changed like, which may affect some override styles.
   ```diff
     <i
   -  class="anticon anticon-right arrow"
   +  class="anticon anticon-right ant-collapse-arrow"
     >
   ```

##### changelog

- 🌟 Add Collapse `expandIcon` to allow customization of Collapse icon. #12212
- 🌟 Add Icon `rotate` to allow icon rotate as specified degress. #14060
- 🌟 Collapse 新增 `icon` 属性，允许用户自定义 Collapse 折叠图标。#12212
- 🌟 Icon 新增 `rotate` 属性，允许用户修改图标旋转角度。#14060

### Self Check before Merge

- [x] Doc is ready or not need
- [x] Demo is provided or not need
- [x] TypeScript definition is ready or not need
- [x] Changelog provided

### Additional Plan?

Nope.
