### PR TITLE
Form onFieldsChange(): document third parameter "allFields", remove non-existent fourth parameter "add" from TypeScript definition

### DIFF
--- a/components/form/Form.tsx
+++ b/components/form/Form.tsx
@@ -20,7 +20,7 @@ interface FormCreateOptionMessages {
 }
 
 export interface FormCreateOption<T> {
-  onFieldsChange?: (props: T, fields: object, allFields: any, add: string) => void;
+  onFieldsChange?: (props: T, fields: object, allFields: any) => void;
   onValuesChange?: (props: T, changedValues: any, allValues: any) => void;
   mapPropsToFields?: (props: T) => void;
   validateMessages?: FormCreateOptionMessages;

--- a/components/form/index.en-US.md
+++ b/components/form/index.en-US.md
@@ -65,7 +65,7 @@ The following `options` are available:
 | mapPropsToFields | Convert props to field value(e.g. reading the values from Redux store). And you must mark returned fields with [`Form.createFormField`](#Form.createFormField). Please note that the form fields will become controlled components. Properties like errors will not be automatically mapped and need to be manually passed in. | (props) => ({ \[fieldName\]: FormField { value } }) |
 | name | Set the id prefix of fields under form | - |
 | validateMessages | Default validate message. And its format is similar with [newMessages](https://github.com/yiminghe/async-validator/blob/master/src/messages.js)'s returned value | Object { \[nested.path]: String } |
-| onFieldsChange | Specify a function that will be called when the fields (including errors) of a `Form.Item` gets changed. Usage example: saving the field's value to Redux store. | Function(props, fields) |
+| onFieldsChange | Specify a function that will be called when the fields (including errors) of a `Form.Item` gets changed. Usage example: saving the field's value to Redux store. | Function(props, changedFields, allFields) |
 | onValuesChange | A handler while value of any field is changed | (props, changedValues, allValues) => void |
 
 If you want to get `ref` after `Form.create`, you can use `wrappedComponentRef` provided by `rc-form`, [details can be viewed here](https://github.com/react-component/form#note-use-wrappedcomponentref-instead-of-withref-after-rc-form140).

--- a/components/form/index.zh-CN.md
+++ b/components/form/index.zh-CN.md
@@ -67,7 +67,7 @@ CustomizedForm = Form.create({})(CustomizedForm);
 | mapPropsToFields | 把父组件的属性映射到表单项上（如：把 Redux store 中的值读出），需要对返回值中的表单域数据用 [`Form.createFormField`](#Form.createFormField) 标记，注意表单项将变成受控组件, error 等也需要一并手动传入 | (props) => ({ \[fieldName\]: FormField { value } }) |
 | name | 设置表单域内字段 id 的前缀 | - |
 | validateMessages | 默认校验信息，可用于把默认错误信息改为中文等，格式与 [newMessages](https://github.com/yiminghe/async-validator/blob/master/src/messages.js) 返回值一致 | Object { \[nested.path]: String } |
-| onFieldsChange | 当 `Form.Item` 子节点的值（包括 error）发生改变时触发，可以把对应的值转存到 Redux store | Function(props, fields) |
+| onFieldsChange | 当 `Form.Item` 子节点的值（包括 error）发生改变时触发，可以把对应的值转存到 Redux store | Function(props, changedFields, allFields) |
 | onValuesChange | 任一表单域的值发生改变时的回调 | (props, changedValues, allValues) => void |
 
 经过 `Form.create` 之后如果要拿到 `ref`，可以使用 `rc-form` 提供的 `wrappedComponentRef`，[详细内容可以查看这里](https://github.com/react-component/form#note-use-wrappedcomponentref-instead-of-withref-after-rc-form140)。


### PR DESCRIPTION
### 🤔 This is a ...

- [x] Site / document update
- [x] TypeScript definition update

### 👻 What's the background?

Form onFieldsChange() has a third parameter `allFields`, see  619b0ed. That was not documented.

Additionally, TypeScript def added a fourth parameter `add: string` by mistake (that parameter does not exist)

### 💡 Solution

Add docs for `allFields` param, remove `add` param from TypeScript definition.

### 📝 Changelog

No special changelog required.

### ☑️ Self Check before Merge

- Doc is not updated (purpose of this PR)
- Demo is not needed
- TypeScript definition is updated (also purpose of this PR)
- Changelog is not needed
