### PR TITLE
refactor: Tag should be span than a div semantically 

### DIFF
--- a/components/config-provider/__tests__/__snapshots__/components.test.js.snap
+++ b/components/config-provider/__tests__/__snapshots__/components.test.js.snap
@@ -12542,46 +12542,46 @@ exports[`ConfigProvider components Tabs prefixCls 1`] = `
 
 exports[`ConfigProvider components Tags configProvider 1`] = `
 <div>
-  <div
+  <span
     class="config-tag"
   >
     Bamboo
-  </div>
-  <div
+  </span>
+  <span
     class="config-tag config-tag-checkable"
   >
     Light
-  </div>
+  </span>
 </div>
 `;
 
 exports[`ConfigProvider components Tags normal 1`] = `
 <div>
-  <div
+  <span
     class="ant-tag"
   >
     Bamboo
-  </div>
-  <div
+  </span>
+  <span
     class="ant-tag ant-tag-checkable"
   >
     Light
-  </div>
+  </span>
 </div>
 `;
 
 exports[`ConfigProvider components Tags prefixCls 1`] = `
 <div>
-  <div
+  <span
     class="prefix-Tags"
   >
     Bamboo
-  </div>
-  <div
+  </span>
+  <span
     class="prefix-Tags prefix-Tags-checkable"
   >
     Light
-  </div>
+  </span>
 </div>
 `;
 

--- a/components/date-picker/__tests__/__snapshots__/RangePicker.test.js.snap
+++ b/components/date-picker/__tests__/__snapshots__/RangePicker.test.js.snap
@@ -3043,11 +3043,11 @@ exports[`RangePicker switch to corresponding month panel when click presetted ra
             <div
               class="ant-calendar-footer-extra ant-calendar-range-quick-selector"
             >
-              <div
+              <span
                 class="ant-tag ant-tag-blue"
               >
                 My Birthday
-              </div>
+              </span>
             </div>
             <a
               class="ant-calendar-time-picker-btn"

--- a/components/page-header/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/page-header/__tests__/__snapshots__/demo.test.js.snap
@@ -54,11 +54,11 @@ exports[`renders ./components/page-header/demo/actions.md correctly 1`] = `
     <span
       class="ant-page-header-heading-tags"
     >
-      <div
+      <span
         class="ant-tag ant-tag-red"
       >
         Warning
-      </div>
+      </span>
     </span>
     <span
       class="ant-page-header-heading-extra"

--- a/components/table/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/table/__tests__/__snapshots__/demo.test.js.snap
@@ -350,16 +350,16 @@ exports[`renders ./components/table/demo/basic.md correctly 1`] = `
                     class=""
                   >
                     <span>
-                      <div
+                      <span
                         class="ant-tag ant-tag-green"
                       >
                         NICE
-                      </div>
-                      <div
+                      </span>
+                      <span
                         class="ant-tag ant-tag-geekblue"
                       >
                         DEVELOPER
-                      </div>
+                      </span>
                     </span>
                   </td>
                   <td
@@ -413,11 +413,11 @@ exports[`renders ./components/table/demo/basic.md correctly 1`] = `
                     class=""
                   >
                     <span>
-                      <div
+                      <span
                         class="ant-tag ant-tag-volcano"
                       >
                         LOSER
-                      </div>
+                      </span>
                     </span>
                   </td>
                   <td
@@ -471,16 +471,16 @@ exports[`renders ./components/table/demo/basic.md correctly 1`] = `
                     class=""
                   >
                     <span>
-                      <div
+                      <span
                         class="ant-tag ant-tag-green"
                       >
                         COOL
-                      </div>
-                      <div
+                      </span>
+                      <span
                         class="ant-tag ant-tag-geekblue"
                       >
                         TEACHER
-                      </div>
+                      </span>
                     </span>
                   </td>
                   <td
@@ -10912,16 +10912,16 @@ exports[`renders ./components/table/demo/jsx.md correctly 1`] = `
                     class=""
                   >
                     <span>
-                      <div
+                      <span
                         class="ant-tag ant-tag-blue"
                       >
                         nice
-                      </div>
-                      <div
+                      </span>
+                      <span
                         class="ant-tag ant-tag-blue"
                       >
                         developer
-                      </div>
+                      </span>
                     </span>
                   </td>
                   <td
@@ -10976,11 +10976,11 @@ exports[`renders ./components/table/demo/jsx.md correctly 1`] = `
                     class=""
                   >
                     <span>
