### PR TITLE
fix: DatePicker's input box is obscured on safari

### DIFF
--- a/components/date-picker/style/RangePicker.less
+++ b/components/date-picker/style/RangePicker.less
@@ -98,6 +98,7 @@
     .input;
 
     height: @input-height-sm;
+    line-height: @input-height-sm;
     padding-right: 0;
     padding-left: 0;
     border: 0;


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?

<img width="569" alt="" src="https://user-images.githubusercontent.com/359395/60558500-0b252500-9d7c-11e9-9d84-e449c1cbec3c.png">

### 💡 Solution

The input style defines `height` and `line-height` as `32px`, and the DatePicker component re-sets `height` to `20px`(by `@input-height-sm`), but forgot to define `line-height`.

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   🐞 Fix DatePicker's input box is obscured on safari.   |
| 🇨🇳 Chinese |    🐞 修复 safari 浏览器 DatePicker 组件输入框被遮挡的问题。  |

### ☑️ Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
