### PR TITLE
update rc-tabs to support customize node

### DIFF
--- a/components/tabs/TabBar.tsx
+++ b/components/tabs/TabBar.tsx
@@ -50,6 +50,7 @@ export default class TabBar extends React.Component<TabsProps> {
 
     const renderProps = {
       ...this.props,
+      children: null,
       inkBarAnimated,
       extraContent: tabBarExtraContent,
       style: tabBarStyle,

--- a/components/tabs/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/tabs/__tests__/__snapshots__/demo.test.js.snap
@@ -829,6 +829,135 @@ exports[`renders ./components/tabs/demo/custom-tab-bar.md correctly 1`] = `
 </div>
 `;
 
+exports[`renders ./components/tabs/demo/custom-tab-bar-node.md correctly 1`] = `
+<div
+  class="ant-tabs ant-tabs-top ant-tabs-line"
+>
+  <div
+    class="ant-tabs-bar ant-tabs-top-bar"
+    role="tablist"
+    tabindex="0"
+  >
+    <div
+      class="ant-tabs-nav-container"
+    >
+      <span
+        class="ant-tabs-tab-prev ant-tabs-tab-btn-disabled"
+        unselectable="unselectable"
+      >
+        <span
+          class="ant-tabs-tab-prev-icon"
+        >
+          <i
+            aria-label="icon: left"
+            class="anticon anticon-left ant-tabs-tab-prev-icon-target"
+          >
+            <svg
+              aria-hidden="true"
+              class=""
+              data-icon="left"
+              fill="currentColor"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M724 218.3V141c0-6.7-7.7-10.4-12.9-6.3L260.3 486.8a31.86 31.86 0 0 0 0 50.3l450.8 352.1c5.3 4.1 12.9.4 12.9-6.3v-77.3c0-4.9-2.3-9.6-6.1-12.6l-360-281 360-281.1c3.8-3 6.1-7.7 6.1-12.6z"
+              />
+            </svg>
+          </i>
+        </span>
+      </span>
+      <span
+        class="ant-tabs-tab-next ant-tabs-tab-btn-disabled"
+        unselectable="unselectable"
+      >
+        <span
+          class="ant-tabs-tab-next-icon"
+        >
+          <i
+            aria-label="icon: right"
+            class="anticon anticon-right ant-tabs-tab-next-icon-target"
+          >
+            <svg
+              aria-hidden="true"
+              class=""
+              data-icon="right"
+              fill="currentColor"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M765.7 486.8L314.9 134.7A7.97 7.97 0 0 0 302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 0 0 0-50.4z"
+              />
+            </svg>
+          </i>
+        </span>
+      </span>
+      <div
+        class="ant-tabs-nav-wrap"
+      >
+        <div
+          class="ant-tabs-nav-scroll"
+        >
+          <div
+            class="ant-tabs-nav ant-tabs-nav-animated"
+          >
+            <div />
+            <div
+              class="ant-tabs-ink-bar ant-tabs-ink-bar-animated"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    role="presentation"
+    style="width:0;height:0;overflow:hidden;position:absolute"
+    tabindex="0"
+  />
+  <div
+    class="ant-tabs-content ant-tabs-content-animated ant-tabs-top-content"
+    style="margin-left:0%"
+  >
+    <div
+      aria-hidden="false"
+      class="ant-tabs-tabpane ant-tabs-tabpane-active"
+      role="tabpanel"
+    >
+      <div
+        role="presentation"
+        style="width:0;height:0;overflow:hidden;position:absolute"
+        tabindex="0"
+      />
+      Content of Tab Pane 1
+      <div
+        role="presentation"
+        style="width:0;height:0;overflow:hidden;position:absolute"
+        tabindex="0"
+      />
+    </div>
+    <div
+      aria-hidden="true"
+      class="ant-tabs-tabpane ant-tabs-tabpane-inactive"
+      role="tabpanel"
+    />
+    <div
+      aria-hidden="true"
+      class="ant-tabs-tabpane ant-tabs-tabpane-inactive"
+      role="tabpanel"
+    />
+  </div>
+  <div
+    role="presentation"
+    style="width:0;height:0;overflow:hidden;position:absolute"
+    tabindex="0"
+  />
+</div>
+`;
+
 exports[`renders ./components/tabs/demo/disabled.md correctly 1`] = `
 <div
   class="ant-tabs ant-tabs-top ant-tabs-line"

--- a/components/tabs/demo/custom-tab-bar-node.md
+++ b/components/tabs/demo/custom-tab-bar-node.md
@@ -1,0 +1,135 @@
+---
+order: 13
+title:
+  zh-CN: 可拖拽标签
+  en-US: Draggable Tabs
+---
+
+## zh-CN
+
+使用 `react-dnd` 实现标签可拖拽。
+
+## en-US
+
+Use `react-dnd` to make tabs draggable.
+
+````jsx
+import { Tabs } from 'antd';
+import { DragDropContextProvider, DragSource, DropTarget } from 'react-dnd';
+import HTML5Backend from 'react-dnd-html5-backend';
+import update from 'immutability-helper';
+
+const TabPane = Tabs.TabPane;
+
+// Drag & Drop node
+class TabNode extends React.Component {
+  render() {
+		const {
+			connectDragSource,
+      connectDropTarget,
+      children,
+		} = this.props
+
+		return connectDragSource(
+			connectDropTarget(children),
+    );
+	}
+}
+
+const cardTarget = {
+  drop(props, monitor) {
+    const dragKey = monitor.getItem().index;
+    const hoverKey = props.index;
+
+    if (dragKey === hoverKey) {
+      return;
+    }
+
+    props.moveTabNode(dragKey, hoverKey);
+    monitor.getItem().index = hoverKey;
+  },
+};
+
+const cardSource = {
+	beginDrag(props) {
+		return {
+			id: props.id,
+			index: props.index,
+		}
+	},
+};
+
+const WrapTabNode = DropTarget(
+	'DND_NODE',
+	cardTarget,
+	(connect) => ({
+		connectDropTarget: connect.dropTarget(),
+	}),
+)(
+	DragSource(
+		'DND_NODE',
+		cardSource,
+		(connect, monitor) => ({
+			connectDragSource: connect.dragSource(),
+			isDragging: monitor.isDragging(),
+		}),
+	)(TabNode),
+);
+
+// Demo
+class Demo extends React.Component {
+  state = {
+    activeKey: '1',
+    tabs: ['1', '2', '3'],
+  };
+
+  onChange = (activeKey) => {
+    console.log(`onChange ${activeKey}`);
+    this.setState({
+      activeKey,
+    });
+  }
+
+  moveTabNode = (dragKey, hoverKey) => {
+    const { tabs } = this.state;
+    const dragIndex = tabs.indexOf(dragKey);
+    const hoverIndex = tabs.indexOf(hoverKey);
+    const dragTab = this.state.tabs[dragIndex];
+    this.setState(
+			update(this.state, {
+				tabs: {
+					$splice: [[dragIndex, 1], [hoverIndex, 0, dragTab]],
+				},
+			}),
+		);
+  };
+
+  renderTabBar = (props, DefaultTabBar) => (
+    <DefaultTabBar {...props}>
+      {node => (
+        <WrapTabNode key={node.key} index={node.key} moveTabNode={this.moveTabNode}>{node}</WrapTabNode>
+      )}
+    </DefaultTabBar>
+  );
+
+  render() {
+    return (
+      <DragDropContextProvider backend={HTML5Backend}>
+        <Tabs
+          renderTabBar={this.renderTabBar}
+          activeKey={this.state.activeKey}
+          onChange={this.onChange}
+        >
+          {this.state.tabs.map(id => (
+            <TabPane tab={`tab ${id}`} key={id}>
+              Content of Tab Pane {id}
+            </TabPane>
+          ))}
+        </Tabs>
+      </DragDropContextProvider>
+    );
+  }
+}
+
+ReactDOM.render(<Demo />, mountNode);
+````

--- a/components/tabs/demo/custom-tab-bar-node.md
+++ b/components/tabs/demo/custom-tab-bar-node.md
@@ -17,7 +17,6 @@ Use `react-dnd` to make tabs draggable.
 import { Tabs } from 'antd';
 import { DragDropContextProvider, DragSource, DropTarget } from 'react-dnd';
 import HTML5Backend from 'react-dnd-html5-backend';
-import update from 'immutability-helper';
 
 const TabPane = Tabs.TabPane;
 
@@ -76,32 +75,30 @@ const WrapTabNode = DropTarget(
 	)(TabNode),
 );
 
-// Demo
-class Demo extends React.Component {
+class DraggableTabs extends React.Component {
   state = {
-    activeKey: '1',
-    tabs: ['1', '2', '3'],
+    order: [],
   };
 
-  onChange = (activeKey) => {
-    console.log(`onChange ${activeKey}`);
-    this.setState({
-      activeKey,
-    });
-  }
-
   moveTabNode = (dragKey, hoverKey) => {
-    const { tabs } = this.state;
-    const dragIndex = tabs.indexOf(dragKey);
-    const hoverIndex = tabs.indexOf(hoverKey);
-    const dragTab = this.state.tabs[dragIndex];
-    this.setState(
-			update(this.state, {
-				tabs: {
-					$splice: [[dragIndex, 1], [hoverIndex, 0, dragTab]],
-				},
-			}),
-		);
+    const newOrder = this.state.order.slice();
+    const { children } = this.props;
+
+    React.Children.forEach(children, (c) => {
+      if (newOrder.indexOf(c.key) === -1) {
+        newOrder.push(c.key);
+      }
+    });
+
+    const dragIndex = newOrder.indexOf(dragKey);
+    const hoverIndex = newOrder.indexOf(hoverKey);
+
+    newOrder.splice(dragIndex, 1);
+    newOrder.splice(hoverIndex, 0, dragKey);
+
+    this.setState({
+      order: newOrder,
+    });
   };
 
   renderTabBar = (props, DefaultTabBar) => (
@@ -113,23 +110,58 @@ class Demo extends React.Component {
   );
 
   render() {
+    const { order } = this.state;
+    const { children } = this.props;
+
+    const tabs = [];
+    React.Children.forEach(children, (c) => {
+      tabs.push(c);
+    });
+
+    const orderTabs = tabs.slice().sort((a, b) => {
+      const orderA = order.indexOf(a.key);
+      const orderB = order.indexOf(b.key);
+
+      if (orderA !== -1 && orderB !== -1) {
+        return orderA - orderB;
+      }
+      if (orderA !== -1) {
+        return -1;
+      }
+      if (orderB !== -1) {
+        return 1;
+      }
+
+      const ia = tabs.indexOf(a);
+      const ib = tabs.indexOf(b);
+
+      return ia - ib;
+    });
+
     return (
       <DragDropContextProvider backend={HTML5Backend}>
         <Tabs
           renderTabBar={this.renderTabBar}
-          activeKey={this.state.activeKey}
-          onChange={this.onChange}
+          {...this.props}
         >
-          {this.state.tabs.map(id => (
-            <TabPane tab={`tab ${id}`} key={id}>
-              Content of Tab Pane {id}
-            </TabPane>
-          ))}
+          {orderTabs}
         </Tabs>
       </DragDropContextProvider>
     );
   }
 }
 
-ReactDOM.render(<Demo />, mountNode);
+ReactDOM.render(
+  <DraggableTabs>
+    <TabPane tab="tab 1" key="1">
+      Content of Tab Pane 1
+    </TabPane>
+    <TabPane tab="tab 2" key="2">
+      Content of Tab Pane 2
+    </TabPane>
+    <TabPane tab="tab 3" key="3">
+      Content of Tab Pane 3
+    </TabPane>
+  </DraggableTabs>
+, mountNode);
 ````

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "rc-steps": "~3.3.0",
     "rc-switch": "~1.8.0",
     "rc-table": "~6.4.0",
-    "rc-tabs": "~9.5.2",
+    "rc-tabs": "~9.6.0",
     "rc-time-picker": "~3.5.0",
     "rc-tooltip": "~3.7.3",
     "rc-tree": "~1.14.6",


### PR DESCRIPTION
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

#9990
  
### API Realization (Optional if not new feature)

```jsx
<Tabs
  renderTabBar={(props, DefaultTabBar) => (
    <DefaultTabBar {...props}>
      {node => node}
    </DefaultTabBar>
  )}
>
  {/* ... */}
</Tabs>
```

### What's the effect? (Optional if not new feature)

1. Not effect for current usage.
2. User can customize node rendering.

### Changelog description (Optional if not new feature)

* Tabs support customize bar node.
* Tabs 支持自定义标签节点。

### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed