### PR TITLE
fix: Should Pagination of List default work

### DIFF
--- a/components/list/__tests__/__snapshots__/pagination.test.js.snap
+++ b/components/list/__tests__/__snapshots__/pagination.test.js.snap
@@ -425,3 +425,143 @@ exports[`List.pagination should change page size work 2`] = `
   </li>
 </ul>
 `;
+
+exports[`List.pagination should default work 1`] = `
+<ul
+  class="ant-pagination "
+  unselectable="unselectable"
+>
+  <li
+    aria-disabled="false"
+    class=" ant-pagination-prev"
+    tabindex="0"
+    title="Previous Page"
+  >
+    <a
+      class="ant-pagination-item-link"
+    >
+      <i
+        aria-label="icon: left"
+        class="anticon anticon-left"
+      >
+        <svg
+          aria-hidden="true"
+          class=""
+          data-icon="left"
+          fill="currentColor"
+          focusable="false"
+          height="1em"
+          viewBox="64 64 896 896"
+          width="1em"
+        >
+          <path
+            d="M724 218.3V141c0-6.7-7.7-10.4-12.9-6.3L260.3 486.8a31.86 31.86 0 0 0 0 50.3l450.8 352.1c5.3 4.1 12.9.4 12.9-6.3v-77.3c0-4.9-2.3-9.6-6.1-12.6l-360-281 360-281.1c3.8-3 6.1-7.7 6.1-12.6z"
+          />
+        </svg>
+      </i>
+    </a>
+  </li>
+  <li
+    class="ant-pagination-item ant-pagination-item-1"
+    tabindex="0"
+    title="1"
+  >
+    <a>
+      1
+    </a>
+  </li>
+  <li
+    class="ant-pagination-item ant-pagination-item-2 ant-pagination-item-active"
+    tabindex="0"
+    title="2"
+  >
+    <a>
+      2
+    </a>
+  </li>
+  <li
+    aria-disabled="true"
+    class="ant-pagination-disabled ant-pagination-next"
+    title="Next Page"
+  >
+    <a
+      class="ant-pagination-item-link"
+    >
+      <i
+        aria-label="icon: right"
+        class="anticon anticon-right"
+      >
+        <svg
+          aria-hidden="true"
+          class=""
+          data-icon="right"
+          fill="currentColor"
+          focusable="false"
+          height="1em"
+          viewBox="64 64 896 896"
+          width="1em"
+        >
+          <path
+            d="M765.7 486.8L314.9 134.7A7.97 7.97 0 0 0 302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 0 0 0-50.4z"
+          />
+        </svg>
+      </i>
+    </a>
+  </li>
+  <li
+    class="ant-pagination-options"
+  >
+    <div
+      class="ant-pagination-options-size-changer ant-select ant-select-enabled"
+    >
+      <div
+        aria-autocomplete="list"
+        aria-controls="test-uuid"
+        aria-expanded="false"
+        aria-haspopup="true"
+        class="ant-select-selection
+            ant-select-selection--single"
+        role="combobox"
+        tabindex="0"
+      >
+        <div
+          class="ant-select-selection__rendered"
+        >
+          <div
+            class="ant-select-selection-selected-value"
+            style="display: block; opacity: 1;"
+            title="3 / page"
+          >
+            3 / page
+          </div>
+        </div>
+        <span
+          class="ant-select-arrow"
+          style="user-select: none;"
+          unselectable="on"
+        >
+          <i
+            aria-label="icon: down"
+            class="anticon anticon-down ant-select-arrow-icon"
+          >
+            <svg
+              aria-hidden="true"
+              class=""
+              data-icon="down"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+              />
+            </svg>
+          </i>
+        </span>
+      </div>
+    </div>
+  </li>
+</ul>
+`;

--- a/components/list/__tests__/pagination.test.js
+++ b/components/list/__tests__/pagination.test.js
@@ -175,4 +175,24 @@ describe('List.pagination', () => {
         .render(),
     ).toMatchSnapshot();
   });
+
+  it('should default work', () => {
+    const wrapper = mount(
+      createList({
+        pagination: {
+          defaultPageSize: 3,
+          defaultCurrent: 2,
+          pageSizeOptions: ['1', '3'],
+          showSizeChanger: true,
+        },
+      }),
+    );
+
+    expect(
+      wrapper
+        .find('Pagination')
+        .first()
+        .render(),
+    ).toMatchSnapshot();
+  });
 });

--- a/components/list/index.tsx
+++ b/components/list/index.tsx
@@ -78,11 +78,6 @@ export default class List<T> extends React.Component<ListProps<T>, ListState> {
     pagination: false as ListProps<any>['pagination'],
   };
 
-  state = {
-    paginationCurrent: 1,
-    paginationSize: 10,
-  };
-
   defaultPaginationProps = {
     current: 1,
     total: 0,
@@ -93,6 +88,18 @@ export default class List<T> extends React.Component<ListProps<T>, ListState> {
   private onPaginationChange = this.triggerPaginationEvent('onChange');
 
   private onPaginationShowSizeChange = this.triggerPaginationEvent('onShowSizeChange');
+
+  constructor(props: ListProps<T>) {
+    super(props);
+
+    const { pagination } = props;
+    const paginationObj = typeof pagination === 'object' ? pagination : {};
+
+    this.state = {
+      paginationCurrent: paginationObj.defaultCurrent || 1,
+      paginationSize: paginationObj.defaultPageSize || 10,
+    };
+  }
 
   getChildContext() {
     return {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?

fix #16100

### 💡 Solution

Pass defaultProps to internal pagination

### 📝 Changelog

Fix default props on Pagination of List not work.

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
