### PR TITLE
chore: Fix affix navigator lost current class after click hashtag anchor.

### DIFF
--- a/docs/react/use-in-typescript.en-US.md
+++ b/docs/react/use-in-typescript.en-US.md
@@ -189,8 +189,6 @@ You can also follow instructions in [Use in create-react-app](/docs/react/use-wi
 
 And you can use [react-scripts-ts-antd](https://www.npmjs.com/package/react-scripts-ts-antd) which includes ts-import-plugin, react-app-rewired, scss, less and etc. You can create a new project that without any configurations by running just one command.
 
-## Alternative ways
-
 - [Create React apps (with Typescript and antd) with no build configuration](https://github.com/SZzzzz/react-scripts-ts-antd)
 - [react-app-rewire-typescript][https://github.com/lwd-technology/react-app-rewire-typescript]
 - [ts-import-plugin](https://github.com/Brooooooklyn/ts-import-plugin)

--- a/docs/react/use-in-typescript.zh-CN.md
+++ b/docs/react/use-in-typescript.zh-CN.md
@@ -183,6 +183,10 @@ module.exports = override(
 
 ## 其他方案
 
+先按照 [在 create-react-app 中使用](/docs/react/use-with-create-react-app.en-US.md) 中的说明操作，再配置 TypeScript 开发环境。
+
+你也可以使用 [react-scripts-ts-antd](https://www.npmjs.com/package/react-scripts-ts-antd)，其中包括了 ts-import-plugin，react-app-rewired，scss，less 等插件。你可以通过只运行一个命令来创建一个没有任何配置的新项目。
+
 - [Create React apps (with Typescript and antd) with no build configuration](https://github.com/SZzzzz/react-scripts-ts-antd)
 - [react-app-rewire-typescript][https://github.com/lwd-technology/react-app-rewire-typescript]
 - [ts-import-plugin](https://github.com/Brooooooklyn/ts-import-plugin)

--- a/site/theme/template/Content/Article.jsx
+++ b/site/theme/template/Content/Article.jsx
@@ -11,6 +11,16 @@ export default class Article extends React.Component {
     intl: PropTypes.object.isRequired,
   };
 
+  shouldComponentUpdate(nextProps) {
+    const { location } = this.props;
+    const { location: nextLocation } = nextProps;
+
+    if (nextLocation.pathname === location.pathname) {
+      return false;
+    }
+    return true;
+  }
+
   onResourceClick = e => {
     if (!window.gtag) {
       return;

--- a/site/theme/template/Content/ComponentDoc.jsx
+++ b/site/theme/template/Content/ComponentDoc.jsx
@@ -29,6 +29,16 @@ export default class ComponentDoc extends React.Component {
     });
   }
 
+  shouldComponentUpdate(nextProps) {
+    const { location } = this.props;
+    const { location: nextLocation } = nextProps;
+
+    if (nextLocation.pathname === location.pathname) {
+      return false;
+    }
+    return true;
+  }
+
   componentWillUnmount() {
     clearTimeout(this.pingTimer);
   }

--- a/site/theme/template/Content/MainContent.jsx
+++ b/site/theme/template/Content/MainContent.jsx
@@ -68,6 +68,7 @@ export default class MainContent extends Component {
 
   componentDidMount() {
     this.componentDidUpdate();
+    window.addEventListener('load', this.handleInitialHashOnLoad);
   }
 
   static getDerivedStateFromProps(props, state) {
@@ -87,13 +88,21 @@ export default class MainContent extends Component {
       this.bindScroller();
     }
     if (!window.location.hash && prevLocation.pathname !== location.pathname) {
-      document.documentElement.scrollTop = 0;
+      window.scrollTo(0, 0);
     }
     // when subMenu not equal
     if (get(this.props, 'route.path') !== get(prevProps, 'route.path')) {
       // reset menu OpenKeys
       this.handleMenuOpenChange();
     }
+  }
+
+  componentWillUnmount() {
+    this.scroller.destroy();
+    window.removeEventListener('load', this.handleInitialHashOnLoad);
+  }
+
+  handleInitialHashOnLoad() {
     setTimeout(() => {
       if (!window.location.hash) {
         return;
@@ -105,10 +114,6 @@ export default class MainContent extends Component {
         element.scrollIntoView();
       }
     }, 0);
-  }
-
-  componentWillUnmount() {
-    this.scroller.disable();
   }
 
   getMenuItems(footerNavIcons = {}) {
@@ -165,7 +170,7 @@ export default class MainContent extends Component {
 
   bindScroller() {
     if (this.scroller) {
-      this.scroller.disable();
+      this.scroller.destroy();
     }
     require('intersection-observer'); // eslint-disable-line
     const scrollama = require('scrollama'); // eslint-disable-line

--- a/site/theme/template/Content/MainContent.jsx
+++ b/site/theme/template/Content/MainContent.jsx
@@ -102,20 +102,6 @@ export default class MainContent extends Component {
     window.removeEventListener('load', this.handleInitialHashOnLoad);
   }
 
-  handleInitialHashOnLoad() {
-    setTimeout(() => {
-      if (!window.location.hash) {
-        return;
-      }
-      const element = document.getElementById(
-        decodeURIComponent(window.location.hash.replace('#', '')),
-      );
-      if (element && document.documentElement.scrollTop === 0) {
-        element.scrollIntoView();
-      }
-    }, 0);
-  }
-
   getMenuItems(footerNavIcons = {}) {
     const { themeConfig } = this.props;
     const {
@@ -166,6 +152,20 @@ export default class MainContent extends Component {
 
   handleMenuOpenChange = openKeys => {
     this.setState({ openKeys });
+  };
+
+  handleInitialHashOnLoad = () => {
+    setTimeout(() => {
+      if (!window.location.hash) {
+        return;
+      }
+      const element = document.getElementById(
+        decodeURIComponent(window.location.hash.replace('#', '')),
+      );
+      if (element && document.documentElement.scrollTop === 0) {
+        element.scrollIntoView();
+      }
+    }, 0);
   };
 
   bindScroller() {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?

1. When click the anchor in the page, the attributes created by `scrollama` will be removed. That lead to the callback of `scrollama` can't set the `.current` to the children of `.toc-affix`.

2. `document.documentElement.scrollTop = 0;` can't work on safari, `window.scrollTo` has more compatible than that.

3. On page load, the original code can't scroll the anchor element on `<Article />`.

### 💡 Solution

1. Update the `<Article />` only when router changed.
2. Change the time of scroll into anchor element to onload.

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

- English Changelog:
- Chinese Changelog (optional):

### ☑️ Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

-----
[View rendered docs/react/use-in-typescript.en-US.md](https://github.com/gxvv/ant-design/blob/master/docs/react/use-in-typescript.en-US.md)
[View rendered docs/react/use-in-typescript.zh-CN.md](https://github.com/gxvv/ant-design/blob/master/docs/react/use-in-typescript.zh-CN.md)