### PR TITLE
fix(radio): delete unnecessary onChange

### DIFF
--- a/components/radio/__tests__/group.test.js
+++ b/components/radio/__tests__/group.test.js
@@ -123,6 +123,15 @@ describe('Radio', () => {
     expect(onChange.mock.calls.length).toBe(2);
   });
 
+  it('should only trigger once when in group with options', () => {
+    const onChange = jest.fn();
+    const options = [{ label: 'Bamboo', value: 'Bamboo' }];
+    const wrapper = mount(<RadioGroup options={options} onChange={onChange} />);
+
+    wrapper.find('input').simulate('change');
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
   it("won't fire change events when value not changes", () => {
     const onChange = jest.fn();
 

--- a/components/radio/group.tsx
+++ b/components/radio/group.tsx
@@ -124,7 +124,6 @@ class RadioGroup extends React.Component<RadioGroupProps, RadioGroupState> {
               prefixCls={prefixCls}
               disabled={this.props.disabled}
               value={option}
-              onChange={this.onRadioChange}
               checked={this.state.value === option}
             >
               {option}
@@ -138,7 +137,6 @@ class RadioGroup extends React.Component<RadioGroupProps, RadioGroupState> {
               prefixCls={prefixCls}
               disabled={option.disabled || this.props.disabled}
               value={option.value}
-              onChange={this.onRadioChange}
               checked={this.state.value === option.value}
             >
               {option.label}


### PR DESCRIPTION
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?
fix[#14976](https://github.com/ant-design/ant-design/issues/14976)


### Changelog description (Optional if not new feature)

> 1. Fix RadioGroup use `options` will trigger `onChange` twice.
> 2. 修复 RadioGroup 在使用 `options` 时会多次触发 `onChange` 的问题。

### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

