### PR TITLE
feat: 在anchor的didUpdate中判断监听容器是否改变,如果有则重新绑定监听函数

### DIFF
--- a/components/anchor/Anchor.tsx
+++ b/components/anchor/Anchor.tsx
@@ -184,7 +184,16 @@ export default class Anchor extends React.Component<AnchorProps, AnchorState> {
     }
   }
 
-  componentDidUpdate() {
+  componentDidUpdate(prevProps: AnchorProps) {
+    if (this.scrollEvent) {
+      const { getContainer } = this.props as AnchorDefaultProps;
+      const { getContainer: preGetContainer } = prevProps as AnchorDefaultProps;
+      if (getContainer() && getContainer() !== preGetContainer()) {
+        this.scrollEvent.remove();
+        this.scrollEvent = addEventListener(getContainer(), 'scroll', this.handleScroll);
+        this.handleScroll();
+      }
+    }
     this.updateInk();
   }
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [x] Other (about what?)

### 👻 What's the background?

<!--
1. Describe the source of requirement, like related issue link.

2. Describe the problem and the scenario.
-->

### 💡 Solution
- 解决getContainer()返回的是容器的ref，在Anchor组件的componentDidMount拿不到ref的情况
- 解决如果getContainer()需要变化的情况下，重新添加滚动事件的情况

<!--
1. How to fix the problem, and list final API implementation and usage sample if that is an new feature.

2. GIF or snapshot should be provided if includes UI/interactive modification.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |In componentDidUpdate to determine whether the incoming container changes, if it changes, re-bind the scroll event, and in order to be compatible with getContainer () return value of refSituation, because didMount can not get the corresponding ref of the rolling container in many cases|
| 🇨🇳 Chinese |在componentDidUpdate判断传入的container是否变化,如果变化则重新绑定滚动事件,同时为了兼容getContainer()返回值为ref的情况,因为didMount很多情况下还拿不到对应的滚动容器的ref|

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
