### PR TITLE
add warning when user both use `expandedRowRender` & `scroll` on Table

### DIFF
--- a/components/table/Table.tsx
+++ b/components/table/Table.tsx
@@ -1,9 +1,3 @@
-// FilterDropdown
-// createBodyRow
-// SelectionCheckboxAll
-// SelectionBox
-// FilterDropdown
-
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import RcTable from 'rc-table';
@@ -122,6 +116,11 @@ export default class Table<T> extends React.Component<TableProps<T>, TableState<
       !('columnsPageRange' in props || 'columnsPageSize' in props),
       '`columnsPageRange` and `columnsPageSize` are removed, please use ' +
         'fixed columns instead, see: https://u.ant.design/fixed-columns.',
+    );
+
+    warning(
+      !('expandedRowRender' in props) || !('scroll' in props),
+      '`expandedRowRender` and `scroll` are not compatible. Please use one of them at one time.',
     );
 
     this.columns = props.columns || normalizeColumns(props.children as React.ReactChildren);

--- a/components/table/__tests__/Table.test.js
+++ b/components/table/__tests__/Table.test.js
@@ -5,6 +5,12 @@ import Table from '..';
 const { Column, ColumnGroup } = Table;
 
 describe('Table', () => {
+  const warnSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+  afterAll(() => {
+    warnSpy.mockRestore();
+  });
+
   it('renders JSX correctly', () => {
     const data = [
       {
@@ -79,5 +85,12 @@ describe('Table', () => {
     const wrapper = mount(<Table components={{ body: { wrapper: BodyWrapper1 } }} />);
     wrapper.setProps({ components: { body: { wrapper: BodyWrapper2 } } });
     expect(wrapper.find('tbody').props().id).toBe('wrapper2');
+  });
+
+  it('warning if both `expandedRowRender` & `scroll` are used', () => {
+    mount(<Table expandedRowRender={() => null} scroll={{}} />);
+    expect(warnSpy).toBeCalledWith(
+      'Warning: `expandedRowRender` and `scroll` are not compatible. Please use one of them at one time.',
+    );
   });
 });


### PR DESCRIPTION
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [x] Other: User friendly tips

### What's the background?

https://github.com/ant-design/ant-design/issues/9900#issuecomment-451866805

### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

cc @afc163 