### PR TITLE
fix .ant-table-row-selected classname is not removed from Table rows when rowSelection prop is removed

### DIFF
--- a/components/table/Table.tsx
+++ b/components/table/Table.tsx
@@ -208,6 +208,10 @@ export default class Table<T> extends React.Component<TableProps<T>, TableState<
       this.store.setState({
         selectedRowKeys: nextProps.rowSelection.selectedRowKeys || [],
       });
+    } else if (this.props.rowSelection && !nextProps.rowSelection) {
+      this.store.setState({
+        selectedRowKeys: [],
+      });
     }
     if ('dataSource' in nextProps && nextProps.dataSource !== this.props.dataSource) {
       this.store.setState({

--- a/components/table/__tests__/Table.rowSelection.test.js
+++ b/components/table/__tests__/Table.rowSelection.test.js
@@ -651,4 +651,17 @@ describe('Table.rowSelection', () => {
     checkboxes.at(2).simulate('change', { target: { checked: true } });
     expect(checkboxAll.instance().state).toEqual({ indeterminate: false, checked: true });
   });
+
+  it('clear selection className when remove `rowSelection`', () => {
+    const dataSource = [{ id: 1, name: 'Hello', age: 10 }, { id: 2, name: 'World', age: 30 }];
+
+    const wrapper = mount(<Table columns={columns} dataSource={dataSource} rowSelection={{}} />);
+    const checkboxes = wrapper.find('input');
+    checkboxes.at(1).simulate('change', { target: { checked: true } });
+
+    expect(wrapper.find('.ant-table-row-selected').length).toBe(1);
+
+    wrapper.setProps({ rowSelection: null });
+    expect(wrapper.find('.ant-table-row-selected').length).toBe(0);
+  });
 });


### PR DESCRIPTION
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

fix #14759

### Changelog description (Optional if not new feature)

> 1. Fix className not sync when Table remove `rowSelection` prop.
> 2. 修复 Table 移除 `rowSelection` 属性时，className 不同步的问题。

### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
