### PR TITLE
Button: add default html type + fix switch

### DIFF
--- a/components/button/button.tsx
+++ b/components/button/button.tsx
@@ -90,6 +90,7 @@ class Button extends React.Component<ButtonProps, ButtonState> {
     loading: false,
     ghost: false,
     block: false,
+    htmlType: 'button',
   };
 
   static propTypes = {
@@ -219,6 +220,7 @@ class Button extends React.Component<ButtonProps, ButtonState> {
         break;
       case 'small':
         sizeCls = 'sm';
+        break;
       default:
         break;
     }
@@ -265,7 +267,7 @@ class Button extends React.Component<ButtonProps, ButtonState> {
       <Wave>
         <button
           {...otherProps as NativeButtonProps}
-          type={htmlType || 'button'}
+          type={htmlType}
           className={classes}
           onClick={this.handleClick}
           ref={this.saveButtonRef}


### PR DESCRIPTION

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [x ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?

1. The button's htmlType prop is marked as required (I'm using WebStorm for coding and the lint always urges me to provide a htmlType, although the button should be `button` by default. I'm hoping providing defaultProps value will solve this.

### 📝 Changelog description

There should be no breaking changes. It shouldn't affect users in any way.

### ☑️ Self Check before Merge

- [ x ] Doc is updated/provided or not needed
- [ x ] Demo is updated/provided or not needed
- [ x ] TypeScript definition is updated/provided or not needed
- [ x ] Changelog is provided or not needed
