### PR TITLE
fix: TypeScript definitions for Select component's onSelect / onDeselect props, update inaccurate docs

### DIFF
--- a/components/select/index.en-US.md
+++ b/components/select/index.en-US.md
@@ -27,7 +27,7 @@ Select component to select value from options.
 | autoClearSearchValue | Whether the current search will be cleared on selecting an item. Only applies when `mode` is set to `multiple` or `tags`. | boolean | true |
 | autoFocus | Get focus by default | boolean | false |
 | defaultActiveFirstOption | Whether active first option by default | boolean | true |
-| defaultValue | Initial selected option. | string\|string\[]<br />number\|number\[] | - |
+| defaultValue | Initial selected option. | string\|string\[]<br />number\|number\[]<br />LabeledValue\|LabeledValue[] | - |
 | disabled | Whether disabled select | boolean | false |
 | dropdownClassName | className of dropdown menu | string | - |
 | dropdownMatchSelectWidth | Whether dropdown's width is same with select. | boolean | true |
@@ -52,17 +52,17 @@ Select component to select value from options.
 | clearIcon | The custom clear icon | ReactNode | - |
 | menuItemSelectedIcon | The custom menuItemSelected icon | ReactNode | - |
 | tokenSeparators | Separator used to tokenize on tag/multiple mode | string\[] |  |
-| value | Current selected option. | string\|number\|string\[]\|number\[] | - |
+| value | Current selected option. | string\|string\[]\<br />number\|number\[]\<br />LabeledValue\|LabeledValue[] | - |
 | onBlur | Called when blur | function | - |
 | onChange | Called when select an option or input value change, or value of input is changed in combobox mode | function(value, option:Option/Array&lt;Option>) | - |
-| onDeselect | Called when a option is deselected, the params are option's value (or key) . only called for multiple or tags, effective in multiple or tags mode only. | function(value, option:Option) | - |
+| onDeselect | Called when a option is deselected, param is the selected option's value. Only called for multiple or tags, effective in multiple or tags mode only. | function(string\|number\|LabeledValue) | - |
 | onFocus | Called when focus | function | - |
 | onInputKeyDown | Called when key pressed | function | - |
 | onMouseEnter | Called when mouse enter | function | - |
 | onMouseLeave | Called when mouse leave | function | - |
 | onPopupScroll | Called when dropdown scrolls | function | - |
 | onSearch | Callback function that is fired when input changed. | function(value: string) |  |
-| onSelect | Called when a option is selected, the params are option's value (or key) and option instance. | function(value, option:Option) | - |
+| onSelect | Called when a option is selected, the params are option's value (or key) and option instance. | function(string\|number\|LabeledValue, option:Option) | - |
 | defaultOpen | Initial open state of dropdown | boolean | - |
 | open | Controlled open state of dropdown | boolean | - |
 | onDropdownVisibleChange | Call when dropdown open (Supported after version 3.9.0) | function(open) | - |

--- a/components/select/index.tsx
+++ b/components/select/index.tsx
@@ -48,6 +48,7 @@ export interface LabeledValue {
 }
 
 export type SelectValue = string | string[] | number | number[] | LabeledValue | LabeledValue[];
