### PR TITLE
fix(forms): improve field error method type defs

### DIFF
--- a/components/form/Form.tsx
+++ b/components/form/Form.tsx
@@ -171,8 +171,8 @@ export type WrappedFormUtils<V = any> = {
   validateFieldsAndScroll(options: ValidateFieldsOptions): void;
   validateFieldsAndScroll(): void;
   /** 获取某个输入控件的 Error */
-  getFieldError(name: string): Object[];
-  getFieldsError(names?: Array<string>): Object;
+  getFieldError(name: string): string[] | undefined;
+  getFieldsError(names?: Array<string>): Record<string, string[] | undefined>;
   /** 判断一个输入控件是否在校验状态 */
   isFieldValidating(name: string): boolean;
   isFieldTouched(name: string): boolean;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?

`getFieldError` and `getFieldsError`'s return types are too restrictive, forcing consumers to cast the methods when using them.

### 💡 Solution

Change `getFieldError` and `getFieldsError` to return actual types, instead of very restrictive `Object` type (which should be avoided in general, in favour of `unknown`, `object`, or `Record` depending on actual use).

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

- English Changelog: improve return type of form field error getters
- Chinese Changelog (optional): ?

### ☑️ Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
