### PR TITLE
feature:hide Input clearIcon when it is not hovered

### DIFF
--- a/components/input/style/mixin.less
+++ b/components/input/style/mixin.less
@@ -350,6 +350,9 @@
   &:hover .@{inputClass}:not(.@{inputClass}-disabled) {
     .hover();
   }
+  &:hover .@{inputClass}-suffix {
+    opacity: 1;
+  }
 
   .@{inputClass} {
     position: relative;
@@ -360,11 +363,16 @@
     position: absolute;
     top: 50%;
     z-index: 2;
+    opacity: 0;
     transform: translateY(-50%);
     line-height: 0;
     color: @input-color;
+    transition: color 0.3s ease, opacity 0.15s ease;
     :not(.anticon) {
       line-height: @line-height-base;
+    }
+    &:hover {
+      color: @text-color-secondary;
     }
   }
 


### PR DESCRIPTION
### This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

> When allowClear is Ture,the clearIcon of Input will always show,I think it doesn't look good.I think it's better if it can hide while it's not hovered just like the Select Component does.  
> [Input Demo](https://codesandbox.io/s/wk2r1ojyxl)
> [Select Demo](https://codesandbox.io/s/42m0vnm0v4)
  
### API Realization (Optional if not new feature)

> 1. Just like the [Select Component](https://github.com/ant-design/ant-design/blob/master/components/select/style/index.less#L7),Change the opacity when the wrapper is hovered.
> 2. GIF:![antd input](https://user-images.githubusercontent.com/12374094/50764371-5d91f700-12ad-11e9-921b-d7208e2456d8.gif)



### Changelog description (Optional if not new feature)

> 1. English description:hide Input clearIcon when it is not hovered

### Self Check before Merge

- [x] Doc is not needed
- [x] Demo is not needed
- [x] TypeScript definition is not needed
- [x] Changelog is provided
