### PR TITLE
ts: Extend ListItemProps from native div element attributes

### DIFF
--- a/components/list/Item.tsx
+++ b/components/list/Item.tsx
@@ -5,7 +5,7 @@ import { ListGridType, ColumnType } from './index';
 import { Col } from '../grid';
 import { ConfigConsumer, ConfigConsumerProps } from '../config-provider';
 
-export interface ListItemProps {
+export interface ListItemProps extends React.HTMLAttributes<HTMLDivElement> {
   className?: string;
   children?: React.ReactNode;
   prefixCls?: string;


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

Close #14171.

### Changelog description (Optional if not new feature)

> 1. English description

- 🌟Extend `ListItemProps` from native div element attributes for `List.Item`.

> 2. Chinese description (optional)

- 🌟继承原生的 `div` 元素属性，以扩展 List.Item 属性的 `TypeScript` 类型定义。

### Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
