### PR TITLE
fix: Select should trigger onSearch when search input is empty

### DIFF
--- a/components/select/demo/search.md
+++ b/components/select/demo/search.md
@@ -18,16 +18,20 @@ import { Select } from 'antd';
 
 const Option = Select.Option;
 
-function handleChange(value) {
+function onChange(value) {
   console.log(`selected ${value}`);
 }
 
-function handleBlur() {
+function onBlur() {
   console.log('blur');
 }
 
-function handleFocus() {
+function onFocus() {
   console.log('focus');
+}
+
+function onSearch(val) {
+  console.log('search:', val);
 }
 
 ReactDOM.render(
@@ -36,9 +40,10 @@ ReactDOM.render(
     style={{ width: 200 }}
     placeholder="Select a person"
     optionFilterProp="children"
-    onChange={handleChange}
-    onFocus={handleFocus}
-    onBlur={handleBlur}
+    onChange={onChange}
+    onFocus={onFocus}
+    onBlur={onBlur}
+    onSearch={onSearch}
     filterOption={(input, option) => option.props.children.toLowerCase().indexOf(input.toLowerCase()) >= 0}
   >
     <Option value="jack">Jack</Option>

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "rc-pagination": "~1.17.7",
     "rc-progress": "~2.3.0",
     "rc-rate": "~2.5.0",
-    "rc-select": "~9.0.0",
+    "rc-select": "~9.1.0",
     "rc-slider": "~8.6.5",
     "rc-steps": "~3.3.0",
     "rc-switch": "~1.9.0",


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?

fix #16223 

### 💡 Solution

update `rc-select`

### 📝 Changelog

Fix Select not trigger onSearch when input is empty

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/select/demo/search.md](https://github.com/ant-design/ant-design/blob/select-onSearch/components/select/demo/search.md)