### PR TITLE
Fix className prop issue when using Tooltip

### DIFF
--- a/components/tooltip/index.tsx
+++ b/components/tooltip/index.tsx
@@ -81,8 +81,8 @@ const splitObject = (obj: any, keys: string[]) => {
   return { picked, omitted };
 };
 
-class Tooltip extends React.Component<TooltipProps, any> {
-  static defaultProps = {
+class Tooltip extends React.Component<TooltipProps & React.HTMLAttributes<HTMLElement>, any> {
+    static defaultProps = {
     placement: 'top' as TooltipPlacement,
     transitionName: 'zoom-big-fast',
     mouseEnterDelay: 0.1,

--- a/components/tooltip/index.tsx
+++ b/components/tooltip/index.tsx
@@ -82,7 +82,7 @@ const splitObject = (obj: any, keys: string[]) => {
 };
 
 class Tooltip extends React.Component<TooltipProps & React.HTMLAttributes<HTMLElement>, any> {
-    static defaultProps = {
+  static defaultProps = {
     placement: 'top' as TooltipPlacement,
     transitionName: 'zoom-big-fast',
     mouseEnterDelay: 0.1,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->
### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [X] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?
1. Cannot add className prop to Tooltip when using Typescript: https://github.com/ant-design/ant-design/issues/16194.
2. TS error is thrown when adding this className prop.
<!--
1. Describe the source of requirement, like related issue link.

2. Describe the problem and the scenario.
-->

### 💡 Solution
Tooltip Props now extend React.HTMLAttributes<HTMLElement>.
<!--
1. How to fix the problem, and list final API implementation and usage sample if that is an new feature.

2. GIF or snapshot should be provided if includes UI/interactive modification.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

- English Changelog:
- Chinese Changelog (optional):

### ☑️ Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
