### PR TITLE
fix: Collapse Panel key type definition

### DIFF
--- a/components/collapse/Collapse.tsx
+++ b/components/collapse/Collapse.tsx
@@ -9,8 +9,8 @@ import animation from '../_util/openAnimation';
 export type ExpandIconPosition = 'left' | 'right';
 
 export interface CollapseProps {
-  activeKey?: Array<string> | string;
-  defaultActiveKey?: Array<string>;
+  activeKey?: Array<string | number> | string | number;
+  defaultActiveKey?: Array<string | number> | string | number;
   /** 手风琴效果 */
   accordion?: boolean;
   destroyInactivePanel?: boolean;

--- a/components/collapse/CollapsePanel.tsx
+++ b/components/collapse/CollapsePanel.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 import { ConfigConsumer, ConfigConsumerProps } from '../config-provider';
 
 export interface CollapsePanelProps {
-  key: string;
+  key: string | number;
   header: React.ReactNode;
   disabled?: boolean;
   className?: string;

--- a/components/collapse/index.en-US.md
+++ b/components/collapse/index.en-US.md
@@ -18,8 +18,8 @@ A content area which can be collapsed and expanded.
 
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
-| activeKey | Key of the active panel | string\[]\|string | No default value. In `accordion` mode, it's the key of the first panel. |  |
-| defaultActiveKey | Key of the initial active panel | string | - |  |
+| activeKey | Key of the active panel | string\[]\|string\| number\[]\|number | No default value. In `accordion` mode, it's the key of the first panel. |  |
+| defaultActiveKey | Key of the initial active panel | string\[]\|string\| number\[]\|number | - |  |
 | bordered | Toggles rendering of the border around the collapse block | boolean | `true` | 3.6.5 |
 | accordion | If `true`, `Collapse` renders as `Accordion` | boolean | `false` | 3.6.5 |
 | onChange | Callback function executed when active panel is changed | Function | - |  |
@@ -34,6 +34,6 @@ A content area which can be collapsed and expanded.
 | disabled | If `true`, panel cannot be opened or closed | boolean | `false` |  |
 | forceRender | Forced render of content on panel, instead of lazy rending after clicking on header | boolean | `false` | 3.2.0 |
 | header | Title of the panel | string\|ReactNode | - |  |
-| key | Unique key identifying the panel from among its siblings | string | - |  |
+| key | Unique key identifying the panel from among its siblings | string\|number | - |  |
 | showArrow | If `false`, panel will not show arrow icon | boolean | `true` | 3.1.0 |
 | extra | extra element in the corner | ReactNode | - | 3.14.0 |

--- a/components/collapse/index.zh-CN.md
+++ b/components/collapse/index.zh-CN.md
@@ -19,8 +19,8 @@ cols: 1
 
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
-| activeKey | 当前激活 tab 面板的 key | string\[]\|string | 默认无，accordion 模式下默认第一个元素 |  |
-| defaultActiveKey | 初始化选中面板的 key | string | 无 |  |
+| activeKey | 当前激活 tab 面板的 key | string\[]\|string\| number\[]\|number | 默认无，accordion 模式下默认第一个元素 |  |
+| defaultActiveKey | 初始化选中面板的 key | string\[]\|string\| number\[]\|number | 无 |  |
 | bordered | 带边框风格的折叠面板 | boolean | `true` | 3.13.0 |
 | accordion | 手风琴模式 | boolean | `false` | 3.13.0 |
 | onChange | 切换面板的回调 | Function | 无 |  |
@@ -35,6 +35,6 @@ cols: 1
 | disabled    | 禁用后的面板展开与否将无法通过用户交互改变 | boolean           | false  |        |
 | forceRender | 被隐藏时是否渲染 DOM 结构                  | boolean           | false  | 3.2.0  |
 | header      | 面板头内容                                 | string\|ReactNode | 无     |        |
-| key         | 对应 activeKey                             | string            | 无     |        |
+| key         | 对应 activeKey                             | string\|number            | 无     |        |
 | showArrow   | 是否展示当前面板上的箭头                   | boolean           | `true` | 3.13.0 |
 | extra       | 自定义渲染每个面板右上角的内容             | ReactNode         | -      | 3.14.0 |


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?
1. Describe the source of requirement, like related issue link.
    Currently the allowed key for the `Collapse.Panel` is just string.

2. Describe the problem and the scenario.
    When you are rendering `Collapse.Panel` with map function, you can't simply provide just index of the map function. Also React's definition for Key type is `number | string`. 

### 💡 Solution

1. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
    Fix is prepared in this PR: Changing type definition of the `key` props.

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |          |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/collapse/index.en-US.md](https://github.com/thylsky/ant-design/blob/patch-1/components/collapse/index.en-US.md)
[View rendered components/collapse/index.zh-CN.md](https://github.com/thylsky/ant-design/blob/patch-1/components/collapse/index.zh-CN.md)