### PR TITLE
Fix Tabs interface missing destroyInactiveTabPane

### DIFF
--- a/components/tabs/index.en-US.md
+++ b/components/tabs/index.en-US.md
@@ -37,6 +37,7 @@ Ant Design has 3 types of Tabs for different situations.
 | onNextClick | Callback executed when next button is clicked | Function | - |
 | onPrevClick | Callback executed when prev button is clicked | Function | - |
 | onTabClick | Callback executed when tab is clicked | Function(key: string, event: MouseEvent) | - |
+| destroyInactiveTabPane | Whether to destroy inactive tabpane when changing tab | boolean | `false` |
 
 More option at [rc-tabs option](https://github.com/react-component/tabs#tabs)
 

--- a/components/tabs/index.tsx
+++ b/components/tabs/index.tsx
@@ -32,6 +32,7 @@ export interface TabsProps {
   animated?: boolean | { inkBar: boolean; tabPane: boolean };
   tabBarGutter?: number;
   renderTabBar?: (props: TabsProps, DefaultTabBar: React.ReactNode) => React.ReactElement<any>;
+  destroyInactiveTabPane?: boolean;
 }
 
 // Tabs


### PR DESCRIPTION
Added missing `destroyInactiveTabPane`

<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->
### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [X] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?

The Tabs component is missing `destroyInactiveTabPane`.

### 💡 Solution

Adding `destroyInactiveTabPane?: boolean;` from [here ](https://github.com/react-component/tabs#tabs) to the TabsProps interface.

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

- English Changelog: Fix the TypeScript definition lack of `destroyInactiveTabPane` for Tabs.

### ☑️ Self Check before Merge

- [X] Doc is updated/provided or not needed
- [X] Demo is updated/provided or not needed
- [X] TypeScript definition is updated/provided or not needed
- [X] Changelog is provided or not needed


-----
[View rendered components/tabs/index.en-US.md](https://github.com/Selfron/ant-design/blob/patch-2/components/tabs/index.en-US.md)