### PR TITLE
Enable theme switching by html-prefix

### DIFF
--- a/components/style/core/base.less
+++ b/components/style/core/base.less
@@ -8,7 +8,7 @@
 // Normalize is licensed MIT. https://github.com/necolas/normalize.css
 
 // HTML & Body reset
-html,
+@{html-selector},
 body {
   .square(100%);
 }
@@ -35,7 +35,7 @@ input::-ms-reveal {
   box-sizing: border-box; // 1
 }
 
-html {
+@{html-selector} {
   font-family: sans-serif; // 2
   line-height: 1.15; // 3
   -webkit-text-size-adjust: 100%; // 4
@@ -373,7 +373,7 @@ select {
 //    controls in Android 4.
 // 2. Correct the inability to style clickable types in iOS and Safari.
 button,
-html [type="button"], /* 1 */
+@{html-selector} [type="button"], /* 1 */
 [type="reset"],
 [type="submit"] {
   -webkit-appearance: button; // 2

--- a/components/style/themes/default.less
+++ b/components/style/themes/default.less
@@ -4,6 +4,9 @@
 // The prefix to use on all css classes from ant.
 @ant-prefix: ant;
 
+// An override for the html selector for theme prefixes
+@html-selector: html;
+
 // -------- Colors -----------
 @primary-color: @blue-6;
 @info-color: @blue-6;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->
### 🤔 This is a ...

- [X] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?

Ref https://github.com/NG-ZORRO/ng-zorro-antd/issues/3110

Currently it is hard to switch between two ant themes using a prefix strategy because ant includes styles for the `html` selector which is the top-most element that one can style.

### 💡 Solution

Add a `@html-selector` variable so that one can override the `html` selector. This would allow for the following code to apply theme based on `html`-prefix:
```less
html.first-theme {
  @import './themes/default';
  @import './core/index';
  @html-selector: &;
}

html.second-theme {
  @import './themes/default';
  @import './core/index';
  @html-selector: &;
}
```

And now we can preload all themes and switch between them by changing the class on `html` to `.first-theme` or `.second-theme`.

### 📝 Changelog description

Added `@html-selector` less variable to enable override of html selector to support theme prefix.


### ☑️ Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
