### PR TITLE
FIX: correct TypeScript definition for EmptyProps in Empty Component

### DIFF
--- a/components/empty/index.tsx
+++ b/components/empty/index.tsx
@@ -11,8 +11,8 @@ export interface EmptyProps {
   prefixCls?: string;
   className?: string;
   style?: React.CSSProperties;
-  image?: string;
-  description?: React.ReactNode;
+  image?: string | React.ReactNode;
+  description?: string | React.ReactNode;
   children?: React.ReactNode;
 }
 


### PR DESCRIPTION
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

> 1. Describe the source of requirement.
Can't use <Empty /> with <Icon /> in TypeScript.
> 2. Resolve what problem.
Correct the typings for `image` and `description` to `string | ReactNode` 
> 3. Related issue link.
https://github.com/ant-design/ant-design/issues/14308
  
### API Realization (Optional if not new feature)

> 1. Basic thought of solution and other optional proposal.
> 2. List final API realization and usage sample.
> 3. GIF or snapshot should be provided if includes UI/interactive modification.

### Changelog description (Optional if not new feature)

> 1. English description
> 2. Chinese description (optional)

### Self Check before Merge

- [x] Doc is not needed
- [x] Demo is not needed
- [x] TypeScript definition is updated
- [x] Changelog is not needed

### Additional Plan? (Optional if not new feature)

> If this PR related with other PR or following info. You can type here.
https://github.com/ant-design/ant-design/issues/14308