### PR TITLE
add text selection in less vars so we can overwrite it independent

### DIFF
--- a/components/style/core/base.less
+++ b/components/style/core/base.less
@@ -501,7 +501,7 @@ mark {
 
 ::selection {
   color: @text-color-inverse;
-  background: @primary-color;
+  background: @text-selection-bg;
 }
 
 // Utility classes

--- a/components/style/themes/default.less
+++ b/components/style/themes/default.less
@@ -56,6 +56,7 @@
 @heading-color-dark: fade(@white, 100%);
 @text-color-dark: fade(@white, 85%);
 @text-color-secondary-dark: fade(@white, 65%);
+@text-selection-bg: @primary-color;
 @font-variant-base: tabular-nums;
 @font-feature-settings-base: 'tnum';
 @font-size-base: 14px;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->
### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / document update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?

<!--
1. Describe the source of requirement, like related issue link.

2. Describe the problem and the scenario.
-->

Use less-loader to overwrite primary-color, but i dont like modify background style in `::selection`

### 💡 Solution

<!--
1. How to fix the problem, and list final API implementation and usage sample if that is an new feature.

2. GIF or snapshot should be provided if includes UI/interactive modification.
-->

add a independent less var to override. but its not affect default style

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

- English Changelog:
add less var `text-selection-bg`
- Chinese Changelog (optional):
增加less变量`text-selection-bg`

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
