### PR TITLE
Fix Hardcoded Heading Color (#14934)

### DIFF
--- a/components/style/themes/default.less
+++ b/components/style/themes/default.less
@@ -42,7 +42,7 @@
   'Hiragino Sans GB', 'Microsoft YaHei', 'Helvetica Neue', Helvetica, Arial, sans-serif,
   'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
 @code-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
-@heading-color: fade(#000, 85%);
+@heading-color: fade(@black, 85%);
 @text-color: fade(@black, 65%);
 @text-color-secondary: fade(@black, 45%);
 @text-color-inverse: @white;


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

Fix for issue #14934. Changing hardcoded color for headings to make it consistent with the other less variables.

