### PR TITLE
Table should pick pageSize over defaultPageSize in priority

### DIFF
--- a/components/table/Table.tsx
+++ b/components/table/Table.tsx
@@ -168,12 +168,24 @@ export default class Table<T> extends React.Component<TableProps<T>, TableState<
 
   getDefaultPagination(props: TableProps<T>) {
     const pagination: PaginationConfig = props.pagination || {};
+    let current;
+    if ('current' in pagination) {
+      current = pagination.current;
+    } else if ('defaultCurrent' in pagination) {
+      current = pagination.defaultCurrent;
+    }
+    let pageSize;
+    if ('pageSize' in pagination) {
+      pageSize = pagination.pageSize;
+    } else if ('defaultPageSize' in pagination) {
+      pageSize = pagination.defaultPageSize;
+    }
     return this.hasPagination(props)
       ? {
           ...defaultPagination,
           ...pagination,
-          current: pagination.defaultCurrent || pagination.current || 1,
-          pageSize: pagination.defaultPageSize || pagination.pageSize || 10,
+          current: current || 1,
+          pageSize: pageSize || 10,
         }
       : {};
   }

--- a/components/table/__tests__/Table.pagination.test.js
+++ b/components/table/__tests__/Table.pagination.test.js
@@ -47,6 +47,11 @@ describe('Table.pagination', () => {
     expect(wrapper.find('.ant-pagination')).toHaveLength(1);
   });
 
+  it('should use pageSize when defaultPageSize and pageSize are both specified', () => {
+    const wrapper = mount(createTable({ pagination: { pageSize: 3, defaultPageSize: 4 } }));
+    expect(wrapper.find('.ant-pagination-item')).toHaveLength(2);
+  });
+
   it('paginate data', () => {
     const wrapper = mount(createTable());
 


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

close #14320

### Changelog description (Optional if not new feature)

- 🐛 Table should pick pageSize over defaultPageSize in priority. #14320
- 🐛 Table 同时指定 pagination 的 `pageSize` 和 `defaultPageSize` 时应优先使用 `pageSize`。#14320

### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed