### PR TITLE
fix: AutoComplete placeholder not display when disabled

### DIFF
--- a/components/auto-complete/style/index.less
+++ b/components/auto-complete/style/index.less
@@ -54,6 +54,7 @@
       }
       &[disabled] {
         .disabled;
+        background-color: transparent;
       }
     }
 


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

> 1. Describe the source of requirement.
```
<AutoComplete
     placeholder="input here"
     disabled
 />
```
> 2. Resolve what problem.
placeholder not display when disabled
> 3. Related issue link.
https://codesandbox.io/s/6z895pjk8z

### What's the effect? (Optional if not new feature)

> 1. Does this PR affect user? Which part will be affected?
no
> 2. What will say in changelog?
 AutoComplete placeholder not display when disabled
> 3. Does this PR contains potential break change or other risk?
no

### Changelog description (Optional if not new feature)

> 1. English description
fix:  AutoComplete placeholder not display when disabled
> 2. Chinese description (optional)
fix: 修复AutoComplete组件disabled时，placeholder不显示的问题
### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

