### PR TITLE
fix: Wrong height of TextArea & DatePicker

### DIFF
--- a/components/date-picker/style/Picker.less
+++ b/components/date-picker/style/Picker.less
@@ -43,6 +43,10 @@
 
   &-input {
     outline: none;
+
+    &.@{ant-prefix}-input {
+      line-height: @line-height-base;
+    }
   }
 
   &-input.@{ant-prefix}-input-sm {

--- a/components/date-picker/style/RangePicker.less
+++ b/components/date-picker/style/RangePicker.less
@@ -7,7 +7,6 @@
   background-color: transparent;
   border: 0;
   outline: 0;
-  vertical-align: top;
   .placeholder();
 
   &[disabled] {

--- a/components/input/style/mixin.less
+++ b/components/input/style/mixin.less
@@ -82,6 +82,7 @@
     min-height: @input-height-base;
     vertical-align: bottom;
     transition: all 0.3s, height 0s;
+    line-height: @line-height-base;
   }
 
   // Size


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?

fix #17163
fix #17143
fix #17159

### 💡 Solution

Reset line-height back

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fix wrong height of TextArea & DatePicker      |
| 🇨🇳 Chinese |     修复 TextArea 和 DatePicker 的高度问题    |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
