### PR TITLE
add waring for props#iconType in component Alert

### DIFF
--- a/components/alert/__tests__/index.test.js
+++ b/components/alert/__tests__/index.test.js
@@ -49,4 +49,19 @@ describe('Alert', () => {
       expect(input.getAttribute('role')).toBe('status');
     });
   });
+
+  it('warning for props#iconType', () => {
+    const warnSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    mount(
+      <Alert
+        message="Warning Text Warning Text Warning TextW arning Text Warning Text Warning TextWarning Text"
+        type="warning"
+        iconType="up"
+      />,
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      'Warning: [antd: Alert] `iconType` is deprecated. Please use `icon` instead.',
+    );
+    warnSpy.mockRestore();
+  });
 });

--- a/components/alert/index.tsx
+++ b/components/alert/index.tsx
@@ -5,6 +5,7 @@ import Icon, { ThemeType } from '../icon';
 import classNames from 'classnames';
 import { ConfigConsumer, ConfigConsumerProps } from '../config-provider';
 import getDataOrAriaProps from '../_util/getDataOrAriaProps';
+import warning from '../_util/warning';
 
 function noop() {}
 
@@ -41,10 +42,20 @@ export interface AlertState {
 }
 
 export default class Alert extends React.Component<AlertProps, AlertState> {
-  state: AlertState = {
-    closing: true,
-    closed: false,
-  };
+  constructor(props: AlertProps) {
+    super(props);
+
+    warning(
+      !('iconType' in props),
+      'Alert',
+      '`iconType` is deprecated. Please use `icon` instead.',
+    );
+
+    this.state = {
+      closing: true,
+      closed: false,
+    };
+  }
 
   handleClose = (e: React.MouseEvent<HTMLAnchorElement>) => {
     e.preventDefault();
@@ -89,8 +100,6 @@ export default class Alert extends React.Component<AlertProps, AlertState> {
     type = banner && type === undefined ? 'warning' : type || 'info';
 
     let iconTheme: ThemeType = 'filled';
-    // should we give a warning?
-    // warning(!iconType, `The property 'iconType' is deprecated. Use the property 'icon' instead.`);
     if (!iconType) {
       switch (type) {
         case 'success':


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [x] Other: add waring for props#iconType in component Alert

### 🔗 Related issue link

https://github.com/ant-design/ant-design/issues/16911

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

Icon component will no longer support props#type in antd v4, so add `deprecated` warning for props#iconType in component Alert, and antd v4 will remove props#iconType in component Alert.

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
