### PR TITLE
add warning when use getCheckboxProps

### DIFF
--- a/components/table/Table.tsx
+++ b/components/table/Table.tsx
@@ -153,7 +153,12 @@ export default class Table<T> extends React.Component<TableProps<T>, TableState<
     const key = this.getRecordKey(item, index);
     // Cache checkboxProps
     if (!this.CheckboxPropsCache[key]) {
-      this.CheckboxPropsCache[key] = rowSelection.getCheckboxProps(item);
+      const checkboxProps = (this.CheckboxPropsCache[key] = rowSelection.getCheckboxProps(item));
+      warning(
+        !('checked' in checkboxProps) && !('defaultChecked' in checkboxProps),
+        'Table',
+        'Do not set `checked` or `defaultChecked` in `getCheckboxProps`. Please use `selectedRowKeys` instead.',
+      );
     }
     return this.CheckboxPropsCache[key];
   };

--- a/components/table/__tests__/Table.rowSelection.test.js
+++ b/components/table/__tests__/Table.rowSelection.test.js
@@ -4,6 +4,16 @@ import Table from '..';
 import Checkbox from '../../checkbox';
 
 describe('Table.rowSelection', () => {
+  const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+  afterEach(() => {
+    errorSpy.mockReset();
+  });
+
+  afterAll(() => {
+    errorSpy.mockRestore();
+  });
+
   const columns = [
     {
       title: 'Name',
@@ -120,6 +130,10 @@ describe('Table.rowSelection', () => {
     checkboxs = wrapper.find('input');
     expect(checkboxs.at(1).props().checked).toBe(true);
     expect(checkboxs.at(2).props().checked).toBe(true);
+
+    expect(errorSpy).toBeCalledWith(
+      'Warning: [antd: Table] Do not set `checked` or `defaultChecked` in `getCheckboxProps`. Please use `selectedRowKeys` instead.',
+    );
   });
 
   it('can be controlled', () => {


### PR DESCRIPTION
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [x] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?

`getCheckboxProps` with `defaultChecked` will not sync with `selectedRowKeys`

close #10966

### 💡 Solution

Add warning info.

### 📝 Changelog description

> Describe changes from user side, and list all potential break changes or other risks.

1. Table add warning when pass `defaultChecked` or `checked` in `getCheckboxProps`.

2. Table 添加 `getCheckboxProps` 中传递  `defaultChecked` 或 `checked` 的警告信息。

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
