### PR TITLE
fix: Input line height in IE

### DIFF
--- a/components/input/style/mixin.less
+++ b/components/input/style/mixin.less
@@ -9,12 +9,14 @@
   padding: @input-padding-vertical-lg @input-padding-horizontal-lg;
   font-size: @font-size-lg;
   line-height: @input-height-lg;
+  line-height: ~'@{line-height-base} \9'; // https://github.com/ant-design/ant-design/issues/17753
 }
 
 .input-sm() {
   height: @input-height-sm;
   padding: @input-padding-vertical-sm @input-padding-horizontal-sm;
   line-height: @input-height-sm;
+  line-height: ~'@{line-height-base} \9'; // https://github.com/ant-design/ant-design/issues/17753
 }
 
 // input status
@@ -52,6 +54,7 @@
   color: @input-color;
   font-size: @font-size-base;
   line-height: @input-height-base;
+  line-height: ~'@{line-height-base} \9'; // https://github.com/ant-design/ant-design/issues/17753
   background-color: @input-bg;
   background-image: none;
   border: @border-width-base @border-style-base @input-border-color;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close #17753

### 💡 Background and solution

<img width="1042" alt="图片" src="https://user-images.githubusercontent.com/507615/61578370-584d1900-ab28-11e9-9148-92490d33630d.png">

Use some css hacks to reset `line-height`.

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Input line height style bug in IE  |
| 🇨🇳 Chinese | 修复 Input 在 IE 下错位的问题 |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
