### PR TITLE
fix: CountDown should support escape

### DIFF
--- a/components/statistic/__tests__/index.test.js
+++ b/components/statistic/__tests__/index.test.js
@@ -3,6 +3,7 @@ import MockDate from 'mockdate';
 import moment from 'moment';
 import { mount } from 'enzyme';
 import Statistic from '..';
+import { formatTimeStr } from '../utils';
 
 const delay = timeout => new Promise(resolve => setTimeout(resolve, timeout));
 
@@ -102,6 +103,12 @@ describe('Statistic', () => {
         expect(onFinish).toHaveBeenCalled();
         jest.useFakeTimers();
       });
+    });
+  });
+
+  describe('utils', () => {
+    it('format should support escape', () => {
+      expect(formatTimeStr(1000 * 60 * 60 * 24, 'D [Day]')).toBe('1 Day');
     });
   });
 });

--- a/components/statistic/utils.tsx
+++ b/components/statistic/utils.tsx
@@ -35,10 +35,14 @@ const timeUnits: [string, number][] = [
   ['S', 1], // million seconds
 ];
 
-function formatTimeStr(duration: number, format: string) {
+export function formatTimeStr(duration: number, format: string) {
   let leftDuration: number = duration;
 
-  return timeUnits.reduce((current, [name, unit]) => {
+  const escapeRegex = /\[[^\]]*\]/g;
+  const keepList: string[] = (format.match(escapeRegex) || []).map(str => str.slice(1, -1));
+  const templateText = format.replace(escapeRegex, '[]');
+
+  const replacedText = timeUnits.reduce((current, [name, unit]) => {
     if (current.indexOf(name) !== -1) {
       const value = Math.floor(leftDuration / unit);
       leftDuration -= value * unit;
@@ -48,7 +52,14 @@ function formatTimeStr(duration: number, format: string) {
       });
     }
     return current;
-  }, format);
+  }, templateText);
+
+  let index = 0;
+  return replacedText.replace(escapeRegex, () => {
+    const match = keepList[index];
+    index += 1;
+    return match;
+  });
 }
 
 export function formatCountdown(value: countdownValueType, config: CountdownFormatConfig) {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close #17830

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Fix Statistic.Countdown `format` not escaping characters in square brackets       |
| 🇨🇳 Chinese |      修复 Statistic.Countdown `format` 不支持方括号保留字符串的问题     |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
