### PR TITLE
fix: Update select component with custom suffixIcon to display loading indicator while loading

### DIFF
--- a/components/grid/style/index.less
+++ b/components/grid/style/index.less
@@ -62,8 +62,8 @@
 
 .@{ant-prefix}-col {
   // Prevent columns from collapsing when empty
-  min-height: 1px;
   position: relative;
+  min-height: 1px;
 }
 
 .make-grid-columns();

--- a/components/select/index.tsx
+++ b/components/select/index.tsx
@@ -57,10 +57,7 @@ export interface SelectProps<T = SelectValue> extends AbstractSelectProps {
   mode?: 'default' | 'multiple' | 'tags' | 'combobox' | string;
   optionLabelProp?: string;
   firstActiveValue?: string | string[];
-  onChange?: (
-    value: T,
-    option: React.ReactElement<any> | React.ReactElement<any>[],
-  ) => void;
+  onChange?: (value: T, option: React.ReactElement<any> | React.ReactElement<any>[]) => void;
   onSelect?: (value: T extends (infer I)[] ? I : T, option: React.ReactElement<any>) => void;
   onDeselect?: (value: T extends (infer I)[] ? I : T) => void;
   onBlur?: (value: T) => void;
@@ -183,15 +180,15 @@ export default class Select<T = SelectValue> extends React.Component<SelectProps
 
   renderSuffixIcon(prefixCls: string) {
     const { loading, suffixIcon } = this.props;
+    if (loading) {
+      return <Icon type="loading" />;
+    }
     if (suffixIcon) {
       return React.isValidElement<{ className?: string }>(suffixIcon)
         ? React.cloneElement(suffixIcon, {
             className: classNames(suffixIcon.props.className, `${prefixCls}-arrow-icon`),
           })
         : suffixIcon;
-    }
-    if (loading) {
-      return <Icon type="loading" />;
     }
     return <Icon type="down" className={`${prefixCls}-arrow-icon`} />;
   }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

The select component does not work properly if a `suffixIcon` is provided. The loading icon is not shown, because of the wrong order of the if conditions in the `renderSuffixIcon` method.
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

- Fix select component with custom suffixIcon to display loading indicator while loading
<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |         x  |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed