### PR TITLE
为.ant-dropdown:before添加负index, 避免其挡住自定义overlay的点击

### DIFF
--- a/components/dropdown/style/index.less
+++ b/components/dropdown/style/index.less
@@ -19,6 +19,7 @@
     bottom: -7px;
     content: ' ';
     opacity: 0.0001;
+    z-index: -9999;
   }
 
   &-wrap {


### PR DESCRIPTION
如果overlay没有设置position也没有transform样式, 其层级会低于这个伪元素, 导致无法被点击到.

[Demo](https://codesandbox.io/s/2wynxzq5zn)

### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)


### What's the background?

文档里写dropdown的overlay是menu或() => menu类型, 但实际上是ReactNode或() => ReactNode类型, 而且因为它没有Popover和Tooltip的箭头, 所以overlay经常是自定义容器. 在这种情况下, 这个容器不会被加上ant-dropdown-menu类, 导致它没有position: relative和transform: translate3d(0,0,0)的样式, 所以会被before伪元素覆盖在上面导致它无法响应点击.


### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