-                      <div
+                      <span
                         class="ant-tag ant-tag-blue"
                       >
                         loser
-                      </div>
+                      </span>
                     </span>
                   </td>
                   <td
@@ -11035,16 +11035,16 @@ exports[`renders ./components/table/demo/jsx.md correctly 1`] = `
                     class=""
                   >
                     <span>
-                      <div
+                      <span
                         class="ant-tag ant-tag-blue"
                       >
                         cool
-                      </div>
-                      <div
+                      </span>
+                      <span
                         class="ant-tag ant-tag-blue"
                       >
                         teacher
-                      </div>
+                      </span>
                     </span>
                   </td>
                   <td

--- a/components/tag/CheckableTag.tsx
+++ b/components/tag/CheckableTag.tsx
@@ -29,7 +29,7 @@ export default class CheckableTag extends React.Component<CheckableTagProps> {
     );
 
     delete (restProps as any).onChange; // TypeScript cannot check delete now.
-    return <div {...(restProps as any)} className={cls} onClick={this.handleClick} />;
+    return <span {...(restProps as any)} className={cls} onClick={this.handleClick} />;
   };
 
   render() {

--- a/components/tag/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/tag/__tests__/__snapshots__/demo.test.js.snap
@@ -9,7 +9,7 @@ exports[`renders ./components/tag/demo/animation.md correctly 1`] = `
       <span
         style="display:inline-block"
       >
-        <div
+        <span
           class="ant-tag"
         >
           Tag 1
@@ -33,12 +33,12 @@ exports[`renders ./components/tag/demo/animation.md correctly 1`] = `
               />
             </svg>
           </i>
-        </div>
+        </span>
       </span>
       <span
         style="display:inline-block"
       >
-        <div
+        <span
           class="ant-tag"
         >
           Tag 2
@@ -62,12 +62,12 @@ exports[`renders ./components/tag/demo/animation.md correctly 1`] = `
               />
             </svg>
           </i>
-        </div>
+        </span>
       </span>
       <span
         style="display:inline-block"
       >
-        <div
+        <span
           class="ant-tag"
         >
           Tag 3
@@ -91,11 +91,11 @@ exports[`renders ./components/tag/demo/animation.md correctly 1`] = `
               />
             </svg>
           </i>
-        </div>
+        </span>
       </span>
     </div>
   </div>
-  <div
+  <span
     class="ant-tag"
     style="background:#fff;border-style:dashed"
   >
@@ -122,18 +122,18 @@ exports[`renders ./components/tag/demo/animation.md correctly 1`] = `
       </svg>
     </i>
      New Tag
-  </div>
+  </span>
 </div>
 `;
 
 exports[`renders ./components/tag/demo/basic.md correctly 1`] = `
 <div>
-  <div
+  <span
     class="ant-tag"
   >
     Tag 1
-  </div>
-  <div
+  </span>
+  <span
     class="ant-tag"
   >
     <a
@@ -141,8 +141,8 @@ exports[`renders ./components/tag/demo/basic.md correctly 1`] = `
     >
       Link
     </a>
-  </div>
-  <div
+  </span>
+  <span
     class="ant-tag"
   >
     Tag 2
@@ -166,8 +166,8 @@ exports[`renders ./components/tag/demo/basic.md correctly 1`] = `
         />
       </svg>
     </i>
-  </div>
-  <div
+  </span>
+  <span
     class="ant-tag"
   >
     Prevent Default
@@ -191,27 +191,27 @@ exports[`renders ./components/tag/demo/basic.md correctly 1`] = `
         />
       </svg>
     </i>
-  </div>
+  </span>
 </div>
 `;
 
 exports[`renders ./components/tag/demo/checkable.md correctly 1`] = `
 <div>
-  <div
+  <span
     class="ant-tag ant-tag-checkable ant-tag-checkable-checked"
   >
     Tag1
-  </div>
-  <div
+  </span>
+  <span
     class="ant-tag ant-tag-checkable ant-tag-checkable-checked"
   >
     Tag2
-  </div>
-  <div
+  </span>
+  <span
     class="ant-tag ant-tag-checkable ant-tag-checkable-checked"
   >
     Tag3
-  </div>
+  </span>
 </div>
 `;
 
