### PR TITLE
fix cascader should tab twice to exist

### DIFF
--- a/components/cascader/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/cascader/__tests__/__snapshots__/demo.test.js.snap
@@ -13,6 +13,7 @@ exports[`renders ./components/cascader/demo/basic.md correctly 1`] = `
     class="ant-input ant-cascader-input "
     placeholder="Please select"
     readonly=""
+    tabindex="-1"
     type="text"
     value=""
   />
@@ -50,6 +51,7 @@ exports[`renders ./components/cascader/demo/change-on-select.md correctly 1`] = 
     class="ant-input ant-cascader-input "
     placeholder="Please select"
     readonly=""
+    tabindex="-1"
     type="text"
     value=""
   />
@@ -101,6 +103,7 @@ exports[`renders ./components/cascader/demo/custom-render.md correctly 1`] = `
     autocomplete="off"
     class="ant-input ant-cascader-input "
     readonly=""
+    tabindex="-1"
     type="text"
     value=""
   />
@@ -170,6 +173,7 @@ exports[`renders ./components/cascader/demo/default-value.md correctly 1`] = `
     autocomplete="off"
     class="ant-input ant-cascader-input "
     readonly=""
+    tabindex="-1"
     type="text"
     value=""
   />
@@ -226,6 +230,7 @@ exports[`renders ./components/cascader/demo/disabled-option.md correctly 1`] = `
     class="ant-input ant-cascader-input "
     placeholder="Please select"
     readonly=""
+    tabindex="-1"
     type="text"
     value=""
   />
@@ -263,6 +268,7 @@ exports[`renders ./components/cascader/demo/fields-name.md correctly 1`] = `
     class="ant-input ant-cascader-input "
     placeholder="Please select"
     readonly=""
+    tabindex="-1"
     type="text"
     value=""
   />
@@ -300,6 +306,7 @@ exports[`renders ./components/cascader/demo/hover.md correctly 1`] = `
     class="ant-input ant-cascader-input "
     placeholder="Please select"
     readonly=""
+    tabindex="-1"
     type="text"
     value=""
   />
@@ -337,6 +344,7 @@ exports[`renders ./components/cascader/demo/lazy.md correctly 1`] = `
     class="ant-input ant-cascader-input "
     placeholder="Please select"
     readonly=""
+    tabindex="-1"
     type="text"
     value=""
   />
@@ -373,6 +381,7 @@ exports[`renders ./components/cascader/demo/search.md correctly 1`] = `
     autocomplete="off"
     class="ant-input ant-cascader-input "
     placeholder="Please select"
+    tabindex="-1"
     type="text"
     value=""
   />
@@ -411,6 +420,7 @@ exports[`renders ./components/cascader/demo/size.md correctly 1`] = `
       class="ant-input ant-cascader-input ant-input-lg"
       placeholder="Please select"
       readonly=""
+      tabindex="-1"
       type="text"
       value=""
     />
@@ -447,6 +457,7 @@ exports[`renders ./components/cascader/demo/size.md correctly 1`] = `
       class="ant-input ant-cascader-input "
       placeholder="Please select"
       readonly=""
+      tabindex="-1"
       type="text"
       value=""
     />
@@ -483,6 +494,7 @@ exports[`renders ./components/cascader/demo/size.md correctly 1`] = `
       class="ant-input ant-cascader-input ant-input-sm"
       placeholder="Please select"
       readonly=""
+      tabindex="-1"
       type="text"
       value=""
     />
@@ -524,6 +536,7 @@ exports[`renders ./components/cascader/demo/suffix.md correctly 1`] = `
       class="ant-input ant-cascader-input "
       placeholder="Please select"
       readonly=""
+      tabindex="-1"
       type="text"
       value=""
     />
@@ -559,6 +572,7 @@ exports[`renders ./components/cascader/demo/suffix.md correctly 1`] = `
       class="ant-input ant-cascader-input "
       placeholder="Please select"
       readonly=""
+      tabindex="-1"
       type="text"
       value=""
     />

--- a/components/cascader/__tests__/__snapshots__/index.test.js.snap
+++ b/components/cascader/__tests__/__snapshots__/index.test.js.snap
@@ -1237,6 +1237,7 @@ exports[`Cascader support controlled mode 1`] = `
     autocomplete="off"
     class="ant-input ant-cascader-input "
     readonly=""
+    tabindex="-1"
     type="text"
     value=""
   />

--- a/components/cascader/index.tsx
+++ b/components/cascader/index.tsx
@@ -520,6 +520,7 @@ class Cascader extends React.Component<CascaderProps, CascaderState> {
         <span className={`${prefixCls}-picker-label`}>{this.getLabel()}</span>
         <Input
           {...inputProps}
+          tabIndex="-1"
           ref={this.saveInput}
           prefixCls={inputPrefixCls}
           placeholder={value && value.length > 0 ? undefined : placeholder}

--- a/components/config-provider/__tests__/__snapshots__/components.test.js.snap
+++ b/components/config-provider/__tests__/__snapshots__/components.test.js.snap
@@ -5799,6 +5799,7 @@ exports[`ConfigProvider components Cascader configProvider 1`] = `
     autocomplete="off"
     class="config-input config-cascader-input "
     placeholder="Please select"
+    tabindex="-1"
     type="text"
     value=""
   />
@@ -5835,6 +5836,7 @@ exports[`ConfigProvider components Cascader normal 1`] = `
     autocomplete="off"
     class="ant-input ant-cascader-input "
     placeholder="Please select"
+    tabindex="-1"
     type="text"
     value=""
   />
@@ -5871,6 +5873,7 @@ exports[`ConfigProvider components Cascader prefixCls 1`] = `
     autocomplete="off"
     class="ant-input prefix-Cascader-input "
     placeholder="Please select"
+    tabindex="-1"
     type="text"
     value=""
   />

--- a/components/empty/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/empty/__tests__/__snapshots__/demo.test.js.snap
@@ -146,6 +146,7 @@ exports[`renders ./components/empty/demo/config-provider.md correctly 1`] = `
         autocomplete="off"
         class="ant-input ant-cascader-input "
         placeholder="Please select"
+        tabindex="-1"
         type="text"
         value=""
       />

--- a/components/form/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/form/__tests__/__snapshots__/demo.test.js.snap
@@ -1711,6 +1711,7 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
               data-__meta="[object Object]"
               id="register_residence"
               readonly=""
+              tabindex="-1"
               type="text"
               value=""
             />
@@ -4692,6 +4693,7 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
               autocomplete="off"
               class="ant-input ant-cascader-input "
               readonly=""
+              tabindex="-1"
               type="text"
               value=""
             />

--- a/components/input/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/input/__tests__/__snapshots__/demo.test.js.snap
@@ -898,6 +898,7 @@ exports[`renders ./components/input/demo/group.md correctly 1`] = `
         class="ant-input ant-cascader-input "
         placeholder="Select Address"
         readonly=""
+        tabindex="-1"
         type="text"
         value=""
       />


### PR DESCRIPTION
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

fix #15115

### Changelog description (Optional if not new feature)

> 1. Fix Cascader should tab twice to exist.
> 2. 修复 Cascader 需要按 Tab 两次切换聚焦的问题。

### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
