### PR TITLE
fix: Table with sort should reset to first page

### DIFF
--- a/components/table/Table.tsx
+++ b/components/table/Table.tsx
@@ -414,6 +414,9 @@ export default class Table<T> extends React.Component<TableProps<T>, TableState<
     if (!column.sorter) {
       return;
     }
+
+    const pagination = { ...this.state.pagination };
+
     const sortDirections = column.sortDirections || (this.props.sortDirections as SortOrder[]);
     const { sortOrder, sortColumn } = this.state;
     // 只同时允许一列进行排序，否则会导致排序顺序的逻辑问题
@@ -428,7 +431,14 @@ export default class Table<T> extends React.Component<TableProps<T>, TableState<
       newSortOrder = sortDirections[0];
     }
 
+    if (this.props.pagination) {
+      // Reset current prop
+      pagination.current = 1;
+      pagination.onChange!(pagination.current);
+    }
+
     const newState = {
+      pagination,
       sortOrder: newSortOrder,
       sortColumn: newSortOrder ? column : null,
     };

--- a/components/table/__tests__/Table.sorter.test.js
+++ b/components/table/__tests__/Table.sorter.test.js
@@ -587,4 +587,23 @@ describe('Table.sorter', () => {
     wrapper.find('.ant-table-column-sorters').simulate('click');
     expect(renderedNames(wrapper)).toEqual(['Jack', 'Lucy', 'Tom', 'Jerry']);
   });
+
+  it('pagination back', () => {
+    const onPageChange = jest.fn();
+    const onChange = jest.fn();
+
+    const wrapper = mount(
+      createTable({
+        pagination: {
+          pageSize: 2,
+          onChange: onPageChange,
+        },
+        onChange,
+      }),
+    );
+
+    wrapper.find('.ant-table-column-sorters').simulate('click');
+    expect(onChange.mock.calls[0][0].current).toBe(1);
+    expect(onPageChange.mock.calls[0][0]).toBe(1);
+  });
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?

close #16978

### 💡 Solution

Add back logic

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Table with sort not back to first page. |
| 🇨🇳 Chinese | 修复 Table 排序时没有回到第一页的问题。 |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
