### PR TITLE
:lipstick: use marginRight remind developer

### DIFF
--- a/components/auto-complete/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/auto-complete/__tests__/__snapshots__/demo.test.js.snap
@@ -443,6 +443,7 @@ exports[`renders ./components/auto-complete/demo/uncertain-category.md correctly
                 >
                   <button
                     class="ant-btn search-btn ant-btn-primary ant-btn-lg"
+                    style="margin-right:-12px"
                     type="button"
                   >
                     <i

--- a/components/auto-complete/demo/uncertain-category.md
+++ b/components/auto-complete/demo/uncertain-category.md
@@ -85,7 +85,12 @@ class Complete extends React.Component {
         >
           <Input
             suffix={
-              <Button className="search-btn" size="large" type="primary">
+              <Button
+                className="search-btn"
+                style={{ marginRight: -12 }}
+                size="large"
+                type="primary"
+              >
                 <Icon type="search" />
               </Button>
             }
@@ -114,10 +119,6 @@ ReactDOM.render(<Complete />, mountNode);
 
 .global-search.ant-select-auto-complete .ant-input-affix-wrapper .ant-input:not(:last-child) {
   padding-right: 62px;
-}
-
-.global-search.ant-select-auto-complete .ant-input-affix-wrapper .ant-input-suffix {
-  right: 0;
 }
 
 .global-search.ant-select-auto-complete .ant-input-affix-wrapper .ant-input-suffix button {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?

https://codesandbox.io/s/interesting-sound-5pc2w

If the developer doesn't copy the style, might see the result below.

![image](https://user-images.githubusercontent.com/13595509/58876778-a1c0e080-8701-11e9-890e-14e7fad256cf.png)




### 💡 Solution

using `marginRight` instead.

<!--
1. How to fix the problem, and list final API implementation and usage sample if that is an new feature.

2. GIF or snapshot should be provided if includes UI/interactive modification.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed


-----
[View rendered components/auto-complete/demo/uncertain-category.md](https://github.com/ant-design/ant-design/blob/tweak-autocomplete-style/components/auto-complete/demo/uncertain-category.md)