### PR TITLE
fix: tooltip arrows do not fuse in dark

### DIFF
--- a/components/tooltip/demo/basic.md
+++ b/components/tooltip/demo/basic.md
@@ -17,11 +17,9 @@ The simplest usage.
 import { Tooltip } from 'antd';
 
 ReactDOM.render(
-  <div style={{ background: '#fff', height: 400, padding: 100 }}>
-    <Tooltip title="prompt text">
-      <span>Tooltip will show on mouse enter.</span>
-    </Tooltip>
-  </div>,
+  <Tooltip title="prompt text">
+    <span>Tooltip will show on mouse enter.</span>
+  </Tooltip>,
   mountNode,
 );
 ```

--- a/components/tooltip/demo/basic.md
+++ b/components/tooltip/demo/basic.md
@@ -17,9 +17,11 @@ The simplest usage.
 import { Tooltip } from 'antd';
 
 ReactDOM.render(
-  <Tooltip title="prompt text">
-    <span>Tooltip will show on mouse enter.</span>
-  </Tooltip>,
+  <div style={{ background: '#fff', height: 400, padding: 100 }}>
+    <Tooltip title="prompt text">
+      <span>Tooltip will show on mouse enter.</span>
+    </Tooltip>
+  </div>,
   mountNode,
 );
 ```

--- a/components/tooltip/style/index.less
+++ b/components/tooltip/style/index.less
@@ -3,6 +3,14 @@
 
 @tooltip-prefix-cls: ~'@{ant-prefix}-tooltip';
 
