### PR TITLE
fix: Clone only valid react child elements

### DIFF
--- a/components/descriptions/__tests__/__snapshots__/index.test.js.snap
+++ b/components/descriptions/__tests__/__snapshots__/index.test.js.snap
@@ -99,3 +99,120 @@ exports[`Descriptions column is number 1`] = `
   </div>
 </Descriptions>
 `;
+
+exports[`Descriptions when item is rendered conditionally 1`] = `
+<Descriptions
+  column={
+    Object {
+      "lg": 3,
+      "md": 3,
+      "sm": 2,
+      "xl": 3,
+      "xs": 1,
+      "xxl": 3,
+    }
+  }
+  size="default"
+>
+  <div
+    className="ant-descriptions"
+  >
+    <div
+      className="ant-descriptions-view"
+    >
+      <table>
+        <tbody>
+          <tr
+            className="ant-descriptions-row"
+            key="0"
+          >
+            <td
+              className="ant-descriptions-item"
+              colSpan={1}
+            >
+              <span
+                className="ant-descriptions-item-label"
+                key="label"
+              >
+                Product
+              </span>
+              <span
+                className="ant-descriptions-item-content"
+                key="content"
+              >
+                Cloud Database
+              </span>
+            </td>
+          </tr>
+          <tr
+            className="ant-descriptions-row"
+            key="1"
+          >
+            <td
+              className="ant-descriptions-item"
+              colSpan={1}
+            >
+              <span
+                className="ant-descriptions-item-label"
+                key="label"
+              >
+                Billing
+              </span>
+              <span
+                className="ant-descriptions-item-content"
+                key="content"
+              >
+                Prepaid
+              </span>
+            </td>
+          </tr>
+          <tr
+            className="ant-descriptions-row"
+            key="2"
+          >
+            <td
+              className="ant-descriptions-item"
+              colSpan={1}
+            >
+              <span
+                className="ant-descriptions-item-label"
+                key="label"
+              >
+                time
+              </span>
+              <span
+                className="ant-descriptions-item-content"
+                key="content"
+              >
+                18:00:00
+              </span>
+            </td>
+          </tr>
+          <tr
+            className="ant-descriptions-row"
+            key="3"
+          >
+            <td
+              className="ant-descriptions-item"
+              colSpan={1}
+            >
+              <span
+                className="ant-descriptions-item-label"
+                key="label"
+              >
+                Amount
+              </span>
+              <span
+                className="ant-descriptions-item-content"
+                key="content"
+              >
+                $80.00
+              </span>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</Descriptions>
+`;

--- a/components/descriptions/__tests__/index.test.js
+++ b/components/descriptions/__tests__/index.test.js
@@ -109,4 +109,19 @@ describe('Descriptions', () => {
       'Warning: [antd: Descriptions] Sum of column `span` in a line exceeds `column` of Descriptions.',
     );
   });
+
+  it('when item is rendered conditionally', () => {
+    const hasDiscount = false;
+    const wrapper = mount(
+      <Descriptions>
+        <Descriptions.Item label="Product">Cloud Database</Descriptions.Item>
+        <Descriptions.Item label="Billing">Prepaid</Descriptions.Item>
+        <Descriptions.Item label="time">18:00:00</Descriptions.Item>
+        <Descriptions.Item label="Amount">$80.00</Descriptions.Item>
+        {hasDiscount && <Descriptions.Item label="Discount">$20.00</Descriptions.Item>}
+      </Descriptions>,
+    );
+    expect(wrapper).toMatchSnapshot();
+    wrapper.unmount();
+  });
 });

--- a/components/descriptions/index.tsx
+++ b/components/descriptions/index.tsx
@@ -209,9 +209,12 @@ class Descriptions extends React.Component<
           const cloneChildren = React.Children.map(
             children,
             (child: React.ReactElement<DescriptionsItemProps>) => {
-              return React.cloneElement(child, {
-                prefixCls,
-              });
+              if (React.isValidElement(child)) {
+                return React.cloneElement(child, {
+                  prefixCls,
+                });
+              }
+              return child;
             },
           );
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?

`React.cloneElement` will throw error if child is not a valid element. Child can be` void | null | boolean | string | number` too. These are not valid react elements.

### 💡 Solution

Use `React.isValidElement(child)` to check for valid element before cloning child.

### 📝 Changelog

No risk or breaking changes.

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
