### PR TITLE
Fix(TimePicker): prop locale should works

### DIFF
--- a/components/time-picker/__tests__/__snapshots__/index.test.js.snap
+++ b/components/time-picker/__tests__/__snapshots__/index.test.js.snap
@@ -39,6 +39,46 @@ exports[`TimePicker not render clean icon when allowClear is false 1`] = `
 </span>
 `;
 
+exports[`TimePicker prop locale should works 1`] = `
+<span
+  class="ant-time-picker "
+  style=""
+>
+  <input
+    class="ant-time-picker-input"
+    id=""
+    placeholder="Избери дата"
+    type="text"
+    value=""
+  />
+  <span
+    class="ant-time-picker-icon"
+  >
+    <i
+      aria-label="icon: clock-circle"
+      class="anticon anticon-clock-circle ant-time-picker-clock-icon"
+    >
+      <svg
+        aria-hidden="true"
+        class=""
+        data-icon="clock-circle"
+        fill="currentColor"
+        height="1em"
+        viewBox="64 64 896 896"
+        width="1em"
+      >
+        <path
+          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+        />
+        <path
+          d="M686.7 638.6L544.1 535.5V288c0-4.4-3.6-8-8-8H488c-4.4 0-8 3.6-8 8v275.4c0 2.6 1.2 5 3.3 6.5l165.4 120.6c3.6 2.6 8.6 1.8 11.2-1.7l28.6-39c2.6-3.7 1.8-8.7-1.8-11.2z"
+        />
+      </svg>
+    </i>
+  </span>
+</span>
+`;
+
 exports[`TimePicker renders addon correctly 1`] = `
 <div
   class="ant-time-picker-panel-addon"

--- a/components/time-picker/__tests__/index.test.js
+++ b/components/time-picker/__tests__/index.test.js
@@ -68,4 +68,12 @@ describe('TimePicker', () => {
       <div className="test-clear-icon ant-time-picker-clear">test</div>,
     );
   });
+
+  it('prop locale should works', () => {
+    const locale = {
+      placeholder: 'Избери дата',
+    };
+    const wrapper = mount(<TimePicker open locale={locale} />);
+    expect(wrapper.render()).toMatchSnapshot();
+  });
 });

--- a/components/time-picker/index.tsx
+++ b/components/time-picker/index.tsx
@@ -7,7 +7,7 @@ import classNames from 'classnames';
 import warning from '../_util/warning';
 import LocaleReceiver from '../locale-provider/LocaleReceiver';
 import { ConfigConsumer, ConfigConsumerProps } from '../config-provider';
-import defaultLocale from './locale/en_US';
+import enUS from './locale/en_US';
 import interopDefault from '../_util/interopDefault';
 import Icon from '../icon';
 
@@ -54,6 +54,7 @@ export interface TimePickerProps {
   popupStyle?: React.CSSProperties;
   suffixIcon?: React.ReactNode;
   clearIcon?: React.ReactNode;
+  locale?: TimePickerLocale;
 }
 
 export interface TimePickerLocale {
@@ -176,6 +177,14 @@ class TimePicker extends React.Component<TimePickerProps, any> {
     return <Icon type="close-circle" className={clearIconPrefixCls} theme="filled" />;
   }
 
+  getDefaultLocale = () => {
+    const defaultLocale = {
+      ...enUS,
+      ...this.props.locale,
+    };
+    return defaultLocale;
+  };
+
   renderTimePicker = (locale: TimePickerLocale) => (
     <ConfigConsumer>
       {({ getPopupContainer: getContextPopupContainer, getPrefixCls }: ConfigConsumerProps) => {
@@ -225,7 +234,7 @@ class TimePicker extends React.Component<TimePickerProps, any> {
 
   render() {
     return (
-      <LocaleReceiver componentName="TimePicker" defaultLocale={defaultLocale}>
+      <LocaleReceiver componentName="TimePicker" defaultLocale={this.getDefaultLocale()}>
         {this.renderTimePicker}
       </LocaleReceiver>
     );


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?

- Close #15813.

### 💡 Solution

<!--
1. How to fix the problem, and list final API implementation and usage sample if that is an new feature.

2. GIF or snapshot should be provided if includes UI/interactive modification.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

- English Changelog:

- 🐞 Fix that prop locale doesn't work for TimePicker. #15813

- Chinese Changelog (optional):

- 🐞 修复 TimePicker 组件的 locale 属性不生效的问题。#15813

### ☑️ Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
