### PR TITLE
Fix mistake in Typography paragraph style

### DIFF
--- a/components/typography/style/index.less
+++ b/components/typography/style/index.less
@@ -70,7 +70,7 @@
   }
 
   // Tag
-  div&,
+  p&,
   p {
     .typography-paragraph();
   }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->
### 🤔 This is a ...

- [x] Component style update

### 👻 What's the background?

There seems to be a mistake in the current Less selector.
I don't think that this mistake has any impact on the Ant Design's website.
It brings unwanted consequences in the context of nesting this Less:

Specifically, nesting the Less in a parent selector that matches a `div` results in having `margin-bottom: 1em` for all elements with `.ant-typography`:

![image](https://user-images.githubusercontent.com/5601730/56052704-6aadfe80-5d52-11e9-8730-5b682ec858d8.png)

### 💡 Solution

Fixed the mistake.

### 📝 Changelog

I am not sure that this should go in the changelog since it has no impact for most users.

- English Changelog:
> Fix the Typography style in the context of nested Less.

### ☑️ Self Check before Merge

- [ ] Doc is ~~updated/provided or~~ not needed
- [ ] Demo is ~~updated/provided or~~ not needed
- [ ] TypeScript definition is ~~updated/provided or~~ not needed
- [ ] Changelog is ~~provided or~~ not needed
