### PR TITLE
Fix extra space at the bottom of table th in chrome

### DIFF
--- a/components/table/style/index.less
+++ b/components/table/style/index.less
@@ -99,6 +99,8 @@
     &.@{table-prefix-cls}-column-has-actions {
       position: relative;
       background-clip: padding-box; // For Firefox background bug, https://github.com/ant-design/ant-design/issues/12628
+      /* stylelint-disable-next-line */
+      -webkit-background-clip: border-box; // For Chrome extra space: https://github.com/ant-design/ant-design/issues/14926
 
       &.@{table-prefix-cls}-column-has-filters {
         .@{iconfont-css-prefix}-filter,


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

close #14926 

### Changelog description (Optional if not new feature)

- 🐛 Fix extra space at the bottom of Table header in chrome. #14926

### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

### Additional Plan? (Optional if not new feature)

> If this PR related with other PR or following info. You can type here.
