### PR TITLE
Fix horizontal submenu wider then menu title in most cases

### DIFF
--- a/components/menu/style/index.less
+++ b/components/menu/style/index.less
@@ -122,9 +122,11 @@
   &-vertical&-sub,
   &-vertical-left&-sub,
   &-vertical-right&-sub {
+    min-width: 160px;
     padding: 0;
     border-right: 0;
     transform-origin: 0 0;
+
     .@{menu-prefix-cls}-item {
       left: 0;
       margin-left: 0;
@@ -139,11 +141,8 @@
     }
   }
 
-  &-horizontal&-sub,
-  &-vertical&-sub,
-  &-vertical-left&-sub,
-  &-vertical-right&-sub {
-    min-width: 160px;
+  &-horizontal&-sub {
+    min-width: 114px; // in case of submenu width is too big: https://codesandbox.io/s/qvpwm6mk66
   }
 
   &-item,


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

https://juejin.im/post/5c717a8d6fb9a049ab0e3e1d

https://codesandbox.io/s/qvpwm6mk66

Reproducible demo: 

<img width="717" alt="image" src="https://user-images.githubusercontent.com/507615/53317927-7d868400-3908-11e9-9685-2898ac0e5c4b.png">

### API Realization (Optional if not new feature)

We can remove `min-width` of sub menu in horizontal menu to resolve it. But it will make sub menu with menu group ugly for too narrow and not aligned centerly. So I decided to just make it smaller.

### What's the effect? (Optional if not new feature)

> 1. Does this PR affect user? Which part will be affected?
> 2. What will say in changelog?
> 3. Does this PR contains potential break change or other risk?

### Changelog description (Optional if not new feature)

> 1. English description
- Fix horizontal submenu wider then menu title in most cases. #15031
> 2. Chinese description (optional)
- 修复水平菜单弹出层宽度超过标题的问题。#15031

### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

### Additional Plan? (Optional if not new feature)

> If this PR related with other PR or following info. You can type here.
