### PR TITLE
not show overflow content when in elastic

### DIFF
--- a/components/table/style/index.less
+++ b/components/table/style/index.less
@@ -563,6 +563,11 @@
     table {
       width: auto;
       min-width: 100%;
+
+      // https://github.com/ant-design/ant-design/issues/14545
+      .@{table-prefix-cls}-fixed-columns-in-body {
+        visibility: hidden;
+      }
     }
   }
 


### PR DESCRIPTION
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

fix #14545
  
### What's the effect? (Optional if not new feature)

Hide overflow content in fixed table column

### Changelog description (Optional if not new feature)

* Fix Table in Safari style issue when use fixed column.
* 修复 Safari 中 Table 的固定列样式问题。

### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
