### PR TITLE
📝 site: use bisheng-plugin-typescript-interface to generate components document

### DIFF
--- a/components/locale-provider/index.en-US.md
+++ b/components/locale-provider/index.en-US.md
@@ -50,6 +50,7 @@ This component aims for localization of the built-in text, if you want to suppor
     "filePath":"components/locale-provider/index.tsx",
     "interfaceName":"LocaleProviderProps",
     "language":"en-US",
+    "exclude":["children"],
     "columnNames":[
         {
             "label":"Property",

--- a/components/locale-provider/index.en-US.md
+++ b/components/locale-provider/index.en-US.md
@@ -45,6 +45,28 @@ This component aims for localization of the built-in text, if you want to suppor
 
 ## API
 
-| Property | Description | Type | Default |
-| -------- | ----------- | ---- | ------- |
-| locale | language package setting, you can find the packages in [antd/lib/locale-provider](http://unpkg.com/antd/lib/locale-provider/) | object | - |
+```typescriptInterface
+{
+    "filePath":"components/locale-provider/index.tsx",
+    "interfaceName":"LocaleProviderProps",
+    "language":"en-US",
+    "columnNames":[
+        {
+            "label":"Property",
+            "key":"name"
+        },
+        {
+            "label":"Description",
+            "key":"description"
+        },
+        {
+            "label":"Type",
+            "key":"types"
+        },
+        {
+            "label":"Default",
+            "key":"default"
+        }
+    ]
+}
+```

--- a/components/locale-provider/index.en-US.md
+++ b/components/locale-provider/index.en-US.md
@@ -49,25 +49,6 @@ This component aims for localization of the built-in text, if you want to suppor
 {
     "filePath":"components/locale-provider/index.tsx",
     "interfaceName":"LocaleProviderProps",
-    "language":"en-US",
-    "exclude":["children"],
-    "columnNames":[
-        {
-            "label":"Property",
-            "key":"name"
-        },
-        {
-            "label":"Description",
-            "key":"description"
-        },
-        {
-            "label":"Type",
-            "key":"types"
-        },
-        {
-            "label":"Default",
-            "key":"default"
-        }
-    ]
+    "language":"en-US"
 }
 ```

--- a/components/locale-provider/index.tsx
+++ b/components/locale-provider/index.tsx
@@ -20,6 +20,9 @@ export interface Locale {
 
 export interface LocaleProviderProps {
   /**
+   * @types Object
+   */
+  /**
    * @language en-US
    * @description language package setting, you can find the packages in [antd/lib/locale-provider](http://unpkg.com/antd/lib/locale-provider/)
    */

--- a/components/locale-provider/index.tsx
+++ b/components/locale-provider/index.tsx
@@ -19,6 +19,14 @@ export interface Locale {
 }
 
 export interface LocaleProviderProps {
+  /**
+   * @language en-US
+   * @description language package setting, you can find the packages in [antd/lib/locale-provider](http://unpkg.com/antd/lib/locale-provider/)
+   */
+  /**
+   * @language zh-CN
+   * @description 语言包配置，语言包可到 [antd/lib/locale-provider](http://unpkg.com/antd/lib/locale-provider/) 目录下寻找
+   */
   locale: Locale;
   children?: React.ReactNode;
 }

--- a/components/locale-provider/index.zh-CN.md
+++ b/components/locale-provider/index.zh-CN.md
@@ -50,25 +50,6 @@ return <LocaleProvider locale={locales.en_US}><App /></LocaleProvider>;
 {
     "filePath":"components/locale-provider/index.tsx",
     "interfaceName":"LocaleProviderProps",
-    "language":"zh-CN",
-    "exclude":["children"],
-    "columnNames":[
-        {
-            "label":"属性",
-            "key":"name"
-        },
-        {
-            "label":"说明",
-            "key":"description"
-        },
-        {
-            "label":"类型",
-            "key":"types"
-        },
-        {
-            "label":"默认值",
-            "key":"default"
-        }
-    ]
+    "language":"zh-CN"
 }
 ```

--- a/components/locale-provider/index.zh-CN.md
+++ b/components/locale-provider/index.zh-CN.md
@@ -46,6 +46,28 @@ return <LocaleProvider locale={locales.en_US}><App /></LocaleProvider>;
 
 ## API
 
-| 参数 | 说明 | 类型 | 默认值 |
-| --- | --- | --- | --- |
-| locale | 语言包配置，语言包可到 [antd/lib/locale-provider](http://unpkg.com/antd/lib/locale-provider/) 目录下寻找 | object | - |
+```typescriptInterface
+{
+    "filePath":"components/locale-provider/index.tsx",
+    "interfaceName":"LocaleProviderProps",
+    "language":"en-US",
+    "columnNames":[
+        {
+            "label":"属性",
+            "key":"name"
+        },
+        {
+            "label":"说明",
+            "key":"description"
+        },
+        {
+            "label":"类型",
+            "key":"types"
+        },
+        {
+            "label":"默认值",
+            "key":"default"
+        }
+    ]
+}
+```

--- a/components/locale-provider/index.zh-CN.md
+++ b/components/locale-provider/index.zh-CN.md
@@ -50,7 +50,8 @@ return <LocaleProvider locale={locales.en_US}><App /></LocaleProvider>;
 {
     "filePath":"components/locale-provider/index.tsx",
     "interfaceName":"LocaleProviderProps",
-    "language":"en-US",
+    "language":"zh-CN",
+    "exclude":["children"],
     "columnNames":[
         {
             "label":"属性",

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "bisheng-plugin-description": "^0.1.4",
     "bisheng-plugin-react": "^1.0.0",
     "bisheng-plugin-toc": "^0.4.4",
+    "bisheng-plugin-typescript-interface": "^1.0.5",
     "chalk": "^2.4.1",
     "commander": "^2.18.0",
     "core-js": "^2.5.7",

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "bisheng-plugin-description": "^0.1.4",
     "bisheng-plugin-react": "^1.0.0",
     "bisheng-plugin-toc": "^0.4.4",
-    "bisheng-plugin-typescript-interface": "^1.0.6",
+    "bisheng-plugin-typescript-interface": "^1.1.1",
     "chalk": "^2.4.1",
     "commander": "^2.18.0",
     "core-js": "^2.5.7",

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "bisheng-plugin-description": "^0.1.4",
     "bisheng-plugin-react": "^1.0.0",
     "bisheng-plugin-toc": "^0.4.4",
-    "bisheng-plugin-typescript-interface": "^1.0.5",
+    "bisheng-plugin-typescript-interface": "^1.0.6",
     "chalk": "^2.4.1",
     "commander": "^2.18.0",
     "core-js": "^2.5.7",

--- a/site/theme/index.js
+++ b/site/theme/index.js
@@ -19,6 +19,54 @@ function pickerGenerator(module) {
   };
 }
 
+const bishengPluginTypescriptInterfaceConfig = {
+  base: {
+    exclude: ['children'],
+  },
+  i18n: {
+    'en-US': {
+      columnNames: [
+        {
+          label: 'Property',
+          key: 'name',
+        },
+        {
+          label: 'Description',
+          key: 'description',
+        },
+        {
+          label: 'Type',
+          key: 'types',
+        },
+        {
+          label: 'Default',
+          key: 'default',
+        },
+      ],
+    },
+    'zh-CN': {
+      columnNames: [
+        {
+          label: '属性',
+          key: 'name',
+        },
+        {
+          label: '说明',
+          key: 'description',
+        },
+        {
+          label: '类型',
+          key: 'types',
+        },
+        {
+          label: '默认值',
+          key: 'default',
+        },
+      ],
+    },
+  },
+};
+
 module.exports = {
   lazyLoad(nodePath, nodeValue) {
     if (typeof nodeValue === 'string') {
@@ -50,7 +98,9 @@ module.exports = {
     'docs/spec': pickerGenerator('spec'),
   },
   plugins: [
-    'bisheng-plugin-typescript-interface',
+    `bisheng-plugin-typescript-interface?encodeConfig=${Buffer.from(
+      JSON.stringify(bishengPluginTypescriptInterfaceConfig),
+    ).toString('base64')}`,
     'bisheng-plugin-description',
     'bisheng-plugin-toc?maxDepth=2&keepElem',
     'bisheng-plugin-antd?injectProvider',

--- a/site/theme/index.js
+++ b/site/theme/index.js
@@ -50,6 +50,7 @@ module.exports = {
     'docs/spec': pickerGenerator('spec'),
   },
   plugins: [
+    'bisheng-plugin-typescript-interface',
     'bisheng-plugin-description',
     'bisheng-plugin-toc?maxDepth=2&keepElem',
     'bisheng-plugin-antd?injectProvider',


### PR DESCRIPTION
### This is a ...

- [x] Site / document update

### What's the background?

> 1. Describe the source of requirement.
During development, I found no comments in d.ts.
开发时候，发现 d.ts 类型文件里没有注释
> 2. Resolve what problem.
Generate documentation via interface comments
通过注释生成文档，这样只需要维护注释
> 3. Related issue link.
https://github.com/ant-design/ant-design/issues/14940

### Additional Plan? 

Because there are too many components, personally think that it is more appropriate to change a component at a time, which is convenient for review.

因为组件太多，个人认为一次 commit 更改一个组件比较合适，这样方便 review。


