### PR TITLE
fix add click prop for BreadcrumbItem

### DIFF
--- a/components/breadcrumb/BreadcrumbItem.tsx
+++ b/components/breadcrumb/BreadcrumbItem.tsx
@@ -6,6 +6,7 @@ export interface BreadcrumbItemProps {
   prefixCls?: string;
   separator?: React.ReactNode;
   href?: string;
+  onClick?: React.MouseEventHandler<HTMLAnchorElement | HTMLSpanElement>;
 }
 
 export default class BreadcrumbItem extends React.Component<BreadcrumbItemProps, any> {


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 组件样式改进
- [x] TypeScript 定义更新
- [ ] 重构
- [ ] 代码风格优化
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 👻 需求背景

 为Breadcrumb.Item组件增加onClick事件的申明，虽然大多数时候Breadcrumb.Item会配合自身的`href`或者嵌套与route相关的路由标签使用，但是有些时候还是需要为Breadcrumb.Item绑定一些单独的逻辑处理事件的
![image](https://user-images.githubusercontent.com/11400784/54139001-91c79680-445b-11e9-8991-9fbf2944b4f3.png)
此时就就会出现如果所示的情况，查询解决方案有在Breadcrumb.Item标签里面写一个<div>元素再进行绑定，但是那样会多出一个元素，于是决定为Breadcrumb.Item添加一个可以写onClick属性的申明

### 💡 解决方案和最终实现是？

![image](https://user-images.githubusercontent.com/11400784/54139477-993b6f80-445c-11e9-895a-7514d1f2728f.png)


### 📝 更新日志怎么写？

> 从用户角度描述具体变化，以及可能的 breaking change 和其他风险？

无breaking change风险

1. 英文描述
add onClick prop for BreadcrumbItem (typescript)

2. 中文描述（可选）

### ☑️ 请求合并前的自查清单

- [x] 文档无须补充
- [x] 代码演示无须提供
- [x] TypeScript 定义已补充