+@tooltip-arrow-shadow-width: 3px;
+
+@tooltip-arrow-rotate-width: sqrt(@tooltip-arrow-width * @tooltip-arrow-width * 2) +
+  @tooltip-arrow-shadow-width * 2;
+
+@tooltip-arrow-offset-vertical: 5px; // 8 - 3px, 减掉阴影的宽度
+@tooltip-arrow-offset-horizontal: 13px; // 16 - 3px, 减掉阴影的宽度
+
 // Base class
 .@{tooltip-prefix-cls} {
   .reset-component;
@@ -20,22 +28,25 @@
   &-placement-top,
   &-placement-topLeft,
   &-placement-topRight {
-    padding-bottom: @tooltip-distance;
+    padding-bottom: @tooltip-arrow-rotate-width - @tooltip-arrow-shadow-width * 2;
   }
+
   &-placement-right,
   &-placement-rightTop,
   &-placement-rightBottom {
-    padding-left: @tooltip-distance;
+    padding-left: @tooltip-arrow-rotate-width - @tooltip-arrow-shadow-width * 2;
   }
+
   &-placement-bottom,
   &-placement-bottomLeft,
   &-placement-bottomRight {
-    padding-top: @tooltip-distance;
+    padding-top: @tooltip-arrow-rotate-width - @tooltip-arrow-shadow-width * 2;
   }
+
   &-placement-left,
   &-placement-leftTop,
   &-placement-leftBottom {
-    padding-right: @tooltip-distance;
+    padding-right: @tooltip-arrow-rotate-width - @tooltip-arrow-shadow-width * 2;
   }
 
   // Wrapper for the tooltip content
@@ -55,108 +66,118 @@
   // Arrows
   &-arrow {
     position: absolute;
-    display: block;
-    width: sqrt(@tooltip-arrow-width * @tooltip-arrow-width * 2);
-    height: sqrt(@tooltip-arrow-width * @tooltip-arrow-width * 2);
+    display: flex;
+    width: @tooltip-arrow-rotate-width;
+    height: @tooltip-arrow-rotate-width;
     background: transparent;
-    border-style: solid;
-    border-width: sqrt(@tooltip-arrow-width * @tooltip-arrow-width * 2) / 2;
-    transform: rotate(45deg);
+    overflow: hidden;
+    pointer-events: none;
+
+    &:before {
+      width: @tooltip-arrow-width;
+      height: @tooltip-arrow-width;
+      content: '';
+      display: block;
+      margin: auto;
+      background: @tooltip-bg;
+      position: relative;
+      pointer-events: auto;
+    }
   }
 
   &-placement-top &-arrow,
   &-placement-topLeft &-arrow,
   &-placement-topRight &-arrow {
-    bottom: @tooltip-distance - @tooltip-arrow-width + 2.2px;
-    border-top-color: transparent;
-    border-right-color: tint(fadein(@tooltip-bg, 100%), 25%); // make it not transparent
-    border-bottom-color: tint(fadein(@tooltip-bg, 100%), 25%); // make it not transparent
-    border-left-color: transparent;
-    box-shadow: 3px 3px 7px fade(@black, 7%);
+    bottom: -@tooltip-arrow-shadow-width * 2;
+
+    &:before {
+      transform: translateY(-@tooltip-arrow-rotate-width / 2) rotate(45deg);
+      box-shadow: @tooltip-arrow-shadow-width @tooltip-arrow-shadow-width 7px fade(@black, 7%);
+    }
   }
 
   &-placement-top &-arrow {
     left: 50%;
-    transform: translateX(-50%) rotate(45deg);
+    transform: translateX(-50%);
   }
 
   &-placement-topLeft &-arrow {
-    left: 16px;
+    left: @tooltip-arrow-offset-horizontal;
   }
 
   &-placement-topRight &-arrow {
-    right: 16px;
+    right: @tooltip-arrow-offset-horizontal;
   }
 
   &-placement-right &-arrow,
   &-placement-rightTop &-arrow,
   &-placement-rightBottom &-arrow {
-    left: @tooltip-distance - @tooltip-arrow-width + 2px;
-    border-top-color: transparent;
-    border-right-color: transparent;
-    border-bottom-color: tint(fadein(@tooltip-bg, 100%), 25%);
-    border-left-color: tint(fadein(@tooltip-bg, 100%), 25%);
-    box-shadow: -3px 3px 7px fade(@black, 7%);
+    left: -@tooltip-arrow-shadow-width * 2;
+
+    &:before {
+      transform: translateX(@tooltip-arrow-rotate-width / 2) rotate(45deg);
+      box-shadow: -@tooltip-arrow-shadow-width @tooltip-arrow-shadow-width 7px fade(@black, 7%);
+    }
   }
 
   &-placement-right &-arrow {
     top: 50%;
-    transform: translateY(-50%) rotate(45deg);
+    transform: translateY(-50%);
   }
 
   &-placement-rightTop &-arrow {
-    top: 8px;
+    top: @tooltip-arrow-offset-vertical;
   }
 
   &-placement-rightBottom &-arrow {
-    bottom: 8px;
+    bottom: @tooltip-arrow-offset-vertical;
   }
 
   &-placement-left &-arrow,
   &-placement-leftTop &-arrow,
   &-placement-leftBottom &-arrow {
-    right: @tooltip-distance - @tooltip-arrow-width + 2px;
-    border-top-color: tint(fadein(@tooltip-bg, 100%), 25%);
-    border-right-color: tint(fadein(@tooltip-bg, 100%), 25%);
-    border-bottom-color: transparent;
-    border-left-color: transparent;
-    box-shadow: 3px -3px 7px fade(@black, 7%);
+    right: -@tooltip-arrow-shadow-width * 2;
+
+    &:before {
+      transform: translateX(-@tooltip-arrow-rotate-width / 2) rotate(45deg);
+      box-shadow: @tooltip-arrow-shadow-width -@tooltip-arrow-shadow-width 7px fade(@black, 7%);
+    }
   }
 
   &-placement-left &-arrow {
     top: 50%;
-    transform: translateY(-50%) rotate(45deg);
+    transform: translateY(-50%);
   }
 
   &-placement-leftTop &-arrow {
-    top: 8px;
+    top: @tooltip-arrow-offset-vertical;
   }
 
   &-placement-leftBottom &-arrow {
-    bottom: 8px;
+    bottom: @tooltip-arrow-offset-vertical;
   }
 
   &-placement-bottom &-arrow,
   &-placement-bottomLeft &-arrow,
   &-placement-bottomRight &-arrow {
-    top: @tooltip-distance - @tooltip-arrow-width + 2px;
-    border-top-color: tint(fadein(@tooltip-bg, 100%), 25%);
-    border-right-color: transparent;
-    border-bottom-color: transparent;
-    border-left-color: tint(fadein(@tooltip-bg, 100%), 25%);
-    box-shadow: -2px -2px 5px fade(@black, 6%);
+    top: -@tooltip-arrow-shadow-width * 2;
+
+    &:before {
+      transform: translateY(@tooltip-arrow-rotate-width / 2) rotate(45deg);
+      box-shadow: -@tooltip-arrow-shadow-width -@tooltip-arrow-shadow-width 7px fade(@black, 7%);
+    }
   }
 
   &-placement-bottom &-arrow {
     left: 50%;
-    transform: translateX(-50%) rotate(45deg);
+    transform: translateX(-50%);
   }
 
   &-placement-bottomLeft &-arrow {
-    left: 16px;
+    left: @tooltip-arrow-offset-horizontal;
   }
 
   &-placement-bottomRight &-arrow {
-    right: 16px;
+    right: @tooltip-arrow-offset-horizontal;
   }
 }

