### PR TITLE
fix: Small table header have background color

### DIFF
--- a/components/table/style/size.less
+++ b/components/table/style/size.less
@@ -74,7 +74,7 @@
       > .@{table-prefix-cls}-tbody > tr > td {
         padding: @table-padding-vertical-sm @table-padding-horizontal-sm;
       }
-      > .@{table-prefix-cls}-thead > tr > th {
+      > .@{table-prefix-cls}-thead > tr {
         background-color: transparent;
         border-bottom: @border-width-base @border-style-base @border-color-split;
       }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?

ref: #16174

Before:
<img width="637" alt="屏幕快照 2019-04-24 上午10 16 23" src="https://user-images.githubusercontent.com/5378891/56627845-212ab100-667a-11e9-958a-56b7a13eb61e.png">

Now:
<img width="642" alt="屏幕快照 2019-04-24 上午10 16 04" src="https://user-images.githubusercontent.com/5378891/56627852-27b92880-667a-11e9-92cf-0a0087bf2f42.png">


### 💡 Solution

Set small table header background color to transparent.

### 📝 Changelog

Fix small table header have background color.

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
