### PR TITLE
fix: typo in console.error

### DIFF
--- a/components/icon/__tests__/index.test.js
+++ b/components/icon/__tests__/index.test.js
@@ -227,23 +227,23 @@ describe('utils', () => {
     ]);
   });
 
-  it('should depracate typo icon name', () => {
+  it('should report an error when there are deprecated typos in icon names', () => {
     const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
     render(<Icon type="interation" />);
     expect(errorSpy).toHaveBeenLastCalledWith(
-      "Warning: [antd: Icon] Icon 'interation' is typo and depracated, please use 'interaction' instead.",
+      "Warning: [antd: Icon] Icon 'interation' was a typo and is now deprecated, please use 'interaction' instead.",
     );
     render(<Icon type="cross" />);
     expect(errorSpy).toHaveBeenLastCalledWith(
-      "Warning: [antd: Icon] Icon 'cross' is typo and depracated, please use 'close' instead.",
+      "Warning: [antd: Icon] Icon 'cross' was a typo and is now deprecated, please use 'close' instead.",
     );
     render(<Icon type="canlendar" theme="twoTone" />);
     expect(errorSpy).toHaveBeenLastCalledWith(
-      "Warning: [antd: Icon] Icon 'canlendar' is typo and depracated, please use 'calendar' instead.",
+      "Warning: [antd: Icon] Icon 'canlendar' was a typo and is now deprecated, please use 'calendar' instead.",
     );
     render(<Icon type="colum-height" />);
     expect(errorSpy).toHaveBeenLastCalledWith(
-      "Warning: [antd: Icon] Icon 'colum-height' is typo and depracated, please use 'column-height' instead.",
+      "Warning: [antd: Icon] Icon 'colum-height' was a typo and is now deprecated, please use 'column-height' instead.",
     );
     expect(errorSpy).toHaveBeenCalledTimes(4);
     errorSpy.mockRestore();

--- a/components/icon/utils.ts
+++ b/components/icon/utils.ts
@@ -72,7 +72,7 @@ export function alias(type: string) {
   warning(
     newType === type,
     'Icon',
-    `Icon '${type}' is typo and depracated, please use '${newType}' instead.`,
+    `Icon '${type}' was a typo and is now deprecated, please use '${newType}' instead.`,
   );
   return newType;
 }


### PR DESCRIPTION
### 🤔 This is a ...

- [x] Bug fix

### 👻 What's the background?
The problem was a typo in test code checking for typos.
When I used a deprecated icon name, I received a console.error log with a typo in the warning.

### 💡 Solution
I fixed the typo in the warning, and in the tests for the warning.

### 📝 Changelog

Shouldn't affect the end user at all.
Should improve the warning the developer receives.

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fix: typo in warning for deprecated icon name  |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or **not needed**
- [x] Demo is updated/provided or **not needed**
- [x] TypeScript definition is updated/provided or **not needed**
- [x] Changelog is provided or **not needed**
