### PR TITLE
feat(CheckboxGroup): add new api sorted.

### DIFF
--- a/components/checkbox/Group.tsx
+++ b/components/checkbox/Group.tsx
@@ -56,7 +56,7 @@ class CheckboxGroup extends React.Component<CheckboxGroupProps, CheckboxGroupSta
     value: PropTypes.array,
     options: PropTypes.array.isRequired,
     onChange: PropTypes.func,
-    sorted: PropTypes.PropTypes.bool
+    sorted: PropTypes.bool
   };
 
   static childContextTypes = {
@@ -173,7 +173,7 @@ class CheckboxGroup extends React.Component<CheckboxGroupProps, CheckboxGroupSta
     );
   };
 
-  onChange = (v) => {
+  onChange = (v: Array<String>) => {
     const {
       onChange,
       sorted,

--- a/components/checkbox/Group.tsx
+++ b/components/checkbox/Group.tsx
@@ -28,6 +28,7 @@ export interface CheckboxGroupProps extends AbstractCheckboxGroupProps {
   name?: string;
   defaultValue?: Array<CheckboxValueType>;
   value?: Array<CheckboxValueType>;
+  sorted?: boolean;
   onChange?: (checkedValue: Array<CheckboxValueType>) => void;
 }
 
@@ -47,6 +48,7 @@ export interface CheckboxGroupContext {
 class CheckboxGroup extends React.Component<CheckboxGroupProps, CheckboxGroupState> {
   static defaultProps = {
     options: [],
+    sorted: false
   };
 
   static propTypes = {
@@ -54,6 +56,7 @@ class CheckboxGroup extends React.Component<CheckboxGroupProps, CheckboxGroupSta
     value: PropTypes.array,
     options: PropTypes.array.isRequired,
     onChange: PropTypes.func,
+    sorted: PropTypes.PropTypes.bool
   };
 
   static childContextTypes = {
@@ -134,10 +137,7 @@ class CheckboxGroup extends React.Component<CheckboxGroupProps, CheckboxGroupSta
     if (!('value' in this.props)) {
       this.setState({ value });
     }
-    const onChange = this.props.onChange;
-    if (onChange) {
-      onChange(value.filter(val => registeredValues.indexOf(val) !== -1));
-    }
+    this.onChange(value.filter(val => registeredValues.indexOf(val) !== -1))
   };
 
   renderGroup = ({ getPrefixCls }: ConfigConsumerProps) => {
@@ -157,7 +157,7 @@ class CheckboxGroup extends React.Component<CheckboxGroupProps, CheckboxGroupSta
           disabled={'disabled' in option ? option.disabled : props.disabled}
           value={option.value}
           checked={state.value.indexOf(option.value) !== -1}
-          onChange={option.onChange}
+          onChange={this.onChange}
           className={`${groupPrefixCls}-item`}
         >
           {option.label}
@@ -172,6 +172,22 @@ class CheckboxGroup extends React.Component<CheckboxGroupProps, CheckboxGroupSta
       </div>
     );
   };
+
+  onChange = (v) => {
+    const {
+      onChange,
+      sorted,
+      options
+    } = this.props
+    if (!onChange) {
+      return
+    }
+    if (sorted) {
+      onChange((options as Array<CheckboxOptionType>).map(i => i.value).filter(key => v.includes(key)))
+    } else {
+      onChange(v)
+    }
+  }
 
   render() {
     return <ConfigConsumer>{this.renderGroup}</ConfigConsumer>;

--- a/components/checkbox/index.en-US.md
+++ b/components/checkbox/index.en-US.md
@@ -36,6 +36,7 @@ Checkbox component.
 | options | Specifies options | string\[] | \[] |
 | value | Used for setting the currently selected value. | string\[] | \[] |
 | onChange | The callback function that is triggered when the state changes. | Function(checkedValue) | - |
+| sorted | keep sorted | boolean | false |
 
 ### Methods
 

--- a/components/checkbox/index.en-US.md
+++ b/components/checkbox/index.en-US.md
@@ -36,7 +36,7 @@ Checkbox component.
 | options | Specifies options | string\[] | \[] |
 | value | Used for setting the currently selected value. | string\[] | \[] |
 | onChange | The callback function that is triggered when the state changes. | Function(checkedValue) | - |
-| sorted | keep sorted | boolean | false |
+| sorted | keep stable sorted | boolean | false |
 
 ### Methods
 

--- a/components/checkbox/index.zh-CN.md
+++ b/components/checkbox/index.zh-CN.md
@@ -37,7 +37,7 @@ title: Checkbox
 | options | 指定可选项 | string\[] | \[] |
 | value | 指定选中的选项 | string\[] | \[] |
 | onChange | 变化时回调函数 | Function(checkedValue) | - |
-| sorted | 是否保持有序排序 | boolean | false |
+| sorted | 保持稳定排序 | boolean | false |
 
 ### 方法
 

--- a/components/checkbox/index.zh-CN.md
+++ b/components/checkbox/index.zh-CN.md
@@ -37,6 +37,7 @@ title: Checkbox
 | options | 指定可选项 | string\[] | \[] |
 | value | 指定选中的选项 | string\[] | \[] |
 | onChange | 变化时回调函数 | Function(checkedValue) | - |
+| sorted | 是否保持有序排序 | boolean | false |
 
 ### 方法
 


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

新特性请提交至 feature 分支，其余可提交至 master 分支。
在一个维护者审核通过后合并。
请确保填写以下 pull request 的信息，谢谢！~

[[English Template / 英文模板](?expand=1)]
-->

### 🤔 这个变动的性质是？

- [x] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 组件样式改进
- [ ] TypeScript 定义更新
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 👻 需求背景
https://github.com/ant-design/ant-design/issues/17297
目前的 Checkbox.Group onChange 的 values 并不是稳定排序，而是根据点击顺序来排的.
期望提供一个 api 使得能够其稳定排序
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。

2. 要解决的具体问题。

-->

### 💡 解决方案和最终实现是？
Group 新增 props 'sorted' , 默认为 false , 当 sorted 为 true 时, 通过对的 options 进行 filter 来保持其最终的 callback 的结果与 options 中的排序保持一致，达到稳定排序.

[demo](https://codepen.io/howel52/pen/qzXaeZ?editors=0011)

<!--
1. 列出最终的 API 实现和用法。
2. 涉及UI/交互变动需要有截图或 GIF。
无
-->

### 📝 更新日志怎么写？

<!--
> 从用户角度描述具体变化，以及可能的 breaking change 和其他风险？
-->

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |    Component Group add new props named 'sorted'. This api can make the value of the 'onChange' keep stable sort |
| 🇨🇳 中文 |    Group 组件新增 props 'sorted', 此 api 可以让 onChange 的 value 保持稳定排序       |


### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供

-----
[View rendered components/checkbox/index.en-US.md](https://github.com/howel52/ant-design/blob/feature-checkbox-value-sort/components/checkbox/index.en-US.md)
[View rendered components/checkbox/index.zh-CN.md](https://github.com/howel52/ant-design/blob/feature-checkbox-value-sort/components/checkbox/index.zh-CN.md)