### PR TITLE
style(Empty): create simple style Empty in a default way

### DIFF
--- a/components/cascader/__tests__/__snapshots__/index.test.js.snap
+++ b/components/cascader/__tests__/__snapshots__/index.test.js.snap
@@ -1189,7 +1189,7 @@ exports[`Cascader should render not found content 1`] = `
                                 componentName="Empty"
                               >
                                 <div
-                                  className="ant-empty ant-empty-small"
+                                  className="ant-empty ant-empty-normal ant-empty-small"
                                 >
                                   <div
                                     className="ant-empty-image"

--- a/components/config-provider/__tests__/__snapshots__/components.test.js.snap
+++ b/components/config-provider/__tests__/__snapshots__/components.test.js.snap
@@ -15478,7 +15478,7 @@ exports[`ConfigProvider components Transfer configProvider 1`] = `
         class="config-transfer-list-body-not-found"
       >
         <div
-          class="config-empty config-empty-small"
+          class="config-empty config-empty-normal config-empty-small"
         >
           <div
             class="config-empty-image"
@@ -15588,7 +15588,7 @@ exports[`ConfigProvider components Transfer configProvider 1`] = `
         class="config-transfer-list-body-not-found"
       >
         <div
-          class="config-empty config-empty-small"
+          class="config-empty config-empty-normal config-empty-small"
         >
           <div
             class="config-empty-image"
@@ -15653,7 +15653,7 @@ exports[`ConfigProvider components Transfer normal 1`] = `
         class="ant-transfer-list-body-not-found"
       >
         <div
-          class="ant-empty ant-empty-small"
+          class="ant-empty ant-empty-normal ant-empty-small"
         >
           <div
             class="ant-empty-image"
@@ -15763,7 +15763,7 @@ exports[`ConfigProvider components Transfer normal 1`] = `
         class="ant-transfer-list-body-not-found"
       >
         <div
-          class="ant-empty ant-empty-small"
+          class="ant-empty ant-empty-normal ant-empty-small"
         >
           <div
             class="ant-empty-image"
@@ -15828,7 +15828,7 @@ exports[`ConfigProvider components Transfer prefixCls 1`] = `
         class="prefix-Transfer-list-body-not-found"
       >
         <div
-          class="ant-empty ant-empty-small"
+          class="ant-empty ant-empty-normal ant-empty-small"
         >
           <div
             class="ant-empty-image"
@@ -15938,7 +15938,7 @@ exports[`ConfigProvider components Transfer prefixCls 1`] = `
         class="prefix-Transfer-list-body-not-found"
       >
         <div
-          class="ant-empty ant-empty-small"
+          class="ant-empty ant-empty-normal ant-empty-small"
         >
           <div
             class="ant-empty-image"

--- a/components/config-provider/renderEmpty.tsx
+++ b/components/config-provider/renderEmpty.tsx
@@ -10,7 +10,7 @@ const renderEmpty = (componentName?: string): React.ReactNode => (
       switch (componentName) {
         case 'Table':
         case 'List':
-          return <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} className={`${prefix}-normal`} />;
+          return <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} />;
 
         case 'Select':
         case 'TreeSelect':

--- a/components/empty/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/empty/__tests__/__snapshots__/demo.test.js.snap
@@ -214,7 +214,7 @@ exports[`renders ./components/empty/demo/config-provider.md correctly 1`] = `
             class="ant-transfer-list-body-not-found"
           >
             <div
-              class="ant-empty ant-empty-small"
+              class="ant-empty ant-empty-normal ant-empty-small"
             >
               <div
                 class="ant-empty-image"
@@ -324,7 +324,7 @@ exports[`renders ./components/empty/demo/config-provider.md correctly 1`] = `
             class="ant-transfer-list-body-not-found"
           >
             <div
-              class="ant-empty ant-empty-small"
+              class="ant-empty ant-empty-normal ant-empty-small"
             >
               <div
                 class="ant-empty-image"
@@ -484,7 +484,7 @@ exports[`renders ./components/empty/demo/customize.md correctly 1`] = `
 >
   <div
     class="ant-empty-image"
-    style="height:200px"
+    style="height:60px"
   >
     <img
       alt="empty"
