### PR TITLE
fix: table filter dropdown trigger onChange on some situation

### DIFF
--- a/components/table/__tests__/Table.filter.test.js
+++ b/components/table/__tests__/Table.filter.test.js
@@ -621,6 +621,39 @@ describe('Table.filter', () => {
     expect(wrapper.find('.ant-input').instance().value).toBe('');
   });
 
+  // https://github.com/ant-design/ant-design/issues/17833
+  it('should not trigger onChange when bluring custom filterDropdown', () => {
+    const onChange = jest.fn();
+    const wrapper = mount(
+      createTable({
+        onChange,
+        columns: [
+          {
+            title: 'Name',
+            dataIndex: 'name',
+            key: 'name',
+            filterDropdown: ({ setSelectedKeys }) => (
+              <input onChange={e => setSelectedKeys([e.target.value])} />
+            ),
+          },
+        ],
+      }),
+    );
+    wrapper
+      .find('.ant-dropdown-trigger')
+      .first()
+      .simulate('click');
+    wrapper
+      .find('input')
+      .first()
+      .simulate('change', { target: { value: 'whatevervalue' } });
+    wrapper
+      .find('.ant-dropdown-trigger')
+      .first()
+      .simulate('click');
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
   // https://github.com/ant-design/ant-design/issues/17089
   it('not crash when dynamic change filter', () => {
     const onChange = jest.fn();

--- a/components/table/demo/custom-filter-panel.md
+++ b/components/table/demo/custom-filter-panel.md
@@ -132,7 +132,7 @@ class App extends React.Component {
         ...this.getColumnSearchProps('address'),
       },
     ];
-    return <Table columns={columns} dataSource={data} />;
+    return <Table columns={columns} dataSource={data} onChange={this.onChange} />;
   }
 }
 

--- a/components/table/demo/custom-filter-panel.md
+++ b/components/table/demo/custom-filter-panel.md
@@ -132,7 +132,7 @@ class App extends React.Component {
         ...this.getColumnSearchProps('address'),
       },
     ];
-    return <Table columns={columns} dataSource={data} onChange={this.onChange} />;
+    return <Table columns={columns} dataSource={data} />;
   }
 }
 

--- a/components/table/filterDropdown.tsx
+++ b/components/table/filterDropdown.tsx
@@ -132,7 +132,9 @@ class FilterMenu<T> extends React.Component<FilterMenuProps<T>, FilterMenuState<
 
   onVisibleChange = (visible: boolean) => {
     this.setVisible(visible);
-    if (!visible) {
+    const { column } = this.props;
+    // https://github.com/ant-design/ant-design/issues/17833
+    if (!visible && !(column.filterDropdown instanceof Function)) {
       this.confirmFilter();
     }
   };

--- a/components/table/filterDropdown.tsx
+++ b/components/table/filterDropdown.tsx
@@ -138,12 +138,13 @@ class FilterMenu<T> extends React.Component<FilterMenuProps<T>, FilterMenuState<
   };
 
   confirmFilter() {
+    const { column, selectedKeys: propSelectedKeys, confirmFilter } = this.props;
     const { selectedKeys, valueKeys } = this.state;
-    const { filterDropdown } = this.props.column;
+    const { filterDropdown } = column;
 
-    if (!shallowequal(selectedKeys, this.props.selectedKeys)) {
-      this.props.confirmFilter(
-        this.props.column,
+    if (!shallowequal(selectedKeys, propSelectedKeys)) {
+      confirmFilter(
+        column,
         filterDropdown
           ? selectedKeys
           : selectedKeys.map(key => valueKeys[key]).filter(key => key !== undefined),


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close #17833

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Table custom `filterDropdown` always triggering `onChange` in some situations. |
| 🇨🇳 Chinese | 修复 Table 自定义 `filterDropdown` 在某些情况下消失时总是触发 `onChange` 的问题。 |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
