### PR TITLE
chore: Add warning if use `inlineCollapsed` under Sider

### DIFF
--- a/components/layout/__tests__/index.test.js
+++ b/components/layout/__tests__/index.test.js
@@ -138,7 +138,17 @@ describe('Layout', () => {
   });
 });
 
-describe('Sider onBreakpoint', () => {
+describe('Sider', () => {
+  const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+  afterEach(() => {
+    errorSpy.mockReset();
+  });
+
+  afterAll(() => {
+    errorSpy.mockRestore();
+  });
+
   beforeAll(() => {
     Object.defineProperty(window, 'matchMedia', {
       value: jest.fn(() => ({
@@ -158,5 +168,16 @@ describe('Sider onBreakpoint', () => {
       </Sider>,
     );
     expect(onBreakpoint).toHaveBeenCalledWith(true);
+  });
+
+  it('should warning if use `inlineCollapsed` with menu', () => {
+    mount(
+      <Sider collapsible>
+        <Menu mode="inline" inlineCollapsed />
+      </Sider>,
+    );
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Warning: [antd: Menu] `inlineCollapsed` not control Menu under Sider. Should set `collapsed` on Sider instead.',
+    );
   });
 });

--- a/components/menu/index.tsx
+++ b/components/menu/index.tsx
@@ -142,6 +142,12 @@ class InternalMenu extends React.Component<InternalMenuProps, MenuState> {
       '`inlineCollapsed` should only be used when `mode` is inline.',
     );
 
+    warning(
+      !(props.siderCollapsed !== undefined && 'inlineCollapsed' in props),
+      'Menu',
+      '`inlineCollapsed` not control Menu under Sider. Should set `collapsed` on Sider instead.',
+    );
+
     let openKeys;
     if ('openKeys' in props) {
       openKeys = props.openKeys;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [x] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?

close #16701

### 💡 Solution

Add warning

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Add warning if Menu use `inlineCollapsed` under Sider |
| 🇨🇳 Chinese | 当 Sider 内 Menu 使用 `inlineCollapsed` 添加提示信息 |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
