### PR TITLE
Fix Spin style when indicator is Icon

### DIFF
--- a/components/config-provider/__tests__/__snapshots__/components.test.js.snap
+++ b/components/config-provider/__tests__/__snapshots__/components.test.js.snap
@@ -11113,10 +11113,18 @@ exports[`ConfigProvider components Spin configProvider 1`] = `
   <span
     class="config-spin-dot config-spin-dot-spin"
   >
-    <i />
-    <i />
-    <i />
-    <i />
+    <i
+      class="config-spin-dot-item"
+    />
+    <i
+      class="config-spin-dot-item"
+    />
+    <i
+      class="config-spin-dot-item"
+    />
+    <i
+      class="config-spin-dot-item"
+    />
   </span>
 </div>
 `;
@@ -11128,10 +11136,18 @@ exports[`ConfigProvider components Spin normal 1`] = `
   <span
     class="ant-spin-dot ant-spin-dot-spin"
   >
-    <i />
-    <i />
-    <i />
-    <i />
+    <i
+      class="ant-spin-dot-item"
+    />
+    <i
+      class="ant-spin-dot-item"
+    />
+    <i
+      class="ant-spin-dot-item"
+    />
+    <i
+      class="ant-spin-dot-item"
+    />
   </span>
 </div>
 `;
@@ -11143,10 +11159,18 @@ exports[`ConfigProvider components Spin prefixCls 1`] = `
   <span
     class="prefix-Spin-dot prefix-Spin-dot-spin"
   >
-    <i />
-    <i />
-    <i />
-    <i />
+    <i
+      class="prefix-Spin-dot-item"
+    />
+    <i
+      class="prefix-Spin-dot-item"
+    />
+    <i
+      class="prefix-Spin-dot-item"
+    />
+    <i
+      class="prefix-Spin-dot-item"
+    />
   </span>
 </div>
 `;

--- a/components/list/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/list/__tests__/__snapshots__/demo.test.js.snap
@@ -377,10 +377,18 @@ exports[`renders ./components/list/demo/loadmore.md correctly 1`] = `
         <span
           class="ant-spin-dot ant-spin-dot-spin"
         >
-          <i />
-          <i />
-          <i />
-          <i />
+          <i
+            class="ant-spin-dot-item"
+          />
+          <i
+            class="ant-spin-dot-item"
+          />
+          <i
+            class="ant-spin-dot-item"
+          />
+          <i
+            class="ant-spin-dot-item"
+          />
         </span>
       </div>
     </div>

--- a/components/spin/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/spin/__tests__/__snapshots__/demo.test.js.snap
@@ -7,10 +7,18 @@ exports[`renders ./components/spin/demo/basic.md correctly 1`] = `
   <span
     class="ant-spin-dot ant-spin-dot-spin"
   >
-    <i />
-    <i />
-    <i />
-    <i />
+    <i
+      class="ant-spin-dot-item"
+    />
+    <i
+      class="ant-spin-dot-item"
+    />
+    <i
+      class="ant-spin-dot-item"
+    />
+    <i
+      class="ant-spin-dot-item"
+    />
   </span>
 </div>
 `;
@@ -94,10 +102,18 @@ exports[`renders ./components/spin/demo/inside.md correctly 1`] = `
     <span
       class="ant-spin-dot ant-spin-dot-spin"
     >
-      <i />
-      <i />
-      <i />
-      <i />
+      <i
+        class="ant-spin-dot-item"
+      />
+      <i
+        class="ant-spin-dot-item"
+      />
+      <i
+        class="ant-spin-dot-item"
+      />
+      <i
+        class="ant-spin-dot-item"
+      />
     </span>
   </div>
 </div>
