### PR TITLE
Remove ancient prop types

### DIFF
--- a/components/breadcrumb/Breadcrumb.tsx
+++ b/components/breadcrumb/Breadcrumb.tsx
@@ -59,8 +59,6 @@ export default class Breadcrumb extends React.Component<BreadcrumbProps, any> {
     separator: PropTypes.node,
     routes: PropTypes.array,
     params: PropTypes.object,
-    linkRender: PropTypes.func,
-    nameRender: PropTypes.func,
   };
 
   componentDidMount() {

--- a/components/modal/Modal.tsx
+++ b/components/modal/Modal.tsx
@@ -154,7 +154,6 @@ export default class Modal extends React.Component<ModalProps, {}> {
     width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     confirmLoading: PropTypes.bool,
     visible: PropTypes.bool,
-    align: PropTypes.object,
     footer: PropTypes.node,
     title: PropTypes.node,
     closable: PropTypes.bool,

--- a/components/progress/progress.tsx
+++ b/components/progress/progress.tsx
@@ -58,7 +58,6 @@ export default class Progress extends React.Component<ProgressProps> {
     trailColor: PropTypes.string,
     format: PropTypes.func,
     gapDegree: PropTypes.number,
-    default: PropTypes.oneOf(['default', 'small']),
   };
 
   getPercentNumber() {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?

I noticed them after upgrading to TypeScript 3.4, since it started complaining that I didn't specify `align` on my Modals, `default` on my Progresses, and `nameRender`/`linkRender` on my Breadcrumbs.

I assume TypeScript is confused by finding the property in `propTypes` but not in the `Props` interface.

<!--
1. Describe the source of requirement, like related issue link.

2. Describe the problem and the scenario.
-->

### 💡 Solution

Remove the `propType` entries.

<!--
1. How to fix the problem, and list final API implementation and usage sample if that is an new feature.

2. GIF or snapshot should be provided if includes UI/interactive modification.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Removed (already obsoleted long ago) `Modal.propTypes.align`, `Progress.propTypes.default`, `Breadcrumbs.propTypes.linkRender`, and `Breadcrumbs.propTypes.nameRender` |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
