### PR TITLE
fix: Add missing russian translations

### DIFF
--- a/components/locale-provider/ru_RU.tsx
+++ b/components/locale-provider/ru_RU.tsx
@@ -15,6 +15,7 @@ export default {
     filterReset: 'Сбросить',
     selectAll: 'Выбрать всё',
     selectInvert: 'Инвертировать выбор',
+    sortTitle: 'Сортировка',
   },
   Modal: {
     okText: 'OK',
@@ -38,5 +39,14 @@ export default {
   },
   Empty: {
     description: 'Нет данных',
+  },
+  Text: {
+    edit: 'редактировать',
+    copy: 'копировать',
+    copied: 'скопировано',
+    expand: 'раскрыть',
+  },
+  PageHeader: {
+    back: 'назад',
   },
 };


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?

The russian locale has less locale keys than the default locale

### 💡 Solution

Add missing translations for the russian locale

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Add missing translations for the russian (ru_RU) locale     |
| 🇨🇳 Chinese |           |
