### PR TITLE
feat: 💥 support tableLayout and column.ellipsis

### DIFF
--- a/components/table/Table.tsx
+++ b/components/table/Table.tsx
@@ -122,6 +122,7 @@ export default class Table<T> extends React.Component<TableProps<T>, TableState<
     showHeader: true,
     sortDirections: ['ascend', 'descend'],
     childrenColumnName: 'children',
+    tableLayout: 'auto',
   };
 
   CheckboxPropsCache: {
@@ -866,6 +867,26 @@ export default class Table<T> extends React.Component<TableProps<T>, TableState<
     return getColumnKey(sortColumn) === getColumnKey(column);
   }
 
+  isTableLayoutFixed() {
+    const { tableLayout, columns = [], rowSelection, useFixedHeader, scroll = {} } = this.props;
+    if (tableLayout === 'fixed') {
+      return true;
+    }
+    // if one column fixed, use fixed table layout to fix align issue
+    if (columns.some(({ fixed }) => !!fixed)) {
+      return true;
+    }
+    // if selection column fixed, use fixed table layout to fix align issue
+    if (rowSelection && rowSelection.fixed) {
+      return true;
+    }
+    // if header fixed, use fixed table layout to fix align issue
+    if (useFixedHeader || scroll.y) {
+      return true;
+    }
+    return false;
+  }
+
   // Get pagination, filters, sorter
   prepareParamsArguments(state: any): PrepareParamsArgumentsReturn<T> {
     const pagination = { ...state.pagination };
@@ -1217,7 +1238,7 @@ export default class Table<T> extends React.Component<TableProps<T>, TableState<
   }) => {
     const { showHeader, locale, getPopupContainer, ...restTableProps } = this.props;
     // do not pass prop.style to rc-table, since already apply it to container div
-    const restProps = omit(restTableProps, ['style']);
+    const restProps = omit(restTableProps, ['style', 'tableLayout']);
     const data = this.getCurrentPageData();
     const expandIconAsCell = this.props.expandedRowRender && this.props.expandIconAsCell !== false;
 
@@ -1230,11 +1251,11 @@ export default class Table<T> extends React.Component<TableProps<T>, TableState<
       mergedLocale.emptyText = renderEmpty('Table');
     }
 
