### PR TITLE
fix: Add some missing TypeScript prop definititions and clean up date-picker definitions

### DIFF
--- a/components/checkbox/Checkbox.tsx
+++ b/components/checkbox/Checkbox.tsx
@@ -23,6 +23,8 @@ export interface AbstractCheckboxProps<T> {
   tabIndex?: number;
   name?: string;
   children?: React.ReactNode;
+  id?: string;
+  autoFocus?: boolean;
 }
 
 export interface CheckboxProps extends AbstractCheckboxProps<CheckboxChangeEvent> {

--- a/components/date-picker/index.en-US.md
+++ b/components/date-picker/index.en-US.md
@@ -56,7 +56,7 @@ The following APIs are shared by DatePicker, MonthPicker, RangePicker, WeekPicke
 | dropdownClassName | to customize the className of the popup calendar | string | - |
 | getCalendarContainer | to set the container of the floating layer, while the default is to create a `div` element in `body` | function(trigger) | - |
 | locale | localization configuration | object | [default](https://github.com/ant-design/ant-design/blob/master/components/date-picker/locale/example.json) |
-| mode | picker panel mode | `time|date|month|year` | 'date' |
+| mode | picker panel mode | `time|date|month|year|decade` | 'date' |
 | open | open state of picker | boolean | - |
 | placeholder | placeholder of date input | string\|RangePicker\[] | - |
 | popupStyle | to customize the style of the popup calendar | object | {} |

--- a/components/date-picker/index.zh-CN.md
+++ b/components/date-picker/index.zh-CN.md
@@ -82,7 +82,7 @@ moment.locale('zh-cn');
 | defaultPickerValue | 默认面板日期 | [moment](http://momentjs.com/) | 无 |
 | disabledTime | 不可选择的时间 | function(date) | 无 |
 | format | 设置日期格式，为数组时支持多格式匹配，展示以第一个为准。配置参考 [moment.js](http://momentjs.com/) | string \| string[] | "YYYY-MM-DD" |
-| mode | 日期面板的状态 | `time|date|month|year` | 'date' |
+| mode | 日期面板的状态 | `time|date|month|year|decade` | 'date' |
 | renderExtraFooter | 在面板中添加额外的页脚 | (mode) => React.ReactNode | - |
 | showTime | 增加时间选择功能 | Object\|boolean | [TimePicker Options](/components/time-picker/#API) |
 | showTime.defaultValue | 设置用户选择日期时默认的时分秒，[例子](#components-date-picker-demo-disabled-date) | [moment](http://momentjs.com/) | moment() |

--- a/components/date-picker/interface.tsx
+++ b/components/date-picker/interface.tsx
@@ -31,7 +31,7 @@ export interface SinglePickerProps {
   defaultValue?: moment.Moment;
   defaultPickerValue?: moment.Moment;
   placeholder?: string;
-  renderExtraFooter?: (mode: 'date' | 'month' | 'year' | 'decade') => React.ReactNode;
+  renderExtraFooter?: (mode: DatePickerMode) => React.ReactNode;
   onChange?: (date: moment.Moment, dateString: string) => void;
 }
 

--- a/components/date-picker/interface.tsx
+++ b/components/date-picker/interface.tsx
@@ -35,7 +35,7 @@ export interface SinglePickerProps {
   onChange?: (date: moment.Moment, dateString: string) => void;
 }
 
-const DatePickerModes = tuple('time', 'date', 'month', 'year');
+const DatePickerModes = tuple('time', 'date', 'month', 'year', 'decade');
 export type DatePickerMode = (typeof DatePickerModes)[number];
 
 export interface DatePickerProps extends PickerProps, SinglePickerProps {

--- a/components/date-picker/interface.tsx
+++ b/components/date-picker/interface.tsx
@@ -24,12 +24,14 @@ export interface PickerProps {
   disabledDate?: (current: moment.Moment | undefined) => boolean;
   renderExtraFooter?: () => React.ReactNode;
   dateRender?: (current: moment.Moment, today: moment.Moment) => React.ReactNode;
+  autoFocus?: boolean;
 }
 
 export interface SinglePickerProps {
   value?: moment.Moment;
   defaultValue?: moment.Moment;
   defaultPickerValue?: moment.Moment;
+  placeholder?: string;
   onChange?: (date: moment.Moment, dateString: string) => void;
 }
 
@@ -37,7 +39,6 @@ const DatePickerModes = tuple('time', 'date', 'month', 'year');
 export type DatePickerMode = (typeof DatePickerModes)[number];
 
 export interface DatePickerProps extends PickerProps, SinglePickerProps {
-  className?: string;
   showTime?: TimePickerProps | boolean;
   showToday?: boolean;
   open?: boolean;
@@ -51,13 +52,11 @@ export interface DatePickerProps extends PickerProps, SinglePickerProps {
   onOpenChange?: (status: boolean) => void;
   onPanelChange?: (value: moment.Moment | undefined, mode: DatePickerMode) => void;
   onOk?: (selectedTime: moment.Moment) => void;
-  placeholder?: string;
   mode?: DatePickerMode;
 }
 
 export interface MonthPickerProps extends PickerProps, SinglePickerProps {
-  className?: string;
-  placeholder?: string;
+  // - currently no own props -
 }
 
 export type RangePickerValue =
@@ -76,6 +75,7 @@ export interface RangePickerProps extends PickerProps {
   onCalendarChange?: (dates: RangePickerValue, dateStrings: [string, string]) => void;
   onOk?: (selectedTime: RangePickerPresetRange) => void;
   showTime?: TimePickerProps | boolean;
+  showToday?: boolean;
   ranges?: {
     [range: string]: RangePickerPresetRange;
   };
@@ -94,8 +94,7 @@ export interface RangePickerProps extends PickerProps {
 }
 
 export interface WeekPickerProps extends PickerProps, SinglePickerProps {
-  className?: string;
-  placeholder?: string;
+  // - currently no own props -
 }
 
 export interface DatePickerDecorator extends React.ClassicComponentClass<DatePickerProps> {

--- a/components/switch/index.tsx
+++ b/components/switch/index.tsx
@@ -21,6 +21,7 @@ export interface SwitchProps {
   loading?: boolean;
   autoFocus?: boolean;
   style?: React.CSSProperties;
+  title?: string;
 }
 
 export default class Switch extends React.Component<SwitchProps, {}> {

--- a/components/tooltip/index.tsx
+++ b/components/tooltip/index.tsx
@@ -61,6 +61,7 @@ export interface AbstractTooltipProps {
   children?: React.ReactNode;
   // align is a more higher api
   align?: TooltipAlignConfig;
+  destroyTooltipOnHide?: boolean;
 }
 
 export type RenderFunction = () => React.ReactNode;


### PR DESCRIPTION
### 🤔 This is a ...

- [x] TypeScript definition update

### 👻 What's the background?

Some props were missing from TypeScript definitions.

TypeScript definitions for date-picker Components were a bit redundant.

### 💡 Solution

Props have been added, redundancies for date-picker Components have been removed.

### 📝 Changelog

No special changelog

### ☑️ Self Check before Merge

- Doc is not needed (props are mostly standard props that are passed to the underlying HTML elements. They are most often not documented. date-picker changes doesnt need to be documented)
- Demo is not needed (same reason)
- TypeScript definition is updated (the purpose of this PR)
- Changelog is not needed
