### PR TITLE
feat: support gray color Timeline.Item

### DIFF
--- a/components/timeline/TimelineItem.tsx
+++ b/components/timeline/TimelineItem.tsx
@@ -46,7 +46,7 @@ const TimelineItem: React.SFC<TimeLineItemProps> = props => (
           <div className={`${prefixCls}-item-tail`} />
           <div
             className={dotClassName}
-            style={{ borderColor: /blue|red|green/.test(color) ? undefined : color }}
+            style={{ borderColor: /blue|red|green|gray/.test(color) ? undefined : color }}
           >
             {dot}
           </div>

--- a/components/timeline/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/timeline/__tests__/__snapshots__/demo.test.js.snap
@@ -270,13 +270,59 @@ exports[`renders ./components/timeline/demo/color.md correctly 1`] = `
     </div>
   </li>
   <li
-    class="ant-timeline-item ant-timeline-item-last"
+    class="ant-timeline-item"
   >
     <div
       class="ant-timeline-item-tail"
     />
     <div
       class="ant-timeline-item-head ant-timeline-item-head-blue"
+    />
+    <div
+      class="ant-timeline-item-content"
+    >
+      <p>
+        Technical testing 1
+      </p>
+      <p>
+        Technical testing 2
+      </p>
+      <p>
+        Technical testing 3 2015-09-01
+      </p>
+    </div>
+  </li>
+  <li
+    class="ant-timeline-item"
+  >
+    <div
+      class="ant-timeline-item-tail"
+    />
+    <div
+      class="ant-timeline-item-head ant-timeline-item-head-gray"
+    />
+    <div
+      class="ant-timeline-item-content"
+    >
+      <p>
+        Technical testing 1
+      </p>
+      <p>
+        Technical testing 2
+      </p>
+      <p>
+        Technical testing 3 2015-09-01
+      </p>
+    </div>
+  </li>
+  <li
+    class="ant-timeline-item ant-timeline-item-last"
+  >
+    <div
+      class="ant-timeline-item-tail"
+    />
+    <div
+      class="ant-timeline-item-head ant-timeline-item-head-gray"
     />
     <div
       class="ant-timeline-item-content"

--- a/components/timeline/demo/color.md
+++ b/components/timeline/demo/color.md
@@ -7,11 +7,11 @@ title:
 
 ## zh-CN
 
-圆圈颜色，绿色用于已完成、成功状态，红色表示告警或错误状态，蓝色可表示正在进行或其他默认状态。
+圆圈颜色，绿色用于已完成、成功状态，红色表示告警或错误状态，蓝色可表示正在进行或其他默认状态，灰色表示未完成或失效状态。
 
 ## en-US
 
-Set the color of circles. `green` means completed or success status, `red` means warning or error, and `blue` means ongoing or other default status.
+Set the color of circles. `green` means completed or success status, `red` means warning or error, and `blue` means ongoing or other default status, `gray` for unfinished or disabled status.
 
 ```jsx
 import { Timeline } from 'antd';
@@ -26,6 +26,16 @@ ReactDOM.render(
       <p>Solve initial network problems 3 2015-09-01</p>
     </Timeline.Item>
     <Timeline.Item>
+      <p>Technical testing 1</p>
+      <p>Technical testing 2</p>
+      <p>Technical testing 3 2015-09-01</p>
+    </Timeline.Item>
+    <Timeline.Item color="gray">
+      <p>Technical testing 1</p>
+      <p>Technical testing 2</p>
+      <p>Technical testing 3 2015-09-01</p>
+    </Timeline.Item>
+    <Timeline.Item color="gray">
       <p>Technical testing 1</p>
       <p>Technical testing 2</p>
       <p>Technical testing 3 2015-09-01</p>

--- a/components/timeline/index.en-US.md
+++ b/components/timeline/index.en-US.md
@@ -39,6 +39,6 @@ Node of timeline
 
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
-| color | Set the circle's color to `blue`, `red`, `green` or other custom colors | string | `blue` |  |
+| color | Set the circle's color to `blue`, `red`, `green`, `gray` or other custom colors | string | `blue` |  |
 | dot | Customize timeline dot | string\|ReactNode | - |  |
 | position | Customize node position | `left` \| `right` | - | 3.17.0 |

--- a/components/timeline/index.zh-CN.md
+++ b/components/timeline/index.zh-CN.md
@@ -38,8 +38,8 @@ title: Timeline
 
 时间轴的每一个节点。
 
-| 参数     | 说明                                            | 类型              | 默认值 | 版本   |
-| -------- | ----------------------------------------------- | ----------------- | ------ | ------ |
-| color    | 指定圆圈颜色 `blue, red, green`，或自定义的色值 | string            | blue   |        |
-| dot      | 自定义时间轴点                                  | string\|ReactNode | -      |        |
-| position | 自定义节点位置                                  | `left` \| `right` | -      | 3.17.0 |
+| 参数 | 说明 | 类型 | 默认值 | 版本 |
+| --- | --- | --- | --- | --- |
+| color | 指定圆圈颜色 `blue, red, green, gray`，或自定义的色值 | string | blue |  |
+| dot | 自定义时间轴点 | string\|ReactNode | - |  |
+| position | 自定义节点位置 | `left` \| `right` | - | 3.17.0 |

--- a/components/timeline/style/index.less
+++ b/components/timeline/style/index.less
@@ -55,6 +55,11 @@
         color: @success-color;
         border-color: @success-color;
       }
+
+      &-gray {
+        color: @disabled-color;
+        border-color: @disabled-color;
+      }
     }
 
     &-head-custom {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

None.

### 💡 Background and solution

```jsx
<Timeline.Item color="gray" />
```

<img width="373" alt="image" src="https://user-images.githubusercontent.com/507615/61508344-04eda480-aa1c-11e9-83c8-5f3bf33a4ef1.png">

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Added new color `gray` for Timeline.Item for unfinished or disabled status. |
| 🇨🇳 Chinese | Timeline.Item 新增 `gray` 色彩类型，可用于未完成或失效状态。  |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/collapse/index.zh-CN.md](https://github.com/ant-design/ant-design/blob/feat-timelint-default-type/components/collapse/index.zh-CN.md)
[View rendered components/descriptions/index.en-US.md](https://github.com/ant-design/ant-design/blob/feat-timelint-default-type/components/descriptions/index.en-US.md)
[View rendered components/descriptions/index.zh-CN.md](https://github.com/ant-design/ant-design/blob/feat-timelint-default-type/components/descriptions/index.zh-CN.md)
[View rendered components/menu/index.en-US.md](https://github.com/ant-design/ant-design/blob/feat-timelint-default-type/components/menu/index.en-US.md)
[View rendered components/menu/index.zh-CN.md](https://github.com/ant-design/ant-design/blob/feat-timelint-default-type/components/menu/index.zh-CN.md)
[View rendered components/timeline/demo/color.md](https://github.com/ant-design/ant-design/blob/feat-timelint-default-type/components/timeline/demo/color.md)
[View rendered components/timeline/index.en-US.md](https://github.com/ant-design/ant-design/blob/feat-timelint-default-type/components/timeline/index.en-US.md)
[View rendered components/timeline/index.zh-CN.md](https://github.com/ant-design/ant-design/blob/feat-timelint-default-type/components/timeline/index.zh-CN.md)