### PR TITLE
📝 Update Menu docs

### DIFF
--- a/components/menu/index.en-US.md
+++ b/components/menu/index.en-US.md
@@ -42,10 +42,10 @@ More layouts with navigation: [layout](/components/layout).
 | subMenuCloseDelay | delay time to hide submenu when mouse leave, unit: second | number | 0.1 |
 | subMenuOpenDelay | delay time to show submenu when mouse enter, unit: second | number | 0 |
 | theme | color theme of the menu | string: `light` `dark` | `light` |
-| onClick | callback executed when a menu item is clicked | function({ item, key, keyPath }) | - |
-| onDeselect | callback executed when a menu item is deselected, only supported for multiple mode | function({ item, key, selectedKeys }) | - |
+| onClick | callback executed when a menu item is clicked | function({ item, key, keyPath, domEvent }) | - |
+| onDeselect | callback executed when a menu item is deselected, only supported for multiple mode | function({ item, key, keyPath, selectedKeys, domEvent }) | - |
 | onOpenChange | called when open/close sub menu | function(openKeys: string\[]) | noop |
-| onSelect | callback executed when a menu item is selected | function({ item, key, selectedKeys }) | none |
+| onSelect | callback executed when a menu item is selected | function({ item, key, keyPath, selectedKeys, domEvent }) | none |
 | overflowedIndicator | Customized icon when menu collapsed | ReactNode | - |
 
 > More options in [rc-menu](https://github.com/react-component/menu#api)

--- a/components/menu/index.zh-CN.md
+++ b/components/menu/index.zh-CN.md
@@ -43,10 +43,10 @@ subtitle: 导航菜单
 | subMenuCloseDelay | 用户鼠标离开子菜单后关闭延时，单位：秒 | number | 0.1 |
 | subMenuOpenDelay | 用户鼠标进入子菜单后开启延时，单位：秒 | number | 0 |
 | theme | 主题颜色 | string: `light` `dark` | `light` |
-| onClick | 点击 MenuItem 调用此函数 | function({ item, key, keyPath }) | - |
-| onDeselect | 取消选中时调用，仅在 multiple 生效 | function({ item, key, selectedKeys }) | - |
+| onClick | 点击 MenuItem 调用此函数 | function({ item, key, keyPath, domEvent }) | - |
+| onDeselect | 取消选中时调用，仅在 multiple 生效 | function({ item, key, keyPath, selectedKeys, domEvent }) | - |
 | onOpenChange | SubMenu 展开/关闭的回调 | function(openKeys: string\[]) | noop |
-| onSelect | 被选中时调用 | function({ item, key, selectedKeys }) | 无   |
+| onSelect | 被选中时调用 | function({ item, key, keyPath, selectedKeys, domEvent }) | 无   |
 | overflowedIndicator | 自定义 Menu 折叠时的图标 | ReactNode | - |
 
 > More options in [rc-menu](https://github.com/react-component/menu#api)


### PR DESCRIPTION
add missing params in Menu's `onClick`, `onSelect` and `onDeselect` callback


-----
[View rendered components/menu/index.en-US.md](https://github.com/hansnow/ant-design/blob/fix-menu-docs/components/menu/index.en-US.md)
[View rendered components/menu/index.zh-CN.md](https://github.com/hansnow/ant-design/blob/fix-menu-docs/components/menu/index.zh-CN.md)