### PR TITLE
Fix always uploading if upload button is hidden during

### DIFF
--- a/components/upload/Upload.tsx
+++ b/components/upload/Upload.tsx
@@ -316,11 +316,17 @@ class Upload extends React.Component<UploadProps, UploadState> {
       [`${prefixCls}-disabled`]: disabled,
     });
 
-    const uploadButton = children ? (
-      <div className={uploadButtonCls}>
+    // Remove id to avoid open by label when trigger is hidden
+    // https://github.com/ant-design/ant-design/issues/14298
+    if (!children) {
+      delete rcUploadProps.id;
+    }
+
+    const uploadButton = (
+      <div className={uploadButtonCls} style={children ? undefined : { display: 'none' }}>
         <RcUpload {...rcUploadProps} ref={this.saveUpload} />
       </div>
-    ) : null;
+    );
 
     if (listType === 'picture-card') {
       return (

--- a/components/upload/__tests__/upload.test.js
+++ b/components/upload/__tests__/upload.test.js
@@ -188,6 +188,19 @@ describe('Upload', () => {
     });
   });
 
+  // https://github.com/ant-design/ant-design/issues/14779
+  it('should contain input file control if upload button is hidden', () => {
+    const wrapper = mount(
+      <Upload action="http://upload.com">
+        <button type="button">upload</button>
+      </Upload>,
+    );
+
+    expect(wrapper.find('input[type="file"]').length).toBe(1);
+    wrapper.setProps({ children: null });
+    expect(wrapper.find('input[type="file"]').length).toBe(1);
+  });
+
   it('should be controlled by fileList', () => {
     const fileList = [
       {

--- a/components/upload/interface.tsx
+++ b/components/upload/interface.tsx
@@ -76,6 +76,7 @@ export interface UploadProps {
   withCredentials?: boolean;
   openFileDialogOnClick?: boolean;
   locale?: UploadLocale;
+  id?: string;
 }
 
 export interface UploadState {


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

close #14779

Upload three files in this demo, the upload status will remains uploading always. This bug was introduced by the previous fix in #14298

Reproducible demo: https://ant.design/components/upload-cn/#components-upload-demo-picture-card

### API Realization (Optional if not new feature)

Reverted and change another way to fix #14299, just delete `upload.id` to avoid binding to label.

### Changelog description (Optional if not new feature)

- 🐛 Fix always uploading if upload button is hidden during. #14779
- 🐛 修复一个上传中隐藏上传按钮后导致上传状态一直是 `uploading` 的问题。#14779

### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

### Additional Plan? (Optional if not new feature)

> If this PR related with other PR or following info. You can type here.
