### PR TITLE
fix destroyFns not reduce when instance.destroy()

### DIFF
--- a/components/modal/__tests__/confirm.test.js
+++ b/components/modal/__tests__/confirm.test.js
@@ -1,4 +1,5 @@
 import Modal from '..';
+import { destroyFns } from '../Modal'
 
 const { confirm } = Modal;
 
@@ -172,5 +173,27 @@ describe('Modal.confirm triggers callbacks correctly', () => {
   it('should be Modal.confirm without mask', () => {
     open({ mask: false });
     expect($$('.ant-modal-mask')).toHaveLength(0);
+  });
+
+  it('destroyFns should reduce when instance.destroy', () => {
+    jest.useFakeTimers();
+    Modal.destroyAll(); // clear destroyFns
+    jest.runAllTimers();
+    const instances = [];
+    ['info', 'success', 'warning', 'error'].forEach(type => {
+      const instance = Modal[type]({
+        title: 'title',
+        content: 'content',
+      });
+      instances.push(instance)
+    });
+    const length = instances.length
+    instances.forEach((instance, index) => {
+      expect(destroyFns.length).toBe(length - index);
+      instance.destroy();
+      jest.runAllTimers();
+      expect(destroyFns.length).toBe(length - index - 1);
+    })
+    jest.useRealTimers();
   });
 });

--- a/components/modal/__tests__/confirm.test.js
+++ b/components/modal/__tests__/confirm.test.js
@@ -187,7 +187,7 @@ describe('Modal.confirm triggers callbacks correctly', () => {
       });
       instances.push(instance)
     });
-    const length = instances.length
+    const { length } = instances
     instances.forEach((instance, index) => {
       expect(destroyFns.length).toBe(length - index);
       instance.destroy();

--- a/components/modal/confirm.tsx
+++ b/components/modal/confirm.tsx
@@ -154,7 +154,7 @@ export default function confirm(config: ModalFuncProps) {
     }
     for (let i = 0; i < destroyFns.length; i++) {
       const fn = destroyFns[i];
-      if (fn === destroy) {
+      if (fn === close) {
         destroyFns.splice(i, 1);
         break;
       }


### PR DESCRIPTION
### This is a ...

- [x] Bug fix

### What's the background?

> 1. in confirm.destroy(), `destroyFns` will never contain `destroy` , it is simple code problem, `destroyFns` contain `close` instead
> 2. it will make the  `destroyFns` not change when user manually close confirm dialog


### Changelog description (Optional if not new feature)

> 1. fixbug,confirm `destroy()` has unreachable code
> 2. fixbug, 销毁对话框函数  `destroy()` 有永远不会执行到的代码块

### Self Check before Merge

- [x] Doc is or not needed
- [x] Demo not needed
- [x] TypeScript not needed
- [x] Changelog not needed

