### PR TITLE
fix config-provide prefixCls props for modal

### DIFF
--- a/components/modal/confirm.tsx
+++ b/components/modal/confirm.tsx
@@ -6,6 +6,7 @@ import Dialog, { ModalFuncProps, destroyFns } from './Modal';
 import ActionButton from './ActionButton';
 import { getConfirmLocale } from './locale';
 import warning from '../_util/warning';
+import { ConfigConsumer, ConfigConsumerProps } from '../config-provider';
 
 interface ConfirmDialogProps extends ModalFuncProps {
   afterClose?: () => void;
@@ -163,7 +164,16 @@ export default function confirm(config: ModalFuncProps) {
   }
 
   function render(props: any) {
-    ReactDOM.render(<ConfirmDialog {...props} />, div);
+    ReactDOM.render(
+      <ConfigConsumer>
+        {({ getPrefixCls }: ConfigConsumerProps) => {
+          const { prefixCls: customizePrefixCls, ...others } = props;
+          const prefixCls = getPrefixCls('modal', customizePrefixCls);
+          return <ConfirmDialog {...others} prefixCls={prefixCls} />;
+        }}
+      </ConfigConsumer>,
+      div,
+    );
   }
 
   render(currentConfig);


### PR DESCRIPTION
close #15260

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?

1. Describe the source of requirement, like related issue link.

2. Describe the problem and the scenario.

### 💡 Solution

1. How to fix the problem, and list final API implementation and usage sample if that is an new feature.

2. GIF or snapshot should be provided if includes UI/interactive modification.

### 📝 Changelog description

> Describe changes from user side, and list all potential break changes or other risks.

1. English description

2. Chinese description (optional)

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
