### PR TITLE
Fix for Pagination ellipsis misalignment

### DIFF
--- a/components/pagination/style/index.less
+++ b/components/pagination/style/index.less
@@ -109,6 +109,7 @@
         position: absolute;
         display: block;
         letter-spacing: 2px;
+        text-indent: 0.13em;
         color: @disabled-color;
         text-align: center;
         opacity: 1;


### PR DESCRIPTION
### This is a ...

- [x] Bug fix #14471 

### What's the background?

Fixes issue #14471.
The ellipsis in the Pagination "more" button is not centered.
A live demo with the bug and the fix can be found here https://codepen.io/ranbena/full/mvdRjZ.

<img width="537" alt="screen shot 2019-01-22 at 9 27 43" src="https://user-images.githubusercontent.com/486954/51519330-57615600-1e29-11e9-8482-d50a0c409bbe.png">

  
### Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
