### PR TITLE
fix: use @error-color & @warning-color instead of @text-color-danger & @text-color-warning #16856

### DIFF
--- a/components/style/themes/default.less
+++ b/components/style/themes/default.less
@@ -47,8 +47,6 @@
 @code-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
 @text-color: fade(@black, 65%);
 @text-color-secondary: fade(@black, 45%);
-@text-color-warning: @gold-7;
-@text-color-danger: @red-7;
 @text-color-inverse: @white;
 @icon-color: inherit;
 @icon-color-hover: fade(@black, 75%);

--- a/components/typography/style/index.less
+++ b/components/typography/style/index.less
@@ -39,11 +39,11 @@
   }
 
   &&-warning {
-    color: @text-color-warning;
+    color: @warning-color;
   }
 
   &&-danger {
-    color: @text-color-danger;
+    color: @error-color;
   }
 
   &&-disabled {


### PR DESCRIPTION


<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?

<!--
1. Describe the source of requirement, like related issue link.

2. Describe the problem and the scenario.
-->
close #16856 
### 💡 Solution

<!--
1. How to fix the problem, and list final API implementation and usage sample if that is an new feature.

2. GIF or snapshot should be provided if includes UI/interactive modification.
-->
use @error-color & @warning-color instead of @text-color-danger & @text-color-warning
### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      use @error-color & @warning-color instead of @text-color-danger & @text-color-warning     |
| 🇨🇳 Chinese |     用 @error-color & @warning-color 代替 @text-color-danger & @text-color-warning     |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
