### PR TITLE
feat: Re-bind scroll events when components change, add test cases

### DIFF
--- a/components/anchor/Anchor.tsx
+++ b/components/anchor/Anchor.tsx
@@ -145,6 +145,8 @@ export default class Anchor extends React.Component<AnchorProps, AnchorState> {
   };
 
   private inkNode: HTMLSpanElement;
+  // scroll scope's container
+  private scrollContainer: HTMLElement | Window;
 
   private links: string[] = [];
   private scrollEvent: any;
@@ -174,7 +176,8 @@ export default class Anchor extends React.Component<AnchorProps, AnchorState> {
 
   componentDidMount() {
     const { getContainer } = this.props as AnchorDefaultProps;
-    this.scrollEvent = addEventListener(getContainer(), 'scroll', this.handleScroll);
+    this.scrollContainer = getContainer();
+    this.scrollEvent = addEventListener(this.scrollContainer, 'scroll', this.handleScroll);
     this.handleScroll();
   }
 
@@ -185,6 +188,16 @@ export default class Anchor extends React.Component<AnchorProps, AnchorState> {
   }
 
   componentDidUpdate() {
+    if (this.scrollEvent) {
+      const { getContainer } = this.props as AnchorDefaultProps;
+      const currentContainer = getContainer();
+      if (this.scrollContainer !== currentContainer) {
+        this.scrollContainer = currentContainer;
+        this.scrollEvent.remove();
+        this.scrollEvent = addEventListener(this.scrollContainer, 'scroll', this.handleScroll);
+        this.handleScroll();
+      }
+    }
     this.updateInk();
   }
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [x] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution
- 获取 DOM 后存变量里做对比
- 解决getContainer()返回的是容器的ref，在Anchor组件的componentDidMount拿不到ref的情况
- 解决如果getContainer()需要变化的情况下，重新添加滚动事件的情况
- 添加测试
1. 不同 function 返回相同 DOM
2. 不同 function 返回不同 DOM
3. 相同 function 返回相同 DOM
4. 相同 function 返回不同 DOM

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |In componentDidUpdate to determine whether the incoming container changes, if it changes, re-bind the scroll event, and in order to be compatible with getContainer () return value of refSituation, because didMount can not get the corresponding ref of the rolling container in many cases|
| 🇨🇳 Chinese |在componentDidUpdate判断传入的container是否变化,如果变化则重新绑定滚动事件,同时为了兼容getContainer()返回值为ref的情况,因为didMount很多情况下还拿不到对应的滚动容器的ref|

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
