### PR TITLE
Fix FormItem warning message

### DIFF
--- a/components/form/FormItem.tsx
+++ b/components/form/FormItem.tsx
@@ -66,8 +66,10 @@ export default class FormItem extends React.Component<FormItemProps, any> {
   helpShow = false;
 
   componentDidMount() {
+    const { children, help, validateStatus } = this.props;
     warning(
-      this.getControls(this.props.children, true).length <= 1,
+      this.getControls(children, true).length <= 1 ||
+        (help !== undefined || validateStatus !== undefined),
       '`Form.Item` cannot generate `validateStatus` and `help` automatically, ' +
         'while there are more than one `getFieldDecorator` in it.',
     );

--- a/components/form/__tests__/message.test.js
+++ b/components/form/__tests__/message.test.js
@@ -87,4 +87,43 @@ describe('Form', () => {
 
     expect(wrapper.render()).toMatchSnapshot();
   });
+
+  it('should print warning for not generating help and validateStatus automatically', () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const Form1 = Form.create()(({ form }) => {
+      return (
+        <Form>
+          <Form.Item label="Account">
+            {form.getFieldDecorator('account')(<input />)}
+            {form.getFieldDecorator('account')(<input />)}
+          </Form.Item>
+        </Form>
+      );
+    });
+
+    mount(<Form1 />);
+    expect(errorSpy).toBeCalledWith(
+      'Warning: `Form.Item` cannot generate `validateStatus` and `help` automatically, while there are more than one `getFieldDecorator` in it.',
+    );
+    errorSpy.mockRestore();
+  });
+
+  // https://github.com/ant-design/ant-design/issues/14911
+  it('should not print warning for not generating help and validateStatus automatically when help or validateStatus is specified', () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const Form1 = Form.create()(({ form }) => {
+      return (
+        <Form>
+          <Form.Item label="Account" help="custom help information">
+            {form.getFieldDecorator('account')(<input />)}
+            {form.getFieldDecorator('account')(<input />)}
+          </Form.Item>
+        </Form>
+      );
+    });
+
+    mount(<Form1 />);
+    expect(errorSpy).not.toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
 });


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

should not print warning for not generating help and validateStatus automatically when help or validateStatus is specified

close #14911

### API Realization (Optional if not new feature)

> 1. Basic thought of solution and other optional proposal.
> 2. List final API realization and usage sample.
> 3. GIF or snapshot should be provided if includes UI/interactive modification.

### What's the effect? (Optional if not new feature)

> 1. Does this PR affect user? Which part will be affected?
> 2. What will say in changelog?
> 3. Does this PR contains potential break change or other risk?

### Changelog description (Optional if not new feature)

- 🐛 优化 FormItem 自动生成 help 和 validateStatus 的警告信息。#14911

### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

### Additional Plan? (Optional if not new feature)

> If this PR related with other PR or following info. You can type here.
