### PR TITLE
Fix the bug that radio onChange will be overide by radioGroup onChange

### DIFF
--- a/components/radio/__tests__/group.test.js
+++ b/components/radio/__tests__/group.test.js
@@ -70,9 +70,10 @@ describe('Radio', () => {
 
   it('both of radio and radioGroup will trigger onchange event when they exists', () => {
     const onChange = jest.fn();
+    const onChangeRadioGroup = jest.fn();
 
     const wrapper = mount(
-      <RadioGroup onChange={onChange}>
+      <RadioGroup onChange={onChangeRadioGroup}>
         <Radio value="A" onChange={onChange}>
           A
         </Radio>
@@ -89,12 +90,13 @@ describe('Radio', () => {
     // uncontrolled component
     wrapper.setState({ value: 'B' });
     radios.at(0).simulate('change');
-    expect(onChange.mock.calls.length).toBe(2);
+    expect(onChange.mock.calls.length).toBe(1);
+    expect(onChangeRadioGroup.mock.calls.length).toBe(1);
 
     // controlled component
     wrapper.setProps({ value: 'A' });
     radios.at(1).simulate('change');
-    expect(onChange.mock.calls.length).toBe(4);
+    expect(onChange.mock.calls.length).toBe(2);
   });
 
   it("won't fire change events when value not changes", () => {

--- a/components/radio/__tests__/group.test.js
+++ b/components/radio/__tests__/group.test.js
@@ -68,6 +68,35 @@ describe('Radio', () => {
     expect(onChange.mock.calls.length).toBe(2);
   });
 
+  it('both of radio and radioGroup will trigger onchange event when they exists', () => {
+    const onChange = jest.fn();
+
+    const wrapper = mount(
+      <RadioGroup onChange={onChange}>
+        <Radio value="A" onChange={onChange}>
+          A
+        </Radio>
+        <Radio value="B" onChange={onChange}>
+          B
+        </Radio>
+        <Radio value="C" onChange={onChange}>
+          C
+        </Radio>
+      </RadioGroup>,
+    );
+    const radios = wrapper.find('input');
+
+    // uncontrolled component
+    wrapper.setState({ value: 'B' });
+    radios.at(0).simulate('change');
+    expect(onChange.mock.calls.length).toBe(2);
+
+    // controlled component
+    wrapper.setProps({ value: 'A' });
+    radios.at(1).simulate('change');
+    expect(onChange.mock.calls.length).toBe(4);
+  });
+
   it("won't fire change events when value not changes", () => {
     const onChange = jest.fn();
 

--- a/components/radio/radio.tsx
+++ b/components/radio/radio.tsx
@@ -49,8 +49,8 @@ export default class Radio extends React.Component<RadioProps, {}> {
       this.props.onChange(e);
     }
 
-    if (this.context.onChange) {
-      this.context.onChange(e);
+    if (this.context.radioGroup.onChange) {
+      this.context.radioGroup.onChange(e);
     }
   };
 
@@ -60,9 +60,10 @@ export default class Radio extends React.Component<RadioProps, {}> {
     const { radioGroup } = context;
     const prefixCls = getPrefixCls('radio', customizePrefixCls);
     const radioProps: RadioProps = { ...restProps };
-    radioProps.onChange = this.onChange;
     if (radioGroup) {
       radioProps.name = radioGroup.name;
+      // radioProps.onChange = radioGroup.onChange;
+      radioProps.onChange = this.onChange;
       radioProps.checked = props.value === radioGroup.value;
       radioProps.disabled = props.disabled || radioGroup.disabled;
     }

--- a/components/radio/radio.tsx
+++ b/components/radio/radio.tsx
@@ -49,7 +49,7 @@ export default class Radio extends React.Component<RadioProps, {}> {
       this.props.onChange(e);
     }
 
-    if (this.context.radioGroup.onChange) {
+    if (this.context.radioGroup && this.context.radioGroup.onChange) {
       this.context.radioGroup.onChange(e);
     }
   };

--- a/components/radio/radio.tsx
+++ b/components/radio/radio.tsx
@@ -5,7 +5,7 @@ import classNames from 'classnames';
 import shallowEqual from 'shallowequal';
 import RadioGroup from './group';
 import RadioButton from './radioButton';
-import { RadioProps, RadioGroupContext } from './interface';
+import { RadioProps, RadioChangeEvent, RadioGroupContext } from './interface';
 import { ConfigConsumer, ConfigConsumerProps } from '../config-provider';
 
 export default class Radio extends React.Component<RadioProps, {}> {
@@ -44,15 +44,25 @@ export default class Radio extends React.Component<RadioProps, {}> {
     this.rcCheckbox = node;
   };
 
+  onChange = (e: RadioChangeEvent) => {
+    if (this.props.onChange) {
+      this.props.onChange(e);
+    }
+
+    if (this.context.onChange) {
+      this.context.onChange(e);
+    }
+  };
+
   renderRadio = ({ getPrefixCls }: ConfigConsumerProps) => {
     const { props, context } = this;
     const { prefixCls: customizePrefixCls, className, children, style, ...restProps } = props;
     const { radioGroup } = context;
     const prefixCls = getPrefixCls('radio', customizePrefixCls);
     const radioProps: RadioProps = { ...restProps };
+    radioProps.onChange = this.onChange;
     if (radioGroup) {
       radioProps.name = radioGroup.name;
-      radioProps.onChange = radioGroup.onChange;
       radioProps.checked = props.value === radioGroup.value;
       radioProps.disabled = props.disabled || radioGroup.disabled;
     }

--- a/components/radio/radio.tsx
+++ b/components/radio/radio.tsx
@@ -62,7 +62,6 @@ export default class Radio extends React.Component<RadioProps, {}> {
     const radioProps: RadioProps = { ...restProps };
     if (radioGroup) {
       radioProps.name = radioGroup.name;
-      // radioProps.onChange = radioGroup.onChange;
       radioProps.onChange = this.onChange;
       radioProps.checked = props.value === radioGroup.value;
       radioProps.disabled = props.disabled || radioGroup.disabled;


### PR DESCRIPTION
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

> 1. Describe the source of requirement.
> 2. Resolve what problem.
Fix https://github.com/ant-design/ant-design/issues/14353
> 3. Related issue link.
  
### API Realization (Optional if not new feature)

> 1. Basic thought of solution and other optional proposal.
> 2. List final API realization and usage sample.
> 3. GIF or snapshot should be provided if includes UI/interactive modification.

### What's the effect? (Optional if not new feature)

> 1. Does this PR affect user? Which part will be affected?
> 2. What will say in changelog?
Fix the bug that radio onChange will be ovrride by radioGroup onChange
修复 radio 的 onChange 事件会被 radioGroup 的 onChange 事件覆盖的 bug
> 3. Does this PR contains potential break change or other risk?

### Changelog description (Optional if not new feature)

> 1. English description
> 2. Chinese description (optional)

### Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

### Additional Plan? (Optional if not new feature)

> If this PR related with other PR or following info. You can type here.
