### PR TITLE
Translate Input.Password properties

### DIFF
--- a/components/input/index.en-US.md
+++ b/components/input/index.en-US.md
@@ -77,6 +77,6 @@ Supports all props of `Input`.
 
 #### Input.Password (Added in 3.12.0)
 
-| 参数 | 说明 | 类型 | 默认值 |
+| Property | Description | Type | Default |
 | --- | --- | --- | --- |
 | visibilityToggle | Whether show toggle button | boolean | true |


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

The properties of Input.Password were in Chinese so I translated them to English.

### Changelog description

Translated table of properties for Input.Password

### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
