### PR TITLE
feat(popconfirm): add disabled props

### DIFF
--- a/components/popconfirm/index.en-US.md
+++ b/components/popconfirm/index.en-US.md
@@ -23,6 +23,7 @@ The difference with the `confirm` modal dialog is that it's more lightweight tha
 | onCancel | callback of cancel | function(e) | - |
 | onConfirm | callback of confirmation | function(e) | - |
 | icon | customize icon of confirmation | ReactNode | &lt;Icon type="exclamation-circle" /&gt; |
+| disabled | is show popconfirm when click its childrenNode | boolean | false |
 
 Consult [Tooltip's documentation](https://ant.design/components/tooltip/#API) to find more APIs.
 

--- a/components/popconfirm/index.tsx
+++ b/components/popconfirm/index.tsx
@@ -10,6 +10,7 @@ import { ConfigConsumer, ConfigConsumerProps } from '../config-provider';
 
 export interface PopconfirmProps extends AbstractTooltipProps {
   title: React.ReactNode;
+  disabled?: boolean;
   onConfirm?: (e?: React.MouseEvent<any>) => void;
   onCancel?: (e?: React.MouseEvent<any>) => void;
   okText?: React.ReactNode;
@@ -37,6 +38,7 @@ class Popconfirm extends React.Component<PopconfirmProps, PopconfirmState> {
     trigger: 'click' as PopconfirmProps['trigger'],
     okType: 'primary' as PopconfirmProps['okType'],
     icon: <Icon type="exclamation-circle" theme="filled" />,
+    disabled: false,
   };
 
   static getDerivedStateFromProps(nextProps: PopconfirmProps) {
@@ -81,6 +83,10 @@ class Popconfirm extends React.Component<PopconfirmProps, PopconfirmState> {
   };
 
   onVisibleChange = (visible: boolean) => {
+    const { disabled } = this.props;
+    if (disabled) {
+      return;
+    }
     this.setVisible(visible);
   };
 

--- a/components/popconfirm/index.zh-CN.md
+++ b/components/popconfirm/index.zh-CN.md
@@ -24,6 +24,7 @@ title: Popconfirm
 | onCancel | 点击取消的回调 | function(e) | 无 |
 | onConfirm | 点击确认的回调 | function(e) | 无 |
 | icon | 自定义弹出气泡 Icon 图标 | ReactNode | &lt;Icon type="exclamation-circle" /&gt; |
+| disabled | 点击 Popconfirm 子元素是否弹出气泡确认框 | boolean | false |
 
 更多属性请参考 [Tooltip](/components/tooltip/#API)。
 


### PR DESCRIPTION
### 这个变动的性质是

- [x] 新特性提交
- [ ] 其他改动（日常 bugfix、文档、站点改进、分支合并等，不需要填写余下的模板）

### 需求背景
  
> 1. 需求的来源：包住有可能disabled的Button的时候，如果按钮是disabled，点击还会弹出确认框
> 2. 这样子，就要加个判断，按照条件去掉外面那层Popconfirm；或者维护一个state控制visible属性，有点麻烦。
> 3. [issue](https://github.com/ant-design/ant-design/issues/16947)
  
### 实现方案和 API
  
> 1. 新增一个disabled的prop，当Popconfirm为disabled状态时，点击它所包住的按钮都不会弹出气泡确认框
> 2. 在onVisibleChange方法中加上一个disabled为true的拦截

  
### 对用户的影响和可能的风险

> 1. 这个改动对用户端无影响
> 2. 预期的 changelog:  
zh-CN: `Popconfirm`组件新增`disabled`属性，控制点击 `Popconfirm` 子元素是否弹出气泡确认框
en-US: add `disabled` prop in `Popconfirm`,to control the display when clicking its childrenNode
> 3. 暂无其他风险

### 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供

### 后续计划

> 透传disabled给button。其实也不是很需要

-----
[View rendered components/popconfirm/index.en-US.md](https://github.com/lhyt/ant-design/blob/feat_disabled_in_popconfirm/components/popconfirm/index.en-US.md)
[View rendered components/popconfirm/index.zh-CN.md](https://github.com/lhyt/ant-design/blob/feat_disabled_in_popconfirm/components/popconfirm/index.zh-CN.md)