### PR TITLE
feat: form customizing variables

### DIFF
--- a/components/form/style/index.less
+++ b/components/form/style/index.less
@@ -456,7 +456,7 @@ form {
 }
 
 .has-warning {
-  .form-control-validation(@warning-color; @warning-color;);
+  .form-control-validation(@warning-color; @warning-color; @form-warning-input-bg;);
 
   &.has-feedback .@{form-prefix-cls}-item-children-icon {
     color: @warning-color;

--- a/components/form/style/index.less
+++ b/components/form/style/index.less
@@ -505,7 +505,7 @@ form {
 }
 
 .has-error {
-  .form-control-validation(@error-color; @error-color;);
+  .form-control-validation(@error-color; @error-color; @form-error-input-bg;);
 
   &.has-feedback .@{form-prefix-cls}-item-children-icon {
     color: @error-color;

--- a/components/form/style/mixin.less
+++ b/components/form/style/mixin.less
@@ -30,6 +30,7 @@
     .@{ant-prefix}-input {
       &,
       &:hover {
+        background-color: @background-color;
         border-color: @border-color;
       }
 

--- a/components/style/themes/default.less
+++ b/components/style/themes/default.less
@@ -280,6 +280,7 @@
 // ---
 @label-required-color: @highlight-color;
 @label-color: @heading-color;
+@form-warning-input-bg: @input-bg;
 @form-item-margin-bottom: 24px;
 @form-item-trailing-colon: true;
 @form-vertical-label-padding: 0 0 8px;

--- a/components/style/themes/default.less
+++ b/components/style/themes/default.less
@@ -285,6 +285,7 @@
 @form-item-trailing-colon: true;
 @form-vertical-label-padding: 0 0 8px;
 @form-vertical-label-margin: 0;
+@form-error-input-bg: @input-bg;
 
 // Input
 // ---


### PR DESCRIPTION
### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / document update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?
Hello there! I just added @form-error-input-bg and @form-warning-input-bg in default.less for customizing form input background-color if it needs. I hope this is correct

### 💡 Solution

### 📝 Changelog
No breaking changes and no any behavior changes
Just some variables for customizing

- English Changelog:
  * added `@form-warning-input-bg` variable for customizing form input in warning state
  * added `@form-error-input-bg` variable for customizing form input in error state
- Chinese Changelog (optional):

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
