### PR TITLE
fix tabs style in card mode

### DIFF
--- a/components/tabs/style/card-style.less
+++ b/components/tabs/style/card-style.less
@@ -12,6 +12,7 @@
     visibility: hidden;
   }
   &&-card &-card-bar &-tab {
+    height: @tabs-card-height - 1px;
     margin: 0;
     margin-right: 2px;
     padding: 0 16px;
@@ -23,6 +24,7 @@
     transition: all 0.3s @ease-in-out;
   }
   &&-card &-card-bar &-tab-active {
+    height: @tabs-card-height;
     padding-bottom: 1px;
     color: @tabs-card-active-color;
     background: @component-background;


### PR DESCRIPTION

### 🤔 This is a ...
- [x] Bug fix


### 👻 What's the background?

resolves issue #15297 `card mode tabs component style is broken when browser scale is not 100%` 

### 💡 Solution

give tabs a fixed height, so it would be 40px instead of 39.6px

### 📝 Changelog description

> Describe changes from user side, and list all potential break changes or other risks.


### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
