### PR TITLE
Fixed typo in theme documentation.

### DIFF
--- a/docs/react/customize-theme.en-US.md
+++ b/docs/react/customize-theme.en-US.md
@@ -129,9 +129,9 @@ You must import styles as less format. A common mistake would be importing multi
 - If you import styles by specifying the `style` option of [babel-plugin-import](https://github.com/ant-design/babel-plugin-import), change it from `'css'` to `true`, which will import the `less` version of antd.
 - If you import styles from `'antd/dist/antd.css'`, change it to `antd/dist/antd.less`.
 
-## Offcial Themes 🌈
+## Official Themes 🌈
 
-We have some offcial themes, try on and give us feedback!
+We have some official themes, try them out and give us some feedback!
 
 - [Dark Theme (Beta)](https://github.com/ant-design/ant-design-dark-theme)
 - [Aliyun Console Theme (Beta)](https://github.com/ant-design/ant-design-aliyun-theme)


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [X] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)


### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           ☑️|
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [X] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed


-----
[View rendered docs/react/customize-theme.en-US.md](https://github.com/cyclic-reference/ant-design/blob/documentation-typo-fix/docs/react/customize-theme.en-US.md)