### PR TITLE
feat: publish using npm official registry

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
   "contributors": [
     "ant"
   ],
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/ant-design/ant-design"


### PR DESCRIPTION

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [x] Other (about what?)

### 👻 What's the background?

npm using `taobao` registry will lead publishing failed.

### 💡 Solution



