### PR TITLE
Support 'transitionName' with 'Modal.method' argument

### DIFF
--- a/components/modal/Modal.tsx
+++ b/components/modal/Modal.tsx
@@ -89,6 +89,8 @@ export interface ModalFuncProps {
   keyboard?: boolean;
   getContainer?: (instance: React.ReactInstance) => HTMLElement;
   autoFocusButton?: null | 'ok' | 'cancel';
+  transitionName?: string;
+  maskTransitionName?: string;
 }
 
 export type ModalFunc = (

--- a/components/modal/confirm.tsx
+++ b/components/modal/confirm.tsx
@@ -50,6 +50,8 @@ const ConfirmDialog = (props: ConfirmDialogProps) => {
   const okText = props.okText || (okCancel ? runtimeLocale.okText : runtimeLocale.justOkText);
   const cancelText = props.cancelText || runtimeLocale.cancelText;
   const autoFocusButton = props.autoFocusButton === null ? false : props.autoFocusButton || 'ok';
+  const transitionName = props.transitionName || 'zoom';
+  const maskTransitionName = props.maskTransitionName || 'fade';
 
   const classString = classNames(
     contentPrefixCls,
@@ -78,9 +80,9 @@ const ConfirmDialog = (props: ConfirmDialogProps) => {
       onCancel={close.bind(this, { triggerCancel: true })}
       visible={visible}
       title=""
-      transitionName="zoom"
+      transitionName={transitionName}
       footer=""
-      maskTransitionName="fade"
+      maskTransitionName={maskTransitionName}
       mask={mask}
       maskClosable={maskClosable}
       maskStyle={maskStyle}


### PR DESCRIPTION
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [X] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

> 1. Describe the source of requirement.

I really love AntD so use AntD of my web application. but I can not customizing 'Modal.confirm' transition' effect. (It is available in 'Modal'.)
so I looked around AntD. and rc-modal codes.
And I understood can customize 'transitionName'.

> 2. Resolve what problem.

- Has extend 'transitionName' and 'maskTransitionName' on ModalFuncProps
- Has changed Dialog component props value.

> 3. Related issue link.
  
### API Realization (Optional if not new feature)

> 1. Basic thought of solution and other optional proposal.
> 2. List final API realization and usage sample.
> 3. GIF or snapshot should be provided if includes UI/interactive modification.

### What's the effect? (Optional if not new feature)

> 1. Does this PR affect user? Which part will be affected?
> 2. What will say in changelog?
> 3. Does this PR contains potential break change or other risk?

### Changelog description (Optional if not new feature)

> 1. English description
> 2. Chinese description (optional)

### Self Check before Merge

- [X] Doc is updated/provided or not needed
- [X] Demo is updated/provided or not needed
- [X] TypeScript definition is updated/provided or not needed
- [X] Changelog is provided or not needed

### Additional Plan? (Optional if not new feature)

> If this PR related with other PR or following info. You can type here.

I had a 'PR' last week. (https://github.com/ant-design/ant-design/pull/14052)
I do not check my email and send 'PR' again.
