### PR TITLE
add radius on table-placeholder to fix table small size border clip

### DIFF
--- a/components/table/style/index.less
+++ b/components/table/style/index.less
@@ -388,6 +388,7 @@
     position: relative;
     padding: @table-padding-vertical @table-padding-horizontal;
     background: @component-background;
+    border-radius: @border-radius-base;
     border-bottom: @border-width-base @border-style-base @border-color-split;
     text-align: center;
     font-size: @font-size-base;


### PR DESCRIPTION
fix #14388

First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

fix #14388
 
### What's the effect? (Optional if not new feature)

None

### Changelog description (Optional if not new feature)

1. Fix Table empty style when `size="small"`.
2. 修复 Table 在 `size="small"` 的 empty 样式问题。

### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
