### PR TITLE
feat(Anchor): add fixDistance props fix fixed nav height

### DIFF
--- a/components/anchor/Anchor.tsx
+++ b/components/anchor/Anchor.tsx
@@ -48,6 +48,7 @@ const sharpMatcherRegx = /#([^#]+)$/;
 function scrollTo(
   href: string,
   offsetTop = 0,
+  fixDistance = 0,
   getContainer: () => AnchorContainer,
   callback = () => {},
 ) {
@@ -62,7 +63,7 @@ function scrollTo(
     return;
   }
   const eleOffsetTop = getOffsetTop(targetElement, container);
-  const targetScrollTop = scrollTop + eleOffsetTop - offsetTop;
+  const targetScrollTop = scrollTop + eleOffsetTop - offsetTop - fixDistance;
   const startTime = Date.now();
   const frameFunc = () => {
     const timestamp = Date.now();
@@ -97,6 +98,7 @@ export interface AnchorProps {
   offsetTop?: number;
   bounds?: number;
   affix?: boolean;
+  fixDistance?: number;
   showInkInFixed?: boolean;
   getContainer?: () => AnchorContainer;
   onClick?: (
@@ -203,10 +205,10 @@ export default class Anchor extends React.Component<AnchorProps, AnchorState> {
   };
 
   handleScrollTo = (link: string) => {
-    const { offsetTop, getContainer } = this.props as AnchorDefaultProps;
+    const { offsetTop, getContainer, fixDistance } = this.props as AnchorDefaultProps;
     this.animating = true;
     this.setState({ activeLink: link });
-    scrollTo(link, offsetTop, getContainer, () => {
+    scrollTo(link, offsetTop, fixDistance, getContainer, () => {
       this.animating = false;
     });
   };


### PR DESCRIPTION

### 🤔 This is a ...

- [x] New feature

### 👻 What's the background?

![image](https://user-images.githubusercontent.com/14831261/61262382-a32d0080-a7b7-11e9-860f-c055e096ec7d.png)

`affix` 模式下锚点滚动后没有减去导航的高度，实际项目中会遮挡，理想情况下 `API` 应该在导航的下方

### 💡 Solution

增加一个 `fixDistance` 属性传入导航的高度，增加容错率

