### PR TITLE
Input: Clear icon doesn't disappear if value is null (vs undefined or empy string)

### DIFF
--- a/components/input/Input.tsx
+++ b/components/input/Input.tsx
@@ -157,7 +157,7 @@ class Input extends React.Component<InputProps, any> {
   renderClearIcon(prefixCls: string) {
     const { allowClear } = this.props;
     const { value } = this.state;
-    if (!allowClear || value === undefined || value === '') {
+    if (!allowClear || value === undefined || value === null || value === '') {
       return null;
     }
     return (

--- a/components/input/__tests__/__snapshots__/index.test.js.snap
+++ b/components/input/__tests__/__snapshots__/index.test.js.snap
@@ -95,6 +95,172 @@ exports[`Input allowClear should change type when click 2`] = `
 </Input>
 `;
 
+exports[`Input allowClear should not show icon if defaultValue is undefined, null or empty string 1`] = `
+<Input
+  allowClear={true}
+  defaultValue={null}
+  disabled={false}
+  type="text"
+>
+  <Consumer>
+    <span
+      className="ant-input-affix-wrapper"
+    >
+      <input
+        className="ant-input"
+        disabled={false}
+        onChange={[Function]}
+        onKeyDown={[Function]}
+        style={null}
+        type="text"
+        value=""
+      />
+      <span
+        className="ant-input-suffix"
+      />
+    </span>
+  </Consumer>
+</Input>
+`;
+
+exports[`Input allowClear should not show icon if defaultValue is undefined, null or empty string 2`] = `
+<Input
+  allowClear={true}
+  disabled={false}
+  type="text"
+>
+  <Consumer>
+    <span
+      className="ant-input-affix-wrapper"
+    >
+      <input
+        className="ant-input"
+        disabled={false}
+        onChange={[Function]}
+        onKeyDown={[Function]}
+        style={null}
+        type="text"
+        value=""
+      />
+      <span
+        className="ant-input-suffix"
+      />
+    </span>
+  </Consumer>
+</Input>
+`;
+
+exports[`Input allowClear should not show icon if defaultValue is undefined, null or empty string 3`] = `
+<Input
+  allowClear={true}
+  defaultValue=""
+  disabled={false}
+  type="text"
+>
+  <Consumer>
+    <span
+      className="ant-input-affix-wrapper"
+    >
+      <input
+        className="ant-input"
+        disabled={false}
+        onChange={[Function]}
+        onKeyDown={[Function]}
+        style={null}
+        type="text"
+        value=""
+      />
+      <span
+        className="ant-input-suffix"
+      />
+    </span>
+  </Consumer>
+</Input>
+`;
+
+exports[`Input allowClear should not show icon if value is undefined, null or empty string 1`] = `
+<Input
+  allowClear={true}
+  disabled={false}
+  type="text"
+  value={null}
+>
+  <Consumer>
+    <span
+      className="ant-input-affix-wrapper"
+    >
+      <input
+        className="ant-input"
+        disabled={false}
+        onChange={[Function]}
+        onKeyDown={[Function]}
+        style={null}
+        type="text"
+        value=""
+      />
+      <span
+        className="ant-input-suffix"
+      />
+    </span>
+  </Consumer>
+</Input>
+`;
+
+exports[`Input allowClear should not show icon if value is undefined, null or empty string 2`] = `
+<Input
+  allowClear={true}
+  disabled={false}
+  type="text"
+>
+  <Consumer>
+    <span
+      className="ant-input-affix-wrapper"
+    >
+      <input
+        className="ant-input"
+        disabled={false}
+        onChange={[Function]}
+        onKeyDown={[Function]}
+        style={null}
+        type="text"
+        value=""
+      />
+      <span
+        className="ant-input-suffix"
+      />
+    </span>
+  </Consumer>
+</Input>
+`;
+
+exports[`Input allowClear should not show icon if value is undefined, null or empty string 3`] = `
+<Input
+  allowClear={true}
+  disabled={false}
+  type="text"
+  value=""
+>
+  <Consumer>
+    <span
+      className="ant-input-affix-wrapper"
+    >
+      <input
+        className="ant-input"
+        disabled={false}
+        onChange={[Function]}
+        onKeyDown={[Function]}
+        style={null}
+        type="text"
+        value=""
+      />
+      <span
+        className="ant-input-suffix"
+      />
+    </span>
+  </Consumer>
+</Input>
+`;
+
 exports[`Input should support maxLength 1`] = `
 <Input
   disabled={false}

--- a/components/input/__tests__/index.test.js
+++ b/components/input/__tests__/index.test.js
@@ -1,7 +1,9 @@
 import React from 'react';
+
 import { mount } from 'enzyme';
-import Input from '..';
+
 import Form from '../../form';
+import Input from '..';
 import focusTest from '../../../tests/shared/focusTest';
 
 const { TextArea } = Input;
@@ -132,6 +134,26 @@ describe('Input allowClear', () => {
       .simulate('click');
     expect(wrapper).toMatchSnapshot();
     expect(wrapper.find('input').getDOMNode().value).toEqual('');
+  });
+
+  it('should not show icon if value is undefined, null or empty string', () => {
+    const wrappers = [null, undefined, ''].map(val => mount(<Input allowClear value={val} />));
+    wrappers.forEach(wrapper => {
+      expect(wrapper.find('input').getDOMNode().value).toEqual('');
+      expect(wrapper.find('.ant-input-clear-icon').exists()).toEqual(false);
+      expect(wrapper).toMatchSnapshot();
+    });
+  });
+
+  it('should not show icon if defaultValue is undefined, null or empty string', () => {
+    const wrappers = [null, undefined, ''].map(val =>
+      mount(<Input allowClear defaultValue={val} />),
+    );
+    wrappers.forEach(wrapper => {
+      expect(wrapper.find('input').getDOMNode().value).toEqual('');
+      expect(wrapper.find('.ant-input-clear-icon').exists()).toEqual(false);
+      expect(wrapper).toMatchSnapshot();
+    });
   });
 
   it('should trigger event correctly', () => {


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

If the value becomes null in the Input component, the clear icon is still shown if activated (setting allowClear).
See example: https://codesandbox.io/s/7jp07nyp9x

A check for null needed to be introduced in Input.tsx.

### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
