### PR TITLE
fix: Calendar select option ellipsis when not in `fullscreen`

### DIFF
--- a/components/calendar/style/index.less
+++ b/components/calendar/style/index.less
@@ -22,7 +22,7 @@
     margin-left: 8px;
 
     &.@{ant-prefix}-select-sm {
-      min-width: 60px;
+      min-width: 70px;
     }
   }
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?

fix #16299 

### 💡 Solution

Update style

### 📝 Changelog

Fix Calendar select option ellipsis when not in `fullscreen`.

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