@@ -520,11 +520,10 @@ exports[`renders ./components/empty/demo/customize.md correctly 1`] = `
 
 exports[`renders ./components/empty/demo/simple.md correctly 1`] = `
 <div
-  class="ant-empty"
+  class="ant-empty ant-empty-normal"
 >
   <div
     class="ant-empty-image"
-    style="height:40px"
   >
     <img
       alt="No Data"

--- a/components/empty/demo/customize.md
+++ b/components/empty/demo/customize.md
@@ -20,7 +20,7 @@ ReactDOM.render(
   <Empty
     image="https://gw.alipayobjects.com/mdn/miniapp_social/afts/img/A*pevERLJC9v0AAAAAAAAAAABjAQAAAQ/original"
     imageStyle={{
-      height: 200,
+      height: 60,
     }}
     description={
       <span>

--- a/components/empty/demo/simple.md
+++ b/components/empty/demo/simple.md
@@ -17,7 +17,7 @@ You can choose another style of `image` by setting image to `Empty.PRESENTED_IMA
 import { Empty } from 'antd';
 
 ReactDOM.render(
-  <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} imageStyle={{ height:40 }} />,
+  <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} />,
   mountNode
 );
 ```

--- a/components/empty/index.tsx
+++ b/components/empty/index.tsx
@@ -51,13 +51,20 @@ const OriginEmpty: React.SFC<EmptyProps> = (props: EmptyProps) => (
             }
 
             return (
-              <div className={classNames(prefixCls, className)} {...restProps}>
+              <div
+                className={classNames(
+                  prefixCls,
+                  {
+                    [`${prefixCls}-normal`]: image === simpleEmptyImg,
+                  },
+                  className,
+                )}
+                {...restProps}
+              >
                 <div className={`${prefixCls}-image`} style={imageStyle}>
                   {imageNode}
                 </div>
-
                 <p className={`${prefixCls}-description`}>{des}</p>
-
                 {children && <div className={`${prefixCls}-footer`}>{children}</div>}
               </div>
             );

--- a/components/empty/style/index.less
+++ b/components/empty/style/index.less
@@ -27,21 +27,21 @@
   }
 
   // antd internal empty style
-  &-small {
-    margin: 8px 0;
-    color: @disabled-color;
-
-    .@{empty-prefix-cls}-image {
-      height: 35px;
-    }
-  }
-
   &-normal {
     margin: 32px 0;
     color: @disabled-color;
 
     .@{empty-prefix-cls}-image {
       height: 40px;
+    }
+  }
+
+  &-small {
+    margin: 8px 0;
+    color: @disabled-color;
+
+    .@{empty-prefix-cls}-image {
+      height: 35px;
     }
   }
 }

