### PR TITLE
Add a new less variable to override the list header background

### DIFF
--- a/components/list/style/index.less
+++ b/components/list/style/index.less
@@ -112,6 +112,10 @@
     background: @list-header-background;
   }
 
+  &-footer {
+    background: @list-footer-background;
+  }
+
   &-header,
   &-footer {
     padding-top: 12px;

--- a/components/list/style/index.less
+++ b/components/list/style/index.less
@@ -108,6 +108,10 @@
     }
   }
 
+  &-header {
+    background: @list-header-background;
+  }
+
   &-header,
   &-footer {
     padding-top: 12px;

--- a/components/style/themes/default.less
+++ b/components/style/themes/default.less
@@ -563,6 +563,7 @@
 
 // List
 // ---
+@list-header-background: transparent;
 @list-empty-text-padding: @padding-md;
 @list-item-padding: @padding-sm 0;
 @list-item-content-margin: 0 0 @padding-md 0;

--- a/components/style/themes/default.less
+++ b/components/style/themes/default.less
@@ -564,6 +564,7 @@
 // List
 // ---
 @list-header-background: transparent;
+@list-footer-background: transparent;
 @list-empty-text-padding: @padding-md;
 @list-item-padding: @padding-sm 0;
 @list-item-content-margin: 0 0 @padding-md 0;


### PR DESCRIPTION
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

We need to edit the header background of the `List` component, like the `Card` or `Table` components, via Ant design Less variables.

### API Realization (Optional if not new feature)

Just add `@list-header-background` Less variable in the [default variables file](https://github.com/ant-design/ant-design/blob/master/components/style/themes/default.less) and use it in the [list style file](https://github.com/ant-design/ant-design/blob/master/components/list/style/index.less).

### What's the effect? (Optional if not new feature)

No side effect. The default value is set to `transparent` (same behaviour as `Card` component).

### Changelog description (Optional if not new feature)

Add a new less variable named `list-header-background` to override the list header background

### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
