### PR TITLE
fix: adjust Carousel children change goto Logic

### DIFF
--- a/components/carousel/__tests__/index.test.js
+++ b/components/carousel/__tests__/index.test.js
@@ -106,12 +106,28 @@ describe('Carousel', () => {
     warnSpy.mockRestore();
   });
 
-  it('should active when children change', () => {
-    const wrapper = mount(<Carousel />);
-    wrapper.setProps({
-      children: <div />,
+  describe('should active when children change', () => {
+    it('should active', () => {
+      const wrapper = mount(<Carousel />);
+      wrapper.setProps({
+        children: <div />,
+      });
+      wrapper.update();
+      expect(wrapper.find('.slick-active').length).toBeTruthy();
     });
-    wrapper.update();
-    expect(wrapper.find('.slick-active').length).toBeTruthy();
+
+    it('should keep initialSlide', () => {
+      const wrapper = mount(<Carousel initialSlide={1} />);
+      wrapper.setProps({
+        children: [<div key="1" />, <div key="2" />, <div key="3" />],
+      });
+      wrapper.update();
+      expect(
+        wrapper
+          .find('.slick-dots li')
+          .at(1)
+          .hasClass('slick-active'),
+      ).toBeTruthy();
+    });
   });
 });

--- a/components/carousel/index.tsx
+++ b/components/carousel/index.tsx
@@ -73,7 +73,7 @@ export default class Carousel extends React.Component<CarouselProps, {}> {
 
   componentDidUpdate(prevProps: CarouselProps) {
     if (React.Children.count(this.props.children) !== React.Children.count(prevProps.children)) {
-      this.goTo(0, false);
+      this.goTo(this.props.initialSlide || 0, false);
     }
   }
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?

fix #16748 

### 💡 Solution

Update `componentDidUpdate` logic

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Carousel `initialSlide` not work when `children` count change |
| 🇨🇳 Chinese | 修复 Carousel `initialSlide` 在 `children` 数量变化时无效的问题 |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
