### PR TITLE
[Fix]: Change Modal's okText and cancelText types

### DIFF
--- a/components/modal/Modal.tsx
+++ b/components/modal/Modal.tsx
@@ -79,7 +79,7 @@ export interface ModalFuncProps {
   okType?: ButtonType;
   cancelText?: React.ReactNode;
   icon?: React.ReactNode;
-  /* Deperated */
+  /* Deprecated */
   iconType?: string;
   mask?: boolean;
   maskClosable?: boolean;

--- a/components/modal/Modal.tsx
+++ b/components/modal/Modal.tsx
@@ -75,9 +75,9 @@ export interface ModalFuncProps {
   centered?: boolean;
   width?: string | number;
   iconClassName?: string;
-  okText?: React.ReactNode | string;
+  okText?: React.ReactNode;
   okType?: ButtonType;
-  cancelText?: React.ReactNode | string;
+  cancelText?: React.ReactNode;
   icon?: React.ReactNode;
   /* Deperated */
   iconType?: string;

--- a/components/modal/Modal.tsx
+++ b/components/modal/Modal.tsx
@@ -35,11 +35,11 @@ export interface ModalProps {
   /** 底部内容*/
   footer?: React.ReactNode;
   /** 确认按钮文字*/
-  okText?: React.ReactNode | string;
+  okText?: React.ReactNode;
   /** 确认按钮类型*/
   okType?: ButtonType;
   /** 取消按钮文字*/
-  cancelText?: React.ReactNode | string;
+  cancelText?: React.ReactNode;
   /** 点击蒙层是否允许关闭*/
   maskClosable?: boolean;
   /** 强制渲染 Modal*/

--- a/components/modal/Modal.tsx
+++ b/components/modal/Modal.tsx
@@ -35,11 +35,11 @@ export interface ModalProps {
   /** 底部内容*/
   footer?: React.ReactNode;
   /** 确认按钮文字*/
-  okText?: string;
+  okText?: React.ReactNode | string;
   /** 确认按钮类型*/
   okType?: ButtonType;
   /** 取消按钮文字*/
-  cancelText?: string;
+  cancelText?: React.ReactNode | string;
   /** 点击蒙层是否允许关闭*/
   maskClosable?: boolean;
   /** 强制渲染 Modal*/
@@ -75,9 +75,9 @@ export interface ModalFuncProps {
   centered?: boolean;
   width?: string | number;
   iconClassName?: string;
-  okText?: string;
+  okText?: React.ReactNode | string;
   okType?: ButtonType;
-  cancelText?: string;
+  cancelText?: React.ReactNode | string;
   icon?: React.ReactNode;
   /* Deperated */
   iconType?: string;
@@ -132,8 +132,8 @@ export default class Modal extends React.Component<ModalProps, {}> {
     prefixCls: PropTypes.string,
     onOk: PropTypes.func,
     onCancel: PropTypes.func,
-    okText: PropTypes.string,
-    cancelText: PropTypes.string,
+    okText: PropTypes.node,
+    cancelText: PropTypes.node,
     centered: PropTypes.bool,
     width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     confirmLoading: PropTypes.bool,

--- a/components/modal/index.en-US.md
+++ b/components/modal/index.en-US.md
@@ -20,7 +20,7 @@ and so on.
 | -------- | ----------- | ---- | ------- |
 | afterClose | Specify a function that will be called when modal is closed completely. | function | - |
 | bodyStyle | Body style for modal body element. Such as height, padding etc. | object | {} |
-| cancelText | Text of the Cancel button | string | `Cancel` |
+| cancelText | Text of the Cancel button | string\|ReactNode | `Cancel` |
 | centered | Centered Modal | Boolean | `false` |
 | closable | Whether a close (x) button is visible on top right of the modal dialog or not | boolean | true |
 | confirmLoading | Whether to apply loading visual effect for OK button or not | boolean | false |
@@ -31,7 +31,7 @@ and so on.
 | mask | Whether show mask or not. | Boolean | true |
 | maskClosable | Whether to close the modal dialog when the mask (area outside the modal) is clicked | boolean | true |
 | maskStyle | Style for modal's mask element. | object | {} |
-| okText | Text of the OK button | string | `OK` |
+| okText | Text of the OK button | string\|ReactNode | `OK` |
 | okType | Button `type` of the OK button | string | `primary` |
 | okButtonProps | The ok button props | [ButtonProps](/components/button) | - |
 | cancelButtonProps | The cancel button props | [ButtonProps](/components/button) | - |

--- a/components/modal/index.zh-CN.md
+++ b/components/modal/index.zh-CN.md
@@ -19,7 +19,7 @@ title: Modal
 | --- | --- | --- | --- |
 | afterClose | Modal 完全关闭后的回调 | function | 无 |
 | bodyStyle | Modal body 样式 | object | {} |
-| cancelText | 取消按钮文字 | string | 取消 |
+| cancelText | 取消按钮文字 | string\|ReactNode | 取消 |
 | centered | 垂直居中展示 Modal | Boolean | `false` |
 | closable | 是否显示右上角的关闭按钮 | boolean | true |
 | confirmLoading | 确定按钮 loading | boolean | 无 |
@@ -31,7 +31,7 @@ title: Modal
 | mask | 是否展示遮罩 | Boolean | true |
 | maskClosable | 点击蒙层是否允许关闭 | boolean | true |
 | maskStyle | 遮罩样式 | object | {} |
-| okText | 确认按钮文字 | string | 确定 |
+| okText | 确认按钮文字 | string\|ReactNode | 确定 |
 | okType | 确认按钮类型 | string | primary |
 | okButtonProps | ok 按钮 props | [ButtonProps](/components/button) | - |
 | cancelButtonProps | cancel 按钮 props | [ButtonProps](/components/button) | - |


### PR DESCRIPTION
### This is a ...

- [X] Bug fix
- [X] Site / document update
- [X] TypeScript definition update

### What's the background?

Modal's `okText` and `cancelText` props doesn't let passing `ReactNode`. Prop validation warning are shown in development mode if these props were passed a `ReactNode`.
https://github.com/ant-design/ant-design/issues/14674

### Changelog description (Optional if not new feature)

English:
 - 🐞Modal: let `okText` and `cancelText` props to be `ReactNode`, not just `string`


### Self Check before Merge

- [X] Doc is updated/provided or not needed
- [X] TypeScript definition is updated/provided or not needed
- [X] Changelog is provided or not needed