+export type SelectedValue = string | number | LabeledValue;
 
 export interface SelectProps<T = SelectValue> extends AbstractSelectProps {
   value?: T;
@@ -56,8 +57,8 @@ export interface SelectProps<T = SelectValue> extends AbstractSelectProps {
   optionLabelProp?: string;
   firstActiveValue?: string | string[];
   onChange?: (value: T, option: React.ReactElement<any> | React.ReactElement<any>[]) => void;
-  onSelect?: (value: T, option: React.ReactElement<any>) => any;
-  onDeselect?: (value: T) => any;
+  onSelect?: (value: SelectedValue, option: React.ReactElement<any>) => any;
+  onDeselect?: (value: SelectedValue) => any;
   onBlur?: (value: T) => void;
   onFocus?: () => void;
   onPopupScroll?: React.UIEventHandler<HTMLDivElement>;

--- a/components/select/index.zh-CN.md
+++ b/components/select/index.zh-CN.md
@@ -28,7 +28,7 @@ title: Select
 | autoClearSearchValue | 是否在选中项后清空搜索框，只在 `mode` 为 `multiple` 或 `tags` 时有效。 | boolean | true |
 | autoFocus | 默认获取焦点 | boolean | false |
 | defaultActiveFirstOption | 是否默认高亮第一个选项。 | boolean | true |
-| defaultValue | 指定默认选中的条目 | string\|string\[]<br />number\|number\[] | - |
+| defaultValue | 指定默认选中的条目 | string\|string\[]\<br />number\|number\[]\<br />LabeledValue\|LabeledValue[] | - |
 | disabled | 是否禁用 | boolean | false |
 | dropdownClassName | 下拉菜单的 className 属性 | string | - |
 | dropdownMatchSelectWidth | 下拉菜单和选择器同宽 | boolean | true |
@@ -53,16 +53,16 @@ title: Select
 | clearIcon | 自定义的多选框清空图标 | ReactNode | - |
 | menuItemSelectedIcon | 自定义当前选中的条目图标 | ReactNode | - |
 | tokenSeparators | 在 tags 和 multiple 模式下自动分词的分隔符 | string\[] |  |
-| value | 指定当前选中的条目 | string\|string\[]\|number\|number\[] | - |
+| value | 指定当前选中的条目 | string\|string\[]\<br />number\|number\[]\<br />LabeledValue\|LabeledValue[] | - |
 | onBlur | 失去焦点的时回调 | function | - |
 | onChange | 选中 option，或 input 的 value 变化（combobox 模式下）时，调用此函数 | function(value, option:Option/Array&lt;Option>) | - |
-| onDeselect | 取消选中时调用，参数为选中项的 value (或 key) 值，仅在 multiple 或 tags 模式下生效 | function(value，option:Option) | - |
+| onDeselect | 取消选中时调用，参数为选中项的 value (或 key) 值，仅在 multiple 或 tags 模式下生效 | function(string\|number\|LabeledValue) | - |
 | onFocus | 获得焦点时回调 | function | - |
 | onMouseEnter | 鼠标移入时回调 | function | - |
 | onMouseLeave | 鼠标移出时回调 | function | - |
 | onPopupScroll | 下拉列表滚动时的回调 | function | - |
 | onSearch | 文本框值变化时回调 | function(value: string) |  |
-| onSelect | 被选中时调用，参数为选中项的 value (或 key) 值 | function(value, option:Option) | - |
+| onSelect | 被选中时调用，参数为选中项的 value (或 key) 值 | function(string\|number\|LabeledValue, option:Option) | - |
 | defaultOpen | 是否默认展开下拉菜单 | boolean | - |
 | open | 是否展开下拉菜单 | boolean | - |
 | onDropdownVisibleChange | 展开下拉菜单的回调 (3.9.0 后支持) | function(open) | - |


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / document update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?
The `SelectProps` interface defines the `value` param for `onSelect` and `onDeselect` as `SelectValue` (https://github.com/ant-design/ant-design/blob/master/components/select/index.tsx#L50)

In the context of these handlers, as I understand it, `value` should never be an array, but always a single member of the array (`string`, `number` or `LabeledValue`). However, TS seems to not be able to correctly infer this. Therefore, typing the `value` param correctly in these handlers is not currently possible.

Moreover, the documentation seems to be inaccurate for the `value`, `defaultValue` and `onDeselect` props (especially as `onDeselect` does not get the `option` param, but is documented as such).

### 💡 Solution

* Define the `value` param for `onSelect` and `onDeselect` as `string|number|LabeledValue`
* Fix inaccurate documentation (partial update for CN docs : only type values)

### 📝 Changelog

- English Changelog: 
  * `Select` component : updated types for `onSelect` and `onDeselect` props to be `string|number|LabeledValue`
  * Update docs
- Chinese Changelog (optional):

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
