### PR TITLE
Fix Card loading style when there is actions

### DIFF
--- a/components/card/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/card/__tests__/__snapshots__/demo.test.js.snap
@@ -539,35 +539,6 @@ exports[`renders ./components/card/demo/loading.md correctly 1`] = `
             />
           </div>
         </div>
-        <div
-          class="ant-row"
-          style="margin-left:-4px;margin-right:-4px"
-        >
-          <div
-            class="ant-col-8"
-            style="padding-left:4px;padding-right:4px"
-          >
-            <div
-              class="ant-card-loading-block"
-            />
-          </div>
-          <div
-            class="ant-col-6"
-            style="padding-left:4px;padding-right:4px"
-          >
-            <div
-              class="ant-card-loading-block"
-            />
-          </div>
-          <div
-            class="ant-col-8"
-            style="padding-left:4px;padding-right:4px"
-          >
-            <div
-              class="ant-card-loading-block"
-            />
-          </div>
-        </div>
       </div>
     </div>
   </div>

--- a/components/card/__tests__/__snapshots__/index.test.js.snap
+++ b/components/card/__tests__/__snapshots__/index.test.js.snap
@@ -117,35 +117,6 @@ exports[`Card should still have padding when card which set padding to 0 is load
           />
         </div>
       </div>
-      <div
-        class="ant-row"
-        style="margin-left: -4px; margin-right: -4px;"
-      >
-        <div
-          class="ant-col-8"
-          style="padding-left: 4px; padding-right: 4px;"
-        >
-          <div
-            class="ant-card-loading-block"
-          />
-        </div>
-        <div
-          class="ant-col-6"
-          style="padding-left: 4px; padding-right: 4px;"
-        >
-          <div
-            class="ant-card-loading-block"
-          />
-        </div>
-        <div
-          class="ant-col-8"
-          style="padding-left: 4px; padding-right: 4px;"
-        >
-          <div
-            class="ant-card-loading-block"
-          />
-        </div>
-      </div>
     </div>
   </div>
 </div>

--- a/components/card/index.tsx
+++ b/components/card/index.tsx
@@ -228,17 +228,6 @@ export default class Card extends React.Component<CardProps, CardState> {
             <div className={`${prefixCls}-loading-block`} />
           </Col>
         </Row>
-        <Row gutter={8}>
-          <Col span={8}>
-            <div className={`${prefixCls}-loading-block`} />
-          </Col>
-          <Col span={6}>
-            <div className={`${prefixCls}-loading-block`} />
-          </Col>
-          <Col span={8}>
-            <div className={`${prefixCls}-loading-block`} />
-          </Col>
-        </Row>
       </div>
     );
 

--- a/components/card/style/index.less
+++ b/components/card/style/index.less
@@ -235,17 +235,6 @@
 
   &-loading {
     overflow: hidden;
-    position: relative;
-
-    &:after {
-      position: absolute;
-      bottom: 0;
-      left: 0;
-      width: 100%;
-      height: @card-padding-base;
-      background: @component-background;
-      content: '';
-    }
   }
 
   &-loading &-body {


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

close #14832 

<img width="1098" alt="image" src="https://user-images.githubusercontent.com/507615/52777076-f589ba00-307d-11e9-917e-0fd9e13ef935.png">


### What's the effect? (Optional if not new feature)

The card with a small specified width would show loading blocks at edge of bottom, and it is no good solution now.

### Changelog description (Optional if not new feature)

- 🐛 Fix Card loading style with actions. #14832
- 🐛 修复一个带 actions 的 Card 加载中样式异常的问题。#14832

### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
