### PR TITLE
Make contributing easier

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,8 @@
+ports:
+- port: 8001
+  onOpen: open-preview
+tasks:
+- before: >
+    export DEV_HOST=$(gp url 8001)
+  init: npm install
+  command: npm start

--- a/README.md
+++ b/README.md
@@ -100,6 +100,12 @@ See [i18n](http://ant.design/docs/react/i18n).
 
 ## ⌨️ Development
 
+Use Gitpod, a free online dev environment for GitHub.
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/ant-design/ant-design)
+
+Or clone locally:
+
 ```bash
 $ git clone git@github.com:ant-design/ant-design.git
 $ cd ant-design

--- a/site/bisheng.config.js
+++ b/site/bisheng.config.js
@@ -123,6 +123,11 @@ module.exports = {
     return config;
   },
 
+  devServerConfig: {
+    public: process.env.DEV_HOST || 'localhost',
+    disableHostCheck: !!process.env.DEV_HOST,
+  },
+
   htmlTemplateExtraData: {
     isDev,
     usePreact,


### PR DESCRIPTION
### This is a ...
 - [x] Other: Proposal

### What's the background?

This PR simplifies contributions and playing around with the ant-design code base, by adding support for Gitpod a free online dev environment for GitHub with good Typescript support.
I configured it so that it automatically runs
```
npm install
npm start
```
Also port 8001 is exposed and the website will be opened in a preview (see below).

You can use Gitpod for code reviews as well. Just go to a PR and prefix the URL with 'https://gitpod.io/#'. A workspace with the PR changes will be started and open in a code review mode (you can comment and submit reviews within in the IDE)

To get an idea of how Gitpod feels, please try this snapshot:

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io#snapshot/82201d39-c4e8-4804-a1f4-220ac7d4c3b0)

<img width="1532" alt="screenshot 2019-01-13 at 12 58 56" src="https://user-images.githubusercontent.com/372735/51085130-1f755700-1735-11e9-8122-c7679e4e2328.png">

### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed