### PR TITLE
Prevent negative margin-bottom for form items with help (e.g. validation errors)

### DIFF
--- a/components/form/style/index.less
+++ b/components/form/style/index.less
@@ -113,7 +113,7 @@ input[type='checkbox'] {
   }
 
   &-with-help {
-    margin-bottom: @form-item-margin-bottom - @form-explain-height - @form-help-margin-top;
+    margin-bottom: max(0, @form-item-margin-bottom - @form-explain-height - @form-help-margin-top);
   }
 
   &-label {


### PR DESCRIPTION
### 🤔 This is a ...

- [x] Bug fix

### 👻 What's the background?

Depending on some LESS variables, the margin-bottom of form items with help texts (e.g. validation errors) can possibly become negative:

Excerpt from `components/form/style/index.less`:

    margin-bottom: @form-item-margin-bottom - @form-explain-height - @form-help-margin-top;

This can cause the next DOM element (e.g. an fieldset) to float right to the field with the validation error:

![grafik](https://user-images.githubusercontent.com/91866/57681425-f5269e00-762f-11e9-911e-d5a2c89f471c.png)

You can see the effect in the wild here in this CodePen: <https://codesandbox.io/s/1ovwxmjr7q>
Try changing bottom-margin.

### 💡 Solution

This PR restricts the margin-bottom to be >= 0.

### 📝 Changelog

No visible changes from userside.

### ☑️ Self Check before Merge

- [x] Doc is not needed
- [x] Demo is not needed
- [x] TypeScript definition is not needed
- [x] Changelog is not needed
