### PR TITLE
fix: Affix should dynamic adjust if size changed

### DIFF
--- a/components/_util/resizeObserver.tsx
+++ b/components/_util/resizeObserver.tsx
@@ -53,7 +53,7 @@ class ReactResizeObserver extends React.Component<ResizeObserverProps, {}> {
   }
 
   render() {
-    const { children } = this.props;
+    const { children = null } = this.props;
     return children;
   }
 }

--- a/components/affix/__tests__/Affix.test.js
+++ b/components/affix/__tests__/Affix.test.js
@@ -137,4 +137,30 @@ describe('Affix Render', () => {
     expect(wrapper.instance().state.affixStyle).toBe(undefined);
     expect(wrapper.instance().state.placeholderStyle).toBe(undefined);
   });
+
+  it('updatePosition when size changed', () => {
+    document.body.innerHTML = '<div id="mounter" />';
+
+    const updateCalled = jest.fn();
+    wrapper = mount(<AffixMounter offsetBottom={0} onTestUpdatePosition={updateCalled} />, {
+      attachTo: document.getElementById('mounter'),
+    });
+
+    jest.runAllTimers();
+
+    movePlaceholder(300);
+    expect(wrapper.instance().affix.state.affixStyle).toBeTruthy();
+    jest.runAllTimers();
+    wrapper.update();
+
+    // Mock trigger resize
+    updateCalled.mockReset();
+    wrapper
+      .find('ReactResizeObserver')
+      .instance()
+      .onResize();
+    jest.runAllTimers();
+
+    expect(updateCalled).toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?

fix: #15600 

### 💡 Solution

Add `ResizeObserver` to check if element size changed.

### 📝 Changelog

Fix Affix position not update when content height changed.

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
