### PR TITLE
Fix Input warning logic for focus lose

### DIFF
--- a/components/input/Input.tsx
+++ b/components/input/Input.tsx
@@ -20,7 +20,7 @@ function fixControlledValue<T>(value: T) {
 }
 
 function hasPrefixSuffix(props: InputProps) {
-  return 'prefix' in props || props.suffix || props.allowClear;
+  return !!('prefix' in props || props.suffix || props.allowClear);
 }
 
 const InputSizes = tuple('small', 'default', 'large');

--- a/components/input/__tests__/index.test.js
+++ b/components/input/__tests__/index.test.js
@@ -9,6 +9,16 @@ import calculateNodeHeight, { calculateNodeStyling } from '../calculateNodeHeigh
 const { TextArea } = Input;
 
 describe('Input', () => {
+  const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+  afterEach(() => {
+    errorSpy.mockReset();
+  });
+
+  afterAll(() => {
+    errorSpy.mockRestore();
+  });
+
   focusTest(Input);
 
   it('should support maxLength', () => {
@@ -19,6 +29,33 @@ describe('Input', () => {
   it('select()', () => {
     const wrapper = mount(<Input />);
     wrapper.instance().select();
+  });
+
+  describe('focus trigger warning', () => {
+    it('not trigger', () => {
+      const wrapper = mount(<Input suffix="bamboo" />);
+      wrapper
+        .find('input')
+        .instance()
+        .focus();
+      wrapper.setProps({
+        suffix: 'light',
+      });
+      expect(errorSpy).not.toBeCalled();
+    });
+    it('trigger warning', () => {
+      const wrapper = mount(<Input />);
+      wrapper
+        .find('input')
+        .instance()
+        .focus();
+      wrapper.setProps({
+        suffix: 'light',
+      });
+      expect(errorSpy).toBeCalledWith(
+        'Warning: [antd: Input] When Input is focused, dynamic add or remove prefix / suffix will make it lose focus caused by dom structure change. Read more: https://ant.design/components/input/#FAQ',
+      );
+    });
   });
 });
 


### PR DESCRIPTION
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?

fix #15243

### 💡 Solution

Adjust check logic.

### 📝 Changelog description

1. Fix Input warning logic for focus lose.

2. 修复 Input 在失去焦点时的逻辑检查问题。

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
