### PR TITLE
Fix closable Drawer hiding without transition

### DIFF
--- a/components/drawer/style/drawer.less
+++ b/components/drawer/style/drawer.less
@@ -12,8 +12,10 @@
   z-index: @zindex-modal;
   width: 0%;
   height: 100%;
+
   > * {
-    transition: transform @animation-duration-slow @ease-base-in;
+    transition: transform @animation-duration-slow @ease-base-in,
+      box-shadow @animation-duration-slow @ease-base-in;
   }
 
   &-content-wrapper {


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

Closable Drawer hiding without transition.

When close Drawer in https://codesandbox.io/s/4r5y562pmx, the box-shadow in drawer will disappear immediately. We should add transtion on it.

### API Realization (Optional if not new feature)

Look the code diff.

### What's the effect? (Optional if not new feature)

> 1. Does this PR affect user? Which part will be affected?
> 2. What will say in changelog?
> 3. Does this PR contains potential break change or other risk?

### Changelog description (Optional if not new feature)

> 1. English description
- Fix closable Drawer hiding without transition.
> 2. Chinese description (optional)
- 修复关闭抽屉时浮层阴影没有缓动消失的细节。

### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed