### PR TITLE
Feat disabled in popconfirm

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -20,7 +20,7 @@ timeline: true
 `2019-06-01`
 
 - 🐞 Fix Tabs vertical card mode not scrollable. [#16825](https://github.com/ant-design/ant-design/pull/16825)
-- 🐞 Fix transfer warn state update on an unmounted component. [#16822](https://github.com/ant-design/ant-design/pull/16822) [@shiningjason](https://github.com/shiningjason)
+- 🐞 Fix Transfer warn state update on an unmounted component. [#16822](https://github.com/ant-design/ant-design/pull/16822) [@shiningjason](https://github.com/shiningjason)
 - 🐞 Fix Less var using `@error-color`, `@warning-color` instead of `@text-color-danger`, `@text-color-warning`. [#16890](https://github.com/ant-design/ant-design/pull/16890) [@MrHeer](https://github.com/MrHeer)
 - 💄 Add warning if Menu use `inlineCollapsed` under Sider. [#16826](https://github.com/ant-design/ant-design/pull/16826)
 - 💄 Remove useless Modal default props `okButtonDisabled`, `cancelButtonDisabled`. [#16869](https://github.com/ant-design/ant-design/pull/16869) [@aiham](https://github.com/aiham)

--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -20,7 +20,7 @@ timeline: true
 `2019-06-01`
 
 - 🐞 Fix Tabs vertical card mode not scrollable. [#16825](https://github.com/ant-design/ant-design/pull/16825)
-- 🐞 Fix Transfer warn state update on an unmounted component. [#16822](https://github.com/ant-design/ant-design/pull/16822) [@shiningjason](https://github.com/shiningjason)
+- 🐞 Fix Transfer warn `setStart` on an unmounted component. [#16822](https://github.com/ant-design/ant-design/pull/16822) [@shiningjason](https://github.com/shiningjason)
 - 🐞 Fix Less var using `@error-color`, `@warning-color` instead of `@text-color-danger`, `@text-color-warning`. [#16890](https://github.com/ant-design/ant-design/pull/16890) [@MrHeer](https://github.com/MrHeer)
 - 💄 Add warning if Menu use `inlineCollapsed` under Sider. [#16826](https://github.com/ant-design/ant-design/pull/16826)
 - TypeScript

--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -26,7 +26,7 @@ timeline: true
 - 🐞 Fix Less var, using `@error-color`、`@warning-color` instead of `@text-color-danger`、`@text-color-warning`. [#16890](https://github.com/ant-design/ant-design/pull/16890) [@MrHeer](https://github.com/MrHeer)
 - TypeScript
   - ⚡️ Add `forceSubmenuRender` into MenuProps. [#16827](https://github.com/ant-design/ant-design/pull/16827)
-  - ⚡️ export `TypographyProps` type. [#16835](https://github.com/ant-design/ant-design/pull/16835)
+  - ⚡️ Export `TypographyProps` type. [#16835](https://github.com/ant-design/ant-design/pull/16835)
   - ⚡️ Add `onChange` prop type definition to Steps. [#16845](https://github.com/ant-design/ant-design/pull/16845) [@JonathanLee-LX](https://github.com/JonathanLee-LX)
   - ⚡️ Add `webkitRelativePath` prop type definition to Upload. [#16850](https://github.com/ant-design/ant-design/pull/16850) [@DiamondYuan](https://github.com/DiamondYuan)
 

--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -21,7 +21,7 @@ timeline: true
 
 - 🐞 Fix Tabs vertical card mode not scrollable. [#16825](https://github.com/ant-design/ant-design/pull/16825)
 - 🐞 Fix Transfer warn `setStart` on an unmounted component. [#16822](https://github.com/ant-design/ant-design/pull/16822) [@shiningjason](https://github.com/shiningjason)
-- 🐞 Fix Less var using `@error-color`, `@warning-color` instead of `@text-color-danger`, `@text-color-warning`. [#16890](https://github.com/ant-design/ant-design/pull/16890) [@MrHeer](https://github.com/MrHeer)
+- 💄 using Less var `@error-color`, `@warning-color` instead of `@text-color-danger`, `@text-color-warning`. [#16890](https://github.com/ant-design/ant-design/pull/16890) [@MrHeer](https://github.com/MrHeer)
 - 💄 Add warning if Menu use `inlineCollapsed` under Sider. [#16826](https://github.com/ant-design/ant-design/pull/16826)
 - TypeScript
   - ⚡️ Add `forceSubmenuRender` into MenuProps. [#16827](https://github.com/ant-design/ant-design/pull/16827)

--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -21,9 +21,9 @@ timeline: true
 
 - 🐞 Fix Tabs vertical card mode not scrollable. [#16825](https://github.com/ant-design/ant-design/pull/16825)
 - 🐞 Fix transfer warn state update on an unmounted component. [#16822](https://github.com/ant-design/ant-design/pull/16822) [@shiningjason](https://github.com/shiningjason)
-- 🐞 Fix Less var, using `@error-color`、`@warning-color` instead of `@text-color-danger`、`@text-color-warning`. [#16890](https://github.com/ant-design/ant-design/pull/16890) [@MrHeer](https://github.com/MrHeer)
+- 🐞 Fix Less var, using `@error-color`, `@warning-color` instead of `@text-color-danger`, `@text-color-warning`. [#16890](https://github.com/ant-design/ant-design/pull/16890) [@MrHeer](https://github.com/MrHeer)
 - 💄 Add warning if Menu use `inlineCollapsed` under Sider. [#16826](https://github.com/ant-design/ant-design/pull/16826)
-- 💄 Remove useless Modal default props `okButtonDisabled` 、`cancelButtonDisabled`. [#16869](https://github.com/ant-design/ant-design/pull/16869) [@aiham](https://github.com/aiham)
+- 💄 Remove useless Modal default props `okButtonDisabled`, `cancelButtonDisabled`. [#16869](https://github.com/ant-design/ant-design/pull/16869) [@aiham](https://github.com/aiham)
 - TypeScript
   - ⚡️ Add `forceSubmenuRender` into MenuProps. [#16827](https://github.com/ant-design/ant-design/pull/16827)
   - ⚡️ Export `TypographyProps` type. [#16835](https://github.com/ant-design/ant-design/pull/16835)

--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -21,7 +21,7 @@ timeline: true
 
 - 🐞 Fix Tabs vertical card mode not scrollable. [#16825](https://github.com/ant-design/ant-design/pull/16825)
 - 🐞 Fix transfer warn state update on an unmounted component. [#16822](https://github.com/ant-design/ant-design/pull/16822) [@shiningjason](https://github.com/shiningjason)
-- 🐞 Fix Less var, using `@error-color`, `@warning-color` instead of `@text-color-danger`, `@text-color-warning`. [#16890](https://github.com/ant-design/ant-design/pull/16890) [@MrHeer](https://github.com/MrHeer)
+- 🐞 Fix Less var using `@error-color`, `@warning-color` instead of `@text-color-danger`, `@text-color-warning`. [#16890](https://github.com/ant-design/ant-design/pull/16890) [@MrHeer](https://github.com/MrHeer)
 - 💄 Add warning if Menu use `inlineCollapsed` under Sider. [#16826](https://github.com/ant-design/ant-design/pull/16826)
 - 💄 Remove useless Modal default props `okButtonDisabled`, `cancelButtonDisabled`. [#16869](https://github.com/ant-design/ant-design/pull/16869) [@aiham](https://github.com/aiham)
 - TypeScript

--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -21,9 +21,9 @@ timeline: true
 
 - 🐞 Fix Tabs vertical card mode not scrollable. [#16825](https://github.com/ant-design/ant-design/pull/16825)
 - 🐞 Fix transfer warn state update on an unmounted component. [#16822](https://github.com/ant-design/ant-design/pull/16822) [@shiningjason](https://github.com/shiningjason)
+- 🐞 Fix Less var, using `@error-color`、`@warning-color` instead of `@text-color-danger`、`@text-color-warning`. [#16890](https://github.com/ant-design/ant-design/pull/16890) [@MrHeer](https://github.com/MrHeer)
 - 💄 Add warning if Menu use `inlineCollapsed` under Sider. [#16826](https://github.com/ant-design/ant-design/pull/16826)
 - 💄 Remove useless Modal default props `okButtonDisabled` 、`cancelButtonDisabled`. [#16869](https://github.com/ant-design/ant-design/pull/16869) [@aiham](https://github.com/aiham)
-- 🐞 Fix Less var, using `@error-color`、`@warning-color` instead of `@text-color-danger`、`@text-color-warning`. [#16890](https://github.com/ant-design/ant-design/pull/16890) [@MrHeer](https://github.com/MrHeer)
 - TypeScript
   - ⚡️ Add `forceSubmenuRender` into MenuProps. [#16827](https://github.com/ant-design/ant-design/pull/16827)
   - ⚡️ Export `TypographyProps` type. [#16835](https://github.com/ant-design/ant-design/pull/16835)

--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -21,7 +21,7 @@ timeline: true
 
 - 🐞 Fix Tabs vertical card mode not scrollable. [#16825](https://github.com/ant-design/ant-design/pull/16825)
 - 🐞 Fix Transfer warn `setStart` on an unmounted component. [#16822](https://github.com/ant-design/ant-design/pull/16822) [@shiningjason](https://github.com/shiningjason)
-- 💄 Using Less var `@error-color`, `@warning-color` instead of `@text-color-danger`, `@text-color-warning`. [#16890](https://github.com/ant-design/ant-design/pull/16890) [@MrHeer](https://github.com/MrHeer)
+- 💄 Using less variables `@error-color`, `@warning-color` instead of `@text-color-danger`, `@text-color-warning`. [#16890](https://github.com/ant-design/ant-design/pull/16890) [@MrHeer](https://github.com/MrHeer)
 - 💄 Add warning if Menu use `inlineCollapsed` under Sider. [#16826](https://github.com/ant-design/ant-design/pull/16826)
 - TypeScript
   - ⚡️ Add `forceSubmenuRender` into MenuProps. [#16827](https://github.com/ant-design/ant-design/pull/16827)

--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -23,7 +23,6 @@ timeline: true
 - 🐞 Fix Transfer warn state update on an unmounted component. [#16822](https://github.com/ant-design/ant-design/pull/16822) [@shiningjason](https://github.com/shiningjason)
 - 🐞 Fix Less var using `@error-color`, `@warning-color` instead of `@text-color-danger`, `@text-color-warning`. [#16890](https://github.com/ant-design/ant-design/pull/16890) [@MrHeer](https://github.com/MrHeer)
 - 💄 Add warning if Menu use `inlineCollapsed` under Sider. [#16826](https://github.com/ant-design/ant-design/pull/16826)
-- 💄 Remove useless Modal default props `okButtonDisabled`, `cancelButtonDisabled`. [#16869](https://github.com/ant-design/ant-design/pull/16869) [@aiham](https://github.com/aiham)
 - TypeScript
   - ⚡️ Add `forceSubmenuRender` into MenuProps. [#16827](https://github.com/ant-design/ant-design/pull/16827)
   - ⚡️ Export `TypographyProps` type. [#16835](https://github.com/ant-design/ant-design/pull/16835)

--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -21,7 +21,7 @@ timeline: true
 
 - 🐞 Fix Tabs vertical card mode not scrollable. [#16825](https://github.com/ant-design/ant-design/pull/16825)
 - 🐞 Fix Transfer warn `setStart` on an unmounted component. [#16822](https://github.com/ant-design/ant-design/pull/16822) [@shiningjason](https://github.com/shiningjason)
-- 💄 using Less var `@error-color`, `@warning-color` instead of `@text-color-danger`, `@text-color-warning`. [#16890](https://github.com/ant-design/ant-design/pull/16890) [@MrHeer](https://github.com/MrHeer)
+- 💄 Using Less var `@error-color`, `@warning-color` instead of `@text-color-danger`, `@text-color-warning`. [#16890](https://github.com/ant-design/ant-design/pull/16890) [@MrHeer](https://github.com/MrHeer)
 - 💄 Add warning if Menu use `inlineCollapsed` under Sider. [#16826](https://github.com/ant-design/ant-design/pull/16826)
 - TypeScript
   - ⚡️ Add `forceSubmenuRender` into MenuProps. [#16827](https://github.com/ant-design/ant-design/pull/16827)

--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -15,6 +15,21 @@ timeline: true
 
 ---
 
+## 3.19.2
+
+`2019-06-01`
+
+- 🐞 Fix Tabs vertical card mode not scrollable. [#16825](https://github.com/ant-design/ant-design/pull/16825)
+- 🐞 Fix transfer warn state update on an unmounted component. [#16822](https://github.com/ant-design/ant-design/pull/16822) [@shiningjason](https://github.com/shiningjason)
+- 💄 Add warning if Menu use `inlineCollapsed` under Sider. [#16826](https://github.com/ant-design/ant-design/pull/16826)
+- 💄 Remove useless Modal default props `okButtonDisabled` 、`cancelButtonDisabled`. [#16869](https://github.com/ant-design/ant-design/pull/16869) [@aiham](https://github.com/aiham)
+- 🐞 Fix Less var, using `@error-color`、`@warning-color` instead of `@text-color-danger`、`@text-color-warning`. [#16890](https://github.com/ant-design/ant-design/pull/16890) [@MrHeer](https://github.com/MrHeer)
+- TypeScript
+  - ⚡️ Add `forceSubmenuRender` into MenuProps. [#16827](https://github.com/ant-design/ant-design/pull/16827)
+  - ⚡️ export `TypographyProps` type. [#16835](https://github.com/ant-design/ant-design/pull/16835)
+  - ⚡️ Add `onChange` prop type definition to Steps. [#16845](https://github.com/ant-design/ant-design/pull/16845) [@JonathanLee-LX](https://github.com/JonathanLee-LX)
+  - ⚡️ Add `webkitRelativePath` prop type definition to Upload. [#16850](https://github.com/ant-design/ant-design/pull/16850) [@DiamondYuan](https://github.com/DiamondYuan)
+
 ## 3.19.1
 
 `2019-05-27`

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -21,7 +21,7 @@ timeline: true
 
 - 🐞 修复 Tabs 在垂直卡片模式下标签不能滚动的问题。[#16825](https://github.com/ant-design/ant-design/pull/16825)
 - 🐞 修复 Transfer 组件在 unmount 时 `setState` 警告。[#16822](https://github.com/ant-design/ant-design/pull/16822) [@shiningjason](https://github.com/shiningjason)
-- 🐞 修复 Less 变量，使用 `@error-color`、`@warning-color` 分别代替 `@text-color-danger`、`@text-color-warning`。[#16890](https://github.com/ant-design/ant-design/pull/16890) [@MrHeer](https://github.com/MrHeer)
+- 💄 使用 Less 变量 `@error-color`、`@warning-color` 代替 `@text-color-danger`、`@text-color-warning`。[#16890](https://github.com/ant-design/ant-design/pull/16890) [@MrHeer](https://github.com/MrHeer)
 - 💄 增加在 Sider 内 Menu 使用 `inlineCollapsed` 时的提示信息。[#16826](https://github.com/ant-design/ant-design/pull/16826)
 - TypeScript
   - ⚡️ 增加 Menu 中 `forceSubMenuRender` 类型定义。[#16827](https://github.com/ant-design/ant-design/pull/16827)

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -15,6 +15,21 @@ timeline: true
 
 ---
 
+## 3.19.2
+
+`2019-06-01`
+
+- 🐞 修复 Tabs 在垂直卡片模式下标签不能滚动的问题。[#16825](https://github.com/ant-design/ant-design/pull/16825)
+- 🐞 修复 Transfer 组件在 unmount 时 setState 警告。[#16822](https://github.com/ant-design/ant-design/pull/16822) [@shiningjason](https://github.com/shiningjason)
+- 💄 增加在 Sider 内 Menu 使用 `inlineCollapsed` 时的提示信息。[#16826](https://github.com/ant-design/ant-design/pull/16826)
+- 💄 去掉 Modal 中 `okButtonDisabled` 、`cancelButtonDisabled` 的默认值。[#16869](https://github.com/ant-design/ant-design/pull/16869) [@aiham](https://github.com/aiham)
+- 🐞 修复 Less 变量，使用 `@error-color`、`@warning-color` 分别代替 `@text-color-danger`、`@text-color-warning`。[#16890](https://github.com/ant-design/ant-design/pull/16890) [@MrHeer](https://github.com/MrHeer)
+- TypeScript
+  - ⚡️ 增加 Menu 中 `forceSubMenuRender` 类型定义。[#16827](https://github.com/ant-design/ant-design/pull/16827)
+  - ⚡️ 导出 Typography 类型定义。[#16835](https://github.com/ant-design/ant-design/pull/16835)
+  - ⚡️ 增加 Steps 中的 `onChange` 类型定义。[#16845](https://github.com/ant-design/ant-design/pull/16845) [@JonathanLee-LX](https://github.com/JonathanLee-LX)
+  - ⚡️ 增加 Upload 中 `webkitRelativePath` 类型定义。[#16850](https://github.com/ant-design/ant-design/pull/16850) [@DiamondYuan](https://github.com/DiamondYuan)
+
 ## 3.19.1
 
 `2019-05-27`

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -23,7 +23,6 @@ timeline: true
 - 🐞 修复 Transfer 组件在 unmount 时 setState 警告。[#16822](https://github.com/ant-design/ant-design/pull/16822) [@shiningjason](https://github.com/shiningjason)
 - 🐞 修复 Less 变量，使用 `@error-color`、`@warning-color` 分别代替 `@text-color-danger`、`@text-color-warning`。[#16890](https://github.com/ant-design/ant-design/pull/16890) [@MrHeer](https://github.com/MrHeer)
 - 💄 增加在 Sider 内 Menu 使用 `inlineCollapsed` 时的提示信息。[#16826](https://github.com/ant-design/ant-design/pull/16826)
-- 💄 去掉 Modal 中 `okButtonDisabled` 、`cancelButtonDisabled` 的默认值。[#16869](https://github.com/ant-design/ant-design/pull/16869) [@aiham](https://github.com/aiham)
 - TypeScript
   - ⚡️ 增加 Menu 中 `forceSubMenuRender` 类型定义。[#16827](https://github.com/ant-design/ant-design/pull/16827)
   - ⚡️ 导出 Typography 类型定义。[#16835](https://github.com/ant-design/ant-design/pull/16835)

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -21,9 +21,9 @@ timeline: true
 
 - 🐞 修复 Tabs 在垂直卡片模式下标签不能滚动的问题。[#16825](https://github.com/ant-design/ant-design/pull/16825)
 - 🐞 修复 Transfer 组件在 unmount 时 setState 警告。[#16822](https://github.com/ant-design/ant-design/pull/16822) [@shiningjason](https://github.com/shiningjason)
+- 🐞 修复 Less 变量，使用 `@error-color`、`@warning-color` 分别代替 `@text-color-danger`、`@text-color-warning`。[#16890](https://github.com/ant-design/ant-design/pull/16890) [@MrHeer](https://github.com/MrHeer)
 - 💄 增加在 Sider 内 Menu 使用 `inlineCollapsed` 时的提示信息。[#16826](https://github.com/ant-design/ant-design/pull/16826)
 - 💄 去掉 Modal 中 `okButtonDisabled` 、`cancelButtonDisabled` 的默认值。[#16869](https://github.com/ant-design/ant-design/pull/16869) [@aiham](https://github.com/aiham)
-- 🐞 修复 Less 变量，使用 `@error-color`、`@warning-color` 分别代替 `@text-color-danger`、`@text-color-warning`。[#16890](https://github.com/ant-design/ant-design/pull/16890) [@MrHeer](https://github.com/MrHeer)
 - TypeScript
   - ⚡️ 增加 Menu 中 `forceSubMenuRender` 类型定义。[#16827](https://github.com/ant-design/ant-design/pull/16827)
   - ⚡️ 导出 Typography 类型定义。[#16835](https://github.com/ant-design/ant-design/pull/16835)

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -20,7 +20,7 @@ timeline: true
 `2019-06-01`
 
 - 🐞 修复 Tabs 在垂直卡片模式下标签不能滚动的问题。[#16825](https://github.com/ant-design/ant-design/pull/16825)
-- 🐞 修复 Transfer 组件在 unmount 时 setState 警告。[#16822](https://github.com/ant-design/ant-design/pull/16822) [@shiningjason](https://github.com/shiningjason)
+- 🐞 修复 Transfer 组件在 unmount 时 `setState` 警告。[#16822](https://github.com/ant-design/ant-design/pull/16822) [@shiningjason](https://github.com/shiningjason)
 - 🐞 修复 Less 变量，使用 `@error-color`、`@warning-color` 分别代替 `@text-color-danger`、`@text-color-warning`。[#16890](https://github.com/ant-design/ant-design/pull/16890) [@MrHeer](https://github.com/MrHeer)
 - 💄 增加在 Sider 内 Menu 使用 `inlineCollapsed` 时的提示信息。[#16826](https://github.com/ant-design/ant-design/pull/16826)
 - TypeScript

--- a/components/breadcrumb/Breadcrumb.tsx
+++ b/components/breadcrumb/Breadcrumb.tsx
@@ -71,13 +71,22 @@ export default class Breadcrumb extends React.Component<BreadcrumbProps, any> {
     );
   }
 
-  getPath = (path = '', params = {}) => {
-     path = path.replace(/^\//, '');
+  getPath = (path: string, params: any) => {
+     path = (path || '').replace(/^\//, '');
      Object.keys(params).forEach(key => {
          path = path.replace(`:${key}`, params[key]);
      });
      return path;
   }
+
+  addChildPath = (paths: string[], childPath: string = '', params: any) => {
+    const originalPaths = [...paths];
+    const path = this.getPath(childPath, params);
+    if (path) {
+       originalPaths.push(path);
+    }
+    return originalPaths;
+ }
 
   genForRoutes = ({
     routes = [],
@@ -98,10 +107,12 @@ export default class Breadcrumb extends React.Component<BreadcrumbProps, any> {
         overlay = (
           <Menu>
             {route.children.map(child => (
-              <Menu.Item key={child.breadcrumbName || child.path}>
-                {itemRender(child, params, routes, [...paths, this.getPath(child.path, params)])}
-              </Menu.Item>
-            ))}
+                <Menu.Item key={child.breadcrumbName || child.path}>
+                  {
+                    itemRender(child, params, routes, this.addChildPath(paths, child.path, params))
+                  }
+                </Menu.Item>
+             ))}
           </Menu>
         );
       }

--- a/components/breadcrumb/Breadcrumb.tsx
+++ b/components/breadcrumb/Breadcrumb.tsx
@@ -70,6 +70,15 @@ export default class Breadcrumb extends React.Component<BreadcrumbProps, any> {
         'see: https://u.ant.design/item-render.',
     );
   }
+
+  getPath = (path, params) => {
+     path = (path || '').replace(/^\//, '');
+     Object.keys(params).forEach(key => {
+         path = path.replace(`:${key}`, params[key]);
+     });
+     return path;
+  }
+
   genForRoutes = ({
     routes = [],
     params = {},
@@ -78,11 +87,7 @@ export default class Breadcrumb extends React.Component<BreadcrumbProps, any> {
   }: BreadcrumbProps) => {
     const paths: string[] = [];
     return routes.map(route => {
-      route.path = route.path || '';
-      let path = route.path.replace(/^\//, '');
-      Object.keys(params).forEach(key => {
-        path = path.replace(`:${key}`, params[key]);
-      });
+      let path = this.getPath(route.path, params);
 
       if (path) {
         paths.push(path);
@@ -94,7 +99,7 @@ export default class Breadcrumb extends React.Component<BreadcrumbProps, any> {
           <Menu>
             {route.children.map(child => (
               <Menu.Item key={child.breadcrumbName || child.path}>
-                {itemRender(child, params, routes, paths)}
+                {itemRender(child, params, routes, [...paths, this.getPath(child.path, params)])}
               </Menu.Item>
             ))}
           </Menu>

--- a/components/breadcrumb/Breadcrumb.tsx
+++ b/components/breadcrumb/Breadcrumb.tsx
@@ -71,8 +71,8 @@ export default class Breadcrumb extends React.Component<BreadcrumbProps, any> {
     );
   }
 
-  getPath = (path, params) => {
-     path = (path || '').replace(/^\//, '');
+  getPath = (path = '', params = {}) => {
+     path = path.replace(/^\//, '');
      Object.keys(params).forEach(key => {
          path = path.replace(`:${key}`, params[key]);
      });

--- a/components/breadcrumb/Breadcrumb.tsx
+++ b/components/breadcrumb/Breadcrumb.tsx
@@ -96,7 +96,7 @@ export default class Breadcrumb extends React.Component<BreadcrumbProps, any> {
   }: BreadcrumbProps) => {
     const paths: string[] = [];
     return routes.map(route => {
-      let path = this.getPath(route.path, params);
+      const path = this.getPath(route.path, params);
 
       if (path) {
         paths.push(path);

--- a/components/breadcrumb/BreadcrumbItem.tsx
+++ b/components/breadcrumb/BreadcrumbItem.tsx
@@ -71,10 +71,10 @@ export default class BreadcrumbItem extends React.Component<BreadcrumbItemProps,
     if (overlay) {
       return (
         <DropDown overlay={overlay} placement="bottomCenter">
-          <a className={`${prefixCls}-overlay-link`}>
+          <span className={`${prefixCls}-overlay-link`}>
             {breadcrumbItem}
             <Icon type="down" />
-          </a>
+          </span>
         </DropDown>
       );
     }

--- a/components/breadcrumb/__tests__/__snapshots__/Breadcrumb.test.js.snap
+++ b/components/breadcrumb/__tests__/__snapshots__/Breadcrumb.test.js.snap
@@ -71,42 +71,43 @@ exports[`Breadcrumb should render a menu 1`] = `
     </span>
   </span>
   <span>
-    <a
+    <span
       class="ant-breadcrumb-overlay-link ant-dropdown-trigger"
     >
       <span
         class="ant-breadcrumb-link"
-      />
-    </a>
-    <a
-      href="#/index/first"
+      >
+        <a
+          href="#/index/first"
+        >
+          first
+        </a>
+      </span>
+      <i
+        aria-label="icon: down"
+        class="anticon anticon-down"
+      >
+        <svg
+          aria-hidden="true"
+          class=""
+          data-icon="down"
+          fill="currentColor"
+          focusable="false"
+          height="1em"
+          viewBox="64 64 896 896"
+          width="1em"
+        >
+          <path
+            d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+          />
+        </svg>
+      </i>
+    </span>
+    <span
+      class="ant-breadcrumb-separator"
     >
-      first
-    </a>
-  </span>
-  <i
-    aria-label="icon: down"
-    class="anticon anticon-down"
-  >
-    <svg
-      aria-hidden="true"
-      class=""
-      data-icon="down"
-      fill="currentColor"
-      focusable="false"
-      height="1em"
-      viewBox="64 64 896 896"
-      width="1em"
-    >
-      <path
-        d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
-      />
-    </svg>
-  </i>
-  <span
-    class="ant-breadcrumb-separator"
-  >
-    /
+      /
+    </span>
   </span>
   <span>
     <span

--- a/components/breadcrumb/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/breadcrumb/__tests__/__snapshots__/demo.test.js.snap
@@ -64,89 +64,88 @@ exports[`renders ./components/breadcrumb/demo/basic.md correctly 1`] = `
 `;
 
 exports[`renders ./components/breadcrumb/demo/overlay.md correctly 1`] = `
-<div>
-  <div
-    class="ant-breadcrumb"
-  >
-    <span>
-      <span
-        class="ant-breadcrumb-link"
-      >
-        Ant Design
-      </span>
-      <span
-        class="ant-breadcrumb-separator"
-      >
-        /
-      </span>
+<div
+  class="ant-breadcrumb"
+>
+  <span>
+    <span
+      class="ant-breadcrumb-link"
+    >
+      Ant Design
     </span>
-    <span>
+    <span
+      class="ant-breadcrumb-separator"
+    >
+      /
+    </span>
+  </span>
+  <span>
+    <span
+      class="ant-breadcrumb-link"
+    >
+      <a
+        href=""
+      >
+        Component
+      </a>
+    </span>
+    <span
+      class="ant-breadcrumb-separator"
+    >
+      /
+    </span>
+  </span>
+  <span>
+    <span
+      class="ant-breadcrumb-overlay-link ant-dropdown-trigger"
+    >
       <span
         class="ant-breadcrumb-link"
       >
         <a
           href=""
         >
-          Component
+          General
         </a>
       </span>
-      <span
-        class="ant-breadcrumb-separator"
+      <i
+        aria-label="icon: down"
+        class="anticon anticon-down"
       >
-        /
-      </span>
+        <svg
+          aria-hidden="true"
+          class=""
+          data-icon="down"
+          fill="currentColor"
+          focusable="false"
+          height="1em"
+          viewBox="64 64 896 896"
+          width="1em"
+        >
+          <path
+            d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+          />
+        </svg>
+      </i>
     </span>
-    <span>
-      <a
-        class="ant-breadcrumb-overlay-link ant-dropdown-trigger"
-      >
-        <span
-          class="ant-breadcrumb-link"
-        />
-      </a>
-      <a
-        href=""
-      >
-        General
-      </a>
-    </span>
-    <i
-      aria-label="icon: down"
-      class="anticon anticon-down"
-    >
-      <svg
-        aria-hidden="true"
-        class=""
-        data-icon="down"
-        fill="currentColor"
-        focusable="false"
-        height="1em"
-        viewBox="64 64 896 896"
-        width="1em"
-      >
-        <path
-          d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
-        />
-      </svg>
-    </i>
     <span
       class="ant-breadcrumb-separator"
     >
       /
     </span>
-    <span>
-      <span
-        class="ant-breadcrumb-link"
-      >
-        Button
-      </span>
-      <span
-        class="ant-breadcrumb-separator"
-      >
-        /
-      </span>
+  </span>
+  <span>
+    <span
+      class="ant-breadcrumb-link"
+    >
+      Button
     </span>
-  </div>
+    <span
+      class="ant-breadcrumb-separator"
+    >
+      /
+    </span>
+  </span>
 </div>
 `;
 

--- a/components/breadcrumb/demo/overlay.md
+++ b/components/breadcrumb/demo/overlay.md
@@ -37,18 +37,16 @@ const menu = (
 );
 
 ReactDOM.render(
-  <div>
-    <Breadcrumb>
-      <Breadcrumb.Item>Ant Design</Breadcrumb.Item>
-      <Breadcrumb.Item>
-        <a href="">Component</a>
-      </Breadcrumb.Item>
-      <Breadcrumb.Item overlay={menu}>
-        <a href="">General</a>
-      </Breadcrumb.Item>
-      <Breadcrumb.Item>Button</Breadcrumb.Item>
-    </Breadcrumb>
-  </div>,
+  <Breadcrumb>
+    <Breadcrumb.Item>Ant Design</Breadcrumb.Item>
+    <Breadcrumb.Item>
+      <a href="">Component</a>
+    </Breadcrumb.Item>
+    <Breadcrumb.Item overlay={menu}>
+      <a href="">General</a>
+    </Breadcrumb.Item>
+    <Breadcrumb.Item>Button</Breadcrumb.Item>
+  </Breadcrumb>,
   mountNode,
 );
 ```

--- a/components/cascader/index.tsx
+++ b/components/cascader/index.tsx
@@ -292,7 +292,8 @@ class Cascader extends React.Component<CascaderProps, CascaderState> {
   };
 
   handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.keyCode === KeyCode.BACKSPACE) {
+    // SPACE => https://github.com/ant-design/ant-design/issues/16871
+    if (e.keyCode === KeyCode.BACKSPACE || e.keyCode === KeyCode.SPACE) {
       e.stopPropagation();
     }
   };

--- a/components/input-number/style/index.less
+++ b/components/input-number/style/index.less
@@ -77,8 +77,14 @@
     border-radius: @border-radius-base;
     outline: 0;
     transition: all 0.3s linear;
-    -moz-appearance: textfield;
+    -moz-appearance: textfield !important;
     .placeholder();
+
+    &[type='number']::-webkit-inner-spin-button,
+    &[type='number']::-webkit-outer-spin-button {
+      margin: 0;
+      -webkit-appearance: none;
+    }
   }
 
   &-lg {

--- a/components/popconfirm/index.en-US.md
+++ b/components/popconfirm/index.en-US.md
@@ -23,6 +23,7 @@ The difference with the `confirm` modal dialog is that it's more lightweight tha
 | onCancel | callback of cancel | function(e) | - |
 | onConfirm | callback of confirmation | function(e) | - |
 | icon | customize icon of confirmation | ReactNode | &lt;Icon type="exclamation-circle" /&gt; |
+| disabled | is show popconfirm when click its childrenNode | boolean | false |
 
 Consult [Tooltip's documentation](https://ant.design/components/tooltip/#API) to find more APIs.
 

--- a/components/popconfirm/index.tsx
+++ b/components/popconfirm/index.tsx
@@ -10,6 +10,7 @@ import { ConfigConsumer, ConfigConsumerProps } from '../config-provider';
 
 export interface PopconfirmProps extends AbstractTooltipProps {
   title: React.ReactNode;
+  disabled?: boolean;
   onConfirm?: (e?: React.MouseEvent<any>) => void;
   onCancel?: (e?: React.MouseEvent<any>) => void;
   okText?: React.ReactNode;
@@ -37,6 +38,7 @@ class Popconfirm extends React.Component<PopconfirmProps, PopconfirmState> {
     trigger: 'click' as PopconfirmProps['trigger'],
     okType: 'primary' as PopconfirmProps['okType'],
     icon: <Icon type="exclamation-circle" theme="filled" />,
+    disabled: false,
   };
 
   static getDerivedStateFromProps(nextProps: PopconfirmProps) {
@@ -81,6 +83,10 @@ class Popconfirm extends React.Component<PopconfirmProps, PopconfirmState> {
   };
 
   onVisibleChange = (visible: boolean) => {
+    const { disabled } = this.props;
+    if (disabled) {
+      return;
+    }
     this.setVisible(visible);
   };
 

--- a/components/popconfirm/index.zh-CN.md
+++ b/components/popconfirm/index.zh-CN.md
@@ -24,6 +24,7 @@ title: Popconfirm
 | onCancel | 点击取消的回调 | function(e) | 无 |
 | onConfirm | 点击确认的回调 | function(e) | 无 |
 | icon | 自定义弹出气泡 Icon 图标 | ReactNode | &lt;Icon type="exclamation-circle" /&gt; |
+| disabled | 点击 Popconfirm 子元素是否弹出气泡确认框 | boolean | false |
 
 更多属性请参考 [Tooltip](/components/tooltip/#API)。
 

--- a/components/style/themes/default.less
+++ b/components/style/themes/default.less
@@ -47,8 +47,6 @@
 @code-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
 @text-color: fade(@black, 65%);
 @text-color-secondary: fade(@black, 45%);
-@text-color-warning: @gold-7;
-@text-color-danger: @red-7;
 @text-color-inverse: @white;
 @icon-color: inherit;
 @icon-color-hover: fade(@black, 75%);

--- a/components/transfer/list.tsx
+++ b/components/transfer/list.tsx
@@ -159,26 +159,25 @@ export default class TransferList extends React.Component<TransferListProps, Tra
       </div>
     ) : null;
 
-    const searchNotFound = !filteredItems.length && (
-      <div className={`${prefixCls}-body-not-found`}>{notFoundContent}</div>
-    );
-
     let listBody: React.ReactNode = bodyDom;
     if (!listBody) {
-      let bodyNode: React.ReactNode = searchNotFound;
-      if (!bodyNode) {
-        const { bodyContent, customize } = renderListNode(renderList, {
-          ...omit(this.props, OmitProps),
-          filteredItems,
-          filteredRenderItems,
-          selectedKeys: checkedKeys,
-        });
+      let bodyNode: React.ReactNode;
 
-        // We should wrap customize list body in a classNamed div to use flex layout.
-        bodyNode = customize ? (
-          <div className={`${prefixCls}-body-customize-wrapper`}>{bodyContent}</div>
-        ) : (
+      const { bodyContent, customize } = renderListNode(renderList, {
+        ...omit(this.props, OmitProps),
+        filteredItems,
+        filteredRenderItems,
+        selectedKeys: checkedKeys,
+      });
+
+      // We should wrap customize list body in a classNamed div to use flex layout.
+      if (customize) {
+        bodyNode = <div className={`${prefixCls}-body-customize-wrapper`}>{bodyContent}</div>;
+      } else {
+        bodyNode = filteredItems.length ? (
           bodyContent
+        ) : (
+          <div className={`${prefixCls}-body-not-found`}>{notFoundContent}</div>
         );
       }
 

--- a/components/typography/style/index.less
+++ b/components/typography/style/index.less
@@ -39,11 +39,11 @@
   }
 
   &&-warning {
-    color: @text-color-warning;
+    color: @warning-color;
   }
 
   &&-danger {
-    color: @text-color-danger;
+    color: @error-color;
   }
 
   &&-disabled {

--- a/components/upload/interface.tsx
+++ b/components/upload/interface.tsx
@@ -32,7 +32,6 @@ export interface UploadFile {
   error?: any;
   linkProps?: any;
   type: string;
-  webkitRelativePath?: string;
 }
 
 export interface UploadChangeParam<T extends object = UploadFile> {
@@ -64,7 +63,7 @@ export interface UploadProps {
   name?: string;
   defaultFileList?: Array<UploadFile>;
   fileList?: Array<UploadFile>;
-  action?: string | ((file: UploadFile) => string) | ((file: UploadFile) => PromiseLike<string>);
+  action?: string | ((file: RcFile) => string) | ((file: RcFile) => PromiseLike<string>);
   directory?: boolean;
   data?: Object | ((file: UploadFile) => any);
   headers?: HttpRequestHeader;

--- a/components/upload/interface.tsx
+++ b/components/upload/interface.tsx
@@ -8,7 +8,12 @@ export interface HttpRequestHeader {
 
 export interface RcFile extends File {
   uid: string;
-  lastModifiedDate: Date;
+  readonly name: string;
+  readonly type: string;
+  readonly lastModified: number;
+  readonly lastModifiedDate: Date;
+  readonly size: number;
+  readonly webkitRelativePath: string;
 }
 
 export interface UploadFile {

--- a/components/upload/interface.tsx
+++ b/components/upload/interface.tsx
@@ -8,11 +8,7 @@ export interface HttpRequestHeader {
 
 export interface RcFile extends File {
   uid: string;
-  readonly name: string;
-  readonly type: string;
-  readonly lastModified: number;
   readonly lastModifiedDate: Date;
-  readonly size: number;
   readonly webkitRelativePath: string;
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "antd",
-  "version": "3.19.1",
+  "version": "3.19.2",
   "title": "Ant Design",
   "description": "An enterprise-class UI design language and React components implementation",
   "homepage": "http://ant.design/",

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
   },
   "devDependencies": {
     "@ant-design/colors": "^3.0.0",
+    "@packtracker/webpack-plugin": "^2.0.1",
     "@sentry/browser": "^5.0.3",
     "@types/classnames": "^2.2.6",
     "@types/prop-types": "^15.5.6",

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "@types/react-intl": "^2.3.14",
     "@types/warning": "^3.0.0",
     "@yesmeck/offline-plugin": "^5.0.5",
-    "ansi-styles": "^3.2.1",
+    "ansi-styles": "^4.0.0",
     "antd-theme-generator": "^1.1.4",
     "antd-tools": "^7.3.5",
     "babel-eslint": "^10.0.1",

--- a/site/theme/en-US.js
+++ b/site/theme/en-US.js
@@ -12,7 +12,7 @@ module.exports = {
     'app.header.menu.spec': 'Guidelines',
     'app.header.menu.resource': 'Resources',
     'app.header.menu.mobile': 'Mobile',
-    'app.header.menu.pro': 'Ant Design Pro',
+    'app.header.menu.pro.v4': 'Ant Design Pro v4',
     'app.header.menu.ecosystem': 'Ecosystem',
     'app.header.lang': '中文',
     'app.content.edit-page': 'Edit this page on GitHub!',

--- a/site/theme/template/Layout/Header.jsx
+++ b/site/theme/template/Layout/Header.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Link } from 'bisheng/router';
 import { FormattedMessage } from 'react-intl';
 import classNames from 'classnames';
-import { Select, Menu, Row, Col, Icon, Popover, Input, Button } from 'antd';
+import { Select, Menu, Row, Col, Icon, Popover, Input, Button, Badge } from 'antd';
 import Santa from './Santa';
 import * as utils from '../utils';
 import { version as antdVersion } from '../../../../package.json';
@@ -179,7 +179,11 @@ export default class Header extends React.Component {
         <Menu.SubMenu
           key="ecosystem"
           className="hide-in-home-page"
-          title={<FormattedMessage id="app.header.menu.ecosystem" />}
+          title={
+            <Badge dot>
+              <FormattedMessage id="app.header.menu.ecosystem" />
+            </Badge>
+          }
         >
           <Menu.Item key="pro">
             <a
@@ -188,7 +192,9 @@ export default class Header extends React.Component {
               target="_blank"
               rel="noopener noreferrer"
             >
-              <FormattedMessage id="app.header.menu.pro" />
+              <Badge dot>
+                <FormattedMessage id="app.header.menu.pro.v4" />
+              </Badge>
             </a>
           </Menu.Item>
           <Menu.Item key="ng">

--- a/site/theme/zh-CN.js
+++ b/site/theme/zh-CN.js
@@ -12,7 +12,7 @@ module.exports = {
     'app.header.menu.spec': '设计语言',
     'app.header.menu.resource': '资源',
     'app.header.menu.mobile': '移动版',
-    'app.header.menu.pro': 'Ant Design Pro',
+    'app.header.menu.pro.v4': 'Ant Design Pro v4',
     'app.header.menu.ecosystem': '生态',
     'app.header.lang': 'English',
     'app.content.edit-page': '在 GitHub 上编辑此页！',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,7 @@
 /* eslint no-param-reassign: 0 */
 // This config is for building dist files
 const getWebpackConfig = require('antd-tools/lib/getWebpackConfig');
+const PacktrackerPlugin = require('@packtracker/webpack-plugin');
 
 const { webpack } = getWebpackConfig;
 
@@ -35,6 +36,14 @@ if (process.env.RUN_ENV === 'PRODUCTION') {
     ignoreMomentLocale(config);
     externalMoment(config);
     addLocales(config);
+    // https://docs.packtracker.io/uploading-your-webpack-stats/webpack-plugin
+    config.plugins.push(
+      new PacktrackerPlugin({
+        project_token: '8adbb892-ee4a-4d6f-93bb-a03219fb6778',
+        upload: process.env.CI === 'true',
+        fail_build: true,
+      }),
+    );
   });
 }
 


### PR DESCRIPTION
### 这个变动的性质是

- [x] 新特性提交
- [ ] 其他改动（日常 bugfix、文档、站点改进、分支合并等，不需要填写余下的模板）

### 需求背景
  
> 1. 需求的来源：包住有可能disabled的Button的时候，如果按钮是disabled，点击还会弹出确认框
> 2. 这样子，就要加个判断，按照条件去掉外面那层Popconfirm；或者维护一个state控制visible属性，有点麻烦。
> 3. [issue](https://github.com/ant-design/ant-design/issues/16947)
  
### 实现方案和 API
  
> 1. 新增一个disabled的prop，当Popconfirm为disabled状态时，点击它所包住的按钮都不会弹出气泡确认框
> 2. 在onVisibleChange方法中加上一个disabled为true的拦截

  
### 对用户的影响和可能的风险

> 1. 这个改动对用户端无影响
> 2. 预期的 changelog:  
zh-CN: `Popconfirm`组件新增`disabled`属性，控制点击 `Popconfirm` 子元素是否弹出气泡确认框
en-US: add `disabled` prop in `Popconfirm`,to control the display when clicking its childrenNode
> 3. 暂无其他风险

### 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供

### 后续计划

> 透传disabled给button。其实也不是很需要

-----
[View rendered CHANGELOG.en-US.md](https://github.com/lhyt/ant-design/blob/feat_disabled_in_popconfirm/CHANGELOG.en-US.md)
[View rendered CHANGELOG.zh-CN.md](https://github.com/lhyt/ant-design/blob/feat_disabled_in_popconfirm/CHANGELOG.zh-CN.md)
[View rendered components/breadcrumb/demo/overlay.md](https://github.com/lhyt/ant-design/blob/feat_disabled_in_popconfirm/components/breadcrumb/demo/overlay.md)
[View rendered components/popconfirm/index.en-US.md](https://github.com/lhyt/ant-design/blob/feat_disabled_in_popconfirm/components/popconfirm/index.en-US.md)
[View rendered components/popconfirm/index.zh-CN.md](https://github.com/lhyt/ant-design/blob/feat_disabled_in_popconfirm/components/popconfirm/index.zh-CN.md)