--- a/components/tooltip/style/index.less
+++ b/components/tooltip/style/index.less
@@ -66,7 +66,7 @@
   // Arrows
   &-arrow {
     position: absolute;
-    display: flex;
+    display: block;
     width: @tooltip-arrow-rotate-width;
     height: @tooltip-arrow-rotate-width;
     background: transparent;
@@ -79,8 +79,12 @@
       content: '';
       display: block;
       margin: auto;
+      top: 0;
+      bottom: 0;
+      left: 0;
+      right: 0;
       background-color: @tooltip-bg;
-      position: relative;
+      position: absolute;
       pointer-events: auto;
     }
   }

--- a/components/tooltip/style/index.less
+++ b/components/tooltip/style/index.less
@@ -28,25 +28,25 @@
   &-placement-top,
   &-placement-topLeft,
   &-placement-topRight {
-    padding-bottom: @tooltip-arrow-rotate-width - @tooltip-arrow-shadow-width * 2;
+    padding-bottom: @tooltip-distance;
   }
 
   &-placement-right,
   &-placement-rightTop,
   &-placement-rightBottom {
-    padding-left: @tooltip-arrow-rotate-width - @tooltip-arrow-shadow-width * 2;
+    padding-left: @tooltip-distance;
   }
 
   &-placement-bottom,
   &-placement-bottomLeft,
   &-placement-bottomRight {
-    padding-top: @tooltip-arrow-rotate-width - @tooltip-arrow-shadow-width * 2;
+    padding-top: @tooltip-distance;
   }
 
   &-placement-left,
   &-placement-leftTop,
   &-placement-leftBottom {
-    padding-right: @tooltip-arrow-rotate-width - @tooltip-arrow-shadow-width * 2;
+    padding-right: @tooltip-distance;
   }
 
   // Wrapper for the tooltip content
