### PR TITLE
fix Skeleton browser applied padding

### DIFF
--- a/components/skeleton/style/index.less
+++ b/components/skeleton/style/index.less
@@ -54,6 +54,8 @@
 
     // paragraph
     .@{skeleton-paragraph-prefix-cls} {
+      padding: 0;
+      
       > li {
         width: 100%;
         height: 16px;


### PR DESCRIPTION
Fix to issue #15413, caused by `padding-inline-start` rule in browser default styles

First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?

Major browsers like Chrome or Firefox in its default stylesheets include rule for `ul` element with `padding-inline-start: 40px`, that breaks styling of `Skeleton` component.

### 💡 Solution

Override browser styles by resetting all paddings on Skeleton's unordered list element.

### 📝 Changelog description

> Describe changes from userside, and list all potential break changes or other risks.

I see no risks.

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
