### PR TITLE
Extend MenuItemProps from HTMLAttributes<HTMLLIElement>

### DIFF
--- a/components/menu/MenuItem.tsx
+++ b/components/menu/MenuItem.tsx
@@ -5,7 +5,11 @@ import { MenuContext, MenuContextProps } from './';
 import Tooltip, { TooltipProps } from '../tooltip';
 import { SiderContext, SiderContextProps } from '../layout/Sider';
 
-export interface MenuItemProps {
+export interface MenuItemProps
+  extends Omit<
+    React.HTMLAttributes<HTMLLIElement>,
+    'title' | 'onClick' | 'onMouseEnter' | 'onMouseLeave'
+  > {
   rootPrefixCls?: string;
   disabled?: boolean;
   level?: number;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?

Passing an HTML attribute as a prop to `Menu.Item` component produces a tsc error.
As a result, there is no possibility to specify id attribute on `Menu.Item` which is useful for UI testing and etc. 

### 💡 Solution
Extend MenuItemProps interface from `React.HTMLAttributes<HTMLLIElement>`

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
