### PR TITLE
:bug: Fix nested Timeline last item missing line

### DIFF
--- a/components/timeline/style/index.less
+++ b/components/timeline/style/index.less
@@ -77,10 +77,10 @@
     }
 
     &-last {
-      .@{timeline-prefix-cls}-item-tail {
+      > .@{timeline-prefix-cls}-item-tail {
         display: none;
       }
-      .@{timeline-prefix-cls}-item-content {
+      > .@{timeline-prefix-cls}-item-content {
         min-height: 48px;
       }
     }


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?
  
Nested Timeline last item missing line.

close #14108

<img width="207" alt="image" src="https://user-images.githubusercontent.com/507615/50721198-70ae9680-10f6-11e9-8f99-701e4a184a1d.png">

### What's the effect? (Optional if not new feature)

changelog: 🐛 Fixed nested Timeline last item missing line. #14108

### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog provided
