### PR TITLE
Fix `fileIndex` not found TypeError (IE 11)

### DIFF
--- a/components/upload/Upload.tsx
+++ b/components/upload/Upload.tsx
@@ -3,6 +3,7 @@ import { polyfill } from 'react-lifecycles-compat';
 import RcUpload from 'rc-upload';
 import classNames from 'classnames';
 import uniqBy from 'lodash/uniqBy';
+import findIndex from 'lodash/findIndex';
 import Dragger from './Dragger';
 import UploadList from './UploadList';
 import {
@@ -73,7 +74,7 @@ class Upload extends React.Component<UploadProps, UploadState> {
 
     const nextFileList = this.state.fileList.concat();
 
-    const fileIndex = nextFileList.findIndex(({ uid }) => uid === targetItem.uid);
+    const fileIndex = findIndex(nextFileList, ({ uid }: UploadFile) => uid === targetItem.uid);
     if (fileIndex === -1) {
       nextFileList.push(targetItem);
     } else {

--- a/typings/custom-typings.d.ts
+++ b/typings/custom-typings.d.ts
@@ -97,7 +97,9 @@ declare module 'lodash/padEnd';
 
 declare module 'lodash/uniqBy';
 
-declare module "raf";
+declare module 'lodash/findIndex';
+
+declare module 'raf';
 
 declare module 'react-lifecycles-compat';
 


### PR DESCRIPTION
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

## Context
`fileIndex` is not present in IE 11 `Array.prototype`, should be used with a polyfill.

## Fixes

### TypeError: Object doesn't support property or method 'findIndex'

## Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [x] Demo not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

