### PR TITLE
fix: use Tabs overflow hidden instead of display none

### DIFF
--- a/components/table/style/size.less
+++ b/components/table/style/size.less
@@ -31,7 +31,8 @@
   }
 
   tr.@{table-prefix-cls}-expanded-row td > .@{table-prefix-cls}-wrapper {
-    margin: -@table-padding-vertical-md -@table-padding-horizontal -@table-padding-vertical-md - 1px;
+    margin: -@table-padding-vertical-md -@table-padding-horizontal / 2 -@table-padding-vertical-md -
+      1px;
   }
 }
 
@@ -154,6 +155,7 @@
   }
 
   tr.@{table-prefix-cls}-expanded-row td > .@{table-prefix-cls}-wrapper {
-    margin: -@table-padding-vertical-sm -@table-padding-horizontal -@table-padding-vertical-sm - 1px;
+    margin: -@table-padding-vertical-sm -@table-padding-horizontal / 2 -@table-padding-vertical-sm -
+      1px;
   }
 }

--- a/components/tabs/style/index.less
+++ b/components/tabs/style/index.less
@@ -4,6 +4,18 @@
 
 @tab-prefix-cls: ~'@{ant-prefix}-tabs';
 
+// Hidden content
+.tabs-hidden-content() {
+  height: 0;
+  padding: 0 !important;
+  overflow: hidden;
+  opacity: 0;
+  pointer-events: none;
+  input {
+    visibility: hidden;
+  }
+}
+
 .@{tab-prefix-cls} {
   .reset-component;
   position: relative;
@@ -231,13 +243,7 @@
     }
 
     > .@{tab-prefix-cls}-tabpane-inactive {
-      height: 0;
-      padding: 0 !important;
-      opacity: 0;
-      pointer-events: none;
-      input {
-        visibility: hidden;
-      }
+      .tabs-hidden-content();
     }
 
     &.@{tab-prefix-cls}-content-animated {
@@ -397,7 +403,7 @@
     transform: none !important;
   }
   > .@{tab-prefix-cls}-tabpane-inactive {
-    display: none;
+    .tabs-hidden-content();
   }
 }
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?

fix #15352

### 💡 Solution

Display none makes sub Tabs can not get correct dom size. Use overflow hidden instead.

### 📝 Changelog

Fix nest Tabs ink bar style issue.

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
