### PR TITLE
fix: remove margin for collapse arrow

### DIFF
--- a/components/collapse/style/index.less
+++ b/components/collapse/style/index.less
@@ -37,7 +37,6 @@
         top: 50%;
         left: @padding-md;
         display: inline-block;
-        margin-top: 2px;
         font-size: @font-size-sm;
         line-height: 46px;
         transform: translateY(-50%);

--- a/components/collapse/style/index.less
+++ b/components/collapse/style/index.less
@@ -38,8 +38,7 @@
         left: @padding-md;
         display: inline-block;
         font-size: @font-size-sm;
-        line-height: 46px;
-        transform: translateY(-21px);
+        transform: translateY(-50%);
 
         & svg {
           transition: transform 0.24s;

--- a/components/collapse/style/index.less
+++ b/components/collapse/style/index.less
@@ -39,7 +39,7 @@
         display: inline-block;
         font-size: @font-size-sm;
         line-height: 46px;
-        transform: translateY(-50%);
+        transform: translateY(-21px);
 
         & svg {
           transition: transform 0.24s;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?

1. Using overflow auto adds scrollbar on collapse component when there is a header below.

![collapseScrollBar](https://user-images.githubusercontent.com/36059111/59113236-a9a39f00-8912-11e9-8038-f26e5c368dd7.gif)

2. We want to have a collapse component where we can scroll if the content is bigger than the height. Adding `height: 100%` and `overflow: auto` to the Collapse component causes a scrollbar to appear because the arrow within the header has a margin attached.

### 💡 Solution

<!--
1. How to fix the problem, and list final API implementation and usage sample if that is an new feature.

2. GIF or snapshot should be provided if includes UI/interactive modification.
-->

1. Remove the added margin for the header arrow.

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
