### PR TITLE
init Spin should also support delay trigger

### DIFF
--- a/components/spin/__tests__/index.test.js
+++ b/components/spin/__tests__/index.test.js
@@ -29,14 +29,45 @@ describe('Spin', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
-  it("should render with delay when it's mounted with spinning=true and delay", () => {
-    const wrapper = shallow(<Spin spinning delay={500} />);
-    expect(
-      wrapper
-        .find('.ant-spin')
-        .at(0)
-        .hasClass('ant-spin-spinning'),
-    ).toEqual(false);
+  describe('delay spinning', () => {
+    beforeAll(() => {
+      jest.useFakeTimers();
+    });
+
+    afterAll(() => {
+      jest.useRealTimers();
+    });
+
+    it("should render with delay when it's mounted with spinning=true and delay", () => {
+      const wrapper = shallow(<Spin spinning delay={500} />);
+      expect(
+        wrapper
+          .find('.ant-spin')
+          .at(0)
+          .hasClass('ant-spin-spinning'),
+      ).toEqual(false);
+    });
+
+    it('should render when delay is init set', () => {
+      const wrapper = mount(<Spin spinning delay={100} />);
+
+      expect(
+        wrapper
+          .find('.ant-spin')
+          .at(0)
+          .hasClass('ant-spin-spinning'),
+      ).toEqual(false);
+
+      jest.runAllTimers();
+      wrapper.update();
+
+      expect(
+        wrapper
+          .find('.ant-spin')
+          .at(0)
+          .hasClass('ant-spin-spinning'),
+      ).toEqual(true);
+    });
   });
 
   it('should be controlled by spinning', () => {

--- a/components/spin/index.tsx
+++ b/components/spin/index.tsx
@@ -94,6 +94,10 @@ class Spin extends React.Component<SpinProps, SpinState> {
     return !!(this.props && this.props.children);
   }
 
+  componentDidMount() {
+    this.componentDidUpdate();
+  }
+
   componentWillUnmount() {
     if (this.debounceTimeout) {
       clearTimeout(this.debounceTimeout);


### PR DESCRIPTION
First of all, thank you for your contribution! 😄

Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?
  
fix #14100
  
### API Realization (Optional if not new feature)
  
Add additional check on `componentDidMount`
  
### What's the effect? (Optional if not new feature)

changelog: 🐛 Fixed spin with delay on first render not trigger. #14100

### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog provided
