### PR TITLE
docs: Correct the default value of mouseEnterDelay

### DIFF
--- a/components/tooltip/index.en-US.md
+++ b/components/tooltip/index.en-US.md
@@ -27,7 +27,7 @@ The following APIs are shared by Tooltip, Popconfirm, Popover.
 | autoAdjustOverflow | Whether to adjust popup placement automatically when popup is off screen | boolean | `true` |
 | defaultVisible | Whether the floating tooltip card is visible by default | boolean | `false` |
 | getPopupContainer | The DOM container of the tip, the default behavior is to create a `div` element in `body` | Function(triggerNode) | () => document.body |
-| mouseEnterDelay | Delay in seconds, before tooltip is shown on mouse enter | number | 0 |
+| mouseEnterDelay | Delay in seconds, before tooltip is shown on mouse enter | number | 0.1 |
 | mouseLeaveDelay | Delay in seconds, before tooltip is hidden on mouse leave | number | 0.1 |
 | overlayClassName | Class name of the tooltip card | string | - |
 | overlayStyle | Style of the tooltip card | object | - |

--- a/components/tooltip/index.zh-CN.md
+++ b/components/tooltip/index.zh-CN.md
@@ -29,7 +29,7 @@ title: Tooltip
 | autoAdjustOverflow | 气泡被遮挡时自动调整位置 | boolean | `true` |
 | defaultVisible | 默认是否显隐 | boolean | false |
 | getPopupContainer | 浮层渲染父节点，默认渲染到 body 上 | Function(triggerNode) | () => document.body |
-| mouseEnterDelay | 鼠标移入后延时多少才显示 Tooltip，单位：秒 | number | 0 |
+| mouseEnterDelay | 鼠标移入后延时多少才显示 Tooltip，单位：秒 | number | 0.1 |
 | mouseLeaveDelay | 鼠标移出后延时多少才隐藏 Tooltip，单位：秒 | number | 0.1 |
 | overlayClassName | 卡片类名 | string | 无 |
 | overlayStyle | 卡片样式 | object | 无 |


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?

The default value of `mouseEnterDelay`  for the tooltip is not consistent with the default value set in the code.

https://github.com/ant-design/ant-design/blob/f0298ba8c1dce2dee3faa83e83e70dcc7e70c938/components/tooltip/index.tsx#L88

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
