### PR TITLE
文档ConfigProvider API错误

### DIFF
--- a/components/config-provider/index.en-US.md
+++ b/components/config-provider/index.en-US.md
@@ -27,6 +27,6 @@ return (
 
 | Property | Description | Type | Default |
 | -------- | ----------- | ---- | ------- |
-| customizeRenderEmpty | set empty content of components. Ref [Empty](/components/empty/) | Function(componentName: string): ReactNode | - |
+| renderEmpty | set empty content of components. Ref [Empty](/components/empty/) | Function(componentName: string): ReactNode | - |
 | getPopupContainer | to set the container of the popup element. The default is to create a `div` element in `body`. | Function(triggerNode) | `() => document.body` |
 | prefixCls | set prefix class | string | ant |

--- a/components/config-provider/index.zh-CN.md
+++ b/components/config-provider/index.zh-CN.md
@@ -28,6 +28,6 @@ return (
 
 | 参数 | 说明 | 类型 | 默认值 |
 | --- | --- | --- | --- |
-| customizeRenderEmpty | 自定义组件空状态。参考 [空状态](/components/empty/) | Function(componentName: string): ReactNode | - |
+| renderEmpty | 自定义组件空状态。参考 [空状态](/components/empty/) | Function(componentName: string): ReactNode | - |
 | getPopupContainer | 弹出框（Select, Tooltip, Menu 等等）渲染父节点，默认渲染到 body 上。 | Function(triggerNode) | () => document.body |
 | prefixCls | 设置统一样式前缀 | string | ant |


### PR DESCRIPTION
### 这个变动的性质是

- [ ] 新特性提交
- [ ] 日常 bug 修复
- [x] 站点、文档改进
- [ ] 组件样式改进
- [ ] TypeScript 定义更新
- [ ] 重构
- [ ] 代码风格优化
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 需求背景

文档存在一处笔误：customizeRenderEmpty => renderEmpty。