### PR TITLE
fix: User has to press down arrow key twice to select the first option while searching #16762

### DIFF
--- a/components/cascader/__tests__/index.test.js
+++ b/components/cascader/__tests__/index.test.js
@@ -258,7 +258,7 @@ describe('Cascader', () => {
     expect(wrapper.state('inputValue')).toBe('');
   });
 
-  it('should not trigger visible change when click search input', () => {
+  it('should trigger visible change when click search input', () => {
     const onPopupVisibleChange = jest.fn();
     const wrapper = mount(
       <Cascader options={options} showSearch onPopupVisibleChange={onPopupVisibleChange} />,
@@ -272,7 +272,7 @@ describe('Cascader', () => {
     wrapper.find('input').simulate('blur');
     wrapper.setState({ popupVisible: false });
     wrapper.find('input').simulate('click');
-    expect(onPopupVisibleChange).toHaveBeenCalledTimes(2);
+    expect(onPopupVisibleChange).toHaveBeenCalledTimes(1);
   });
 
   it('should change filtered item when options are changed', () => {

--- a/components/cascader/index.tsx
+++ b/components/cascader/index.tsx
@@ -274,12 +274,6 @@ class Cascader extends React.Component<CascaderProps, CascaderState> {
     }
   };
 
-  handleInputBlur = () => {
-    this.setState({
-      inputFocused: false,
-    });
-  };
-
   handleInputClick = (e: React.MouseEvent<HTMLInputElement>) => {
     const { inputFocused, popupVisible } = this.state;
     // Prevent `Trigger` behaviour.
@@ -530,7 +524,6 @@ class Cascader extends React.Component<CascaderProps, CascaderState> {
           readOnly={!showSearch}
           autoComplete="off"
           onClick={showSearch ? this.handleInputClick : undefined}
-          onBlur={showSearch ? this.handleInputBlur : undefined}
           onKeyDown={this.handleKeyDown}
           onChange={showSearch ? this.handleInputChange : undefined}
         />


### PR DESCRIPTION
 fix: User has to press down arrow key twice to select the first option while searching #16762

<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?
close #16762
<!--
1. Describe the source of requirement, like related issue link.

2. Describe the problem and the scenario.
-->

### 💡 Solution
delete handleInputBlur
<!--
1. How to fix the problem, and list final API implementation and usage sample if that is an new feature.

2. GIF or snapshot should be provided if includes UI/interactive modification.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
