### PR TITLE
fix: loading circle button can handle pointer events.

### DIFF
--- a/components/button/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/button/__tests__/__snapshots__/demo.test.js.snap
@@ -606,7 +606,7 @@ exports[`renders ./components/button/demo/icon.md correctly 1`] = `
 `;
 
 exports[`renders ./components/button/demo/loading.md correctly 1`] = `
-<span>
+<div>
   <button
     class="ant-btn ant-btn-primary ant-btn-loading"
     type="button"
@@ -746,7 +746,7 @@ exports[`renders ./components/button/demo/loading.md correctly 1`] = `
       </svg>
     </i>
   </button>
-</span>
+</div>
 `;
 
 exports[`renders ./components/button/demo/multiple.md correctly 1`] = `

--- a/components/button/demo/loading.md
+++ b/components/button/demo/loading.md
@@ -32,7 +32,7 @@ class App extends React.Component {
 
   render() {
     return (
-      <span>
+      <div>
         <Button type="primary" loading>
           Loading
         </Button>
@@ -49,7 +49,7 @@ class App extends React.Component {
         <br />
         <Button shape="circle" loading />
         <Button type="primary" shape="circle" loading />
-      </span>
+      </div>
     );
   }
 }

--- a/components/button/style/index.less
+++ b/components/button/style/index.less
@@ -107,14 +107,17 @@
     }
   }
 
+  &&-loading {
+    position: relative;
+    pointer-events: none;
+  }
+
   &&-loading::before {
     display: block;
   }
 
   &&-loading:not(&-circle):not(&-circle-outline):not(&-icon-only) {
-    position: relative;
     padding-left: 29px;
-    pointer-events: none;
     .@{iconfont-css-prefix}:not(:last-child) {
       margin-left: -14px;
     }


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?
Different others loading button, the circle button can handle pointer events. Because it's excluded by the css selector [`&&-loading:not(&-circle):not(&-circle-outline):not(&-icon-only)`](https://github.com/ant-design/ant-design/blob/master/components/button/style/index.less#L114)

### 💡 Solution

Setting `pointer-events: none;` style to all loading button, and setting `position: relative;` for the pseudo of loading button can position to its parent.

### 📝 Changelog

- English Changelog: fix: loading circle button can handle pointer events.
- Chinese Changelog (optional):

### ☑️ Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

-----
[View rendered components/button/demo/loading.md](https://github.com/gxvv/ant-design/blob/master/components/button/demo/loading.md)