### PR TITLE
fix(documentation): :book: Add missing transitions properties for `Select`, `AutoComplete` and `TreeSelect`

### DIFF
--- a/components/auto-complete/index.en-US.md
+++ b/components/auto-complete/index.en-US.md
@@ -25,6 +25,7 @@ const dataSource = ['12345', '23456', '34567'];
 | backfill | backfill selected item the input when using keyboard | boolean | false |  |
 | children (for customize input element) | customize input element | HTMLInputElement / HTMLTextAreaElement / React.ReactElement<InputProps> | `<Input />` |  |
 | children (for dataSource) | Data source for autocomplete | React.ReactElement<OptionProps> / Array&lt;React.ReactElement<OptionProps>> | - |  |
+| choiceTransitionName | CSS animation name for selected items. Only applies when `mode` is set to `multiple` or `tags`. Set to `''` to discard the animation. | string | 'zoom' |  |
 | dataSource | Data source for autocomplete | [DataSourceItemType](https://git.io/vMMKF)\[] | - |  |
 | defaultActiveFirstOption | Whether active first option by default | boolean | true |  |
 | defaultValue | Initial selected option. | string\|string\[] | - |  |
@@ -32,6 +33,7 @@ const dataSource = ['12345', '23456', '34567'];
 | filterOption | If true, filter options by input, if function, filter options against it. The function will receive two arguments, `inputValue` and `option`, if the function returns `true`, the option will be included in the filtered set; Otherwise, it will be excluded. | boolean or function(inputValue, option) | true |  |
 | optionLabelProp | Which prop value of option will render as content of select. | string | `children` |  |
 | placeholder | placeholder of input | string | - |  |
+| transitionName | Dropdown CSS animation name | string | 'slide-up' |  |
 | value | selected option | string\|string\[]\|{ key: string, label: string\|ReactNode }\|Array&lt;{ key: string, label: string\|ReactNode }> | - |  |
 | onBlur | Called when leaving the component. | function() | - | 3.6.5 |
 | onChange | Called when select an option or input value change, or value of input is changed | function(value) | - |  |

--- a/components/select/index.en-US.md
+++ b/components/select/index.en-US.md
@@ -26,6 +26,7 @@ Select component to select value from options.
 | allowClear | Show clear button. | boolean | false |  |
 | autoClearSearchValue | Whether the current search will be cleared on selecting an item. Only applies when `mode` is set to `multiple` or `tags`. | boolean | true | 3.10.0 |
 | autoFocus | Get focus by default | boolean | false |  |
+| choiceTransitionName | CSS animation name for selected items. Only applies when `mode` is set to `multiple` or `tags`. Set to `''` to discard the animation. | string | 'zoom' |  |
 | defaultActiveFirstOption | Whether active first option by default | boolean | true |  |
 | defaultValue | Initial selected option. | string\|string\[]<br />number\|number\[]<br />LabeledValue\|LabeledValue[] | - |  |
 | disabled | Whether disabled select | boolean | false |  |
@@ -53,6 +54,7 @@ Select component to select value from options.
 | clearIcon | The custom clear icon | ReactNode | - | 3.11.0 |
 | menuItemSelectedIcon | The custom menuItemSelected icon with multiple options | ReactNode | - | 3.11.0 |
 | tokenSeparators | Separator used to tokenize on tag/multiple mode | string\[] |  |  |
+| transitionName | Dropdown CSS animation name | string | 'slide-up' |  |
 | value | Current selected option. | string\|string\[]\<br />number\|number\[]\<br />LabeledValue\|LabeledValue[] | - |  |
 | onBlur | Called when blur | function | - |  |
 | onChange | Called when select an option or input value change, or value of input is changed in combobox mode | function(value, option:Option/Array&lt;Option>) | - |  |

--- a/components/tree-select/index.en-US.md
+++ b/components/tree-select/index.en-US.md
@@ -18,6 +18,7 @@ Tree selection control.
 | --- | --- | --- | --- | --- |
 | allowClear | Whether allow clear | boolean | false |  |
 | autoClearSearchValue | auto clear search input value when multiple select is selected/deselected | boolean | true | 3.7.0 |
+| choiceTransitionName | CSS animation name for selected items. Only applies when `mode` is set to `multiple` or `tags`. Set to `''` to discard the animation. | string | 'zoom' |  |
 | defaultValue | To set the initial selected treeNode(s). | string\|string\[] | - |  |
 | disabled | Disabled or not | boolean | false |  |
 | dropdownClassName | className of dropdown menu | string | - | 3.3.0 |
@@ -38,6 +39,7 @@ Tree selection control.
 | showSearch | Support search or not | boolean | single: `false` \| multiple: `true` |  |
 | size | To set the size of the select input, options: `large` `small` | string | 'default' |  |
 | suffixIcon | The custom suffix icon | ReactNode | - | 3.10.0 |
+| transitionName | Dropdown CSS animation name | string | 'slide-up' |  |
 | treeCheckable | Whether to show checkbox on the treeNodes | boolean | false |  |
 | treeCheckStrictly | Whether to check nodes precisely (in the `checkable` mode), means parent and child nodes are not associated, and it will make `labelInValue` be true | boolean | false |  |
 | treeData | Data of the treeNodes, manual construction work is no longer needed if this property has been set(ensure the Uniqueness of each value) | array\<{ value, title, children, \[disabled, disableCheckbox, selectable] }> | \[] |  |


### PR DESCRIPTION
### 🤔 This is a ...

- [x] Site / document update

### 💡 Background and solution

 ⚠️ _**PLEASE NOTICE**_ ⚠️ This PR adds missing properties documentation, but as I am not speaking Chinese I could only add it to the English documentation versions.

My team and I struggled a bit with disabling animations for rendering choices _inside_ the `Select` component in _multi/tag_ mode.

After looking to different approaches...
We couldn't use the suggested one in #951 as the styling structure in our codebase didn't allow us to override the input's specific animation.
Later we tried to set the `animation` property for the descendants of the input to `none` what lead lead to disabling the animation itself, but added a delay to the removal / addition of new choices to the input - causes a very weird "laggy" feeling.

Slightly further into the investigation we found that the underlying `rc-select` component is the one to control the animation and it does that using the `choiceTrnaisitionName` property. Which is set defaultly to `zoom` by ant-design's `Select`, `AutoComplete` and `TreeSelect` components.

Overriding the default value with an empty string turned out to work perfectly without css manipulation and I suppose there are more people out there that didn't know that these components expose this property when using it as **it is not listed in the API table** for the components in the website.

This PR adds the `choiceTransitionName` and `transitionName` supported by the underlying `rc-select` and exposed by ant-design's `Select`, `AutoComplete` and `TreeSelect` to the API properties list.

Here one can see the difference, the first is with css override to `animation: none;` and the second using the property `choiceTransitionName=''`:

![unanimated-select](https://user-images.githubusercontent.com/6689688/62216183-92c87880-b3a8-11e9-90d7-420d293b98ff.gif)

And a code example in [codesandbox](https://codesandbox.io/s/gracious-leakey-bk7ce)

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Add missing `choiceTranitionName` and `transitionName` properites in `Select`, `AutoComplete` and `TreeSelect` documentation |
| 🇨🇳 Chinese |  **_???_**     |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/auto-complete/index.en-US.md](https://github.com/altJake/ant-design/blob/add-missing-transition-doc/components/auto-complete/index.en-US.md)
[View rendered components/select/index.en-US.md](https://github.com/altJake/ant-design/blob/add-missing-transition-doc/components/select/index.en-US.md)
[View rendered components/tree-select/index.en-US.md](https://github.com/altJake/ant-design/blob/add-missing-transition-doc/components/tree-select/index.en-US.md)