### PR TITLE
Update use-in-typescript.en-US.md

### DIFF
--- a/docs/react/use-in-typescript.en-US.md
+++ b/docs/react/use-in-typescript.en-US.md
@@ -106,6 +106,13 @@ module.exports = function override(config, env) {
 };
 ```
 
+### Use customize-cra
+[customize-cra](https://github.com/arackaf/customize-cra) is used to override webpack configurations for create-react-app 2.0 with react-app-rewired.
+
+```bash
+$ yarn add customize-cra --dev
+```
+
 ### Use babel-plugin-import
 
 [babel-plugin-import](https://github.com/ant-design/babel-plugin-import) is a babel plugin for importing components on demand ([How does it work?](/docs/react/getting-started#Import-on-Demand)). We are now trying to install it and modify `config-overrides.js`.


### PR DESCRIPTION
[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### This is a ...

- [x] Site / document update

### What's the background?
When I tried to use Ant Design with TypeScript, I followed [this](https://ant.design/docs/react/use-in-typescript). But I had a trouble with below message after installing `babel-plugin-import` and `yarn start`.

```bash
internal/modules/cjs/loader.js:596
    throw err;
    ^

Error: Cannot find module 'customize-cra'
```

I added `customize-cra`, no trouble occurred.

### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

