### PR TITLE
English translation for notFoundContent

### DIFF
--- a/components/mention/index.en-US.md
+++ b/components/mention/index.en-US.md
@@ -38,7 +38,7 @@ When need to mention someone or something.
 | getSuggestionContainer | rendered to the root of the menu. Default rendered to the body dom. If gets any problem of the menu while scrolling. Try to make the root the dom scrolled, and make it position relative. | function | () => document.body |
 | loading | loading mode | boolean | false |
 | multiLines | multilines mode | boolean | false |
-| notFoundContent | suggestion when suggestions empty | string | '无匹配结果，轻敲空格完成输入' |
+| notFoundContent | suggestion when suggestions empty | string | 'No matches found' |
 | placeholder | placeholder of input | string | null |
 | placement | The position of the suggestion relative to the target, which can be one of `top` and `bottom` | string | 'bottom'. |
 | prefix | character which will trigger Mention to show mention list | string or Array&lt;string> | '@' |

--- a/components/mention/index.tsx
+++ b/components/mention/index.tsx
@@ -40,7 +40,7 @@ export interface MentionState {
 class Mention extends React.Component<MentionProps, MentionState> {
   static getMentions = getMentions;
   static defaultProps = {
-    notFoundContent: '无匹配结果，轻敲空格完成输入',
+    notFoundContent: 'No matches found',
     loading: false,
     multiLines: false,
     placement: 'bottom' as MentionPlacement,


### PR DESCRIPTION

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [x] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?

1. Describe the source of requirement, like related issue link.
<Mention> component, notFoundContent default value will now be in english.
[Code Sandbox link example](https://codesandbox.io/s/x9l970906p)

2. Describe the problem and the scenario.
<Mention> type @somethingthatwontbematched

### 💡 Solution

1. How to fix the problem, and list final API implementation and usage sample if that is an new feature.

2. GIF or snapshot should be provided if includes UI/interactive modification.

### 📝 Changelog description

> Describe changes from userside, and list all potential break changes or other risks.

1. English description
When using a <Mention> component, when no matches are found the default message will now be in english instead of chinese.

2. Chinese description (optional)

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
