### PR TITLE
fix: children of Tabs[type="editable-card"] cannot be falsy

### DIFF
--- a/components/tabs/__tests__/index.test.js
+++ b/components/tabs/__tests__/index.test.js
@@ -16,6 +16,9 @@ describe('Tabs', () => {
           <TabPane tab="foo" key="1">
             foo
           </TabPane>
+          {undefined}
+          {null}
+          {false}
         </Tabs>,
       );
     });
@@ -31,6 +34,10 @@ describe('Tabs', () => {
     it('remove card', () => {
       wrapper.find('.anticon-close').simulate('click');
       expect(handleEdit).toHaveBeenCalledWith('1', 'remove');
+    });
+
+    it('validateElement', () => {
+      expect(wrapper.find('.ant-tabs-tab').length).toBe(1);
     });
   });
 

--- a/components/tabs/demo/custom-add-trigger.md
+++ b/components/tabs/demo/custom-add-trigger.md
@@ -84,7 +84,6 @@ class Demo extends React.Component {
               {pane.content}
             </TabPane>
           ))}
-          {undefined}
         </Tabs>
       </div>
     );

--- a/components/tabs/demo/custom-add-trigger.md
+++ b/components/tabs/demo/custom-add-trigger.md
@@ -84,6 +84,7 @@ class Demo extends React.Component {
               {pane.content}
             </TabPane>
           ))}
+          {undefined}
         </Tabs>
       </div>
     );

--- a/components/tabs/index.tsx
+++ b/components/tabs/index.tsx
@@ -132,6 +132,7 @@ export default class Tabs extends React.Component<TabsProps, any> {
       React.Children.forEach(
         children as React.ReactNode,
         (child: React.ReactElement<any>, index) => {
+        if(child){
           let closable = child.props.closable;
           closable = typeof closable === 'undefined' ? true : closable;
           const closeIcon = closable ? (
@@ -152,6 +153,7 @@ export default class Tabs extends React.Component<TabsProps, any> {
               key: child.key || index,
             }),
           );
+        }
         },
       );
       // Add new tab handler