--- a/components/empty/style/index.less
+++ b/components/empty/style/index.less
@@ -29,6 +29,7 @@
   // antd internal empty style
   &-small {
     margin: 8px 0;
+    color: @disabled-color;
 
     .@{empty-prefix-cls}-image {
       height: 35px;
@@ -37,6 +38,7 @@
 
   &-normal {
     margin: 32px 0;
+    color: @disabled-color;
 
     .@{empty-prefix-cls}-image {
       height: 40px;

--- a/components/list/style/index.less
+++ b/components/list/style/index.less
@@ -32,7 +32,7 @@
 
   &-empty-text {
     padding: @list-empty-text-padding;
-    color: @text-color-secondary;
+    color: @disabled-color;
     font-size: @font-size-base;
     text-align: center;
   }

--- a/components/locale-provider/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/locale-provider/__tests__/__snapshots__/demo.test.js.snap
@@ -513,7 +513,7 @@ exports[`renders ./components/locale-provider/demo/all.md correctly 1`] = `
               class="ant-transfer-list-body-not-found"
             >
               <div
-                class="ant-empty ant-empty-small"
+                class="ant-empty ant-empty-normal ant-empty-small"
               >
                 <div
                   class="ant-empty-image"
@@ -657,7 +657,7 @@ exports[`renders ./components/locale-provider/demo/all.md correctly 1`] = `
               class="ant-transfer-list-body-not-found"
             >
               <div
-                class="ant-empty ant-empty-small"
+                class="ant-empty ant-empty-normal ant-empty-small"
               >
                 <div
                   class="ant-empty-image"

--- a/components/table/style/index.less
+++ b/components/table/style/index.less
@@ -408,7 +408,7 @@
     position: relative;
     z-index: 1;
     padding: @table-padding-vertical @table-padding-horizontal;
-    color: @text-color-secondary;
+    color: @disabled-color;
     font-size: @font-size-base;
     text-align: center;
     background: @component-background;

--- a/components/transfer/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/transfer/__tests__/__snapshots__/demo.test.js.snap
@@ -78,7 +78,7 @@ exports[`renders ./components/transfer/demo/advanced.md correctly 1`] = `
         class="ant-transfer-list-body-not-found"
       >
         <div
-          class="ant-empty ant-empty-small"
+          class="ant-empty ant-empty-normal ant-empty-small"
         >
           <div
             class="ant-empty-image"
@@ -242,7 +242,7 @@ exports[`renders ./components/transfer/demo/advanced.md correctly 1`] = `
         class="ant-transfer-list-body-not-found"
       >
         <div
-          class="ant-empty ant-empty-small"
+          class="ant-empty ant-empty-normal ant-empty-small"
         >
           <div
             class="ant-empty-image"
@@ -561,7 +561,7 @@ exports[`renders ./components/transfer/demo/custom-item.md correctly 1`] = `
         class="ant-transfer-list-body-not-found"
       >
         <div
-          class="ant-empty ant-empty-small"
+          class="ant-empty ant-empty-normal ant-empty-small"
         >
           <div
             class="ant-empty-image"
@@ -672,7 +672,7 @@ exports[`renders ./components/transfer/demo/custom-item.md correctly 1`] = `
         class="ant-transfer-list-body-not-found"
       >
         <div
-          class="ant-empty ant-empty-small"
+          class="ant-empty ant-empty-normal ant-empty-small"
         >
           <div
             class="ant-empty-image"
@@ -737,7 +737,7 @@ exports[`renders ./components/transfer/demo/large-data.md correctly 1`] = `
         class="ant-transfer-list-body-not-found"
       >
         <div
-          class="ant-empty ant-empty-small"
+          class="ant-empty ant-empty-normal ant-empty-small"
         >
           <div
             class="ant-empty-image"
@@ -847,7 +847,7 @@ exports[`renders ./components/transfer/demo/large-data.md correctly 1`] = `
         class="ant-transfer-list-body-not-found"
       >
         <div
-          class="ant-empty ant-empty-small"
+          class="ant-empty ant-empty-normal ant-empty-small"
         >
           <div
             class="ant-empty-image"
@@ -946,7 +946,7 @@ exports[`renders ./components/transfer/demo/search.md correctly 1`] = `
         class="ant-transfer-list-body-not-found"
       >
         <div
-          class="ant-empty ant-empty-small"
+          class="ant-empty ant-empty-normal ant-empty-small"
         >
           <div
             class="ant-empty-image"
@@ -1090,7 +1090,7 @@ exports[`renders ./components/transfer/demo/search.md correctly 1`] = `
         class="ant-transfer-list-body-not-found"
       >
         <div
-          class="ant-empty ant-empty-small"
+          class="ant-empty ant-empty-normal ant-empty-small"
         >
           <div
             class="ant-empty-image"


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->
### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?

Now we use `<Empty image={Empty.PRESENTED_IMAGE_SIMPLE} />`, it looks like:

<img width="378" alt="image" src="https://user-images.githubusercontent.com/507615/55474174-1bc1e400-5643-11e9-8f54-bc1e6f49fe88.png">

https://codesandbox.io/s/4rw1n098w4

We should make it's look same as:

<img width="126" alt="image" src="https://user-images.githubusercontent.com/507615/55474225-33996800-5643-11e9-9bfa-50d92ad6fdd4.png">


### 💡 Solution

Add proper className when `image` is equals to `Empty.PRESENTED_IMAGE_SIMPLE`.

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

- English Changelog: 💄 Optimize default UI of `<Empty image={Empty.PRESENTED_IMAGE_SIMPLE} />`.
- Chinese Changelog (optional): 💄 优化 `<Empty image={Empty.PRESENTED_IMAGE_SIMPLE} />` 的默认样式。

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
