### PR TITLE
[WIP] fix(PageHeader): Extra content should be aligned with title

### DIFF
--- a/components/page-header/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/page-header/__tests__/__snapshots__/demo.test.js.snap
@@ -5,60 +5,80 @@ exports[`renders ./components/page-header/demo/actions.md correctly 1`] = `
   class="ant-page-header ant-page-header-has-footer"
 >
   <div
-    class="ant-page-header-back"
+    class="ant-breadcrumb"
   >
-    <div
-      aria-label="back"
-      class="ant-page-header-back-button"
-      role="button"
-      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-block"
-      tabindex="0"
-    >
-      <i
-        aria-label="icon: arrow-left"
-        class="anticon anticon-arrow-left"
+    <span>
+      <span
+        class="ant-breadcrumb-link"
       >
-        <svg
-          aria-hidden="true"
-          class=""
-          data-icon="arrow-left"
-          fill="currentColor"
-          focusable="false"
-          height="1em"
-          viewBox="64 64 896 896"
-          width="1em"
+        <a
+          href="#/index"
         >
-          <path
-            d="M872 474H286.9l350.2-304c5.6-4.9 2.2-14-5.2-14h-88.5c-3.9 0-7.6 1.4-10.5 3.9L155 487.8a31.96 31.96 0 0 0 0 48.3L535.1 866c1.5 1.3 3.3 2 5.2 2h91.5c7.4 0 10.8-9.2 5.2-14L286.9 550H872c4.4 0 8-3.6 8-8v-60c0-4.4-3.6-8-8-8z"
-          />
-        </svg>
-      </i>
-    </div>
-    <div
-      class="ant-divider ant-divider-vertical"
-    />
+          First-level Menu
+        </a>
+      </span>
+      <span
+        class="ant-breadcrumb-separator"
+      >
+        /
+      </span>
+    </span>
+    <span>
+      <span
+        class="ant-breadcrumb-link"
+      >
+        <a
+          href="#/index/first"
+        >
+          Second-level Menu
+        </a>
+      </span>
+      <span
+        class="ant-breadcrumb-separator"
+      >
+        /
+      </span>
+    </span>
+    <span>
+      <span
+        class="ant-breadcrumb-link"
+      >
+        <span>
+          Third-level Menu
+        </span>
+      </span>
+      <span
+        class="ant-breadcrumb-separator"
+      >
+        /
+      </span>
+    </span>
   </div>
   <div
     class="ant-page-header-heading"
   >
     <span
-      class="ant-page-header-heading-title"
+      class="ant-page-header-heading-left-wrapper"
     >
-      Title
-    </span>
-    <span
-      class="ant-page-header-heading-sub-title"
-    >
-      This is a subtitle
-    </span>
-    <span
-      class="ant-page-header-heading-tags"
-    >
-      <div
-        class="ant-tag ant-tag-red"
+      <span
+        class="ant-page-header-heading-title"
       >
-        Warning
-      </div>
+        Title
+      </span>
+      <span
+        class="ant-page-header-heading-sub-title"
+      >
+        This is a subtitle
+      </span>
+      <span
+        class="ant-page-header-heading-tags"
+      >
+        <div
+          class="ant-tag ant-tag-red"
+        >
+          Warning
+        </div>
+      </span>
     </span>
     <span
       class="ant-page-header-heading-extra"
@@ -451,14 +471,18 @@ exports[`renders ./components/page-header/demo/basic.md correctly 1`] = `
     class="ant-page-header-heading"
   >
     <span
-      class="ant-page-header-heading-title"
+      class="ant-page-header-heading-left-wrapper"
     >
-      Title
-    </span>
-    <span
-      class="ant-page-header-heading-sub-title"
-    >
-      This is a subtitle
+      <span
+        class="ant-page-header-heading-title"
+      >
+        Title
+      </span>
+      <span
+        class="ant-page-header-heading-sub-title"
+      >
+        This is a subtitle
+      </span>
     </span>
   </div>
 </div>
@@ -522,9 +546,13 @@ exports[`renders ./components/page-header/demo/breadcrumb.md correctly 1`] = `
     class="ant-page-header-heading"
   >
     <span
-      class="ant-page-header-heading-title"
+      class="ant-page-header-heading-left-wrapper"
     >
-      Title
+      <span
+        class="ant-page-header-heading-title"
+      >
+        Title
+      </span>
     </span>
   </div>
 </div>
@@ -588,9 +616,13 @@ exports[`renders ./components/page-header/demo/content.md correctly 1`] = `
     class="ant-page-header-heading"
   >
     <span
-      class="ant-page-header-heading-title"
+      class="ant-page-header-heading-left-wrapper"
     >
-      Title
+      <span
+        class="ant-page-header-heading-title"
+      >
+        Title
+      </span>
     </span>
   </div>
   <div

