### PR TITLE
Add sentry in ant.design

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
   },
   "devDependencies": {
     "@ant-design/colors": "^2.0.0",
+    "@sentry/browser": "^4.5.2",
     "@types/classnames": "^2.2.6",
     "@types/prop-types": "^15.5.6",
     "@types/react": "~16.7.13",

--- a/site/theme/template/Layout/SentryBoundary.jsx
+++ b/site/theme/template/Layout/SentryBoundary.jsx
@@ -1,0 +1,31 @@
+import React, { Component } from 'react';
+import * as Sentry from '@sentry/browser';
+
+Sentry.init({
+  dsn: 'https://2a2c2568315846dab9083a32e37f61fc@sentry.io/1375737',
+});
+
+export default class SentryBoundary extends Component {
+  state = { error: null };
+
+  componentDidCatch(error, errorInfo) {
+    this.setState({ error });
+    Sentry.withScope(scope => {
+      Object.keys(errorInfo).forEach(key => {
+        scope.setExtra(key, errorInfo[key]);
+      });
+      Sentry.captureException(error);
+    });
+  }
+
+  render() {
+    const { children } = this.props;
+    const { error } = this.state;
+    if (error) {
+      // render fallback UI
+      return <a onClick={() => Sentry.showReportDialog()}>Report feedback</a>;
+    }
+    // when there's not an error, render children untouched
+    return children;
+  }
+}

--- a/site/theme/template/Layout/SentryBoundary.jsx
+++ b/site/theme/template/Layout/SentryBoundary.jsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import * as Sentry from '@sentry/browser';
 
 Sentry.init({
-  dsn: 'https://2a2c2568315846dab9083a32e37f61fc@sentry.io/1375737',
+  dsn: 'https://41977dd48e5b4da2aa3600ccbe7dda6d@sentry.io/1375756',
 });
 
 export default class SentryBoundary extends Component {

--- a/site/theme/template/Layout/index.jsx
+++ b/site/theme/template/Layout/index.jsx
@@ -7,6 +7,7 @@ import 'moment/locale/zh-cn';
 import { LocaleProvider } from 'antd';
 import zhCN from 'antd/lib/locale-provider/zh_CN';
 import Header from './Header';
+import SentryBoundary from './SentryBoundary';
 import enLocale from '../../en-US';
 import cnLocale from '../../zh-CN';
 import * as utils from '../utils';
@@ -95,14 +96,16 @@ export default class Layout extends React.Component {
     const { appLocale } = this.state;
 
     return (
-      <IntlProvider locale={appLocale.locale} messages={appLocale.messages}>
-        <LocaleProvider locale={appLocale.locale === 'zh-CN' ? zhCN : null}>
-          <div className="page-wrapper">
-            <Header {...restProps} />
-            {children}
-          </div>
-        </LocaleProvider>
-      </IntlProvider>
+      <SentryBoundary>
+        <IntlProvider locale={appLocale.locale} messages={appLocale.messages}>
+          <LocaleProvider locale={appLocale.locale === 'zh-CN' ? zhCN : null}>
+            <div className="page-wrapper">
+              <Header {...restProps} />
+              {children}
+            </div>
+          </LocaleProvider>
+        </IntlProvider>
+      </SentryBoundary>
     );
   }
 }


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

Trying capture js errors in ant.design, we can find some problems in advanced. And, more important, sentry has free plan for github repo now! :tada:
  
### API Realization (Optional if not new feature)

Follow https://sentry.io/onboarding/ant-design/ant-design/configure/javascript-react

### What's the effect? (Optional if not new feature)

Developers will be able to see all errors captured in https://sentry.io/ant-design/ant-design/

### Changelog description (Optional if not new feature)

No need.

### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

### Additional Plan? (Optional if not new feature)

Maybe for http://github.com/ant-design/ant-design-pro, which is using rollbar before, but removed cause it is been copied to real applications: https://github.com/ant-design/ant-design-pro/pull/2057
