### PR TITLE
fix: ConfigProvider should not block LocaleProvider

### DIFF
--- a/components/config-provider/__tests__/locale.test.js
+++ b/components/config-provider/__tests__/locale.test.js
@@ -1,6 +1,9 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import ConfigProvider from '..';
+import LocaleProvider from '../../locale-provider';
+import locale from '../../locale/zh_CN';
+import TimePicker from '../../time-picker';
 
 describe('ConfigProvider.Locale', () => {
   it('not throw', () => {
@@ -14,5 +17,45 @@ describe('ConfigProvider.Locale', () => {
         <span />
       </ConfigProvider>,
     );
+  });
+
+  describe('support legacy LocaleProvider', () => {
+    function testLocale(wrapper) {
+      expect(wrapper.find('input').props().placeholder).toBe(locale.TimePicker.placeholder);
+    }
+
+    it('LocaleProvider', () => {
+      const wrapper = mount(
+        <LocaleProvider locale={locale}>
+          <TimePicker />
+        </LocaleProvider>,
+      );
+
+      testLocale(wrapper);
+    });
+
+    it('LocaleProvider > ConfigProvider', () => {
+      const wrapper = mount(
+        <LocaleProvider locale={locale}>
+          <ConfigProvider>
+            <TimePicker />
+          </ConfigProvider>
+        </LocaleProvider>,
+      );
+
+      testLocale(wrapper);
+    });
+
+    it('ConfigProvider > ConfigProvider', () => {
+      const wrapper = mount(
+        <ConfigProvider locale={locale}>
+          <ConfigProvider>
+            <TimePicker />
+          </ConfigProvider>
+        </ConfigProvider>,
+      );
+
+      testLocale(wrapper);
+    });
   });
 });

--- a/components/config-provider/index.tsx
+++ b/components/config-provider/index.tsx
@@ -3,6 +3,7 @@ import createReactContext from '@ant-design/create-react-context';
 
 import defaultRenderEmpty, { RenderEmptyHandler } from './renderEmpty';
 import LocaleProvider, { Locale, ANT_MARK } from '../locale-provider';
+import LocaleReceiver from '../locale-provider/LocaleReceiver';
 
 export { RenderEmptyHandler };
 
@@ -62,7 +63,7 @@ class ConfigProvider extends React.Component<ConfigProviderProps> {
     return suffixCls ? `${prefixCls}-${suffixCls}` : prefixCls;
   };
 
-  renderProvider = (context: ConfigConsumerProps) => {
+  renderProvider = (context: ConfigConsumerProps, legacyLocale: Locale) => {
     const {
       children,
       getPopupContainer,
@@ -88,7 +89,7 @@ class ConfigProvider extends React.Component<ConfigProviderProps> {
 
     return (
       <ConfigContext.Provider value={config}>
-        <LocaleProvider locale={locale} _ANT_MARK__={ANT_MARK}>
+        <LocaleProvider locale={locale || legacyLocale} _ANT_MARK__={ANT_MARK}>
           {children}
         </LocaleProvider>
       </ConfigContext.Provider>
@@ -96,7 +97,15 @@ class ConfigProvider extends React.Component<ConfigProviderProps> {
   };
 
   render() {
-    return <ConfigConsumer>{this.renderProvider}</ConfigConsumer>;
+    return (
+      <LocaleReceiver>
+        {(_, __, legacyLocale) => (
+          <ConfigConsumer>
+            {context => this.renderProvider(context, legacyLocale as Locale)}
+          </ConfigConsumer>
+        )}
+      </LocaleReceiver>
+    );
   }
 }
 

--- a/components/locale-provider/LocaleReceiver.tsx
+++ b/components/locale-provider/LocaleReceiver.tsx
@@ -5,7 +5,7 @@ import defaultLocaleData from './default';
 export interface LocaleReceiverProps {
   componentName?: string;
   defaultLocale?: object | Function;
-  children: (locale: object, localeCode?: string) => React.ReactNode;
+  children: (locale: object, localeCode?: string, fullLocale?: object) => React.ReactNode;
 }
 
 interface LocaleInterface {
@@ -50,6 +50,6 @@ export default class LocaleReceiver extends React.Component<LocaleReceiverProps>
   }
 
   render() {
-    return this.props.children(this.getLocale(), this.getLocaleCode());
+    return this.props.children(this.getLocale(), this.getLocaleCode(), this.context.antLocale);
   }
 }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

ConfigProvider will block LocaleProvider work
```jsx
<LocaleProvider locale={locale}>
  <ConfigProvider>
    {...}
  </ConfigProvider>
</LocaleProvider>
```

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Fix ConfigProvider nest in LocaleProvider make `locale` not work.     |
| 🇨🇳 Chinese |    修复 ConfigProvider 嵌套于 LocaleProvider 内时 `locale` 无效的问题。      |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
