### PR TITLE
RangePicker.renderExtraFooter() gets no args, fix TypeScript definition and clean up code

### DIFF
--- a/components/date-picker/RangePicker.tsx
+++ b/components/date-picker/RangePicker.tsx
@@ -226,7 +226,7 @@ class RangePicker extends React.Component<any, RangePickerState> {
     this.picker = node;
   };
 
-  renderFooter = (...args: any[]) => {
+  renderFooter = () => {
     const { ranges, renderExtraFooter } = this.props;
     const { prefixCls, tagPrefixCls } = this;
     if (!ranges && !renderExtraFooter) {
@@ -234,7 +234,7 @@ class RangePicker extends React.Component<any, RangePickerState> {
     }
     const customFooter = renderExtraFooter ? (
       <div className={`${prefixCls}-footer-extra`} key="extra">
-        {renderExtraFooter(...args)}
+        {renderExtraFooter()}
       </div>
     ) : null;
     const operations = Object.keys(ranges || {}).map(range => {

--- a/components/date-picker/interface.tsx
+++ b/components/date-picker/interface.tsx
@@ -22,7 +22,6 @@ export interface PickerProps {
   open?: boolean;
   onOpenChange?: (status: boolean) => void;
   disabledDate?: (current: moment.Moment | undefined) => boolean;
-  renderExtraFooter?: () => React.ReactNode;
   dateRender?: (current: moment.Moment, today: moment.Moment) => React.ReactNode;
 }
 
@@ -30,6 +29,7 @@ export interface SinglePickerProps {
   value?: moment.Moment;
   defaultValue?: moment.Moment;
   defaultPickerValue?: moment.Moment;
+  renderExtraFooter?: (mode: 'date' | 'month' | 'year' | 'decade') => React.ReactNode;
   onChange?: (date: moment.Moment, dateString: string) => void;
 }
 
@@ -91,6 +91,7 @@ export interface RangePickerProps extends PickerProps {
     disabledSeconds?: () => number[];
   };
   onPanelChange?: (value?: RangePickerValue, mode?: string | string[]) => void;
+  renderExtraFooter?: () => React.ReactNode;
 }
 
 export interface WeekPickerProps extends PickerProps, SinglePickerProps {


### PR DESCRIPTION
### 🤔 This is a ...

- [x] TypeScript definition update
- [x] Code style optimization

### 👻 What's the background?

`RangeCalendar` (from `rc-calendar`) [calls renderFooter` without any arguments](https://github.com/react-component/calendar/blob/master/src/RangeCalendar.js#L696)

This fact is correctly documented at [RangePicker's documentation for renderExtraFooter](https://ant.design/components/date-picker/#RangePicker) but the code passes (non-existent) arguments to renderExtraFooter(). This can be confusing.

### 💡 Solution

Do not pass args to `renderExtraFooter()`

Fix TypeScript defs.

### 📝 Changelog

No extra changelog needed because behavior was already correctly documented.

### ☑️ Self Check before Merge

- Doc is not needed (alreay correct)
- Demo is not needed
- TypeScript definition is updated
- Changelog is not needed
