### PR TITLE
fix: CheckboxGroup onChange 值保持选项的顺序

### DIFF
--- a/components/checkbox/Group.tsx
+++ b/components/checkbox/Group.tsx
@@ -143,13 +143,7 @@ class CheckboxGroup extends React.Component<CheckboxGroupProps, CheckboxGroupSta
           .sort((a, b) => {
             const indexA = options.findIndex(opt => opt.value === a);
             const indexB = options.findIndex(opt => opt.value === b);
-            if (indexA > indexB) {
-              return 1;
-            }
-            if (indexA < indexB) {
-              return -1;
-            }
-            return 0;
+            return indexA - indexB;
           }),
       );
     }

--- a/components/checkbox/Group.tsx
+++ b/components/checkbox/Group.tsx
@@ -136,7 +136,9 @@ class CheckboxGroup extends React.Component<CheckboxGroupProps, CheckboxGroupSta
     }
     const onChange = this.props.onChange;
     if (onChange) {
-      onChange(value.filter(val => registeredValues.indexOf(val) !== -1));
+      const values = value.filter(val => registeredValues.indexOf(val) !== -1);
+      const options = this.getOptions();
+      onChange(options.map(opt => values.includes(opt.value)));
     }
   };
 

--- a/components/checkbox/Group.tsx
+++ b/components/checkbox/Group.tsx
@@ -138,7 +138,7 @@ class CheckboxGroup extends React.Component<CheckboxGroupProps, CheckboxGroupSta
     if (onChange) {
       const values = value.filter(val => registeredValues.indexOf(val) !== -1);
       const options = this.getOptions();
-      onChange(options.map(opt => values.includes(opt.value)));
+      onChange(options.map(opt => opt.value).filter(val => values.includes(val)));
     }
   };
 

--- a/components/checkbox/Group.tsx
+++ b/components/checkbox/Group.tsx
@@ -136,9 +136,22 @@ class CheckboxGroup extends React.Component<CheckboxGroupProps, CheckboxGroupSta
     }
     const onChange = this.props.onChange;
     if (onChange) {
-      const values = value.filter(val => registeredValues.indexOf(val) !== -1);
       const options = this.getOptions();
-      onChange(options.map(opt => opt.value).filter(val => values.includes(val)));
+      onChange(
+        value
+          .filter(val => registeredValues.indexOf(val) !== -1)
+          .sort((a, b) => {
+            const indexA = options.findIndex(opt => opt.value === a);
+            const indexB = options.findIndex(opt => opt.value === b);
+            if (indexA > indexB) {
+              return 1;
+            }
+            if (indexA < indexB) {
+              return -1;
+            }
+            return 0;
+          }),
+      );
     }
   };
 

--- a/components/checkbox/__tests__/group.test.js
+++ b/components/checkbox/__tests__/group.test.js
@@ -133,4 +133,38 @@ describe('CheckboxGroup', () => {
 
     expect(onChange).toHaveBeenCalledWith([2]);
   });
+
+  // https://github.com/ant-design/ant-design/issues/17297
+  it('onChange should keep the order of the original values', () => {
+    const onChange = jest.fn();
+    const wrapper = mount(
+      <Checkbox.Group onChange={onChange}>
+        <Checkbox key={1} value={1} />
+        <Checkbox key={2} value={2} />
+        <Checkbox key={3} value={3} />
+        <Checkbox key={4} value={4} />
+      </Checkbox.Group>,
+    );
+
+    wrapper
+      .find('.ant-checkbox-input')
+      .at(0)
+      .simulate('change');
+    expect(onChange).toHaveBeenCalledWith([1]);
+    wrapper
+      .find('.ant-checkbox-input')
+      .at(1)
+      .simulate('change');
+    expect(onChange).toHaveBeenCalledWith([1, 2]);
+    wrapper
+      .find('.ant-checkbox-input')
+      .at(0)
+      .simulate('change');
+    expect(onChange).toHaveBeenCalledWith([2]);
+    wrapper
+      .find('.ant-checkbox-input')
+      .at(0)
+      .simulate('change');
+    expect(onChange).toHaveBeenCalledWith([1, 2]);
+  });
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [x] Other (about what?)

### 👻 What's the background?
close #17297
<!--
1. Describe the source of requirement, like related issue link.

2. Describe the problem and the scenario.
-->

### 💡 Solution

<!--
1. How to fix the problem, and list final API implementation and usage sample if that is an new feature.

2. GIF or snapshot should be provided if includes UI/interactive modification.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |    CheckboxGroup onChange 值保持选项的顺序       |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
