### PR TITLE
Not show aria-label when Icon type is empty

### DIFF
--- a/components/icon/__tests__/__snapshots__/index.test.js.snap
+++ b/components/icon/__tests__/__snapshots__/index.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`Icon \`component\` prop can access to svg defs if has children 1`] = `
 <i
-  aria-label="icon: undefined"
   class="anticon my-home-icon"
 >
   <svg
@@ -25,7 +24,6 @@ exports[`Icon \`component\` prop can access to svg defs if has children 1`] = `
 
 exports[`Icon should give warning and render <i>{null}</i> 1`] = `
 <i
-  aria-label="icon: undefined"
   class="anticon"
 />
 `;
@@ -258,7 +256,6 @@ exports[`Icon should support older usage 1`] = `
 
 exports[`Icon should support pass svg paths as children 1`] = `
 <i
-  aria-label="icon: undefined"
   class="anticon"
 >
   <svg
@@ -282,7 +279,6 @@ exports[`Icon should support pass svg paths as children 1`] = `
 
 exports[`Icon should support svg react component 1`] = `
 <i
-  aria-label="icon: undefined"
   class="anticon my-home-icon"
 >
   <svg
@@ -335,7 +331,6 @@ exports[`Icon should support two-tone icon 1`] = `
 
 exports[`Icon support render svg as component 1`] = `
 <i
-  aria-label="icon: undefined"
   class="anticon"
 >
   <svg
@@ -352,7 +347,6 @@ exports[`Icon.createFromIconfontCN() should support iconfont.cn 1`] = `
   class="icons-list"
 >
   <i
-    aria-label="icon: undefined"
     class="anticon"
   >
     <svg
@@ -369,7 +363,6 @@ exports[`Icon.createFromIconfontCN() should support iconfont.cn 1`] = `
     </svg>
   </i>
   <i
-    aria-label="icon: undefined"
     class="anticon"
   >
     <svg
@@ -386,7 +379,6 @@ exports[`Icon.createFromIconfontCN() should support iconfont.cn 1`] = `
     </svg>
   </i>
   <i
-    aria-label="icon: undefined"
     class="anticon"
   >
     <svg

--- a/components/icon/index.tsx
+++ b/components/icon/index.tsx
@@ -179,7 +179,7 @@ const Icon: IconComponent<IconProps> = props => {
     <LocaleReceiver componentName="Icon">
       {(locale: TransferLocale) => (
         <i
-          aria-label={`${locale.icon}: ${type}`}
+          aria-label={type && `${locale.icon}: ${type}`}
           {...restProps}
           tabIndex={iconTabIndex}
           onClick={onClick}


### PR DESCRIPTION
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

close #14970

### Changelog description (Optional if not new feature)

> 1. Not set Icon `aria-label` when `type` is empty.
> 2. 当 Icon `type` 为空时，不设置 `aria-label`。

### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
