### PR TITLE
Text ellipsis should be optional

### DIFF
--- a/components/typography/Text.tsx
+++ b/components/typography/Text.tsx
@@ -3,7 +3,7 @@ import warning from '../_util/warning';
 import Base, { BlockProps } from './Base';
 
 interface TextProps extends BlockProps {
-  ellipsis: boolean;
+  ellipsis?: boolean;
 }
 
 const Text: React.SFC<TextProps> = ({ ellipsis, ...restProps }) => {


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?

1. Describe the source of requirement, like related issue link.

close #15189

2. Describe the problem and the scenario.

In TypeScript, `<Text ellipsis />` should be optional.

### 💡 Solution

Like changes.

### 📝 Changelog description

> Describe changes from user side, and list all potential break changes or other risks.

1. English description

- Text ellipsis should be optional in TypeScript. #15189

2. Chinese description (optional)

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
