### PR TITLE
fix(date-picker): merge origin input and popup input focus

### DIFF
--- a/components/date-picker/createPicker.tsx
+++ b/components/date-picker/createPicker.tsx
@@ -21,6 +21,7 @@ export interface PickerProps {
 
 export interface PickerState {
   open: boolean;
+  hadFocus: boolean;
   value: moment.Moment | null;
   showDate: moment.Moment | null;
 }
@@ -68,6 +69,7 @@ export default function createPicker(TheCalendar: React.ComponentClass): any {
         value,
         showDate: value,
         open: false,
+        hadFocus: false,
       };
     }
 
@@ -114,6 +116,22 @@ export default function createPicker(TheCalendar: React.ComponentClass): any {
 
       if (onOpenChange) {
         onOpenChange(open);
+      }
+    };
+
+    onFocus = () => {
+      const { open, hadFocus } = this.state;
+      if (!open && !hadFocus) {
+        this.setState({ hadFocus: true });
+        this.props.onFocus()
+      }
+    };
+
+    onBlur = () => {
+      const { open, hadFocus } = this.state;
+      if (!open && hadFocus) {
+        this.setState({ hadFocus: false });
+        this.props.onBlur()
       }
     };
 
@@ -245,8 +263,8 @@ export default function createPicker(TheCalendar: React.ComponentClass): any {
           id={props.id}
           className={classNames(props.className, props.pickerClass)}
           style={{ ...pickerStyle, ...props.style }}
-          onFocus={props.onFocus}
-          onBlur={props.onBlur}
+          onFocus={this.onFocus}
+          onBlur={this.onBlur}
           onMouseEnter={props.onMouseEnter}
           onMouseLeave={props.onMouseLeave}
         >

--- a/tests/shared/focusTest.js
+++ b/tests/shared/focusTest.js
@@ -29,6 +29,14 @@ export default function focusTest(Component) {
       expect(handleFocus).toBeCalled();
     });
 
+    it('focus() and onFocus trigger only once', () => {
+      const handleFocus = jest.fn();
+      const wrapper = mount(<Component onFocus={handleFocus} />, { attachTo: container });
+      wrapper.instance().focus();
+      jest.runAllTimers();
+      expect(handleFocus).toBeCalledTimes(1);
+    });
+
     it('blur() and onBlur', () => {
       const handleBlur = jest.fn();
       const wrapper = mount(<Component onBlur={handleBlur} />, { attachTo: container });
@@ -37,6 +45,16 @@ export default function focusTest(Component) {
       wrapper.instance().blur();
       jest.runAllTimers();
       expect(handleBlur).toBeCalled();
+    });
+
+    it('blur() and onBlur only trigger once', () => {
+      const handleBlur = jest.fn();
+      const wrapper = mount(<Component onBlur={handleBlur} />, { attachTo: container });
+      wrapper.instance().focus();
+      jest.runAllTimers();
+      wrapper.instance().blur();
+      jest.runAllTimers();
+      expect(handleBlur).toBeCalledTimes(1);
     });
 
     it('autoFocus', () => {


### PR DESCRIPTION
## 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?

fix[#11249](https://github.com/ant-design/ant-design/issues/11249)
add test for shared/focusTest.js
