### PR TITLE
fix: Tooltip not hidden when menu is in control mode

### DIFF
--- a/components/menu/MenuItem.tsx
+++ b/components/menu/MenuItem.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Item } from 'rc-menu';
 import { ClickParam } from '.';
 import { MenuContext, MenuContextProps } from './';
-import Tooltip from '../tooltip';
+import Tooltip, { TooltipProps } from '../tooltip';
 import { SiderContext, SiderContextProps } from '../layout/Sider';
 
 export interface MenuItemProps {
@@ -37,13 +37,19 @@ export default class MenuItem extends React.Component<MenuItemProps> {
     return (
       <MenuContext.Consumer>
         {({ inlineCollapsed }: MenuContextProps) => {
+          const tooltipProps: TooltipProps = {};
+
           let titleNode = title || (level === 1 ? children : '');
           if (!siderCollapsed && !inlineCollapsed) {
             titleNode = null;
+            // Reset `visible` to fix control mode tooltip display not correct
+            // ref: https://github.com/ant-design/ant-design/issues/16742
+            tooltipProps.visible = false;
           }
 
           return (
             <Tooltip
+              {...tooltipProps}
               title={titleNode}
               placement="right"
               overlayClassName={`${rootPrefixCls}-inline-collapsed-tooltip`}


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?

fix #16742

### 💡 Solution

Reset Tooltip visible when disabled

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Tooltip not hidden when Menu collapsed in control mode |
| 🇨🇳 Chinese | 修复 Menu 在受控模式下收起 Tooltip 不消失的问题  |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

PS: Not easy way to add test case