### PR TITLE
fix result global Icon color

### DIFF
--- a/components/result/style/index.less
+++ b/components/result/style/index.less
@@ -8,19 +8,19 @@
   background-color: @component-background;
 
   // status color
-  &-success .anticon {
+  &-success &-icon .anticon {
     color: @success-color;
   }
 
-  &-error .anticon {
+  &-error &-icon .anticon {
     color: @error-color;
   }
 
-  &-info .anticon {
+  &-info &-icon .anticon {
     color: @info-color;
   }
 
-  &-warning .anticon {
+  &-warning &-icon .anticon {
     color: @warning-color;
   }
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?

The Result component style all Icons in it to the color baseed on `status`，that make some UI looks strange.

https://codepen.io/liyan/pen/QXmJZV?editors=0010

<!--
1. Describe the source of requirement, like related issue link.

2. Describe the problem and the scenario.
-->

### 💡 Solution

The Icon color style should only apply to Icons in `.ant-result-icon`

<!--
1. How to fix the problem, and list final API implementation and usage sample if that is an new feature.

2. GIF or snapshot should be provided if includes UI/interactive modification.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
