### PR TITLE
only set getPopupContainer when scroll provides

### DIFF
--- a/components/table/Table.tsx
+++ b/components/table/Table.tsx
@@ -744,11 +744,9 @@ export default class Table<T> extends React.Component<TableProps<T>, TableState<
 
   generatePopupContainerFunc = () => {
     const { scroll } = this.props;
-    if (scroll) {
-      return this.getPopupContainer;
-    }
+
     // Use undefined to let rc component use default logic.
-    return undefined;
+    return scroll ? this.getPopupContainer : undefined;
   };
 
   renderRowSelection(prefixCls: string, locale: TableLocale) {

--- a/components/table/Table.tsx
+++ b/components/table/Table.tsx
@@ -742,6 +742,15 @@ export default class Table<T> extends React.Component<TableProps<T>, TableState<
     return ReactDOM.findDOMNode(this) as HTMLElement;
   };
 
+  generatePopupContainerFunc = () => {
+    const { scroll } = this.props;
+    if (scroll) {
+      return this.getPopupContainer;
+    }
+    // Use undefined to let rc component use default logic.
+    return undefined;
+  };
+
   renderRowSelection(prefixCls: string, locale: TableLocale) {
     const { rowSelection, childrenColumnName } = this.props;
     const columns = this.columns.concat();
@@ -779,7 +788,7 @@ export default class Table<T> extends React.Component<TableProps<T>, TableState<
             onSelect={this.handleSelectRow}
             selections={rowSelection.selections}
             hideDefaultSelections={rowSelection.hideDefaultSelections}
-            getPopupContainer={this.getPopupContainer}
+            getPopupContainer={this.generatePopupContainerFunc()}
           />
         );
       }
@@ -842,7 +851,7 @@ export default class Table<T> extends React.Component<TableProps<T>, TableState<
             confirmFilter={this.handleFilter}
             prefixCls={`${prefixCls}-filter`}
             dropdownPrefixCls={dropdownPrefixCls || 'ant-dropdown'}
-            getPopupContainer={this.getPopupContainer}
+            getPopupContainer={this.generatePopupContainerFunc()}
             key="filter-dropdown"
           />
         );

--- a/components/table/interface.tsx
+++ b/components/table/interface.tsx
@@ -6,18 +6,13 @@ import { CheckboxChangeEvent } from '../checkbox';
 import { PaginationConfig } from '../pagination';
 export { PaginationConfig } from '../pagination';
 
-export type CompareFn<T> = ((a: T, b: T, sortOrder?: SortOrder) => number);
+export type CompareFn<T> = (a: T, b: T, sortOrder?: SortOrder) => number;
 export type ColumnFilterItem = { text: string; value: string; children?: ColumnFilterItem[] };
 
 export interface ColumnProps<T> {
   title?:
     | React.ReactNode
-    | ((
-        options: {
-          filters: TableStateFilters;
-          sortOrder?: SortOrder;
-        },
-      ) => React.ReactNode);
+    | ((options: { filters: TableStateFilters; sortOrder?: SortOrder }) => React.ReactNode);
   key?: React.Key;
   dataIndex?: string; // Note: We can not use generic type here, since we need to support nested key, see #9393
   render?: (text: any, record: T, index: number) => React.ReactNode;
@@ -185,6 +180,7 @@ export interface TableState<T> {
 }
 
 export type SelectionItemSelectFn = (key: string[]) => any;
+type GetPopupContainer = (triggerNode?: Element) => HTMLElement;
 
 export interface SelectionItem {
   key: string;
@@ -203,7 +199,7 @@ export interface SelectionCheckboxAllProps<T> {
   onSelect: (key: string, index: number, selectFunc: any) => void;
   hideDefaultSelections?: boolean;
   selections?: SelectionItem[] | boolean;
-  getPopupContainer: (triggerNode?: Element) => HTMLElement;
+  getPopupContainer?: GetPopupContainer;
 }
 
 export interface SelectionCheckboxAllState {
@@ -240,7 +236,7 @@ export interface FilterMenuProps<T> {
   confirmFilter: (column: ColumnProps<T>, selectedKeys: string[]) => any;
   prefixCls: string;
   dropdownPrefixCls: string;
-  getPopupContainer: (triggerNode?: Element) => HTMLElement;
+  getPopupContainer?: GetPopupContainer;
 }
 
 export interface FilterMenuState {


### PR DESCRIPTION
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

fix #11730
close #14426

### What's the effect? (Optional if not new feature)

Table default filter dropdown will popup in body instead of table dom (expect with `scroll` props)

### Changelog description (Optional if not new feature)

> 1. Fix Table filter can not fully display when container use `overflow: hidden;`.
> 2. 修复 Table 的过滤框会因为外层容器设置 `overflow: hidden;` 而显示不全的问题。

### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#11730: Tabs will cover the Tabel filter dropdown when tabpane too low and filter dropdown too high](https://issuehunt.io/repos/34526884/issues/11730)
---

IssueHunt has been backed by the following sponsors. [Become a sponsor](https://issuehunt.io/membership/members)
</details>
<!-- /Issuehunt content-->