### PR TITLE
fix: RangePicker wrong input line-height

### DIFF
--- a/components/date-picker/style/Picker.less
+++ b/components/date-picker/style/Picker.less
@@ -45,6 +45,10 @@
     outline: none;
   }
 
+  &-input.@{ant-prefix}-input {
+    line-height: @line-height-base;
+  }
+
   &-input.@{ant-prefix}-input-sm {
     padding-top: 0;
     padding-bottom: 0;


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?

resolve #17123 

### 💡 Solution

set `.ant-calendar-picker-input ant-input` element's line-height to default

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    FIx RangePicker wrong line-height       |
| 🇨🇳 Chinese |     修复 RangePicker 下错误的 line-height      |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
