### PR TITLE
Fix check marker style of Select selected item

### DIFF
--- a/components/form/__tests__/label.test.js
+++ b/components/form/__tests__/label.test.js
@@ -5,7 +5,7 @@ import Form from '..';
 describe('Form', () => {
   // Mock of `querySelector`
   const originQuerySelector = HTMLElement.prototype.querySelector;
-  HTMLElement.prototype.querySelector = function(str) {
+  HTMLElement.prototype.querySelector = function querySelector(str) {
     const match = str.match(/^\[id=('|")(.*)('|")]$/);
     const id = match && match[2];
 

--- a/components/select/style/index.less
+++ b/components/select/style/index.less
@@ -552,8 +552,8 @@
         top: 50%;
         right: @control-padding-horizontal;
         color: transparent;
-        font-size: 12px;
         font-weight: bold;
+        font-size: 12px;
         text-shadow: 0 0.1px 0, 0.1px 0 0, 0 -0.1px 0, -0.1px 0;
         transform: translateY(-50%);
         transition: all .2s;

--- a/components/select/style/index.less
+++ b/components/select/style/index.less
@@ -552,11 +552,11 @@
         top: 50%;
         right: @control-padding-horizontal;
         color: transparent;
+        font-size: 12px;
         font-weight: bold;
         text-shadow: 0 0.1px 0, 0.1px 0 0, 0 -0.1px 0, -0.1px 0;
         transform: translateY(-50%);
-        transition: all 0.2s ease;
-        .iconfont-size-under-12px(10px);
+        transition: all .2s;
       }
 
       &:hover .@{select-prefix-cls}-selected-icon {


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

Multiple select arrow is not align center.

<img width="436" alt="default" src="https://user-images.githubusercontent.com/507615/53244597-4f295e80-36e6-11e9-8054-218ed7deb1ff.png">

Fix to:

<img width="469" alt="default" src="https://user-images.githubusercontent.com/507615/53244617-60726b00-36e6-11e9-8f3c-ffdb4a42a73f.png">

### Changelog description (Optional if not new feature)

> 1. English description

🐛 Fixed that Select check icon is not aligned center. #15016

> 2. Chinese description (optional)

🐛 修复 Select 选中图标位置偏下的问题。#15016

### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

### Additional Plan? (Optional if not new feature)

> If this PR related with other PR or following info. You can type here.
