### PR TITLE
refactor(form-item): move `ant-form-item-no-colon` selector position

### DIFF
--- a/components/form/FormItem.tsx
+++ b/components/form/FormItem.tsx
@@ -348,9 +348,6 @@ export default class FormItem extends React.Component<FormItemProps, any> {
             labelAlign === 'left' && `${labelClsBasic}-left`,
             mergedLabelCol.className,
           );
-          const labelClassName = classNames({
-            [`${prefixCls}-item-required`]: required,
-          });
 
           let labelChildren = label;
           // Keep label is original where there should have no colon
@@ -360,6 +357,11 @@ export default class FormItem extends React.Component<FormItemProps, any> {
           if (haveColon && typeof label === 'string' && (label as string).trim() !== '') {
             labelChildren = (label as string).replace(/[：|:]\s*$/, '');
           }
+
+          const labelClassName = classNames({
+            [`${prefixCls}-item-required`]: required,
+            [`${prefixCls}-item-no-colon`]: !computedColon,
+          });
 
           return label ? (
             <Col {...mergedLabelCol} className={labelColClassName}>
@@ -395,28 +397,19 @@ export default class FormItem extends React.Component<FormItemProps, any> {
   }
 
   renderFormItem = ({ getPrefixCls }: ConfigConsumerProps) => {
+    const { prefixCls: customizePrefixCls, style, className } = this.props;
+    const prefixCls = getPrefixCls('form', customizePrefixCls);
+    const children = this.renderChildren(prefixCls);
+    const itemClassName = {
+      [`${prefixCls}-item`]: true,
+      [`${prefixCls}-item-with-help`]: this.helpShow,
+      [`${className}`]: !!className,
+    };
+
     return (
-      <FormContext.Consumer key="row">
-        {({ colon: contextColon }: FormContextProps) => {
-          const { prefixCls: customizePrefixCls, style, colon, className } = this.props;
-
-          const computedColon = colon === true || (contextColon !== false && colon !== false);
-
-          const prefixCls = getPrefixCls('form', customizePrefixCls);
-          const children = this.renderChildren(prefixCls);
-          const itemClassName = {
-            [`${prefixCls}-item`]: true,
-            [`${prefixCls}-item-with-help`]: this.helpShow,
-            [`${prefixCls}-item-no-colon`]: !computedColon,
-            [`${className}`]: !!className,
-          };
-          return (
-            <Row className={classNames(itemClassName)} style={style}>
-              {children}
-            </Row>
-          );
-        }}
-      </FormContext.Consumer>
+      <Row className={classNames(itemClassName)} style={style} key="row">
+        {children}
+      </Row>
     );
   };
 

--- a/components/form/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/form/__tests__/__snapshots__/demo.test.js.snap
@@ -2157,7 +2157,7 @@ exports[`renders ./components/form/demo/style-check-debug.md correctly 1`] = `
             class="ant-form-item-label"
           >
             <label
-              class=""
+              class="ant-form-item-required ant-form-item-no-colon"
               title="select:64px"
             >
               select:64px
@@ -2230,7 +2230,7 @@ exports[`renders ./components/form/demo/style-check-debug.md correctly 1`] = `
             class="ant-form-item-label"
           >
             <label
-              class=""
+              class="ant-form-item-no-colon"
               title="InputNumber:64px"
             >
               InputNumber:64px
@@ -2334,7 +2334,7 @@ exports[`renders ./components/form/demo/style-check-debug.md correctly 1`] = `
             class="ant-form-item-label"
           >
             <label
-              class=""
+              class="ant-form-item-no-colon"
               title="DatePicker: 64.5px"
             >
               DatePicker: 64.5px
@@ -2395,7 +2395,7 @@ exports[`renders ./components/form/demo/style-check-debug.md correctly 1`] = `
             class="ant-form-item-label"
           >
             <label
-              class=""
+              class="ant-form-item-no-colon"
               title="RadioGroup: 64px"
             >
               RadioGroup: 64px

--- a/components/form/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/form/__tests__/__snapshots__/demo.test.js.snap
@@ -2121,7 +2121,7 @@ exports[`renders ./components/form/demo/style-check-debug.md correctly 1`] = `
             class="ant-form-item-label"
           >
             <label
-              class=""
+              class="ant-form-item-no-colon"
               title="input:64.5px"
             >
               input:64.5px
@@ -2157,7 +2157,7 @@ exports[`renders ./components/form/demo/style-check-debug.md correctly 1`] = `
             class="ant-form-item-label"
           >
             <label
-              class="ant-form-item-required ant-form-item-no-colon"
+              class=""
               title="select:64px"
             >
               select:64px
@@ -2230,7 +2230,7 @@ exports[`renders ./components/form/demo/style-check-debug.md correctly 1`] = `
             class="ant-form-item-label"
           >
             <label
-              class="ant-form-item-no-colon"
+              class=""
               title="InputNumber:64px"
             >
               InputNumber:64px
@@ -2334,7 +2334,7 @@ exports[`renders ./components/form/demo/style-check-debug.md correctly 1`] = `
             class="ant-form-item-label"
           >
             <label
-              class="ant-form-item-no-colon"
+              class=""
               title="DatePicker: 64.5px"
             >
               DatePicker: 64.5px
@@ -2395,7 +2395,7 @@ exports[`renders ./components/form/demo/style-check-debug.md correctly 1`] = `
             class="ant-form-item-label"
           >
             <label
-              class="ant-form-item-no-colon"
+              class=""
               title="RadioGroup: 64px"
             >
               RadioGroup: 64px

--- a/components/form/__tests__/__snapshots__/label.test.js.snap
+++ b/components/form/__tests__/__snapshots__/label.test.js.snap
@@ -5,13 +5,13 @@ exports[`Form should props colon of Form.Item override the props colon of Form. 
   class="ant-form ant-form-horizontal"
 >
   <div
-    class="ant-row ant-form-item ant-form-item-no-colon"
+    class="ant-row ant-form-item"
   >
     <div
       class="ant-form-item-label"
     >
       <label
-        class=""
+        class="ant-form-item-no-colon"
         title="label"
       >
         label
@@ -59,13 +59,13 @@ exports[`Form should props colon of Form.Item override the props colon of Form. 
     </div>
   </div>
   <div
-    class="ant-row ant-form-item ant-form-item-no-colon"
+    class="ant-row ant-form-item"
   >
     <div
       class="ant-form-item-label"
     >
       <label
-        class=""
+        class="ant-form-item-no-colon"
         title="label"
       >
         label

--- a/components/form/__tests__/label.test.js
+++ b/components/form/__tests__/label.test.js
@@ -31,6 +31,7 @@ describe('Form', () => {
         <Form.Item label="label：">input</Form.Item>
       </Form>,
     );
+
     expect(
       wrapper
         .find('.ant-form-item-label label')
@@ -48,12 +49,12 @@ describe('Form', () => {
   it('should disable colon when props colon Form is false', () => {
     const wrapper = mount(
       <Form colon={false}>
-        <Form.Item>input</Form.Item>
+        <Form.Item label="label">input</Form.Item>
       </Form>,
     );
     expect(
       wrapper
-        .find('.ant-form-item')
+        .find('.ant-form-item-label label')
         .at(0)
         .hasClass('ant-form-item-no-colon'),
     ).toBe(true);

--- a/components/form/demo/style-check-debug.md
+++ b/components/form/demo/style-check-debug.md
@@ -74,7 +74,7 @@ class App extends React.Component {
           <Form layout="horizontal" onSubmit={this.handleSubmit}>
             <Row>
               <Col span={span}>
-                <Item {...itemLayout} label="测试字段">
+                <Item colon={false} {...itemLayout} label="测试字段">
                   {getFieldDecorator("item1", {
                     rules: [{ required: true, message: "请必须填写此字段" }],
                   })(<Input />)}
@@ -121,7 +121,7 @@ class App extends React.Component {
         <Form>
             <Row gutter={16}>
                 <Col {...ColSpan}>
-                    <Item label="input:64.5px">
+                    <Item colon={false} label="input:64.5px">
                         <Input />
                     </Item>
                 </Col>

--- a/components/form/style/index.less
+++ b/components/form/style/index.less
@@ -35,6 +35,27 @@
   }
 }
 
+.@{form-prefix-cls}-item-label > label {
+  color: @label-color;
+
+  &::after {
+    & when (@form-item-trailing-colon=true) {
+      content: ':';
+    }
+    & when not (@form-item-trailing-colon=true) {
+      content: ' ';
+    }
+
+    position: relative;
+    top: -0.5px;
+    margin: 0 8px 0 2px;
+  }
+
+  &.@{form-prefix-cls}-item-no-colon::after {
+    content: ' ';
+  }
+}
+
 // Radio && Checkbox
 input[type='radio'],
 input[type='checkbox'] {
@@ -105,30 +126,10 @@ input[type='checkbox'] {
     &-left {
       text-align: left;
     }
-
-    > label {
-      color: @label-color;
-
-      &::after {
-        & when (@form-item-trailing-colon=true) {
-          content: ':';
-        }
-        & when not (@form-item-trailing-colon=true) {
-          content: ' ';
-        }
-        position: relative;
-        top: -0.5px;
-        margin: 0 8px 0 2px;
-      }
-    }
   }
 
   .@{ant-prefix}-switch {
     margin: 2px 0 4px;
-  }
-
-  &-no-colon &-label label::after {
-    content: ' ';
   }
 }
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->
### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [x] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?

1. Describe the source of requirement, like related issue link.
#15585
2. Describe the problem and the scenario.
#15585
### 💡 Solution

1. How to fix the problem, and list final API implementation and usage sample if that is an new feature.

2. GIF or snapshot should be provided if includes UI/interactive modification.

### 📝 Changelog description

> Describe changes from userside, and list all potential break changes or other risks.

1. English description
Refactor move `ant-form-item-no-colon` selector position in `Form.Item`
2. Chinese description (optional)
重构 移动 `Form.Item` 中 `ant-form-item-no-colon` 选择器的位置
### ☑️ Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
