### PR TITLE
fix: 修复 List rowKey 不生效

### DIFF
--- a/components/list/index.tsx
+++ b/components/list/index.tsx
@@ -97,16 +97,18 @@ export default class List extends React.Component<ListProps> {
     };
   }
 
-  renderItem = (item: React.ReactElement<any>, index: number) => {
-    const { dataSource, renderItem, rowKey } = this.props;
+  renderItem = (record: any, index: number) => {
+    const { renderItem, rowKey } = this.props;
     let key;
 
-    if (typeof rowKey === 'function') {
-      key = rowKey(dataSource[index]);
-    } else if (typeof rowKey === 'string') {
-      key = dataSource[rowKey];
-    } else {
-      key = dataSource.key;
+    if (typeof record === 'object') {
+      if (typeof rowKey === 'function') {
+        key = rowKey(record, index);
+      } else if (typeof rowKey === 'string') {
+        key = record[rowKey];
+      } else {
+        key = record.key;
+      }
     }
 
     if (!key) {
@@ -115,7 +117,7 @@ export default class List extends React.Component<ListProps> {
 
     this.keys[index] = key;
 
-    return renderItem(item, index);
+    return renderItem(record, index);
   };
 
   isSomethingAfterLastItem() {


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

<List /> 组件默认使用索引作为 key，但是在数据插入的时候会遇到问题（尤其 是图片元素（`<img src="xx.png" />`））

详见下面diff 图：

![diff](https://gw.alipayobjects.com/mdn/rms_b35fa3/afts/img/A*7-DWSLN4HO8AAAAAAAAAAABjARQnAQ)

本应该直接在列表前面追加一个图片元素，结果由于 key 的原因改成了图片地址更新操作...，又因为图片资源是需要加载时间的，在新图片还未 load 的时候，会一直显示为之前的旧图片，就像下面这样 gif (点击打开) ：

[demo gif](https://gw.alipayobjects.com/mdn/rms_b35fa3/afts/img/A*a6ZXR7aug0cAAAAAAAAAAABjARQnAQ)

### What's the effect? (Optional if not new feature)

应该没太大影响，本身 props.rowKey 属性也没有暴露在 API 文档上，实现和使用方式上基本保持和 Table rowKey 组件一致
