### PR TITLE
fix: bad position of collapsible submenu in sider when collapsed

### DIFF
--- a/components/layout/demo/side.md
+++ b/components/layout/demo/side.md
@@ -1,7 +1,6 @@
 ---
 order: 3
 iframe: 360
-only: true
 title:
   zh-CN: 侧边布局
   en-US: Sider
@@ -50,7 +49,7 @@ class SiderDemo extends React.Component {
           onCollapse={this.onCollapse}
         >
           <div className="logo" />
-          <Menu theme="dark" defaultSelectedKeys={['1']} mode="inline" subMenuCloseDelay={9999}>
+          <Menu theme="dark" defaultSelectedKeys={['1']} mode="inline">
             <Menu.Item key="1">
               <Icon type="pie-chart" />
               <span>Option 1</span>

--- a/components/layout/demo/side.md
+++ b/components/layout/demo/side.md
@@ -1,6 +1,7 @@
 ---
 order: 3
 iframe: 360
+only: true
 title:
   zh-CN: 侧边布局
   en-US: Sider
@@ -10,7 +11,7 @@ title:
 
 侧边两列式布局。页面横向空间有限时，侧边导航可收起。
 
-侧边导航在页面布局上采用的是左右的结构，一般主导航放置于页面的左侧固定位置，辅助菜单放置于工作区顶部。内容根据浏览器终端进行自适应，能提高横向空间的使用率，但是整个页面排版不稳定。侧边导航的模式层级扩展性强，一、二、三级导航项目可以更为顺畅且具关联性的被展示，同时侧边导航可以固定，使得用户在操作和浏览中可以快速的定位和切换当前位置，有很高的操作效率。但这类导航横向页面内容的空间会被牺牲一部份。
+侧边导航在页面布局上采用的是左右的结构，一般主导航放置于页面的左侧固定位置，辅助菜单放置于工作区顶部。内容根据浏览器终端进行自适应，能提高横向空间的使用率，但是整个页面排版不稳定。侧边导航的模式层级扩展性强，一、二、三级导航项目可以更为顺畅且具关联性的被展示，同时侧边导航可以固定，使得用户在操作和浏览中可以快速的定位和切换当前位置，有很高的操作效率。但这类导航横向页面内容的空间会被牺牲一部分。
 
 ## en-US
 
@@ -49,7 +50,7 @@ class SiderDemo extends React.Component {
           onCollapse={this.onCollapse}
         >
           <div className="logo" />
-          <Menu theme="dark" defaultSelectedKeys={['1']} mode="inline">
+          <Menu theme="dark" defaultSelectedKeys={['1']} mode="inline" subMenuCloseDelay={9999}>
             <Menu.Item key="1">
               <Icon type="pie-chart" />
               <span>Option 1</span>

--- a/components/menu/__tests__/index.test.js
+++ b/components/menu/__tests__/index.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { mount } from 'enzyme';
 import Menu from '..';
 import Icon from '../../icon';
+import Layout from '../../layout';
 
 jest.mock('mutationobserver-shim', () => {
   global.MutationObserver = function MutationObserver() {
@@ -493,5 +494,47 @@ describe('Menu', () => {
 
     const text = wrapper.find('.ant-tooltip-inner').text();
     expect(text).toBe('bamboo lucky');
+  });
+
+  it('render correctly when using with Layout.Sider', () => {
+    class Demo extends React.Component {
+      state = {
+        collapsed: false,
+      };
+
+      onCollapse = collapsed => this.setState({ collapsed });
+
+      render() {
+        const { collapsed } = this.state;
+        return (
+          <Layout style={{ minHeight: '100vh' }}>
+            <Layout.Sider collapsible collapsed={collapsed} onCollapse={this.onCollapse}>
+              <div className="logo" />
+              <Menu theme="dark" defaultSelectedKeys={['1']} mode="inline">
+                <SubMenu
+                  key="sub1"
+                  title={
+                    <span>
+                      <Icon type="user" />
+                      <span>User</span>
+                    </span>
+                  }
+                >
+                  <Menu.Item key="3">Tom</Menu.Item>
+                  <Menu.Item key="4">Bill</Menu.Item>
+                  <Menu.Item key="5">Alex</Menu.Item>
+                </SubMenu>
+              </Menu>
+            </Layout.Sider>
+          </Layout>
+        );
+      }
+    }
+    const wrapper = mount(<Demo />);
+    wrapper.find('.ant-menu-submenu-title').simulate('click');
+    wrapper.find('.ant-layout-sider-trigger').simulate('click');
+    jest.runAllTimers();
+    wrapper.update();
+    expect(wrapper.find('.ant-menu-submenu-popup').length).toBe(0);
   });
 });

--- a/components/menu/index.tsx
+++ b/components/menu/index.tsx
@@ -89,6 +89,7 @@ class Menu extends React.Component<MenuProps, MenuState> {
   context: any;
   switchingModeFromInline: boolean;
   inlineOpenKeys: string[] = [];
+  contextSiderCollapsed: boolean = true;
 
   constructor(props: MenuProps) {
     super(props);
@@ -129,12 +130,20 @@ class Menu extends React.Component<MenuProps, MenuState> {
     if (prevProps.mode === 'inline' && this.props.mode !== 'inline') {
       this.switchingModeFromInline = true;
     }
-    if (this.props.inlineCollapsed && !prevProps.inlineCollapsed) {
+    if (
+      (this.props.inlineCollapsed && !prevProps.inlineCollapsed) ||
+      (this.getInlineCollapsed() && this.contextSiderCollapsed)
+    ) {
+      this.contextSiderCollapsed = false;
       this.switchingModeFromInline = true;
       this.inlineOpenKeys = this.state.openKeys;
       this.setState({ openKeys: [] });
     }
-    if (!this.props.inlineCollapsed && prevProps.inlineCollapsed) {
+    if (
+      (!this.props.inlineCollapsed && prevProps.inlineCollapsed) ||
+      (!this.getInlineCollapsed() && !this.contextSiderCollapsed)
+    ) {
+      this.contextSiderCollapsed = true;
       this.setState({ openKeys: this.inlineOpenKeys });
       this.inlineOpenKeys = [];
     }


### PR DESCRIPTION
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?

1. Describe the source of requirement, like related issue link.

    To close #15321. 

2. Describe the problem and the scenario.

### 💡 Solution

1. How to fix the problem, and list final API implementation and usage sample if that is an new feature.

    When migrating to new lifecycle methods, I forget to record the status of context, and caused this bug. Just make it up, and everything goes smoothly.

2. GIF or snapshot should be provided if includes UI/interactive modification.

### 📝 Changelog description

> Describe changes from userside, and list all potential break changes or other risks.

1. English description

    Fix error rendering of SubMenu when Menu collapsed

2. Chinese description (optional)

    修复 Menu 收缩后，SubMenu 异常渲染的问题

### ☑️ Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
