### PR TITLE
fix: make ant-timeline-item-pending background-color transparent

### DIFF
--- a/components/timeline/style/index.less
+++ b/components/timeline/style/index.less
@@ -27,6 +27,7 @@
 
     &-pending &-head {
       font-size: @font-size-sm;
+      background-color: transparent;
     }
 
     &-pending &-tail {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

[#17927](https://github.com/ant-design/ant-design/issues/17927)

### 💡 Background and solution

1. Timeline pending icon background always white
![image](https://user-images.githubusercontent.com/49077331/62045463-f54e3700-b237-11e9-82a7-1832ffd8c241.png)
2. add 
```less
&-pending &-head {
      ...
      background-color: transparent;
}
```
can fixed this issue.
![image](https://user-images.githubusercontent.com/49077331/62045640-75749c80-b238-11e9-8ef8-2915c7a5cd50.png)

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
