### PR TITLE
feat(Anchor): add defaultActive prop

### DIFF
--- a/components/anchor/Anchor.tsx
+++ b/components/anchor/Anchor.tsx
@@ -98,6 +98,7 @@ export interface AnchorProps {
   bounds?: number;
   affix?: boolean;
   showInkInFixed?: boolean;
+  defaultActive?: string;
   getContainer?: () => AnchorContainer;
   onClick?: (
     e: React.MouseEvent<HTMLElement>,
@@ -193,8 +194,17 @@ export default class Anchor extends React.Component<AnchorProps, AnchorState> {
       return;
     }
     const { activeLink } = this.state;
-    const { offsetTop, bounds } = this.props;
+    const { offsetTop, bounds, defaultActive } = this.props;
     const currentActiveLink = this.getCurrentAnchor(offsetTop, bounds);
+
+    if (!currentActiveLink && defaultActive) {
+      if (activeLink === defaultActive) return;
+      this.setState({
+        activeLink: defaultActive,
+      });
+      return;
+    }
+
     if (activeLink !== currentActiveLink) {
       this.setState({
         activeLink: currentActiveLink,

--- a/components/anchor/__tests__/Anchor.test.js
+++ b/components/anchor/__tests__/Anchor.test.js
@@ -132,6 +132,9 @@ describe('Anchor Render', () => {
   });
 
   it('Anchor defaultActive Prop', () => {
+    const mockGetCurrentAnchor = jest.fn().mockReturnValueOnce('');
+    Anchor.prototype.getCurrentAnchor = mockGetCurrentAnchor;
+
     const wrapper = mount(
       <Anchor defaultActive="#DEMO">
         <Link href="#API" title="API" />
@@ -139,5 +142,6 @@ describe('Anchor Render', () => {
       </Anchor>,
     );
     expect(wrapper.instance().state.activeLink).toEqual('#DEMO');
+    expect(mockGetCurrentAnchor).toHaveBeenCalledTimes(1);
   });
 });

--- a/components/anchor/__tests__/Anchor.test.js
+++ b/components/anchor/__tests__/Anchor.test.js
@@ -130,4 +130,14 @@ describe('Anchor Render', () => {
     expect(event).not.toBe(undefined);
     expect(link).toEqual({ href, title });
   });
+
+  it('Anchor defaultActive Prop', () => {
+    const wrapper = mount(
+      <Anchor defaultActive="#DEMO">
+        <Link href="#API" title="API" />
+        <Link href="#DEMO" title="DEMO" />
+      </Anchor>,
+    );
+    expect(wrapper.instance().state.activeLink).toEqual('#DEMO');
+  });
 });

--- a/components/anchor/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/anchor/__tests__/__snapshots__/demo.test.js.snap
@@ -80,6 +80,86 @@ exports[`renders ./components/anchor/demo/basic.md correctly 1`] = `
 </div>
 `;
 
+exports[`renders ./components/anchor/demo/defaultActive.md correctly 1`] = `
+<div>
+  <div
+    class=""
+  >
+    <div
+      class="ant-anchor-wrapper"
+      style="max-height:100vh"
+    >
+      <div
+        class="ant-anchor"
+      >
+        <div
+          class="ant-anchor-ink"
+        >
+          <span
+            class="ant-anchor-ink-ball"
+          />
+        </div>
+        <div
+          class="ant-anchor-link"
+        >
+          <a
+            class="ant-anchor-link-title"
+            href="#components-anchor-demo-basic"
+            title="Basic demo"
+          >
+            Basic demo
+          </a>
+        </div>
+        <div
+          class="ant-anchor-link"
+        >
+          <a
+            class="ant-anchor-link-title"
+            href="#components-anchor-demo-static"
+            title="Static demo"
+          >
+            Static demo
+          </a>
+        </div>
+        <div
+          class="ant-anchor-link"
+        >
+          <a
+            class="ant-anchor-link-title"
+            href="#API"
+            title="API"
+          >
+            API
+          </a>
+          <div
+            class="ant-anchor-link"
+          >
+            <a
+              class="ant-anchor-link-title"
+              href="#Anchor-Props"
+              title="Anchor Props"
+            >
+              Anchor Props
+            </a>
+          </div>
+          <div
+            class="ant-anchor-link"
+          >
+            <a
+              class="ant-anchor-link-title"
+              href="#Link-Props"
+              title="Link Props"
+            >
+              Link Props
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`renders ./components/anchor/demo/onClick.md correctly 1`] = `
 <div
   class="ant-anchor-wrapper"

--- a/components/anchor/demo/defaultActive.md
+++ b/components/anchor/demo/defaultActive.md
@@ -1,0 +1,32 @@
+---
+order: 4
+title:
+  zh-CN: 默认高亮
+  en-US: Default Active
+---
+
+## zh-CN
+
+如果没有高亮设置默认高亮
+
+## en-US
+
+if not active set default.
+
+```jsx
+import { Anchor } from 'antd';
+
+const { Link } = Anchor;
+
+ReactDOM.render(
+  <Anchor defaultActive="#components-anchor-demo-basic">
+    <Link href="#components-anchor-demo-basic" title="Basic demo" />
+    <Link href="#components-anchor-demo-static" title="Static demo" />
+    <Link href="#API" title="API">
+      <Link href="#Anchor-Props" title="Anchor Props" />
+      <Link href="#Link-Props" title="Link Props" />
+    </Link>
+  </Anchor>,
+  mountNode,
+);
+```


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [x] New feature

### 👻 What's the background?

滚动到对应的区域高亮

### 💡 Solution

设置默认高亮，类似 [Airbnb](https://www.airbnb.cn/rooms/22319401?source_impression_id=p3_1563249416_vkLCGisDSU%2FHh710) 的实现



-----
[View rendered components/anchor/demo/defaultActive.md](https://github.com/shaodahong/ant-design/blob/feat-anchor-default-active-link/components/anchor/demo/defaultActive.md)