### PR TITLE
fix: MenuItem should not render Tooltip when inlineCollapsed is false

### DIFF
--- a/components/menu/MenuItem.tsx
+++ b/components/menu/MenuItem.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Item } from 'rc-menu';
 import Tooltip from '../tooltip';
-import { ClickParam } from './index';
+import { ClickParam } from '.';
 
 export interface MenuItemProps {
   rootPrefixCls?: string;
@@ -16,33 +16,29 @@ export interface MenuItemProps {
   onMouseLeave?: (e: { key: string; domEvent: MouseEvent }) => void;
 }
 
-class MenuItem extends React.Component<MenuItemProps> {
-  static isMenuItem = 1;
+export default class MenuItem extends React.Component<MenuItemProps> {
+  static isMenuItem = true;
   private menuItem: this;
 
   onKeyDown = (e: React.MouseEvent<HTMLElement>) => {
     this.menuItem.onKeyDown(e);
   };
+
   saveMenuItem = (menuItem: this) => {
     this.menuItem = menuItem;
   };
-  render() {
-    const { level, children, rootPrefixCls } = this.props;
-    const { title, ...rest } = this.props;
 
-    let titleNode;
-    titleNode = title || (level === 1 ? children : '');
+  render() {
+    const { rootPrefixCls, title, ...rest } = this.props;
 
     return (
       <Tooltip
-        title={titleNode}
+        title={title}
         placement="right"
         overlayClassName={`${rootPrefixCls}-inline-collapsed-tooltip`}
       >
-        <Item {...rest} title={title} ref={this.saveMenuItem} />
+        <Item {...rest} rootPrefixCls={rootPrefixCls} title={title} ref={this.saveMenuItem} />
       </Tooltip>
     );
   }
 }
-
-export default MenuItem;

--- a/components/menu/__tests__/index.test.js
+++ b/components/menu/__tests__/index.test.js
@@ -588,4 +588,31 @@ describe('Menu', () => {
     wrapper.update();
     expect(wrapper.instance().contextSiderCollapsed).toBe(false);
   });
+
+  it('MenuItem should not render Tooltip when inlineCollapsed is false', () => {
+    const wrapper = mount(
+      <Menu defaultSelectedKeys={['mail']} defaultOpenKeys={['mail']} mode="horizontal">
+        <Menu.Item key="mail">
+          <Icon type="mail" />
+          Navigation One
+        </Menu.Item>
+        <Menu.Item key="app">
+          <Icon type="appstore" />
+          Navigation Two
+        </Menu.Item>
+        <Menu.Item key="alipay">
+          <a href="https://ant.design" target="_blank" rel="noopener noreferrer">
+            Navigation Four - Link
+          </a>
+        </Menu.Item>
+      </Menu>,
+    );
+    wrapper
+      .find('MenuItem')
+      .first()
+      .simulate('mouseenter');
+    jest.runAllTimers();
+    wrapper.update();
+    expect(wrapper.find('.ant-tooltip-inner').length).toBe(0);
+  });
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?

1. Describe the source of requirement, like related issue link.

    Related to https://github.com/ant-design/ant-design/pull/15625#discussion_r269479526

2. Describe the problem and the scenario.

### 💡 Solution

1. How to fix the problem, and list final API implementation and usage sample if that is an new feature.

2. GIF or snapshot should be provided if includes UI/interactive modification.

### 📝 Changelog description

> Describe changes from userside, and list all potential break changes or other risks.

1. English description
    
    Fix MenuItem rendered unexpected Tooltip when inlineCollapsed is false.

2. Chinese description (optional)

    修复 MenuItem 在非 `inlineCollapsed` 时显示了多余 Tooltip 的问题。

### ☑️ Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
