### PR TITLE
table reader mobile friendly

### DIFF
--- a/site/theme/static/markdown.less
+++ b/site/theme/static/markdown.less
@@ -204,35 +204,39 @@
   clear: both;
 }
 
-.markdown.api-container table {
-  margin: 2em 0;
-  font-size: @font-size-base;
-  font-family: @code-family;
-  line-height: @line-height-base;
-  border-width: 0;
-  th,
-  td {
-    padding: 14px 16px;
-    border-width: 1px 0;
-    border-color: @border-color-split;
-  }
-  th {
-    border-width: 0 0 2px 0;
-  }
-  td:first-child {
-    width: 20%;
-    color: @blue-9;
-    font-weight: 500;
-  }
-  td:nth-child(3) {
-    width: 22%;
-    color: @magenta-7;
-    font-size: @font-size-base - 1px;
-    word-break: break-all;
-  }
-  td:last-child {
-    width: 13%;
-    font-size: @font-size-base - 1px;
+.markdown.api-container {
+  overflow-x: auto;
+  table {
+    min-width: 719px;
+    margin: 2em 0;
+    font-size: @font-size-base;
+    font-family: @code-family;
+    line-height: @line-height-base;
+    border-width: 0;
+    th,
+    td {
+      padding: 14px 16px;
+      border-width: 1px 0;
+      border-color: @border-color-split;
+    }
+    th {
+      border-width: 0 0 2px 0;
+    }
+    td:first-child {
+      width: 20%;
+      color: @blue-9;
+      font-weight: 500;
+    }
+    td:nth-child(3) {
+      width: 22%;
+      color: @magenta-7;
+      font-size: @font-size-base - 1px;
+      word-break: break-all;
+    }
+    td:last-child {
+      width: 13%;
+      font-size: @font-size-base - 1px;
+    }
   }
 }
 


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

####  1. Describe the source of requirement.

在手机上访问ant-design，发现无法查看组件的API
<img width="362" alt="wx20190302-103105 2x" src="https://user-images.githubusercontent.com/11746742/53678290-067e3080-3cf8-11e9-95ad-1499513a801c.png">
#### 2. Resolve what problem.

在手机或者小屏幕用户，更友好的阅读官网的文档
#### 3. Related issue link.
无

### API Realization (Optional if not new feature)

####  1. Basic thought of solution and other optional proposal.

固定表格最小宽度，保持表格的工整，超出部分可滚动。
做了最简单的修复。只是加了一个overflow-x，和min-width，其他样式原样移动。
#### 2. GIF or snapshot should be provided if includes UI/interactive modification.
![2019-03-02 14 36 56](https://user-images.githubusercontent.com/11746742/53678341-acca3600-3cf8-11e9-8b8f-93cd2541b4f0.gif)

### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed