### PR TITLE
fix: use mounted property, replace mounted state, resolves #16290

### DIFF
--- a/components/menu/__tests__/index.test.js
+++ b/components/menu/__tests__/index.test.js
@@ -3,7 +3,6 @@ import { mount } from 'enzyme';
 import Menu from '..';
 import Icon from '../../icon';
 import Layout from '../../layout';
-import raf from '../../_util/raf';
 
 jest.mock('mutationobserver-shim', () => {
   global.MutationObserver = function MutationObserver() {
@@ -74,10 +73,6 @@ describe('Menu', () => {
         .at(0)
         .hasClass('ant-menu-hidden'),
     ).not.toBe(true);
-
-    const rafCount = Object.keys(raf.ids).length;
-    wrapper.unmount();
-    expect(Object.keys(raf.ids).length).toBe(rafCount - 1);
   });
 
   it('should accept defaultOpenKeys in mode vertical', () => {

--- a/components/menu/index.tsx
+++ b/components/menu/index.tsx
@@ -10,7 +10,6 @@ import animation from '../_util/openAnimation';
 import warning from '../_util/warning';
 import { polyfill } from 'react-lifecycles-compat';
 import { SiderContext, SiderContextProps } from '../layout/Sider';
-import raf from '../_util/raf';
 
 export interface SelectParam {
   key: string;
@@ -70,7 +69,6 @@ export interface MenuState {
   switchingModeFromInline: boolean;
   inlineOpenKeys: string[];
   prevProps: InternalMenuProps;
-  mounted: boolean;
 }
 
 export interface MenuContextProps {
@@ -124,7 +122,7 @@ class InternalMenu extends React.Component<InternalMenuProps, MenuState> {
     return newState;
   }
 
-  private mountRafId: number;
+  private mounted = false;
 
   constructor(props: InternalMenuProps) {
     super(props);
@@ -154,7 +152,6 @@ class InternalMenu extends React.Component<InternalMenuProps, MenuState> {
       switchingModeFromInline: false,
       inlineOpenKeys: [],
       prevProps: props,
-      mounted: false,
     };
   }
 
@@ -162,15 +159,7 @@ class InternalMenu extends React.Component<InternalMenuProps, MenuState> {
   // We have to workaround this to prevent animation on first render.
   // https://github.com/ant-design/ant-design/issues/15966
   componentDidMount() {
-    this.mountRafId = raf(() => {
-      this.setState({
-        mounted: true,
-      });
-    }, 10);
-  }
-
-  componentWillUnmount() {
-    raf.cancel(this.mountRafId);
+    this.mounted = true;
   }
 
   restoreModeVerticalFromInline() {
@@ -282,7 +271,6 @@ class InternalMenu extends React.Component<InternalMenuProps, MenuState> {
   }
 
   renderMenu = ({ getPopupContainer, getPrefixCls }: ConfigConsumerProps) => {
-    const { mounted } = this.state;
     const { prefixCls: customizePrefixCls, className, theme, collapsedWidth } = this.props;
     const passProps = omit(this.props, ['collapsedWidth', 'siderCollapsed']);
     const menuMode = this.getRealMenuMode();
@@ -303,9 +291,9 @@ class InternalMenu extends React.Component<InternalMenuProps, MenuState> {
     if (menuMode !== 'inline') {
       // closing vertical popup submenu after click it
       menuProps.onClick = this.handleClick;
-      menuProps.openTransitionName = mounted ? menuOpenAnimation : '';
+      menuProps.openTransitionName = this.mounted ? menuOpenAnimation : '';
     } else {
-      menuProps.openAnimation = mounted ? menuOpenAnimation : {};
+      menuProps.openAnimation = this.mounted ? menuOpenAnimation : {};
     }
 
     // https://github.com/ant-design/ant-design/issues/8587


### PR DESCRIPTION

### 🤔 This is a ...

- [x] Bug fix

### 👻 What's the background?

resolves issue : destroyed Menu right after it's created will cause React warning #16290

### 💡 Solution

use mounted property instead of mounted state

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
