### PR TITLE
fix: labelAlign should work in Form.Item

### DIFF
--- a/components/form/Form.tsx
+++ b/components/form/Form.tsx
@@ -8,7 +8,7 @@ import { ConfigConsumer, ConfigConsumerProps } from '../config-provider';
 import { ColProps } from '../grid/col';
 import { Omit, tuple } from '../_util/type';
 import warning from '../_util/warning';
-import FormItem, { LabelAlign } from './FormItem';
+import FormItem, { FormLabelAlign } from './FormItem';
 import { FIELD_META_PROP, FIELD_DATA_PROP } from './constants';
 import { FormContext } from './context';
 
@@ -47,7 +47,7 @@ export interface FormProps extends React.FormHTMLAttributes<HTMLFormElement> {
    * @since 3.15.0
    */
   colon?: boolean;
-  labelAlign?: LabelAlign;
+  labelAlign?: FormLabelAlign;
 }
 
 export type ValidationRule = {

--- a/components/form/Form.tsx
+++ b/components/form/Form.tsx
@@ -8,7 +8,7 @@ import { ConfigConsumer, ConfigConsumerProps } from '../config-provider';
 import { ColProps } from '../grid/col';
 import { Omit, tuple } from '../_util/type';
 import warning from '../_util/warning';
-import FormItem from './FormItem';
+import FormItem, { LabelAlign } from './FormItem';
 import { FIELD_META_PROP, FIELD_DATA_PROP } from './constants';
 import { FormContext } from './context';
 
@@ -47,7 +47,7 @@ export interface FormProps extends React.FormHTMLAttributes<HTMLFormElement> {
    * @since 3.15.0
    */
   colon?: boolean;
-  labelAlign?: 'left' | 'right';
+  labelAlign?: LabelAlign;
 }
 
 export type ValidationRule = {

--- a/components/form/FormItem.tsx
+++ b/components/form/FormItem.tsx
@@ -14,12 +14,14 @@ import { FormContext, FormContextProps } from './context';
 
 const ValidateStatuses = tuple('success', 'warning', 'error', 'validating', '');
 
+export type LabelAlign = 'left' | 'right';
+
 export interface FormItemProps {
   prefixCls?: string;
   className?: string;
   id?: string;
   label?: React.ReactNode;
-  labelAlign?: 'left' | 'right';
+  labelAlign?: LabelAlign;
   labelCol?: ColProps;
   wrapperCol?: ColProps;
   help?: React.ReactNode;
@@ -322,20 +324,23 @@ export default class FormItem extends React.Component<FormItemProps, any> {
       <FormContext.Consumer key="label">
         {({
           vertical,
-          labelAlign,
+          labelAlign: contextLabelAlign,
           labelCol: contextLabelCol,
           colon: contextColon,
         }: FormContextProps) => {
-          const { label, labelCol, colon, id } = this.props;
+          const { label, labelCol, labelAlign, colon, id } = this.props;
           const required = this.isRequired();
 
           const mergedLabelCol: ColProps =
             ('labelCol' in this.props ? labelCol : contextLabelCol) || {};
 
+          const mergedLabelAlign: LabelAlign | undefined =
+            'labelAlign' in this.props ? labelAlign : contextLabelAlign;
+
           const labelClsBasic = `${prefixCls}-item-label`;
           const labelColClassName = classNames(
             labelClsBasic,
-            labelAlign === 'left' && `${labelClsBasic}-left`,
+            mergedLabelAlign === 'left' && `${labelClsBasic}-left`,
             mergedLabelCol.className,
           );
 

--- a/components/form/FormItem.tsx
+++ b/components/form/FormItem.tsx
@@ -14,14 +14,14 @@ import { FormContext, FormContextProps } from './context';
 
 const ValidateStatuses = tuple('success', 'warning', 'error', 'validating', '');
 
-export type LabelAlign = 'left' | 'right';
+export type FormLabelAlign = 'left' | 'right';
 
 export interface FormItemProps {
   prefixCls?: string;
   className?: string;
   id?: string;
   label?: React.ReactNode;
-  labelAlign?: LabelAlign;
+  labelAlign?: FormLabelAlign;
   labelCol?: ColProps;
   wrapperCol?: ColProps;
   help?: React.ReactNode;
@@ -334,7 +334,7 @@ export default class FormItem extends React.Component<FormItemProps, any> {
           const mergedLabelCol: ColProps =
             ('labelCol' in this.props ? labelCol : contextLabelCol) || {};
 
-          const mergedLabelAlign: LabelAlign | undefined =
+          const mergedLabelAlign: FormLabelAlign | undefined =
             'labelAlign' in this.props ? labelAlign : contextLabelAlign;
 
           const labelClsBasic = `${prefixCls}-item-label`;

--- a/components/form/__tests__/__snapshots__/label.test.js.snap
+++ b/components/form/__tests__/__snapshots__/label.test.js.snap
@@ -28,6 +28,38 @@ exports[`Form should \`labelAlign\` work in FormItem 1`] = `
 </div>
 `;
 
+exports[`Form should \`labelAlign\` work in FormItem 2`] = `
+<form
+  class="ant-form ant-form-horizontal"
+>
+  <div
+    class="ant-row ant-form-item"
+  >
+    <div
+      class="ant-col ant-form-item-label ant-form-item-label-left"
+    >
+      <label
+        class=""
+        title="test"
+      >
+        test
+      </label>
+    </div>
+    <div
+      class="ant-col ant-form-item-control-wrapper"
+    >
+      <div
+        class="ant-form-item-control"
+      >
+        <span
+          class="ant-form-item-children"
+        />
+      </div>
+    </div>
+  </div>
+</form>
+`;
+
 exports[`Form should props colon of Form.Item override the props colon of Form. 1`] = `
 <form
   class="ant-form ant-form-horizontal"

--- a/components/form/__tests__/__snapshots__/label.test.js.snap
+++ b/components/form/__tests__/__snapshots__/label.test.js.snap
@@ -1,5 +1,33 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Form should \`labelAlign\` work in FormItem 1`] = `
+<div
+  class="ant-row ant-form-item"
+>
+  <div
+    class="ant-col ant-form-item-label ant-form-item-label-left"
+  >
+    <label
+      class=""
+      title="test"
+    >
+      test
+    </label>
+  </div>
+  <div
+    class="ant-col ant-form-item-control-wrapper"
+  >
+    <div
+      class="ant-form-item-control"
+    >
+      <span
+        class="ant-form-item-children"
+      />
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Form should props colon of Form.Item override the props colon of Form. 1`] = `
 <form
   class="ant-form ant-form-horizontal"

--- a/components/form/__tests__/label.test.js
+++ b/components/form/__tests__/label.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { mount } from 'enzyme';
+import { mount, render } from 'enzyme';
 import Form from '..';
 
 describe('Form', () => {
@@ -221,5 +221,9 @@ describe('Form', () => {
         .at(0)
         .getDOMNode(),
     ).toBe(document.activeElement);
+  });
+
+  it('should `labelAlign` work in FormItem', () => {
+    expect(render(<Form.Item label="test" labelAlign="left" />)).toMatchSnapshot();
   });
 });

--- a/components/form/__tests__/label.test.js
+++ b/components/form/__tests__/label.test.js
@@ -224,6 +224,16 @@ describe('Form', () => {
   });
 
   it('should `labelAlign` work in FormItem', () => {
+    // Works in Form.Item
     expect(render(<Form.Item label="test" labelAlign="left" />)).toMatchSnapshot();
+
+    // Use Form.Item first
+    expect(
+      render(
+        <Form labelAlign="right">
+          <Form.Item label="test" labelAlign="left" />
+        </Form>,
+      ),
+    ).toMatchSnapshot();
   });
 });

--- a/components/form/context.ts
+++ b/components/form/context.ts
@@ -1,10 +1,11 @@
 import createReactContext, { Context } from 'create-react-context';
 import { ColProps } from '../grid/col';
+import { LabelAlign } from './FormItem';
 
 export interface FormContextProps {
   vertical: boolean;
   colon?: boolean;
-  labelAlign?: string;
+  labelAlign?: LabelAlign;
   labelCol?: ColProps;
   wrapperCol?: ColProps;
 }

--- a/components/form/context.ts
+++ b/components/form/context.ts
@@ -1,11 +1,11 @@
 import createReactContext, { Context } from 'create-react-context';
 import { ColProps } from '../grid/col';
-import { LabelAlign } from './FormItem';
+import { FormLabelAlign } from './FormItem';
 
 export interface FormContextProps {
   vertical: boolean;
   colon?: boolean;
-  labelAlign?: LabelAlign;
+  labelAlign?: FormLabelAlign;
   labelCol?: ColProps;
   wrapperCol?: ColProps;
 }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?

fix #16067 

### 💡 Solution

Check `labelAlign` in props of Form.Item.

### 📝 Changelog

Fix `labelAlign` not works on Form.Item.

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
