### PR TITLE
fix: customize icon in notification size not correct

### DIFF
--- a/components/notification/style/index.less
+++ b/components/notification/style/index.less
@@ -83,12 +83,17 @@
       font-size: @font-size-base;
     }
 
-    .@{iconfont-css-prefix}&-icon {
+    // Icon & color style in different selector level
+    // https://github.com/ant-design/ant-design/issues/16503
+    // https://github.com/ant-design/ant-design/issues/15512
+    &-icon {
       position: absolute;
       margin-left: 4px;
       font-size: 24px;
       line-height: 24px;
+    }
 
+    .@{iconfont-css-prefix}&-icon {
       &-success {
         color: @success-color;
       }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?

close #16503 

### 💡 Solution

Adjust style

### 📝 Changelog

Fix customize icon style in notification size not correct.

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
