### PR TITLE
fix: Input not align with other components in Chrome

### DIFF
--- a/components/input/style/mixin.less
+++ b/components/input/style/mixin.less
@@ -8,11 +8,13 @@
   height: @input-height-lg;
   padding: @input-padding-vertical-lg @input-padding-horizontal-lg;
   font-size: @font-size-lg;
+  line-height: @input-height-lg;
 }
 
 .input-sm() {
   height: @input-height-sm;
   padding: @input-padding-vertical-sm @input-padding-horizontal-sm;
+  line-height: @input-height-sm;
 }
 
 // input status
@@ -49,7 +51,7 @@
   padding: @input-padding-vertical-base @input-padding-horizontal-base;
   color: @input-color;
   font-size: @font-size-base;
-  line-height: @line-height-base;
+  line-height: @input-height-base;
   background-color: @input-bg;
   background-image: none;
   border: @border-width-base @border-style-base @input-border-color;

--- a/components/time-picker/style/index.less
+++ b/components/time-picker/style/index.less
@@ -225,3 +225,14 @@
     right: @control-padding-horizontal-sm - 1px;
   }
 }
+
+// Fix cursor height in safari
+// https://stackoverflow.com/q/3843408/3040605
+// https://browserstrangeness.github.io/css_hacks.html#safari
+@media not all and (min-resolution: 0.001dpcm) {
+  @supports (-webkit-appearance: none) and (stroke-color: transparent) {
+    .@{ant-prefix}-input {
+      line-height: @line-height-base;
+    }
+  }
+}


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?

close #17082

Only happens in Chrome.

### 💡 Solution

1. Add `line-height` for all inputs to fix align issue, in Chrome
2. It will break safari cursor height: https://stackoverflow.com/q/3843408/3040605
3. Use safari only hacks to reset it. https://browserstrangeness.github.io/css_hacks.html#safari

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Input not align with other components in Chrome |
| 🇨🇳 Chinese | 修复 Input 在 Chrome 下不对齐的问题。 |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
