### PR TITLE
fix: Ajudst typescript def of `allowSyntheticDefaultImports: false` user

### DIFF
--- a/components/form/interface.ts
+++ b/components/form/interface.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import hoistNonReactStatics from 'hoist-non-react-statics';
+import * as hoistNonReactStatics from 'hoist-non-react-statics';
 import { Omit } from '../_util/type';
 import { FormComponentProps } from './Form';
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->
### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?

close #16210

### 💡 Solution

```tsx
import * as hoistNonReactStatics from 'hoist-non-react-statics';
```

### 📝 Changelog

Fix typescript `hoist-non-react-statics' has no default export` warning with `allowSyntheticDefaultImports: false` user.

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
