### PR TITLE
Accessibility for custom icons

### DIFF
--- a/components/icon/index.tsx
+++ b/components/icon/index.tsx
@@ -146,7 +146,7 @@ const Icon: IconComponent<IconProps> = props => {
     );
   }
 
-  if (typeof type === 'string') {
+  if (typeof type === 'string' && !Component) {
     let computedType = type;
     if (theme) {
       const themeInName = getThemeFromTypeName(type);


### PR DESCRIPTION
Enable `type` prop for custom icon component. Simple change so you can provide `type` prop with custom icon and get aria-label="icon: your type" instead of aria-label="icon: undefined" 

First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

> 1. Describe the source of requirement.
I wanted to provide icon type with custom svg component
> 2. Resolve what problem.
Fixes aria-label to be your custom type instead of undefined when you use custom svg
> 3. Related issue link.
[In docs inspect the custom icon to see aria-label: undefined on i element](https://ant.design/components/icon/)


### What's the effect? (Optional if not new feature)

> 1. Does this PR affect user? Which part will be affected?
Nope - just added extra option
> 2. What will say in changelog?
Accessibility update to icon
> 3. Does this PR contains potential break change or other risk?
No

### Changelog description (Optional if not new feature)
> 1. English description
> 2. Chinese description (optional)

### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

### Additional Plan? (Optional if not new feature)

> If this PR related with other PR or following info. You can type here.
