### PR TITLE
fix: Transfer change `dataSource` will re-fresh lazy render

### DIFF
--- a/components/transfer/__tests__/list.test.js
+++ b/components/transfer/__tests__/list.test.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { mount } from 'enzyme';
 import List from '../list';
 import Checkbox from '../../checkbox';
-import raf from '../../_util/raf';
 
 const listCommonProps = {
   prefixCls: 'ant-transfer-list',

--- a/components/transfer/__tests__/list.test.js
+++ b/components/transfer/__tests__/list.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { mount } from 'enzyme';
 import List from '../list';
 import Checkbox from '../../checkbox';
+import raf from '../../_util/raf';
 
 const listCommonProps = {
   prefixCls: 'ant-transfer-list',

--- a/components/transfer/renderListBody.tsx
+++ b/components/transfer/renderListBody.tsx
@@ -30,6 +30,7 @@ class ListBody extends React.Component<TransferListBodyProps> {
   };
 
   private mountId: number;
+  private lazyId: number;
 
   componentDidMount() {
     this.mountId = raf(() => {
@@ -45,7 +46,8 @@ class ListBody extends React.Component<TransferListBodyProps> {
       // TODO: Replace this with ref when react 15 support removed.
       const container = findDOMNode(this);
 
-      raf(() => {
+      raf.cancel(this.lazyId);
+      this.lazyId = raf(() => {
         if (container) {
           const scrollEvent = new Event('scroll', { bubbles: true });
           container.dispatchEvent(scrollEvent);
@@ -56,6 +58,7 @@ class ListBody extends React.Component<TransferListBodyProps> {
 
   componentWillUnmount() {
     raf.cancel(this.mountId);
+    raf.cancel(this.lazyId);
   }
 
   onItemSelect = (item: TransferItem) => {

--- a/components/transfer/renderListBody.tsx
+++ b/components/transfer/renderListBody.tsx
@@ -38,7 +38,10 @@ class ListBody extends React.Component<TransferListBodyProps> {
   }
 
   componentDidUpdate(prevProps: TransferListBodyProps) {
-    if (prevProps.filteredRenderItems.length !== this.props.filteredRenderItems.length) {
+    if (
+      prevProps.filteredRenderItems.length !== this.props.filteredRenderItems.length &&
+      this.props.lazy !== false
+    ) {
       // TODO: Replace this with ref when react 15 support removed.
       const container = findDOMNode(this);
 

--- a/components/transfer/renderListBody.tsx
+++ b/components/transfer/renderListBody.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { findDOMNode } from 'react-dom';
 import Animate from 'rc-animate';
 import raf from '../_util/raf';
 import { Omit, tuple } from '../_util/type';
@@ -34,6 +35,20 @@ class ListBody extends React.Component<TransferListBodyProps> {
     this.mountId = raf(() => {
       this.setState({ mounted: true });
     });
+  }
+
+  componentDidUpdate(prevProps: TransferListBodyProps) {
+    if (prevProps.filteredRenderItems.length !== this.props.filteredRenderItems.length) {
+      // TODO: Replace this with ref when react 15 support removed.
+      const container = findDOMNode(this);
+
+      raf(() => {
+        if (container) {
+          const scrollEvent = new Event('scroll', { bubbles: true });
+          container.dispatchEvent(scrollEvent);
+        }
+      });
+    }
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

fix #17716

### 💡 Background and solution

## `react-lazy-load` N 年没更新了，这边模拟触发个 `scroll` 事件来强制刷新。

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fix Transfer not re-render list when `dataSource` with `lazy`     |
| 🇨🇳 Chinese |   修复 Transfer 在 `lazy` 时更新数据不触发重新渲染的问题。        |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
