### PR TITLE
Add missing spanish translations

### DIFF
--- a/components/locale-provider/es_ES.tsx
+++ b/components/locale-provider/es_ES.tsx
@@ -9,12 +9,16 @@ export default {
   DatePicker,
   TimePicker,
   Calendar,
+  global: {
+    placeholder: 'Seleccione',
+  },
   Table: {
     filterTitle: 'Filtrar menú',
     filterConfirm: 'Aceptar',
     filterReset: 'Reiniciar',
     selectAll: 'Seleccionar todo',
     selectInvert: 'Invertir selección',
+    sortTitle: 'Ordenar',
   },
   Modal: {
     okText: 'Aceptar',
@@ -38,5 +42,17 @@ export default {
   },
   Empty: {
     description: 'No hay datos',
+  },
+  Icon: {
+    icon: 'ícono',
+  },
+  Text: {
+    edit: 'editar',
+    copy: 'copiar',
+    copied: 'copiado',
+    expand: 'expandir',
+  },
+  PageHeader: {
+    back: 'volver',
   },
 };


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [X] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?

The spanish locale has less locale keys than the default locale

### 💡 Solution

Add missing translations for the spanish locale

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Add missing translations for the spanish (es_ES) locale |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [X] Doc is updated/provided or not needed
- [X] Demo is updated/provided or not needed
- [X] TypeScript definition is updated/provided or not needed
- [X] Changelog is provided or not needed
