### PR TITLE
doc: update Table component's selectedRowKeys wrong type

### DIFF
--- a/components/table/index.en-US.md
+++ b/components/table/index.en-US.md
@@ -169,7 +169,7 @@ Properties for row selection.
 | fixed | Fixed selection column on the left | boolean | - |  |
 | getCheckboxProps | Get Checkbox or Radio props | Function(record) | - |  |
 | hideDefaultSelections | Remove the default `Select All` and `Select Invert` selections when [custom selection](#components-table-demo-row-selection-custom) | boolean | `false` |  |
-| selectedRowKeys | Controlled selected row keys | string\[] | \[] |  |
+| selectedRowKeys | Controlled selected row keys | string\[]\|number[] | \[] |  |
 | selections | Custom selection [config](#rowSelection), only displays default selections when set to `true` | object\[]\|boolean | - |  |
 | type | `checkbox` or `radio` | `checkbox` \| `radio` | `checkbox` |  |
 | onChange | Callback executed when selected rows change | Function(selectedRowKeys, selectedRows) | - |  |

--- a/components/table/index.zh-CN.md
+++ b/components/table/index.zh-CN.md
@@ -174,7 +174,7 @@ const columns = [
 | fixed | 把选择框列固定在左边 | boolean | - |  |
 | getCheckboxProps | 选择框的默认属性配置 | Function(record) | - |  |
 | hideDefaultSelections | [自定义选择项](#components-table-demo-row-selection-custom)时去掉『全选』『反选』两个默认选项 | boolean | false |  |
-| selectedRowKeys | 指定选中项的 key 数组，需要和 onChange 进行配合 | string\[] | \[] |  |
+| selectedRowKeys | 指定选中项的 key 数组，需要和 onChange 进行配合 | string\[]\|number[] | \[] |  |
 | selections | 自定义选择项 [配置项](#selection), 设为 `true` 时使用默认选择项 | object\[]\|boolean | true |  |
 | type | 多选/单选，`checkbox` or `radio` | string | `checkbox` |  |
 | onChange | 选中项发生变化时的回调 | Function(selectedRowKeys, selectedRows) | - |  |


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / document update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution
**Why?**
- When I referenced ant-design's table interface, It should be fixed as i updated docs in this pr
  - https://github.com/ant-design/ant-design/blob/master/components/table/interface.tsx#L97

**Solutions**
  - string[] -> string[] \| number[]  
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   string[] -> string[] \| number[]     |
| 🇨🇳 Chinese |   string[] -> string[] \| number[]    |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed


-----
[View rendered components/table/index.en-US.md](https://github.com/zx6658/ant-design/blob/master/components/table/index.en-US.md)
[View rendered components/table/index.zh-CN.md](https://github.com/zx6658/ant-design/blob/master/components/table/index.zh-CN.md)