### PR TITLE
Fix for changes in @types/react (see issue #15700)

### DIFF
--- a/components/button/button.tsx
+++ b/components/button/button.tsx
@@ -7,7 +7,7 @@ import omit from 'omit.js';
 import Icon from '../icon';
 import { ConfigConsumer, ConfigConsumerProps } from '../config-provider';
 import Wave from '../_util/wave';
-import { tuple } from '../_util/type';
+import { Omit, tuple } from '../_util/type';
 
 const rxTwoCNChar = /^[\u4e00-\u9fa5]{2}$/;
 const isTwoCNChar = rxTwoCNChar.test.bind(rxTwoCNChar);
@@ -67,13 +67,13 @@ export type AnchorButtonProps = {
   target?: string;
   onClick?: React.MouseEventHandler<HTMLAnchorElement>;
 } & BaseButtonProps &
-  React.AnchorHTMLAttributes<HTMLAnchorElement>;
+  Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, 'type'>;
 
 export type NativeButtonProps = {
   htmlType?: ButtonHTMLType;
   onClick?: React.MouseEventHandler<HTMLButtonElement>;
 } & BaseButtonProps &
-  React.ButtonHTMLAttributes<HTMLButtonElement>;
+  Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'type'>;
 
 export type ButtonProps = AnchorButtonProps | NativeButtonProps;
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->
### 🤔 This is a ...

- [ ] New feature
- [X] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?

The @types/react package is updated and this breaks the Button in Ant Design when using typescript. More info can be found in the issue: https://github.com/ant-design/ant-design/issues/15700

The typings for React changed the type property from a string to "submit"|"button"|"reset" which conflicts with the Button props type property:
https://github.com/DefinitelyTyped/DefinitelyTyped/commit/4d371be185ddd77264a8d7f30a7f7f8912738ed8#diff-5b1e41d6479609ff1a7f33979dcca466

### 💡 Solution

We need to omit the 'type' property from the React.ButtonHTMLAttributes and React.AnchorHTMLAttributes, since we need to use the type defined in the BaseButtonProps. Ant design utilities already have a nice Omit type to do this 👍 

### 📝 Changelog description

Updated the NativeButtonProps and AnchorButtonProps in the Button component class, so the 'type' property from the React.NativeButtonProps is ignored. All tests are OK, no functional changes in code. I have not yet updated the changelog.

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [] Changelog is provided or not needed
