### PR TITLE
Allow vertical form labels to break line

### DIFF
--- a/components/form/style/index.less
+++ b/components/form/style/index.less
@@ -303,6 +303,7 @@ form {
   display: block;
   text-align: left;
   line-height: @line-height-base;
+  white-space: initial;
 
   label:after {
     display: none;


### PR DESCRIPTION
This is a Bug fix

#### Background
  
In horizontal forms, labels are cut short so as to not break the layout if text is long.
But in vertical form layouts this feature is an unnecessary limitation.

![50728505-fdb31900-1111-11e9-9dde-6dcb1dd34c00](https://user-images.githubusercontent.com/486954/50738384-e3de0880-11db-11e9-8eba-bbce2dd0faf9.png)

#### API Realization
  
A one line addition to return `white-space` to `initial` value when in vertical layout.

#### Self Check before Merge

This change will be pretty much invisible as it is mostly an edge case. No docs, demo or definition needed.

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog provided

