### PR TITLE
feat: Inherit menu line-height from header

### DIFF
--- a/components/layout/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/layout/__tests__/__snapshots__/demo.test.js.snap
@@ -280,12 +280,11 @@ exports[`renders ./components/layout/demo/fixed.md correctly 1`] = `
     <ul
       class="ant-menu ant-menu-dark ant-menu-root ant-menu-horizontal"
       role="menu"
-      style="line-height:64px"
     >
       <li
         class="ant-menu-submenu ant-menu-submenu-horizontal ant-menu-overflowed-submenu"
         role="menuitem"
-        style="line-height:64px;display:none"
+        style="display:none"
       >
         <div
           aria-expanded="false"
@@ -309,7 +308,7 @@ exports[`renders ./components/layout/demo/fixed.md correctly 1`] = `
       <li
         class="ant-menu-submenu ant-menu-submenu-horizontal ant-menu-overflowed-submenu"
         role="menuitem"
-        style="line-height:64px;display:none"
+        style="display:none"
       >
         <div
           aria-expanded="false"
@@ -333,7 +332,7 @@ exports[`renders ./components/layout/demo/fixed.md correctly 1`] = `
       <li
         class="ant-menu-submenu ant-menu-submenu-horizontal ant-menu-overflowed-submenu"
         role="menuitem"
-        style="line-height:64px;display:none"
+        style="display:none"
       >
         <div
           aria-expanded="false"
@@ -357,7 +356,7 @@ exports[`renders ./components/layout/demo/fixed.md correctly 1`] = `
       <li
         class="ant-menu-submenu ant-menu-submenu-horizontal ant-menu-overflowed-submenu"
         role="menuitem"
-        style="line-height:64px;visibility:hidden;position:absolute"
+        style="visibility:hidden;position:absolute"
       >
         <div
           aria-expanded="false"
@@ -1264,12 +1263,11 @@ exports[`renders ./components/layout/demo/top.md correctly 1`] = `
     <ul
       class="ant-menu ant-menu-dark ant-menu-root ant-menu-horizontal"
       role="menu"
-      style="line-height:64px"
     >
       <li
         class="ant-menu-submenu ant-menu-submenu-horizontal ant-menu-overflowed-submenu"
         role="menuitem"
-        style="line-height:64px;display:none"
+        style="display:none"
       >
         <div
           aria-expanded="false"
@@ -1293,7 +1291,7 @@ exports[`renders ./components/layout/demo/top.md correctly 1`] = `
       <li
         class="ant-menu-submenu ant-menu-submenu-horizontal ant-menu-overflowed-submenu"
         role="menuitem"
-        style="line-height:64px;display:none"
+        style="display:none"
       >
         <div
           aria-expanded="false"
@@ -1317,7 +1315,7 @@ exports[`renders ./components/layout/demo/top.md correctly 1`] = `
       <li
         class="ant-menu-submenu ant-menu-submenu-horizontal ant-menu-overflowed-submenu"
         role="menuitem"
-        style="line-height:64px;display:none"
+        style="display:none"
       >
         <div
           aria-expanded="false"
@@ -1341,7 +1339,7 @@ exports[`renders ./components/layout/demo/top.md correctly 1`] = `
       <li
         class="ant-menu-submenu ant-menu-submenu-horizontal ant-menu-overflowed-submenu"
         role="menuitem"
-        style="line-height:64px;visibility:hidden;position:absolute"
+        style="visibility:hidden;position:absolute"
       >
         <div
           aria-expanded="false"
@@ -1431,12 +1429,11 @@ exports[`renders ./components/layout/demo/top-side.md correctly 1`] = `
     <ul
       class="ant-menu ant-menu-dark ant-menu-root ant-menu-horizontal"
       role="menu"
-      style="line-height:64px"
     >
       <li
         class="ant-menu-submenu ant-menu-submenu-horizontal ant-menu-overflowed-submenu"
         role="menuitem"
-        style="line-height:64px;display:none"
+        style="display:none"
       >
         <div
           aria-expanded="false"
@@ -1460,7 +1457,7 @@ exports[`renders ./components/layout/demo/top-side.md correctly 1`] = `
       <li
         class="ant-menu-submenu ant-menu-submenu-horizontal ant-menu-overflowed-submenu"
         role="menuitem"
-        style="line-height:64px;display:none"
+        style="display:none"
       >
         <div
           aria-expanded="false"
@@ -1484,7 +1481,7 @@ exports[`renders ./components/layout/demo/top-side.md correctly 1`] = `
       <li
         class="ant-menu-submenu ant-menu-submenu-horizontal ant-menu-overflowed-submenu"
         role="menuitem"
-        style="line-height:64px;display:none"
+        style="display:none"
       >
         <div
           aria-expanded="false"
@@ -1508,7 +1505,7 @@ exports[`renders ./components/layout/demo/top-side.md correctly 1`] = `
       <li
         class="ant-menu-submenu ant-menu-submenu-horizontal ant-menu-overflowed-submenu"
         role="menuitem"
-        style="line-height:64px;visibility:hidden;position:absolute"
+        style="visibility:hidden;position:absolute"
       >
         <div
           aria-expanded="false"
