### PR TITLE
Tabs props missing prop

### DIFF
--- a/components/tabs/index.tsx
+++ b/components/tabs/index.tsx
@@ -32,6 +32,7 @@ export interface TabsProps {
   animated?: boolean | { inkBar: boolean; tabPane: boolean };
   tabBarGutter?: number;
   renderTabBar?: (props: TabsProps, DefaultTabBar: React.ReactNode) => React.ReactElement<unknown>;
+  destroyInactiveTabPane?: boolean;
 }
 
 // Tabs


### PR DESCRIPTION
Added Missing prop 'destroyInactiveTabPane' in Tabs

<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

###  This is a  Bug fix


### What's the background?
A Prop destroyInactiveTabPane is missing in Tabs Props

<!--
1. Describe the source of requirement, like related issue link.

2. Describe the problem and the scenario.
-->

### 💡 Solution
Added the missing Prop
<!--
1. How to fix the problem, and list final API implementation and usage sample if that is an new feature.

2. GIF or snapshot should be provided if includes UI/interactive modification.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge
TypeScript definition is updated.
