### PR TITLE
fix(PageHeader): Should be no wrap for header content

### DIFF
--- a/components/page-header/style/index.less
+++ b/components/page-header/style/index.less
@@ -7,6 +7,7 @@
   .reset-component;
   position: relative;
   padding: @page-header-padding-vertical @page-header-padding-horizontal;
+  white-space: nowrap;
   background: @component-background;
 
   &.@{pageheader-prefix-cls}-has-footer {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?

- Close #15664.

<!--
1. Describe the source of requirement, like related issue link.

2. Describe the problem and the scenario.
-->

### 💡 Solution

<!--
1. How to fix the problem, and list final API implementation and usage sample if that is an new feature.

2. GIF or snapshot should be provided if includes UI/interactive modification.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

- English Changelog:

- 🐞 Fix wrap style when title is too long for PageHeader. #15664

- Chinese Changelog (optional):

- 🐞 修复 PageHeader 组件的标题过长导致自动换行的问题。#15664

### ☑️ Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
