### PR TITLE
Revert "chore: use none-dist icons entry"

### DIFF
--- a/components/badge/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/badge/__tests__/__snapshots__/demo.test.js.snap
@@ -437,7 +437,6 @@ exports[`renders ./components/badge/demo/change.md correctly 1`] = `
             viewBox="64 64 896 896"
             width="1em"
           >
-            <defs />
             <path
               d="M482 152h60q8 0 8 8v704q0 8-8 8h-60q-8 0-8-8V160q0-8 8-8z"
             />

--- a/components/drawer/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/drawer/__tests__/__snapshots__/demo.test.js.snap
@@ -33,7 +33,6 @@ exports[`renders ./components/drawer/demo/form-in-drawer.md correctly 1`] = `
         viewBox="64 64 896 896"
         width="1em"
       >
-        <defs />
         <path
           d="M482 152h60q8 0 8 8v704q0 8-8 8h-60q-8 0-8-8V160q0-8 8-8z"
         />

--- a/components/form/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/form/__tests__/__snapshots__/demo.test.js.snap
@@ -779,7 +779,6 @@ exports[`renders ./components/form/demo/dynamic-form-item.md correctly 1`] = `
                 viewBox="64 64 896 896"
                 width="1em"
               >
-                <defs />
                 <path
                   d="M482 152h60q8 0 8 8v704q0 8-8 8h-60q-8 0-8-8V160q0-8 8-8z"
                 />

--- a/components/icon/index.tsx
+++ b/components/icon/index.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import classNames from 'classnames';
-import * as allIcons from '@ant-design/icons';
+import * as allIcons from '@ant-design/icons/lib/dist';
 import ReactIcon from '@ant-design/icons-react';
 import createFromIconfontCN from './IconFont';
 import {

--- a/components/progress/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/progress/__tests__/__snapshots__/demo.test.js.snap
@@ -254,7 +254,6 @@ exports[`renders ./components/progress/demo/circle-dynamic.md correctly 1`] = `
           viewBox="64 64 896 896"
           width="1em"
         >
-          <defs />
           <path
             d="M482 152h60q8 0 8 8v704q0 8-8 8h-60q-8 0-8-8V160q0-8 8-8z"
           />
@@ -549,7 +548,6 @@ exports[`renders ./components/progress/demo/dynamic.md correctly 1`] = `
           viewBox="64 64 896 896"
           width="1em"
         >
-          <defs />
           <path
             d="M482 152h60q8 0 8 8v704q0 8-8 8h-60q-8 0-8-8V160q0-8 8-8z"
           />

--- a/components/tabs/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/tabs/__tests__/__snapshots__/demo.test.js.snap
@@ -1182,7 +1182,6 @@ exports[`renders ./components/tabs/demo/editable-card.md correctly 1`] = `
             viewBox="64 64 896 896"
             width="1em"
           >
-            <defs />
             <path
               d="M482 152h60q8 0 8 8v704q0 8-8 8h-60q-8 0-8-8V160q0-8 8-8z"
             />

--- a/components/tag/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/tag/__tests__/__snapshots__/demo.test.js.snap
@@ -113,7 +113,6 @@ exports[`renders ./components/tag/demo/animation.md correctly 1`] = `
         viewBox="64 64 896 896"
         width="1em"
       >
-        <defs />
         <path
           d="M482 152h60q8 0 8 8v704q0 8-8 8h-60q-8 0-8-8V160q0-8 8-8z"
         />
@@ -389,7 +388,6 @@ exports[`renders ./components/tag/demo/control.md correctly 1`] = `
         viewBox="64 64 896 896"
         width="1em"
       >
-        <defs />
         <path
           d="M482 152h60q8 0 8 8v704q0 8-8 8h-60q-8 0-8-8V160q0-8 8-8z"
         />


### PR DESCRIPTION
Reverts ant-design/ant-design#17517

<img width="548" alt="image" src="https://user-images.githubusercontent.com/507615/60857496-643dfe80-a23d-11e9-9c69-8f6a6c2b2faf.png">
