### PR TITLE
fix: Typography edit mode should support `className`

### DIFF
--- a/components/typography/Base.tsx
+++ b/components/typography/Base.tsx
@@ -363,13 +363,15 @@ class Base extends React.Component<InternalBlockProps & ConfigConsumerProps, Bas
   }
 
   renderEditInput() {
-    const { children, prefixCls } = this.props;
+    const { children, prefixCls, className, style } = this.props;
     return (
       <Editable
         value={typeof children === 'string' ? children : ''}
         onSave={this.onEditChange}
         onCancel={this.onEditCancel}
         prefixCls={prefixCls}
+        className={className}
+        style={style}
       />
     );
   }

--- a/components/typography/Editable.tsx
+++ b/components/typography/Editable.tsx
@@ -10,6 +10,8 @@ interface EditableProps {
   ['aria-label']?: string;
   onSave: (value: string) => void;
   onCancel: () => void;
+  className?: string;
+  style?: React.CSSProperties;
 }
 
 interface EditableState {
@@ -106,10 +108,10 @@ class Editable extends React.Component<EditableProps, EditableState> {
 
   render() {
     const { current } = this.state;
-    const { prefixCls, ['aria-label']: ariaLabel } = this.props;
+    const { prefixCls, ['aria-label']: ariaLabel, className, style } = this.props;
 
     return (
-      <div className={`${prefixCls} ${prefixCls}-edit-content`}>
+      <div className={`${prefixCls} ${prefixCls}-edit-content ${className}`} style={style}>
         <TextArea
           ref={this.setTextarea}
           value={current}

--- a/components/typography/__tests__/index.test.js
+++ b/components/typography/__tests__/index.test.js
@@ -168,7 +168,14 @@ describe('Typography', () => {
           const onStart = jest.fn();
           const onChange = jest.fn();
 
-          const wrapper = mount(<Paragraph editable={{ onChange, onStart }}>Bamboo</Paragraph>);
+          const className = 'test';
+          const style = {};
+
+          const wrapper = mount(
+            <Paragraph editable={{ onChange, onStart }} className={className} style={style}>
+              Bamboo
+            </Paragraph>,
+          );
 
           wrapper
             .find('.ant-typography-edit')
@@ -176,6 +183,11 @@ describe('Typography', () => {
             .simulate('click');
 
           expect(onStart).toHaveBeenCalled();
+
+          // Should have className
+          const props = wrapper.find('div').props();
+          expect(props.style).toEqual(style);
+          expect(props.className.includes(className)).toBeTruthy();
 
           wrapper.find('TextArea').simulate('change', {
             target: { value: 'Bamboo' },


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?

fix #16288

### 💡 Solution

Pass `className` to sub Editable Component.

### 📝 Changelog

Fix Typography edit mode not support `className`

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
