### PR TITLE
fix(Doc): remove useless option in API Doc for row-selection-custom Table

### DIFF
--- a/components/table/demo/row-selection-custom.md
+++ b/components/table/demo/row-selection-custom.md
@@ -96,7 +96,6 @@ class App extends React.Component {
           },
         },
       ],
-      onSelection: this.onSelection,
     };
     return <Table rowSelection={rowSelection} columns={columns} dataSource={data} />;
   }


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?

There is an useless option setting in the ["Custom selection table"](https://ant.design/components/table/#components-table-demo-row-selection-custom) in the API Doc.

### 💡 Solution

Just removes this useless option to avoid making any confusion.

### 📝 Changelog

Table API Doc fix.

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/table/demo/row-selection-custom.md](https://github.com/wtzeng1/ant-design/blob/master/components/table/demo/row-selection-custom.md)