### PR TITLE
support pagination go button

### DIFF
--- a/components/pagination/Pagination.tsx
+++ b/components/pagination/Pagination.tsx
@@ -19,7 +19,7 @@ export interface PaginationProps {
   showSizeChanger?: boolean;
   pageSizeOptions?: string[];
   onShowSizeChange?: (current: number, size: number) => void;
-  showQuickJumper?: boolean;
+  showQuickJumper?: boolean | { goButton?: React.ReactNode };
   showTotal?: (total: number, range: [number, number]) => React.ReactNode;
   size?: string;
   simple?: boolean;

--- a/components/pagination/index.en-US.md
+++ b/components/pagination/index.en-US.md
@@ -27,7 +27,7 @@ A long list can be divided into several pages by `Pagination`, and only one page
 | itemRender | to customize item innerHTML | (page, type: 'page' \| 'prev' \| 'next', originalElement) => React.ReactNode | - |
 | pageSize | number of data items per page | number | - |
 | pageSizeOptions | specify the sizeChanger options | string\[] | \['10', '20', '30', '40'] |
-| showQuickJumper | determine whether you can jump to pages directly | boolean | false |
+| showQuickJumper | determine whether you can jump to pages directly | boolean \| `{ goButton: ReactNode }` | false |
 | showSizeChanger | determine whether `pageSize` can be changed | boolean | false |
 | showTotal | to display the total number and range | Function(total, range) | - |
 | simple | whether to use simple mode | boolean | - |

--- a/components/pagination/index.zh-CN.md
+++ b/components/pagination/index.zh-CN.md
@@ -28,7 +28,7 @@ cols: 1
 | itemRender | 用于自定义页码的结构，可用于优化 SEO | (page, type: 'page' \| 'prev' \| 'next', originalElement) => React.ReactNode | - |
 | pageSize | 每页条数 | number | - |
 | pageSizeOptions | 指定每页可以显示多少条 | string\[] | \['10', '20', '30', '40'] |
-| showQuickJumper | 是否可以快速跳转至某页 | boolean | false |
+| showQuickJumper | 是否可以快速跳转至某页 | boolean \| `{ goButton: ReactNode }` | false |
 | showSizeChanger | 是否可以改变 pageSize | boolean | false |
 | showTotal | 用于显示数据总量和当前数据顺序 | Function(total, range) | - |
 | simple | 当添加该属性时，显示为简单分页 | boolean | - |


### PR DESCRIPTION
### This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

close #14798
close #14535
close #10201
close #7328

Pagination need a goto button to confirm jump action after input page number.

### API Realization (Optional if not new feature)

We already support it in rc-pagination via https://github.com/react-component/pagination/pull/101 and we can use it in this way:

```jsx
<Pagination showQuickJumper={{ gobutton: <button>xxx</button> }} />
```

But it is not documented and without any TypeScript definite.

Now we add it offcially.

### Changelog description (Optional if not new feature)

-  🌟 support goto button in Pagination. #14798
- 🌟 Pagination 支持添加分页跳转按钮。#14798

### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed