### PR TITLE
Fix slider focus style

### DIFF
--- a/components/style/themes/default.less
+++ b/components/style/themes/default.less
@@ -505,7 +505,7 @@
 @slider-handle-color: @primary-3;
 @slider-handle-color-hover: @primary-4;
 @slider-handle-color-focus: tint(@primary-color, 20%);
-@slider-handle-color-focus-shadow: tint(@primary-color, 50%);
+@slider-handle-color-focus-shadow: fade(@primary-color, 20%);
 @slider-handle-color-tooltip-open: @primary-color;
 @slider-dot-border-color: @border-color-split;
 @slider-dot-border-color-active: tint(@primary-color, 50%);


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

Slider focus style became ugly:

<img width="155" alt="default" src="https://user-images.githubusercontent.com/507615/51122686-5d699c80-1855-11e9-8cad-fe22f4e0a5e0.png">
  
### What's the effect? (Optional if not new feature)

Fix to:

<img width="154" alt="default" src="https://user-images.githubusercontent.com/507615/51122835-b802f880-1855-11e9-9a1c-efeef487912d.png">

### Changelog description (Optional if not new feature)

- 🐛 Fix Slider focus shadow style.

### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed