### PR TITLE
fix: two colons will appear in FormItem label

### DIFF
--- a/components/form/style/index.less
+++ b/components/form/style/index.less
@@ -105,7 +105,7 @@ input[type='checkbox'] {
       text-align: left;
     }
 
-    label {
+    &>label {
       color: @label-color;
 
       &::after {

--- a/components/form/style/index.less
+++ b/components/form/style/index.less
@@ -105,7 +105,7 @@ input[type='checkbox'] {
       text-align: left;
     }
 
-    &>label {
+    > label {
       color: @label-color;
 
       &::after {


### PR DESCRIPTION
If the label attribute of the component Form.Item is a ReactNode and the same label tag exists inside the ReactNode, two colons will appear.

First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?

If the label attribute of the component Form.Item is a ReactNode and the same label tag exists inside the ReactNode, two colons will appear.

https://codepen.io/jinxin0112/pen/jJmmKE?&editable=true&editors=001

### 💡 Solution

Match only the next level label, not all

### 📝 Changelog description

pass

### ☑️ Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
