### PR TITLE
fix: Fix typo name icons

### DIFF
--- a/components/icon/__tests__/index.test.js
+++ b/components/icon/__tests__/index.test.js
@@ -226,4 +226,22 @@ describe('utils', () => {
       'home-o',
     ]);
   });
+
+  it('should depracate typo icon name', () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    render(<Icon type="interation" />);
+    expect(errorSpy).toHaveBeenLastCalledWith(
+      "Warning: [antd: Icon] Icon 'interation' is typo and depracated, please use 'interaction' instead.",
+    );
+    render(<Icon type="cross" />);
+    expect(errorSpy).toHaveBeenLastCalledWith(
+      "Warning: [antd: Icon] Icon 'cross' is typo and depracated, please use 'close' instead.",
+    );
+    render(<Icon type="canlendar" theme="twoTone" />);
+    expect(errorSpy).toHaveBeenLastCalledWith(
+      "Warning: [antd: Icon] Icon 'canlendar' is typo and depracated, please use 'calendar' instead.",
+    );
+    expect(errorSpy).toHaveBeenCalledTimes(3);
+    errorSpy.mockRestore();
+  });
 });

--- a/components/icon/utils.ts
+++ b/components/icon/utils.ts
@@ -50,10 +50,25 @@ export function withThemeSuffix(type: string, theme: ThemeType) {
 
 // For alias or compatibility
 export function alias(type: string) {
+  let newType = type;
   switch (type) {
     case 'cross':
-      return 'close';
+      newType = 'close';
+      break;
+    // https://github.com/ant-design/ant-design/issues/13007
+    case 'interation':
+      newType = 'interaction';
+      break;
+    // https://github.com/ant-design/ant-design/issues/16810
+    case 'canlendar':
+      newType = 'calendar';
+      break;
     default:
   }
-  return type;
+  warning(
+    newType === type,
+    'Icon',
+    `Icon '${type}' is typo and depracated, please use '${newType}' instead.`,
+  );
+  return newType;
 }

--- a/site/theme/template/IconDisplay/fields.ts
+++ b/site/theme/template/IconDisplay/fields.ts
@@ -5,6 +5,9 @@ Object.keys(manifest).forEach(theme => {
   allIcons = [...allIcons, ...(manifest as any)[theme]];
 });
 
+// Hide typo-name icons
+allIcons = allIcons.filter((name: string) => !['interation', 'canlendar'].includes(name));
+
 export const categories = {
   all: [...new Set(allIcons)],
   direction: [


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?

close #13007
close #16810

deps: ant-design/ant-design-icons#63

### 💡 Solution

Added warning and aliased, document updated too.

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Correct typo icon names `canlendar`/`interation` to `calendar`/`interaction`. #13007 #16810  |
| 🇨🇳 Chinese | 修复图标 `canlendar` 和 `interation` 为正确的拼写 `calendar` 和 `interaction`. #13007 #16810 |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
