### PR TITLE
fix: Align cascader loading style & update doc

### DIFF
--- a/components/cascader/index.en-US.md
+++ b/components/cascader/index.en-US.md
@@ -14,8 +14,8 @@ Cascade selection box.
 
 ## API
 
-```html
-<Cascader options="{options}" onChange="{onChange}" />
+```jsx
+<Cascader options={options} onChange={onChange} />
 ```
 
 | Property | Description | Type | Default |
@@ -32,7 +32,7 @@ Cascade selection box.
 | getPopupContainer | Parent Node which the selector should be rendered to. Default to `body`. When position issues happen, try to modify it into scrollable content and position it relative.[example](https://codepen.io/afc163/pen/zEjNOy?editors=0010) | Function(triggerNode) | () => document.body |
 | loadData | To load option lazily, and it cannot work with `showSearch` | `(selectedOptions) => void` | - |
 | notFoundContent | Specify content to show when no result matches. | string | 'Not Found' |
-| options | data options of cascade | object | - |
+| options | data options of cascade | [Option](#Option)[] | - |
 | placeholder | input placeholder | string | 'Please select' |
 | popupClassName | additional className of popup overlay | string | - |
 | popupPlacement | use preset popup align config from builtinPlacements：`bottomLeft` `bottomRight` `topLeft` `topRight` | string | `bottomLeft` |
@@ -54,6 +54,17 @@ Fields in `showSearch`:
 | matchInputWidth | Whether the width of result list equals to input's | boolean |  |
 | render | Used to render filtered options. | `function(inputValue, path): ReactNode` |  |
 | sort | Used to sort filtered options. | `function(a, b, inputValue)` |  |
+
+### Option
+
+```typescript
+interface Option {
+  value: string;
+  label?: React.ReactNode;
+  disabled?: boolean;
+  children?: Option[];
+}
+```
 
 ## Methods
 

--- a/components/cascader/index.zh-CN.md
+++ b/components/cascader/index.zh-CN.md
@@ -15,8 +15,8 @@ subtitle: 级联选择
 
 ## API
 
-```html
-<Cascader options="{options}" onChange="{onChange}" />
+```jsx
+<Cascader options={options} onChange={onChange} />
 ```
 
 | 参数 | 说明 | 类型 | 默认值 |
@@ -33,7 +33,7 @@ subtitle: 级联选择
 | getPopupContainer | 菜单渲染父节点。默认渲染到 body 上，如果你遇到菜单滚动定位问题，试试修改为滚动的区域，并相对其定位。[示例](https://codepen.io/afc163/pen/zEjNOy?editors=0010) | Function(triggerNode) | () => document.body |
 | loadData | 用于动态加载选项，无法与 `showSearch` 一起使用 | `(selectedOptions) => void` | - |
 | notFoundContent | 当下拉列表为空时显示的内容 | string | 'Not Found' |
-| options | 可选项数据源 | object | - |
+| options | 可选项数据源 | [Option](#Option)[] | - |
 | placeholder | 输入框占位文本 | string | '请选择' |
 | popupClassName | 自定义浮层类名 | string | - |
 | popupPlacement | 浮层预设位置：`bottomLeft` `bottomRight` `topLeft` `topRight` | Enum | `bottomLeft` |
@@ -55,6 +55,17 @@ subtitle: 级联选择
 | matchInputWidth | 搜索结果列表是否与输入框同宽 | boolean |  |
 | render | 用于渲染 filter 后的选项 | `function(inputValue, path): ReactNode` |  |
 | sort | 用于排序 filter 后的选项 | `function(a, b, inputValue)` |  |
+
+### Option
+
+```typescript
+interface Option {
+  value: string;
+  label?: React.ReactNode;
+  disabled?: boolean;
+  children?: Option[];
+}
+```
 
 ## 方法
 

--- a/components/cascader/style/index.less
+++ b/components/cascader/style/index.less
@@ -211,7 +211,7 @@
     }
 
     &-expand &-expand-icon,
-    &-expand &-loading-icon {
+    &-loading-icon {
       .iconfont-size-under-12px(10px);
 
       position: absolute;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [x] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?

fix #17547

### 💡 Solution

Adjust style

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fix Cascader loading style when `isLeaf` is `true`      |
| 🇨🇳 Chinese |     修复 Cascader 节点 `isLeaf` 为 `true` 时，载入的样式问题       |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/cascader/index.en-US.md](https://github.com/ant-design/ant-design/blob/docs/components/cascader/index.en-US.md)
[View rendered components/cascader/index.zh-CN.md](https://github.com/ant-design/ant-design/blob/docs/components/cascader/index.zh-CN.md)