@@ -88,7 +88,7 @@
   &-placement-top &-arrow,
   &-placement-topLeft &-arrow,
   &-placement-topRight &-arrow {
-    bottom: -@tooltip-arrow-shadow-width * 2;
+    bottom: @tooltip-distance - @tooltip-arrow-rotate-width;
 
     &::before {
       transform: translateY(-@tooltip-arrow-rotate-width / 2) rotate(45deg);
@@ -112,7 +112,7 @@
   &-placement-right &-arrow,
   &-placement-rightTop &-arrow,
   &-placement-rightBottom &-arrow {
-    left: -@tooltip-arrow-shadow-width * 2;
+    left: @tooltip-distance - @tooltip-arrow-rotate-width;
 
     &::before {
       transform: translateX(@tooltip-arrow-rotate-width / 2) rotate(45deg);
@@ -136,7 +136,7 @@
   &-placement-left &-arrow,
   &-placement-leftTop &-arrow,
   &-placement-leftBottom &-arrow {
-    right: -@tooltip-arrow-shadow-width * 2;
+    right: @tooltip-distance - @tooltip-arrow-rotate-width;
 
     &::before {
       transform: translateX(-@tooltip-arrow-rotate-width / 2) rotate(45deg);
@@ -160,7 +160,7 @@
   &-placement-bottom &-arrow,
   &-placement-bottomLeft &-arrow,
   &-placement-bottomRight &-arrow {
-    top: -@tooltip-arrow-shadow-width * 2;
+    top: @tooltip-distance - @tooltip-arrow-rotate-width;
 
     &::before {
       transform: translateY(@tooltip-arrow-rotate-width / 2) rotate(45deg);

--- a/components/tooltip/style/index.less
+++ b/components/tooltip/style/index.less
@@ -73,13 +73,13 @@
     overflow: hidden;
     pointer-events: none;
 
-    &:before {
+    &::before {
       width: @tooltip-arrow-width;
       height: @tooltip-arrow-width;
       content: '';
       display: block;
       margin: auto;
-      background: @tooltip-bg;
+      background-color: @tooltip-bg;
       position: relative;
       pointer-events: auto;
     }
@@ -90,7 +90,7 @@
   &-placement-topRight &-arrow {
     bottom: -@tooltip-arrow-shadow-width * 2;
 
-    &:before {
+    &::before {
       transform: translateY(-@tooltip-arrow-rotate-width / 2) rotate(45deg);
       box-shadow: @tooltip-arrow-shadow-width @tooltip-arrow-shadow-width 7px fade(@black, 7%);
     }
@@ -114,7 +114,7 @@
   &-placement-rightBottom &-arrow {
     left: -@tooltip-arrow-shadow-width * 2;
 
-    &:before {
+    &::before {
       transform: translateX(@tooltip-arrow-rotate-width / 2) rotate(45deg);
       box-shadow: -@tooltip-arrow-shadow-width @tooltip-arrow-shadow-width 7px fade(@black, 7%);
     }
@@ -138,7 +138,7 @@
   &-placement-leftBottom &-arrow {
     right: -@tooltip-arrow-shadow-width * 2;
 
-    &:before {
+    &::before {
       transform: translateX(-@tooltip-arrow-rotate-width / 2) rotate(45deg);
       box-shadow: @tooltip-arrow-shadow-width -@tooltip-arrow-shadow-width 7px fade(@black, 7%);
     }
@@ -162,7 +162,7 @@
   &-placement-bottomRight &-arrow {
     top: -@tooltip-arrow-shadow-width * 2;
 
-    &:before {
+    &::before {
       transform: translateY(@tooltip-arrow-rotate-width / 2) rotate(45deg);
       box-shadow: -@tooltip-arrow-shadow-width -@tooltip-arrow-shadow-width 7px fade(@black, 7%);
     }

--- a/components/tooltip/style/index.less
+++ b/components/tooltip/style/index.less
@@ -8,8 +8,8 @@
 @tooltip-arrow-rotate-width: sqrt(@tooltip-arrow-width * @tooltip-arrow-width * 2) +
   @tooltip-arrow-shadow-width * 2;
 
-@tooltip-arrow-offset-vertical: 5px; // 8 - 3px, 减掉阴影的宽度
-@tooltip-arrow-offset-horizontal: 13px; // 16 - 3px, 减掉阴影的宽度
+@tooltip-arrow-offset-vertical: 5px; // 8 - 3px
+@tooltip-arrow-offset-horizontal: 13px; // 16 - 3px
 
 // Base class
 .@{tooltip-prefix-cls} {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [X] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese | fix: tooltip 在暗色下箭头颜色不融合。    |

### ☑️ Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

![image](https://user-images.githubusercontent.com/6802825/61522640-578f8680-aa45-11e9-90f1-ff149f6596fc.png)


改用 div 加伪元素，伪元素用背景色，旋转 45 度，往 div 边界移动 50%，div 遮住多出部份