@@ -223,61 +223,61 @@ exports[`renders ./components/tag/demo/colorful.md correctly 1`] = `
     Presets:
   </h4>
   <div>
-    <div
+    <span
       class="ant-tag ant-tag-magenta"
     >
       magenta
-    </div>
-    <div
+    </span>
+    <span
       class="ant-tag ant-tag-red"
     >
       red
-    </div>
-    <div
+    </span>
+    <span
       class="ant-tag ant-tag-volcano"
     >
       volcano
-    </div>
-    <div
+    </span>
+    <span
       class="ant-tag ant-tag-orange"
     >
       orange
-    </div>
-    <div
+    </span>
+    <span
       class="ant-tag ant-tag-gold"
     >
       gold
-    </div>
-    <div
+    </span>
+    <span
       class="ant-tag ant-tag-lime"
     >
       lime
-    </div>
-    <div
+    </span>
+    <span
       class="ant-tag ant-tag-green"
     >
       green
-    </div>
-    <div
+    </span>
+    <span
       class="ant-tag ant-tag-cyan"
     >
       cyan
-    </div>
-    <div
+    </span>
+    <span
       class="ant-tag ant-tag-blue"
     >
       blue
-    </div>
-    <div
+    </span>
+    <span
       class="ant-tag ant-tag-geekblue"
     >
       geekblue
-    </div>
-    <div
+    </span>
+    <span
       class="ant-tag ant-tag-purple"
     >
       purple
-    </div>
+    </span>
   </div>
   <h4
     style="margin:16px 0"
@@ -285,42 +285,42 @@ exports[`renders ./components/tag/demo/colorful.md correctly 1`] = `
     Custom:
   </h4>
   <div>
-    <div
+    <span
       class="ant-tag ant-tag-has-color"
       style="background-color:#f50"
     >
       #f50
-    </div>
-    <div
+    </span>
+    <span
       class="ant-tag ant-tag-has-color"
       style="background-color:#2db7f5"
     >
       #2db7f5
-    </div>
-    <div
+    </span>
+    <span
       class="ant-tag ant-tag-has-color"
       style="background-color:#87d068"
     >
       #87d068
-    </div>
-    <div
+    </span>
+    <span
       class="ant-tag ant-tag-has-color"
       style="background-color:#108ee9"
     >
       #108ee9
-    </div>
+    </span>
   </div>
 </div>
 `;
 
 exports[`renders ./components/tag/demo/control.md correctly 1`] = `
 <div>
-  <div
+  <span
     class="ant-tag"
   >
     Unremovable
-  </div>
-  <div
+  </span>
+  <span
     class="ant-tag"
   >
     Tag 2
@@ -344,8 +344,8 @@ exports[`renders ./components/tag/demo/control.md correctly 1`] = `
         />
       </svg>
     </i>
-  </div>
-  <div
+  </span>
+  <span
     class="ant-tag"
   >
     Tag 3
@@ -369,8 +369,8 @@ exports[`renders ./components/tag/demo/control.md correctly 1`] = `
         />
       </svg>
     </i>
-  </div>
-  <div
+  </span>
+  <span
     class="ant-tag"
     style="background:#fff;border-style:dashed"
   >
@@ -397,13 +397,13 @@ exports[`renders ./components/tag/demo/control.md correctly 1`] = `
       </svg>
     </i>
      New Tag
-  </div>
+  </span>
 </div>
 `;
 
 exports[`renders ./components/tag/demo/controlled.md correctly 1`] = `
 <div>
-  <div
+  <span
     class="ant-tag"
   >
     Movies
@@ -427,7 +427,7 @@ exports[`renders ./components/tag/demo/controlled.md correctly 1`] = `
         />
       </svg>
     </i>
-  </div>
+  </span>
   <br />
   <button
     class="ant-btn ant-btn-sm"
@@ -447,25 +447,25 @@ exports[`renders ./components/tag/demo/hot-tags.md correctly 1`] = `
   >
     Categories:
   </h6>
-  <div
+  <span
     class="ant-tag ant-tag-checkable"
   >
     Movies
-  </div>
-  <div
+  </span>
+  <span
     class="ant-tag ant-tag-checkable"
   >
     Books
-  </div>
-  <div
+  </span>
+  <span
     class="ant-tag ant-tag-checkable"
   >
     Music
-  </div>
-  <div
+  </span>
+  <span
     class="ant-tag ant-tag-checkable"
   >
     Sports
-  </div>
+  </span>
 </div>
 `;

