### PR TITLE
Export TextProps and update english in error

### DIFF
--- a/components/typography/Text.tsx
+++ b/components/typography/Text.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import warning from '../_util/warning';
 import Base, { BlockProps } from './Base';
 
-interface TextProps extends BlockProps {
+export interface TextProps extends BlockProps {
   ellipsis?: boolean;
 }
 
@@ -10,7 +10,7 @@ const Text: React.SFC<TextProps> = ({ ellipsis, ...restProps }) => {
   warning(
     typeof ellipsis !== 'object',
     'Typography.Text',
-    '`ellipsis` is only support boolean value.',
+    '`ellipsis` only supports boolean value.',
   );
   return <Base {...restProps} ellipsis={!!ellipsis} component="span" />;
 };


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [x ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?

<!--
1. Describe the source of requirement, like related issue link.
The need to extend the Text Component
2. Describe the problem and the scenario.
The need to extend the Text component in Type Script fails because the TextProp interface is not exported
-->

### 💡 Solution

<!--
1. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
export TextProp interface

2. GIF or snapshot should be provided if includes UI/interactive modification.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [x ] Doc is updated/provided or not needed
- [ x] Demo is updated/provided or not needed
- [ x] TypeScript definition is updated/provided or not needed
- [ x] Changelog is provided or not needed
