### PR TITLE
Make Modal closeIcon customizable

### DIFF
--- a/components/modal/Modal.tsx
+++ b/components/modal/Modal.tsx
@@ -39,6 +39,8 @@ export interface ModalProps {
   title?: React.ReactNode | string;
   /** 是否显示右上角的关闭按钮*/
   closable?: boolean;
+  /** Custom Close Icon */
+  closeIcon?: React.ReactNode;
   /** 点击确定回调*/
   onOk?: (e: React.MouseEvent<any>) => void;
   /** 点击模态框右上角叉、取消按钮、Props.maskClosable 值为 true 时的遮罩层或键盘按下 Esc 时的回调*/
@@ -200,6 +202,7 @@ export default class Modal extends React.Component<ModalProps, {}> {
       visible,
       wrapClassName,
       centered,
+      closeIcon,
       ...restProps
     } = this.props;
 
@@ -210,7 +213,7 @@ export default class Modal extends React.Component<ModalProps, {}> {
       </LocaleReceiver>
     );
 
-    const closeIcon = (
+    const customCloseIcon = closeIcon || (
       <span className={`${prefixCls}-close-x`}>
         <Icon className={`${prefixCls}-close-icon`} type={'close'} />
       </span>
@@ -225,7 +228,7 @@ export default class Modal extends React.Component<ModalProps, {}> {
         visible={visible}
         mousePosition={mousePosition}
         onClose={this.handleCancel}
-        closeIcon={closeIcon}
+        closeIcon={customCloseIcon}
       />
     );
   };


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [x] New feature

### 👻 What's the background?

Just want to be able to customize Modal Close icon.

### 💡 Solution

Added `closeIcon` prop to Modal. It's basically just a proxy prop.

### 📝 Changelog

- English Changelog:
No breaking changes!
Modal has new `closeIcon` prop.

### ☑️ Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
