### PR TITLE
fix: Added missing showLessItems from prop type from rc-pagination to PaginationProps

### DIFF
--- a/components/pagination/Pagination.tsx
+++ b/components/pagination/Pagination.tsx
@@ -34,6 +34,7 @@ export interface PaginationProps {
     originalElement: React.ReactElement<HTMLElement>,
   ) => React.ReactNode;
   role?: string;
+  showLessItems?: boolean;
 }
 
 export interface PaginationConfig extends PaginationProps {

--- a/components/pagination/index.en-US.md
+++ b/components/pagination/index.en-US.md
@@ -27,6 +27,7 @@ A long list can be divided into several pages by `Pagination`, and only one page
 | itemRender | to customize item innerHTML | (page, type: 'page' \| 'prev' \| 'next', originalElement) => React.ReactNode | - |
 | pageSize | number of data items per page | number | - |
 | pageSizeOptions | specify the sizeChanger options | string\[] | \['10', '20', '30', '40'] |
+| showLessItems | show less page items | boolean | false |
 | showQuickJumper | determine whether you can jump to pages directly | boolean \| `{ goButton: ReactNode }` | false |
 | showSizeChanger | determine whether `pageSize` can be changed | boolean | false |
 | showTotal | to display the total number and range | Function(total, range) | - |

--- a/components/pagination/index.zh-CN.md
+++ b/components/pagination/index.zh-CN.md
@@ -28,6 +28,7 @@ cols: 1
 | itemRender | 用于自定义页码的结构，可用于优化 SEO | (page, type: 'page' \| 'prev' \| 'next', originalElement) => React.ReactNode | - |
 | pageSize | 每页条数 | number | - |
 | pageSizeOptions | 指定每页可以显示多少条 | string\[] | \['10', '20', '30', '40'] |
+| showLessItems | show less page items | boolean | false |
 | showQuickJumper | 是否可以快速跳转至某页 | boolean \| `{ goButton: ReactNode }` | false |
 | showSizeChanger | 是否可以改变 pageSize | boolean | false |
 | showTotal | 用于显示数据总量和当前数据顺序 | Function(total, range) | - |


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?
<!--
1. Describe the source of requirement, like related issue link.

2. Describe the problem and the scenario.
-->
The `showLessItems` prop from rc-pagination is not defined on PaginationProps

### 💡 Solution

<!--
1. How to fix the problem, and list final API implementation and usage sample if that is an new feature.

2. GIF or snapshot should be provided if includes UI/interactive modification.
-->
Just added this prop to PaginationProps

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

- English Changelog:
Added missing `showLessItems` from rc-pagination to PaginationProps
- Chinese Changelog (optional):

### ☑️ Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

I've changed the English docs but the Chinese translation should be updated. I'm not sure if this requires a new example on pagination component docs.
