### PR TITLE
Upgrade rc-input-number@4.4.0 to fix #13896

### DIFF
--- a/components/input-number/__tests__/index.test.js
+++ b/components/input-number/__tests__/index.test.js
@@ -1,4 +1,18 @@
+import React from 'react';
+import { mount } from 'enzyme';
 import InputNumber from '..';
 import focusTest from '../../../tests/shared/focusTest';
 
-focusTest(InputNumber);
+describe('InputNumber', () => {
+  focusTest(InputNumber);
+
+  // https://github.com/ant-design/ant-design/issues/13896
+  it('should return null when blur a empty input number', () => {
+    const onChange = jest.fn();
+    const wrapper = mount(<InputNumber defaultValue="1" onChange={onChange} />);
+    wrapper.find('input').simulate('change', { target: { value: '' } });
+    expect(onChange).toHaveBeenLastCalledWith('');
+    wrapper.find('input').simulate('blur');
+    expect(onChange).toHaveBeenLastCalledWith(null);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "rc-dropdown": "~2.4.1",
     "rc-editor-mention": "^1.1.7",
     "rc-form": "^2.4.0",
-    "rc-input-number": "~4.3.7",
+    "rc-input-number": "~4.4.0",
     "rc-menu": "~7.4.12",
     "rc-notification": "~3.3.0",
     "rc-pagination": "~1.17.7",


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

#13896

### API Realization (Optional if not new feature)

> 1. Basic thought of solution and other optional proposal.
> 2. List final API realization and usage sample.
> 3. GIF or snapshot should be provided if includes UI/interactive modification.

### What's the effect? (Optional if not new feature)

```
<InputNumber defaultValue="1" onChange={onChange} />
```

When we delete existed value in input, then blur it. The `onChange` will return `null` instead of original `undefined` now, according to discussion in #13896

### Changelog description (Optional if not new feature)

- 🐛 修正 InputNumber `onChange` 返回 `undefined` 为 `null`，以避免控件的值无法正确收集清空的问题。#13896

### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

### Additional Plan? (Optional if not new feature)

> If this PR related with other PR or following info. You can type here.
