### PR TITLE
support `Modal.confirm({ icon: null })` to hide default Icon

### DIFF
--- a/components/modal/confirm.tsx
+++ b/components/modal/confirm.tsx
@@ -36,7 +36,9 @@ const ConfirmDialog = (props: ConfirmDialogProps) => {
     'Modal',
     `The property 'iconType' is deprecated. Use the property 'icon' instead.`,
   );
-  const icon = props.icon ? props.icon : iconType;
+
+  // 支持传入{ icon: null }来隐藏`Modal.confirm`默认的Icon
+  const icon = props.icon === undefined ? iconType : props.icon;
   const okType = props.okType || 'primary';
   const prefixCls = props.prefixCls || 'ant-modal';
   const contentPrefixCls = `${prefixCls}-confirm`;

--- a/components/modal/style/confirm.less
+++ b/components/modal/style/confirm.less
@@ -33,7 +33,6 @@
 
     .@{confirm-prefix-cls}-content {
       margin-top: 8px;
-      margin-left: 38px;
       color: @text-color;
       font-size: @font-size-base;
     }
@@ -42,6 +41,11 @@
       float: left;
       margin-right: 16px;
       font-size: 22px;
+
+      // `content` after `icon` should set marginLeft
+      + .@{confirm-prefix-cls}-title + .@{confirm-prefix-cls}-content {
+        margin-left: 38px;
+      }
     }
   }
 


### PR DESCRIPTION
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?

希望在调用`Modal.confirm`时可以省略图标

### 💡 Solution

```javascript
Modal.confirm({
  icon: null,
  content: 'hello world'
})
```

### 📝 Changelog description

> Describe changes from user side, and list all potential break changes or other risks.

No break changes.

### ☑️ Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
