### PR TITLE
给上传组件添加disabled状态的cursor样式

### DIFF
--- a/components/upload/style/index.less
+++ b/components/upload/style/index.less
@@ -29,6 +29,10 @@
     display: inline-block;
   }
 
+  &&-disabled {
+    cursor: not-allowed;
+  }
+
   &&-select-picture-card {
     display: table;
     width: @upload-picture-card-size;


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [] 日常 bug 修复
- [ ] 站点、文档改进
- [x] 组件样式改进
- [ ] TypeScript 定义更新
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 👻 需求背景

目前的Upload组件在disabled状态下自身没有鼠标的not-allowed样式。
### 💡 解决方案和最终实现是？
给处于disabled状态下的Upload组件的.ant-upload-disabled节点添加`cursor: not-allowed;`

### 📝 更新日志怎么写？

### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供