### PR TITLE
fix: List pagination is null should not crash

### DIFF
--- a/components/list/__tests__/pagination.test.js
+++ b/components/list/__tests__/pagination.test.js
@@ -195,4 +195,12 @@ describe('List.pagination', () => {
         .render(),
     ).toMatchSnapshot();
   });
+
+  it('should not crash when pagination is null', () => {
+    mount(
+      createList({
+        pagination: null,
+      }),
+    );
+  });
 });

--- a/components/list/index.tsx
+++ b/components/list/index.tsx
@@ -93,7 +93,7 @@ export default class List<T> extends React.Component<ListProps<T>, ListState> {
     super(props);
 
     const { pagination } = props;
-    const paginationObj = typeof pagination === 'object' ? pagination : {};
+    const paginationObj = pagination && typeof pagination === 'object' ? pagination : {};
 
     this.state = {
       paginationCurrent: paginationObj.defaultCurrent || 1,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?

https://codesandbox.io/s/p52mm2vj97

### 💡 Solution

`pagination && typeof pagination === 'object'`

### 📝 Changelog

Fix List `pagination` crash when is `null`

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
