### PR TITLE
fix(Layout): disable `hasSider` when specifically declared

### DIFF
--- a/components/layout/__tests__/index.test.js
+++ b/components/layout/__tests__/index.test.js
@@ -95,6 +95,15 @@ describe('Layout', () => {
     wrapper.setProps({ collapsed: true });
     expect(wrapper.instance().state.collapsed).toBe(true);
   });
+
+  it('should not add ant-layout-has-sider when `hasSider` is `false`', () => {
+    const wrapper = mount(
+      <Layout hasSider={false}>
+        <Sider>Sider</Sider>
+      </Layout>,
+    );
+    expect(wrapper.find('.ant-layout').hasClass('ant-layout-has-sider')).toBe(false);
+  });
 });
 
 describe('Sider onBreakpoint', () => {

--- a/components/layout/layout.tsx
+++ b/components/layout/layout.tsx
@@ -77,7 +77,8 @@ class BasicLayout extends React.Component<BasicPropsWithTagName, BasicLayoutStat
   render() {
     const { prefixCls, className, children, hasSider, tagName, ...others } = this.props;
     const classString = classNames(className, prefixCls, {
-      [`${prefixCls}-has-sider`]: hasSider || this.state.siders.length > 0,
+      [`${prefixCls}-has-sider`]:
+        typeof hasSider === 'boolean' ? hasSider : this.state.siders.length > 0,
     });
     return React.createElement(tagName, { className: classString, ...others }, children);
   }


### PR DESCRIPTION
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?

1. Describe the source of requirement, like related issue link.

Just find a bug (probably) when coding

2. Describe the problem and the scenario.

In some situation `Sider` is deeply rendered in Children of `Layout`,
and if we don't want to judge whether `Layout` has sider, the attr `hasSider`
set to `false` should properly work. However `hasSider || this.state.siders.length > 0`
will ignore `hasSider` when it is `false`.

### 💡 Solution

1. How to fix the problem, and list final API implementation and usage sample if that is an new feature.

Judge `hasSider` is type of Boolean first.

2. GIF or snapshot should be provided if includes UI/interactive modification.

### 📝 Changelog description

> Describe changes from userside, and list all potential break changes or other risks.

1. English description

Fix a bug: `Layout` has classname `ant-layout-has-sider` even if `hasFixer` is set to `false` when `sider` is one of its descendants.

2. Chinese description (optional)

修复即使在指定 `Layout` 的 `hasSider` 属性为 `false` 的时候依然会加 `ant-layout-has-sider` 的 `classname` 的问题

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
