### PR TITLE
FIx RadioButton cause RadioGroup onChange event trigger twice

### DIFF
--- a/components/radio/__tests__/group.test.js
+++ b/components/radio/__tests__/group.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { mount, render } from 'enzyme';
 import Radio from '../radio';
 import RadioGroup from '../group';
+import RadioButton from '../radioButton';
 
 describe('Radio', () => {
   function createRadioGroup(props) {
@@ -92,6 +93,29 @@ describe('Radio', () => {
     radios.at(0).simulate('change');
     expect(onChange.mock.calls.length).toBe(1);
     expect(onChangeRadioGroup.mock.calls.length).toBe(1);
+
+    // controlled component
+    wrapper.setProps({ value: 'A' });
+    radios.at(1).simulate('change');
+    expect(onChange.mock.calls.length).toBe(2);
+  });
+
+  it('Trigger onChange when both of radioButton and radioGroup exists', () => {
+    const onChange = jest.fn();
+
+    const wrapper = mount(
+      <RadioGroup onChange={onChange}>
+        <RadioButton value="A">A</RadioButton>
+        <RadioButton value="B">B</RadioButton>
+        <RadioButton value="C">C</RadioButton>
+      </RadioGroup>,
+    );
+    const radios = wrapper.find('input');
+
+    // uncontrolled component
+    wrapper.setState({ value: 'B' });
+    radios.at(0).simulate('change');
+    expect(onChange.mock.calls.length).toBe(1);
 
     // controlled component
     wrapper.setProps({ value: 'A' });

--- a/components/radio/radio.tsx
+++ b/components/radio/radio.tsx
@@ -45,7 +45,7 @@ export default class Radio extends React.Component<RadioProps, {}> {
   };
 
   onChange = (e: RadioChangeEvent) => {
-    if (this.props.onChange) {
+    if (this.props.onChange && this.props.prefixCls !== 'ant-radio-button') {
       this.props.onChange(e);
     }
 

--- a/components/radio/radio.tsx
+++ b/components/radio/radio.tsx
@@ -45,7 +45,7 @@ export default class Radio extends React.Component<RadioProps, {}> {
   };
 
   onChange = (e: RadioChangeEvent) => {
-    if (this.props.onChange && this.props.prefixCls !== 'ant-radio-button') {
+    if (this.props.onChange) {
       this.props.onChange(e);
     }
 

--- a/components/radio/radioButton.tsx
+++ b/components/radio/radioButton.tsx
@@ -18,7 +18,6 @@ export default class RadioButton extends React.Component<RadioButtonProps, any> 
     const { prefixCls: customizePrefixCls, ...radioProps }: RadioButtonProps = this.props;
     const prefixCls = getPrefixCls('radio-button', customizePrefixCls);
     if (this.context.radioGroup) {
-      radioProps.onChange = this.context.radioGroup.onChange;
       radioProps.checked = this.props.value === this.context.radioGroup.value;
       radioProps.disabled = this.props.disabled || this.context.radioGroup.disabled;
     }


### PR DESCRIPTION
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

> 1. Describe the source of requirement.
> 2. Resolve what problem.
Fix https://github.com/ant-design/ant-design/issues/14485
> 3. Related issue link.
https://github.com/ant-design/ant-design/issues/14485
  
### API Realization (Optional if not new feature)

> 1. Basic thought of solution and other optional proposal.
> 2. List final API realization and usage sample.
> 3. GIF or snapshot should be provided if includes UI/interactive modification.

### What's the effect? (Optional if not new feature)

> 1. Does this PR affect user? Which part will be affected?
> 2. What will say in changelog?
Fix the problem that if the RadioButton exists, it will cause the RadioGroup onChange callback to trigger twice.
> 3. Does this PR contains potential break change or other risk?

### Changelog description (Optional if not new feature)

> 1. English description
> 2. Chinese description (optional)

### Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

### Additional Plan? (Optional if not new feature)

> If this PR related with other PR or following info. You can type here.