-    const classString = classNames({
-      [`${prefixCls}-${this.props.size}`]: true,
+    const classString = classNames(`${prefixCls}-${this.props.size}`, {
       [`${prefixCls}-bordered`]: this.props.bordered,
       [`${prefixCls}-empty`]: !data.length,
       [`${prefixCls}-without-column-header`]: !showHeader,
+      [`${prefixCls}-layout-fixed`]: this.isTableLayoutFixed(),
     });
 
     const columnsWithRowSelection = this.renderRowSelection({

--- a/components/table/Table.tsx
+++ b/components/table/Table.tsx
@@ -867,26 +867,6 @@ export default class Table<T> extends React.Component<TableProps<T>, TableState<
     return getColumnKey(sortColumn) === getColumnKey(column);
   }
 
-  isTableLayoutFixed() {
-    const { tableLayout, columns = [], rowSelection, useFixedHeader, scroll = {} } = this.props;
-    if (tableLayout === 'fixed') {
-      return true;
-    }
-    // if one column fixed, use fixed table layout to fix align issue
-    if (columns.some(({ fixed }) => !!fixed)) {
-      return true;
-    }
-    // if selection column fixed, use fixed table layout to fix align issue
-    if (rowSelection && rowSelection.fixed) {
-      return true;
-    }
-    // if header fixed, use fixed table layout to fix align issue
-    if (useFixedHeader || scroll.y) {
-      return true;
-    }
-    return false;
-  }
-
   // Get pagination, filters, sorter
   prepareParamsArguments(state: any): PrepareParamsArgumentsReturn<T> {
     const pagination = { ...state.pagination };
@@ -1238,7 +1218,7 @@ export default class Table<T> extends React.Component<TableProps<T>, TableState<
   }) => {
     const { showHeader, locale, getPopupContainer, ...restTableProps } = this.props;
     // do not pass prop.style to rc-table, since already apply it to container div
-    const restProps = omit(restTableProps, ['style', 'tableLayout']);
+    const restProps = omit(restTableProps, ['style']);
     const data = this.getCurrentPageData();
     const expandIconAsCell = this.props.expandedRowRender && this.props.expandIconAsCell !== false;
 
@@ -1255,7 +1235,6 @@ export default class Table<T> extends React.Component<TableProps<T>, TableState<
       [`${prefixCls}-bordered`]: this.props.bordered,
       [`${prefixCls}-empty`]: !data.length,
       [`${prefixCls}-without-column-header`]: !showHeader,
-      [`${prefixCls}-layout-fixed`]: this.isTableLayoutFixed(),
     });
 
     const columnsWithRowSelection = this.renderRowSelection({

--- a/components/table/Table.tsx
+++ b/components/table/Table.tsx
@@ -122,7 +122,6 @@ export default class Table<T> extends React.Component<TableProps<T>, TableState<
     showHeader: true,
     sortDirections: ['ascend', 'descend'],
     childrenColumnName: 'children',
-    tableLayout: 'auto',
   };
 
   CheckboxPropsCache: {

--- a/components/table/__tests__/__snapshots__/Table.rowSelection.test.js.snap
+++ b/components/table/__tests__/__snapshots__/Table.rowSelection.test.js.snap
@@ -11,7 +11,7 @@ exports[`Table.rowSelection fix selection column on the left 1`] = `
       class="ant-spin-container"
     >
       <div
-        class="ant-table ant-table-default ant-table-scroll-position-left"
+        class="ant-table ant-table-default ant-table-scroll-position-left ant-table-layout-fixed"
       >
         <div
           class="ant-table-content"

--- a/components/table/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/table/__tests__/__snapshots__/demo.test.js.snap
@@ -5000,7 +5000,7 @@ exports[`renders ./components/table/demo/fixed-columns.md correctly 1`] = `
       class="ant-spin-container"
     >
       <div
-        class="ant-table ant-table-default ant-table-scroll-position-left"
+        class="ant-table ant-table-default ant-table-scroll-position-left ant-table-layout-fixed"
       >
         <div
           class="ant-table-content"
@@ -5636,7 +5636,7 @@ exports[`renders ./components/table/demo/fixed-columns-header.md correctly 1`] =
       class="ant-spin-container"
     >
       <div
-        class="ant-table ant-table-default ant-table-fixed-header ant-table-scroll-position-left"
+        class="ant-table ant-table-default ant-table-fixed-header ant-table-scroll-position-left ant-table-layout-fixed"
       >
         <div
           class="ant-table-content"
@@ -7155,7 +7155,7 @@ exports[`renders ./components/table/demo/fixed-header.md correctly 1`] = `
       class="ant-spin-container"
     >
       <div
-        class="ant-table ant-table-default ant-table-fixed-header ant-table-scroll-position-left"
+        class="ant-table ant-table-default ant-table-fixed-header ant-table-scroll-position-left ant-table-layout-fixed"
       >
         <div
           class="ant-table-content"
@@ -8364,7 +8364,7 @@ exports[`renders ./components/table/demo/grouping-columns.md correctly 1`] = `
       class="ant-spin-container"
     >
       <div
-        class="ant-table ant-table-middle ant-table-bordered ant-table-fixed-header ant-table-scroll-position-left"
+        class="ant-table ant-table-middle ant-table-bordered ant-table-fixed-header ant-table-scroll-position-left ant-table-layout-fixed"
       >
         <div
           class="ant-table-content"

--- a/components/table/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/table/__tests__/__snapshots__/demo.test.js.snap
@@ -4365,6 +4365,350 @@ exports[`renders ./components/table/demo/edit-row.md correctly 1`] = `
 </div>
 `;
 
+exports[`renders ./components/table/demo/ellipsis.md correctly 1`] = `
+<div
+  class="ant-table-wrapper"
+>
+  <div
+    class="ant-spin-nested-loading"
+  >
+    <div
+      class="ant-spin-container"
+    >
+      <div
+        class="ant-table ant-table-default ant-table-scroll-position-left ant-table-layout-fixed"
+      >
+        <div
+          class="ant-table-content"
+        >
+          <div
+            class="ant-table-body"
+          >
+            <table
+              class=""
+            >
+              <colgroup>
+                <col
+                  style="width:150px;min-width:150px"
+                />
+                <col
+                  style="width:80px;min-width:80px"
+                />
+                <col />
+                <col />
+                <col />
+                <col />
+              </colgroup>
+              <thead
+                class="ant-table-thead"
+              >
+                <tr>
+                  <th
+                    class=""
+                  >
+                    <span
+                      class="ant-table-header-column"
+                    >
+                      <div>
+                        <span
+                          class="ant-table-column-title"
+                        >
+                          Name
+                        </span>
+                        <span
+                          class="ant-table-column-sorter"
+                        />
+                      </div>
+                    </span>
+                  </th>
+                  <th
+                    class=""
+                  >
+                    <span
+                      class="ant-table-header-column"
+                    >
+                      <div>
+                        <span
+                          class="ant-table-column-title"
+                        >
+                          Age
+                        </span>
+                        <span
+                          class="ant-table-column-sorter"
+                        />
+                      </div>
+                    </span>
+                  </th>
+                  <th
+                    class="ant-table-row-cell-ellipsis"
+                  >
+                    <span
+                      class="ant-table-header-column"
+                    >
+                      <div>
+                        <span
+                          class="ant-table-column-title"
+                        >
+                          Address
+                        </span>
+                        <span
+                          class="ant-table-column-sorter"
+                        />
+                      </div>
+                    </span>
+                  </th>
+                  <th
+                    class="ant-table-row-cell-ellipsis"
+                  >
+                    <span
+                      class="ant-table-header-column"
+                    >
+                      <div>
+                        <span
+                          class="ant-table-column-title"
+                        >
+                          Long Column Long Column Long Column
+                        </span>
+                        <span
+                          class="ant-table-column-sorter"
+                        />
+                      </div>
+                    </span>
+                  </th>
+                  <th
+                    class="ant-table-row-cell-ellipsis"
+                  >
+                    <span
+                      class="ant-table-header-column"
+                    >
+                      <div>
+                        <span
+                          class="ant-table-column-title"
+                        >
+                          Long Column Long Column
+                        </span>
+                        <span
+                          class="ant-table-column-sorter"
+                        />
+                      </div>
+                    </span>
+                  </th>
+                  <th
+                    class="ant-table-row-cell-ellipsis"
+                  >
+                    <span
+                      class="ant-table-header-column"
+                    >
+                      <div>
+                        <span
+                          class="ant-table-column-title"
+                        >
+                          Long Column
+                        </span>
+                        <span
+                          class="ant-table-column-sorter"
+                        />
+                      </div>
+                    </span>
+                  </th>
+                </tr>
+              </thead>
+              <tbody
+                class="ant-table-tbody"
+              >
+                <tr
+                  class="ant-table-row ant-table-row-level-0"
+                  data-row-key="1"
+                >
+                  <td
+                    class=""
+                  >
+                    <a>
+                      John Brown
+                    </a>
+                  </td>
+                  <td
+                    class=""
+                  >
+                    32
+                  </td>
+                  <td
+                    class="ant-table-row-cell-ellipsis"
+                  >
+                    New York No. 1 Lake Park, New York No. 1 Lake Park
+                  </td>
+                  <td
+                    class="ant-table-row-cell-ellipsis"
+                  >
+                    New York No. 1 Lake Park, New York No. 1 Lake Park
+                  </td>
+                  <td
+                    class="ant-table-row-cell-ellipsis"
+                  >
+                    New York No. 1 Lake Park, New York No. 1 Lake Park
+                  </td>
+                  <td
+                    class="ant-table-row-cell-ellipsis"
+                  >
+                    New York No. 1 Lake Park, New York No. 1 Lake Park
+                  </td>
+                </tr>
+                <tr
+                  class="ant-table-row ant-table-row-level-0"
+                  data-row-key="2"
+                >
+                  <td
+                    class=""
+                  >
+                    <a>
+                      Jim Green
+                    </a>
+                  </td>
+                  <td
+                    class=""
+                  >
+                    42
+                  </td>
+                  <td
+                    class="ant-table-row-cell-ellipsis"
+                  >
+                    London No. 2 Lake Park, London No. 2 Lake Park
+                  </td>
+                  <td
+                    class="ant-table-row-cell-ellipsis"
+                  >
+                    London No. 2 Lake Park, London No. 2 Lake Park
+                  </td>
+                  <td
+                    class="ant-table-row-cell-ellipsis"
+                  >
+                    London No. 2 Lake Park, London No. 2 Lake Park
+                  </td>
+                  <td
+                    class="ant-table-row-cell-ellipsis"
+                  >
+                    London No. 2 Lake Park, London No. 2 Lake Park
+                  </td>
+                </tr>
+                <tr
+                  class="ant-table-row ant-table-row-level-0"
+                  data-row-key="3"
+                >
+                  <td
+                    class=""
+                  >
+                    <a>
+                      Joe Black
+                    </a>
+                  </td>
+                  <td
+                    class=""
+                  >
+                    32
+                  </td>
+                  <td
+                    class="ant-table-row-cell-ellipsis"
+                  >
+                    Sidney No. 1 Lake Park, Sidney No. 1 Lake Park
+                  </td>
+                  <td
+                    class="ant-table-row-cell-ellipsis"
+                  >
+                    Sidney No. 1 Lake Park, Sidney No. 1 Lake Park
+                  </td>
+                  <td
+                    class="ant-table-row-cell-ellipsis"
+                  >
+                    Sidney No. 1 Lake Park, Sidney No. 1 Lake Park
+                  </td>
+                  <td
+                    class="ant-table-row-cell-ellipsis"
+                  >
+                    Sidney No. 1 Lake Park, Sidney No. 1 Lake Park
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+      <ul
+        class="ant-pagination ant-table-pagination"
+        unselectable="unselectable"
+      >
+        <li
+          aria-disabled="true"
+          class="ant-pagination-disabled ant-pagination-prev"
+          title="Previous Page"
+        >
+          <a
+            class="ant-pagination-item-link"
+          >
+            <i
+              aria-label="icon: left"
+              class="anticon anticon-left"
+            >
+              <svg
+                aria-hidden="true"
+                class=""
+                data-icon="left"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M724 218.3V141c0-6.7-7.7-10.4-12.9-6.3L260.3 486.8a31.86 31.86 0 0 0 0 50.3l450.8 352.1c5.3 4.1 12.9.4 12.9-6.3v-77.3c0-4.9-2.3-9.6-6.1-12.6l-360-281 360-281.1c3.8-3 6.1-7.7 6.1-12.6z"
+                />
+              </svg>
+            </i>
+          </a>
+        </li>
+        <li
+          class="ant-pagination-item ant-pagination-item-1 ant-pagination-item-active"
+          tabindex="0"
+          title="1"
+        >
+          <a>
+            1
+          </a>
+        </li>
+        <li
+          aria-disabled="true"
+          class="ant-pagination-disabled ant-pagination-next"
+          title="Next Page"
+        >
+          <a
+            class="ant-pagination-item-link"
+          >
+            <i
+              aria-label="icon: right"
+              class="anticon anticon-right"
+            >
+              <svg
+                aria-hidden="true"
+                class=""
+                data-icon="right"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M765.7 486.8L314.9 134.7A7.97 7.97 0 0 0 302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 0 0 0-50.4z"
+                />
+              </svg>
+            </i>
+          </a>
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`renders ./components/table/demo/expand.md correctly 1`] = `
 <div
   class="ant-table-wrapper"
@@ -10999,7 +11343,7 @@ exports[`renders ./components/table/demo/reset-filter.md correctly 1`] = `
         class="ant-spin-container"
       >
         <div
-          class="ant-table ant-table-default ant-table-scroll-position-left"
+          class="ant-table ant-table-default ant-table-scroll-position-left ant-table-layout-fixed"
         >
           <div
             class="ant-table-content"
@@ -11020,7 +11364,7 @@ exports[`renders ./components/table/demo/reset-filter.md correctly 1`] = `
                 >
                   <tr>
                     <th
-                      class="ant-table-column-has-actions ant-table-column-has-filters ant-table-column-has-sorters"
+                      class="ant-table-column-has-actions ant-table-column-has-filters ant-table-column-has-sorters ant-table-row-cell-ellipsis"
                     >
                       <span
                         class="ant-table-header-column"
@@ -11105,7 +11449,7 @@ exports[`renders ./components/table/demo/reset-filter.md correctly 1`] = `
                       </i>
                     </th>
                     <th
-                      class="ant-table-column-has-actions ant-table-column-has-sorters"
+                      class="ant-table-column-has-actions ant-table-column-has-sorters ant-table-row-cell-ellipsis"
                     >
                       <span
                         class="ant-table-header-column"
@@ -11169,7 +11513,7 @@ exports[`renders ./components/table/demo/reset-filter.md correctly 1`] = `
                       </span>
                     </th>
                     <th
-                      class="ant-table-column-has-actions ant-table-column-has-filters ant-table-column-has-sorters"
+                      class="ant-table-column-has-actions ant-table-column-has-filters ant-table-column-has-sorters ant-table-row-cell-ellipsis"
                     >
                       <span
                         class="ant-table-header-column"
@@ -11263,17 +11607,17 @@ exports[`renders ./components/table/demo/reset-filter.md correctly 1`] = `
                     data-row-key="1"
                   >
                     <td
-                      class="ant-table-column-has-actions ant-table-column-has-filters ant-table-column-has-sorters"
+                      class="ant-table-column-has-actions ant-table-column-has-filters ant-table-column-has-sorters ant-table-row-cell-ellipsis"
                     >
                       John Brown
                     </td>
                     <td
-                      class="ant-table-column-has-actions ant-table-column-has-sorters"
+                      class="ant-table-column-has-actions ant-table-column-has-sorters ant-table-row-cell-ellipsis"
                     >
                       32
                     </td>
                     <td
-                      class="ant-table-column-has-actions ant-table-column-has-filters ant-table-column-has-sorters"
+                      class="ant-table-column-has-actions ant-table-column-has-filters ant-table-column-has-sorters ant-table-row-cell-ellipsis"
                     >
                       New York No. 1 Lake Park
                     </td>
@@ -11283,17 +11627,17 @@ exports[`renders ./components/table/demo/reset-filter.md correctly 1`] = `
                     data-row-key="2"
                   >
                     <td
-                      class="ant-table-column-has-actions ant-table-column-has-filters ant-table-column-has-sorters"
+                      class="ant-table-column-has-actions ant-table-column-has-filters ant-table-column-has-sorters ant-table-row-cell-ellipsis"
                     >
                       Jim Green
                     </td>
                     <td
-                      class="ant-table-column-has-actions ant-table-column-has-sorters"
+                      class="ant-table-column-has-actions ant-table-column-has-sorters ant-table-row-cell-ellipsis"
                     >
                       42
                     </td>
                     <td
-                      class="ant-table-column-has-actions ant-table-column-has-filters ant-table-column-has-sorters"
+                      class="ant-table-column-has-actions ant-table-column-has-filters ant-table-column-has-sorters ant-table-row-cell-ellipsis"
                     >
                       London No. 1 Lake Park
                     </td>
@@ -11303,17 +11647,17 @@ exports[`renders ./components/table/demo/reset-filter.md correctly 1`] = `
                     data-row-key="3"
                   >
                     <td
-                      class="ant-table-column-has-actions ant-table-column-has-filters ant-table-column-has-sorters"
+                      class="ant-table-column-has-actions ant-table-column-has-filters ant-table-column-has-sorters ant-table-row-cell-ellipsis"
                     >
                       Joe Black
                     </td>
                     <td
-                      class="ant-table-column-has-actions ant-table-column-has-sorters"
+                      class="ant-table-column-has-actions ant-table-column-has-sorters ant-table-row-cell-ellipsis"
                     >
                       32
                     </td>
                     <td
-                      class="ant-table-column-has-actions ant-table-column-has-filters ant-table-column-has-sorters"
+                      class="ant-table-column-has-actions ant-table-column-has-filters ant-table-column-has-sorters ant-table-row-cell-ellipsis"
                     >
                       Sidney No. 1 Lake Park
                     </td>
@@ -11323,17 +11667,17 @@ exports[`renders ./components/table/demo/reset-filter.md correctly 1`] = `
                     data-row-key="4"
                   >
                     <td
-                      class="ant-table-column-has-actions ant-table-column-has-filters ant-table-column-has-sorters"
+                      class="ant-table-column-has-actions ant-table-column-has-filters ant-table-column-has-sorters ant-table-row-cell-ellipsis"
                     >
                       Jim Red
                     </td>
                     <td
-                      class="ant-table-column-has-actions ant-table-column-has-sorters"
+                      class="ant-table-column-has-actions ant-table-column-has-sorters ant-table-row-cell-ellipsis"
                     >
                       32
                     </td>
                     <td
-                      class="ant-table-column-has-actions ant-table-column-has-filters ant-table-column-has-sorters"
+                      class="ant-table-column-has-actions ant-table-column-has-filters ant-table-column-has-sorters ant-table-row-cell-ellipsis"
                     >
                       London No. 2 Lake Park
                     </td>

--- a/components/table/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/table/__tests__/__snapshots__/demo.test.js.snap
@@ -1795,538 +1795,639 @@ exports[`renders ./components/table/demo/drag-sorting.md correctly 1`] = `
 
 exports[`renders ./components/table/demo/dynamic-settings.md correctly 1`] = `
 <div>
-  <div
-    class="components-table-demo-control-bar"
+  <form
+    class="ant-form ant-form-inline components-table-demo-control-bar"
+    style="margin-bottom:16px"
   >
-    <form
-      class="ant-form ant-form-inline"
+    <div
+      class="ant-row ant-form-item"
     >
       <div
-        class="ant-row ant-form-item"
+        class="ant-col ant-form-item-label"
       >
-        <div
-          class="ant-col ant-form-item-label"
+        <label
+          class=""
+          title="Bordered"
         >
-          <label
-            class=""
-            title="Bordered"
-          >
-            Bordered
-          </label>
-        </div>
-        <div
-          class="ant-col ant-form-item-control-wrapper"
-        >
-          <div
-            class="ant-form-item-control"
-          >
-            <span
-              class="ant-form-item-children"
-            >
-              <button
-                aria-checked="false"
-                class="ant-switch"
-                role="switch"
-                type="button"
-              >
-                <span
-                  class="ant-switch-inner"
-                />
-              </button>
-            </span>
-          </div>
-        </div>
+          Bordered
+        </label>
       </div>
       <div
-        class="ant-row ant-form-item"
+        class="ant-col ant-form-item-control-wrapper"
       >
         <div
-          class="ant-col ant-form-item-label"
+          class="ant-form-item-control"
         >
-          <label
-            class=""
-            title="loading"
+          <span
+            class="ant-form-item-children"
           >
-            loading
-          </label>
-        </div>
-        <div
-          class="ant-col ant-form-item-control-wrapper"
-        >
-          <div
-            class="ant-form-item-control"
-          >
-            <span
-              class="ant-form-item-children"
+            <button
+              aria-checked="false"
+              class="ant-switch"
+              role="switch"
+              type="button"
             >
-              <button
-                aria-checked="false"
-                class="ant-switch"
-                role="switch"
-                type="button"
-              >
-                <span
-                  class="ant-switch-inner"
-                />
-              </button>
-            </span>
-          </div>
+              <span
+                class="ant-switch-inner"
+              />
+            </button>
+          </span>
         </div>
       </div>
+    </div>
+    <div
+      class="ant-row ant-form-item"
+    >
       <div
-        class="ant-row ant-form-item"
+        class="ant-col ant-form-item-label"
       >
-        <div
-          class="ant-col ant-form-item-label"
+        <label
+          class=""
+          title="loading"
         >
-          <label
-            class=""
-            title="Title"
-          >
-            Title
-          </label>
-        </div>
-        <div
-          class="ant-col ant-form-item-control-wrapper"
-        >
-          <div
-            class="ant-form-item-control"
-          >
-            <span
-              class="ant-form-item-children"
-            >
-              <button
-                aria-checked="false"
-                class="ant-switch"
-                role="switch"
-                type="button"
-              >
-                <span
-                  class="ant-switch-inner"
-                />
-              </button>
-            </span>
-          </div>
-        </div>
+          loading
+        </label>
       </div>
       <div
-        class="ant-row ant-form-item"
+        class="ant-col ant-form-item-control-wrapper"
       >
         <div
-          class="ant-col ant-form-item-label"
+          class="ant-form-item-control"
         >
-          <label
-            class=""
-            title="Column Header"
+          <span
+            class="ant-form-item-children"
           >
-            Column Header
-          </label>
-        </div>
-        <div
-          class="ant-col ant-form-item-control-wrapper"
-        >
-          <div
-            class="ant-form-item-control"
-          >
-            <span
-              class="ant-form-item-children"
+            <button
+              aria-checked="false"
+              class="ant-switch"
+              role="switch"
+              type="button"
             >
-              <button
-                aria-checked="true"
-                checked=""
-                class="ant-switch ant-switch-checked"
-                role="switch"
-                type="button"
-              >
-                <span
-                  class="ant-switch-inner"
-                />
-              </button>
-            </span>
-          </div>
+              <span
+                class="ant-switch-inner"
+              />
+            </button>
+          </span>
         </div>
       </div>
+    </div>
+    <div
+      class="ant-row ant-form-item"
+    >
       <div
-        class="ant-row ant-form-item"
+        class="ant-col ant-form-item-label"
       >
-        <div
-          class="ant-col ant-form-item-label"
+        <label
+          class=""
+          title="Title"
         >
-          <label
-            class=""
-            title="Footer"
-          >
-            Footer
-          </label>
-        </div>
-        <div
-          class="ant-col ant-form-item-control-wrapper"
-        >
-          <div
-            class="ant-form-item-control"
-          >
-            <span
-              class="ant-form-item-children"
-            >
-              <button
-                aria-checked="true"
-                checked=""
-                class="ant-switch ant-switch-checked"
-                role="switch"
-                type="button"
-              >
-                <span
-                  class="ant-switch-inner"
-                />
-              </button>
-            </span>
-          </div>
-        </div>
+          Title
+        </label>
       </div>
       <div
-        class="ant-row ant-form-item"
+        class="ant-col ant-form-item-control-wrapper"
       >
         <div
-          class="ant-col ant-form-item-label"
+          class="ant-form-item-control"
         >
-          <label
-            class=""
-            title="Expandable"
+          <span
+            class="ant-form-item-children"
           >
-            Expandable
-          </label>
-        </div>
-        <div
-          class="ant-col ant-form-item-control-wrapper"
-        >
-          <div
-            class="ant-form-item-control"
-          >
-            <span
-              class="ant-form-item-children"
+            <button
+              aria-checked="false"
+              class="ant-switch"
+              role="switch"
+              type="button"
             >
-              <button
-                aria-checked="true"
-                checked=""
-                class="ant-switch ant-switch-checked"
-                role="switch"
-                type="button"
-              >
-                <span
-                  class="ant-switch-inner"
-                />
-              </button>
-            </span>
-          </div>
+              <span
+                class="ant-switch-inner"
+              />
+            </button>
+          </span>
         </div>
       </div>
+    </div>
+    <div
+      class="ant-row ant-form-item"
+    >
       <div
-        class="ant-row ant-form-item"
+        class="ant-col ant-form-item-label"
       >
-        <div
-          class="ant-col ant-form-item-label"
+        <label
+          class=""
+          title="Column Header"
         >
-          <label
-            class=""
-            title="Checkbox"
-          >
-            Checkbox
-          </label>
-        </div>
-        <div
-          class="ant-col ant-form-item-control-wrapper"
-        >
-          <div
-            class="ant-form-item-control"
-          >
-            <span
-              class="ant-form-item-children"
-            >
-              <button
-                aria-checked="true"
-                checked=""
-                class="ant-switch ant-switch-checked"
-                role="switch"
-                type="button"
-              >
-                <span
-                  class="ant-switch-inner"
-                />
-              </button>
-            </span>
-          </div>
-        </div>
+          Column Header
+        </label>
       </div>
       <div
-        class="ant-row ant-form-item"
+        class="ant-col ant-form-item-control-wrapper"
       >
         <div
-          class="ant-col ant-form-item-label"
+          class="ant-form-item-control"
         >
-          <label
-            class=""
-            title="Fixed Header"
+          <span
+            class="ant-form-item-children"
           >
-            Fixed Header
-          </label>
-        </div>
-        <div
-          class="ant-col ant-form-item-control-wrapper"
-        >
-          <div
-            class="ant-form-item-control"
-          >
-            <span
-              class="ant-form-item-children"
+            <button
+              aria-checked="true"
+              checked=""
+              class="ant-switch ant-switch-checked"
+              role="switch"
+              type="button"
             >
-              <button
-                aria-checked="false"
-                class="ant-switch"
-                role="switch"
-                type="button"
-              >
-                <span
-                  class="ant-switch-inner"
-                />
-              </button>
-            </span>
-          </div>
+              <span
+                class="ant-switch-inner"
+              />
+            </button>
+          </span>
         </div>
       </div>
+    </div>
+    <div
+      class="ant-row ant-form-item"
+    >
       <div
-        class="ant-row ant-form-item"
+        class="ant-col ant-form-item-label"
       >
-        <div
-          class="ant-col ant-form-item-label"
+        <label
+          class=""
+          title="Footer"
         >
-          <label
-            class=""
-            title="Has Data"
-          >
-            Has Data
-          </label>
-        </div>
-        <div
-          class="ant-col ant-form-item-control-wrapper"
-        >
-          <div
-            class="ant-form-item-control"
-          >
-            <span
-              class="ant-form-item-children"
-            >
-              <button
-                aria-checked="true"
-                checked=""
-                class="ant-switch ant-switch-checked"
-                role="switch"
-                type="button"
-              >
-                <span
-                  class="ant-switch-inner"
-                />
-              </button>
-            </span>
-          </div>
-        </div>
+          Footer
+        </label>
       </div>
       <div
-        class="ant-row ant-form-item"
+        class="ant-col ant-form-item-control-wrapper"
       >
         <div
-          class="ant-col ant-form-item-label"
+          class="ant-form-item-control"
         >
-          <label
-            class=""
-            title="Size"
+          <span
+            class="ant-form-item-children"
           >
-            Size
-          </label>
-        </div>
-        <div
-          class="ant-col ant-form-item-control-wrapper"
-        >
-          <div
-            class="ant-form-item-control"
-          >
-            <span
-              class="ant-form-item-children"
+            <button
+              aria-checked="true"
+              checked=""
+              class="ant-switch ant-switch-checked"
+              role="switch"
+              type="button"
             >
-              <div
-                class="ant-radio-group ant-radio-group-outline ant-radio-group-default"
+              <span
+                class="ant-switch-inner"
+              />
+            </button>
+          </span>
+        </div>
+      </div>
+    </div>
+    <div
+      class="ant-row ant-form-item"
+    >
+      <div
+        class="ant-col ant-form-item-label"
+      >
+        <label
+          class=""
+          title="Expandable"
+        >
+          Expandable
+        </label>
+      </div>
+      <div
+        class="ant-col ant-form-item-control-wrapper"
+      >
+        <div
+          class="ant-form-item-control"
+        >
+          <span
+            class="ant-form-item-children"
+          >
+            <button
+              aria-checked="true"
+              checked=""
+              class="ant-switch ant-switch-checked"
+              role="switch"
+              type="button"
+            >
+              <span
+                class="ant-switch-inner"
+              />
+            </button>
+          </span>
+        </div>
+      </div>
+    </div>
+    <div
+      class="ant-row ant-form-item"
+    >
+      <div
+        class="ant-col ant-form-item-label"
+      >
+        <label
+          class=""
+          title="Checkbox"
+        >
+          Checkbox
+        </label>
+      </div>
+      <div
+        class="ant-col ant-form-item-control-wrapper"
+      >
+        <div
+          class="ant-form-item-control"
+        >
+          <span
+            class="ant-form-item-children"
+          >
+            <button
+              aria-checked="true"
+              checked=""
+              class="ant-switch ant-switch-checked"
+              role="switch"
+              type="button"
+            >
+              <span
+                class="ant-switch-inner"
+              />
+            </button>
+          </span>
+        </div>
+      </div>
+    </div>
+    <div
+      class="ant-row ant-form-item"
+    >
+      <div
+        class="ant-col ant-form-item-label"
+      >
+        <label
+          class=""
+          title="Fixed Header"
+        >
+          Fixed Header
+        </label>
+      </div>
+      <div
+        class="ant-col ant-form-item-control-wrapper"
+      >
+        <div
+          class="ant-form-item-control"
+        >
+          <span
+            class="ant-form-item-children"
+          >
+            <button
+              aria-checked="false"
+              class="ant-switch"
+              role="switch"
+              type="button"
+            >
+              <span
+                class="ant-switch-inner"
+              />
+            </button>
+          </span>
+        </div>
+      </div>
+    </div>
+    <div
+      class="ant-row ant-form-item"
+    >
+      <div
+        class="ant-col ant-form-item-label"
+      >
+        <label
+          class=""
+          title="Has Data"
+        >
+          Has Data
+        </label>
+      </div>
+      <div
+        class="ant-col ant-form-item-control-wrapper"
+      >
+        <div
+          class="ant-form-item-control"
+        >
+          <span
+            class="ant-form-item-children"
+          >
+            <button
+              aria-checked="true"
+              checked=""
+              class="ant-switch ant-switch-checked"
+              role="switch"
+              type="button"
+            >
+              <span
+                class="ant-switch-inner"
+              />
+            </button>
+          </span>
+        </div>
+      </div>
+    </div>
+    <div
+      class="ant-row ant-form-item"
+    >
+      <div
+        class="ant-col ant-form-item-label"
+      >
+        <label
+          class=""
+          title="Ellipsis"
+        >
+          Ellipsis
+        </label>
+      </div>
+      <div
+        class="ant-col ant-form-item-control-wrapper"
+      >
+        <div
+          class="ant-form-item-control"
+        >
+          <span
+            class="ant-form-item-children"
+          >
+            <button
+              aria-checked="false"
+              class="ant-switch"
+              role="switch"
+              type="button"
+            >
+              <span
+                class="ant-switch-inner"
+              />
+            </button>
+          </span>
+        </div>
+      </div>
+    </div>
+    <div
+      class="ant-row ant-form-item"
+    >
+      <div
+        class="ant-col ant-form-item-label"
+      >
+        <label
+          class=""
+          title="Size"
+        >
+          Size
+        </label>
+      </div>
+      <div
+        class="ant-col ant-form-item-control-wrapper"
+      >
+        <div
+          class="ant-form-item-control"
+        >
+          <span
+            class="ant-form-item-children"
+          >
+            <div
+              class="ant-radio-group ant-radio-group-outline"
+            >
+              <label
+                class="ant-radio-button-wrapper ant-radio-button-wrapper-checked"
               >
-                <label
-                  class="ant-radio-button-wrapper ant-radio-button-wrapper-checked"
+                <span
+                  class="ant-radio-button ant-radio-button-checked"
                 >
+                  <input
+                    checked=""
+                    class="ant-radio-button-input"
+                    type="radio"
+                    value="default"
+                  />
                   <span
-                    class="ant-radio-button ant-radio-button-checked"
-                  >
-                    <input
-                      checked=""
-                      class="ant-radio-button-input"
-                      type="radio"
-                      value="default"
-                    />
-                    <span
-                      class="ant-radio-button-inner"
-                    />
-                  </span>
-                  <span>
-                    Default
-                  </span>
-                </label>
-                <label
-                  class="ant-radio-button-wrapper"
+                    class="ant-radio-button-inner"
+                  />
+                </span>
+                <span>
+                  Default
+                </span>
+              </label>
+              <label
+                class="ant-radio-button-wrapper"
+              >
+                <span
+                  class="ant-radio-button"
                 >
+                  <input
+                    class="ant-radio-button-input"
+                    type="radio"
+                    value="middle"
+                  />
                   <span
-                    class="ant-radio-button"
-                  >
-                    <input
-                      class="ant-radio-button-input"
-                      type="radio"
-                      value="middle"
-                    />
-                    <span
-                      class="ant-radio-button-inner"
-                    />
-                  </span>
-                  <span>
-                    Middle
-                  </span>
-                </label>
-                <label
-                  class="ant-radio-button-wrapper"
+                    class="ant-radio-button-inner"
+                  />
+                </span>
+                <span>
+                  Middle
+                </span>
+              </label>
+              <label
+                class="ant-radio-button-wrapper"
+              >
+                <span
+                  class="ant-radio-button"
                 >
+                  <input
+                    class="ant-radio-button-input"
+                    type="radio"
+                    value="small"
+                  />
                   <span
-                    class="ant-radio-button"
-                  >
-                    <input
-                      class="ant-radio-button-input"
-                      type="radio"
-                      value="small"
-                    />
-                    <span
-                      class="ant-radio-button-inner"
-                    />
-                  </span>
-                  <span>
-                    Small
-                  </span>
-                </label>
-              </div>
-            </span>
-          </div>
+                    class="ant-radio-button-inner"
+                  />
+                </span>
+                <span>
+                  Small
+                </span>
+              </label>
+            </div>
+          </span>
         </div>
+      </div>
+    </div>
+    <div
+      class="ant-row ant-form-item"
+    >
+      <div
+        class="ant-col ant-form-item-label"
+      >
+        <label
+          class=""
+          title="Table Layout"
+        >
+          Table Layout
+        </label>
       </div>
       <div
-        class="ant-row ant-form-item"
+        class="ant-col ant-form-item-control-wrapper"
       >
         <div
-          class="ant-col ant-form-item-label"
+          class="ant-form-item-control"
         >
-          <label
-            class=""
-            title="Pagination"
+          <span
+            class="ant-form-item-children"
           >
-            Pagination
-          </label>
-        </div>
-        <div
-          class="ant-col ant-form-item-control-wrapper"
-        >
-          <div
-            class="ant-form-item-control"
-          >
-            <span
-              class="ant-form-item-children"
+            <div
+              class="ant-radio-group ant-radio-group-outline"
             >
-              <div
-                class="ant-radio-group ant-radio-group-outline"
+              <label
+                class="ant-radio-button-wrapper ant-radio-button-wrapper-checked"
               >
-                <label
-                  class="ant-radio-button-wrapper"
+                <span
+                  class="ant-radio-button ant-radio-button-checked"
                 >
+                  <input
+                    checked=""
+                    class="ant-radio-button-input"
+                    type="radio"
+                  />
                   <span
-                    class="ant-radio-button"
-                  >
-                    <input
-                      class="ant-radio-button-input"
-                      type="radio"
-                      value="top"
-                    />
-                    <span
-                      class="ant-radio-button-inner"
-                    />
-                  </span>
-                  <span>
-                    Top
-                  </span>
-                </label>
-                <label
-                  class="ant-radio-button-wrapper ant-radio-button-wrapper-checked"
+                    class="ant-radio-button-inner"
+                  />
+                </span>
+                <span>
+                  Unset
+                </span>
+              </label>
+              <label
+                class="ant-radio-button-wrapper"
+              >
+                <span
+                  class="ant-radio-button"
                 >
+                  <input
+                    class="ant-radio-button-input"
+                    type="radio"
+                    value="fixed"
+                  />
                   <span
-                    class="ant-radio-button ant-radio-button-checked"
-                  >
-                    <input
-                      checked=""
-                      class="ant-radio-button-input"
-                      type="radio"
-                      value="bottom"
-                    />
-                    <span
-                      class="ant-radio-button-inner"
-                    />
-                  </span>
-                  <span>
-                    Bottom
-                  </span>
-                </label>
-                <label
-                  class="ant-radio-button-wrapper"
-                >
-                  <span
-                    class="ant-radio-button"
-                  >
-                    <input
-                      class="ant-radio-button-input"
-                      type="radio"
-                      value="both"
-                    />
-                    <span
-                      class="ant-radio-button-inner"
-                    />
-                  </span>
-                  <span>
-                    Both
-                  </span>
-                </label>
-                <label
-                  class="ant-radio-button-wrapper"
-                >
-                  <span
-                    class="ant-radio-button"
-                  >
-                    <input
-                      class="ant-radio-button-input"
-                      type="radio"
-                      value="none"
-                    />
-                    <span
-                      class="ant-radio-button-inner"
-                    />
-                  </span>
-                  <span>
-                    None
-                  </span>
-                </label>
-              </div>
-            </span>
-          </div>
+                    class="ant-radio-button-inner"
+                  />
+                </span>
+                <span>
+                  Fixed
+                </span>
+              </label>
+            </div>
+          </span>
         </div>
       </div>
-    </form>
-  </div>
+    </div>
+    <div
+      class="ant-row ant-form-item"
+    >
+      <div
+        class="ant-col ant-form-item-label"
+      >
+        <label
+          class=""
+          title="Pagination"
+        >
+          Pagination
+        </label>
+      </div>
+      <div
+        class="ant-col ant-form-item-control-wrapper"
+      >
+        <div
+          class="ant-form-item-control"
+        >
+          <span
+            class="ant-form-item-children"
+          >
+            <div
+              class="ant-radio-group ant-radio-group-outline"
+            >
+              <label
+                class="ant-radio-button-wrapper"
+              >
+                <span
+                  class="ant-radio-button"
+                >
+                  <input
+                    class="ant-radio-button-input"
+                    type="radio"
+                    value="top"
+                  />
+                  <span
+                    class="ant-radio-button-inner"
+                  />
+                </span>
+                <span>
+                  Top
+                </span>
+              </label>
+              <label
+                class="ant-radio-button-wrapper ant-radio-button-wrapper-checked"
+              >
+                <span
+                  class="ant-radio-button ant-radio-button-checked"
+                >
+                  <input
+                    checked=""
+                    class="ant-radio-button-input"
+                    type="radio"
+                    value="bottom"
+                  />
+                  <span
+                    class="ant-radio-button-inner"
+                  />
+                </span>
+                <span>
+                  Bottom
+                </span>
+              </label>
+              <label
+                class="ant-radio-button-wrapper"
+              >
+                <span
+                  class="ant-radio-button"
+                >
+                  <input
+                    class="ant-radio-button-input"
+                    type="radio"
+                    value="both"
+                  />
+                  <span
+                    class="ant-radio-button-inner"
+                  />
+                </span>
+                <span>
+                  Both
+                </span>
+              </label>
+              <label
+                class="ant-radio-button-wrapper"
+              >
+                <span
+                  class="ant-radio-button"
+                >
+                  <input
+                    class="ant-radio-button-input"
+                    type="radio"
+                    value="none"
+                  />
+                  <span
+                    class="ant-radio-button-inner"
+                  />
+                </span>
+                <span>
+                  None
+                </span>
+              </label>
+            </div>
+          </span>
+        </div>
+      </div>
+    </div>
+  </form>
   <div
     class="ant-table-wrapper"
   >
@@ -2355,16 +2456,10 @@ exports[`renders ./components/table/demo/dynamic-settings.md correctly 1`] = `
                   <col
                     class="ant-table-selection-col"
                   />
-                  <col
-                    style="width:150px;min-width:150px"
-                  />
-                  <col
-                    style="width:70px;min-width:70px"
-                  />
                   <col />
-                  <col
-                    style="width:360px;min-width:360px"
-                  />
+                  <col />
+                  <col />
+                  <col />
                 </colgroup>
                 <thead
                   class="ant-table-thead"

--- a/components/table/__tests__/__snapshots__/empty.test.js.snap
+++ b/components/table/__tests__/__snapshots__/empty.test.js.snap
@@ -453,7 +453,7 @@ exports[`Table renders empty table with fixed columns 1`] = `
       class="ant-spin-container"
     >
       <div
-        class="ant-table ant-table-default ant-table-empty ant-table-scroll-position-left"
+        class="ant-table ant-table-default ant-table-empty ant-table-scroll-position-left ant-table-layout-fixed"
       >
         <div
           class="ant-table-content"

--- a/components/table/demo/dynamic-settings.md
+++ b/components/table/demo/dynamic-settings.md
@@ -1,5 +1,5 @@
 ---
-order: 27
+order: 100
 title:
   en-US: Dynamic Settings
   zh-CN: 动态控制表格属性

--- a/components/table/demo/dynamic-settings.md
+++ b/components/table/demo/dynamic-settings.md
@@ -16,21 +16,17 @@ Select different settings to see the result.
 ```jsx
 import { Table, Icon, Switch, Radio, Form, Divider } from 'antd';
 
-const FormItem = Form.Item;
-
 const columns = [
   {
     title: 'Name',
     dataIndex: 'name',
     key: 'name',
-    width: 150,
     render: text => <a>{text}</a>,
   },
   {
     title: 'Age',
     dataIndex: 'age',
     key: 'age',
-    width: 70,
   },
   {
     title: 'Address',
@@ -40,7 +36,6 @@ const columns = [
   {
     title: 'Action',
     key: 'action',
-    width: 360,
     render: (text, record) => (
       <span>
         <a>Action 一 {record.name}</a>
@@ -86,6 +81,7 @@ class Demo extends React.Component {
     rowSelection: {},
     scroll: undefined,
     hasData: true,
+    tableLayout: undefined,
   };
 
   handleToggle = prop => enable => {
@@ -96,8 +92,16 @@ class Demo extends React.Component {
     this.setState({ size: e.target.value });
   };
 
+  handleTableLayoutChange = e => {
+    this.setState({ tableLayout: e.target.value });
+  };
+
   handleExpandChange = enable => {
     this.setState({ expandedRowRender: enable ? expandedRowRender : undefined });
+  };
+
+  handleEllipsisChange = enable => {
+    this.setState({ ellipsis: enable });
   };
 
   handleTitleChange = enable => {
@@ -135,56 +139,71 @@ class Demo extends React.Component {
     const { state } = this;
     return (
       <div>
-        <div className="components-table-demo-control-bar">
-          <Form layout="inline">
-            <FormItem label="Bordered">
-              <Switch checked={state.bordered} onChange={this.handleToggle('bordered')} />
-            </FormItem>
-            <FormItem label="loading">
-              <Switch checked={state.loading} onChange={this.handleToggle('loading')} />
-            </FormItem>
-            <FormItem label="Title">
-              <Switch checked={!!state.title} onChange={this.handleTitleChange} />
-            </FormItem>
-            <FormItem label="Column Header">
-              <Switch checked={!!state.showHeader} onChange={this.handleHeaderChange} />
-            </FormItem>
-            <FormItem label="Footer">
-              <Switch checked={!!state.footer} onChange={this.handleFooterChange} />
-            </FormItem>
-            <FormItem label="Expandable">
-              <Switch checked={!!state.expandedRowRender} onChange={this.handleExpandChange} />
-            </FormItem>
-            <FormItem label="Checkbox">
-              <Switch checked={!!state.rowSelection} onChange={this.handleRowSelectionChange} />
-            </FormItem>
-            <FormItem label="Fixed Header">
-              <Switch checked={!!state.scroll} onChange={this.handleScollChange} />
-            </FormItem>
-            <FormItem label="Has Data">
-              <Switch checked={!!state.hasData} onChange={this.handleDataChange} />
-            </FormItem>
-            <FormItem label="Size">
-              <Radio.Group size="default" value={state.size} onChange={this.handleSizeChange}>
-                <Radio.Button value="default">Default</Radio.Button>
-                <Radio.Button value="middle">Middle</Radio.Button>
-                <Radio.Button value="small">Small</Radio.Button>
-              </Radio.Group>
-            </FormItem>
-            <FormItem label="Pagination">
-              <Radio.Group
-                value={state.pagination ? state.pagination.position : 'none'}
-                onChange={this.handlePaginationChange}
-              >
-                <Radio.Button value="top">Top</Radio.Button>
-                <Radio.Button value="bottom">Bottom</Radio.Button>
-                <Radio.Button value="both">Both</Radio.Button>
-                <Radio.Button value="none">None</Radio.Button>
-              </Radio.Group>
-            </FormItem>
-          </Form>
-        </div>
-        <Table {...this.state} columns={columns} dataSource={state.hasData ? data : null} />
+        <Form
+          layout="inline"
+          className="components-table-demo-control-bar"
+          style={{ marginBottom: 16 }}
+        >
+          <Form.Item label="Bordered">
+            <Switch checked={state.bordered} onChange={this.handleToggle('bordered')} />
+          </Form.Item>
+          <Form.Item label="loading">
+            <Switch checked={state.loading} onChange={this.handleToggle('loading')} />
+          </Form.Item>
+          <Form.Item label="Title">
+            <Switch checked={!!state.title} onChange={this.handleTitleChange} />
+          </Form.Item>
+          <Form.Item label="Column Header">
+            <Switch checked={!!state.showHeader} onChange={this.handleHeaderChange} />
+          </Form.Item>
+          <Form.Item label="Footer">
+            <Switch checked={!!state.footer} onChange={this.handleFooterChange} />
+          </Form.Item>
+          <Form.Item label="Expandable">
+            <Switch checked={!!state.expandedRowRender} onChange={this.handleExpandChange} />
+          </Form.Item>
+          <Form.Item label="Checkbox">
+            <Switch checked={!!state.rowSelection} onChange={this.handleRowSelectionChange} />
+          </Form.Item>
+          <Form.Item label="Fixed Header">
+            <Switch checked={!!state.scroll} onChange={this.handleScollChange} />
+          </Form.Item>
+          <Form.Item label="Has Data">
+            <Switch checked={!!state.hasData} onChange={this.handleDataChange} />
+          </Form.Item>
+          <Form.Item label="Ellipsis">
+            <Switch checked={!!state.ellipsis} onChange={this.handleEllipsisChange} />
+          </Form.Item>
+          <Form.Item label="Size">
+            <Radio.Group value={state.size} onChange={this.handleSizeChange}>
+              <Radio.Button value="default">Default</Radio.Button>
+              <Radio.Button value="middle">Middle</Radio.Button>
+              <Radio.Button value="small">Small</Radio.Button>
+            </Radio.Group>
+          </Form.Item>
+          <Form.Item label="Table Layout">
+            <Radio.Group value={state.tableLayout} onChange={this.handleTableLayoutChange}>
+              <Radio.Button value={undefined}>Unset</Radio.Button>
+              <Radio.Button value="fixed">Fixed</Radio.Button>
+            </Radio.Group>
+          </Form.Item>
+          <Form.Item label="Pagination">
+            <Radio.Group
+              value={state.pagination ? state.pagination.position : 'none'}
+              onChange={this.handlePaginationChange}
+            >
+              <Radio.Button value="top">Top</Radio.Button>
+              <Radio.Button value="bottom">Bottom</Radio.Button>
+              <Radio.Button value="both">Both</Radio.Button>
+              <Radio.Button value="none">None</Radio.Button>
+            </Radio.Group>
+          </Form.Item>
+        </Form>
+        <Table
+          {...this.state}
+          columns={columns.map(item => ({ ...item, ellipsis: state. ellipsis }))}
+          dataSource={state.hasData ? data : null}
+        />
       </div>
     );
   }
@@ -194,9 +213,6 @@ ReactDOM.render(<Demo />, mountNode);
 ```
 
 <style>
-.components-table-demo-control-bar {
-  margin-bottom: 10px;
-}
 .components-table-demo-control-bar .ant-form-item {
   margin-right: 16px;
   margin-bottom: 8px;

--- a/components/table/demo/ellipsis.md
+++ b/components/table/demo/ellipsis.md
@@ -9,9 +9,13 @@ title:
 
 设置 `column.ellipsis` 可以让单元格内容根据宽度自动省略。
 
+> 列头缩略暂不支持和排序筛选一起使用。
+
 ## en-US
 
 Ellipsize cell content via setting `column.ellipsis`.
+
+> Cannot ellipsize table header with sorters and filters for now.
 
 ```jsx
 import { Table } from 'antd';

--- a/components/table/demo/ellipsis.md
+++ b/components/table/demo/ellipsis.md
@@ -14,7 +14,7 @@ title:
 Ellipsize cell content via setting `column.ellipsis`.
 
 ```jsx
-import { Table, Divider, Tag } from 'antd';
+import { Table } from 'antd';
 
 const columns = [
   {

--- a/components/table/demo/ellipsis.md
+++ b/components/table/demo/ellipsis.md
@@ -1,0 +1,84 @@
+---
+order: 27
+title:
+  en-US: ellipsis column
+  zh-CN: 单元格自动省略
+---
+
+## zh-CN
+
+设置 `column.ellipsis` 可以让单元格内容根据宽度自动省略。
+
+## en-US
+
+Ellipsize cell content via setting `column.ellipsis`.
+
+```jsx
+import { Table, Divider, Tag } from 'antd';
+
+const columns = [
+  {
+    title: 'Name',
+    dataIndex: 'name',
+    key: 'name',
+    render: text => <a>{text}</a>,
+    width: 150,
+  },
+  {
+    title: 'Age',
+    dataIndex: 'age',
+    key: 'age',
+    width: 80,
+  },
+  {
+    title: 'Address',
+    dataIndex: 'address',
+    key: 'address 1',
+    ellipsis: true,
+  },
+  {
+    title: 'Long Column Long Column Long Column',
+    dataIndex: 'address',
+    key: 'address 2',
+    ellipsis: true,
+  },
+  {
+    title: 'Long Column Long Column',
+    dataIndex: 'address',
+    key: 'address 3',
+    ellipsis: true,
+  },
+  {
+    title: 'Long Column',
+    dataIndex: 'address',
+    key: 'address 4',
+    ellipsis: true,
+  },
+];
+
+const data = [
+  {
+    key: '1',
+    name: 'John Brown',
+    age: 32,
+    address: 'New York No. 1 Lake Park, New York No. 1 Lake Park',
+    tags: ['nice', 'developer'],
+  },
+  {
+    key: '2',
+    name: 'Jim Green',
+    age: 42,
+    address: 'London No. 2 Lake Park, London No. 2 Lake Park',
+    tags: ['loser'],
+  },
+  {
+    key: '3',
+    name: 'Joe Black',
+    age: 32,
+    address: 'Sidney No. 1 Lake Park, Sidney No. 1 Lake Park',
+    tags: ['cool', 'teacher'],
+  },
+];
+
+ReactDOM.render(<Table columns={columns} dataSource={data} />, mountNode);
+```

--- a/components/table/demo/reset-filter.md
+++ b/components/table/demo/reset-filter.md
@@ -99,6 +99,7 @@ class App extends React.Component {
         onFilter: (value, record) => record.name.includes(value),
         sorter: (a, b) => a.name.length - b.name.length,
         sortOrder: sortedInfo.columnKey === 'name' && sortedInfo.order,
+        ellipsis: true,
       },
       {
         title: 'Age',
@@ -106,6 +107,7 @@ class App extends React.Component {
         key: 'age',
         sorter: (a, b) => a.age - b.age,
         sortOrder: sortedInfo.columnKey === 'age' && sortedInfo.order,
+        ellipsis: true,
       },
       {
         title: 'Address',
@@ -116,6 +118,7 @@ class App extends React.Component {
         onFilter: (value, record) => record.address.includes(value),
         sorter: (a, b) => a.address.length - b.address.length,
         sortOrder: sortedInfo.columnKey === 'address' && sortedInfo.order,
+        ellipsis: true,
       },
     ];
     return (

--- a/components/table/demo/resizable-column.md
+++ b/components/table/demo/resizable-column.md
@@ -7,11 +7,11 @@ title:
 
 ## zh-CN
 
-集成 react-resizable 来实现可伸缩列。
+集成 [react-resizable](https://github.com/STRML/react-resizable) 来实现可伸缩列。
 
 ## en-US
 
-Implement resizable column by integrate with react-resizable.
+Implement resizable column by integrate with [react-resizable](https://github.com/STRML/react-resizable).
 
 ```jsx
 import { Table } from 'antd';

--- a/components/table/index.en-US.md
+++ b/components/table/index.en-US.md
@@ -59,7 +59,7 @@ const columns = [
 
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
-| tableLayout | [table-layout](https://developer.mozilla.org/en-US/docs/Web/CSS/table-layout) attribute of table element | 'auto' \| 'fixed' | 'auto'<br /><br />`fixed` when header/columns are fixed, or using `column.ellipsis` | 3.24.0 |
+| tableLayout | [table-layout](https://developer.mozilla.org/en-US/docs/Web/CSS/table-layout) attribute of table element | - \| 'auto' \| 'fixed' | -<hr />`fixed` when header/columns are fixed, or using `column.ellipsis` | 3.24.0 |
 | bordered | Whether to show all table borders | boolean | `false` |  |
 | childrenColumnName | The column contains children to display | string\[] | children | 3.4.2 |
 | columns | Columns of table | [ColumnProps](https://git.io/vMMXC)\[] | - |  |

--- a/components/table/index.en-US.md
+++ b/components/table/index.en-US.md
@@ -59,7 +59,7 @@ const columns = [
 
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
-| tableLayout | [table-layout](https://developer.mozilla.org/en-US/docs/Web/CSS/table-layout) attribute of table element | 'auto' \| 'fixed' | 'auto', `fixed` when header or columns are fixed` | 3.24.0 |
+| tableLayout | [table-layout](https://developer.mozilla.org/en-US/docs/Web/CSS/table-layout) attribute of table element | 'auto' \| 'fixed' | 'auto'<br /><br />`fixed` when header/columns are fixed, or using `column.ellipsis` | 3.24.0 |
 | bordered | Whether to show all table borders | boolean | `false` |  |
 | childrenColumnName | The column contains children to display | string\[] | children | 3.4.2 |
 | columns | Columns of table | [ColumnProps](https://git.io/vMMXC)\[] | - |  |
@@ -120,6 +120,7 @@ One of the Table `columns` prop for describing the table's columns, Column has t
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
 | align | specify which way that column is aligned | 'left' \| 'right' \| 'center' | 'left' | 3.3.2 |
+| ellipsis | ellipsize cell content, not working with sorter and filters for now.<br />tableLayout would be `fixed` when `ellipsis` is true. | boolean | false | 3.24.0 |
 | className | className of this column | string | - |  |
 | colSpan | Span of this column's title | number |  |  |
 | dataIndex | Display field of the data record, could be set like `a.b.c`, `a[0].b.c[1]` | string | - |  |

--- a/components/table/index.en-US.md
+++ b/components/table/index.en-US.md
@@ -59,6 +59,7 @@ const columns = [
 
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
+| tableLayout | [table-layout](https://developer.mozilla.org/zh-CN/docs/Web/CSS/table-layout) attribute of table element  | 'auto' \| 'fixed' | 'auto', `fixed` when header or columns are fixed` | 3.24.0 |
 | bordered | Whether to show all table borders | boolean | `false` |  |
 | childrenColumnName | The column contains children to display | string\[] | children | 3.4.2 |
 | columns | Columns of table | [ColumnProps](https://git.io/vMMXC)\[] | - |  |

--- a/components/table/index.en-US.md
+++ b/components/table/index.en-US.md
@@ -59,7 +59,7 @@ const columns = [
 
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
-| tableLayout | [table-layout](https://developer.mozilla.org/zh-CN/docs/Web/CSS/table-layout) attribute of table element  | 'auto' \| 'fixed' | 'auto', `fixed` when header or columns are fixed` | 3.24.0 |
+| tableLayout | [table-layout](https://developer.mozilla.org/en-US/docs/Web/CSS/table-layout) attribute of table element | 'auto' \| 'fixed' | 'auto', `fixed` when header or columns are fixed` | 3.24.0 |
 | bordered | Whether to show all table borders | boolean | `false` |  |
 | childrenColumnName | The column contains children to display | string\[] | children | 3.4.2 |
 | columns | Columns of table | [ColumnProps](https://git.io/vMMXC)\[] | - |  |

--- a/components/table/index.zh-CN.md
+++ b/components/table/index.zh-CN.md
@@ -64,7 +64,7 @@ const columns = [
 
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
-| tableLayout | 表格元素的 [table-layout](https://developer.mozilla.org/zh-CN/docs/Web/CSS/table-layout) 属性，设为 `fixed` 表示内容不会影响列的布局 | 'auto' \| 'fixed' | 'auto'<br /><br />固定表头/列或使用了 `column.ellipsis` 时，默认值为 `fixed` | 3.24.0 |
+| tableLayout | 表格元素的 [table-layout](https://developer.mozilla.org/zh-CN/docs/Web/CSS/table-layout) 属性，设为 `fixed` 表示内容不会影响列的布局 | - \| 'auto' \| 'fixed' | 无<hr />固定表头/列或使用了 `column.ellipsis` 时，默认值为 `fixed` | 3.24.0 |
 | bordered | 是否展示外边框和列边框 | boolean | false |  |
 | childrenColumnName | 指定树形结构的列名 | string\[] | children | 3.4.2 |
 | columns | 表格列的配置描述，具体项见下表 | [ColumnProps](https://git.io/vMMXC)\[] | - |  |

--- a/components/table/index.zh-CN.md
+++ b/components/table/index.zh-CN.md
@@ -64,7 +64,7 @@ const columns = [
 
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
-| tableLayout | 表格元素的 [table-layout](https://developer.mozilla.org/zh-CN/docs/Web/CSS/table-layout) 属性 | 'auto' \| 'fixed' | 'auto'，当固定头或固定列时默认值为 `fixed` | 3.24.0 |
+| tableLayout | 表格元素的 [table-layout](https://developer.mozilla.org/zh-CN/docs/Web/CSS/table-layout) 属性，设为 `fixed` 表示内容不会影响列的布局 | 'auto' \| 'fixed' | 'auto'，当固定头或固定列时默认值为 `fixed` | 3.24.0 |
 | bordered | 是否展示外边框和列边框 | boolean | false |  |
 | childrenColumnName | 指定树形结构的列名 | string\[] | children | 3.4.2 |
 | columns | 表格列的配置描述，具体项见下表 | [ColumnProps](https://git.io/vMMXC)\[] | - |  |

--- a/components/table/index.zh-CN.md
+++ b/components/table/index.zh-CN.md
@@ -64,7 +64,7 @@ const columns = [
 
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
-| tableLayout | 表格元素的 [table-layout](https://developer.mozilla.org/zh-CN/docs/Web/CSS/table-layout) 属性，设为 `fixed` 表示内容不会影响列的布局 | 'auto' \| 'fixed' | 'auto'，当固定头或固定列时默认值为 `fixed` | 3.24.0 |
+| tableLayout | 表格元素的 [table-layout](https://developer.mozilla.org/zh-CN/docs/Web/CSS/table-layout) 属性，设为 `fixed` 表示内容不会影响列的布局 | 'auto' \| 'fixed' | 'auto'<br /><br />固定表头/列或使用了 `column.ellipsis` 时，默认值为 `fixed` | 3.24.0 |
 | bordered | 是否展示外边框和列边框 | boolean | false |  |
 | childrenColumnName | 指定树形结构的列名 | string\[] | children | 3.4.2 |
 | columns | 表格列的配置描述，具体项见下表 | [ColumnProps](https://git.io/vMMXC)\[] | - |  |
@@ -125,6 +125,7 @@ const columns = [
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
 | align | 设置列的对齐方式 | 'left' \| 'right' \| 'center' | 'left' | 3.3.2 |
+| ellipsis | 超过宽度将自动省略，暂不支持和排序筛选一起使用。<br />设置为 `true` 时，表格布局将变成 `tableLayout="fixed"`。 | boolean | false | 3.24.0 |
 | className | 列样式类名 | string | - |  |
 | colSpan | 表头列合并,设置为 0 时，不渲染 | number |  |  |
 | dataIndex | 列数据在数据项中对应的 key，支持 `a.b.c`、`a[0].b.c[1]` 的嵌套写法 | string | - |  |

--- a/components/table/index.zh-CN.md
+++ b/components/table/index.zh-CN.md
@@ -64,6 +64,7 @@ const columns = [
 
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
+| tableLayout | 表格元素的 [table-layout](https://developer.mozilla.org/zh-CN/docs/Web/CSS/table-layout) 属性 | 'auto' \| 'fixed' | 'auto'，当固定头或固定列时默认值为 `fixed` | 3.24.0 |
 | bordered | 是否展示外边框和列边框 | boolean | false |  |
 | childrenColumnName | 指定树形结构的列名 | string\[] | children | 3.4.2 |
 | columns | 表格列的配置描述，具体项见下表 | [ColumnProps](https://git.io/vMMXC)\[] | - |  |

--- a/components/table/interface.tsx
+++ b/components/table/interface.tsx
@@ -33,6 +33,7 @@ export interface ColumnProps<T> {
   dataIndex?: string; // Note: We can not use generic type here, since we need to support nested key, see #9393
   render?: (text: any, record: T, index: number) => React.ReactNode;
   align?: 'left' | 'right' | 'center';
+  ellipsis?: boolean;
   filters?: ColumnFilterItem[];
   onFilter?: (value: any, record: T) => boolean;
   filterMultiple?: boolean;

--- a/components/table/interface.tsx
+++ b/components/table/interface.tsx
@@ -190,6 +190,7 @@ export interface TableProps<T> {
   bodyStyle?: React.CSSProperties;
   className?: string;
   style?: React.CSSProperties;
+  tableLayout?: React.CSSProperties['tableLayout'];
   children?: React.ReactNode;
   sortDirections?: SortOrder[];
   getPopupContainer?: (triggerNode: HTMLElement) => HTMLElement;

--- a/components/table/style/index.less
+++ b/components/table/style/index.less
@@ -37,6 +37,10 @@
     border-spacing: 0;
   }
 
+  &-layout-fixed table {
+    table-layout: fixed;
+  }
+
   &-thead > tr > th {
     color: @table-header-color;
     font-weight: 500;

--- a/components/table/style/index.less
+++ b/components/table/style/index.less
@@ -332,6 +332,7 @@
   &-thead > tr > th,
   &-tbody > tr > td {
     padding: @table-padding-vertical @table-padding-horizontal;
+    overflow-wrap: break-word;
   }
 
   &-expand-icon-th,

--- a/components/table/style/index.less
+++ b/components/table/style/index.less
@@ -617,7 +617,6 @@
     overflow: auto;
     overflow-x: hidden;
     table {
-      width: auto;
       min-width: 100%;
 
       // https://github.com/ant-design/ant-design/issues/14545

--- a/components/table/style/index.less
+++ b/components/table/style/index.less
@@ -173,6 +173,7 @@
 
     .@{table-prefix-cls}-header-column {
       display: inline-block;
+      max-width: 100%;
       vertical-align: top;
 
       .@{table-prefix-cls}-column-sorters {
@@ -583,6 +584,17 @@
       &::after {
         content: '.';
       }
+    }
+
+    &-cell-ellipsis,
+    &-cell-ellipsis .@{table-prefix-cls}-column-title {
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+    }
+
+    &-cell-ellipsis .@{table-prefix-cls}-column-title {
+      display: block;
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "rc-slider": "~8.6.11",
     "rc-steps": "~3.5.0",
     "rc-switch": "~1.9.0",
-    "rc-table": "~6.7.0",
+    "rc-table": "~6.8.1",
     "rc-tabs": "~9.6.4",
     "rc-time-picker": "~3.7.1",
     "rc-tooltip": "~3.7.3",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "rc-slider": "~8.6.11",
     "rc-steps": "~3.5.0",
     "rc-switch": "~1.9.0",
-    "rc-table": "~6.8.1",
+    "rc-table": "~6.8.2",
     "rc-tabs": "~9.6.4",
     "rc-time-picker": "~3.7.1",
     "rc-tooltip": "~3.7.3",

--- a/site/theme/static/markdown.less
+++ b/site/theme/static/markdown.less
@@ -252,10 +252,14 @@
         word-break: break-all;
       }
       &:nth-child(4) {
-        width: 13%;
+        width: 16%;
         font-size: @font-size-base - 1px;
       }
     }
+  }
+
+  hr {
+    margin: 12px 0;
   }
 }
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

https://github.com/react-component/table/pull/369

close https://github.com/ant-design/ant-design/issues/13825#issuecomment-449889241
close #17127
close #5753

### 💡 Background and solution

1. `<Table tableLayout="fixed" />`
2. [column.ellipsis](https://deploy-preview-17284--ant-design.netlify.com/components/table-cn/#components-table-demo-ellipsis)

<img width="824" alt="image" src="https://user-images.githubusercontent.com/507615/64167242-6c9c6980-ce7b-11e9-9672-8abe75f3fb08.png">

```diff
const columns = [{
   title: 'Long Column Long Column Long Column',
   dataIndex: 'address',
   key: 'address 2',
+  ellipsis: true,
}]
```

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | - Table supports `tableLayout` property for [table-layout](https://developer.mozilla.org/zh-CN/docs/Web/CSS/table-layout) attribute. And using `tableLayout="fixed"` defaully in scrollable table situation to resolve align issue caused by cell content.<br />- Table supports `column.ellipsis` to ellipsize cell content.  |
| 🇨🇳 Chinese | - Table 新增 `tableLayout` 属性，支持设置表格的 [table-layout](https://developer.mozilla.org/zh-CN/docs/Web/CSS/table-layout) 布局，并在固定表头/列下默认开启 `tableLayout="fixed"`，解决因为表格自动根据内容排版造成的列对齐问题。<br />- Table 新增 `column.ellipsis` 支持单元格内容自动省略。  |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#11822: 关于固定表头必须要给表头设置宽度](https://issuehunt.io/repos/34526884/issues/11822)
---

IssueHunt has been backed by the following sponsors. [Become a sponsor](https://issuehunt.io/membership/members)
</details>
<!-- /Issuehunt content-->