### PR TITLE
fix: Typography.Title should also support `type`

### DIFF
--- a/components/typography/style/index.less
+++ b/components/typography/style/index.less
@@ -51,19 +51,19 @@
 .@{typography-prefix-cls} {
   color: @text-color;
 
-  &-secondary {
+  &&-secondary {
     color: @text-color-secondary;
   }
 
-  &-warning {
+  &&-warning {
     color: @text-color-warning;
   }
 
-  &-danger {
+  &&-danger {
     color: @text-color-danger;
   }
 
-  &-disabled {
+  &&-disabled {
     color: @disabled-color;
     cursor: not-allowed;
     user-select: none;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?

close #16261 

### 💡 Solution

Rise css selector priority

### 📝 Changelog

Fix Typography.Title not support `type`

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
