### PR TITLE
style: add extra parentheses to the arguments of the ceil function

### DIFF
--- a/components/style/themes/default.less
+++ b/components/style/themes/default.less
@@ -60,10 +60,10 @@
 @font-size-base: 14px;
 @font-size-lg: @font-size-base + 2px;
 @font-size-sm: 12px;
-@heading-1-size: ceil(@font-size-base * 2.71);
-@heading-2-size: ceil(@font-size-base * 2.14);
-@heading-3-size: ceil(@font-size-base * 1.71);
-@heading-4-size: ceil(@font-size-base * 1.42);
+@heading-1-size: ceil((@font-size-base * 2.71));
+@heading-2-size: ceil((@font-size-base * 2.14));
+@heading-3-size: ceil((@font-size-base * 1.71));
+@heading-4-size: ceil((@font-size-base * 1.42));
 @line-height-base: 1.5;
 @border-radius-base: 4px;
 @border-radius-sm: 2px;


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?

When I compile my own component library on the basis of antd, I get the following error:

```shell
(node:2895) UnhandledPromiseRejectionWarning: CssSyntaxError: postcss-less-engine: **/themes/default.less: error evaluating function `ceil`: argument must be a number
```
The compilation process refers to the process of [ant-design-pro-site v1](https://github.com/ant-design/ant-design-pro-site/tree/v1/config/components).

### 💡 Solution

Add extra parentheses to the arguments of the `ceil` function in the `default.less`，it works fine.

```less
@heading-1-size: ceil((@font-size-base * 2.71));
@heading-2-size: ceil((@font-size-base * 2.14));
@heading-3-size: ceil((@font-size-base * 1.71));
@heading-4-size: ceil((@font-size-base * 1.42));
```

So I tried to fix this error in this way.

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Add extra parentheses to the arguments of the ceil function  |
| 🇨🇳 Chinese | 在 ceil 函数的参数中添加额外的括号 |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