--- a/components/tag/__tests__/__snapshots__/index.test.js.snap
+++ b/components/tag/__tests__/__snapshots__/index.test.js.snap
@@ -1,37 +1,37 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Tag visibility can be controlled by visible with hidden as initial value 1`] = `
-<div
+<span
   class="ant-tag ant-tag-hidden"
 />
 `;
 
 exports[`Tag visibility can be controlled by visible with hidden as initial value 2`] = `
-<div
+<span
   class="ant-tag"
 />
 `;
 
 exports[`Tag visibility can be controlled by visible with hidden as initial value 3`] = `
-<div
+<span
   class="ant-tag ant-tag-hidden"
 />
 `;
 
 exports[`Tag visibility can be controlled by visible with visible as initial value 1`] = `
-<div
+<span
   class="ant-tag"
 />
 `;
 
 exports[`Tag visibility can be controlled by visible with visible as initial value 2`] = `
-<div
+<span
   class="ant-tag ant-tag-hidden"
 />
 `;
 
 exports[`Tag visibility can be controlled by visible with visible as initial value 3`] = `
-<div
+<span
   class="ant-tag"
 />
 `;

--- a/components/tag/__tests__/index.test.js
+++ b/components/tag/__tests__/index.test.js
@@ -15,12 +15,12 @@ describe('Tag', () => {
     const onClose = jest.fn();
     const wrapper = mount(<Tag closable onClose={onClose} />);
     expect(wrapper.find('.anticon-close').length).toBe(1);
-    expect(wrapper.find('div.ant-tag:not(.ant-tag-hidden)').length).toBe(1);
+    expect(wrapper.find('.ant-tag:not(.ant-tag-hidden)').length).toBe(1);
     wrapper.find('.anticon-close').simulate('click');
     expect(onClose).toHaveBeenCalled();
     jest.runAllTimers();
     wrapper.update();
-    expect(wrapper.find('div.ant-tag:not(.ant-tag-hidden)').length).toBe(0);
+    expect(wrapper.find('.ant-tag:not(.ant-tag-hidden)').length).toBe(0);
   });
 
   it('should not be closed when prevent default', () => {
@@ -29,10 +29,10 @@ describe('Tag', () => {
     };
     const wrapper = mount(<Tag closable onClose={onClose} />);
     expect(wrapper.find('.anticon-close').length).toBe(1);
-    expect(wrapper.find('div.ant-tag:not(.ant-tag-hidden)').length).toBe(1);
+    expect(wrapper.find('.ant-tag:not(.ant-tag-hidden)').length).toBe(1);
     wrapper.find('.anticon-close').simulate('click');
     jest.runAllTimers();
-    expect(wrapper.find('div.ant-tag:not(.ant-tag-hidden)').length).toBe(1);
+    expect(wrapper.find('.ant-tag:not(.ant-tag-hidden)').length).toBe(1);
   });
 
   describe('visibility', () => {

--- a/components/tag/index.tsx
+++ b/components/tag/index.tsx
@@ -11,7 +11,7 @@ import Wave from '../_util/wave';
 
 export { CheckableTagProps } from './CheckableTag';
 
-export interface TagProps extends React.HTMLAttributes<HTMLDivElement> {
+export interface TagProps extends React.HTMLAttributes<HTMLSpanElement> {
   prefixCls?: string;
   className?: string;
   color?: string;
@@ -118,19 +118,23 @@ class Tag extends React.Component<TagProps, TagState> {
     const { prefixCls: customizePrefixCls, children, ...otherProps } = this.props;
     const isNeedWave =
       'onClick' in otherProps || (children && (children as React.ReactElement<any>).type === 'a');
-    const divProps = omit(otherProps, ['onClose', 'afterClose', 'color', 'visible', 'closable']);
+    const tagProps = omit(otherProps, ['onClose', 'afterClose', 'color', 'visible', 'closable']);
     return isNeedWave ? (
       <Wave>
-        <div {...divProps} className={this.getTagClassName(configProps)} style={this.getTagStyle()}>
+        <span
+          {...tagProps}
+          className={this.getTagClassName(configProps)}
+          style={this.getTagStyle()}
+        >
           {children}
           {this.renderCloseIcon()}
-        </div>
+        </span>
       </Wave>
     ) : (
-      <div {...divProps} className={this.getTagClassName(configProps)} style={this.getTagStyle()}>
+      <span {...tagProps} className={this.getTagClassName(configProps)} style={this.getTagStyle()}>
         {children}
         {this.renderCloseIcon()}
-      </div>
+      </span>
     );
   };
 

--- a/components/transfer/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/transfer/__tests__/__snapshots__/demo.test.js.snap
@@ -1320,11 +1320,11 @@ exports[`renders ./components/transfer/demo/table-transfer.md correctly 1`] = `
                             <td
                               class=""
                             >
