### PR TITLE
fix: Print reject error when ActionButton catch promise rejects

### DIFF
--- a/components/modal/ActionButton.tsx
+++ b/components/modal/ActionButton.tsx
@@ -56,7 +56,9 @@ export default class ActionButton extends React.Component<ActionButtonProps, Act
             // this.setState({ loading: false });
             closeModal(...args);
           },
-          () => {
+          (e: Error) => {
+            // Emit error when catch promise reject
+            console.error(e);
             // See: https://github.com/ant-design/ant-design/issues/6183
             this.setState({ loading: false });
           },

--- a/components/modal/__tests__/confirm.test.js
+++ b/components/modal/__tests__/confirm.test.js
@@ -67,6 +67,19 @@ describe('Modal.confirm triggers callbacks correctly', () => {
     expect(errorSpy).not.toHaveBeenCalled();
   });
 
+  it('should emit error when onOk return Promise.reject', () => {
+    const error = new Error('something wrong');
+    open({
+      onOk: () => Promise.reject(error),
+    });
+    // Fifth Modal
+    $$('.ant-btn-primary')[0].click();
+    // wait promise
+    return Promise.resolve().then(() => {
+      expect(errorSpy).toHaveBeenCalledWith(error);
+    });
+  });
+
   if (process.env.REACT !== '15') {
     it('shows animation when close', () => {
       jest.useFakeTimers();


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?

There is nothing output on browser console when an error occurs while `<Modal>` components call `onOk` callback function.

### 💡 Solution

Emit error manually by add `console.error(e)`

### 📝 Changelog

- English Changelog:
  - Print reject error when ActionButton catch promise rejects
  - Print reject error when `Modal`'s `onOk` callback retures an promise rejects
- Chinese Changelog (optional):
  - 当 `ActionButton` 捕获到 Promise 的 Reject 的时候，打印错误。
  - 当 `Modal` 组件 `onOk` 回调返回的 Promise 被 Reject 的时候，打印错误。

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
