### PR TITLE
fix: Call Carousel force update when children lenght changed

### DIFF
--- a/components/carousel/__tests__/index.test.js
+++ b/components/carousel/__tests__/index.test.js
@@ -105,4 +105,13 @@ describe('Carousel', () => {
     );
     warnSpy.mockRestore();
   });
+
+  it('should active when children change', () => {
+    const wrapper = mount(<Carousel />);
+    wrapper.setProps({
+      children: <div />,
+    });
+    wrapper.update();
+    expect(wrapper.find('.slick-active').length).toBeTruthy();
+  });
 });

--- a/components/carousel/index.tsx
+++ b/components/carousel/index.tsx
@@ -33,6 +33,7 @@ export interface CarouselProps extends Settings {
   prefixCls?: string;
   slickGoTo?: number;
   dotPosition?: DotPosition;
+  children?: React.ReactNode;
 }
 
 export default class Carousel extends React.Component<CarouselProps, {}> {
@@ -68,6 +69,12 @@ export default class Carousel extends React.Component<CarouselProps, {}> {
     }
     // https://github.com/ant-design/ant-design/issues/7191
     this.innerSlider = this.slick && this.slick.innerSlider;
+  }
+
+  componentDidUpdate(prevProps: CarouselProps) {
+    if (React.Children.count(this.props.children) !== React.Children.count(prevProps.children)) {
+      this.goTo(0, false);
+    }
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?

fix #16583

### 💡 Solution

Call Carousel force update when children length changed

### 📝 Changelog

Fix Carousel miss active status when Children changed

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
