### PR TITLE
chore: Translate remainder of Typography & AutoComplete

### DIFF
--- a/components/auto-complete/demo/certain-category.md
+++ b/components/auto-complete/demo/certain-category.md
@@ -20,7 +20,7 @@ const { Option, OptGroup } = AutoComplete;
 
 const dataSource = [
   {
-    title: '话题',
+    title: 'Libraries',
     children: [
       {
         title: 'AntDesign',
@@ -33,23 +33,23 @@ const dataSource = [
     ],
   },
   {
-    title: '问题',
+    title: 'Solutions',
     children: [
       {
-        title: 'AntDesign UI 有多好',
+        title: 'AntDesign UI',
         count: 60100,
       },
       {
-        title: 'AntDesign 是啥',
+        title: 'AntDesign',
         count: 30010,
       },
     ],
   },
   {
-    title: '文章',
+    title: 'Articles',
     children: [
       {
-        title: 'AntDesign 是一个设计语言',
+        title: 'AntDesign design language',
         count: 100000,
       },
     ],
@@ -66,7 +66,7 @@ function renderTitle(title) {
         target="_blank"
         rel="noopener noreferrer"
       >
-        更多
+        more
       </a>
     </span>
   );
@@ -78,7 +78,7 @@ const options = dataSource
       {group.children.map(opt => (
         <Option key={opt.title} value={opt.title}>
           {opt.title}
-          <span className="certain-search-item-count">{opt.count} 人 关注</span>
+          <span className="certain-search-item-count">{opt.count} people</span>
         </Option>
       ))}
     </OptGroup>
@@ -86,7 +86,7 @@ const options = dataSource
   .concat([
     <Option disabled key="all" className="show-all">
       <a href="https://www.google.com/search?q=antd" target="_blank" rel="noopener noreferrer">
-        查看所有结果
+        View all results
       </a>
     </Option>,
   ]);

--- a/components/auto-complete/demo/uncertain-category.md
+++ b/components/auto-complete/demo/uncertain-category.md
@@ -42,7 +42,7 @@ function renderOption(item) {
     <Option key={item.category} text={item.category}>
       <div className="global-search-item">
         <span className="global-search-item-desc">
-          {item.query} 在
+          Found {item.query} on
           <a
             href={`https://s.taobao.com/search?q=${item.query}`}
             target="_blank"
@@ -50,9 +50,8 @@ function renderOption(item) {
           >
             {item.category}
           </a>
-          区块中
         </span>
-        <span className="global-search-item-count">约 {item.count} 个结果</span>
+        <span className="global-search-item-count">{item.count} results</span>
       </div>
     </Option>
   );


### PR DESCRIPTION
### 🤔 This is a ...
- [x] Site / document update

### 👻 What's the background?
- Some AutoComplete examples were still in Chinese

### 💡 Solution
- Translated AutoComplete examples

### 📝 Changelog
| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/auto-complete/demo/certain-category.md](https://github.com/SamKirkland/ant-design/blob/AutoComplete-translate/components/auto-complete/demo/certain-category.md)
[View rendered components/auto-complete/demo/uncertain-category.md](https://github.com/SamKirkland/ant-design/blob/AutoComplete-translate/components/auto-complete/demo/uncertain-category.md)