### PR TITLE
Refactor List Item dom structure

### DIFF
--- a/components/list/Item.tsx
+++ b/components/list/Item.tsx
@@ -81,8 +81,6 @@ export default class Item extends React.Component<ListItemProps, any> {
       ...others
     } = this.props;
     const prefixCls = getPrefixCls('list', customizePrefixCls);
-    const classString = classNames(`${prefixCls}-item`, className);
-
     const actionsContent = actions && actions.length > 0 && (
       <ul className={`${prefixCls}-item-action`}>
         {actions.map((action: React.ReactNode, i: number) => (
@@ -93,24 +91,23 @@ export default class Item extends React.Component<ListItemProps, any> {
         ))}
       </ul>
     );
-
-    const extraContent = (
-      <div className={`${prefixCls}-item-extra-wrap`}>
-        <div className={`${prefixCls}-item-main`}>
-          {children}
-          {actionsContent}
-        </div>
-        <div className={`${prefixCls}-item-extra`}>{extra}</div>
-      </div>
-    );
-
     const itemChildren = (
-      <div {...others} className={classString}>
-        {extra ? extraContent : [children, actionsContent]}
+      <div {...others} className={classNames(`${prefixCls}-item`, className)}>
+        {extra ? (
+          <div className={`${prefixCls}-item-extra-wrap`}>
+            <div className={`${prefixCls}-item-main`}>
+              {children}
+              {actionsContent}
+            </div>
+            <div className={`${prefixCls}-item-extra`}>{extra}</div>
+          </div>
+        ) : (
+          [children, actionsContent]
+        )}
       </div>
     );
 
-    const mainContent = grid ? (
+    return grid ? (
       <Col
         span={getGrid(grid, 'column')}
         xs={getGrid(grid, 'xs')}
@@ -125,8 +122,6 @@ export default class Item extends React.Component<ListItemProps, any> {
     ) : (
       itemChildren
     );
-
-    return mainContent;
   };
 
   render() {

--- a/components/list/Item.tsx
+++ b/components/list/Item.tsx
@@ -83,46 +83,30 @@ export default class Item extends React.Component<ListItemProps, any> {
     const prefixCls = getPrefixCls('list', customizePrefixCls);
     const classString = classNames(`${prefixCls}-item`, className);
 
-    const metaContent: React.ReactElement<any>[] = [];
-    const otherContent: React.ReactElement<any>[] = [];
-
-    React.Children.forEach(children, (element: React.ReactElement<any>) => {
-      if (element && element.type && element.type === Meta) {
-        metaContent.push(element);
-      } else {
-        otherContent.push(element);
-      }
-    });
-
-    const contentClassString = classNames(`${prefixCls}-item-content`, {
-      [`${prefixCls}-item-content-single`]: metaContent.length < 1,
-    });
-    const content =
-      otherContent.length > 0 ? <div className={contentClassString}>{otherContent}</div> : null;
-
-    let actionsContent;
-    if (actions && actions.length > 0) {
-      const actionsContentItem = (action: React.ReactNode, i: number) => (
-        <li key={`${prefixCls}-item-action-${i}`}>
-          {action}
-          {i !== actions.length - 1 && <em className={`${prefixCls}-item-action-split`} />}
-        </li>
-      );
-      actionsContent = (
-        <ul className={`${prefixCls}-item-action`}>
-          {actions.map((action, i) => actionsContentItem(action, i))}
-        </ul>
-      );
-    }
+    const actionsContent = actions && actions.length > 0 && (
+      <ul className={`${prefixCls}-item-action`}>
+        {actions.map((action: React.ReactNode, i: number) => (
+          <li key={`${prefixCls}-item-action-${i}`}>
+            {action}
+            {i !== actions.length - 1 && <em className={`${prefixCls}-item-action-split`} />}
+          </li>
+        ))}
+      </ul>
+    );
 
     const extraContent = (
       <div className={`${prefixCls}-item-extra-wrap`}>
         <div className={`${prefixCls}-item-main`}>
-          {metaContent}
-          {content}
+          {children}
           {actionsContent}
         </div>
         <div className={`${prefixCls}-item-extra`}>{extra}</div>
+      </div>
+    );
+
+    const itemChildren = (
+      <div {...others} className={classString}>
+        {extra ? extraContent : [children, actionsContent]}
       </div>
     );
 
@@ -136,20 +120,10 @@ export default class Item extends React.Component<ListItemProps, any> {
         xl={getGrid(grid, 'xl')}
         xxl={getGrid(grid, 'xxl')}
       >
-        <div {...others} className={classString}>
-          {extra && extraContent}
-          {!extra && metaContent}
-          {!extra && content}
-          {!extra && actionsContent}
-        </div>
+        {itemChildren}
       </Col>
     ) : (
-      <div {...others} className={classString}>
-        {extra && extraContent}
-        {!extra && metaContent}
-        {!extra && content}
-        {!extra && actionsContent}
-      </div>
+      itemChildren
     );
 
     return mainContent;

--- a/components/list/Item.tsx
+++ b/components/list/Item.tsx
@@ -70,6 +70,17 @@ export default class Item extends React.Component<ListItemProps, any> {
 
   context: any;
 
+  isItemContainsTextNode() {
+    const { children } = this.props;
+    let result;
+    React.Children.forEach(children, (element: React.ReactElement<any>) => {
+      if (typeof element === 'string') {
+        result = true;
+      }
+    });
+    return result;
+  }
+
   renderItem = ({ getPrefixCls }: ConfigConsumerProps) => {
     const { grid } = this.context;
     const {
@@ -82,7 +93,7 @@ export default class Item extends React.Component<ListItemProps, any> {
     } = this.props;
     const prefixCls = getPrefixCls('list', customizePrefixCls);
     const actionsContent = actions && actions.length > 0 && (
-      <ul className={`${prefixCls}-item-action`}>
+      <ul className={`${prefixCls}-item-action`} key="actions">
         {actions.map((action: React.ReactNode, i: number) => (
           <li key={`${prefixCls}-item-action-${i}`}>
             {action}
@@ -92,18 +103,23 @@ export default class Item extends React.Component<ListItemProps, any> {
       </ul>
     );
     const itemChildren = (
-      <div {...others} className={classNames(`${prefixCls}-item`, className)}>
-        {extra ? (
-          <div className={`${prefixCls}-item-extra-wrap`}>
-            <div className={`${prefixCls}-item-main`}>
-              {children}
-              {actionsContent}
-            </div>
-            <div className={`${prefixCls}-item-extra`}>{extra}</div>
-          </div>
-        ) : (
-          [children, actionsContent]
-        )}
+      <div
+        {...others}
+        className={classNames(`${prefixCls}-item`, className, {
+          [`${prefixCls}-item-no-flex`]: !extra && this.isItemContainsTextNode(),
+        })}
+      >
+        {extra
+          ? [
+              <div className={`${prefixCls}-item-main`} key="content">
+                {children}
+                {actionsContent}
+              </div>,
+              <div className={`${prefixCls}-item-extra`} key="extra">
+                {extra}
+              </div>,
+            ]
+          : [children, actionsContent]}
       </div>
     );
 

--- a/components/list/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/list/__tests__/__snapshots__/demo.test.js.snap
@@ -185,29 +185,25 @@ exports[`renders ./components/list/demo/grid.md correctly 1`] = `
             class="ant-list-item"
           >
             <div
-              class="ant-list-item-content ant-list-item-content-single"
+              class="ant-card ant-card-bordered"
             >
               <div
-                class="ant-card ant-card-bordered"
+                class="ant-card-head"
               >
                 <div
-                  class="ant-card-head"
+                  class="ant-card-head-wrapper"
                 >
                   <div
-                    class="ant-card-head-wrapper"
+                    class="ant-card-head-title"
                   >
-                    <div
-                      class="ant-card-head-title"
-                    >
-                      Title 1
-                    </div>
+                    Title 1
                   </div>
                 </div>
-                <div
-                  class="ant-card-body"
-                >
-                  Card content
-                </div>
+              </div>
+              <div
+                class="ant-card-body"
+              >
+                Card content
               </div>
             </div>
           </div>
@@ -220,29 +216,25 @@ exports[`renders ./components/list/demo/grid.md correctly 1`] = `
             class="ant-list-item"
           >
             <div
-              class="ant-list-item-content ant-list-item-content-single"
+              class="ant-card ant-card-bordered"
             >
               <div
-                class="ant-card ant-card-bordered"
+                class="ant-card-head"
               >
                 <div
-                  class="ant-card-head"
+                  class="ant-card-head-wrapper"
                 >
                   <div
-                    class="ant-card-head-wrapper"
+                    class="ant-card-head-title"
                   >
-                    <div
-                      class="ant-card-head-title"
-                    >
-                      Title 2
-                    </div>
+                    Title 2
                   </div>
                 </div>
-                <div
-                  class="ant-card-body"
-                >
-                  Card content
-                </div>
+              </div>
+              <div
+                class="ant-card-body"
+              >
+                Card content
               </div>
             </div>
           </div>
@@ -255,29 +247,25 @@ exports[`renders ./components/list/demo/grid.md correctly 1`] = `
             class="ant-list-item"
           >
             <div
-              class="ant-list-item-content ant-list-item-content-single"
+              class="ant-card ant-card-bordered"
             >
               <div
-                class="ant-card ant-card-bordered"
+                class="ant-card-head"
               >
                 <div
-                  class="ant-card-head"
+                  class="ant-card-head-wrapper"
                 >
                   <div
-                    class="ant-card-head-wrapper"
+                    class="ant-card-head-title"
                   >
-                    <div
-                      class="ant-card-head-title"
-                    >
-                      Title 3
-                    </div>
+                    Title 3
                   </div>
                 </div>
-                <div
-                  class="ant-card-body"
-                >
-                  Card content
-                </div>
+              </div>
+              <div
+                class="ant-card-body"
+              >
+                Card content
               </div>
             </div>
           </div>
@@ -290,29 +278,25 @@ exports[`renders ./components/list/demo/grid.md correctly 1`] = `
             class="ant-list-item"
           >
             <div
-              class="ant-list-item-content ant-list-item-content-single"
+              class="ant-card ant-card-bordered"
             >
               <div
-                class="ant-card ant-card-bordered"
+                class="ant-card-head"
               >
                 <div
-                  class="ant-card-head"
+                  class="ant-card-head-wrapper"
                 >
                   <div
-                    class="ant-card-head-wrapper"
+                    class="ant-card-head-title"
                   >
-                    <div
-                      class="ant-card-head-title"
-                    >
-                      Title 4
-                    </div>
+                    Title 4
                   </div>
                 </div>
-                <div
-                  class="ant-card-body"
-                >
-                  Card content
-                </div>
+              </div>
+              <div
+                class="ant-card-body"
+              >
+                Card content
               </div>
             </div>
           </div>
@@ -433,29 +417,25 @@ exports[`renders ./components/list/demo/resposive.md correctly 1`] = `
             class="ant-list-item"
           >
             <div
-              class="ant-list-item-content ant-list-item-content-single"
+              class="ant-card ant-card-bordered"
             >
               <div
-                class="ant-card ant-card-bordered"
+                class="ant-card-head"
               >
                 <div
-                  class="ant-card-head"
+                  class="ant-card-head-wrapper"
                 >
                   <div
-                    class="ant-card-head-wrapper"
+                    class="ant-card-head-title"
                   >
-                    <div
-                      class="ant-card-head-title"
-                    >
-                      Title 1
-                    </div>
+                    Title 1
                   </div>
                 </div>
-                <div
-                  class="ant-card-body"
-                >
-                  Card content
-                </div>
+              </div>
+              <div
+                class="ant-card-body"
+              >
+                Card content
               </div>
             </div>
           </div>
@@ -468,29 +448,25 @@ exports[`renders ./components/list/demo/resposive.md correctly 1`] = `
             class="ant-list-item"
           >
             <div
-              class="ant-list-item-content ant-list-item-content-single"
+              class="ant-card ant-card-bordered"
             >
               <div
-                class="ant-card ant-card-bordered"
+                class="ant-card-head"
               >
                 <div
-                  class="ant-card-head"
+                  class="ant-card-head-wrapper"
                 >
                   <div
-                    class="ant-card-head-wrapper"
+                    class="ant-card-head-title"
                   >
-                    <div
-                      class="ant-card-head-title"
-                    >
-                      Title 2
-                    </div>
+                    Title 2
                   </div>
                 </div>
-                <div
-                  class="ant-card-body"
-                >
-                  Card content
-                </div>
+              </div>
+              <div
+                class="ant-card-body"
+              >
+                Card content
               </div>
             </div>
           </div>
@@ -503,29 +479,25 @@ exports[`renders ./components/list/demo/resposive.md correctly 1`] = `
             class="ant-list-item"
           >
             <div
-              class="ant-list-item-content ant-list-item-content-single"
+              class="ant-card ant-card-bordered"
             >
               <div
-                class="ant-card ant-card-bordered"
+                class="ant-card-head"
               >
                 <div
-                  class="ant-card-head"
+                  class="ant-card-head-wrapper"
                 >
                   <div
-                    class="ant-card-head-wrapper"
+                    class="ant-card-head-title"
                   >
-                    <div
-                      class="ant-card-head-title"
-                    >
-                      Title 3
-                    </div>
+                    Title 3
                   </div>
                 </div>
-                <div
-                  class="ant-card-body"
-                >
-                  Card content
-                </div>
+              </div>
+              <div
+                class="ant-card-body"
+              >
+                Card content
               </div>
             </div>
           </div>
@@ -538,29 +510,25 @@ exports[`renders ./components/list/demo/resposive.md correctly 1`] = `
             class="ant-list-item"
           >
             <div
-              class="ant-list-item-content ant-list-item-content-single"
+              class="ant-card ant-card-bordered"
             >
               <div
-                class="ant-card ant-card-bordered"
+                class="ant-card-head"
               >
                 <div
-                  class="ant-card-head"
+                  class="ant-card-head-wrapper"
                 >
                   <div
-                    class="ant-card-head-wrapper"
+                    class="ant-card-head-title"
                   >
-                    <div
-                      class="ant-card-head-title"
-                    >
-                      Title 4
-                    </div>
+                    Title 4
                   </div>
                 </div>
-                <div
-                  class="ant-card-body"
-                >
-                  Card content
-                </div>
+              </div>
+              <div
+                class="ant-card-body"
+              >
+                Card content
               </div>
             </div>
           </div>
@@ -573,29 +541,25 @@ exports[`renders ./components/list/demo/resposive.md correctly 1`] = `
             class="ant-list-item"
           >
             <div
-              class="ant-list-item-content ant-list-item-content-single"
+              class="ant-card ant-card-bordered"
             >
               <div
-                class="ant-card ant-card-bordered"
+                class="ant-card-head"
               >
                 <div
-                  class="ant-card-head"
+                  class="ant-card-head-wrapper"
                 >
                   <div
-                    class="ant-card-head-wrapper"
+                    class="ant-card-head-title"
                   >
-                    <div
-                      class="ant-card-head-title"
-                    >
-                      Title 5
-                    </div>
+                    Title 5
                   </div>
                 </div>
-                <div
-                  class="ant-card-body"
-                >
-                  Card content
-                </div>
+              </div>
+              <div
+                class="ant-card-body"
+              >
+                Card content
               </div>
             </div>
           </div>
@@ -608,29 +572,25 @@ exports[`renders ./components/list/demo/resposive.md correctly 1`] = `
             class="ant-list-item"
           >
             <div
-              class="ant-list-item-content ant-list-item-content-single"
+              class="ant-card ant-card-bordered"
             >
               <div
-                class="ant-card ant-card-bordered"
+                class="ant-card-head"
               >
                 <div
-                  class="ant-card-head"
+                  class="ant-card-head-wrapper"
                 >
                   <div
-                    class="ant-card-head-wrapper"
+                    class="ant-card-head-title"
                   >
-                    <div
-                      class="ant-card-head-title"
-                    >
-                      Title 6
-                    </div>
+                    Title 6
                   </div>
                 </div>
-                <div
-                  class="ant-card-body"
-                >
-                  Card content
-                </div>
+              </div>
+              <div
+                class="ant-card-body"
+              >
+                Card content
               </div>
             </div>
           </div>
@@ -665,49 +625,64 @@ exports[`renders ./components/list/demo/simple.md correctly 1`] = `
         class="ant-spin-container"
       >
         <div
-          class="ant-list-item"
+          class="ant-list-item ant-list-item-no-flex"
         >
-          <div
-            class="ant-list-item-content ant-list-item-content-single"
+          <span
+            class="ant-typography"
           >
-            Racing car sprays burning fuel into crowd.
-          </div>
+            <mark>
+              [ITEM]
+            </mark>
+          </span>
+           Racing car sprays burning fuel into crowd.
         </div>
         <div
-          class="ant-list-item"
+          class="ant-list-item ant-list-item-no-flex"
         >
-          <div
-            class="ant-list-item-content ant-list-item-content-single"
+          <span
+            class="ant-typography"
           >
-            Japanese princess to wed commoner.
-          </div>
+            <mark>
+              [ITEM]
+            </mark>
+          </span>
+           Japanese princess to wed commoner.
         </div>
         <div
-          class="ant-list-item"
+          class="ant-list-item ant-list-item-no-flex"
         >
-          <div
-            class="ant-list-item-content ant-list-item-content-single"
+          <span
+            class="ant-typography"
           >
-            Australian walks 100km after outback crash.
-          </div>
+            <mark>
+              [ITEM]
+            </mark>
+          </span>
+           Australian walks 100km after outback crash.
         </div>
         <div
-          class="ant-list-item"
+          class="ant-list-item ant-list-item-no-flex"
         >
-          <div
-            class="ant-list-item-content ant-list-item-content-single"
+          <span
+            class="ant-typography"
           >
-            Man charged over missing wedding girl.
-          </div>
+            <mark>
+              [ITEM]
+            </mark>
+          </span>
+           Man charged over missing wedding girl.
         </div>
         <div
-          class="ant-list-item"
+          class="ant-list-item ant-list-item-no-flex"
         >
-          <div
-            class="ant-list-item-content ant-list-item-content-single"
+          <span
+            class="ant-typography"
           >
-            Los Angeles battles huge wildfires.
-          </div>
+            <mark>
+              [ITEM]
+            </mark>
+          </span>
+           Los Angeles battles huge wildfires.
         </div>
       </div>
     </div>
@@ -741,49 +716,29 @@ exports[`renders ./components/list/demo/simple.md correctly 1`] = `
         class="ant-spin-container"
       >
         <div
-          class="ant-list-item"
+          class="ant-list-item ant-list-item-no-flex"
         >
-          <div
-            class="ant-list-item-content ant-list-item-content-single"
-          >
-            Racing car sprays burning fuel into crowd.
-          </div>
+          Racing car sprays burning fuel into crowd.
         </div>
         <div
-          class="ant-list-item"
+          class="ant-list-item ant-list-item-no-flex"
         >
-          <div
-            class="ant-list-item-content ant-list-item-content-single"
-          >
-            Japanese princess to wed commoner.
-          </div>
+          Japanese princess to wed commoner.
         </div>
         <div
-          class="ant-list-item"
+          class="ant-list-item ant-list-item-no-flex"
         >
-          <div
-            class="ant-list-item-content ant-list-item-content-single"
-          >
-            Australian walks 100km after outback crash.
-          </div>
+          Australian walks 100km after outback crash.
         </div>
         <div
-          class="ant-list-item"
+          class="ant-list-item ant-list-item-no-flex"
         >
-          <div
-            class="ant-list-item-content ant-list-item-content-single"
-          >
-            Man charged over missing wedding girl.
-          </div>
+          Man charged over missing wedding girl.
         </div>
         <div
-          class="ant-list-item"
+          class="ant-list-item ant-list-item-no-flex"
         >
-          <div
-            class="ant-list-item-content ant-list-item-content-single"
-          >
-            Los Angeles battles huge wildfires.
-          </div>
+          Los Angeles battles huge wildfires.
         </div>
       </div>
     </div>
@@ -817,49 +772,29 @@ exports[`renders ./components/list/demo/simple.md correctly 1`] = `
         class="ant-spin-container"
       >
         <div
-          class="ant-list-item"
+          class="ant-list-item ant-list-item-no-flex"
         >
-          <div
-            class="ant-list-item-content ant-list-item-content-single"
-          >
-            Racing car sprays burning fuel into crowd.
-          </div>
+          Racing car sprays burning fuel into crowd.
         </div>
         <div
-          class="ant-list-item"
+          class="ant-list-item ant-list-item-no-flex"
         >
-          <div
-            class="ant-list-item-content ant-list-item-content-single"
-          >
-            Japanese princess to wed commoner.
-          </div>
+          Japanese princess to wed commoner.
         </div>
         <div
-          class="ant-list-item"
+          class="ant-list-item ant-list-item-no-flex"
         >
-          <div
-            class="ant-list-item-content ant-list-item-content-single"
-          >
-            Australian walks 100km after outback crash.
-          </div>
+          Australian walks 100km after outback crash.
         </div>
         <div
-          class="ant-list-item"
+          class="ant-list-item ant-list-item-no-flex"
         >
-          <div
-            class="ant-list-item-content ant-list-item-content-single"
-          >
-            Man charged over missing wedding girl.
-          </div>
+          Man charged over missing wedding girl.
         </div>
         <div
-          class="ant-list-item"
+          class="ant-list-item ant-list-item-no-flex"
         >
-          <div
-            class="ant-list-item-content ant-list-item-content-single"
-          >
-            Los Angeles battles huge wildfires.
-          </div>
+          Los Angeles battles huge wildfires.
         </div>
       </div>
     </div>
@@ -888,423 +823,399 @@ exports[`renders ./components/list/demo/vertical.md correctly 1`] = `
         class="ant-list-item"
       >
         <div
-          class="ant-list-item-extra-wrap"
+          class="ant-list-item-main"
         >
           <div
-            class="ant-list-item-main"
+            class="ant-list-item-meta"
           >
             <div
-              class="ant-list-item-meta"
+              class="ant-list-item-meta-avatar"
             >
-              <div
-                class="ant-list-item-meta-avatar"
+              <span
+                class="ant-avatar ant-avatar-circle ant-avatar-image"
               >
-                <span
-                  class="ant-avatar ant-avatar-circle ant-avatar-image"
-                >
-                  <img
-                    src="https://zos.alipayobjects.com/rmsportal/ODTLcjxAfvqbxHnVXCYX.png"
-                  />
-                </span>
-              </div>
-              <div
-                class="ant-list-item-meta-content"
-              >
-                <h4
-                  class="ant-list-item-meta-title"
-                >
-                  <a
-                    href="http://ant.design"
-                  >
-                    ant design part 0
-                  </a>
-                </h4>
-                <div
-                  class="ant-list-item-meta-description"
-                >
-                  Ant Design, a design language for background applications, is refined by Ant UED Team.
-                </div>
-              </div>
+                <img
+                  src="https://zos.alipayobjects.com/rmsportal/ODTLcjxAfvqbxHnVXCYX.png"
+                />
+              </span>
             </div>
             <div
-              class="ant-list-item-content"
+              class="ant-list-item-meta-content"
             >
-              We supply a series of design principles, practical patterns and high quality design resources (Sketch and Axure), to help people create their product prototypes beautifully and efficiently.
+              <h4
+                class="ant-list-item-meta-title"
+              >
+                <a
+                  href="http://ant.design"
+                >
+                  ant design part 0
+                </a>
+              </h4>
+              <div
+                class="ant-list-item-meta-description"
+              >
+                Ant Design, a design language for background applications, is refined by Ant UED Team.
+              </div>
             </div>
-            <ul
-              class="ant-list-item-action"
-            >
-              <li>
-                <span>
-                  <i
-                    aria-label="icon: star-o"
-                    class="anticon anticon-star-o"
-                    style="margin-right:8px"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      class=""
-                      data-icon="star"
-                      fill="currentColor"
-                      height="1em"
-                      viewBox="64 64 896 896"
-                      width="1em"
-                    >
-                      <path
-                        d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 0 0 .6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0 0 46.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3zM664.8 561.6l36.1 210.3L512 672.7 323.1 772l36.1-210.3-152.8-149L417.6 382 512 190.7 606.4 382l211.2 30.7-152.8 148.9z"
-                      />
-                    </svg>
-                  </i>
-                  156
-                </span>
-                <em
-                  class="ant-list-item-action-split"
-                />
-              </li>
-              <li>
-                <span>
-                  <i
-                    aria-label="icon: like-o"
-                    class="anticon anticon-like-o"
-                    style="margin-right:8px"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      class=""
-                      data-icon="like"
-                      fill="currentColor"
-                      height="1em"
-                      viewBox="64 64 896 896"
-                      width="1em"
-                    >
-                      <path
-                        d="M885.9 533.7c16.8-22.2 26.1-49.4 26.1-77.7 0-44.9-25.1-87.4-65.5-111.1a67.67 67.67 0 0 0-34.3-9.3H572.4l6-122.9c1.4-29.7-9.1-57.9-29.5-79.4A106.62 106.62 0 0 0 471 99.9c-52 0-98 35-111.8 85.1l-85.9 311H144c-17.7 0-32 14.3-32 32v364c0 17.7 14.3 32 32 32h601.3c9.2 0 18.2-1.8 26.5-5.4 47.6-20.3 78.3-66.8 78.3-118.4 0-12.6-1.8-25-5.4-37 16.8-22.2 26.1-49.4 26.1-77.7 0-12.6-1.8-25-5.4-37 16.8-22.2 26.1-49.4 26.1-77.7-.2-12.6-2-25.1-5.6-37.1zM184 852V568h81v284h-81zm636.4-353l-21.9 19 13.9 25.4a56.2 56.2 0 0 1 6.9 27.3c0 16.5-7.2 32.2-19.6 43l-21.9 19 13.9 25.4a56.2 56.2 0 0 1 6.9 27.3c0 16.5-7.2 32.2-19.6 43l-21.9 19 13.9 25.4a56.2 56.2 0 0 1 6.9 27.3c0 22.4-13.2 42.6-33.6 51.8H329V564.8l99.5-360.5a44.1 44.1 0 0 1 42.2-32.3c7.6 0 15.1 2.2 21.1 6.7 9.9 7.4 15.2 18.6 14.6 30.5l-9.6 198.4h314.4C829 418.5 840 436.9 840 456c0 16.5-7.2 32.1-19.6 43z"
-                      />
-                    </svg>
-                  </i>
-                  156
-                </span>
-                <em
-                  class="ant-list-item-action-split"
-                />
-              </li>
-              <li>
-                <span>
-                  <i
-                    aria-label="icon: message"
-                    class="anticon anticon-message"
-                    style="margin-right:8px"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      class=""
-                      data-icon="message"
-                      fill="currentColor"
-                      height="1em"
-                      viewBox="64 64 896 896"
-                      width="1em"
-                    >
-                      <path
-                        d="M464 512a48 48 0 1 0 96 0 48 48 0 1 0-96 0zm200 0a48 48 0 1 0 96 0 48 48 0 1 0-96 0zm-400 0a48 48 0 1 0 96 0 48 48 0 1 0-96 0zm661.2-173.6c-22.6-53.7-55-101.9-96.3-143.3a444.35 444.35 0 0 0-143.3-96.3C630.6 75.7 572.2 64 512 64h-2c-60.6.3-119.3 12.3-174.5 35.9a445.35 445.35 0 0 0-142 96.5c-40.9 41.3-73 89.3-95.2 142.8-23 55.4-34.6 114.3-34.3 174.9A449.4 449.4 0 0 0 112 714v152a46 46 0 0 0 46 46h152.1A449.4 449.4 0 0 0 510 960h2.1c59.9 0 118-11.6 172.7-34.3a444.48 444.48 0 0 0 142.8-95.2c41.3-40.9 73.8-88.7 96.5-142 23.6-55.2 35.6-113.9 35.9-174.5.3-60.9-11.5-120-34.8-175.6zm-151.1 438C704 845.8 611 884 512 884h-1.7c-60.3-.3-120.2-15.3-173.1-43.5l-8.4-4.5H188V695.2l-4.5-8.4C155.3 633.9 140.3 574 140 513.7c-.4-99.7 37.7-193.3 107.6-263.8 69.8-70.5 163.1-109.5 262.8-109.9h1.7c50 0 98.5 9.7 144.2 28.9 44.6 18.7 84.6 45.6 119 80 34.3 34.3 61.3 74.4 80 119 19.4 46.2 29.1 95.2 28.9 145.8-.6 99.6-39.7 192.9-110.1 262.7z"
-                      />
-                    </svg>
-                  </i>
-                  2
-                </span>
-              </li>
-            </ul>
           </div>
-          <div
-            class="ant-list-item-extra"
+          We supply a series of design principles, practical patterns and high quality design resources (Sketch and Axure), to help people create their product prototypes beautifully and efficiently.
+          <ul
+            class="ant-list-item-action"
           >
-            <img
-              alt="logo"
-              src="https://gw.alipayobjects.com/zos/rmsportal/mqaQswcyDLcXyDKnZfES.png"
-              width="272"
-            />
-          </div>
+            <li>
+              <span>
+                <i
+                  aria-label="icon: star-o"
+                  class="anticon anticon-star-o"
+                  style="margin-right:8px"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class=""
+                    data-icon="star"
+                    fill="currentColor"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 0 0 .6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0 0 46.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3zM664.8 561.6l36.1 210.3L512 672.7 323.1 772l36.1-210.3-152.8-149L417.6 382 512 190.7 606.4 382l211.2 30.7-152.8 148.9z"
+                    />
+                  </svg>
+                </i>
+                156
+              </span>
+              <em
+                class="ant-list-item-action-split"
+              />
+            </li>
+            <li>
+              <span>
+                <i
+                  aria-label="icon: like-o"
+                  class="anticon anticon-like-o"
+                  style="margin-right:8px"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class=""
+                    data-icon="like"
+                    fill="currentColor"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M885.9 533.7c16.8-22.2 26.1-49.4 26.1-77.7 0-44.9-25.1-87.4-65.5-111.1a67.67 67.67 0 0 0-34.3-9.3H572.4l6-122.9c1.4-29.7-9.1-57.9-29.5-79.4A106.62 106.62 0 0 0 471 99.9c-52 0-98 35-111.8 85.1l-85.9 311H144c-17.7 0-32 14.3-32 32v364c0 17.7 14.3 32 32 32h601.3c9.2 0 18.2-1.8 26.5-5.4 47.6-20.3 78.3-66.8 78.3-118.4 0-12.6-1.8-25-5.4-37 16.8-22.2 26.1-49.4 26.1-77.7 0-12.6-1.8-25-5.4-37 16.8-22.2 26.1-49.4 26.1-77.7-.2-12.6-2-25.1-5.6-37.1zM184 852V568h81v284h-81zm636.4-353l-21.9 19 13.9 25.4a56.2 56.2 0 0 1 6.9 27.3c0 16.5-7.2 32.2-19.6 43l-21.9 19 13.9 25.4a56.2 56.2 0 0 1 6.9 27.3c0 16.5-7.2 32.2-19.6 43l-21.9 19 13.9 25.4a56.2 56.2 0 0 1 6.9 27.3c0 22.4-13.2 42.6-33.6 51.8H329V564.8l99.5-360.5a44.1 44.1 0 0 1 42.2-32.3c7.6 0 15.1 2.2 21.1 6.7 9.9 7.4 15.2 18.6 14.6 30.5l-9.6 198.4h314.4C829 418.5 840 436.9 840 456c0 16.5-7.2 32.1-19.6 43z"
+                    />
+                  </svg>
+                </i>
+                156
+              </span>
+              <em
+                class="ant-list-item-action-split"
+              />
+            </li>
+            <li>
+              <span>
+                <i
+                  aria-label="icon: message"
+                  class="anticon anticon-message"
+                  style="margin-right:8px"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class=""
+                    data-icon="message"
+                    fill="currentColor"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M464 512a48 48 0 1 0 96 0 48 48 0 1 0-96 0zm200 0a48 48 0 1 0 96 0 48 48 0 1 0-96 0zm-400 0a48 48 0 1 0 96 0 48 48 0 1 0-96 0zm661.2-173.6c-22.6-53.7-55-101.9-96.3-143.3a444.35 444.35 0 0 0-143.3-96.3C630.6 75.7 572.2 64 512 64h-2c-60.6.3-119.3 12.3-174.5 35.9a445.35 445.35 0 0 0-142 96.5c-40.9 41.3-73 89.3-95.2 142.8-23 55.4-34.6 114.3-34.3 174.9A449.4 449.4 0 0 0 112 714v152a46 46 0 0 0 46 46h152.1A449.4 449.4 0 0 0 510 960h2.1c59.9 0 118-11.6 172.7-34.3a444.48 444.48 0 0 0 142.8-95.2c41.3-40.9 73.8-88.7 96.5-142 23.6-55.2 35.6-113.9 35.9-174.5.3-60.9-11.5-120-34.8-175.6zm-151.1 438C704 845.8 611 884 512 884h-1.7c-60.3-.3-120.2-15.3-173.1-43.5l-8.4-4.5H188V695.2l-4.5-8.4C155.3 633.9 140.3 574 140 513.7c-.4-99.7 37.7-193.3 107.6-263.8 69.8-70.5 163.1-109.5 262.8-109.9h1.7c50 0 98.5 9.7 144.2 28.9 44.6 18.7 84.6 45.6 119 80 34.3 34.3 61.3 74.4 80 119 19.4 46.2 29.1 95.2 28.9 145.8-.6 99.6-39.7 192.9-110.1 262.7z"
+                    />
+                  </svg>
+                </i>
+                2
+              </span>
+            </li>
+          </ul>
+        </div>
+        <div
+          class="ant-list-item-extra"
+        >
+          <img
+            alt="logo"
+            src="https://gw.alipayobjects.com/zos/rmsportal/mqaQswcyDLcXyDKnZfES.png"
+            width="272"
+          />
         </div>
       </div>
       <div
         class="ant-list-item"
       >
         <div
-          class="ant-list-item-extra-wrap"
+          class="ant-list-item-main"
         >
           <div
-            class="ant-list-item-main"
+            class="ant-list-item-meta"
           >
             <div
-              class="ant-list-item-meta"
+              class="ant-list-item-meta-avatar"
             >
-              <div
-                class="ant-list-item-meta-avatar"
+              <span
+                class="ant-avatar ant-avatar-circle ant-avatar-image"
               >
-                <span
-                  class="ant-avatar ant-avatar-circle ant-avatar-image"
-                >
-                  <img
-                    src="https://zos.alipayobjects.com/rmsportal/ODTLcjxAfvqbxHnVXCYX.png"
-                  />
-                </span>
-              </div>
-              <div
-                class="ant-list-item-meta-content"
-              >
-                <h4
-                  class="ant-list-item-meta-title"
-                >
-                  <a
-                    href="http://ant.design"
-                  >
-                    ant design part 1
-                  </a>
-                </h4>
-                <div
-                  class="ant-list-item-meta-description"
-                >
-                  Ant Design, a design language for background applications, is refined by Ant UED Team.
-                </div>
-              </div>
+                <img
+                  src="https://zos.alipayobjects.com/rmsportal/ODTLcjxAfvqbxHnVXCYX.png"
+                />
+              </span>
             </div>
             <div
-              class="ant-list-item-content"
+              class="ant-list-item-meta-content"
             >
-              We supply a series of design principles, practical patterns and high quality design resources (Sketch and Axure), to help people create their product prototypes beautifully and efficiently.
+              <h4
+                class="ant-list-item-meta-title"
+              >
+                <a
+                  href="http://ant.design"
+                >
+                  ant design part 1
+                </a>
+              </h4>
+              <div
+                class="ant-list-item-meta-description"
+              >
+                Ant Design, a design language for background applications, is refined by Ant UED Team.
+              </div>
             </div>
-            <ul
-              class="ant-list-item-action"
-            >
-              <li>
-                <span>
-                  <i
-                    aria-label="icon: star-o"
-                    class="anticon anticon-star-o"
-                    style="margin-right:8px"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      class=""
-                      data-icon="star"
-                      fill="currentColor"
-                      height="1em"
-                      viewBox="64 64 896 896"
-                      width="1em"
-                    >
-                      <path
-                        d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 0 0 .6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0 0 46.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3zM664.8 561.6l36.1 210.3L512 672.7 323.1 772l36.1-210.3-152.8-149L417.6 382 512 190.7 606.4 382l211.2 30.7-152.8 148.9z"
-                      />
-                    </svg>
-                  </i>
-                  156
-                </span>
-                <em
-                  class="ant-list-item-action-split"
-                />
-              </li>
-              <li>
-                <span>
-                  <i
-                    aria-label="icon: like-o"
-                    class="anticon anticon-like-o"
-                    style="margin-right:8px"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      class=""
-                      data-icon="like"
-                      fill="currentColor"
-                      height="1em"
-                      viewBox="64 64 896 896"
-                      width="1em"
-                    >
-                      <path
-                        d="M885.9 533.7c16.8-22.2 26.1-49.4 26.1-77.7 0-44.9-25.1-87.4-65.5-111.1a67.67 67.67 0 0 0-34.3-9.3H572.4l6-122.9c1.4-29.7-9.1-57.9-29.5-79.4A106.62 106.62 0 0 0 471 99.9c-52 0-98 35-111.8 85.1l-85.9 311H144c-17.7 0-32 14.3-32 32v364c0 17.7 14.3 32 32 32h601.3c9.2 0 18.2-1.8 26.5-5.4 47.6-20.3 78.3-66.8 78.3-118.4 0-12.6-1.8-25-5.4-37 16.8-22.2 26.1-49.4 26.1-77.7 0-12.6-1.8-25-5.4-37 16.8-22.2 26.1-49.4 26.1-77.7-.2-12.6-2-25.1-5.6-37.1zM184 852V568h81v284h-81zm636.4-353l-21.9 19 13.9 25.4a56.2 56.2 0 0 1 6.9 27.3c0 16.5-7.2 32.2-19.6 43l-21.9 19 13.9 25.4a56.2 56.2 0 0 1 6.9 27.3c0 16.5-7.2 32.2-19.6 43l-21.9 19 13.9 25.4a56.2 56.2 0 0 1 6.9 27.3c0 22.4-13.2 42.6-33.6 51.8H329V564.8l99.5-360.5a44.1 44.1 0 0 1 42.2-32.3c7.6 0 15.1 2.2 21.1 6.7 9.9 7.4 15.2 18.6 14.6 30.5l-9.6 198.4h314.4C829 418.5 840 436.9 840 456c0 16.5-7.2 32.1-19.6 43z"
-                      />
-                    </svg>
-                  </i>
-                  156
-                </span>
-                <em
-                  class="ant-list-item-action-split"
-                />
-              </li>
-              <li>
-                <span>
-                  <i
-                    aria-label="icon: message"
-                    class="anticon anticon-message"
-                    style="margin-right:8px"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      class=""
-                      data-icon="message"
-                      fill="currentColor"
-                      height="1em"
-                      viewBox="64 64 896 896"
-                      width="1em"
-                    >
-                      <path
-                        d="M464 512a48 48 0 1 0 96 0 48 48 0 1 0-96 0zm200 0a48 48 0 1 0 96 0 48 48 0 1 0-96 0zm-400 0a48 48 0 1 0 96 0 48 48 0 1 0-96 0zm661.2-173.6c-22.6-53.7-55-101.9-96.3-143.3a444.35 444.35 0 0 0-143.3-96.3C630.6 75.7 572.2 64 512 64h-2c-60.6.3-119.3 12.3-174.5 35.9a445.35 445.35 0 0 0-142 96.5c-40.9 41.3-73 89.3-95.2 142.8-23 55.4-34.6 114.3-34.3 174.9A449.4 449.4 0 0 0 112 714v152a46 46 0 0 0 46 46h152.1A449.4 449.4 0 0 0 510 960h2.1c59.9 0 118-11.6 172.7-34.3a444.48 444.48 0 0 0 142.8-95.2c41.3-40.9 73.8-88.7 96.5-142 23.6-55.2 35.6-113.9 35.9-174.5.3-60.9-11.5-120-34.8-175.6zm-151.1 438C704 845.8 611 884 512 884h-1.7c-60.3-.3-120.2-15.3-173.1-43.5l-8.4-4.5H188V695.2l-4.5-8.4C155.3 633.9 140.3 574 140 513.7c-.4-99.7 37.7-193.3 107.6-263.8 69.8-70.5 163.1-109.5 262.8-109.9h1.7c50 0 98.5 9.7 144.2 28.9 44.6 18.7 84.6 45.6 119 80 34.3 34.3 61.3 74.4 80 119 19.4 46.2 29.1 95.2 28.9 145.8-.6 99.6-39.7 192.9-110.1 262.7z"
-                      />
-                    </svg>
-                  </i>
-                  2
-                </span>
-              </li>
-            </ul>
           </div>
-          <div
-            class="ant-list-item-extra"
+          We supply a series of design principles, practical patterns and high quality design resources (Sketch and Axure), to help people create their product prototypes beautifully and efficiently.
+          <ul
+            class="ant-list-item-action"
           >
-            <img
-              alt="logo"
-              src="https://gw.alipayobjects.com/zos/rmsportal/mqaQswcyDLcXyDKnZfES.png"
-              width="272"
-            />
-          </div>
+            <li>
+              <span>
+                <i
+                  aria-label="icon: star-o"
+                  class="anticon anticon-star-o"
+                  style="margin-right:8px"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class=""
+                    data-icon="star"
+                    fill="currentColor"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 0 0 .6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0 0 46.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3zM664.8 561.6l36.1 210.3L512 672.7 323.1 772l36.1-210.3-152.8-149L417.6 382 512 190.7 606.4 382l211.2 30.7-152.8 148.9z"
+                    />
+                  </svg>
+                </i>
+                156
+              </span>
+              <em
+                class="ant-list-item-action-split"
+              />
+            </li>
+            <li>
+              <span>
+                <i
+                  aria-label="icon: like-o"
+                  class="anticon anticon-like-o"
+                  style="margin-right:8px"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class=""
+                    data-icon="like"
+                    fill="currentColor"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M885.9 533.7c16.8-22.2 26.1-49.4 26.1-77.7 0-44.9-25.1-87.4-65.5-111.1a67.67 67.67 0 0 0-34.3-9.3H572.4l6-122.9c1.4-29.7-9.1-57.9-29.5-79.4A106.62 106.62 0 0 0 471 99.9c-52 0-98 35-111.8 85.1l-85.9 311H144c-17.7 0-32 14.3-32 32v364c0 17.7 14.3 32 32 32h601.3c9.2 0 18.2-1.8 26.5-5.4 47.6-20.3 78.3-66.8 78.3-118.4 0-12.6-1.8-25-5.4-37 16.8-22.2 26.1-49.4 26.1-77.7 0-12.6-1.8-25-5.4-37 16.8-22.2 26.1-49.4 26.1-77.7-.2-12.6-2-25.1-5.6-37.1zM184 852V568h81v284h-81zm636.4-353l-21.9 19 13.9 25.4a56.2 56.2 0 0 1 6.9 27.3c0 16.5-7.2 32.2-19.6 43l-21.9 19 13.9 25.4a56.2 56.2 0 0 1 6.9 27.3c0 16.5-7.2 32.2-19.6 43l-21.9 19 13.9 25.4a56.2 56.2 0 0 1 6.9 27.3c0 22.4-13.2 42.6-33.6 51.8H329V564.8l99.5-360.5a44.1 44.1 0 0 1 42.2-32.3c7.6 0 15.1 2.2 21.1 6.7 9.9 7.4 15.2 18.6 14.6 30.5l-9.6 198.4h314.4C829 418.5 840 436.9 840 456c0 16.5-7.2 32.1-19.6 43z"
+                    />
+                  </svg>
+                </i>
+                156
+              </span>
+              <em
+                class="ant-list-item-action-split"
+              />
+            </li>
+            <li>
+              <span>
+                <i
+                  aria-label="icon: message"
+                  class="anticon anticon-message"
+                  style="margin-right:8px"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class=""
+                    data-icon="message"
+                    fill="currentColor"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M464 512a48 48 0 1 0 96 0 48 48 0 1 0-96 0zm200 0a48 48 0 1 0 96 0 48 48 0 1 0-96 0zm-400 0a48 48 0 1 0 96 0 48 48 0 1 0-96 0zm661.2-173.6c-22.6-53.7-55-101.9-96.3-143.3a444.35 444.35 0 0 0-143.3-96.3C630.6 75.7 572.2 64 512 64h-2c-60.6.3-119.3 12.3-174.5 35.9a445.35 445.35 0 0 0-142 96.5c-40.9 41.3-73 89.3-95.2 142.8-23 55.4-34.6 114.3-34.3 174.9A449.4 449.4 0 0 0 112 714v152a46 46 0 0 0 46 46h152.1A449.4 449.4 0 0 0 510 960h2.1c59.9 0 118-11.6 172.7-34.3a444.48 444.48 0 0 0 142.8-95.2c41.3-40.9 73.8-88.7 96.5-142 23.6-55.2 35.6-113.9 35.9-174.5.3-60.9-11.5-120-34.8-175.6zm-151.1 438C704 845.8 611 884 512 884h-1.7c-60.3-.3-120.2-15.3-173.1-43.5l-8.4-4.5H188V695.2l-4.5-8.4C155.3 633.9 140.3 574 140 513.7c-.4-99.7 37.7-193.3 107.6-263.8 69.8-70.5 163.1-109.5 262.8-109.9h1.7c50 0 98.5 9.7 144.2 28.9 44.6 18.7 84.6 45.6 119 80 34.3 34.3 61.3 74.4 80 119 19.4 46.2 29.1 95.2 28.9 145.8-.6 99.6-39.7 192.9-110.1 262.7z"
+                    />
+                  </svg>
+                </i>
+                2
+              </span>
+            </li>
+          </ul>
+        </div>
+        <div
+          class="ant-list-item-extra"
+        >
+          <img
+            alt="logo"
+            src="https://gw.alipayobjects.com/zos/rmsportal/mqaQswcyDLcXyDKnZfES.png"
+            width="272"
+          />
         </div>
       </div>
       <div
         class="ant-list-item"
       >
         <div
-          class="ant-list-item-extra-wrap"
+          class="ant-list-item-main"
         >
           <div
-            class="ant-list-item-main"
+            class="ant-list-item-meta"
           >
             <div
-              class="ant-list-item-meta"
+              class="ant-list-item-meta-avatar"
             >
-              <div
-                class="ant-list-item-meta-avatar"
+              <span
+                class="ant-avatar ant-avatar-circle ant-avatar-image"
               >
-                <span
-                  class="ant-avatar ant-avatar-circle ant-avatar-image"
-                >
-                  <img
-                    src="https://zos.alipayobjects.com/rmsportal/ODTLcjxAfvqbxHnVXCYX.png"
-                  />
-                </span>
-              </div>
-              <div
-                class="ant-list-item-meta-content"
-              >
-                <h4
-                  class="ant-list-item-meta-title"
-                >
-                  <a
-                    href="http://ant.design"
-                  >
-                    ant design part 2
-                  </a>
-                </h4>
-                <div
-                  class="ant-list-item-meta-description"
-                >
-                  Ant Design, a design language for background applications, is refined by Ant UED Team.
-                </div>
-              </div>
+                <img
+                  src="https://zos.alipayobjects.com/rmsportal/ODTLcjxAfvqbxHnVXCYX.png"
+                />
+              </span>
             </div>
             <div
-              class="ant-list-item-content"
+              class="ant-list-item-meta-content"
             >
-              We supply a series of design principles, practical patterns and high quality design resources (Sketch and Axure), to help people create their product prototypes beautifully and efficiently.
+              <h4
+                class="ant-list-item-meta-title"
+              >
+                <a
+                  href="http://ant.design"
+                >
+                  ant design part 2
+                </a>
+              </h4>
+              <div
+                class="ant-list-item-meta-description"
+              >
+                Ant Design, a design language for background applications, is refined by Ant UED Team.
+              </div>
             </div>
-            <ul
-              class="ant-list-item-action"
-            >
-              <li>
-                <span>
-                  <i
-                    aria-label="icon: star-o"
-                    class="anticon anticon-star-o"
-                    style="margin-right:8px"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      class=""
-                      data-icon="star"
-                      fill="currentColor"
-                      height="1em"
-                      viewBox="64 64 896 896"
-                      width="1em"
-                    >
-                      <path
-                        d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 0 0 .6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0 0 46.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3zM664.8 561.6l36.1 210.3L512 672.7 323.1 772l36.1-210.3-152.8-149L417.6 382 512 190.7 606.4 382l211.2 30.7-152.8 148.9z"
-                      />
-                    </svg>
-                  </i>
-                  156
-                </span>
-                <em
-                  class="ant-list-item-action-split"
-                />
-              </li>
-              <li>
-                <span>
-                  <i
-                    aria-label="icon: like-o"
-                    class="anticon anticon-like-o"
-                    style="margin-right:8px"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      class=""
-                      data-icon="like"
-                      fill="currentColor"
-                      height="1em"
-                      viewBox="64 64 896 896"
-                      width="1em"
-                    >
-                      <path
-                        d="M885.9 533.7c16.8-22.2 26.1-49.4 26.1-77.7 0-44.9-25.1-87.4-65.5-111.1a67.67 67.67 0 0 0-34.3-9.3H572.4l6-122.9c1.4-29.7-9.1-57.9-29.5-79.4A106.62 106.62 0 0 0 471 99.9c-52 0-98 35-111.8 85.1l-85.9 311H144c-17.7 0-32 14.3-32 32v364c0 17.7 14.3 32 32 32h601.3c9.2 0 18.2-1.8 26.5-5.4 47.6-20.3 78.3-66.8 78.3-118.4 0-12.6-1.8-25-5.4-37 16.8-22.2 26.1-49.4 26.1-77.7 0-12.6-1.8-25-5.4-37 16.8-22.2 26.1-49.4 26.1-77.7-.2-12.6-2-25.1-5.6-37.1zM184 852V568h81v284h-81zm636.4-353l-21.9 19 13.9 25.4a56.2 56.2 0 0 1 6.9 27.3c0 16.5-7.2 32.2-19.6 43l-21.9 19 13.9 25.4a56.2 56.2 0 0 1 6.9 27.3c0 16.5-7.2 32.2-19.6 43l-21.9 19 13.9 25.4a56.2 56.2 0 0 1 6.9 27.3c0 22.4-13.2 42.6-33.6 51.8H329V564.8l99.5-360.5a44.1 44.1 0 0 1 42.2-32.3c7.6 0 15.1 2.2 21.1 6.7 9.9 7.4 15.2 18.6 14.6 30.5l-9.6 198.4h314.4C829 418.5 840 436.9 840 456c0 16.5-7.2 32.1-19.6 43z"
-                      />
-                    </svg>
-                  </i>
-                  156
-                </span>
-                <em
-                  class="ant-list-item-action-split"
-                />
-              </li>
-              <li>
-                <span>
-                  <i
-                    aria-label="icon: message"
-                    class="anticon anticon-message"
-                    style="margin-right:8px"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      class=""
-                      data-icon="message"
-                      fill="currentColor"
-                      height="1em"
-                      viewBox="64 64 896 896"
-                      width="1em"
-                    >
-                      <path
-                        d="M464 512a48 48 0 1 0 96 0 48 48 0 1 0-96 0zm200 0a48 48 0 1 0 96 0 48 48 0 1 0-96 0zm-400 0a48 48 0 1 0 96 0 48 48 0 1 0-96 0zm661.2-173.6c-22.6-53.7-55-101.9-96.3-143.3a444.35 444.35 0 0 0-143.3-96.3C630.6 75.7 572.2 64 512 64h-2c-60.6.3-119.3 12.3-174.5 35.9a445.35 445.35 0 0 0-142 96.5c-40.9 41.3-73 89.3-95.2 142.8-23 55.4-34.6 114.3-34.3 174.9A449.4 449.4 0 0 0 112 714v152a46 46 0 0 0 46 46h152.1A449.4 449.4 0 0 0 510 960h2.1c59.9 0 118-11.6 172.7-34.3a444.48 444.48 0 0 0 142.8-95.2c41.3-40.9 73.8-88.7 96.5-142 23.6-55.2 35.6-113.9 35.9-174.5.3-60.9-11.5-120-34.8-175.6zm-151.1 438C704 845.8 611 884 512 884h-1.7c-60.3-.3-120.2-15.3-173.1-43.5l-8.4-4.5H188V695.2l-4.5-8.4C155.3 633.9 140.3 574 140 513.7c-.4-99.7 37.7-193.3 107.6-263.8 69.8-70.5 163.1-109.5 262.8-109.9h1.7c50 0 98.5 9.7 144.2 28.9 44.6 18.7 84.6 45.6 119 80 34.3 34.3 61.3 74.4 80 119 19.4 46.2 29.1 95.2 28.9 145.8-.6 99.6-39.7 192.9-110.1 262.7z"
-                      />
-                    </svg>
-                  </i>
-                  2
-                </span>
-              </li>
-            </ul>
           </div>
-          <div
-            class="ant-list-item-extra"
+          We supply a series of design principles, practical patterns and high quality design resources (Sketch and Axure), to help people create their product prototypes beautifully and efficiently.
+          <ul
+            class="ant-list-item-action"
           >
-            <img
-              alt="logo"
-              src="https://gw.alipayobjects.com/zos/rmsportal/mqaQswcyDLcXyDKnZfES.png"
-              width="272"
-            />
-          </div>
+            <li>
+              <span>
+                <i
+                  aria-label="icon: star-o"
+                  class="anticon anticon-star-o"
+                  style="margin-right:8px"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class=""
+                    data-icon="star"
+                    fill="currentColor"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 0 0 .6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0 0 46.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3zM664.8 561.6l36.1 210.3L512 672.7 323.1 772l36.1-210.3-152.8-149L417.6 382 512 190.7 606.4 382l211.2 30.7-152.8 148.9z"
+                    />
+                  </svg>
+                </i>
+                156
+              </span>
+              <em
+                class="ant-list-item-action-split"
+              />
+            </li>
+            <li>
+              <span>
+                <i
+                  aria-label="icon: like-o"
+                  class="anticon anticon-like-o"
+                  style="margin-right:8px"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class=""
+                    data-icon="like"
+                    fill="currentColor"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M885.9 533.7c16.8-22.2 26.1-49.4 26.1-77.7 0-44.9-25.1-87.4-65.5-111.1a67.67 67.67 0 0 0-34.3-9.3H572.4l6-122.9c1.4-29.7-9.1-57.9-29.5-79.4A106.62 106.62 0 0 0 471 99.9c-52 0-98 35-111.8 85.1l-85.9 311H144c-17.7 0-32 14.3-32 32v364c0 17.7 14.3 32 32 32h601.3c9.2 0 18.2-1.8 26.5-5.4 47.6-20.3 78.3-66.8 78.3-118.4 0-12.6-1.8-25-5.4-37 16.8-22.2 26.1-49.4 26.1-77.7 0-12.6-1.8-25-5.4-37 16.8-22.2 26.1-49.4 26.1-77.7-.2-12.6-2-25.1-5.6-37.1zM184 852V568h81v284h-81zm636.4-353l-21.9 19 13.9 25.4a56.2 56.2 0 0 1 6.9 27.3c0 16.5-7.2 32.2-19.6 43l-21.9 19 13.9 25.4a56.2 56.2 0 0 1 6.9 27.3c0 16.5-7.2 32.2-19.6 43l-21.9 19 13.9 25.4a56.2 56.2 0 0 1 6.9 27.3c0 22.4-13.2 42.6-33.6 51.8H329V564.8l99.5-360.5a44.1 44.1 0 0 1 42.2-32.3c7.6 0 15.1 2.2 21.1 6.7 9.9 7.4 15.2 18.6 14.6 30.5l-9.6 198.4h314.4C829 418.5 840 436.9 840 456c0 16.5-7.2 32.1-19.6 43z"
+                    />
+                  </svg>
+                </i>
+                156
+              </span>
+              <em
+                class="ant-list-item-action-split"
+              />
+            </li>
+            <li>
+              <span>
+                <i
+                  aria-label="icon: message"
+                  class="anticon anticon-message"
+                  style="margin-right:8px"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class=""
+                    data-icon="message"
+                    fill="currentColor"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M464 512a48 48 0 1 0 96 0 48 48 0 1 0-96 0zm200 0a48 48 0 1 0 96 0 48 48 0 1 0-96 0zm-400 0a48 48 0 1 0 96 0 48 48 0 1 0-96 0zm661.2-173.6c-22.6-53.7-55-101.9-96.3-143.3a444.35 444.35 0 0 0-143.3-96.3C630.6 75.7 572.2 64 512 64h-2c-60.6.3-119.3 12.3-174.5 35.9a445.35 445.35 0 0 0-142 96.5c-40.9 41.3-73 89.3-95.2 142.8-23 55.4-34.6 114.3-34.3 174.9A449.4 449.4 0 0 0 112 714v152a46 46 0 0 0 46 46h152.1A449.4 449.4 0 0 0 510 960h2.1c59.9 0 118-11.6 172.7-34.3a444.48 444.48 0 0 0 142.8-95.2c41.3-40.9 73.8-88.7 96.5-142 23.6-55.2 35.6-113.9 35.9-174.5.3-60.9-11.5-120-34.8-175.6zm-151.1 438C704 845.8 611 884 512 884h-1.7c-60.3-.3-120.2-15.3-173.1-43.5l-8.4-4.5H188V695.2l-4.5-8.4C155.3 633.9 140.3 574 140 513.7c-.4-99.7 37.7-193.3 107.6-263.8 69.8-70.5 163.1-109.5 262.8-109.9h1.7c50 0 98.5 9.7 144.2 28.9 44.6 18.7 84.6 45.6 119 80 34.3 34.3 61.3 74.4 80 119 19.4 46.2 29.1 95.2 28.9 145.8-.6 99.6-39.7 192.9-110.1 262.7z"
+                    />
+                  </svg>
+                </i>
+                2
+              </span>
+            </li>
+          </ul>
+        </div>
+        <div
+          class="ant-list-item-extra"
+        >
+          <img
+            alt="logo"
+            src="https://gw.alipayobjects.com/zos/rmsportal/mqaQswcyDLcXyDKnZfES.png"
+            width="272"
+          />
         </div>
       </div>
     </div>

--- a/components/list/__tests__/__snapshots__/pagination.test.js.snap
+++ b/components/list/__tests__/__snapshots__/pagination.test.js.snap
@@ -11,22 +11,14 @@ exports[`List.pagination renders pagination correctly 1`] = `
       class="ant-spin-container"
     >
       <div
-        class="ant-list-item"
+        class="ant-list-item ant-list-item-no-flex"
       >
-        <div
-          class="ant-list-item-content ant-list-item-content-single"
-        >
-          Jack
-        </div>
+        Jack
       </div>
       <div
-        class="ant-list-item"
+        class="ant-list-item ant-list-item-no-flex"
       >
-        <div
-          class="ant-list-item-content ant-list-item-content-single"
-        >
-          Lucy
-        </div>
+        Lucy
       </div>
     </div>
   </div>

--- a/components/list/__tests__/pagination.test.js
+++ b/components/list/__tests__/pagination.test.js
@@ -25,7 +25,7 @@ describe('List.pagination', () => {
   }
 
   function renderedNames(wrapper) {
-    return wrapper.find('.ant-list-item-content').map(row => row.text());
+    return wrapper.find('.ant-list-item').map(row => row.text());
   }
 
   it('renders pagination correctly', () => {

--- a/components/list/demo/simple.md
+++ b/components/list/demo/simple.md
@@ -40,7 +40,7 @@ ReactDOM.render(
       footer={<div>Footer</div>}
       bordered
       dataSource={data}
-      renderItem={item => (<List.Item>abc <Typography.Text mark>mark</Typography.Text> {item}</List.Item>)}
+      renderItem={item => (<List.Item><Typography.Text mark>[ITEM]</Typography.Text> {item}</List.Item>)}
     />
     <h3 style={{ margin: '16px 0' }}>Small Size</h3>
     <List

--- a/components/list/demo/simple.md
+++ b/components/list/demo/simple.md
@@ -22,7 +22,7 @@ If a large or small list is desired, set the size property to either large or sm
 Customizing the header and footer of list by setting `header` and `footer` property.
 
 ````jsx
-import { List } from 'antd';
+import { List, Typography } from 'antd';
 
 const data = [
   'Racing car sprays burning fuel into crowd.',
@@ -40,7 +40,7 @@ ReactDOM.render(
       footer={<div>Footer</div>}
       bordered
       dataSource={data}
-      renderItem={item => (<List.Item>{item}</List.Item>)}
+      renderItem={item => (<List.Item>abc <Typography.Text mark>mark</Typography.Text> {item}</List.Item>)}
     />
     <h3 style={{ margin: '16px 0' }}>Small Size</h3>
     <List

--- a/components/list/style/index.less
+++ b/components/list/style/index.less
@@ -36,11 +36,6 @@
     align-items: center;
     padding: @list-item-padding;
 
-    // https://github.com/ant-design/ant-design/issues/15186
-    > span {
-      display: contents;
-    }
-
     &-meta {
       display: flex;
       flex: 1;
@@ -70,14 +65,6 @@
         font-size: @font-size-base;
         line-height: 22px;
       }
-    }
-    &-content {
-      display: flex;
-      flex: 1;
-      justify-content: flex-end;
-    }
-    &-content-single {
-      justify-content: flex-start;
     }
     &-action {
       flex: 0 0 auto;

--- a/components/list/style/index.less
+++ b/components/list/style/index.less
@@ -35,6 +35,12 @@
     display: flex;
     align-items: center;
     padding: @list-item-padding;
+
+    // https://github.com/ant-design/ant-design/issues/15186
+    > span {
+      display: contents;
+    }
+
     &-meta {
       display: flex;
       flex: 1;

--- a/components/list/style/index.less
+++ b/components/list/style/index.less
@@ -33,8 +33,11 @@
   }
   &-item {
     display: flex;
-    align-items: center;
     padding: @list-item-padding;
+
+    &-no-flex {
+      display: block;
+    }
 
     &-meta {
       display: flex;
@@ -95,10 +98,6 @@
         background-color: @border-color-split;
       }
     }
-    &-main {
-      display: flex;
-      flex: 1;
-    }
   }
 
   &-header {
@@ -152,19 +151,18 @@
   }
 
   &-vertical &-item {
-    display: block;
-    &-extra-wrap {
-      display: flex;
-    }
     &-main {
       display: block;
       flex: 1;
     }
+
     &-extra {
-      margin-left: 58px;
+      margin-left: 40px;
     }
+
     &-meta {
       margin-bottom: @list-item-meta-margin-bottom;
+
       &-title {
         margin-bottom: @list-item-meta-title-margin-bottom;
         color: @heading-color;
@@ -172,14 +170,11 @@
         line-height: 24px;
       }
     }
-    &-content {
-      display: block;
-      margin: @list-item-content-margin;
-      color: @text-color;
-      font-size: @font-size-base;
-    }
+
     &-action {
+      margin-top: @padding-md;
       margin-left: auto;
+
       > li {
         padding: 0 16px;
         &:first-child {
@@ -190,14 +185,12 @@
   }
 
   &-grid &-item {
+    display: block;
+    max-width: 100%;
     margin-bottom: 16px;
     padding-top: 0;
     padding-bottom: 0;
     border-bottom: none;
-    &-content {
-      display: block;
-      max-width: 100%;
-    }
   }
 }
 

--- a/components/list/style/responsive.less
+++ b/components/list/style/responsive.less
@@ -16,7 +16,7 @@
   }
 }
 
-@media screen and (max-width: @screen-xs) {
+@media screen and (max-width: @screen-sm) {
   .@{list-prefix-cls} {
     &-item {
       flex-wrap: wrap;
@@ -28,14 +28,12 @@
 
   .@{list-prefix-cls}-vertical {
     .@{list-prefix-cls}-item {
-      &-extra-wrap {
-        flex-wrap: wrap-reverse;
-      }
+      flex-wrap: wrap-reverse;
       &-main {
         min-width: 220px;
       }
       &-extra {
-        margin-left: 0;
+        margin: auto auto 16px;
       }
     }
   }

--- a/components/skeleton/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/skeleton/__tests__/__snapshots__/demo.test.js.snap
@@ -126,32 +126,28 @@ exports[`renders ./components/skeleton/demo/list.md correctly 1`] = `
           class="ant-list-item"
         >
           <div
-            class="ant-list-item-content ant-list-item-content-single"
+            class="ant-skeleton ant-skeleton-with-avatar ant-skeleton-active"
           >
             <div
-              class="ant-skeleton ant-skeleton-with-avatar ant-skeleton-active"
+              class="ant-skeleton-header"
             >
-              <div
-                class="ant-skeleton-header"
+              <span
+                class="ant-skeleton-avatar ant-skeleton-avatar-lg ant-skeleton-avatar-circle"
+              />
+            </div>
+            <div
+              class="ant-skeleton-content"
+            >
+              <h3
+                class="ant-skeleton-title"
+                style="width:50%"
+              />
+              <ul
+                class="ant-skeleton-paragraph"
               >
-                <span
-                  class="ant-skeleton-avatar ant-skeleton-avatar-lg ant-skeleton-avatar-circle"
-                />
-              </div>
-              <div
-                class="ant-skeleton-content"
-              >
-                <h3
-                  class="ant-skeleton-title"
-                  style="width:50%"
-                />
-                <ul
-                  class="ant-skeleton-paragraph"
-                >
-                  <li />
-                  <li />
-                </ul>
-              </div>
+                <li />
+                <li />
+              </ul>
             </div>
           </div>
         </div>
@@ -159,32 +155,28 @@ exports[`renders ./components/skeleton/demo/list.md correctly 1`] = `
           class="ant-list-item"
         >
           <div
-            class="ant-list-item-content ant-list-item-content-single"
+            class="ant-skeleton ant-skeleton-with-avatar ant-skeleton-active"
           >
             <div
-              class="ant-skeleton ant-skeleton-with-avatar ant-skeleton-active"
+              class="ant-skeleton-header"
             >
-              <div
-                class="ant-skeleton-header"
+              <span
+                class="ant-skeleton-avatar ant-skeleton-avatar-lg ant-skeleton-avatar-circle"
+              />
+            </div>
+            <div
+              class="ant-skeleton-content"
+            >
+              <h3
+                class="ant-skeleton-title"
+                style="width:50%"
+              />
+              <ul
+                class="ant-skeleton-paragraph"
               >
-                <span
-                  class="ant-skeleton-avatar ant-skeleton-avatar-lg ant-skeleton-avatar-circle"
-                />
-              </div>
-              <div
-                class="ant-skeleton-content"
-              >
-                <h3
-                  class="ant-skeleton-title"
-                  style="width:50%"
-                />
-                <ul
-                  class="ant-skeleton-paragraph"
-                >
-                  <li />
-                  <li />
-                </ul>
-              </div>
+                <li />
+                <li />
+              </ul>
             </div>
           </div>
         </div>
@@ -192,32 +184,28 @@ exports[`renders ./components/skeleton/demo/list.md correctly 1`] = `
           class="ant-list-item"
         >
           <div
-            class="ant-list-item-content ant-list-item-content-single"
+            class="ant-skeleton ant-skeleton-with-avatar ant-skeleton-active"
           >
             <div
-              class="ant-skeleton ant-skeleton-with-avatar ant-skeleton-active"
+              class="ant-skeleton-header"
             >
-              <div
-                class="ant-skeleton-header"
+              <span
+                class="ant-skeleton-avatar ant-skeleton-avatar-lg ant-skeleton-avatar-circle"
+              />
+            </div>
+            <div
+              class="ant-skeleton-content"
+            >
+              <h3
+                class="ant-skeleton-title"
+                style="width:50%"
+              />
+              <ul
+                class="ant-skeleton-paragraph"
               >
-                <span
-                  class="ant-skeleton-avatar ant-skeleton-avatar-lg ant-skeleton-avatar-circle"
-                />
-              </div>
-              <div
-                class="ant-skeleton-content"
-              >
-                <h3
-                  class="ant-skeleton-title"
-                  style="width:50%"
-                />
-                <ul
-                  class="ant-skeleton-paragraph"
-                >
-                  <li />
-                  <li />
-                </ul>
-              </div>
+                <li />
+                <li />
+              </ul>
             </div>
           </div>
         </div>

--- a/components/style/themes/default.less
+++ b/components/style/themes/default.less
@@ -574,7 +574,6 @@
 @list-footer-background: transparent;
 @list-empty-text-padding: @padding-md;
 @list-item-padding: @padding-sm 0;
-@list-item-content-margin: 0 0 @padding-md 0;
 @list-item-meta-margin-bottom: @padding-md;
 @list-item-meta-avatar-margin-right: @padding-md;
 @list-item-meta-title-margin-bottom: @padding-sm;


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [x] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?

#15186 told a bug that default flex layout will cut all spaces in plain string of children.

[![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/8z503zj7m9)

<img width="180" alt="image" src="https://user-images.githubusercontent.com/507615/53875830-6b12f580-4040-11e9-8ddf-f27c50b39207.png">

### 💡 Solution

After a deep digging, I decide to refactor whole list item dom structure which is a mess. And resolve #15186 via check it there any string element under children.

https://github.com/ant-design/ant-design/pull/15210/files#diff-9cef4c52eb35ccf96cbdc9432372ebb5R73

### 📝 Changelog description

> Describe changes from user side, and list all potential break changes or other risks.

1. English description

- ⚡️ Refactor and simplify List Item dom structure, and fix spaces lost inside List Item. #15210

2. Chinese description (optional)

- ⚡️ 重构并简化了 List Item 的 dom 结构，并且修复了 Item 中内容空格丢失的问题。#15210

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
