### PR TITLE
Fix:去除相同月份相同时，结束月加1的操作

### DIFF
--- a/components/date-picker/RangePicker.tsx
+++ b/components/date-picker/RangePicker.tsx
@@ -27,8 +27,7 @@ function getShowDateFromValue(value: RangePickerValue) {
   if (!start && !end) {
     return;
   }
-  const newEnd = end && end.isSame(start, 'month') ? end.clone().add(1, 'month') : end;
-  return [start, newEnd] as RangePickerValue;
+  return [start, end] as RangePickerValue;
 }
 
 function pickerValueAdapter(

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "prop-types": "^15.6.2",
     "raf": "^3.4.0",
     "rc-animate": "^2.5.4",
-    "rc-calendar": "~9.10.3",
+    "rc-calendar": "~9.11.0",
     "rc-cascader": "~0.17.0",
     "rc-checkbox": "~2.1.5",
     "rc-collapse": "~1.11.1",


### PR DESCRIPTION
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!


### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?

1.https://github.com/react-component/calendar/pull/478
2.https://github.com/ant-design/ant-design/issues/13302


### 📝 Changelog description

> Describe changes from userside, and list all potential break changes or other risks.

1. English description
Fixed an issue about the component(RangePicker)  could not select the same month
2. Chinese description (optional)

### ☑️ Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


