### PR TITLE
fix: Upload preview should work with Blob

### DIFF
--- a/components/upload/UploadList.tsx
+++ b/components/upload/UploadList.tsx
@@ -42,19 +42,22 @@ export default class UploadList extends React.Component<UploadListProps, any> {
       return;
     }
     (items || []).forEach(file => {
+      const isValidateFile =
+        file.originFileObj instanceof File || file.originFileObj instanceof Blob;
+
       if (
         typeof document === 'undefined' ||
         typeof window === 'undefined' ||
         !(window as any).FileReader ||
         !(window as any).File ||
-        !(file.originFileObj instanceof File) ||
+        !isValidateFile ||
         file.thumbUrl !== undefined
       ) {
         return;
       }
       file.thumbUrl = '';
       if (previewFile) {
-        previewFile(file.originFileObj).then((previewDataUrl: string) => {
+        previewFile(file.originFileObj as File).then((previewDataUrl: string) => {
           // Need append '' to avoid dead loop
           file.thumbUrl = previewDataUrl || '';
           this.forceUpdate();

--- a/components/upload/__tests__/uploadlist.test.js
+++ b/components/upload/__tests__/uploadlist.test.js
@@ -506,28 +506,35 @@ describe('Upload List', () => {
     });
   });
 
-  it('customize previewFile support', async () => {
-    const mockThumbnail = 'mock-image';
-    const previewFile = jest.fn(() => {
-      return Promise.resolve(mockThumbnail);
-    });
-    const file = {
-      ...fileList[0],
-      originFileObj: new File([], 'xxx.png'),
-    };
-    delete file.thumbUrl;
+  describe.only('customize previewFile support', () => {
+    function test(name, renderInstance) {
+      it(name, async () => {
+        const mockThumbnail = 'mock-image';
+        const previewFile = jest.fn(() => {
+          return Promise.resolve(mockThumbnail);
+        });
+        const file = {
+          ...fileList[0],
+          originFileObj: renderInstance(),
+        };
+        delete file.thumbUrl;
 
-    const wrapper = mount(
-      <Upload listType="picture" defaultFileList={[file]} previewFile={previewFile}>
-        <button type="button" />
-      </Upload>,
-    );
-    wrapper.setState({});
-    await delay(0);
+        const wrapper = mount(
+          <Upload listType="picture" defaultFileList={[file]} previewFile={previewFile}>
+            <button type="button" />
+          </Upload>,
+        );
+        wrapper.setState({});
+        await delay(0);
 
-    expect(previewFile).toHaveBeenCalledWith(file.originFileObj);
-    wrapper.update();
+        expect(previewFile).toHaveBeenCalledWith(file.originFileObj);
+        wrapper.update();
 
-    expect(wrapper.find('.ant-upload-list-item-thumbnail img').prop('src')).toBe(mockThumbnail);
+        expect(wrapper.find('.ant-upload-list-item-thumbnail img').prop('src')).toBe(mockThumbnail);
+      });
+    }
+
+    test('File', () => new File([], 'xxx.png'));
+    test('Blob', () => new Blob());
   });
 });

--- a/components/upload/__tests__/uploadlist.test.js
+++ b/components/upload/__tests__/uploadlist.test.js
@@ -506,7 +506,7 @@ describe('Upload List', () => {
     });
   });
 
-  describe.only('customize previewFile support', () => {
+  describe('customize previewFile support', () => {
     function test(name, renderInstance) {
       it(name, async () => {
         const mockThumbnail = 'mock-image';

--- a/components/upload/interface.tsx
+++ b/components/upload/interface.tsx
@@ -23,7 +23,7 @@ export interface UploadFile {
   status?: UploadFileStatus;
   percent?: number;
   thumbUrl?: string;
-  originFileObj?: File;
+  originFileObj?: File | Blob;
   response?: any;
   error?: any;
   linkProps?: any;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?

fix #17368

### 💡 Solution

Add Blob check

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      fix Upload `previewFile` not called when use Blob     |
| 🇨🇳 Chinese |      修复 Upload `previewFile` 在文件为 Blob 时不调用的问题     |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
