### PR TITLE
fix prefixCls of empty go to div

### DIFF
--- a/components/empty/index.tsx
+++ b/components/empty/index.tsx
@@ -19,8 +19,15 @@ export interface EmptyProps {
 const Empty: React.SFC<EmptyProps> = (props: EmptyProps) => (
   <ConfigConsumer>
     {({ getPrefixCls }: ConfigConsumerProps) => {
-      const { className, image, description, children, ...restProps } = props;
-      const prefixCls = getPrefixCls('empty', props.prefixCls);
+      const {
+        className,
+        prefixCls: customizePrefixCls,
+        image,
+        description,
+        children,
+        ...restProps
+      } = props;
+      const prefixCls = getPrefixCls('empty', customizePrefixCls);
 
       return (
         <LocaleReceiver componentName="Empty">


### PR DESCRIPTION
close #14403

First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

fix #14403
  
### Changelog description (Optional if not new feature)

1. Fix `prefixCls` prop pass to Empty div.
2. 修复 `prefixCls` 属性被传递到了 Empty 元素上。

### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
