### PR TITLE
fix: prop headerRender should be optional for component Calendar

### DIFF
--- a/components/calendar/Header.tsx
+++ b/components/calendar/Header.tsx
@@ -12,6 +12,8 @@ export interface RenderHeader {
   onTypeChange: (type: string) => void;
 }
 
+export type HeaderRender = (headerRender: RenderHeader) => React.ReactNode;
+
 export interface HeaderProps {
   prefixCls?: string;
   locale?: any;
@@ -23,7 +25,7 @@ export interface HeaderProps {
   onTypeChange?: (type: string) => void;
   value: moment.Moment;
   validRange?: [moment.Moment, moment.Moment];
-  headerRender: (header: RenderHeader) => React.ReactNode;
+  headerRender?: HeaderRender;
 }
 
 export default class Header extends React.Component<HeaderProps, any> {
@@ -178,8 +180,8 @@ export default class Header extends React.Component<HeaderProps, any> {
     );
   };
 
-  headerRenderCustom = (): React.ReactNode => {
-    const { headerRender, type, onValueChange, value } = this.props;
+  headerRenderCustom = (headerRender: HeaderRender): React.ReactNode => {
+    const { type, onValueChange, value } = this.props;
 
     return headerRender({
       value,
@@ -194,7 +196,7 @@ export default class Header extends React.Component<HeaderProps, any> {
     const typeSwitch = this.getTypeSwitch();
     const { yearReactNode, monthReactNode } = this.getMonthYearSelections(getPrefixCls);
     return headerRender ? (
-      this.headerRenderCustom()
+      this.headerRenderCustom(headerRender)
     ) : (
       <div className={`${prefixCls}-header`} ref={this.getCalenderHeaderNode}>
         {yearReactNode}

--- a/components/calendar/index.tsx
+++ b/components/calendar/index.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import * as PropTypes from 'prop-types';
 import * as moment from 'moment';
 import FullCalendar from 'rc-calendar/lib/FullCalendar';
-import Header, { RenderHeader } from './Header';
+import Header, { HeaderRender } from './Header';
 import enUS from './locale/en_US';
 import LocaleReceiver from '../locale-provider/LocaleReceiver';
 import { ConfigConsumer, ConfigConsumerProps } from '../config-provider';
@@ -41,7 +41,7 @@ export interface CalendarProps {
   onChange?: (date?: moment.Moment) => void;
   disabledDate?: (current: moment.Moment) => boolean;
   validRange?: [moment.Moment, moment.Moment];
-  headerRender: (header: RenderHeader) => React.ReactNode;
+  headerRender?: HeaderRender;
 }
 
 export interface CalendarState {
@@ -56,7 +56,6 @@ class Calendar extends React.Component<CalendarProps, CalendarState> {
     onSelect: noop,
     onPanelChange: noop,
     onChange: noop,
-    headerRender: null,
   };
 
   static propTypes = {
@@ -73,6 +72,7 @@ class Calendar extends React.Component<CalendarProps, CalendarState> {
     value: PropTypes.object as PropTypes.Requireable<moment.Moment>,
     onSelect: PropTypes.func,
     onChange: PropTypes.func,
+    headerRender: PropTypes.func,
   };
 
   static getDerivedStateFromProps(nextProps: CalendarProps) {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?

<!--
1. Describe the source of requirement, like related issue link.

2. Describe the problem and the scenario.
-->

In Release 13.19.0, new prop headerRender is added for component Calendar(#16535 ), but the ts definition define it mandatory. It's designed as optional in fact.

### 💡 Solution

<!--
1. How to fix the problem, and list final API implementation and usage sample if that is an new feature.

2. GIF or snapshot should be provided if includes UI/interactive modification.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