@@ -154,10 +170,18 @@ exports[`renders ./components/spin/demo/size.md correctly 1`] = `
     <span
       class="ant-spin-dot ant-spin-dot-spin"
     >
-      <i />
-      <i />
-      <i />
-      <i />
+      <i
+        class="ant-spin-dot-item"
+      />
+      <i
+        class="ant-spin-dot-item"
+      />
+      <i
+        class="ant-spin-dot-item"
+      />
+      <i
+        class="ant-spin-dot-item"
+      />
     </span>
   </div>
   <div
@@ -166,10 +190,18 @@ exports[`renders ./components/spin/demo/size.md correctly 1`] = `
     <span
       class="ant-spin-dot ant-spin-dot-spin"
     >
-      <i />
-      <i />
-      <i />
-      <i />
+      <i
+        class="ant-spin-dot-item"
+      />
+      <i
+        class="ant-spin-dot-item"
+      />
+      <i
+        class="ant-spin-dot-item"
+      />
+      <i
+        class="ant-spin-dot-item"
+      />
     </span>
   </div>
   <div
@@ -178,10 +210,18 @@ exports[`renders ./components/spin/demo/size.md correctly 1`] = `
     <span
       class="ant-spin-dot ant-spin-dot-spin"
     >
-      <i />
-      <i />
-      <i />
-      <i />
+      <i
+        class="ant-spin-dot-item"
+      />
+      <i
+        class="ant-spin-dot-item"
+      />
+      <i
+        class="ant-spin-dot-item"
+      />
+      <i
+        class="ant-spin-dot-item"
+      />
     </span>
   </div>
 </div>
@@ -198,10 +238,18 @@ exports[`renders ./components/spin/demo/tip.md correctly 1`] = `
       <span
         class="ant-spin-dot ant-spin-dot-spin"
       >
-        <i />
-        <i />
-        <i />
-        <i />
+        <i
+          class="ant-spin-dot-item"
+        />
+        <i
+          class="ant-spin-dot-item"
+        />
+        <i
+          class="ant-spin-dot-item"
+        />
+        <i
+          class="ant-spin-dot-item"
+        />
       </span>
       <div
         class="ant-spin-text"

--- a/components/spin/index.tsx
+++ b/components/spin/index.tsx
@@ -47,10 +47,10 @@ function renderIndicator(prefixCls: string, props: SpinProps): React.ReactNode {
 
   return (
     <span className={classNames(dotClassName, `${prefixCls}-dot-spin`)}>
-      <i />
-      <i />
-      <i />
-      <i />
+      <i className={`${prefixCls}-dot-item`} />
+      <i className={`${prefixCls}-dot-item`} />
+      <i className={`${prefixCls}-dot-item`} />
+      <i className={`${prefixCls}-dot-item`} />
     </span>
   );
 }

--- a/components/spin/style/index.less
+++ b/components/spin/style/index.less
@@ -125,7 +125,7 @@
 
     .square(@spin-dot-size);
 
-    i {
+    &-item {
       position: absolute;
       display: block;
       width: 9px;
@@ -136,6 +136,7 @@
       transform-origin: 50% 50%;
       opacity: 0.3;
       animation: antSpinMove 1s infinite linear alternate;
+
       &:nth-child(1) {
         top: 0;
         left: 0;

--- a/components/table/__tests__/__snapshots__/empty.test.js.snap
+++ b/components/table/__tests__/__snapshots__/empty.test.js.snap
@@ -499,10 +499,18 @@ exports[`Table renders empty table without emptyText when loading 1`] = `
         <span
           class="ant-spin-dot ant-spin-dot-spin"
         >
-          <i />
-          <i />
-          <i />
-          <i />
+          <i
+            class="ant-spin-dot-item"
+          />
+          <i
+            class="ant-spin-dot-item"
+          />
+          <i
+            class="ant-spin-dot-item"
+          />
+          <i
+            class="ant-spin-dot-item"
+          />
         </span>
       </div>
     </div>


### PR DESCRIPTION


<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?

close #15693

### 💡 Solution

Add `classNames` to `i` inside Spin.

### 📝 Changelog description

> Describe changes from userside, and list all potential break changes or other risks.

1. English description

- 🐛 Fix Spin style when indicator is Icon. #15693

2. Chinese description (optional)

- 🐛 修复 Spin `indicator` 为 Icon 时的样式。 #15693

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
