### PR TITLE
fix: remove active style from disabled Switch

### DIFF
--- a/components/switch/style/index.less
+++ b/components/switch/style/index.less
@@ -47,8 +47,8 @@
     box-shadow: 0 2px 4px 0 @switch-shadow-color;
   }
 
-  &:active::before,
-  &:active::after {
+  &:not(&-disabled):active::before,
+  &:not(&-disabled):active::after {
     width: 24px;
   }
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?

fix #16246

### 💡 Solution

change `&:active::after` to `&:not(&-disabled):active::after`

### 📝 Changelog
- English Changelog:
remove the active style of disabled Switch
- Chinese Changelog (optional):
去掉了失效状态下Switch的active样式

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
