### PR TITLE
fix: 🐛 Avoid disabled Upload being triggered by label

### DIFF
--- a/components/upload/Upload.tsx
+++ b/components/upload/Upload.tsx
@@ -319,7 +319,8 @@ class Upload extends React.Component<UploadProps, UploadState> {
 
     // Remove id to avoid open by label when trigger is hidden
     // https://github.com/ant-design/ant-design/issues/14298
-    if (!children) {
+    // https://github.com/ant-design/ant-design/issues/16478
+    if (!children || disabled) {
       delete rcUploadProps.id;
     }
 

--- a/components/upload/__tests__/upload.test.js
+++ b/components/upload/__tests__/upload.test.js
@@ -2,6 +2,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import Upload from '..';
+import Form from '../../form';
 import { T, fileToObject, genPercentAdd, getFileItem, removeFileItem } from '../utils';
 import { setup, teardown } from './mock';
 
@@ -199,6 +200,64 @@ describe('Upload', () => {
     expect(wrapper.find('input[type="file"]').length).toBe(1);
     wrapper.setProps({ children: null });
     expect(wrapper.find('input[type="file"]').length).toBe(1);
+  });
+
+  // https://github.com/ant-design/ant-design/issues/14298
+  it('should not have id if upload children is null, avoid being triggered by label', () => {
+    // eslint-disable-next-line
+    class Demo extends React.Component {
+      render() {
+        const {
+          form: { getFieldDecorator },
+          children,
+        } = this.props;
+        return (
+          <Form>
+            <Form.Item label="Upload">
+              {getFieldDecorator('upload')(<Upload>{children}</Upload>)}
+            </Form.Item>
+          </Form>
+        );
+      }
+    }
+    const WrappedDemo = Form.create()(Demo);
+    const wrapper = mount(
+      <WrappedDemo>
+        <div>upload</div>
+      </WrappedDemo>,
+    );
+    expect(wrapper.find('input#upload').length).toBe(1);
+    wrapper.setProps({ children: null });
+    expect(wrapper.find('input#upload').length).toBe(0);
+  });
+
+  // https://github.com/ant-design/ant-design/issues/16478
+  it('should not have id if upload is disabled, avoid being triggered by label', () => {
+    // eslint-disable-next-line
+    class Demo extends React.Component {
+      render() {
+        const {
+          form: { getFieldDecorator },
+          disabled,
+        } = this.props;
+        return (
+          <Form>
+            <Form.Item label="Upload">
+              {getFieldDecorator('upload')(
+                <Upload disabled={disabled}>
+                  <div>upload</div>
+                </Upload>,
+              )}
+            </Form.Item>
+          </Form>
+        );
+      }
+    }
+    const WrappedDemo = Form.create()(Demo);
+    const wrapper = mount(<WrappedDemo />);
+    expect(wrapper.find('input#upload').length).toBe(1);
+    wrapper.setProps({ disabled: true });
+    expect(wrapper.find('input#upload').length).toBe(0);
   });
 
   it('should be controlled by fileList', () => {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?

close #16478, similar issue #14298

### 💡 Solution

Same solution as https://github.com/ant-design/ant-design/pull/14780

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

- English Changelog: 🐛 Avoid disabled Upload being triggered by label.
- Chinese Changelog (optional): 🐛 修复 Upload `disabled` 状态下会被 label 激活的问题。

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
