### PR TITLE
feat: support checkable tag with colors

### DIFF
--- a/components/tag/CheckableTag.tsx
+++ b/components/tag/CheckableTag.tsx
@@ -24,13 +24,14 @@ export default class CheckableTag extends React.Component<CheckableTagProps> {
   renderCheckableTag = ({ getPrefixCls }: ConfigConsumerProps) => {
     const { prefixCls: customizePrefixCls, className, checked, color, ...restProps } = this.props;
     const prefixCls = getPrefixCls('tag', customizePrefixCls);
+    const isPreset = isPresetColor(color);
     const cls = classNames(
       prefixCls,
       {
         [`${prefixCls}-checkable`]: true,
         [`${prefixCls}-checkable-checked`]: checked,
-        [`${prefixCls}-has-color`]: !!color,
-        [`${prefixCls}-${color}`]: color && isPresetColor(color) ? !!color : false,
+        [`${prefixCls}-has-color`]: !!color && !isPreset,
+        [`${prefixCls}-${color}`]: color && isPreset ? !!color : false,
       },
       className,
     );
@@ -54,9 +55,11 @@ export default class CheckableTag extends React.Component<CheckableTagProps> {
 
   getTagStyle() {
     const { color, unCheckedColor, style, checked } = this.props;
+    const isPreset = isPresetColor(color);
     return {
+      color: !isPreset && !checked ? color : undefined,
       backgroundColor:
-        color && !isPresetColor(color) ? (checked ? color : unCheckedColor) : undefined,
+        color && !isPreset ? (checked ? color : unCheckedColor) : undefined,
       ...style,
     };
   }

--- a/components/tag/CheckableTag.tsx
+++ b/components/tag/CheckableTag.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import classNames from 'classnames';
-import { PresetColorTypes } from '../_util/colors';
 import { ConfigConsumer, ConfigConsumerProps } from '../config-provider';
+import { isPresetColor } from './util';
 
 export interface CheckableTagProps {
   prefixCls?: string;
@@ -12,8 +12,6 @@ export interface CheckableTagProps {
   onChange?: (checked: boolean) => void;
   style?: React.CSSProperties;
 }
-
-const PresetColorRegex = new RegExp(`^(${PresetColorTypes.join('|')})(-inverse)?$`);
 
 export default class CheckableTag extends React.Component<CheckableTagProps> {
   handleClick = () => {
@@ -32,7 +30,7 @@ export default class CheckableTag extends React.Component<CheckableTagProps> {
         [`${prefixCls}-checkable`]: true,
         [`${prefixCls}-checkable-checked`]: checked,
         [`${prefixCls}-has-color`]: !!color,
-        [`${prefixCls}-${color}`]: color && this.isPresetColor(color) ? !!color : false,
+        [`${prefixCls}-${color}`]: color && isPresetColor(color) ? !!color : false,
       },
       className,
     );
@@ -56,17 +54,10 @@ export default class CheckableTag extends React.Component<CheckableTagProps> {
 
   getTagStyle() {
     const { color, unCheckedColor, style, checked } = this.props;
-    const isPresetColor = this.isPresetColor(color);
     return {
-      backgroundColor: color && !isPresetColor ? (checked ? color : unCheckedColor) : undefined,
+      backgroundColor:
+        color && !isPresetColor(color) ? (checked ? color : unCheckedColor) : undefined,
       ...style,
     };
-  }
-
-  isPresetColor(color?: string): boolean {
-    if (!color) {
-      return false;
-    }
-    return PresetColorRegex.test(color);
   }
 }

--- a/components/tag/CheckableTag.tsx
+++ b/components/tag/CheckableTag.tsx
@@ -1,13 +1,19 @@
 import * as React from 'react';
 import classNames from 'classnames';
+import { PresetColorTypes } from '../_util/colors';
 import { ConfigConsumer, ConfigConsumerProps } from '../config-provider';
 
 export interface CheckableTagProps {
   prefixCls?: string;
   className?: string;
   checked: boolean;
+  color?: string;
+  unCheckedColor?: string;
   onChange?: (checked: boolean) => void;
+  style?: React.CSSProperties;
 }
+
+const PresetColorRegex = new RegExp(`^(${PresetColorTypes.join('|')})(-inverse)?$`);
 
 export default class CheckableTag extends React.Component<CheckableTagProps> {
   handleClick = () => {
@@ -16,23 +22,51 @@ export default class CheckableTag extends React.Component<CheckableTagProps> {
       onChange(!checked);
     }
   };
+
   renderCheckableTag = ({ getPrefixCls }: ConfigConsumerProps) => {
-    const { prefixCls: customizePrefixCls, className, checked, ...restProps } = this.props;
+    const { prefixCls: customizePrefixCls, className, checked, color, ...restProps } = this.props;
     const prefixCls = getPrefixCls('tag', customizePrefixCls);
     const cls = classNames(
       prefixCls,
       {
         [`${prefixCls}-checkable`]: true,
         [`${prefixCls}-checkable-checked`]: checked,
+        [`${prefixCls}-has-color`]: !!color,
+        [`${prefixCls}-${color}`]: color && this.isPresetColor(color) ? !!color : false,
       },
       className,
     );
 
-    delete (restProps as any).onChange; // TypeScript cannot check delete now.
-    return <div {...restProps as any} className={cls} onClick={this.handleClick} />;
+    Reflect.deleteProperty(restProps, 'onChange');
+    Reflect.deleteProperty(restProps, 'unCheckedColor');
+
+    return (
+      <div
+        {...restProps as any}
+        style={this.getTagStyle()}
+        className={cls}
+        onClick={this.handleClick}
+      />
+    );
   };
 
   render() {
     return <ConfigConsumer>{this.renderCheckableTag}</ConfigConsumer>;
+  }
+
+  getTagStyle() {
+    const { color, unCheckedColor, style, checked } = this.props;
+    const isPresetColor = this.isPresetColor(color);
+    return {
+      backgroundColor: color && !isPresetColor ? (checked ? color : unCheckedColor) : undefined,
+      ...style,
+    };
+  }
+
+  isPresetColor(color?: string): boolean {
+    if (!color) {
+      return false;
+    }
+    return PresetColorRegex.test(color);
   }
 }

--- a/components/tag/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/tag/__tests__/__snapshots__/demo.test.js.snap
@@ -203,12 +203,13 @@ exports[`renders ./components/tag/demo/checkable.md correctly 1`] = `
     Tag1
   </div>
   <div
-    class="ant-tag ant-tag-checkable ant-tag-checkable-checked"
+    class="ant-tag ant-tag-checkable ant-tag-checkable-checked ant-tag-has-color"
+    style="background-color:#f50"
   >
     Tag2
   </div>
   <div
-    class="ant-tag ant-tag-checkable ant-tag-checkable-checked"
+    class="ant-tag ant-tag-checkable ant-tag-checkable-checked ant-tag-has-color ant-tag-magenta"
   >
     Tag3
   </div>

--- a/components/tag/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/tag/__tests__/__snapshots__/demo.test.js.snap
@@ -209,7 +209,7 @@ exports[`renders ./components/tag/demo/checkable.md correctly 1`] = `
     Tag2
   </div>
   <div
-    class="ant-tag ant-tag-checkable ant-tag-checkable-checked ant-tag-has-color ant-tag-magenta"
+    class="ant-tag ant-tag-checkable ant-tag-checkable-checked ant-tag-magenta"
   >
     Tag3
   </div>

--- a/components/tag/demo/checkable.md
+++ b/components/tag/demo/checkable.md
@@ -37,7 +37,7 @@ class MyTag extends React.Component {
 ReactDOM.render(
   <div>
     <MyTag>Tag1</MyTag>
-    <MyTag color="#f50" unCheckedColor="#f88">Tag2</MyTag>
+    <MyTag color="#f50" unCheckedColor="rgba(256, 80, 0, 0.2)">Tag2</MyTag>
     <MyTag color="magenta">Tag3</MyTag>
   </div>,
   mountNode

--- a/components/tag/demo/checkable.md
+++ b/components/tag/demo/checkable.md
@@ -30,7 +30,7 @@ class MyTag extends React.Component {
   }
 
   render() {
-    return <CheckableTag {...this.props} checked={this.state.checked} onChange={this.handleChange}/>;
+    return <CheckableTag {...this.props} checked={this.state.checked} onChange={this.handleChange} />;
   }
 }
 

--- a/components/tag/demo/checkable.md
+++ b/components/tag/demo/checkable.md
@@ -30,15 +30,15 @@ class MyTag extends React.Component {
   }
 
   render() {
-    return <CheckableTag {...this.props} checked={this.state.checked} onChange={this.handleChange} />;
+    return <CheckableTag {...this.props} checked={this.state.checked} onChange={this.handleChange}/>;
   }
 }
 
 ReactDOM.render(
   <div>
     <MyTag>Tag1</MyTag>
-    <MyTag>Tag2</MyTag>
-    <MyTag>Tag3</MyTag>
+    <MyTag color="#f50" unCheckedColor="#f88">Tag2</MyTag>
+    <MyTag color="magenta">Tag3</MyTag>
   </div>,
   mountNode
 );

--- a/components/tag/index.en-US.md
+++ b/components/tag/index.en-US.md
@@ -28,5 +28,7 @@ Tag for categorizing or markup.
 
 | Property | Description | Type | Default |
 | -------- | ----------- | ---- | ------- |
-| checked | Checked status of Tag | boolean | `false` |
+| checked | Checked status of Tag | boolean | `false` | 
+| color | Color of the Tag when it is checked | string | - | 
+| unCheckedColor | Color of the Tag when it is unchecked | string | - | 
 | onChange | Callback executed when Tag is checked/unchecked | (checked) => void | - |

--- a/components/tag/index.tsx
+++ b/components/tag/index.tsx
@@ -7,7 +7,7 @@ import CheckableTag from './CheckableTag';
 import { ConfigConsumer, ConfigConsumerProps } from '../config-provider';
 import warning from '../_util/warning';
 import Wave from '../_util/wave';
-import { isPresetColor, PresetColorRegex } from './util';
+import { isPresetColor } from './util';
 
 export { CheckableTagProps } from './CheckableTag';
 

--- a/components/tag/index.tsx
+++ b/components/tag/index.tsx
@@ -5,9 +5,9 @@ import { polyfill } from 'react-lifecycles-compat';
 import Icon from '../icon';
 import CheckableTag from './CheckableTag';
 import { ConfigConsumer, ConfigConsumerProps } from '../config-provider';
-import { PresetColorTypes } from '../_util/colors';
 import warning from '../_util/warning';
 import Wave from '../_util/wave';
+import { isPresetColor, PresetColorRegex } from './util';
 
 export { CheckableTagProps } from './CheckableTag';
 
@@ -25,8 +25,6 @@ export interface TagProps extends React.HTMLAttributes<HTMLDivElement> {
 interface TagState {
   visible: boolean;
 }
-
-const PresetColorRegex = new RegExp(`^(${PresetColorTypes.join('|')})(-inverse)?$`);
 
 class Tag extends React.Component<TagProps, TagState> {
   static CheckableTag = CheckableTag;
@@ -77,18 +75,10 @@ class Tag extends React.Component<TagProps, TagState> {
     this.setVisible(false, e);
   };
 
-  isPresetColor(color?: string): boolean {
-    if (!color) {
-      return false;
-    }
-    return PresetColorRegex.test(color);
-  }
-
   getTagStyle() {
     const { color, style } = this.props;
-    const isPresetColor = this.isPresetColor(color);
     return {
-      backgroundColor: color && !isPresetColor ? color : undefined,
+      backgroundColor: color && !isPresetColor(color) ? color : undefined,
       ...style,
     };
   }
@@ -96,13 +86,13 @@ class Tag extends React.Component<TagProps, TagState> {
   getTagClassName({ getPrefixCls }: ConfigConsumerProps) {
     const { prefixCls: customizePrefixCls, className, color } = this.props;
     const { visible } = this.state;
-    const isPresetColor = this.isPresetColor(color);
+    const isPreset = isPresetColor(color);
     const prefixCls = getPrefixCls('tag', customizePrefixCls);
     return classNames(
       prefixCls,
       {
-        [`${prefixCls}-${color}`]: isPresetColor,
-        [`${prefixCls}-has-color`]: color && !isPresetColor,
+        [`${prefixCls}-${color}`]: isPreset,
+        [`${prefixCls}-has-color`]: color && !isPreset,
         [`${prefixCls}-hidden`]: !visible,
       },
       className,

--- a/components/tag/index.zh-CN.md
+++ b/components/tag/index.zh-CN.md
@@ -29,4 +29,6 @@ title: Tag
 | 参数 | 说明 | 类型 | 默认值 |
 | --- | --- | --- | --- |
 | checked | 设置标签的选中状态 | boolean | false |
+| color | 标签选中时的颜色，默认为蓝色 | string | - |
+| unCheckedColor | 标签未选中时的颜色，默认为透明 | string | - |
 | onChange | 点击标签时触发的回调 | (checked) => void | - |

--- a/components/tag/style/index.less
+++ b/components/tag/style/index.less
@@ -102,35 +102,44 @@
     }
   }
 
+  .make-checkable-color-classes(@j: length(@preset-colors)) when (@j > 0) {
+    .make-checkable-color-classes(@j - 1);
+    @color: extract(@preset-colors, @j);
+    @lightColor: '@{color}-1';
+    @lightBorderColor: '@{color}-3';
+    @darkColor: '@{color}-6';
+
+    &-checkable {
+      &.@{tag-prefix-cls}-@{color} {
+        color: @@lightBorderColor;
+        background: @@lightColor;
+        border-color: @@lightColor;
+
+        &-inverse {
+          color: @text-color-inverse;
+          background: @@darkColor;
+          border-color: @@darkColor;
+        }
+
+        &:hover {
+          color: @@darkColor;
+        }
+      }
+
+      &-checked.@{tag-prefix-cls}-@{color} {
+        color: @@darkColor;
+        background: @@lightColor;
+        border-color: @@lightBorderColor;
+
+        &-inverse {
+          color: @text-color-inverse;
+          background: @@darkColor;
+          border-color: @@darkColor;
+        }
+      }
+    }
+  }
+
   .make-color-classes();
+  .make-checkable-color-classes();
 }
-
-.make-checkable-color-classes(@j: length(@preset-colors)) when (@j > 0) {
-  .make-checkable-color-classes(@j - 1);
-  @color: extract(@preset-colors, @j);
-  @lightColor: '@{color}-1';
-  @lightBorderColor: '@{color}-3';
-  @darkColor: '@{color}-6';
-  .@{tag-prefix-cls}-checkable.@{tag-prefix-cls}-@{color} {
-    color: @@lightBorderColor;
-    background: @@lightColor;
-    border-color: @@lightColor;
-  }
-  .@{tag-prefix-cls}-checkable.@{tag-prefix-cls}-@{color}-inverse {
-    color: @text-color-inverse;
-    background: @@darkColor;
-    border-color: @@darkColor;
-  }
-  .@{tag-prefix-cls}-checkable.@{tag-prefix-cls}-checkable-checked.@{tag-prefix-cls}-@{color} {
-    color: @@darkColor;
-    background: @@lightColor;
-    border-color: @@lightBorderColor;
-  }
-  .@{tag-prefix-cls}-checkable.@{tag-prefix-cls}-checkable-checked.@{color}-inverse {
-    color: @text-color-inverse;
-    background: @@darkColor;
-    border-color: @@darkColor;
-  }
-}
-
-.make-checkable-color-classes();

--- a/components/tag/style/index.less
+++ b/components/tag/style/index.less
@@ -104,3 +104,33 @@
 
   .make-color-classes();
 }
+
+.make-checkable-color-classes(@j: length(@preset-colors)) when (@j > 0) {
+  .make-checkable-color-classes(@j - 1);
+  @color: extract(@preset-colors, @j);
+  @lightColor: '@{color}-1';
+  @lightBorderColor: '@{color}-3';
+  @darkColor: '@{color}-6';
+  .@{tag-prefix-cls}-checkable.@{tag-prefix-cls}-@{color} {
+    color: @@lightBorderColor;
+    background: @@lightColor;
+    border-color: @@lightColor;
+  }
+  .@{tag-prefix-cls}-checkable.@{tag-prefix-cls}-@{color}-inverse {
+    color: @text-color-inverse;
+    background: @@darkColor;
+    border-color: @@darkColor;
+  }
+  .@{tag-prefix-cls}-checkable.@{tag-prefix-cls}-checkable-checked.@{tag-prefix-cls}-@{color} {
+    color: @@darkColor;
+    background: @@lightColor;
+    border-color: @@lightBorderColor;
+  }
+  .@{tag-prefix-cls}-checkable.@{tag-prefix-cls}-checkable-checked.@{color}-inverse {
+    color: @text-color-inverse;
+    background: @@darkColor;
+    border-color: @@darkColor;
+  }
+}
+
+.make-checkable-color-classes();

--- a/components/tag/util.ts
+++ b/components/tag/util.ts
@@ -1,0 +1,10 @@
+import { PresetColorTypes } from '../_util/colors';
+
+export const PresetColorRegex = new RegExp(`^(${PresetColorTypes.join('|')})(-inverse)?$`);
+
+export function isPresetColor(color?: string): boolean {
+  if (!color) {
+    return false;
+  }
+  return PresetColorRegex.test(color);
+}


### PR DESCRIPTION
close #11889

<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->
### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?

Ref #11889. User may want checkable tags to have colors too.

<!--
1. Describe the source of requirement, like related issue link.

2. Describe the problem and the scenario.
-->

### 💡 Solution

Add two API to `Tag.Checkable`, `color` and `unCheckedColor`.

<!--
1. How to fix the problem, and list final API implementation and usage sample if that is a new feature.

2. GIF or snapshot should be provided if includes UI/interactive modification.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

![屏幕快照 2019-04-23 16 55 23](https://user-images.githubusercontent.com/12122021/56567991-a2d1fe80-65e8-11e9-89aa-3864799a9bd3.png)

- English Changelog:
- Chinese Changelog (optional):

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed


-----
[View rendered components/tag/demo/checkable.md](https://github.com/wendzhue/ant-design/blob/preset-check/components/tag/demo/checkable.md)