### PR TITLE
Refactor Avatar scale calculate logic

### DIFF
--- a/components/avatar/__tests__/Avatar.test.js
+++ b/components/avatar/__tests__/Avatar.test.js
@@ -14,8 +14,12 @@ describe('Avatar Render', () => {
     global.document.body.appendChild(div);
 
     const wrapper = mount(<Avatar src="http://error.url">Fallback</Avatar>, { attachTo: div });
-    wrapper.instance().setScale = jest.fn(() => wrapper.instance().setState({ scale: 0.5 }));
-
+    wrapper.instance().setScale = jest.fn(() => {
+      if (wrapper.state().scale === 0.5) {
+        return;
+      }
+      wrapper.instance().setState({ scale: 0.5 });
+    });
     wrapper.find('img').simulate('error');
 
     const children = wrapper.find('.ant-avatar-string');

--- a/components/avatar/__tests__/Avatar.test.js
+++ b/components/avatar/__tests__/Avatar.test.js
@@ -3,6 +3,31 @@ import { mount } from 'enzyme';
 import Avatar from '..';
 
 describe('Avatar Render', () => {
+  let originOffsetWidth;
+  let originGetBoundingClientRect;
+  beforeAll(() => {
+    // Mock offsetHeight
+    originOffsetWidth =
+      Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'offsetWidth').get;
+    Object.defineProperty(HTMLElement.prototype, 'offsetWidth', {
+      get() {
+        return 100;
+      },
+    });
+    // Mock getBoundingClientRect
+    originGetBoundingClientRect = HTMLElement.prototype.getBoundingClientRect;
+    HTMLElement.prototype.getBoundingClientRect = () => ({ width: 80 });
+  });
+
+  afterAll(() => {
+    // Restore Mock offsetHeight
+    Object.defineProperty(HTMLElement.prototype, 'offsetWidth', {
+      get: originOffsetWidth,
+    });
+    // Restore Mock getBoundingClientRect
+    HTMLElement.prototype.getBoundingClientRect = originGetBoundingClientRect;
+  });
+
   it('Render long string correctly', () => {
     const wrapper = mount(<Avatar>TestString</Avatar>);
     const children = wrapper.find('.ant-avatar-string');
@@ -93,5 +118,13 @@ describe('Avatar Render', () => {
     // cleanup
     wrapper.detach();
     global.document.body.removeChild(div);
+  });
+
+  it('should calculate scale of avatar children correctly', () => {
+    const wrapper = mount(<Avatar>Avatar</Avatar>);
+    expect(wrapper.state().scale).toBe(0.72);
+    HTMLElement.prototype.getBoundingClientRect = () => ({ width: 40 });
+    wrapper.setProps({ children: 'xx' });
+    expect(wrapper.state().scale).toBe(0.32);
   });
 });

--- a/components/avatar/__tests__/Avatar.test.js
+++ b/components/avatar/__tests__/Avatar.test.js
@@ -4,19 +4,17 @@ import Avatar from '..';
 
 describe('Avatar Render', () => {
   let originOffsetWidth;
-  let originGetBoundingClientRect;
   beforeAll(() => {
     // Mock offsetHeight
-    originOffsetWidth =
-      Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'offsetWidth').get;
+    originOffsetWidth = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'offsetWidth').get;
     Object.defineProperty(HTMLElement.prototype, 'offsetWidth', {
       get() {
-        return 100;
+        if (this.className === 'ant-avatar-string') {
+          return 100;
+        }
+        return 80;
       },
     });
-    // Mock getBoundingClientRect
-    originGetBoundingClientRect = HTMLElement.prototype.getBoundingClientRect;
-    HTMLElement.prototype.getBoundingClientRect = () => ({ width: 80 });
   });
 
   afterAll(() => {
@@ -24,8 +22,6 @@ describe('Avatar Render', () => {
     Object.defineProperty(HTMLElement.prototype, 'offsetWidth', {
       get: originOffsetWidth,
     });
-    // Restore Mock getBoundingClientRect
-    HTMLElement.prototype.getBoundingClientRect = originGetBoundingClientRect;
   });
 
   it('Render long string correctly', () => {
@@ -123,7 +119,14 @@ describe('Avatar Render', () => {
   it('should calculate scale of avatar children correctly', () => {
     const wrapper = mount(<Avatar>Avatar</Avatar>);
     expect(wrapper.state().scale).toBe(0.72);
-    HTMLElement.prototype.getBoundingClientRect = () => ({ width: 40 });
+    Object.defineProperty(HTMLElement.prototype, 'offsetWidth', {
+      get() {
+        if (this.className === 'ant-avatar-string') {
+          return 100;
+        }
+        return 40;
+      },
+    });
     wrapper.setProps({ children: 'xx' });
     expect(wrapper.state().scale).toBe(0.32);
   });

--- a/components/avatar/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/avatar/__tests__/__snapshots__/demo.test.js.snap
@@ -439,6 +439,59 @@ exports[`renders ./components/avatar/demo/dynamic.md correctly 1`] = `
 </div>
 `;
 
+exports[`renders ./components/avatar/demo/toggle-debug.md correctly 1`] = `
+<div>
+  <button
+    class="ant-btn"
+    type="button"
+  >
+    <span>
+      Toggle Avatar
+    </span>
+  </button>
+  <span
+    class="ant-avatar ant-avatar-lg ant-avatar-circle"
+    style="background:#7265e6;display:"
+  >
+    <span
+      class="ant-avatar-string"
+    >
+      Avatar
+    </span>
+  </span>
+  <span
+    class="ant-avatar ant-avatar-lg ant-avatar-circle ant-avatar-image"
+    style="background:#00a2ae;display:"
+  >
+    <img
+      src="invalid"
+    />
+  </span>
+  <div
+    style="display:"
+  >
+    <span
+      class="ant-avatar ant-avatar-lg ant-avatar-circle"
+      style="background:#7265e6"
+    >
+      <span
+        class="ant-avatar-string"
+      >
+        Avatar
+      </span>
+    </span>
+    <span
+      class="ant-avatar ant-avatar-lg ant-avatar-circle ant-avatar-image"
+      style="background:#00a2ae"
+    >
+      <img
+        src="invalid"
+      />
+    </span>
+  </div>
+</div>
+`;
+
 exports[`renders ./components/avatar/demo/type.md correctly 1`] = `
 <div>
   <span

--- a/components/avatar/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/avatar/__tests__/__snapshots__/demo.test.js.snap
@@ -446,12 +446,20 @@ exports[`renders ./components/avatar/demo/toggle-debug.md correctly 1`] = `
     type="button"
   >
     <span>
-      Toggle Avatar
+      Toggle Avatar visibility
+    </span>
+  </button>
+  <button
+    class="ant-btn"
+    type="button"
+  >
+    <span>
+      Toggle Avatar size
     </span>
   </button>
   <span
     class="ant-avatar ant-avatar-lg ant-avatar-circle"
-    style="background:#7265e6;display:"
+    style="background:#7265e6;display:none"
   >
     <span
       class="ant-avatar-string"
@@ -461,14 +469,14 @@ exports[`renders ./components/avatar/demo/toggle-debug.md correctly 1`] = `
   </span>
   <span
     class="ant-avatar ant-avatar-lg ant-avatar-circle ant-avatar-image"
-    style="background:#00a2ae;display:"
+    style="background:#00a2ae;display:none"
   >
     <img
       src="invalid"
     />
   </span>
   <div
-    style="display:"
+    style="display:none"
   >
     <span
       class="ant-avatar ant-avatar-lg ant-avatar-circle"

--- a/components/avatar/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/avatar/__tests__/__snapshots__/demo.test.js.snap
@@ -457,30 +457,22 @@ exports[`renders ./components/avatar/demo/toggle-debug.md correctly 1`] = `
       Toggle Avatar size
     </span>
   </button>
-  <span
-    class="ant-avatar ant-avatar-lg ant-avatar-circle"
-    style="background:#7265e6;display:none"
+  <button
+    class="ant-btn"
+    type="button"
   >
-    <span
-      class="ant-avatar-string"
-    >
-      Avatar
+    <span>
+      Change Avatar scale
     </span>
-  </span>
-  <span
-    class="ant-avatar ant-avatar-lg ant-avatar-circle ant-avatar-image"
-    style="background:#00a2ae;display:none"
-  >
-    <img
-      src="invalid"
-    />
-  </span>
+  </button>
+  <br />
+  <br />
   <div
-    style="display:none"
+    style="text-align:center;transform:scale(1);margin-top:24px"
   >
     <span
       class="ant-avatar ant-avatar-lg ant-avatar-circle"
-      style="background:#7265e6"
+      style="background:#7265e6;display:none"
     >
       <span
         class="ant-avatar-string"
@@ -490,12 +482,34 @@ exports[`renders ./components/avatar/demo/toggle-debug.md correctly 1`] = `
     </span>
     <span
       class="ant-avatar ant-avatar-lg ant-avatar-circle ant-avatar-image"
-      style="background:#00a2ae"
+      style="background:#00a2ae;display:none"
     >
       <img
         src="invalid"
       />
     </span>
+    <div
+      style="display:none"
+    >
+      <span
+        class="ant-avatar ant-avatar-lg ant-avatar-circle"
+        style="background:#7265e6"
+      >
+        <span
+          class="ant-avatar-string"
+        >
+          Avatar
+        </span>
+      </span>
+      <span
+        class="ant-avatar ant-avatar-lg ant-avatar-circle ant-avatar-image"
+        style="background:#00a2ae"
+      >
+        <img
+          src="invalid"
+        />
+      </span>
+    </div>
   </div>
 </div>
 `;

--- a/components/avatar/demo/toggle-debug.md
+++ b/components/avatar/demo/toggle-debug.md
@@ -1,0 +1,55 @@
+---
+order: 4
+title:
+  zh-CN: 隐藏情况下计算字符对齐
+  en-US: Calculate text style when hiding
+debug: true
+---
+
+## zh-CN
+
+切换 Avatar 显示的时候，文本样式应该居中并正确调整字体大小。
+
+## en-US
+
+Text inside Avatar should be set a proper font size when toggle it's visibility.
+
+````jsx
+import { Avatar, Button } from 'antd';
+
+class App extends React.Component {
+  state = {
+    hide: false,
+  };
+
+  toggle = () => {
+    this.setState({
+      hide: !this.state.hide,
+    });
+  }
+
+  render() {
+    const { hide } = this.state;
+    return (
+      <div>
+        <Button onClick={this.toggle}>Toggle Avatar</Button>
+        <Avatar size="large" style={{ background: '#7265e6', display: hide ? 'none' : '' }}>
+          Avatar
+        </Avatar>
+        <Avatar size="large" src="invalid" style={{ background: '#00a2ae', display: hide ? 'none' : '' }}>
+          Invalid src
+        </Avatar>
+        <div style={{ display: hide ? 'none' : '' }}>
+          <Avatar size="large" style={{ background: '#7265e6' }}>
+            Avatar
+          </Avatar>
+          <Avatar size="large" src="invalid" style={{ background: '#00a2ae' }}>
+            Invalid src
+          </Avatar>
+        </div>
+      </div>
+    );
+  }
+}
+
+ReactDOM.render(<App />, mountNode);

--- a/components/avatar/demo/toggle-debug.md
+++ b/components/avatar/demo/toggle-debug.md
@@ -37,14 +37,14 @@ class App extends React.Component {
           Avatar
         </Avatar>
         <Avatar size="large" src="invalid" style={{ background: '#00a2ae', display: hide ? 'none' : '' }}>
-          Invalid src
+          Invalid
         </Avatar>
         <div style={{ display: hide ? 'none' : '' }}>
           <Avatar size="large" style={{ background: '#7265e6' }}>
             Avatar
           </Avatar>
           <Avatar size="large" src="invalid" style={{ background: '#00a2ae' }}>
-            Invalid src
+            Invalid
           </Avatar>
         </div>
       </div>

--- a/components/avatar/demo/toggle-debug.md
+++ b/components/avatar/demo/toggle-debug.md
@@ -20,6 +20,7 @@ import { Avatar, Button } from 'antd';
 class App extends React.Component {
   state = {
     hide: false,
+    size: 'large',
   };
 
   toggle = () => {
@@ -28,22 +29,34 @@ class App extends React.Component {
     });
   }
 
+  toggleSize = () => {
+    const sizes = ['small', 'default', 'large'];
+    let current = sizes.indexOf(this.state.size) + 1;
+    if (current > 2) {
+      current = 0;
+    }
+    this.setState({
+      size: sizes[current],
+    });
+  }
+
   render() {
-    const { hide } = this.state;
+    const { hide, size } = this.state;
     return (
       <div>
-        <Button onClick={this.toggle}>Toggle Avatar</Button>
-        <Avatar size="large" style={{ background: '#7265e6', display: hide ? 'none' : '' }}>
+        <Button onClick={this.toggle}>Toggle Avatar visibility</Button>
+        <Button onClick={this.toggleSize}>Toggle Avatar size</Button>
+        <Avatar size={size} style={{ background: '#7265e6', display: hide ? 'none' : '' }}>
           Avatar
         </Avatar>
-        <Avatar size="large" src="invalid" style={{ background: '#00a2ae', display: hide ? 'none' : '' }}>
+        <Avatar size={size} src="invalid" style={{ background: '#00a2ae', display: hide ? 'none' : '' }}>
           Invalid
         </Avatar>
         <div style={{ display: hide ? 'none' : '' }}>
-          <Avatar size="large" style={{ background: '#7265e6' }}>
+          <Avatar size={size} style={{ background: '#7265e6' }}>
             Avatar
           </Avatar>
-          <Avatar size="large" src="invalid" style={{ background: '#00a2ae' }}>
+          <Avatar size={size} src="invalid" style={{ background: '#00a2ae' }}>
             Invalid
           </Avatar>
         </div>

--- a/components/avatar/demo/toggle-debug.md
+++ b/components/avatar/demo/toggle-debug.md
@@ -19,7 +19,7 @@ import { Avatar, Button } from 'antd';
 
 class App extends React.Component {
   state = {
-    hide: false,
+    hide: true,
     size: 'large',
   };
 

--- a/components/avatar/demo/toggle-debug.md
+++ b/components/avatar/demo/toggle-debug.md
@@ -21,6 +21,7 @@ class App extends React.Component {
   state = {
     hide: true,
     size: 'large',
+    scale: 1,
   };
 
   toggle = () => {
@@ -40,25 +41,36 @@ class App extends React.Component {
     });
   }
 
+  changeScale = () => {
+    this.setState({
+      scale: this.state.scale === 1 ? 2 : 1,
+    });
+  }
+
   render() {
-    const { hide, size } = this.state;
+    const { hide, size, scale } = this.state;
     return (
       <div>
         <Button onClick={this.toggle}>Toggle Avatar visibility</Button>
         <Button onClick={this.toggleSize}>Toggle Avatar size</Button>
-        <Avatar size={size} style={{ background: '#7265e6', display: hide ? 'none' : '' }}>
-          Avatar
-        </Avatar>
-        <Avatar size={size} src="invalid" style={{ background: '#00a2ae', display: hide ? 'none' : '' }}>
-          Invalid
-        </Avatar>
-        <div style={{ display: hide ? 'none' : '' }}>
-          <Avatar size={size} style={{ background: '#7265e6' }}>
+        <Button onClick={this.changeScale}>Change Avatar scale</Button>
+        <br />
+        <br />
+        <div style={{ textAlign: 'center', transform: `scale(${scale})`, marginTop: 24 }}>
+          <Avatar size={size} style={{ background: '#7265e6', display: hide ? 'none' : '' }}>
             Avatar
           </Avatar>
-          <Avatar size={size} src="invalid" style={{ background: '#00a2ae' }}>
+          <Avatar size={size} src="invalid" style={{ background: '#00a2ae', display: hide ? 'none' : '' }}>
             Invalid
           </Avatar>
+          <div style={{ display: hide ? 'none' : '' }}>
+            <Avatar size={size} style={{ background: '#7265e6' }}>
+              Avatar
+            </Avatar>
+            <Avatar size={size} src="invalid" style={{ background: '#00a2ae' }}>
+              Invalid
+            </Avatar>
+          </div>
         </div>
       </div>
     );

--- a/components/avatar/index.tsx
+++ b/components/avatar/index.tsx
@@ -46,6 +46,7 @@ export default class Avatar extends React.Component<AvatarProps, AvatarState> {
   private avatarNode: HTMLElement;
   private avatarChildren: HTMLElement;
   private lastChildrenWidth: number;
+  private lastNodeWidth: number;
 
   componentDidMount() {
     this.setScale();
@@ -59,20 +60,24 @@ export default class Avatar extends React.Component<AvatarProps, AvatarState> {
   }
 
   setScale = () => {
+    if (!this.avatarChildren || !this.avatarNode) {
+      return;
+    }
+    const childrenWidth = this.avatarChildren.offsetWidth; // offsetWidth avoid affecting be transform scale
+    const nodeWidth = this.avatarNode.getBoundingClientRect().width;
+    // denominator is 0 is no meaning
     if (
-      !this.avatarChildren ||
-      this.avatarChildren.offsetWidth === 0 ||
-      this.lastChildrenWidth === this.avatarChildren.offsetWidth
+      childrenWidth === 0 ||
+      nodeWidth === 0 ||
+      (this.lastChildrenWidth === childrenWidth && this.lastNodeWidth === nodeWidth)
     ) {
       return;
     }
-    // denominator is 0 is no meaning
-    const { offsetWidth } = this.avatarChildren;
-    this.lastChildrenWidth = offsetWidth;
-    const avatarWidth = this.avatarNode.getBoundingClientRect().width;
+    this.lastChildrenWidth = childrenWidth;
+    this.lastNodeWidth = nodeWidth;
     // add 4px gap for each side to get better performance
     this.setState({
-      scale: avatarWidth - 8 < offsetWidth ? (avatarWidth - 8) / offsetWidth : 1,
+      scale: nodeWidth - 8 < childrenWidth ? (nodeWidth - 8) / childrenWidth : 1,
     });
   };
 

--- a/components/avatar/index.tsx
+++ b/components/avatar/index.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import * as ReactDOM from 'react-dom';
 import Icon from '../icon';
 import classNames from 'classnames';
 import { ConfigConsumer, ConfigConsumerProps } from '../config-provider';
@@ -31,7 +30,6 @@ export interface AvatarProps {
 export interface AvatarState {
   scale: number;
   isImgExist: boolean;
-  avatarDisplay: boolean;
 }
 
 export default class Avatar extends React.Component<AvatarProps, AvatarState> {
@@ -43,59 +41,39 @@ export default class Avatar extends React.Component<AvatarProps, AvatarState> {
   state = {
     scale: 1,
     isImgExist: true,
-    avatarDisplay: true,
   };
 
-  private avatarChildren: any;
+  private avatarNode: HTMLElement;
+  private avatarChildren: HTMLElement;
+  private lastChildrenWidth: number;
 
   componentDidMount() {
     this.setScale();
   }
 
-  componentDidUpdate(prevProps: AvatarProps, prevState: AvatarState) {
-    if (
-      prevProps.children !== this.props.children ||
-      (prevState.scale !== this.state.scale && this.state.scale === 1) ||
-      prevState.isImgExist !== this.state.isImgExist ||
-      !this.state.avatarDisplay
-    ) {
-      this.setScale();
-      if (this.avatarChildren && this.avatarChildren.offsetWidth !== 0) {
-        this.setState({
-          avatarDisplay: true,
-        });
-      }
-    } else {
-      if (this.avatarChildren && this.avatarChildren.offsetWidth === 0 && this.state.scale === 1) {
-        this.setState({
-          avatarDisplay: false,
-        });
-      }
-    }
-
+  componentDidUpdate(prevProps: AvatarProps) {
+    this.setScale();
     if (prevProps.src !== this.props.src) {
       this.setState({ isImgExist: true, scale: 1 });
     }
   }
 
   setScale = () => {
-    const childrenNode = this.avatarChildren;
-    // denominator is 0 is no meaning
-    if (childrenNode && childrenNode.offsetWidth !== 0) {
-      const childrenWidth = childrenNode.offsetWidth;
-      const avatarNode = ReactDOM.findDOMNode(this) as Element;
-      const avatarWidth = avatarNode.getBoundingClientRect().width;
-      // add 4px gap for each side to get better performance
-      if (avatarWidth - 8 < childrenWidth) {
-        this.setState({
-          scale: (avatarWidth - 8) / childrenWidth,
-        });
-      } else {
-        this.setState({
-          scale: 1,
-        });
-      }
+    if (
+      !this.avatarChildren ||
+      this.avatarChildren.offsetWidth === 0 ||
+      this.lastChildrenWidth === this.avatarChildren.offsetWidth
+    ) {
+      return;
     }
+    // denominator is 0 is no meaning
+    const { offsetWidth } = this.avatarChildren;
+    this.lastChildrenWidth = offsetWidth;
+    const avatarWidth = this.avatarNode.getBoundingClientRect().width;
+    // add 4px gap for each side to get better performance
+    this.setState({
+      scale: avatarWidth - 8 < offsetWidth ? (avatarWidth - 8) / offsetWidth : 1,
+    });
   };
 
   handleImgLoadError = () => {
@@ -167,7 +145,7 @@ export default class Avatar extends React.Component<AvatarProps, AvatarState> {
         children = (
           <span
             className={`${prefixCls}-string`}
-            ref={span => (this.avatarChildren = span)}
+            ref={(node: HTMLElement) => (this.avatarChildren = node)}
             style={{ ...sizeChildrenStyle, ...childrenStyle }}
           >
             {children}
@@ -175,14 +153,22 @@ export default class Avatar extends React.Component<AvatarProps, AvatarState> {
         );
       } else {
         children = (
-          <span className={`${prefixCls}-string`} ref={span => (this.avatarChildren = span)}>
+          <span
+            className={`${prefixCls}-string`}
+            ref={(node: HTMLElement) => (this.avatarChildren = node)}
+          >
             {children}
           </span>
         );
       }
     }
     return (
-      <span {...others} style={{ ...sizeStyle, ...others.style }} className={classString}>
+      <span
+        {...others}
+        style={{ ...sizeStyle, ...others.style }}
+        className={classString}
+        ref={(node: HTMLElement) => (this.avatarNode = node)}
+      >
         {children}
       </span>
     );

--- a/components/avatar/index.tsx
+++ b/components/avatar/index.tsx
@@ -64,7 +64,7 @@ export default class Avatar extends React.Component<AvatarProps, AvatarState> {
       return;
     }
     const childrenWidth = this.avatarChildren.offsetWidth; // offsetWidth avoid affecting be transform scale
-    const nodeWidth = this.avatarNode.getBoundingClientRect().width;
+    const nodeWidth = this.avatarNode.offsetWidth;
     // denominator is 0 is no meaning
     if (
       childrenWidth === 0 ||


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [x] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?

1. Describe the source of requirement, like related issue link.

close #15351

close #15468

2. Describe the problem and the scenario.


|            |  改之前的（ 3.15.0 ）  | 第一次修改后（3.15.1）| 本次修改后 |
| ------- | ------------------------ | -------------------------- | ------------  |
| 普通字符型  | ![3 15 0普通从隐藏到显示](https://user-images.githubusercontent.com/33046279/54509212-c4095480-4983-11e9-927c-012c5eae567d.gif) | ![3 15 1普通从显示到隐藏](https://user-images.githubusercontent.com/33046279/54509510-bef8d500-4984-11e9-84d0-f7eb38c96b42.gif) | ![这次修改-普通隐藏到显示](https://user-images.githubusercontent.com/33046279/54509702-683fcb00-4985-11e9-8a45-ecf75d0e5018.gif) |
| 无效src + 字符型 | ![3 15 0错误url加有占位文本从隐藏到显示 ](https://user-images.githubusercontent.com/33046279/54509142-7db3f580-4983-11e9-87c0-c90cafd3abda.gif) | ![3 15 1错误url+占位文本从隐藏到显示](https://user-images.githubusercontent.com/33046279/54509535-d33cd200-4984-11e9-8fca-c6a611148e46.gif) | ![这次修改-错误url+占位文本从隐藏到显示](https://user-images.githubusercontent.com/33046279/54509714-71c93300-4985-11e9-8f75-171005b6f335.gif) |

### 💡 Solution

将原来的逻辑简单改为判断 `offsetWidth` 是否改变。

### 📝 Changelog description

> Describe changes from userside, and list all potential break changes or other risks.

1. English description

- :bug: Refactor Avatar scale calculate logic to fix calculation when invisible. #15468

2. Chinese description (optional)

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
