### PR TITLE
Update practical-projects.zh-CN.md and practical-projects.en-US.md

### DIFF
--- a/docs/react/practical-projects.en-US.md
+++ b/docs/react/practical-projects.en-US.md
@@ -35,20 +35,22 @@ yarn create v1.12.0
 [3/4] 🔗  Linking dependencies...
 [4/4] 📃  Building fresh packages...
 
-success Installed "create-umi@0.3.1" with binaries:
+success Installed "create-umi@0.9.5" with binaries:
       - create-umi
-
-? What functionality do you want to enable? (Press <space> to select, <a> to toggle all, <i
-> to invert selection)
-❯◯ antd
- ◯ dva
- ◯ code splitting
- ◯ pwa
- ◯ dll
- ◯ hard source
 ```
 
 Yarn will install the latest version of [create-umi](https://github.com/umijs/create-umi) and then create the app with interactive ui.
+
+Select `app` and press Enter to confirm.
+
+```
+? Select the boilerplate type 
+  ant-design-pro  - Create project with an layout-only ant-design-pro boilerplate, use together with umi block. 
+❯ app             - Create project with a simple boilerplate, support typescript. 
+  block           - Create a umi block. 
+  library         - Create a library with umi. 
+  plugin          - Create a umi plugin. 
+```
 
 Select `antd` and `dva` and press Enter to confirm.
 

--- a/docs/react/practical-projects.zh-CN.md
+++ b/docs/react/practical-projects.zh-CN.md
@@ -35,20 +35,22 @@ yarn create v1.12.0
 [3/4] 🔗  Linking dependencies...
 [4/4] 📃  Building fresh packages...
 
-success Installed "create-umi@0.3.1" with binaries:
+success Installed "create-umi@0.9.5" with binaries:
       - create-umi
-
-? What functionality do you want to enable? (Press <space> to select, <a> to toggle all, <i
-> to invert selection)
-❯◯ antd
- ◯ dva
- ◯ code splitting
- ◯ pwa
- ◯ dll
- ◯ hard source
 ```
 
 yarn 会先安装最新版的 [create-umi](https://github.com/umijs/create-umi)，然后提供交互式的提示来创建应用。
+
+选择 `app`, 然后回车确认。
+
+```
+? Select the boilerplate type 
+  ant-design-pro  - Create project with an layout-only ant-design-pro boilerplate, use together with umi block. 
+❯ app             - Create project with a simple boilerplate, support typescript. 
+  block           - Create a umi block. 
+  library         - Create a library with umi. 
+  plugin          - Create a umi plugin. 
+```
 
 选上 `antd` 和 `dva`，然后回车确认。
 


### PR DESCRIPTION
将教程中的指令更新为最新版的`create-umi@0.9.5`
Update `create-umi@0.9.5` steps in practical-projects

### This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

> 1. Describe the source of requirement.
- [practical-projects](https://ant.design/docs/react/practical-projects)中的`create-umi`教程版本更新，用户操作教程需要更新
> 2. Resolve what problem.
- 更新至`create-umi@0.9.5`
> 3. Related issue link.
- 无

### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