@@ -1767,12 +1764,11 @@ exports[`renders ./components/layout/demo/top-side-2.md correctly 1`] = `
     <ul
       class="ant-menu ant-menu-dark ant-menu-root ant-menu-horizontal"
       role="menu"
-      style="line-height:64px"
     >
       <li
         class="ant-menu-submenu ant-menu-submenu-horizontal ant-menu-overflowed-submenu"
         role="menuitem"
-        style="line-height:64px;display:none"
+        style="display:none"
       >
         <div
           aria-expanded="false"
@@ -1796,7 +1792,7 @@ exports[`renders ./components/layout/demo/top-side-2.md correctly 1`] = `
       <li
         class="ant-menu-submenu ant-menu-submenu-horizontal ant-menu-overflowed-submenu"
         role="menuitem"
-        style="line-height:64px;display:none"
+        style="display:none"
       >
         <div
           aria-expanded="false"
@@ -1820,7 +1816,7 @@ exports[`renders ./components/layout/demo/top-side-2.md correctly 1`] = `
       <li
         class="ant-menu-submenu ant-menu-submenu-horizontal ant-menu-overflowed-submenu"
         role="menuitem"
-        style="line-height:64px;display:none"
+        style="display:none"
       >
         <div
           aria-expanded="false"
@@ -1844,7 +1840,7 @@ exports[`renders ./components/layout/demo/top-side-2.md correctly 1`] = `
       <li
         class="ant-menu-submenu ant-menu-submenu-horizontal ant-menu-overflowed-submenu"
         role="menuitem"
-        style="line-height:64px;visibility:hidden;position:absolute"
+        style="visibility:hidden;position:absolute"
       >
         <div
           aria-expanded="false"

--- a/components/layout/demo/fixed.md
+++ b/components/layout/demo/fixed.md
@@ -27,7 +27,6 @@ ReactDOM.render(
         theme="dark"
         mode="horizontal"
         defaultSelectedKeys={['2']}
-        style={{ lineHeight: '64px' }}
       >
         <Menu.Item key="1">nav 1</Menu.Item>
         <Menu.Item key="2">nav 2</Menu.Item>

--- a/components/layout/demo/top-side-2.md
+++ b/components/layout/demo/top-side-2.md
@@ -29,7 +29,6 @@ ReactDOM.render(
         theme="dark"
         mode="horizontal"
         defaultSelectedKeys={['2']}
-        style={{ lineHeight: '64px' }}
       >
         <Menu.Item key="1">nav 1</Menu.Item>
         <Menu.Item key="2">nav 2</Menu.Item>

--- a/components/layout/demo/top-side.md
+++ b/components/layout/demo/top-side.md
@@ -31,7 +31,6 @@ ReactDOM.render(
         theme="dark"
         mode="horizontal"
         defaultSelectedKeys={['2']}
-        style={{ lineHeight: '64px' }}
       >
         <Menu.Item key="1">nav 1</Menu.Item>
         <Menu.Item key="2">nav 2</Menu.Item>

--- a/components/layout/demo/top.md
+++ b/components/layout/demo/top.md
@@ -33,7 +33,6 @@ ReactDOM.render(
         theme="dark"
         mode="horizontal"
         defaultSelectedKeys={['2']}
-        style={{ lineHeight: '64px' }}
       >
         <Menu.Item key="1">nav 1</Menu.Item>
         <Menu.Item key="2">nav 2</Menu.Item>

--- a/components/menu/style/index.less
+++ b/components/menu/style/index.less
@@ -500,4 +500,11 @@
   }
 }
 
+// Integration with header element so menu items have the same height
+.@{ant-prefix}-layout-header {
+  .@{menu-prefix-cls} {
+    line-height: inherit;
+  }
+}
+
 @import './dark';


### PR DESCRIPTION
### 🤔 This is a ...

- [x] New feature
- [x] Bug fix

### 👻 What's the background?

One of the first things developer does when working with antd is to create `Layout` and site's `Header`. The next thing is usually adding horizontal `Menu` to header and here's disappointment: the line-height of the menu doesn't match line-height of header (header's default line-height is 64px while horizontal menu's is [hardcored](https://github.com/ant-design/ant-design/blob/3a114020424d44a573fe595c11dd709c3757e3bb/components/menu/style/index.less#L283) to `46px`.

It would be really nice if horizontal menu placed inside header automatically inherited the height of header, so manually setting line-height of menu (like you do in [antd-pro](https://github.com/ant-design/ant-design-pro/blob/123f46d79dcfaa9bf0500eb2d814deacbaf321c0/src/components/TopNavHeader/index.less)) is not necessary.

### 💡 Solution

This pull request adds single rule that makes horizontal menu inside header to automatically inherit its line-height. I've also updated documentation and removed manually setting lineHeight of menu because now it's not necessary.

This change is backward-compatible because inline styles of Menu take precedence.

### 📝 Changelog

- English Changelog: Inherit menu line-height from header
- Chinese Changelog (optional):

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

-----
[View rendered components/layout/demo/fixed.md](https://github.com/sheerun/ant-design/blob/menu-line-height/components/layout/demo/fixed.md)
[View rendered components/layout/demo/top-side-2.md](https://github.com/sheerun/ant-design/blob/menu-line-height/components/layout/demo/top-side-2.md)
[View rendered components/layout/demo/top-side.md](https://github.com/sheerun/ant-design/blob/menu-line-height/components/layout/demo/top-side.md)
[View rendered components/layout/demo/top.md](https://github.com/sheerun/ant-design/blob/menu-line-height/components/layout/demo/top.md)