### PR TITLE
doc fix: handle invalid date in message.info() call

### DIFF
--- a/docs/react/getting-started.en-US.md
+++ b/docs/react/getting-started.en-US.md
@@ -37,7 +37,7 @@ class App extends React.Component {
   };
 
   handleChange = date => {
-    message.info(`Selected Date: ${date.format("YYYY-MM-DD")}`);
+    message.info(`Selected Date: ${date ? date.format("YYYY-MM-DD") : "None"}`);
     this.setState({ date });
   };
 


### PR DESCRIPTION
- Site / document update

The picker allows to change from a valid date to an empty value (`date` becomes `null` and therefore cannot be formatted).
Added the same conditional as in the `<div>` contained message.

