### PR TITLE
fix: make timeline component show more comfort under none-white background color

### DIFF
--- a/components/timeline/style/index.less
+++ b/components/timeline/style/index.less
@@ -152,8 +152,9 @@
 
   &&-reverse &-item-pending {
     .@{timeline-prefix-cls}-item-tail {
-      top: 13px;
+      top: 15px;
       display: block;
+      height: calc(100% - 15px);
       border-left: 2px dotted @timeline-color;
     }
     .@{timeline-prefix-cls}-item-content {

--- a/components/timeline/style/index.less
+++ b/components/timeline/style/index.less
@@ -142,6 +142,7 @@
 
   &&-pending &-item-last &-item-tail {
     display: block;
+    height: calc(100% - 14px);
     border-left: 2px dotted @timeline-color;
   }
 
@@ -151,9 +152,9 @@
 
   &&-reverse &-item-pending {
     .@{timeline-prefix-cls}-item-tail {
+      top: 13px;
       display: block;
       border-left: 2px dotted @timeline-color;
-      top: 11px;
     }
     .@{timeline-prefix-cls}-item-content {
       min-height: 48px;

--- a/components/timeline/style/index.less
+++ b/components/timeline/style/index.less
@@ -19,14 +19,15 @@
 
     &-tail {
       position: absolute;
-      top: 0.75em;
+      top: 10px;
       left: 4px;
-      height: 100%;
+      height: calc(100% - 10px);
       border-left: @timeline-width solid @timeline-color;
     }
 
     &-pending &-head {
       font-size: @font-size-sm;
+      background-color: transparent;
     }
 
     &-pending &-tail {

--- a/components/timeline/style/index.less
+++ b/components/timeline/style/index.less
@@ -153,6 +153,7 @@
     .@{timeline-prefix-cls}-item-tail {
       display: block;
       border-left: 2px dotted @timeline-color;
+      top: 11px;
     }
     .@{timeline-prefix-cls}-item-content {
       min-height: 48px;


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close #17927

### 💡 Background and solution

This is bug:
![issue](https://user-images.githubusercontent.com/7405300/62058814-9ba83580-b254-11e9-8ae8-b7c0f1a49bdd.gif)

And this fixed:
![fix1](https://user-images.githubusercontent.com/7405300/62061168-386cd200-b259-11e9-8f35-1915c4dafe5e.gif)
![fix2](https://user-images.githubusercontent.com/7405300/62061177-3a369580-b259-11e9-86bf-0dad052f8a71.gif)
![fix3](https://user-images.githubusercontent.com/7405300/62061183-3c005900-b259-11e9-9b60-ddb06cf06d15.gif)

Solution:
change background-color&top&height



### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  make timeline component show more comfort under none-white background color |
| 🇨🇳 Chinese | 修复了 timeline 组件在非纯白色背景下显示不和谐的问题 |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
