### PR TITLE
fix: ConfigProvider wrapper locale no need with only children

### DIFF
--- a/components/config-provider/__tests__/locale.test.js
+++ b/components/config-provider/__tests__/locale.test.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import ConfigProvider from '..';
+
+describe('ConfigProvider.Locale', () => {
+  it('not throw', () => {
+    mount(
+      <ConfigProvider locale={{}}>
+        <span />
+        <span />
+      </ConfigProvider>,
+    );
+  });
+});

--- a/components/config-provider/__tests__/locale.test.js
+++ b/components/config-provider/__tests__/locale.test.js
@@ -4,6 +4,10 @@ import ConfigProvider from '..';
 
 describe('ConfigProvider.Locale', () => {
   it('not throw', () => {
+    if (process.env.REACT === '15') {
+      return;
+    }
+
     mount(
       <ConfigProvider locale={{}}>
         <span />

--- a/components/locale-provider/index.tsx
+++ b/components/locale-provider/index.tsx
@@ -82,6 +82,6 @@ export default class LocaleProvider extends React.Component<LocaleProviderProps,
   }
 
   render() {
-    return React.Children.only(this.props.children);
+    return this.props.children;
   }
 }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

Crash when ConfigProvider with multiple children

### 💡 Background and solution

Remove `Children.only`

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fix ConfigProvider crash with multiple children     |
| 🇨🇳 Chinese |    修复 ConfigProvider 存在多个子节点崩溃的问题。       |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
