### PR TITLE
Allow font-feature-settings to be customizable

### DIFF
--- a/components/style/core/base.less
+++ b/components/style/core/base.less
@@ -77,7 +77,7 @@ body {
   font-variant: @font-variant-base;
   line-height: @line-height-base;
   background-color: @body-background; // 2
-  font-feature-settings: 'tnum';
+  font-feature-settings: @font-feature-settings-base;
 }
 
 // Suppress the focus outline on elements that cannot be accessed via keyboard.

--- a/components/style/mixins/reset.less
+++ b/components/style/mixins/reset.less
@@ -9,5 +9,5 @@
   font-variant: @font-variant-base;
   line-height: @line-height-base;
   list-style: none;
-  font-feature-settings: 'tnum';
+  font-feature-settings: @font-feature-settings-base;
 }

--- a/components/style/themes/default.less
+++ b/components/style/themes/default.less
@@ -54,6 +54,7 @@
 @text-color-dark: fade(@white, 85%);
 @text-color-secondary-dark: fade(@white, 65%);
 @font-variant-base: tabular-nums;
+@font-feature-settings-base: 'tnum';
 @font-size-base: 14px;
 @font-size-lg: @font-size-base + 2px;
 @font-size-sm: 12px;


### PR DESCRIPTION
### 🤔 This is a ...

- [x] New feature

### 👻 What's the background?

Related Issue: #12690

Related Pull Request: #12691

### 💡 Solution

export a less var called `@font-feature-settings-base` with default value of `'tnum'`

### 📝 Changelog description

Allow developers to use `@font-feature-settings-base` to custom.

No break change.

### ☑️ Self Check before Merge

- [x] Doc is not needed
- [x] Demo is not needed
- [x] TypeScript definition is not needed
- [x] Changelog is not needed
