### PR TITLE
fix: size fields in Skeleton AvatarProps to accept numbers

### DIFF
--- a/components/skeleton/Avatar.tsx
+++ b/components/skeleton/Avatar.tsx
@@ -5,7 +5,7 @@ export interface SkeletonAvatarProps {
   prefixCls?: string;
   className?: string;
   style?: object;
-  size?: 'large' | 'small' | 'default';
+  size?: 'large' | 'small' | 'default' | number;
   shape?: 'circle' | 'square';
 }
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?
close #17288 

The size field in the documentation (https://ant.design/components/skeleton/#SkeletonAvatarProps) actually allows number, but the code does not.
(https://github.com/ant-design/ant-design/blob/master/components/skeleton/Avatar.tsx#L8)

<!--
1. Describe the source of requirement, like related issue link.

2. Describe the problem and the scenario.
-->

### 💡 Solution

before
```
size?: 'large' | 'small' | 'default';
```
after
```
size?: 'large' | 'small' | 'default' | number;
```

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
