### PR TITLE
Keep same content color of List like previous version

### DIFF
--- a/components/list/style/index.less
+++ b/components/list/style/index.less
@@ -6,13 +6,16 @@
 .@{list-prefix-cls} {
   .reset-component;
   position: relative;
+
   * {
     outline: none;
   }
+
   &-pagination {
     margin-top: 24px;
     text-align: right;
   }
+
   &-more {
     margin-top: 12px;
     text-align: center;
@@ -21,22 +24,29 @@
       padding-left: 32px;
     }
   }
+
   &-spin {
     min-height: 40px;
     text-align: center;
   }
+
   &-empty-text {
     padding: @list-empty-text-padding;
     color: @text-color-secondary;
     font-size: @font-size-base;
     text-align: center;
   }
+
   &-item {
     display: flex;
     padding: @list-item-padding;
 
     &-no-flex {
       display: block;
+    }
+
+    &-content {
+      color: @text-color;
     }
 
     &-meta {


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?

1. Describe the source of requirement, like related issue link.

close #15296 

2. Describe the problem and the scenario.

- 3.14.1: https://codesandbox.io/s/xp32603nkp
- 3.15.1: https://codesandbox.io/s/57q64141k

### 💡 Solution

Add text color to content.

### 📝 Changelog description

> Describe changes from user side, and list all potential break changes or other risks.

1. English description

- Keep same content color of List like previous version. #15296 

2. Chinese description (optional)

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
