### PR TITLE
Fix 'href' is missing in type error

### DIFF
--- a/components/button/button.tsx
+++ b/components/button/button.tsx
@@ -63,7 +63,7 @@ export interface BaseButtonProps {
 }
 
 export type AnchorButtonProps = {
-  href: string;
+  href?: string;
   target?: string;
   onClick?: React.MouseEventHandler<HTMLAnchorElement>;
 } & BaseButtonProps &

--- a/components/button/button.tsx
+++ b/components/button/button.tsx
@@ -63,8 +63,6 @@ export interface BaseButtonProps {
 }
 
 export type AnchorButtonProps = {
-  href?: string;
-  target?: string;
   onClick?: React.MouseEventHandler<HTMLAnchorElement>;
 } & BaseButtonProps &
   Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, 'type'>;


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?

1. Describe the source of requirement, like related issue link.

* typescript version: 3.3.3333
* ant-design: 3.15.2

If Button has type prop, it will report such an type error: 

```
Type '{ children: string; type: "primary"; }' is not assignable to type '(IntrinsicAttributes & IntrinsicClassA
ttributes<Button> & Pick<{ readonly href: string; readonly target?: string | undefined; readonly onClick?: ((event: MouseEvent<HTMLAnchorElement, MouseEvent>) => void) | undefined; ... 262 more ...; readonly onTransitionEndCapture?: ((
event: TransitionEvent<...>) => void) | unde...'.
  Property 'href' is missing in type '{ className: string; type: "danger"; shape: "circle"; icon: string; title: string; ghost: true; onClick: any; }' but required in type 'Pick<{ readonly href: string; readonly target?: string | undef
ined; readonly onClick?: ((event: MouseEvent<HTMLAnchorElement, MouseEvent>) => void) | undefined; readonly type?: "default" | ... 4 more ... | undefined; ... 261 more ...; readonly onTransitionEndCapture?: ((event: TransitionEvent<...
>) => void) | undefi...'.

button.d.ts(28, 5): 'href' is declared here.
```
Error sample code:

```typescript
import * as React from 'react';
import { Button } from 'antd';

class Demo extends React.Component {
  render(): React.ReactNode {

    return (
      <Button type="primary">button</Button>
    );
  }
}
```

2. Describe the problem and the scenario.

Fixed a type error when Button had type prop.

### 💡 Solution

1. How to fix the problem, and list final API implementation and usage sample if that is an new feature.

2. GIF or snapshot should be provided if includes UI/interactive modification.

### 📝 Changelog description

> Describe changes from userside, and list all potential break changes or other risks.

1. English description

Fixed a type error when Button has type prop.

2. Chinese description (optional)

修复了Button有type属性时的类型错误.

### ☑️ Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
