### PR TITLE
fix: add link type to Button's doc

### DIFF
--- a/components/button/demo/basic.md
+++ b/components/button/demo/basic.md
@@ -7,11 +7,11 @@ title:
 
 ## zh-CN
 
-按钮有四种类型：主按钮、次按钮、虚线按钮、危险按钮。主按钮在同一个操作区域最多出现一次。
+按钮有五种类型：主按钮、次按钮、虚线按钮、危险按钮和链接按钮。主按钮在同一个操作区域最多出现一次。
 
 ## en-US
 
-There are `primary` button, `default` button, `dashed` button and `danger` button in antd.
+There are `primary` button, `default` button, `dashed` button, `danger` button and `link` button in antd.
 
 ```jsx
 import { Button } from 'antd';


### PR DESCRIPTION
### 🤔 This is a ...

- [x] Site / document update

### 👻 What's the background?

Link type was not provided in doc of Button.

### 💡 Solution

Add link type to doc of `Button`.

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Add link type to doc of `Button`  |
| 🇨🇳 Chinese | `Button` 文档的按钮类型增加链接按钮 |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/button/demo/basic.md](https://github.com/cnlon/ant-design/blob/fix/button-docs/components/button/demo/basic.md)