-                              <div
+                              <span
                                 class="ant-tag"
                               >
                                 cat
-                              </div>
+                              </span>
                             </td>
                             <td
                               class=""
@@ -1369,11 +1369,11 @@ exports[`renders ./components/transfer/demo/table-transfer.md correctly 1`] = `
                             <td
                               class=""
                             >
-                              <div
+                              <span
                                 class="ant-tag"
                               >
                                 dog
-                              </div>
+                              </span>
                             </td>
                             <td
                               class=""
@@ -1418,11 +1418,11 @@ exports[`renders ./components/transfer/demo/table-transfer.md correctly 1`] = `
                             <td
                               class=""
                             >
-                              <div
+                              <span
                                 class="ant-tag"
                               >
                                 cat
-                              </div>
+                              </span>
                             </td>
                             <td
                               class=""
@@ -1468,11 +1468,11 @@ exports[`renders ./components/transfer/demo/table-transfer.md correctly 1`] = `
                             <td
                               class=""
                             >
-                              <div
+                              <span
                                 class="ant-tag"
                               >
                                 dog
-                              </div>
+                              </span>
                             </td>
                             <td
                               class=""
@@ -1517,11 +1517,11 @@ exports[`renders ./components/transfer/demo/table-transfer.md correctly 1`] = `
                             <td
                               class=""
                             >
-                              <div
+                              <span
                                 class="ant-tag"
                               >
                                 cat
-                              </div>
+                              </span>
                             </td>
                             <td
                               class=""
@@ -1566,11 +1566,11 @@ exports[`renders ./components/transfer/demo/table-transfer.md correctly 1`] = `
                             <td
                               class=""
                             >
-                              <div
+                              <span
                                 class="ant-tag"
                               >
                                 dog
-                              </div>
+                              </span>
                             </td>
                             <td
                               class=""
@@ -1615,11 +1615,11 @@ exports[`renders ./components/transfer/demo/table-transfer.md correctly 1`] = `
                             <td
                               class=""
                             >
-                              <div
+                              <span
                                 class="ant-tag"
                               >
                                 cat
-                              </div>
+                              </span>
                             </td>
                             <td
                               class=""
@@ -1664,11 +1664,11 @@ exports[`renders ./components/transfer/demo/table-transfer.md correctly 1`] = `
                             <td
                               class=""
                             >
-                              <div
+                              <span
                                 class="ant-tag"
                               >
                                 dog
-                              </div>
+                              </span>
                             </td>
                             <td
                               class=""
@@ -1714,11 +1714,11 @@ exports[`renders ./components/transfer/demo/table-transfer.md correctly 1`] = `
                             <td
                               class=""
                             >
-                              <div
+                              <span
                                 class="ant-tag"
                               >
                                 cat
-                              </div>
+                              </span>
                             </td>
                             <td
                               class=""
@@ -1763,11 +1763,11 @@ exports[`renders ./components/transfer/demo/table-transfer.md correctly 1`] = `
                             <td
                               class=""
                             >
-                              <div
+                              <span
                                 class="ant-tag"
                               >
                                 dog
-                              </div>
+                              </span>
                             </td>
                             <td
                               class=""


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [x] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close #17963

### 💡 Background and solution

```
Warning: validateDOMNesting(...): <div> cannot appear as a descendant of <p>.
    in div (created by Context.Consumer)
    in Tag
    in p
```

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Tag now will be rendered as a `span`. |
| 🇨🇳 Chinese | 调整 Tag 的 html 标签为 `span`。 |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
