### PR TITLE
fix: remove a tag in Alert component

### DIFF
--- a/components/alert/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/alert/__tests__/__snapshots__/demo.test.js.snap
@@ -68,6 +68,7 @@ exports[`renders ./components/alert/demo/banner.md correctly 1`] = `
     />
     <span
       class="ant-alert-close-icon"
+      role="button"
     >
       <i
         aria-label="icon: close"
@@ -172,6 +173,7 @@ exports[`renders ./components/alert/demo/closable.md correctly 1`] = `
     />
     <span
       class="ant-alert-close-icon"
+      role="button"
     >
       <i
         aria-label="icon: close"
@@ -210,6 +212,7 @@ exports[`renders ./components/alert/demo/closable.md correctly 1`] = `
     </span>
     <span
       class="ant-alert-close-icon"
+      role="button"
     >
       <i
         aria-label="icon: close"
@@ -250,6 +253,7 @@ exports[`renders ./components/alert/demo/close-text.md correctly 1`] = `
   />
   <span
     class="ant-alert-close-icon"
+    role="button"
   >
     <span
       class="ant-alert-close-text"
@@ -904,6 +908,7 @@ exports[`renders ./components/alert/demo/smooth-closed.md correctly 1`] = `
     />
     <span
       class="ant-alert-close-icon"
+      role="button"
     >
       <i
         aria-label="icon: close"

--- a/components/alert/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/alert/__tests__/__snapshots__/demo.test.js.snap
@@ -66,7 +66,7 @@ exports[`renders ./components/alert/demo/banner.md correctly 1`] = `
     <span
       class="ant-alert-description"
     />
-    <a
+    <span
       class="ant-alert-close-icon"
     >
       <i
@@ -88,7 +88,7 @@ exports[`renders ./components/alert/demo/banner.md correctly 1`] = `
           />
         </svg>
       </i>
-    </a>
+    </span>
   </div>
   <br />
   <div
@@ -170,7 +170,7 @@ exports[`renders ./components/alert/demo/closable.md correctly 1`] = `
     <span
       class="ant-alert-description"
     />
-    <a
+    <span
       class="ant-alert-close-icon"
     >
       <i
@@ -192,7 +192,7 @@ exports[`renders ./components/alert/demo/closable.md correctly 1`] = `
           />
         </svg>
       </i>
-    </a>
+    </span>
   </div>
   <div
     class="ant-alert ant-alert-error ant-alert-with-description ant-alert-no-icon ant-alert-closable"
@@ -208,7 +208,7 @@ exports[`renders ./components/alert/demo/closable.md correctly 1`] = `
     >
       Error Description Error Description Error Description Error Description Error Description Error Description
     </span>
-    <a
+    <span
       class="ant-alert-close-icon"
     >
       <i
@@ -230,7 +230,7 @@ exports[`renders ./components/alert/demo/closable.md correctly 1`] = `
           />
         </svg>
       </i>
-    </a>
+    </span>
   </div>
 </div>
 `;
@@ -248,11 +248,15 @@ exports[`renders ./components/alert/demo/close-text.md correctly 1`] = `
   <span
     class="ant-alert-description"
   />
-  <a
+  <span
     class="ant-alert-close-icon"
   >
-    Close Now
-  </a>
+    <span
+      class="ant-alert-close-text"
+    >
+      Close Now
+    </span>
+  </span>
 </div>
 `;
 
@@ -898,7 +902,7 @@ exports[`renders ./components/alert/demo/smooth-closed.md correctly 1`] = `
     <span
       class="ant-alert-description"
     />
-    <a
+    <span
       class="ant-alert-close-icon"
     >
       <i
@@ -920,7 +924,7 @@ exports[`renders ./components/alert/demo/smooth-closed.md correctly 1`] = `
           />
         </svg>
       </i>
-    </a>
+    </span>
   </div>
   <p>
     placeholder text here

--- a/components/alert/index.tsx
+++ b/components/alert/index.tsx
@@ -134,9 +134,13 @@ export default class Alert extends React.Component<AlertProps, AlertState> {
     );
 
     const closeIcon = closable ? (
-      <a onClick={this.handleClose} className={`${prefixCls}-close-icon`}>
-        {closeText || <Icon type="close" />}
-      </a>
+      <span onClick={this.handleClose} className={`${prefixCls}-close-icon`}>
+        {closeText ? (
+          <span className={`${prefixCls}-close-text`}>{closeText}</span>
+        ) : (
+          <Icon type="close" />
+        )}
+      </span>
     ) : null;
 
     const dataOrAriaProps = getDataOrAriaProps(this.props);

--- a/components/alert/index.tsx
+++ b/components/alert/index.tsx
@@ -134,7 +134,7 @@ export default class Alert extends React.Component<AlertProps, AlertState> {
     );
 
     const closeIcon = closable ? (
-      <span onClick={this.handleClose} className={`${prefixCls}-close-icon`}>
+      <span role="button" onClick={this.handleClose} className={`${prefixCls}-close-icon`}>
         {closeText ? (
           <span className={`${prefixCls}-close-text`}>{closeText}</span>
         ) : (

--- a/components/alert/style/index.less
+++ b/components/alert/style/index.less
@@ -86,8 +86,11 @@
   }
 
   &-close-text {
-    position: absolute;
-    right: 16px;
+    color: @alert-close-color;
+    transition: color 0.3s;
+    &:hover {
+      color: @alert-close-hover-color;
+    }
   }
 
   &-with-description {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

https://github.com/ant-design/ant-design/issues/17853

### 💡 Background and solution

when <a> component wrapper <Alert> component, react produce warnning `Warning: validateDOMNesting(...): <a> cannot appear as a descendant of <a>.`

![image](https://user-images.githubusercontent.com/9160851/61844398-db2bf600-aed1-11e9-9c97-b02e2c4f6560.png)
![image](https://user-images.githubusercontent.com/9160851/61844424-f139b680-aed1-11e9-8f25-0abd93ecceaf.png)


I switch <a> component to <span> component and add `.ant-alert-close-text` css class to `closeText`. `.ant-alert-close-text` is use here only. I change style rules the same as closeIcon.
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