--- a/components/page-header/__tests__/__snapshots__/index.test.js.snap
+++ b/components/page-header/__tests__/__snapshots__/index.test.js.snap
@@ -14,9 +14,13 @@ exports[`PageHeader pageHeader should support className 1`] = `
     class="ant-page-header-heading"
   >
     <span
-      class="ant-page-header-heading-title"
+      class="ant-page-header-heading-left-wrapper"
     >
-      Page Title
+      <span
+        class="ant-page-header-heading-title"
+      >
+        Page Title
+      </span>
     </span>
   </div>
 </div>

--- a/components/page-header/demo/actions.md
+++ b/components/page-header/demo/actions.md
@@ -18,6 +18,21 @@ import { PageHeader, Tag, Tabs, Button, Statistic, Row, Col } from 'antd';
 
 const { TabPane } = Tabs;
 
+const routes = [
+  {
+    path: 'index',
+    breadcrumbName: 'First-level Menu',
+  },
+  {
+    path: 'first',
+    breadcrumbName: 'Second-level Menu',
+  },
+  {
+    path: 'second',
+    breadcrumbName: 'Third-level Menu',
+  },
+];
+
 const Description = ({ term, children, span = 12 }) => (
   <Col span={span}>
     <div className="description">
@@ -57,6 +72,7 @@ ReactDOM.render(
     onBack={() => window.history.back()}
     title="Title"
     subTitle="This is a subtitle"
+    breadcrumb={{ routes }}
     tags={<Tag color="red">Warning</Tag>}
     extra={[
       <Button key="3">Operation</Button>,

--- a/components/page-header/demo/basic.md
+++ b/components/page-header/demo/basic.md
@@ -14,10 +14,21 @@ title:
 Standard header, suitable for use in scenarios that require a brief description.
 
 ```jsx
-import { PageHeader } from 'antd';
+import { PageHeader, Button } from 'antd';
 
 ReactDOM.render(
-  <PageHeader onBack={() => null} title="Title" subTitle="This is a subtitle" />,
+  <PageHeader
+    onBack={() => null}
+    title="Title"
+    subTitle="This is a subtitle"
+    extra={[
+      <Button key="3">Operation</Button>,
+      <Button key="2">Operation</Button>,
+      <Button key="1" type="primary">
+        Primary
+      </Button>,
+    ]}
+  />,
   mountNode,
 );
 ```

--- a/components/page-header/index.tsx
+++ b/components/page-header/index.tsx
@@ -71,9 +71,11 @@ const renderTitle = (prefixCls: string, props: PageHeaderProps) => {
   if (title || subTitle || tags || extra) {
     return (
       <div className={headingPrefixCls}>
-        {title && <span className={`${headingPrefixCls}-title`}>{title}</span>}
-        {subTitle && <span className={`${headingPrefixCls}-sub-title`}>{subTitle}</span>}
-        {tags && <span className={`${headingPrefixCls}-tags`}>{tags}</span>}
+        <span className={`${headingPrefixCls}-left-wrapper`}>
+          {title && <span className={`${headingPrefixCls}-title`}>{title}</span>}
+          {subTitle && <span className={`${headingPrefixCls}-sub-title`}>{subTitle}</span>}
+          {tags && <span className={`${headingPrefixCls}-tags`}>{tags}</span>}
+        </span>
         {extra && <span className={`${headingPrefixCls}-extra`}>{extra}</span>}
       </div>
     );

--- a/components/page-header/style/index.less
+++ b/components/page-header/style/index.less
@@ -36,33 +36,35 @@
   }
 
   &-heading {
-    display: inline-block;
-    &-title {
-      display: inline-block;
-      padding-right: 12px;
-      color: @heading-color;
-      font-weight: bold;
-      font-size: 16px;
-      line-height: 1.4;
-    }
+    display: table;
+    width: 100%;
+    &-left-wrapper {
+      display: table-cell;
+      vertical-align: middle;
+      .@{pageheader-prefix-cls}-heading-title {
+        display: inline-block;
+        padding-right: 12px;
+        color: @heading-color;
+        font-weight: bold;
+        font-size: 16px;
+        line-height: 1.4;
+      }
 
-    &-sub-title {
-      display: inline-block;
-      padding-right: 12px;
-      color: @text-color-secondary;
-      font-size: 14px;
-      line-height: 1.8;
-    }
+      .@{pageheader-prefix-cls}-heading-sub-title {
+        display: inline-block;
+        padding-right: 12px;
+        color: @text-color-secondary;
+        font-size: 14px;
+        line-height: 1.8;
+      }
 
-    &-tags {
-      display: inline-block;
-      vertical-align: top;
+      .@{pageheader-prefix-cls}-heading-tags {
+        display: inline-block;
+      }
     }
 
     &-extra {
-      position: absolute;
-      top: 16px;
-      right: @page-header-padding-horizontal;
+      float: right;
       > * {
         margin-left: 8px;
       }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?

- Close #17564.

![image](https://user-images.githubusercontent.com/14918822/60956900-41434580-a336-11e9-8d7e-13d2a6d50e6e.png)

<!--
1. Describe the source of requirement, like related issue link.

2. Describe the problem and the scenario.
-->

### 💡 Solution

<!--
1. How to fix the problem, and list final API implementation and usage sample if that is an new feature.

2. GIF or snapshot should be provided if includes UI/interactive modification.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 🐞 Fix PageHeader's extra content not aligned with title. #17564          |
| 🇨🇳 Chinese | 🐞 修复 PageHeader 组件的操作区内容没有和标题垂直对齐的问题。#17564          |

### ☑️ Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/page-header/demo/actions.md](https://github.com/ant-design/ant-design/blob/fix-PageHeader-extra-align/components/page-header/demo/actions.md)