### PR TITLE
fix: Checkbox.Group onChange should not pass removed value

### DIFF
--- a/components/checkbox/Checkbox.tsx
+++ b/components/checkbox/Checkbox.tsx
@@ -55,13 +55,6 @@ class Checkbox extends React.Component<CheckboxProps, {}> {
 
   private rcCheckbox: any;
 
-  constructor(props: CheckboxProps) {
-    super(props);
-    this.state = {
-      prevValue: props.value,
-    };
-  }
-
   componentDidMount() {
     const { value } = this.props;
     const { checkboxGroup = {} } = this.context || {};

--- a/components/checkbox/Group.tsx
+++ b/components/checkbox/Group.tsx
@@ -32,7 +32,8 @@ export interface CheckboxGroupProps extends AbstractCheckboxGroupProps {
 }
 
 export interface CheckboxGroupState {
-  value: any;
+  value: CheckboxValueType[];
+  registeredValues: CheckboxValueType[];
 }
 
 export interface CheckboxGroupContext {
@@ -72,6 +73,7 @@ class CheckboxGroup extends React.Component<CheckboxGroupProps, CheckboxGroupSta
     super(props);
     this.state = {
       value: props.value || props.defaultValue || [],
+      registeredValues: [],
     };
   }
 
@@ -82,6 +84,10 @@ class CheckboxGroup extends React.Component<CheckboxGroupProps, CheckboxGroupSta
         value: this.state.value,
         disabled: this.props.disabled,
         name: this.props.name,
+
+        // https://github.com/ant-design/ant-design/issues/16376
+        registerValue: this.registerValue,
+        cancelValue: this.cancelValue,
       },
     };
   }
@@ -89,6 +95,17 @@ class CheckboxGroup extends React.Component<CheckboxGroupProps, CheckboxGroupSta
   shouldComponentUpdate(nextProps: CheckboxGroupProps, nextState: CheckboxGroupState) {
     return !shallowEqual(this.props, nextProps) || !shallowEqual(this.state, nextState);
   }
+
+  registerValue = (value: string) => {
+    this.setState(({ registeredValues }) => ({
+      registeredValues: [...registeredValues, value],
+    }));
+  };
+  cancelValue = (value: string) => {
+    this.setState(({ registeredValues }) => ({
+      registeredValues: registeredValues.filter(val => val !== value),
+    }));
+  };
 
   getOptions() {
     const { options } = this.props;
@@ -105,6 +122,7 @@ class CheckboxGroup extends React.Component<CheckboxGroupProps, CheckboxGroupSta
   }
 
   toggleOption = (option: CheckboxOptionType) => {
+    const { registeredValues } = this.state;
     const optionIndex = this.state.value.indexOf(option.value);
     const value = [...this.state.value];
     if (optionIndex === -1) {
@@ -117,7 +135,7 @@ class CheckboxGroup extends React.Component<CheckboxGroupProps, CheckboxGroupSta
     }
     const onChange = this.props.onChange;
     if (onChange) {
-      onChange(value);
+      onChange(value.filter(val => registeredValues.indexOf(val) !== -1));
     }
   };
 

--- a/components/checkbox/Group.tsx
+++ b/components/checkbox/Group.tsx
@@ -101,6 +101,7 @@ class CheckboxGroup extends React.Component<CheckboxGroupProps, CheckboxGroupSta
       registeredValues: [...registeredValues, value],
     }));
   };
+
   cancelValue = (value: string) => {
     this.setState(({ registeredValues }) => ({
       registeredValues: registeredValues.filter(val => val !== value),

--- a/components/checkbox/__tests__/group.test.js
+++ b/components/checkbox/__tests__/group.test.js
@@ -111,4 +111,26 @@ describe('CheckboxGroup', () => {
     expect(onChange).toHaveBeenCalled();
     expect(onChange.mock.calls[0][0].target.value).toEqual('my');
   });
+
+  // https://github.com/ant-design/ant-design/issues/16376
+  it('onChange should filter removed value', () => {
+    const onChange = jest.fn();
+    const wrapper = mount(
+      <Checkbox.Group defaultValue={[1]} onChange={onChange}>
+        <Checkbox key={1} value={1} />
+        <Checkbox key={2} value={2} />
+      </Checkbox.Group>,
+    );
+
+    wrapper.setProps({
+      children: [<Checkbox key={2} value={2} />],
+    });
+
+    wrapper
+      .find('.ant-checkbox-input')
+      .at(0)
+      .simulate('change');
+
+    expect(onChange).toHaveBeenCalledWith([2]);
+  });
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?

fix #16376 

### 💡 Solution

Register value for filter.

### 📝 Changelog

Fix Checkbox.Group onChange pass removed value.

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
