### PR TITLE
fix(Transfer): avoid setState on an unmounted component

### DIFF
--- a/components/transfer/renderListBody.tsx
+++ b/components/transfer/renderListBody.tsx
@@ -36,7 +36,7 @@ class ListBody extends React.Component<TransferListBodyProps> {
     });
   }
 
-  componentWillMount() {
+  componentWillUnmount() {
     raf.cancel(this.mountId);
   }
 


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?

Transfer component may warn `Can't perform a React state update on an unmounted component` sometimes.

### 💡 Solution

Revise incorrect react lifecycle using.

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix transfer component warn state update on an unmounted component  |
| 🇨🇳 Chinese | 修复 Transfer 组件发出“在销毁的组件呼叫 setState”的警告  |

### ☑️ Self Check before Merge

- [x] Doc is not needed
- [x] Demo is not needed
- [x] TypeScript definition is not needed
- [x] Changelog is provided
