### PR TITLE
fix: Progress shows the success status incorrectly

### DIFF
--- a/components/progress/__tests__/index.test.js
+++ b/components/progress/__tests__/index.test.js
@@ -9,6 +9,9 @@ describe('Progress', () => {
 
     wrapper.setProps({ percent: 50, successPercent: 100 });
     expect(wrapper.find('.ant-progress-status-success')).toHaveLength(1);
+
+    wrapper.setProps({ percent: 100, successPercent: 0 });
+    expect(wrapper.find('.ant-progress-status-success')).toHaveLength(0);
   });
 
   it('render out-of-range progress', () => {

--- a/components/progress/progress.tsx
+++ b/components/progress/progress.tsx
@@ -103,7 +103,7 @@ export default class Progress extends React.Component<ProgressProps, {}> {
     } = props;
     const prefixCls = getPrefixCls('progress', customizePrefixCls);
     const progressStatus =
-      parseInt(successPercent ? successPercent.toString() : percent.toString(), 10) >= 100 &&
+      parseInt(successPercent !== undefined ? successPercent.toString() : percent.toString(), 10) >= 100 &&
       !('status' in props)
         ? 'success'
         : status || 'normal';


### PR DESCRIPTION
fix: Progress shows the success status while `successPercent={0}` and `percent={100}`

First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

> 1. Describe the source of requirement.

Progress shouldn't show success status when `successPercent` is `0`.
```tsx
<Progress percent={100} successPercent={0} />
```
But now I can only do that like this:
```tsx
<Progress percent={100} successPercent="0" />
```
https://codepen.io/anon/pen/KJoarW?editors=0010
> 2. Resolve what problem.
> 3. Related issue link.

### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

