### PR TITLE
Revert #17508

### DIFF
--- a/components/button/style/index.less
+++ b/components/button/style/index.less
@@ -24,8 +24,8 @@
   > i,
   > span {
     display: inline-block;
-    transition: margin-left 0.3s @ease-in-out;
     pointer-events: none;
+    transition: margin-left 0.3s @ease-in-out;
   }
 
   &-primary {

--- a/components/descriptions/style/index.less
+++ b/components/descriptions/style/index.less
@@ -53,8 +53,8 @@
 
   &-item-no-label {
     &::after {
-      margin: 0;
       content: '';
+      margin: 0;
     }
   }
 

--- a/components/input/style/mixin.less
+++ b/components/input/style/mixin.less
@@ -373,16 +373,8 @@
     color: @input-color;
     line-height: 0;
     transform: translateY(-50%);
-    background-color: #fff;
-    height: calc(100% - 2px);
     :not(.anticon) {
       line-height: @line-height-base;
-    }
-    .anticon {
-      position: relative;
-      vertical-align: top;
-      top: 50%;
-      transform: translateY(-50%);
     }
   }
 

--- a/components/input/style/mixin.less
+++ b/components/input/style/mixin.less
@@ -370,18 +370,18 @@
     position: absolute;
     top: 50%;
     z-index: 2;
-    height: calc(100% - 2px);
     color: @input-color;
     line-height: 0;
-    background-color: #fff;
     transform: translateY(-50%);
+    background-color: #fff;
+    height: calc(100% - 2px);
     :not(.anticon) {
       line-height: @line-height-base;
     }
     .anticon {
       position: relative;
-      top: 50%;
       vertical-align: top;
+      top: 50%;
       transform: translateY(-50%);
     }
   }

--- a/components/mentions/style/index.less
+++ b/components/mentions/style/index.less
@@ -11,9 +11,9 @@
   position: relative;
   display: inline-block;
   height: auto;
+  line-height: unset;
   padding: 0;
   overflow: hidden;
-  line-height: unset;
   white-space: pre-wrap;
   vertical-align: bottom;
 


### PR DESCRIPTION
This PR reverts https://github.com/ant-design/ant-design/pull/17508

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?

回滚 #17508 中对 Input 后缀样式的修改，因其导致了其他更多问题。

Before #17508 

![Screen Shot 2019-07-15 at 2 37 22 PM](https://user-images.githubusercontent.com/465125/61198802-1b3eec00-a70e-11e9-8ac0-d7438be4cb32.png)

After #17508 

![Screen Shot 2019-07-15 at 2 37 25 PM](https://user-images.githubusercontent.com/465125/61198806-1e39dc80-a70e-11e9-9d8e-fe6f6e7159be.png)


<!--
1. Describe the source of requirement, like related issue link.

2. Describe the problem and the scenario.
-->

### 💡 Solution

<!--
1. How to fix the problem, and list final API implementation and usage sample if that is an new feature.

2. GIF or snapshot should be provided if includes UI/interactive modification.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |Revert change of Input suffix style in #17508, since it causes other problems|
| 🇨🇳 Chinese |回滚 #17508 中对 Input 后缀样式的修改，因其导致了其他更多问题。|

### ☑️ Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
