### PR TITLE
fix: Tooltips show work when Menu collapsed

### DIFF
--- a/components/layout/__tests__/index.test.js
+++ b/components/layout/__tests__/index.test.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import { mount, render } from 'enzyme';
 import Layout from '..';
+import Icon from '../../icon';
+import Menu from '../../menu';
 
 const { Sider, Content } = Layout;
 
@@ -103,6 +105,36 @@ describe('Layout', () => {
       </Layout>,
     );
     expect(wrapper.find('.ant-layout').hasClass('ant-layout-has-sider')).toBe(false);
+  });
+
+  it('render correct with Tooltip', () => {
+    jest.useFakeTimers();
+    const wrapper = mount(
+      <Sider collapsible collapsed={false}>
+        <Menu mode="inline">
+          <Menu.Item key="1">
+            <Icon type="user" />
+            <span>Light</span>
+          </Menu.Item>
+        </Menu>
+      </Sider>,
+    );
+
+    wrapper.find('.ant-menu-item').simulate('mouseenter');
+    jest.runAllTimers();
+    wrapper.update();
+    expect(wrapper.find('.ant-tooltip-inner').length).toBeFalsy();
+    wrapper.find('.ant-menu-item').simulate('mouseout');
+    jest.runAllTimers();
+    wrapper.update();
+
+    wrapper.setProps({ collapsed: true });
+    wrapper.find('.ant-menu-item').simulate('mouseenter');
+    jest.runAllTimers();
+    wrapper.update();
+    expect(wrapper.find('.ant-tooltip-inner').length).toBeTruthy();
+
+    jest.useRealTimers();
   });
 });
 

--- a/components/menu/MenuItem.tsx
+++ b/components/menu/MenuItem.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { Item } from 'rc-menu';
-import Tooltip from '../tooltip';
 import { ClickParam } from '.';
+import Tooltip from '../tooltip';
+import { SiderContext, SiderContextProps } from '../layout/Sider';
 
 export interface MenuItemProps {
   rootPrefixCls?: string;
@@ -28,17 +29,27 @@ export default class MenuItem extends React.Component<MenuItemProps> {
     this.menuItem = menuItem;
   };
 
-  render() {
-    const { rootPrefixCls, title, ...rest } = this.props;
+  renderItem = ({ siderCollapsed }: SiderContextProps) => {
+    const { level, children, rootPrefixCls } = this.props;
+    const { title, ...rest } = this.props;
+
+    let titleNode = title || (level === 1 ? children : '');
+    if (!siderCollapsed) {
+      titleNode = null;
+    }
 
     return (
       <Tooltip
-        title={title}
+        title={titleNode}
         placement="right"
         overlayClassName={`${rootPrefixCls}-inline-collapsed-tooltip`}
       >
-        <Item {...rest} rootPrefixCls={rootPrefixCls} title={title} ref={this.saveMenuItem} />
+        <Item {...rest} title={title} ref={this.saveMenuItem} />
       </Tooltip>
     );
+  };
+
+  render() {
+    return <SiderContext.Consumer>{this.renderItem}</SiderContext.Consumer>;
   }
 }

--- a/components/menu/MenuItem.tsx
+++ b/components/menu/MenuItem.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { Item } from 'rc-menu';
 import { ClickParam } from '.';
+import { MenuContext, MenuContextProps } from './';
 import Tooltip from '../tooltip';
 import { SiderContext, SiderContextProps } from '../layout/Sider';
 
@@ -33,19 +34,25 @@ export default class MenuItem extends React.Component<MenuItemProps> {
     const { level, children, rootPrefixCls } = this.props;
     const { title, ...rest } = this.props;
 
-    let titleNode = title || (level === 1 ? children : '');
-    if (!siderCollapsed) {
-      titleNode = null;
-    }
-
     return (
-      <Tooltip
-        title={titleNode}
-        placement="right"
-        overlayClassName={`${rootPrefixCls}-inline-collapsed-tooltip`}
-      >
-        <Item {...rest} title={title} ref={this.saveMenuItem} />
-      </Tooltip>
+      <MenuContext.Consumer>
+        {({ inlineCollapsed }: MenuContextProps) => {
+          let titleNode = title || (level === 1 ? children : '');
+          if (!siderCollapsed && !inlineCollapsed) {
+            titleNode = null;
+          }
+
+          return (
+            <Tooltip
+              title={titleNode}
+              placement="right"
+              overlayClassName={`${rootPrefixCls}-inline-collapsed-tooltip`}
+            >
+              <Item {...rest} title={title} ref={this.saveMenuItem} />
+            </Tooltip>
+          );
+        }}
+      </MenuContext.Consumer>
     );
   };
 

--- a/components/menu/__tests__/index.test.js
+++ b/components/menu/__tests__/index.test.js
@@ -494,6 +494,8 @@ describe('Menu', () => {
 
     const text = wrapper.find('.ant-tooltip-inner').text();
     expect(text).toBe('bamboo lucky');
+
+    jest.useRealTimers();
   });
 
   it('render correctly when using with Layout.Sider', () => {
@@ -607,5 +609,25 @@ describe('Menu', () => {
     wrapper.setProps({ inlineCollapsed: true });
 
     expect(wrapper.render()).toMatchSnapshot();
+  });
+
+  it('not title if not collapsed', () => {
+    jest.useFakeTimers();
+    const wrapper = mount(
+      <Menu mode="inline" inlineCollapsed={false}>
+        <Menu.Item key="1">
+          <Icon type="pie-chart" />
+          <span>Option 1</span>
+        </Menu.Item>
+      </Menu>,
+    );
+
+    wrapper.find('.ant-menu-item').simulate('mouseenter');
+    jest.runAllTimers();
+    wrapper.update();
+
+    expect(wrapper.find('.ant-tooltip-inner').length).toBeFalsy();
+
+    jest.useRealTimers();
   });
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?

fix #15943

### 💡 Solution

Revert related code and add Collapsed check

### 📝 Changelog

Fix Tooltips not work when Menu collapsed

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
