### PR TITLE
fix: raf should keep same id

### DIFF
--- a/components/_util/__tests__/util.test.js
+++ b/components/_util/__tests__/util.test.js
@@ -99,6 +99,10 @@ describe('Test utils function', () => {
       bamboo = true;
     }, 3);
 
+    // Do nothing, but insert in the frame
+    // https://github.com/ant-design/ant-design/issues/16290
+    delayRaf(() => {}, 3);
+
     // Variable bamboo should be false in frame 2 but true in frame 4
     raf(() => {
       expect(bamboo).toBe(false);

--- a/components/_util/raf.ts
+++ b/components/_util/raf.ts
@@ -17,13 +17,13 @@ export default function wrapperRaf(callback: () => void, delayFrames: number = 1
 
     if (restFrames <= 0) {
       callback();
-      delete ids[id];
+      delete ids[myId];
     } else {
-      ids[id] = raf(internalCallback);
+      ids[myId] = raf(internalCallback);
     }
   }
 
-  ids[id] = raf(internalCallback);
+  ids[myId] = raf(internalCallback);
 
   return myId;
 }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?

fix #16290

### 💡 Solution

raf not use same id. Use same one instead.

### 📝 Changelog

Fix destroyed Menu right after it's created will cause React warning

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
