### PR TITLE
fix: Allow Object.entries (only for type checks, this is not a polyfill)

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     "noUnusedLocals": true,
     "noImplicitAny": true,
     "target": "es6",
-    "lib": ["dom", "es7"]
+    "lib": ["dom", "es2017"]
   },
   "exclude": ["node_modules", "lib", "es"]
 }


### PR DESCRIPTION
### 🤔 This is a ...

- [x] TypeScript definition update (global definition via `tsconfig.json`)

### 👻 What's the background?

Fixes the following linting error for antd authors (run via `npm run tlint` or implicitly e.g. after commits):

```shell
> tsc
components/progress/Line.tsx:21:37 - error TS2339: Property 'entries' does not exist on type 'ObjectConstructor'.

21   for (const [key, value] of Object.entries(gradients)) {
                                       ~~~~~~~
Found 1 error.
```

`Object.entries()` is used in `components/progress/Line.tsx`.

### 💡 Solution

Change in `tsconfig.json` lets TypeScript allows calls to `Object.entries`.

Note: this is only for type checks, tsc will assume that there's a polyfill in place, which is [required at least for IE11](https://caniuse.com/#feat=object-entries).

Polyfills are mentioned [in the antd Documentation](https://ant.design/docs/react/getting-started#Compatibility), but I think it is necessary to also exactly specify the required polyfills there,  `Object.entries` is one of them.

### ☑️ Self Check before Merge

- 👨‍🚒 Doc update is needed IMO **See my note about polyfills**
- Demo is not needed
- TypeScript definition is updated (the change itself)
- Changelog not needed **I'm not aware of a changelog for antd authors, where this change belongs to**
