### PR TITLE
Revert "fix IE 11 bug"

### DIFF
--- a/components/list/style/index.less
+++ b/components/list/style/index.less
@@ -44,7 +44,7 @@
         margin-right: @list-item-meta-avatar-margin-right;
       }
       &-content {
-        flex: 1 0 auto;
+        flex: 1 0;
       }
       &-title {
         color: @text-color;


### PR DESCRIPTION
Reverts ant-design/ant-design#14602

Due to this change, long descriptions break in browsers. Detailed discussions on why this revert is made can be found [here](https://github.com/ant-design/ant-design/pull/14602#issuecomment-462097452).