### PR TITLE
Add Grid flex fill rest demo

### DIFF
--- a/components/grid/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/grid/__tests__/__snapshots__/demo.test.js.snap
@@ -199,6 +199,30 @@ exports[`renders ./components/grid/demo/flex.md correctly 1`] = `
       col-4
     </div>
   </div>
+  <p>
+    sub-element fill rest
+  </p>
+  <div
+    class="ant-row-flex"
+  >
+    <div
+      class=""
+      style="width:100px"
+    >
+      100px
+    </div>
+    <div
+      class="ant-col-4"
+    >
+      col-4
+    </div>
+    <div
+      class=""
+      style="flex:auto"
+    >
+      fill rest
+    </div>
+  </div>
 </div>
 `;
 

--- a/components/grid/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/grid/__tests__/__snapshots__/demo.test.js.snap
@@ -360,6 +360,79 @@ exports[`renders ./components/grid/demo/flex-align.md correctly 1`] = `
 </div>
 `;
 
+exports[`renders ./components/grid/demo/flex-fill-rest.md correctly 1`] = `
+<div>
+  <p>
+    Fix left
+  </p>
+  <div
+    class="ant-row-flex"
+  >
+    <div
+      class=""
+      style="width:100px"
+    >
+      100px
+    </div>
+    <div
+      class=""
+      style="flex:auto"
+    >
+      fill rest
+    </div>
+  </div>
+  <p>
+    Fix middle
+  </p>
+  <div
+    class="ant-row-flex"
+  >
+    <div
+      class=""
+      style="flex:auto"
+    >
+      fill rest
+    </div>
+    <div
+      class=""
+      style="width:100px"
+    >
+      100px
+    </div>
+    <div
+      class=""
+      style="flex:auto"
+    >
+      fill rest
+    </div>
+  </div>
+  <p>
+    Merge with span
+  </p>
+  <div
+    class="ant-row-flex"
+  >
+    <div
+      class=""
+      style="width:100px"
+    >
+      100px
+    </div>
+    <div
+      class="ant-col-4"
+    >
+      col-4
+    </div>
+    <div
+      class=""
+      style="flex:auto"
+    >
+      fill rest
+    </div>
+  </div>
+</div>
+`;
+
 exports[`renders ./components/grid/demo/flex-order.md correctly 1`] = `
 <div>
   <div

--- a/components/grid/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/grid/__tests__/__snapshots__/demo.test.js.snap
@@ -199,30 +199,6 @@ exports[`renders ./components/grid/demo/flex.md correctly 1`] = `
       col-4
     </div>
   </div>
-  <p>
-    sub-element fill rest
-  </p>
-  <div
-    class="ant-row-flex"
-  >
-    <div
-      class=""
-      style="width:100px"
-    >
-      100px
-    </div>
-    <div
-      class="ant-col-4"
-    >
-      col-4
-    </div>
-    <div
-      class=""
-      style="flex:auto"
-    >
-      fill rest
-    </div>
-  </div>
 </div>
 `;
 

--- a/components/grid/demo/flex-fill-rest.md
+++ b/components/grid/demo/flex-fill-rest.md
@@ -1,0 +1,43 @@
+---
+order: 7
+title:
+  zh-CN: Flex 填充
+  en-US: Flex Fill Rest
+---
+
+## zh-CN
+
+Flex 填充剩余空间。
+
+## en-US
+
+Flex fill rest space.
+
+````jsx
+import { Row, Col } from 'antd';
+
+ReactDOM.render(
+  <div>
+    <p>Fix left</p>
+    <Row type="flex">
+      <Col style={{ width: 100 }}>100px</Col>
+      <Col style={{ flex: 'auto' }}>fill rest</Col>
+    </Row>
+
+    <p>Fix middle</p>
+    <Row type="flex">
+      <Col style={{ flex: 'auto' }}>fill rest</Col>
+      <Col style={{ width: 100 }}>100px</Col>
+      <Col style={{ flex: 'auto' }}>fill rest</Col>
+    </Row>
+
+    <p>Merge with span</p>
+    <Row type="flex">
+      <Col style={{ width: 100 }}>100px</Col>
+      <Col span={4}>col-4</Col>
+      <Col style={{ flex: 'auto' }}>fill rest</Col>
+    </Row>
+  </div>,
+  mountNode
+);
+````

--- a/components/grid/demo/flex.md
+++ b/components/grid/demo/flex.md
@@ -59,6 +59,13 @@ ReactDOM.render(
       <Col span={4}>col-4</Col>
       <Col span={4}>col-4</Col>
     </Row>
+
+    <p>sub-element fill rest</p>
+    <Row type="flex">
+      <Col style={{ width: 100 }}>100px</Col>
+      <Col span={4}>col-4</Col>
+      <Col style={{ flex: 'auto' }}>fill rest</Col>
+    </Row>
   </div>,
   mountNode
 );

--- a/components/grid/demo/flex.md
+++ b/components/grid/demo/flex.md
@@ -59,13 +59,6 @@ ReactDOM.render(
       <Col span={4}>col-4</Col>
       <Col span={4}>col-4</Col>
     </Row>
-
-    <p>sub-element fill rest</p>
-    <Row type="flex">
-      <Col style={{ width: 100 }}>100px</Col>
-      <Col span={4}>col-4</Col>
-      <Col style={{ flex: 'auto' }}>fill rest</Col>
-    </Row>
   </div>,
   mountNode
 );

--- a/components/grid/demo/playground.md
+++ b/components/grid/demo/playground.md
@@ -1,5 +1,5 @@
 ---
-order: 9
+order: 10
 title:
   zh-CN: 栅格配置器
   en-US: Playground

--- a/components/grid/demo/responsive-more.md
+++ b/components/grid/demo/responsive-more.md
@@ -1,5 +1,5 @@
 ---
-order: 8
+order: 9
 title:
   zh-CN: 其他属性的响应式
   en-US: More responsive

--- a/components/grid/demo/responsive.md
+++ b/components/grid/demo/responsive.md
@@ -1,5 +1,5 @@
 ---
-order: 7
+order: 8
 title:
   zh-CN: 响应式布局
   en-US: Responsive


### PR DESCRIPTION
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?

Missing demo for flex Grid fill rest demo.

### 💡 Solution

Add one demo:
<img width="854" alt="2019-03-06 2 40 43" src="https://user-images.githubusercontent.com/5378891/53861124-28d8bc80-401e-11e9-97a1-004451e2ee4b.png">

### 📝 Changelog description

None.

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
