### PR TITLE
fix: Spin size not correct when set `fontSize`

### DIFF
--- a/components/spin/style/index.less
+++ b/components/spin/style/index.less
@@ -124,7 +124,7 @@
     display: inline-block;
     font-size: @spin-dot-size;
 
-    .square(@spin-dot-size);
+    .square(1em);
 
     &-item {
       position: absolute;
@@ -172,7 +172,6 @@
   &-sm &-dot {
     font-size: @spin-dot-size-sm;
 
-    .square(@spin-dot-size-sm);
     i {
       width: 6px;
       height: 6px;
@@ -183,7 +182,6 @@
   &-lg &-dot {
     font-size: @spin-dot-size-lg;
 
-    .square(@spin-dot-size-lg);
     i {
       width: 14px;
       height: 14px;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?

close #15206

### 💡 Solution

Use `em` unit.

### 📝 Changelog

Fix Spin size not correct when set `fontSize`

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
