### PR TITLE
Statistic should support negetive numbers

### DIFF
--- a/components/statistic/Number.tsx
+++ b/components/statistic/Number.tsx
@@ -17,14 +17,15 @@ const StatisticNumber: React.SFC<NumberProps> = props => {
   } else {
     // Internal formatter
     const val: string = String(value);
-    const cells = val.match(/^(\d*)(\.(\d+))?$/);
+    const cells = val.match(/^(-?)(\d*)(\.(\d+))?$/);
 
     // Process if illegal number
     if (!cells) {
       valueNode = val;
     } else {
-      let int = cells[1] || '0';
-      let decimal = cells[3] || '';
+      const negative = cells[1];
+      let int = cells[2] || '0';
+      let decimal = cells[4] || '';
 
       int = int.replace(/\B(?=(\d{3})+(?!\d))/g, groupSeparator);
 
@@ -38,6 +39,7 @@ const StatisticNumber: React.SFC<NumberProps> = props => {
 
       valueNode = [
         <span key="int" className={`${prefixCls}-content-value-int`}>
+          {negative}
           {int}
         </span>,
         decimal && (

--- a/components/statistic/__tests__/__snapshots__/index.test.js.snap
+++ b/components/statistic/__tests__/__snapshots__/index.test.js.snap
@@ -1,0 +1,31 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Statistic support negetive number 1`] = `
+<div
+  class="ant-statistic"
+>
+  <div
+    class="ant-statistic-title"
+  >
+    Account Balance (CNY)
+  </div>
+  <div
+    class="ant-statistic-content"
+  >
+    <span
+      class="ant-statistic-content-value"
+    >
+      <span
+        class="ant-statistic-content-value-int"
+      >
+        -112,893
+      </span>
+      <span
+        class="ant-statistic-content-value-decimal"
+      >
+        .12
+      </span>
+    </span>
+  </div>
+</div>
+`;

--- a/components/statistic/__tests__/index.test.js
+++ b/components/statistic/__tests__/index.test.js
@@ -32,6 +32,13 @@ describe('Statistic', () => {
     expect(wrapper.find('.ant-statistic-content-value').text()).toEqual('bamboo');
   });
 
+  it('support negetive number', () => {
+    const wrapper = mount(
+      <Statistic title="Account Balance (CNY)" value={-112893.12345} precision={2} />,
+    );
+    expect(wrapper.render()).toMatchSnapshot();
+  });
+
   describe('Countdown', () => {
     it('render correctly', () => {
       const now = moment()


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

Statistic cannot works with negetive number like `-112133` or `-123213.32423` now.

close #14692

### API Realization (Optional if not new feature)

Nothing changed.

### What's the effect? (Optional if not new feature)

No side effect.

### Changelog description (Optional if not new feature)

- 🐛 Fixed problem of Statistic not support negetive number.
- 🐛 修复 Statistic 不支持负数的问题。

### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed