### PR TITLE
fix: select-search-box broken style

### DIFF
--- a/components/select/style/index.less
+++ b/components/select/style/index.less
@@ -109,7 +109,7 @@
     }
   }
 
-  &-no-arrow &-selection-selected-value {
+  &-selection-selected-value {
     padding-right: 0;
   }
 
@@ -150,6 +150,14 @@
 
     .@{select-prefix-cls}-selection__rendered {
       margin-right: 24px;
+    }
+  }
+
+  &-no-arrow {
+    padding-right: 0;
+
+    .@{select-prefix-cls}-selection__rendered {
+      margin-right: 11px;
     }
   }
 

--- a/components/select/style/index.less
+++ b/components/select/style/index.less
@@ -109,7 +109,7 @@
     }
   }
 
-  &-selection-selected-value {
+  &-no-arrow &-selection-selected-value {
     padding-right: 0;
   }
 
@@ -154,8 +154,6 @@
   }
 
   &-no-arrow {
-    padding-right: 0;
-
     .@{select-prefix-cls}-selection__rendered {
       margin-right: 11px;
     }

--- a/components/select/style/index.less
+++ b/components/select/style/index.less
@@ -155,7 +155,7 @@
 
   &-no-arrow {
     .@{select-prefix-cls}-selection__rendered {
-      margin-right: 11px;
+      margin-right: @control-padding-horizontal - 1px;
     }
   }
 


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
[#17760 ](https://github.com/ant-design/ant-design/pull/17760)
### 💡 Background and solution
修复上面的pr引进的问题
![image](https://user-images.githubusercontent.com/31769726/62305687-00f96200-b4b3-11e9-817c-73eb07cf8d63.png)
之前在ant-select-selection--single选择器下修改其子类选择器的margin属性值，修复了[#17760 ](https://github.com/ant-design/ant-design/pull/17760)的问题，但是导致了上图所示的bug。 

"搜索框" 为单选(应用了ant-select--selection--single)  但是右边却没有对应的下箭头图标占位。这是单选的唯一一个例外情况。

该例外与其他单选的差别是在应用了ant-select--selection--single的节点的父节点多了一个ant-select-no-arrow选择器，考虑到不过多改动之前的代码，采用了样式覆盖这种比较hack 的做法hhh

### 📝 Changelog
| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |      修复pr     |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
