### PR TITLE
Add name attribute support to Checkbox.Group

### DIFF
--- a/components/checkbox/Checkbox.tsx
+++ b/components/checkbox/Checkbox.tsx
@@ -100,6 +100,7 @@ export default class Checkbox extends React.Component<CheckboxProps, {}> {
         }
         checkboxGroup.toggleOption({ label: children, value: props.value });
       };
+      checkboxProps.name = checkboxGroup.name;
       checkboxProps.checked = checkboxGroup.value.indexOf(props.value) !== -1;
       checkboxProps.disabled = props.disabled || checkboxGroup.disabled;
     }

--- a/components/checkbox/Group.tsx
+++ b/components/checkbox/Group.tsx
@@ -81,6 +81,7 @@ class CheckboxGroup extends React.Component<CheckboxGroupProps, CheckboxGroupSta
         toggleOption: this.toggleOption,
         value: this.state.value,
         disabled: this.props.disabled,
+        name: this.props.name,
       },
     };
   }

--- a/components/checkbox/__tests__/group.test.js
+++ b/components/checkbox/__tests__/group.test.js
@@ -71,6 +71,16 @@ describe('CheckboxGroup', () => {
     expect(onChangeGroup).toBeCalledWith(['Apple']);
   });
 
+  it('all children should have a name property', () => {
+    const wrapper = mount(<Checkbox.Group name="checkboxgroup" options={['Yes', 'No']} />);
+
+    expect(
+      wrapper.find('input[type="checkbox"]').forEach(el => {
+        expect(el.props().name).toEqual('checkboxgroup');
+      }),
+    );
+  });
+
   it('passes prefixCls down to checkbox', () => {
     const options = [{ label: 'Apple', value: 'Apple' }, { label: 'Orange', value: 'Orange' }];
 

--- a/components/checkbox/index.en-US.md
+++ b/components/checkbox/index.en-US.md
@@ -32,6 +32,7 @@ Checkbox component.
 | -------- | ----------- | ---- | ------- |
 | defaultValue | Default selected value | string\[] | \[] |
 | disabled | Disable all checkboxes | boolean | false |
+| name | The `name` property of all `input[type="checkbox"]` children | string | - |
 | options | Specifies options | string\[] | \[] |
 | value | Used for setting the currently selected value. | string\[] | \[] |
 | onChange | The callback function that is triggered when the state changes. | Function(checkedValue) | - |

--- a/components/checkbox/index.zh-CN.md
+++ b/components/checkbox/index.zh-CN.md
@@ -33,6 +33,7 @@ title: Checkbox
 | --- | --- | --- | --- |
 | defaultValue | 默认选中的选项 | string\[] | \[] |
 | disabled | 整组失效 | boolean | false |
+| name | CheckboxGroup 下所有 `input[type="checkbox"]` 的 `name` 属性 | string | - |
 | options | 指定可选项 | string\[] | \[] |
 | value | 指定选中的选项 | string\[] | \[] |
 | onChange | 变化时回调函数 | Function(checkedValue) | - |


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->
### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [x] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?

1. Describe the source of requirement, like related issue link.
This PR resolves #15751 and is related to #15753.

2. Describe the problem and the scenario.
`Checkbox.Group` does not render the `name` attribute for children inputs as `Radio.Group` does. Adding support for this property would make its API more consistent with `Radio.Group`, and therefore easier to work with both.

### 💡 Solution

1. How to fix the problem, and list final API implementation and usage sample if that is a new feature. 
This should work the same as `Radio.Group` as implemented in #7009.

2. GIF or snapshot should be provided if includes UI/interactive modification.
n/a

### 📝 Changelog description

> Describe changes from userside, and list all potential break changes or other risks.

1. English description
This only extends the API of `Checkbox.Group` with an optional prop. It should present no breaking changes.

2. Chinese description (optional)

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
