### PR TITLE
Fix rowKey usages in List

### DIFF
--- a/components/list/index.tsx
+++ b/components/list/index.tsx
@@ -97,8 +97,8 @@ export default class List extends React.Component<ListProps> {
     };
   }
 
-  renderItem = (item: React.ReactElement<any>, index: number) => {
-    const { dataSource, renderItem, rowKey } = this.props;
+  renderItem = (item: any, index: number) => {
+    const { renderItem, rowKey } = this.props;
     let key;
 
     if (typeof rowKey === 'function') {

--- a/components/list/index.tsx
+++ b/components/list/index.tsx
@@ -102,11 +102,11 @@ export default class List extends React.Component<ListProps> {
     let key;
 
     if (typeof rowKey === 'function') {
-      key = rowKey(dataSource[index]);
+      key = rowKey(item);
     } else if (typeof rowKey === 'string') {
-      key = dataSource[rowKey];
+      key = item[rowKey];
     } else {
-      key = dataSource.key;
+      key = item.key;
     }
 
     if (!key) {


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

The `rowKey` attributes works weird in `List`.

#### 1. When `rowKey` is a function

Why get the item from `dataSource` when `item` is already in the arguments? Especially `dataSource` maybe splitted as `splitDataSource`. The `index` received in this function may not be the actual index in the `dataSource`.

#### 2. When `rowKey` is a `string`

`dataSource` is the array of all the items, right?

What does it even mean by assigning the key of one specific item to `dataSource[rowKey]`, which are highly possible to be `undefined`?

Since there also lacks the doc about how to use string `rowKey`, i would guess it means an attribute in the corresponding item, say `rowKey="id"` then `key={item.id}`.

So I update it to `item[rowKey]`

#### 3. When `rowKey` is anything else

Same, what does `dataSource.key` mean when `dataSource` is an array of all items?

I would guess you would like to set the `key` to the attibute `key` in the item. Then it should be `item.key`

#### Disclaimer
Since there is no detailed documentation about how to use `rowKey`, all the above fixes are based on my understanding of the source code. Please let me know how it actually works if my guess is wrong.

### Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
