### PR TITLE
feat: add getDropdownContainer prop

### DIFF
--- a/components/table/Table.tsx
+++ b/components/table/Table.tsx
@@ -84,6 +84,7 @@ export default class Table<T> extends React.Component<TableProps<T>, TableState<
     onChange: PropTypes.func,
     locale: PropTypes.object,
     dropdownPrefixCls: PropTypes.string,
+    getDropdownContainer: PropTypes.func,
     sortDirections: PropTypes.array,
   };
 
@@ -726,6 +727,9 @@ export default class Table<T> extends React.Component<TableProps<T>, TableState<
   };
 
   getPopupContainer = () => {
+    if (this.props.getDropdownContainer) {
+      return this.props.getDropdownContainer(this);
+    }
     return ReactDOM.findDOMNode(this) as HTMLElement;
   };
 

--- a/components/table/index.en-US.md
+++ b/components/table/index.en-US.md
@@ -55,6 +55,7 @@ const columns = [{
 | bordered | Whether to show all table borders | boolean | `false` |
 | childrenColumnName | The column contains children to display | string\[] | children |
 | columns | Columns of table | [ColumnProps](https://git.io/vMMXC)\[] | - |
+| getDropdownContainer | Dropdown container | (table: Table<T>) => HTMLElement | - |
 | components | Override default table elements | [TableComponents](https://git.io/fANxz) | - |
 | dataSource | Data record array to be displayed | any\[] | - |
 | defaultExpandAllRows | Expand all rows initially | boolean | `false` |

--- a/components/table/index.zh-CN.md
+++ b/components/table/index.zh-CN.md
@@ -60,6 +60,7 @@ const columns = [{
 | bordered | 是否展示外边框和列边框 | boolean | false |
 | childrenColumnName | 指定树形结构的列名 | string\[] | children |
 | columns | 表格列的配置描述，具体项见下表 | [ColumnProps](https://git.io/vMMXC)\[] | - |
+| getDropdownContainer | 弹出框的容器 | (table: Table<T>) => HTMLElement | - |
 | components | 覆盖默认的 table 元素 | [TableComponents](https://git.io/fANxz) | - |
 | dataSource | 数据数组 | any\[] |  |
 | defaultExpandAllRows | 初始时，是否展开所有行 | boolean | false |

--- a/components/table/interface.tsx
+++ b/components/table/interface.tsx
@@ -4,6 +4,7 @@ import { Store } from './createStore';
 import { RadioChangeEvent } from '../radio';
 import { CheckboxChangeEvent } from '../checkbox';
 import { PaginationConfig } from '../pagination';
+import Table from './Table';
 export { PaginationConfig } from '../pagination';
 
 export type CompareFn<T> = ((a: T, b: T, sortOrder?: SortOrder) => number);
@@ -123,6 +124,7 @@ export interface TableCurrentDataSource<T> {
 export interface TableProps<T> {
   prefixCls?: string;
   dropdownPrefixCls?: string;
+  getDropdownContainer?: (table: Table<T>) => HTMLElement;
   rowSelection?: TableRowSelection<T>;
   pagination?: PaginationConfig | false;
   size?: TableSize;


### PR DESCRIPTION
### This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

ISSUE: #11730 
The table filter dropdown rendered in table wrapper `div`. If table height is too low with many filter items, and the table parent element has a `overflow: hidden`. The filter dropdown would be hidden.
  
表格的筛选列表是直接渲染在 Table 组件的 div 容器上。如果表格高度很低并且筛选有很多属性，并且表格的父元素有一个 `overflow: hidden` 属性，那么筛选列表会被隐藏。
典型的例子就是 Table 组件在 Tab 组件中。

### API Realization (Optional if not new feature)

I added a new prop in `TableProps` called `getDropdownContainer`. looks like:
添加一个新的属性，叫做 `getDropdownContainer`，如下：

```type
interface TableProps<T> {
  // ...others
  getDropdownContainer?: (table: Table<T>) => HTMLElement
}
```

You can use this prop to control where is dropdown render to.
你可以用这个属性控制弹出框在哪里渲染。

Why is `table` param here? Somtime times, You just want to render dropdown into table parent dom element rather than `document.body`.
问什么需要 table 参数呢？因为有时候仅仅想将弹出框渲染到表格组件的父级容器中，和表格组件并列。而不是渲染到 `document.body` 中。

### What's the effect? (Optional if not new feature)

If you don't use this new prop, nothing effect.
你不用就没影响

### Changelog description (Optional if not new feature)

English:
Add a new prop `getDropdownContainer` in `Table`.

Chinese:
Table 组件添加了 `getDropdownContainer` 参数

### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
