### PR TITLE
Button icon core is not fully handled

### DIFF
--- a/components/button/button.tsx
+++ b/components/button/button.tsx
@@ -48,10 +48,14 @@ const ButtonSizes = tuple('large', 'default', 'small');
 export type ButtonSize = (typeof ButtonSizes)[number];
 const ButtonHTMLTypes = tuple('submit', 'button', 'reset');
 export type ButtonHTMLType = (typeof ButtonHTMLTypes)[number];
+const IconThemes = tuple('filled', 'outlined', 'twoTone');
+export type IconTheme = (typeof IconThemes)[number];
 
 export interface BaseButtonProps {
   type?: ButtonType;
   icon?: string;
+  iconTheme?: IconTheme;
+  iconTwoToneColor?: string;
   shape?: ButtonShape;
   size?: ButtonSize;
   loading?: boolean | { delay?: number };
@@ -105,6 +109,8 @@ class Button extends React.Component<ButtonProps, ButtonState> {
     loading: PropTypes.oneOfType([PropTypes.bool, PropTypes.object]),
     className: PropTypes.string,
     icon: PropTypes.string,
+    iconTheme: PropTypes.oneOf(IconThemes),
+    iconTwoToneColor: PropTypes.string,
     block: PropTypes.bool,
   };
 
@@ -204,6 +210,8 @@ class Button extends React.Component<ButtonProps, ButtonState> {
       className,
       children,
       icon,
+      iconTheme,
+      iconTwoToneColor,
       ghost,
       loading: _loadingProp,
       block,
@@ -240,7 +248,9 @@ class Button extends React.Component<ButtonProps, ButtonState> {
     });
 
     const iconType = loading ? 'loading' : icon;
-    const iconNode = iconType ? <Icon type={iconType} /> : null;
+    const iconNode = iconType ? (
+      <Icon type={iconType} theme={iconTheme} twoToneColor={iconTwoToneColor} />
+    ) : null;
     const kids =
       children || children === 0
         ? React.Children.map(children, child =>

--- a/components/button/index.en-US.md
+++ b/components/button/index.en-US.md
@@ -21,6 +21,8 @@ To get a customized button, just set `type`/`shape`/`size`/`loading`/`disabled`.
 | href | redirect url of link button | string | - |
 | htmlType | set the original html `type` of `button`, see: [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#attr-type) | string | `button` |
 | icon | set the icon of button, see: Icon component | string | - |
+| iconTheme | set the icon theme of the button, icon see: Icon component | `'outlined' | 'filled' | 'twoToneColor'` | - |
+| iconTwoToneColor | set the icon two tone color of the button icon, in the case `iconTheme` is set to `'twoToneColor'`, see: Icon component | string | - |
 | loading | set the loading status of button | boolean \| { delay: number } | `false` |
 | shape | can be set to `circle`, `round` or omitted | string | - |
 | size | can be set to `small` `large` or omitted | string | `default` |


### PR DESCRIPTION
### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?

We often use Button with the icon property but we aren't able to set an icon theme directly with Button component declaration. We could have used a nested icon but what i'd say is : If the Button component has an `icon` property, it could handle it all the way.

### 💡 Solution

I added two new props to the `Button` component :

1. `iconTheme`, a `union` set to either 'filled' or 'outlined' or 'twoTone'
2. `iconTwoToneColor`, a `string` set to the primary two tone color as in the `Icon` component API

### 📝 Changelog

* User can now set `iconTheme` and `iconTwoToneColor` directly to the Button component declaration


-----
[View rendered components/button/index.en-US.md](https://github.com/mikedotJS/ant-design/blob/button-icon-is-not-fully-handled/components/button/index.en-US.md)