### PR TITLE
modify interface ListLocale.emptyText from text to ReactNode

### DIFF
--- a/components/list/index.tsx
+++ b/components/list/index.tsx
@@ -54,7 +54,7 @@ export interface ListProps {
 }
 
 export interface ListLocale {
-  emptyText: string;
+  emptyText: React.ReactNode | (() => React.ReactNode);
 }
 
 export default class List extends React.Component<ListProps> {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->
### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?

List locale.emptyText actually support ReactNode like Table, but currently just support string.
it is not quite handy to use, so I change it.

### 💡 Solution

modify `emptyText: string` => `emptyText: React.ReactNode | (() => React.ReactNode)`;

### 📝 Changelog description

> Describe changes from userside, and list all potential break changes or other risks.

Now List locale.emptyText is support React.Element.

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