--- a/components/tabs/index.tsx
+++ b/components/tabs/index.tsx
@@ -129,33 +129,29 @@ export default class Tabs extends React.Component<TabsProps, any> {
     let childrenWithClose: React.ReactElement<any>[] = [];
     if (type === 'editable-card') {
       childrenWithClose = [];
-      React.Children.forEach(
-        children as React.ReactNode,
-        (child: React.ReactElement<any>, index) => {
-          if (child) {
-            let closable = child.props.closable;
-            closable = typeof closable === 'undefined' ? true : closable;
-            const closeIcon = closable ? (
-              <Icon
-                type="close"
-                className={`${prefixCls}-close-x`}
-                onClick={e => this.removeTab(child.key as string, e)}
-              />
-            ) : null;
-            childrenWithClose.push(
-              React.cloneElement(child, {
-                tab: (
-                  <div className={closable ? undefined : `${prefixCls}-tab-unclosable`}>
-                    {child.props.tab}
-                    {closeIcon}
-                  </div>
-                ),
-                key: child.key || index,
-              }),
-            );
-          }
-        },
-      );
+      React.Children.forEach(children as React.ReactNode, (child, index) => {
+        if (!React.isValidElement(child)) return child;
+        let closable = child.props.closable;
+        closable = typeof closable === 'undefined' ? true : closable;
+        const closeIcon = closable ? (
+          <Icon
+            type="close"
+            className={`${prefixCls}-close-x`}
+            onClick={e => this.removeTab(child.key as string, e)}
+          />
+        ) : null;
+        childrenWithClose.push(
+          React.cloneElement(child, {
+            tab: (
+              <div className={closable ? undefined : `${prefixCls}-tab-unclosable`}>
+                {child.props.tab}
+                {closeIcon}
+              </div>
+            ),
+            key: child.key || index,
+          }),
+        );
+      });
       // Add new tab handler
       if (!hideAdd) {
         tabBarExtraContent = (

--- a/components/tabs/index.tsx
+++ b/components/tabs/index.tsx
@@ -125,7 +125,6 @@ export default class Tabs extends React.Component<TabsProps, any> {
       [`${prefixCls}-${type}`]: true,
       [`${prefixCls}-no-animation`]: !tabPaneAnimated,
     });
-
     // only card type tabs can be added and closed
     let childrenWithClose: React.ReactElement<any>[] = [];
     if (type === 'editable-card') {

--- a/components/tabs/index.tsx
+++ b/components/tabs/index.tsx
@@ -132,28 +132,28 @@ export default class Tabs extends React.Component<TabsProps, any> {
       React.Children.forEach(
         children as React.ReactNode,
         (child: React.ReactElement<any>, index) => {
-        if(child){
-          let closable = child.props.closable;
-          closable = typeof closable === 'undefined' ? true : closable;
-          const closeIcon = closable ? (
-            <Icon
-              type="close"
-              className={`${prefixCls}-close-x`}
-              onClick={e => this.removeTab(child.key as string, e)}
-            />
-          ) : null;
-          childrenWithClose.push(
-            React.cloneElement(child, {
-              tab: (
-                <div className={closable ? undefined : `${prefixCls}-tab-unclosable`}>
-                  {child.props.tab}
-                  {closeIcon}
-                </div>
-              ),
-              key: child.key || index,
-            }),
-          );
-        }
+          if (child) {
+            let closable = child.props.closable;
+            closable = typeof closable === 'undefined' ? true : closable;
+            const closeIcon = closable ? (
+              <Icon
+                type="close"
+                className={`${prefixCls}-close-x`}
+                onClick={e => this.removeTab(child.key as string, e)}
+              />
+            ) : null;
+            childrenWithClose.push(
+              React.cloneElement(child, {
+                tab: (
+                  <div className={closable ? undefined : `${prefixCls}-tab-unclosable`}>
+                    {child.props.tab}
+                    {closeIcon}
+                  </div>
+                ),
+                key: child.key || index,
+              }),
+            );
+          }
         },
       );
       // Add new tab handler

--- a/components/tabs/index.tsx
+++ b/components/tabs/index.tsx
@@ -129,33 +129,29 @@ export default class Tabs extends React.Component<TabsProps, any> {
     let childrenWithClose: React.ReactElement<any>[] = [];
     if (type === 'editable-card') {
       childrenWithClose = [];
-      React.Children.forEach(
-        children as React.ReactNode,
-        (child: React.ReactElement<any>, index) => {
-        if(child){
-          let closable = child.props.closable;
-          closable = typeof closable === 'undefined' ? true : closable;
-          const closeIcon = closable ? (
-            <Icon
-              type="close"
-              className={`${prefixCls}-close-x`}
-              onClick={e => this.removeTab(child.key as string, e)}
-            />
-          ) : null;
-          childrenWithClose.push(
-            React.cloneElement(child, {
-              tab: (
-                <div className={closable ? undefined : `${prefixCls}-tab-unclosable`}>
-                  {child.props.tab}
-                  {closeIcon}
-                </div>
-              ),
-              key: child.key || index,
-            }),
-          );
-        }
-        },
-      );
+      React.Children.forEach(children as React.ReactNode, (child, index) => {
+        if (!React.isValidElement(child)) return child;
+        let closable = child.props.closable;
+        closable = typeof closable === 'undefined' ? true : closable;
+        const closeIcon = closable ? (
+          <Icon
+            type="close"
+            className={`${prefixCls}-close-x`}
+            onClick={e => this.removeTab(child.key as string, e)}
+          />
+        ) : null;
+        childrenWithClose.push(
+          React.cloneElement(child, {
+            tab: (
+              <div className={closable ? undefined : `${prefixCls}-tab-unclosable`}>
+                {child.props.tab}
+                {closeIcon}
+              </div>
+            ),
+            key: child.key || index,
+          }),
+        );
+      });
       // Add new tab handler
       if (!hideAdd) {
         tabBarExtraContent = (

--- a/components/tabs/index.tsx
+++ b/components/tabs/index.tsx
@@ -125,6 +125,7 @@ export default class Tabs extends React.Component<TabsProps, any> {
       [`${prefixCls}-${type}`]: true,
       [`${prefixCls}-no-animation`]: !tabPaneAnimated,
     });
+
     // only card type tabs can be added and closed
     let childrenWithClose: React.ReactElement<any>[] = [];
     if (type === 'editable-card') {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    if tabs type ="editable-card",if children has falsy value ,we will get error message,so we should fix it。 [demo](https://codesandbox.io/s/lively-glade-jmg5s ) here is error info      |
| 🇨🇳 Chinese |      当tabs组件使用type为"editable-card"时，如果子组件为falsy值会导致程序报错，因此增加了一个判断去修复这个bug     |

### ☑️ Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed


-----
[View rendered components/tabs/demo/custom-add-trigger.md](https://github.com/oldturkey/ant-design/blob/master/components/tabs/demo/custom-add-trigger.md)