### PR TITLE
ConfigProvider support `csp` prop

### DIFF
--- a/components/_util/wave.tsx
+++ b/components/_util/wave.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { findDOMNode } from 'react-dom';
 import TransitionEvents from 'css-animation/lib/Event';
 import raf from '../_util/raf';
+import { ConfigConsumer, ConfigConsumerProps, CSPConfig } from '../config-provider';
 
 let styleForPesudo: HTMLStyleElement | null;
 
@@ -23,6 +24,7 @@ export default class Wave extends React.Component<{ insertExtraNode?: boolean }>
   private animationStartId: number;
   private animationStart: boolean = false;
   private destroy: boolean = false;
+  private csp?: CSPConfig;
 
   isNotGrey(color: string) {
     const match = (color || '').match(/rgba?\((\d*), (\d*), (\d*)(, [\.\d]*)?\)/);
@@ -53,6 +55,11 @@ export default class Wave extends React.Component<{ insertExtraNode?: boolean }>
       !/rgba\(\d*, \d*, \d*, 0\)/.test(waveColor) && // any transparent rgba color
       waveColor !== 'transparent'
     ) {
+      // Add nonce if CSP exist
+      if (this.csp && this.csp.nonce) {
+        styleForPesudo.nonce = this.csp.nonce;
+      }
+
       extraNode.style.borderColor = waveColor;
       styleForPesudo.innerHTML = `[ant-click-animating-without-extra-node]:after { border-color: ${waveColor}; }`;
       if (!document.body.contains(styleForPesudo)) {
@@ -169,7 +176,14 @@ export default class Wave extends React.Component<{ insertExtraNode?: boolean }>
     this.destroy = true;
   }
 
+  renderWave = ({ csp }: ConfigConsumerProps) => {
+    const { children } = this.props;
+    this.csp = csp;
+
+    return children;
+  };
+
   render() {
-    return this.props.children;
+    return <ConfigConsumer>{this.renderWave}</ConfigConsumer>;
   }
 }

--- a/components/config-provider/__tests__/csp.test.js
+++ b/components/config-provider/__tests__/csp.test.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import ConfigProvider from '..';
+import Button from '../../button';
+
+describe('ConfigProvider', () => {
+  it('Content Security Policy', () => {
+    const csp = { nonce: 'test-antd' };
+    const wrapper = mount(
+      <ConfigProvider csp={csp}>
+        <Button />
+      </ConfigProvider>,
+    );
+
+    expect(wrapper.find('Wave').instance().csp).toBe(csp);
+  });
+});

--- a/components/config-provider/index.en-US.md
+++ b/components/config-provider/index.en-US.md
@@ -23,6 +23,16 @@ return (
 );
 ```
 
+### Content Security Policy
+
+Some component use dynamic style to support wave effect. You can config `csp` prop if Content Security Policy (CSP) is enabled:
+
+```jsx
+<ConfigProvider csp={{ nonce: 'YourNonceCode' }}>
+  <Button>My Button</Button>
+</ConfigProvider>
+```
+
 ## API
 
 | Property | Description | Type | Default |

--- a/components/config-provider/index.tsx
+++ b/components/config-provider/index.tsx
@@ -5,11 +5,16 @@ import defaultRenderEmpty, { RenderEmptyHandler } from './renderEmpty';
 
 export { RenderEmptyHandler };
 
+export interface CSPConfig {
+  nonce?: string;
+}
+
 export interface ConfigConsumerProps {
   getPopupContainer?: (triggerNode?: HTMLElement) => HTMLElement;
   rootPrefixCls?: string;
   getPrefixCls: (suffixCls: string, customizePrefixCls?: string) => string;
   renderEmpty: RenderEmptyHandler;
+  csp?: CSPConfig;
 }
 
 interface ConfigProviderProps {
@@ -17,6 +22,7 @@ interface ConfigProviderProps {
   prefixCls?: string;
   children?: React.ReactNode;
   renderEmpty?: RenderEmptyHandler;
+  csp?: CSPConfig;
 }
 
 const ConfigContext: Context<ConfigConsumerProps | null> = createReactContext({
@@ -42,11 +48,12 @@ class ConfigProvider extends React.Component<ConfigProviderProps> {
   };
 
   renderProvider = (context: ConfigConsumerProps) => {
-    const { children, getPopupContainer, renderEmpty } = this.props;
+    const { children, getPopupContainer, renderEmpty, csp } = this.props;
 
     const config: ConfigConsumerProps = {
       ...context,
       getPrefixCls: this.getPrefixCls,
+      csp,
     };
 
     if (getPopupContainer) {

--- a/components/config-provider/index.zh-CN.md
+++ b/components/config-provider/index.zh-CN.md
@@ -24,6 +24,16 @@ return (
 );
 ```
 
+### Content Security Policy
+
+部分组件为了支持波纹效果，使用了动态样式。如果开启了 Content Security Policy (CSP)，你可以通过 `csp` 属性来进行配置：
+
+```jsx
+<ConfigProvider csp={{ nonce: 'YourNonceCode' }}>
+  <Button>My Button</Button>
+</ConfigProvider>
+```
+
 ## API
 
 | 参数 | 说明 | 类型 | 默认值 |

--- a/docs/react/faq.en-US.md
+++ b/docs/react/faq.en-US.md
@@ -106,6 +106,10 @@ After 3.9.x [we are using svg icon](/components/icon#svg-icons), so you don't ne
 
 If you need some features which should not be included in antd, try to extend antd's component with [HOC](https://gist.github.com/sebmarkbage/ef0bf1f338a7182b6775). [more](https://medium.com/@dan_abramov/mixins-are-dead-long-live-higher-order-components-94a0d2f9e750#.eeu8q01s1)
 
+### How to fix dynamic style when open Content Security Policy (CSP)?
+
+You can config `nonce` by [ConfigProvider](/components/config-provider/#Content-Security-Policy).
+
 ### How to spell Ant Design correctly?
 
 - ✅ **Ant Design**: Capitalized with space, for the design language.

--- a/docs/react/faq.zh-CN.md
+++ b/docs/react/faq.zh-CN.md
@@ -104,6 +104,10 @@ import { Menu, Breadcrumb, Icon } from 'antd';
 
 如果你需要一些 antd 没有包含的功能，你可以尝试通过 [HOC](https://gist.github.com/sebmarkbage/ef0bf1f338a7182b6775) 拓展 antd 的组件。 [更多](https://medium.com/@dan_abramov/mixins-are-dead-long-live-higher-order-components-94a0d2f9e750#.eeu8q01s1)
 
+### 开启了 Content Security Policy (CSP) 如何处理动态样式？
+
+你可以通过 [ConfigProvider](/components/config-provider/#Content-Security-Policy) 来配置 `nonce` 属性。
+
 ### 如何正确的拼写 Ant Design？
 
 - ✅ **Ant Design**：用空格分隔的首字母大写单词，指代设计语言。


### PR DESCRIPTION
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

#12438
  
### API Realization (Optional if not new feature)

```jsx
<ConfigProvider csp={{ nonce: 'YourNonceCode' }}>
  <Button>My Button</Button>
</ConfigProvider>
```

### What's the effect? (Optional if not new feature)

No affect

### Changelog description (Optional if not new feature)

> 1. ConfigProvider support Content Security Policy (CSP) config
> 2. ConfigProvider 支持 Content Security Policy (CSP) 配置

### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
