### PR TITLE
Adds immutable to the dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,6 +133,7 @@
     "fetch-jsonp": "^1.1.3",
     "glob": "^7.1.3",
     "immutability-helper": "^3.0.0",
+    "immutable": "^3.8.2",
     "intersection-observer": "^0.5.0",
     "jest": "^24.0.0",
     "jsdom": "^13.0.0",


### PR DESCRIPTION
### This is a ...

- [x] Bug fix

### What's the background?

The `rc-editor-mention` package has a peer dependency on `immutable` which isn't satisfied by `antd`.

### What's the effect? (Optional if not new feature)

> 1. Does this PR affect user? Which part will be affected?

Probably not. It might cause Immutable to be included in the dependency tree one extra time, but given that the current behavior is unspecified it doesn't sound too bad.

> 2. What will say in changelog?

I don't think it needs to be described in the changelog? Or just a line to explain that immutable is now listed as a dependency.

> 3. Does this PR contains potential break change or other risk?

Nope.

### Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
