### PR TITLE
fix: Styling issue where all spans next to a checkbox wrapper get a padding

### DIFF
--- a/components/checkbox/style/mixin.less
+++ b/components/checkbox/style/mixin.less
@@ -150,7 +150,6 @@
     }
   }
 
-  .@{checkbox-prefix-cls}-wrapper + span,
   .@{checkbox-prefix-cls} + span {
     padding-right: 8px;
     padding-left: 8px;

--- a/components/table/style/index.less
+++ b/components/table/style/index.less
@@ -473,6 +473,10 @@
       overflow: hidden;
     }
 
+    .@{ant-prefix}-checkbox-wrapper + span {
+      padding-left: 8px;
+    }
+
     > .@{ant-prefix}-dropdown-menu > .@{ant-prefix}-dropdown-menu-item:last-child,
     > .@{ant-prefix}-dropdown-menu
       > .@{ant-prefix}-dropdown-menu-submenu:last-child


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

closes #17714

### 💡 Background and solution


- See issue #17714 for background
- Removed padding for ```.ant-checkbox-wrapper + span```, since I don't see it being used anywhere. This style should be only available on the ```.ant-checkbox + span``` class.


| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
