### PR TITLE
[Fix Pagination Bug] Show correct page data when pagination data length is less than pageSize

### DIFF
--- a/components/table/Table.tsx
+++ b/components/table/Table.tsx
@@ -1013,7 +1013,11 @@ export default class Table<T> extends React.Component<TableProps<T>, TableState<
     // ---
     // 当数据量少于等于每页数量时，直接设置数据
     // 否则进行读取分页数据
-    if (data.length > pageSize || pageSize === Number.MAX_VALUE) {
+    if (
+      data.length > pageSize ||
+      pageSize === Number.MAX_VALUE ||
+      current * pageSize > data.length
+    ) {
       data = data.filter((_, i) => {
         return i >= (current - 1) * pageSize && i < current * pageSize;
       });

--- a/components/table/__tests__/Table.pagination.test.js
+++ b/components/table/__tests__/Table.pagination.test.js
@@ -176,4 +176,14 @@ describe('Table.pagination', () => {
         .find('.ant-pagination'),
     ).toHaveLength(1);
   });
+
+  // https://github.com/ant-design/ant-design/issues/14557
+  it('Show correct page data when pagination data length is less than pageSize.', () => {
+    const wrapper = mount(
+      createTable({ pagination: { pageSize: 10, total: 100 }, dataSource: data }),
+    );
+    expect(renderedNames(wrapper)[0]).toEqual('Jack');
+    wrapper.find('.ant-pagination-item-2').simulate('click');
+    expect(renderedNames(wrapper)).toEqual([]);
+  });
 });


### PR DESCRIPTION

### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

> 1. Describe the source of requirement.
https://codepen.io/sdli-code/pen/RvrWmM?editors=0010
> 2. Resolve what problem.
Changing Pagination doesn't work ,when pageSize is larger than data length.
> 3. Related issue link.
  https://github.com/ant-design/ant-design/issues/14557


### What's the effect? (Optional if not new feature)

> 1. Does this PR affect user? Which part will be affected?
No
> 2. What will say in changelog?
[Fix Pagination Bug] Show correct table data when pagination data length is less than pageSize
> 3. Does this PR contains potential break change or other risk?
No

### Changelog description (Optional if not new feature)

> 1. English description
[Fix Pagination Bug] Show correct table data when pagination data length is less than pageSize.
> 2. Chinese description (optional)
修改table数据时，如果低于一页数据而total超过pageSize，则点击分页无效，超过一页的部分点击仍然显示第一页数据。