### PR TITLE
feat: Add warning when DatePicker using invalidate time

### DIFF
--- a/components/date-picker/__tests__/DatePicker.test.js
+++ b/components/date-picker/__tests__/DatePicker.test.js
@@ -7,6 +7,8 @@ import { selectDate, openPanel, clearInput, nextYear, nextMonth, hasSelected } f
 import focusTest from '../../../tests/shared/focusTest';
 
 describe('DatePicker', () => {
+  const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
   focusTest(DatePicker);
 
   beforeEach(() => {
@@ -15,6 +17,11 @@ describe('DatePicker', () => {
 
   afterEach(() => {
     MockDate.reset();
+    errorSpy.mockReset();
+  });
+
+  afterAll(() => {
+    errorSpy.mockRestore();
   });
 
   it('support name prop', () => {
@@ -209,5 +216,23 @@ describe('DatePicker', () => {
     openPanel(wrapper);
     wrapper.find('.ant-calendar-input').simulate('change', { target: { value: '02/07/18' } });
     expect(wrapper.find('.ant-calendar-picker-input').getDOMNode().value).toBe('02/07/2018');
+  });
+
+  describe('warning use if use invalidate moment', () => {
+    const invalidateTime = moment('I AM INVALIDATE');
+
+    it('defaultValue', () => {
+      mount(<DatePicker defaultValue={invalidateTime} />);
+      expect(errorSpy).toHaveBeenCalledWith(
+        'Warning: [antd: DatePicker] `defaultValue` provides invalidate moment time. If you want to set empty value, use `null` instead.',
+      );
+    });
+
+    it('value', () => {
+      mount(<DatePicker value={invalidateTime} />);
+      expect(errorSpy).toHaveBeenCalledWith(
+        'Warning: [antd: DatePicker] `value` provides invalidate moment time. If you want to set empty value, use `null` instead.',
+      );
+    });
   });
 });

--- a/components/date-picker/wrapPicker.tsx
+++ b/components/date-picker/wrapPicker.tsx
@@ -1,10 +1,13 @@
 import * as React from 'react';
+import { polyfill } from 'react-lifecycles-compat';
 import TimePickerPanel from 'rc-time-picker/lib/Panel';
 import classNames from 'classnames';
+import * as moment from 'moment';
 import enUS from './locale/en_US';
 import LocaleReceiver from '../locale-provider/LocaleReceiver';
 import { generateShowHourMinuteSecond } from '../time-picker';
 import { ConfigConsumer, ConfigConsumerProps } from '../config-provider';
+import warning from '../_util/warning';
 
 type PickerType = 'date' | 'week' | 'month';
 
@@ -43,8 +46,21 @@ function getColumns({ showHour, showMinute, showSecond, use12Hours }: any) {
   return column;
 }
 
+function checkValidate(value: any, propName: string) {
+  const values: any[] = Array.isArray(value) ? value : [value];
+  values.forEach(val => {
+    if (!val) return;
+
+    warning(
+      !moment.isMoment(val) || val.isValid(),
+      'DatePicker',
+      `\`${propName}\` provides invalidate moment time. If you want to set empty value, use \`null\` instead.`,
+    );
+  });
+}
+
 export default function wrapPicker(Picker: React.ComponentClass<any>, pickerType: PickerType): any {
-  return class PickerWrapper extends React.Component<any, any> {
+  class PickerWrapper extends React.Component<any, any> {
     static defaultProps = {
       transitionName: 'slide-up',
       popupStyle: {},
@@ -53,6 +69,15 @@ export default function wrapPicker(Picker: React.ComponentClass<any>, pickerType
       onOpenChange() {},
       locale: {},
     };
+
+    static getDerivedStateFromProps({ value, defaultValue }: any) {
+      checkValidate(defaultValue, 'defaultValue');
+      checkValidate(value, 'value');
+      return {};
+    }
+
+    // Since we need call `getDerivedStateFromProps` for check. Need leave an empty `state` here.
+    state = {};
 
     private picker: any;
 
@@ -199,5 +224,8 @@ export default function wrapPicker(Picker: React.ComponentClass<any>, pickerType
         </LocaleReceiver>
       );
     }
-  };
+  }
+
+  polyfill(PickerWrapper);
+  return PickerWrapper;
 }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->
### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [x] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?

close #15917

### 💡 Solution

Add additional check of `defaultValue` & `value`

### 📝 Changelog

Add warning when DatePicker using invalidate time.

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
