### PR TITLE
feat: Add mask prop for Modal method

### DIFF
--- a/components/modal/Modal.tsx
+++ b/components/modal/Modal.tsx
@@ -79,6 +79,7 @@ export interface ModalFuncProps {
   icon?: React.ReactNode;
   /* Deperated */
   iconType?: string;
+  mask?: boolean;
   maskClosable?: boolean;
   zIndex?: number;
   okCancel?: boolean;

--- a/components/modal/__tests__/confirm.test.js
+++ b/components/modal/__tests__/confirm.test.js
@@ -168,4 +168,9 @@ describe('Modal.confirm triggers callbacks correctly', () => {
     expect($$('.custom-modal-confirm')).toHaveLength(1);
     expect($$('.custom-modal-confirm-body-wrapper')).toHaveLength(1);
   });
+
+  it('should be Modal.confirm without mask', () => {
+    open({ mask: false });
+    expect($$('.ant-modal-mask')).toHaveLength(0);
+  });
 });

--- a/components/modal/confirm.tsx
+++ b/components/modal/confirm.tsx
@@ -43,6 +43,7 @@ const ConfirmDialog = (props: ConfirmDialogProps) => {
   const okCancel = 'okCancel' in props ? props.okCancel! : true;
   const width = props.width || 416;
   const style = props.style || {};
+  const mask = props.mask === undefined ? true : props.mask;
   // 默认为 false，保持旧版默认行为
   const maskClosable = props.maskClosable === undefined ? false : props.maskClosable;
   const runtimeLocale = getConfirmLocale();
@@ -80,6 +81,7 @@ const ConfirmDialog = (props: ConfirmDialogProps) => {
       transitionName="zoom"
       footer=""
       maskTransitionName="fade"
+      mask={mask}
       maskClosable={maskClosable}
       maskStyle={maskStyle}
       style={style}

--- a/components/modal/index.en-US.md
+++ b/components/modal/index.en-US.md
@@ -71,6 +71,7 @@ The properties of the object are follows:
 | icon | custom icon (`Added in 3.12.0`) | string\|ReactNode | `<Icon type="question-circle">` |
 | iconType | Icon `type` of the Icon component (deperated after `3.12.0`) | string | `question-circle` |
 | keyboard | Whether support press esc to close | Boolean | true |
+| mask | Whether show mask or not. | Boolean | true |
 | maskClosable | Whether to close the modal dialog when the mask (area outside the modal) is clicked | Boolean | `false` |
 | okText | Text of the OK button | string | `OK` |
 | okType | Button `type` of the OK button | string | `primary` |

--- a/components/modal/index.zh-CN.md
+++ b/components/modal/index.zh-CN.md
@@ -69,6 +69,7 @@ title: Modal
 | content | 内容 | string\|ReactNode | 无 |
 | icon | 自定义图标（3.12.0 新增） | string\|ReactNode | `<Icon type="question-circle">` |
 | iconType | 图标类型（3.12.0 后废弃，请使用 `icon`） | string | `question-circle` |
+| mask | 是否展示遮罩 | Boolean | true |
 | maskClosable | 点击蒙层是否允许关闭 | Boolean | `false` |
 | okText | 确认按钮文字 | string | 确定 |
 | okType | 确认按钮类型 | string | primary |


### PR DESCRIPTION
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

- Add `mask` property for Modal method
- Close #14177.
  
### API Realization (Optional if not new feature)

> 1. Basic thought of solution and other optional proposal.

- Pass `mask` prop to `Dialog` component.

> 2. List final API realization and usage sample.

```jsx
import { Modal, Button } from 'antd';

const confirm = Modal.confirm;

function showConfirm() {
  confirm({
    title: 'Do you Want to delete these items?',
    content: 'Some descriptions',
    mask: false, // Display without mask
    onOk() {
      console.log('OK');
    },
    onCancel() {
      console.log('Cancel');
    },
  });
}

ReactDOM.render(
  <div>
    <Button onClick={showConfirm}>
      Confirm
    </Button>
  </div>,
  mountNode
);
```

> 3. GIF or snapshot should be provided if includes UI/interactive modification.
![image](https://user-images.githubusercontent.com/14918822/50846207-8c8d9300-13a9-11e9-9b43-f085b7adaa61.png)


### What's the effect? (Optional if not new feature)

> 1. Does this PR affect user? Which part will be affected?

- No, it will not affect user.

> 2. What will say in changelog?

- 🌟 Add `mask` property for Modal method to set whether show mask or not.
- 🌟 Modal 函数组件新增 `mask` 属性，用于设置遮罩的显示与否。

> 3. Does this PR contains potential break change or other risk?

- No, there is no potential break change or other risk.

### Changelog description (Optional if not new feature)

> 1. English description
- 🌟 Add `mask` property for Modal method to set whether show mask or not.
> 2. Chinese description (optional)
- 🌟 Modal 函数组件新增 `mask` 属性，用于设置遮罩的显示与否。

### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
