### PR TITLE
fix: avatar cannot calculate the offset when display: none

### DIFF
--- a/components/avatar/index.tsx
+++ b/components/avatar/index.tsx
@@ -31,6 +31,7 @@ export interface AvatarProps {
 export interface AvatarState {
   scale: number;
   isImgExist: boolean;
+  avatarDisplay: boolean;
 }
 
 export default class Avatar extends React.Component<AvatarProps, AvatarState> {
@@ -42,6 +43,7 @@ export default class Avatar extends React.Component<AvatarProps, AvatarState> {
   state = {
     scale: 1,
     isImgExist: true,
+    avatarDisplay: true,
   };
 
   private avatarChildren: any;
@@ -54,9 +56,21 @@ export default class Avatar extends React.Component<AvatarProps, AvatarState> {
     if (
       prevProps.children !== this.props.children ||
       (prevState.scale !== this.state.scale && this.state.scale === 1) ||
-      prevState.isImgExist !== this.state.isImgExist
+      prevState.isImgExist !== this.state.isImgExist ||
+      !this.state.avatarDisplay
     ) {
       this.setScale();
+      if (this.avatarChildren && this.avatarChildren.offsetWidth !== 0) {
+        this.setState({
+          avatarDisplay: true,
+        });
+      }
+    } else {
+      if (this.avatarChildren && this.avatarChildren.offsetWidth === 0 && this.state.scale === 1) {
+        this.setState({
+          avatarDisplay: false,
+        });
+      }
     }
 
     if (prevProps.src !== this.props.src) {
@@ -66,7 +80,8 @@ export default class Avatar extends React.Component<AvatarProps, AvatarState> {
 
   setScale = () => {
     const childrenNode = this.avatarChildren;
-    if (childrenNode) {
+    // denominator is 0 is no meaning
+    if (childrenNode && childrenNode.offsetWidth !== 0) {
       const childrenWidth = childrenNode.offsetWidth;
       const avatarNode = ReactDOM.findDOMNode(this) as Element;
       const avatarWidth = avatarNode.getBoundingClientRect().width;


### PR DESCRIPTION
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?

1. [重现链接](https://codepen.io/ppbl/pen/Bbwgmv?editors=0011)

2. 上述链接有一个 Avatar 初始是 `dispaly:none` 的，然后通过点击显示，但是此时的偏移量和 `scale` 是没有的，因为 `dispaly:none` 的时候拿到元素的 `offsetWidth` 是 `0`， 分母为 `0` 算出来的 `scale` 为 `-Infinity`, 不合法所以 `transform` 加不上去， 导致头像文字位置不居中（可能字还大）

### 💡 Solution

1. 通过判断 `avatarChildren` 的 `offsetWidth` 为 0 时没必要计算 scale,。
2. 但是过会如果头像再次显示的话，需要再次计算， 可以增加一个 state  `avatarDisplay`表示当前状态，如果 `avatarDisplay` 为 `false` 说明此时可能头像属于 `display:none` 的状态，这样在下次 update 的时候起码需要有再次计算的机会 , 计算完成重置 state
```ts
componentDidUpdate(prevProps: AvatarProps, prevState: AvatarState) {
    if (
      prevProps.children !== this.props.children ||
      (prevState.scale !== this.state.scale && this.state.scale === 1) ||
      prevState.isImgExist !== this.state.isImgExist ||
      !this.state.avatarDisplay
    ) {
      this.setScale();
      if (this.avatarChildren && this.avatarChildren.offsetWidth !== 0) {
        this.setState({
          avatarDisplay: true,
        });
      }
    } else {
      if (this.avatarChildren && this.avatarChildren.offsetWidth === 0 && this.state.scale === 1) {
        this.setState({
          avatarDisplay: false,
        });
      }
    }

    if (prevProps.src !== this.props.src) {
      this.setState({ isImgExist: true, scale: 1 });
    }
  }
```

### 📝 Changelog description

> Describe changes from user side, and list all potential break changes or other risks.

1. 对用户应该没有影响或者可以解决类似问题

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

### others
1. 第一次提交pr不知道符不符合规则😅，只是想帮忙修个bug，
2. 我这实现肯定不能说是最好的， 不过自己的项目遇到了我按照这样的套路修改是可以的。。
3. 英语不太好怕描述不清楚所以只能用中文~
