### PR TITLE
should not call afterClose when change visible from false to true

### DIFF
--- a/components/tag/__tests__/index.test.js
+++ b/components/tag/__tests__/index.test.js
@@ -35,6 +35,18 @@ describe('Tag', () => {
     expect(wrapper.find('div.ant-tag:not(.ant-tag-hidden)').length).toBe(1);
   });
 
+  it('should not call afterClose when change visible from false to true', () => {
+    const handleAfterClose = jest.fn();
+    const wrapper = mount(<Tag visible afterClose={handleAfterClose} />);
+    wrapper.setProps({ visible: false });
+    jest.runAllTimers();
+    expect(handleAfterClose).toHaveBeenCalled();
+    handleAfterClose.mockRestore();
+    wrapper.setProps({ visible: true });
+    jest.runAllTimers();
+    expect(handleAfterClose).not.toHaveBeenCalled();
+  });
+
   describe('visibility', () => {
     it('can be controlled by visible with visible as initial value', () => {
       const wrapper = mount(<Tag visible />);

--- a/components/tag/index.tsx
+++ b/components/tag/index.tsx
@@ -70,10 +70,12 @@ class Tag extends React.Component<TagProps, TagState> {
     this.setVisible(false, e);
   };
 
-  animationEnd = () => {
-    const { afterClose } = this.props;
-    if (afterClose) {
-      afterClose();
+  animationEnd = (_: string, existed: boolean) => {
+    if (!existed) {
+      const { afterClose } = this.props;
+      if (afterClose) {
+        afterClose();
+      }
     }
   };
 


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

Tag should not call afterClose when change visible from false to true
 
