### PR TITLE
fix: Result extra is not centered

### DIFF
--- a/components/result/style/index.less
+++ b/components/result/style/index.less
@@ -57,6 +57,9 @@
     text-align: center;
     > * {
       margin-right: 8px;
+      &:last-child {
+        margin-right: 0;
+      }
     }
   }
 


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

Result extra 部分视觉上不居中

### 💡 Background and solution

为 extra 最后一个子元素设置 `margin-right: 0`

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Repair Result extra is not centered |
| 🇨🇳 Chinese | 修复 Result 组件 extra 部分不居中 |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

不需要更新文档
