### PR TITLE
Statistic support `groupSeparator`

### DIFF
--- a/components/statistic/Number.tsx
+++ b/components/statistic/Number.tsx
@@ -7,7 +7,7 @@ interface NumberProps extends FormatConfig {
 }
 
 const StatisticNumber: React.SFC<NumberProps> = props => {
-  const { value, formatter, precision, decimalSeparator, prefixCls } = props;
+  const { value, formatter, precision, decimalSeparator, groupSeparator = '', prefixCls } = props;
 
   let valueNode: React.ReactNode;
 
@@ -26,7 +26,7 @@ const StatisticNumber: React.SFC<NumberProps> = props => {
       let int = cells[1] || '0';
       let decimal = cells[3] || '';
 
-      int = int.replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+      int = int.replace(/\B(?=(\d{3})+(?!\d))/g, groupSeparator);
 
       if (typeof precision === 'number') {
         decimal = padEnd(decimal, precision, '0').slice(0, precision);

--- a/components/statistic/Statistic.tsx
+++ b/components/statistic/Statistic.tsx
@@ -55,6 +55,7 @@ const Statistic: React.SFC<StatisticProps & ConfigConsumerProps> = props => {
 
 Statistic.defaultProps = {
   decimalSeparator: '.',
+  groupSeparator: ',',
 };
 
 const WrapperStatistic = withConfigConsumer<StatisticProps>({

--- a/components/statistic/__tests__/index.test.js
+++ b/components/statistic/__tests__/index.test.js
@@ -22,6 +22,11 @@ describe('Statistic', () => {
     expect(wrapper.find('.ant-statistic-content-value').text()).toEqual('93');
   });
 
+  it('groupSeparator', () => {
+    const wrapper = mount(<Statistic value={1128} groupSeparator="__TEST__" />);
+    expect(wrapper.find('.ant-statistic-content-value').text()).toEqual('1__TEST__128');
+  });
+
   it('not a number', () => {
     const wrapper = mount(<Statistic value="bamboo" />);
     expect(wrapper.find('.ant-statistic-content-value').text()).toEqual('bamboo');

--- a/components/statistic/index.en-US.md
+++ b/components/statistic/index.en-US.md
@@ -17,8 +17,9 @@ Display statistic number.
 
 | Property | Description | Type | Default |
 | -------- | ----------- | ---- | ------- |
-| decimalSeparator | decimal separator | string | - |
+| decimalSeparator | decimal separator | string | . |
 | formatter | customize value display logic | (value) => ReactNode | - |
+| groupSeparator | group separator | string | , |
 | precision | precision of input value | number | - |
 | prefix | prefix node of value | string \| ReactNode | - |
 | suffix | suffix node of value | string \| ReactNode | - |

--- a/components/statistic/index.zh-CN.md
+++ b/components/statistic/index.zh-CN.md
@@ -18,8 +18,9 @@ title: Statistic
 
 | 参数 | 说明 | 类型 | 默认值 |
 | -------- | ----------- | ---- | ------- |
-| decimalSeparator | 设置小数点 | string | - |
+| decimalSeparator | 设置小数点 | string | . |
 | formatter | 自定义数值展示 | (value) => ReactNode | - |
+| groupSeparator | 设置千分位标识符 | string | , |
 | precision | 数值精度 | number | - |
 | prefix | 设置数值的前缀 | string \| ReactNode | - |
 | suffix | 设置数值的后缀 | string \| ReactNode | - |

--- a/components/statistic/utils.tsx
+++ b/components/statistic/utils.tsx
@@ -15,6 +15,7 @@ export type Formatter =
 export interface FormatConfig {
   formatter?: Formatter;
   decimalSeparator?: string;
+  groupSeparator?: string;
   precision?: number;
   prefixCls?: string;
 }


### PR DESCRIPTION
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

https://github.com/ant-design/ant-design/pull/14154#discussion_r246660805
  
### API Realization (Optional if not new feature)

```jsx
<Statistic value={1128} groupSeparator="'" />
// 1'128
```

### What's the effect? (Optional if not new feature)

No effect

### Changelog description (Optional if not new feature)

This can be merged by #14154

### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
