### PR TITLE
Fix custom filterDropdown trigger sorter

### DIFF
--- a/components/table/__tests__/__snapshots__/Table.filter.test.js.snap
+++ b/components/table/__tests__/__snapshots__/Table.filter.test.js.snap
@@ -31,7 +31,9 @@ exports[`Table.filter renders custom content correctly 1`] = `
   <div
     class="ant-dropdown  ant-dropdown-placement-bottomRight  ant-dropdown-hidden"
   >
-    <div>
+    <div
+      class="ant-table-filter-dropdown"
+    >
       <div
         class="custom-filter-dropdown"
       >

--- a/components/table/demo/custom-filter-panel.md
+++ b/components/table/demo/custom-filter-panel.md
@@ -50,7 +50,7 @@ class App extends React.Component {
     filterDropdown: ({
       setSelectedKeys, selectedKeys, confirm, clearFilters,
     }) => (
-      <div className="custom-filter-dropdown">
+      <div style={{ padding: 8 }}>
         <Input
           ref={node => { this.searchInput = node; }}
           placeholder={`Search ${dataIndex}`}
@@ -128,13 +128,4 @@ class App extends React.Component {
 }
 
 ReactDOM.render(<App />, mountNode);
-````
-
-````css
-.custom-filter-dropdown {
-  padding: 8px;
-  border-radius: 4px;
-  background: #fff;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, .15);
-}
 ````

--- a/components/table/filterDropdown.tsx
+++ b/components/table/filterDropdown.tsx
@@ -247,7 +247,9 @@ export default class FilterMenu<T> extends React.Component<FilterMenuProps<T>, F
     }
 
     const menus = filterDropdown ? (
-      <FilterDropdownMenuWrapper>{filterDropdown}</FilterDropdownMenuWrapper>
+      <FilterDropdownMenuWrapper className={`${prefixCls}-dropdown`}>
+        {filterDropdown}
+      </FilterDropdownMenuWrapper>
     ) : (
       <FilterDropdownMenuWrapper className={`${prefixCls}-dropdown`}>
         <Menu


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

close #14238 

### What's the effect? (Optional if not new feature)

改动后 filterDropdown 会默认带有下拉菜单浮层样式：

1. 可以简化 filterDropdown 的自定义样式负担和规范还原。
2. 使用了 https://ant.design/components/table-cn/#components-table-demo-custom-filter-panel 这个例子的样式的同学，可能会遇到浮层多了一层阴影的问题。按照新的 demo 写法重构即可：https://github.com/ant-design/ant-design/pull/14243/files#r246643015

### Changelog description (Optional if not new feature)

- 🐛 Fixed custom Table `filterDropdown` will trigger sorter behavior. #14238

### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed