### PR TITLE
fix: make alert message attribute affect message even without description

### DIFF
--- a/components/alert/style/index.less
+++ b/components/alert/style/index.less
@@ -124,6 +124,10 @@
     font-size: @font-size-lg;
   }
 
+  &-message {
+    color: @alert-message-color;
+  }
+
   &-with-description &-description {
     display: block;
   }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

https://github.com/ant-design/ant-design/issues/12626

When I create an alert without a description `alert-message-color` does not affect the color.



### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

1. When I switch to dark theme on my app the default text color is light which makes it unreadable on the warning message.
2. ![Selection_042](https://user-images.githubusercontent.com/36059111/61667547-3e3a4480-aca8-11e9-8407-8dd83f98ea81.png)
3. Make it an option to change the message color even without a description.


### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->
Ability to change the text color of an alert message without a description.

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | x          |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
