### PR TITLE
 (Site_Icon_Display) modify background color for two tone icon item

### DIFF
--- a/site/theme/static/icons.less
+++ b/site/theme/static/icons.less
@@ -46,6 +46,10 @@ ul.anticons-list {
       }
     }
 
+    &.outlined:hover {
+      background-color: #8ecafe;
+    }
+
     &.copied:hover {
       color: rgba(255, 255, 255, 0.2);
     }

--- a/site/theme/template/IconDisplay/CopyableIcon.tsx
+++ b/site/theme/template/IconDisplay/CopyableIcon.tsx
@@ -23,7 +23,7 @@ const CopyableIcon: React.SFC<CopyableIconProps> = ({
 }) => {
   const className = classNames({
     copied: justCopied === type,
-    outlined: theme === 'twoTone'
+    outlined: theme === 'twoTone',
   });
   return (
     <CopyToClipboard

--- a/site/theme/template/IconDisplay/CopyableIcon.tsx
+++ b/site/theme/template/IconDisplay/CopyableIcon.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import CopyToClipboard from 'react-copy-to-clipboard';
 import { Icon as AntdIcon, Badge } from 'antd';
+import classNames from 'classnames';
 import { ThemeType, IconProps } from '../../../../components/icon';
 
 const Icon: React.SFC<IconProps> = AntdIcon;
@@ -20,6 +21,10 @@ const CopyableIcon: React.SFC<CopyableIconProps> = ({
   justCopied,
   onCopied,
 }) => {
+  const className = classNames({
+    copied: justCopied === type,
+    outlined: theme === 'twoTone'
+  });
   return (
     <CopyToClipboard
       text={
@@ -29,7 +34,7 @@ const CopyableIcon: React.SFC<CopyableIconProps> = ({
       }
       onCopy={(text: string) => onCopied(type, text)}
     >
-      <li className={justCopied === type ? 'copied' : ''}>
+      <li className={className}>
         <Icon type={type} theme={theme} />
         <span className="anticon-class">
           <Badge dot={isNew}>{type}</Badge>


### PR DESCRIPTION
when theme equal two-tone add class to li tag, modify hover color from primary color to #8ecafe.


### This is a ...

- [x] Site / document update


### What's the background?

when the mouse hovers on Icons of Two Tone, the background color will cover the icons SVG path.
![twotone](https://user-images.githubusercontent.com/21355783/53723867-9e6c4d80-3ea3-11e9-98b0-beb953fbf78f.gif)

