### PR TITLE
Remove underlines from focused links

### DIFF
--- a/components/dropdown/style/index.less
+++ b/components/dropdown/style/index.less
@@ -97,9 +97,6 @@
         padding: 5px @control-padding-horizontal;
         color: @text-color;
         transition: all 0.3s;
-        &:focus {
-          text-decoration: none;
-        }
       }
 
       &-selected,

--- a/components/menu/style/index.less
+++ b/components/menu/style/index.less
@@ -58,9 +58,6 @@
     &:hover {
       color: @menu-highlight-color;
     }
-    &:focus {
-      text-decoration: none;
-    }
     &::before {
       position: absolute;
       top: 0;

--- a/components/notification/style/index.less
+++ b/components/notification/style/index.less
@@ -110,10 +110,6 @@
       color: @text-color-secondary;
       outline: none;
 
-      a&:focus {
-        text-decoration: none;
-      }
-
       &:hover {
         color: shade(@text-color-secondary, 40%);
       }

--- a/components/pagination/style/index.less
+++ b/components/pagination/style/index.less
@@ -51,7 +51,6 @@
     a {
       margin: 0 6px;
       color: @text-color;
-      text-decoration: none;
       transition: none;
     }
 

--- a/components/style/core/base.less
+++ b/components/style/core/base.less
@@ -231,11 +231,6 @@ a {
   transition: color 0.3s;
   -webkit-text-decoration-skip: objects; // remove gaps in links underline in iOS 8+ and Safari 8+.
 
-  &:focus {
-    text-decoration: underline;
-    text-decoration-skip-ink: auto;
-  }
-
   &:hover {
     color: @link-hover-color;
   }

--- a/components/typography/style/index.less
+++ b/components/typography/style/index.less
@@ -42,11 +42,6 @@
     color: @link-hover-color;
   }
 
-  &:focus {
-    text-decoration: underline;
-    text-decoration-skip-ink: auto;
-  }
-
   &:active {
     color: @link-active-color;
   }

--- a/site/theme/static/common.less
+++ b/site/theme/static/common.less
@@ -15,10 +15,6 @@ body {
 
 a {
   transition: color 0.3s ease;
-  &:focus {
-    text-decoration: underline;
-    text-decoration-skip-ink: auto;
-  }
 }
 
 .main-wrapper {
@@ -121,9 +117,6 @@ a {
   width: 100%;
   padding: 0;
   overflow: hidden;
-  a {
-    text-decoration: none;
-  }
 }
 
 .drawer-content {

--- a/site/theme/static/home.less
+++ b/site/theme/static/home.less
@@ -346,7 +346,6 @@ svg {
       display: flex;
       justify-content: center;
       color: @home-text-color;
-      text-decoration: none;
     }
     &:hover {
       h3 {


### PR DESCRIPTION
### This is a ...

- [x] Component style update

### What's the background?
  
This PR removes underlines from focused links.
It avoids an appearing/disappearing underline when hovering a focused link.
See https://github.com/ant-design/ant-design/issues/15725.
  
### API Realization
  
The API is unchanged.
  
### What's the affect?

> Focused links are not underlined.

### Self Check before Merge

- [x] Doc not needed
- [x] Demo not needed
- [x] TypeScript definition not needed
- [x] Changelog provided (just above)

### Additional Plan?

No.