### PR TITLE
[Bug fix] getCurrentPageData

### DIFF
--- a/components/table/Table.tsx
+++ b/components/table/Table.tsx
@@ -1013,7 +1013,7 @@ export default class Table<T> extends React.Component<TableProps<T>, TableState<
     // ---
     // 当数据量少于等于每页数量时，直接设置数据
     // 否则进行读取分页数据
-    if (data.length > pageSize || pageSize === Number.MAX_VALUE) {
+    if (data.length > pageSize || pageSize === Number.MAX_VALUE || current * pageSize > data.length) {
       data = data.filter((_, i) => {
         return i >= (current - 1) * pageSize && i < current * pageSize;
       });


### PR DESCRIPTION
Make it possible to rendering new data source when new table source data length is short than page size.

First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

> 1. Describe the source of requirement.
https://codepen.io/sdli-code/pen/RvrWmM?editors=0010
> 2. Resolve what problem.
Changing Pagination doesn't work ,when pageSize is larger than data length.
> 3. Related issue link.
https://github.com/ant-design/ant-design/issues/14557
  

### What's the effect? (Optional if not new feature)

> 1. Does this PR affect user? Which part will be affected?
No affect.
> 2. What will say in changelog?
[Table Pagination Bug Fix]when PageSize is larger than current data length, <Table /> will always show the first page data. 
> 3. Does this PR contains potential break change or other risk?
No.

### Changelog description (Optional if not new feature)

> 1. English description
When PageSize is larger than current data length, <Table /> will always show the first page data. 
> 2. Chinese description (optional)
修改table数据时，如果低于一页数据而total超过pageSize，则点击分页无效，超过一页的部分点击仍然显示第一页数据。。

