### PR TITLE
fix(Tree): Switcher loading icon and checkbox should be vertical align when @tree-title-height is modified

### DIFF
--- a/components/tree/style/index.less
+++ b/components/tree/style/index.less
@@ -73,7 +73,7 @@
               left: 0;
               display: inline-block;
               width: 24px;
-              height: 24px;
+              height: @tree-title-height;
               color: @primary-color;
               font-size: 14px;
               transform: none;
@@ -120,13 +120,16 @@
     }
     span {
       &.@{tree-prefix-cls}-checkbox {
-        margin: 4px 4px 0 2px;
+        top: initial;
+        height: @tree-title-height;
+        margin: 0 4px 0 2px;
+        padding: ((@tree-title-height - 16px) / 2) 0;
       }
       &.@{tree-prefix-cls}-switcher,
       &.@{tree-prefix-cls}-iconEle {
         display: inline-block;
         width: 24px;
-        height: 24px;
+        height: @tree-title-height;
         margin: 0;
         line-height: @tree-title-height;
         text-align: center;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?

- Close #15955

<!--
1. Describe the source of requirement, like related issue link.

2. Describe the problem and the scenario.
-->

### 💡 Solution

<!--
1. How to fix the problem, and list final API implementation and usage sample if that is an new feature.

2. GIF or snapshot should be provided if includes UI/interactive modification.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

- English Changelog:

- 🐞 Fix switcher loading icon and checkbox not vertical align for Tree when @tree-title-height is modified. #15955

- Chinese Changelog (optional):

- 🐞 修复定制 @tree-title-height 变量时 Tree 组件中的 `loading` 图标和 `checkbox` 没有垂直居中的问题。#15955

### ☑️ Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
