### PR TITLE
ConfigConsumer support `withConsumer`

### DIFF
--- a/components/config-provider/index.tsx
+++ b/components/config-provider/index.tsx
@@ -64,4 +64,35 @@ class ConfigProvider extends React.Component<ConfigProviderProps> {
   }
 }
 
+// =========================== withConfigConsumer ===========================
+// We need define many types here. So let's put in the block region
+type IReactComponent<P = any> =
+  | React.StatelessComponent<P>
+  | React.ComponentClass<P>
+  | React.ClassicComponentClass<P>;
+
+interface BasicExportProps {
+  prefixCls?: string;
+}
+
+interface ConsumerConfig {
+  prefixCls: string;
+}
+
+export function withConfigConsumer<ExportProps extends BasicExportProps>(config: ConsumerConfig) {
+  return function(Component: IReactComponent): React.SFC<ExportProps> {
+    return (props: ExportProps) => (
+      <ConfigConsumer>
+        {(configProps: ConfigConsumerProps) => {
+          const { prefixCls: basicPrefixCls } = config;
+          const { getPrefixCls } = configProps;
+          const { prefixCls: customizePrefixCls } = props;
+          const prefixCls = getPrefixCls(basicPrefixCls, customizePrefixCls);
+          return <Component {...configProps} {...props} prefixCls={prefixCls} />;
+        }}
+      </ConfigConsumer>
+    );
+  };
+}
+
 export default ConfigProvider;

--- a/components/config-provider/index.tsx
+++ b/components/config-provider/index.tsx
@@ -81,17 +81,19 @@ interface ConsumerConfig {
 
 export function withConfigConsumer<ExportProps extends BasicExportProps>(config: ConsumerConfig) {
   return function(Component: IReactComponent): React.SFC<ExportProps> {
-    return (props: ExportProps) => (
+    const wrapper: React.SFC<ExportProps> = (props: ExportProps, ref?: Function) => (
       <ConfigConsumer>
         {(configProps: ConfigConsumerProps) => {
           const { prefixCls: basicPrefixCls } = config;
           const { getPrefixCls } = configProps;
           const { prefixCls: customizePrefixCls } = props;
           const prefixCls = getPrefixCls(basicPrefixCls, customizePrefixCls);
-          return <Component {...configProps} {...props} prefixCls={prefixCls} />;
+          return <Component ref={ref} {...configProps} {...props} prefixCls={prefixCls} />;
         }}
       </ConfigConsumer>
     );
+
+    return wrapper;
   };
 }
 

--- a/components/config-provider/index.tsx
+++ b/components/config-provider/index.tsx
@@ -81,19 +81,18 @@ interface ConsumerConfig {
 
 export function withConfigConsumer<ExportProps extends BasicExportProps>(config: ConsumerConfig) {
   return function(Component: IReactComponent): React.SFC<ExportProps> {
-    const wrapper: React.SFC<ExportProps> = (props: ExportProps, ref?: Function) => (
+    // Wrap with ConfigConsumer. Since we need compatible with react 15, be care when using ref methods
+    return (props: ExportProps) => (
       <ConfigConsumer>
         {(configProps: ConfigConsumerProps) => {
           const { prefixCls: basicPrefixCls } = config;
           const { getPrefixCls } = configProps;
           const { prefixCls: customizePrefixCls } = props;
           const prefixCls = getPrefixCls(basicPrefixCls, customizePrefixCls);
-          return <Component ref={ref} {...configProps} {...props} prefixCls={prefixCls} />;
+          return <Component {...configProps} {...props} prefixCls={prefixCls} />;
         }}
       </ConfigConsumer>
     );
-
-    return wrapper;
   };
 }
 


### PR DESCRIPTION
First of all, thank you for your contribution! 😄

Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版](?expand=1&template=pr_cn.md)]

### This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?
  
Current ConfigConsumer need all render pass merged `prefixClss` to sub node render.
Add an `withConsumer` function to simplify this.
  
### API Realization (Optional if not new feature)

```jsx
class Drawer extends React.Component<DemoProps, DemoState> {
  // ...
}

export default withConsumer({ prefixCls: 'drawer' })(Drawer);
```
  
### What's the effect? (Optional if not new feature)

1. This update no affect user normal usage.
2. ☣️Do not use if Component provides methods when user use ref to call.
    * like `input`, `select`, etc.
    * We do not use `React.forwardRef` since we still need to support React 15

### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] ~Changelog provided~

### Additional Plan? (Optional if not new feature)

All the component update in future should consider use `withConsumer` at first.
