### PR TITLE
style: less variables for comment component font-size

### DIFF
--- a/components/comment/style/index.less
+++ b/components/comment/style/index.less
@@ -27,25 +27,25 @@
     position: relative;
     flex: 1 1 auto;
     min-width: 1px;
-    font-size: 14px;
+    font-size: @comment-font-size-base;
     word-wrap: break-word;
 
     &-author {
       display: flex;
       justify-content: flex-start;
       margin-bottom: 4px;
-      font-size: 14px;
+      font-size: @comment-font-size-base;
       & > a,
       & > span {
         height: 18px;
         padding-right: 8px;
-        font-size: 12px;
+        font-size: @comment-font-size-sm;
         line-height: 18px;
       }
 
       &-name {
         color: @comment-author-name-color;
-        font-size: 14px;
+        font-size: @comment-font-size-base;
         transition: color 0.3s;
         > * {
           color: @comment-author-name-color;
@@ -76,7 +76,7 @@
       > span {
         padding-right: 10px;
         color: @comment-action-color;
-        font-size: 12px;
+        font-size: @comment-font-size-sm;
         cursor: pointer;
         transition: color 0.3s;
         user-select: none;

--- a/components/style/themes/default.less
+++ b/components/style/themes/default.less
@@ -452,6 +452,8 @@
 // ---
 @comment-padding-base: 16px 0;
 @comment-nest-indent: 44px;
+@comment-font-size-base: @font-size-base;
+@comment-font-size-sm: @font-size-sm;
 @comment-author-name-color: @text-color-secondary;
 @comment-author-time-color: #ccc;
 @comment-action-color: @text-color-secondary;


### PR DESCRIPTION
### 🤔 This is a ...

- [x] Bug fix

### 👻 What's the background?
The comment component used hard-coded font-sizes in it's .less file instead of using the font-sizes defined in default.less

### 💡 Solution
I added 2 new font-size less vars in default.less (following existing patterns) and set them the the default font-size set in the theme.

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Comment component font-size less variables |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
