### PR TITLE
fix docs(table): update `rowSelection` default value

### DIFF
--- a/components/table/index.en-US.md
+++ b/components/table/index.en-US.md
@@ -77,7 +77,7 @@ const columns = [
 | pagination | Config of pagination. You can ref table pagination [config](#pagination) or full [`pagination`](/components/pagination/) document, hide it by setting it to `false` | object |  |
 | rowClassName | Row's className | Function(record, index):string | - |
 | rowKey | Row's unique key, could be a string or function that returns a string | string\|Function(record):string | `key` |
-| rowSelection | Row selection [config](#rowSelection) | object | null |
+| rowSelection | Row selection [config](#rowSelection) | object | {} |
 | scroll | Set horizontal or vertical scrolling, can also be used to specify the width and height of the scroll area, could be number, percent value, `true` and ['max-content'](https://developer.mozilla.org/en-US/docs/Web/CSS/width) | { x: number \| true, y: number } | - |
 | showHeader | Whether to show table header | boolean | `true` |
 | size | Size of table | `default` \| `middle` \| `small` | `default` |

--- a/components/table/index.zh-CN.md
+++ b/components/table/index.zh-CN.md
@@ -82,7 +82,7 @@ const columns = [
 | pagination | 分页器，参考[配置项](#pagination)或 [pagination](/components/pagination/) 文档，设为 false 时不展示和进行分页 | object |  |
 | rowClassName | 表格行的类名 | Function(record, index):string | - |
 | rowKey | 表格行 key 的取值，可以是字符串或一个函数 | string\|Function(record):string | 'key' |
-| rowSelection | 表格行是否可选择，[配置项](#rowSelection) | object | null |
+| rowSelection | 表格行是否可选择，[配置项](#rowSelection) | object | {} |
 | scroll | 设置横向或纵向滚动，也可用于指定滚动区域的宽和高，可以设置为像素值，百分比，`true` 和 ['max-content'](https://developer.mozilla.org/zh-CN/docs/Web/CSS/width#max-content) | { x: number \| true, y: number } | - |
 | showHeader | 是否显示表头 | boolean | true |
 | size | 表格大小 | default \| middle \| small | default |


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?

rowSelection default value should be `{}`, cause `null` is an invalid value in typescript

<!--
1. Describe the source of requirement, like related issue link.

2. Describe the problem and the scenario.
-->

### 💡 Solution
refer: https://github.com/ant-design/ant-design/blob/master/components/table/Table.tsx#L54
https://github.com/ant-design/ant-design/blob/master/components/table/interface.tsx#L135

change `null` to `{}`
<!--
1. How to fix the problem, and list final API implementation and usage sample if that is an new feature.

2. GIF or snapshot should be provided if includes UI/interactive modification.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | correct the default value for rowSelection |
| 🇨🇳 Chinese | 更正 rowSelection 的默认值 |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
