### PR TITLE
docs: Add width attr to the table's grouping columns demo

### DIFF
--- a/components/table/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/table/__tests__/__snapshots__/demo.test.js.snap
@@ -2638,7 +2638,7 @@ exports[`renders ./components/table/demo/dynamic-settings.md correctly 1`] = `
                           class="ant-dropdown-link"
                           href="javascript:;"
                         >
-                          More actions 
+                          More actions
                           <i
                             aria-label="icon: down"
                             class="anticon anticon-down"
@@ -2737,7 +2737,7 @@ exports[`renders ./components/table/demo/dynamic-settings.md correctly 1`] = `
                           class="ant-dropdown-link"
                           href="javascript:;"
                         >
-                          More actions 
+                          More actions
                           <i
                             aria-label="icon: down"
                             class="anticon anticon-down"
@@ -2836,7 +2836,7 @@ exports[`renders ./components/table/demo/dynamic-settings.md correctly 1`] = `
                           class="ant-dropdown-link"
                           href="javascript:;"
                         >
-                          More actions 
+                          More actions
                           <i
                             aria-label="icon: down"
                             class="anticon anticon-down"
@@ -2935,7 +2935,7 @@ exports[`renders ./components/table/demo/dynamic-settings.md correctly 1`] = `
                           class="ant-dropdown-link"
                           href="javascript:;"
                         >
-                          More actions 
+                          More actions
                           <i
                             aria-label="icon: down"
                             class="anticon anticon-down"
@@ -3034,7 +3034,7 @@ exports[`renders ./components/table/demo/dynamic-settings.md correctly 1`] = `
                           class="ant-dropdown-link"
                           href="javascript:;"
                         >
-                          More actions 
+                          More actions
                           <i
                             aria-label="icon: down"
                             class="anticon anticon-down"
@@ -3133,7 +3133,7 @@ exports[`renders ./components/table/demo/dynamic-settings.md correctly 1`] = `
                           class="ant-dropdown-link"
                           href="javascript:;"
                         >
-                          More actions 
+                          More actions
                           <i
                             aria-label="icon: down"
                             class="anticon anticon-down"
@@ -3232,7 +3232,7 @@ exports[`renders ./components/table/demo/dynamic-settings.md correctly 1`] = `
                           class="ant-dropdown-link"
                           href="javascript:;"
                         >
-                          More actions 
+                          More actions
                           <i
                             aria-label="icon: down"
                             class="anticon anticon-down"
@@ -3331,7 +3331,7 @@ exports[`renders ./components/table/demo/dynamic-settings.md correctly 1`] = `
                           class="ant-dropdown-link"
                           href="javascript:;"
                         >
-                          More actions 
+                          More actions
                           <i
                             aria-label="icon: down"
                             class="anticon anticon-down"
@@ -3430,7 +3430,7 @@ exports[`renders ./components/table/demo/dynamic-settings.md correctly 1`] = `
                           class="ant-dropdown-link"
                           href="javascript:;"
                         >
-                          More actions 
+                          More actions
                           <i
                             aria-label="icon: down"
                             class="anticon anticon-down"
@@ -3529,7 +3529,7 @@ exports[`renders ./components/table/demo/dynamic-settings.md correctly 1`] = `
                           class="ant-dropdown-link"
                           href="javascript:;"
                         >
-                          More actions 
+                          More actions
                           <i
                             aria-label="icon: down"
                             class="anticon anticon-down"
@@ -8877,7 +8877,9 @@ exports[`renders ./components/table/demo/grouping-columns.md correctly 1`] = `
                   <col
                     style="width:100px;min-width:100px"
                   />
-                  <col />
+                  <col
+                    style="width:200px;min-width:200px"
+                  />
                   <col />
                   <col
                     style="width:80px;min-width:80px"
@@ -9214,7 +9216,9 @@ exports[`renders ./components/table/demo/grouping-columns.md correctly 1`] = `
                   <col
                     style="width:100px;min-width:100px"
                   />
-                  <col />
+                  <col
+                    style="width:200px;min-width:200px"
+                  />
                   <col />
                   <col
                     style="width:80px;min-width:80px"

--- a/components/table/demo/grouping-columns.md
+++ b/components/table/demo/grouping-columns.md
@@ -82,6 +82,7 @@ const columns = [
         title: 'Company Address',
         dataIndex: 'companyAddress',
         key: 'companyAddress',
+        width: 200,
       },
       {
         title: 'Company Name',


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?

The body of table can't align it's header in grouping columns demo

### 💡 Solution

Add wdith attr

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/table/demo/grouping-columns.md](https://github.com/zjffun/ant-design/blob/patch-2/components/table/demo/grouping-columns.md)