### PR TITLE
fix: Textarea show scroll when autosize

### DIFF
--- a/components/input/__tests__/index.test.js
+++ b/components/input/__tests__/index.test.js
@@ -79,6 +79,7 @@ describe('TextArea', () => {
     wrapper.setProps({ value: '1111' });
     jest.runAllTimers();
     expect(mockFunc).toHaveBeenCalledTimes(2);
+    expect(wrapper.find('textarea').props().style.overflow).toBeFalsy();
   });
 
   it('should support onPressEnter and onKeyDown', () => {

--- a/components/input/calculateNodeHeight.tsx
+++ b/components/input/calculateNodeHeight.tsx
@@ -4,7 +4,7 @@
  * calculateNodeHeight(uiTextNode, useCache = false)
  */
 
-const HIDDEN_TEXTAREA_STYLE1 = `
+const HIDDEN_TEXTAREA_STYLE = `
   min-height:0 !important;
   max-height:none !important;
   height:0 !important;
@@ -12,16 +12,6 @@ const HIDDEN_TEXTAREA_STYLE1 = `
   overflow:hidden !important;
   position:absolute !important;
   z-index:-1000 !important;
-  top:0 !important;
-  right:0 !important
-`;
-const HIDDEN_TEXTAREA_STYLE = `
-  min-height:0 !important;
-  max-height:none !important;
-  height:0 !important;
-  overflow:hidden !important;
-  position:absolute !important;
-  z-index:1000 !important;
   top:0 !important;
   right:0 !important
 `;

--- a/components/input/calculateNodeHeight.tsx
+++ b/components/input/calculateNodeHeight.tsx
@@ -4,7 +4,7 @@
  * calculateNodeHeight(uiTextNode, useCache = false)
  */
 
-const HIDDEN_TEXTAREA_STYLE = `
+const HIDDEN_TEXTAREA_STYLE1 = `
   min-height:0 !important;
   max-height:none !important;
   height:0 !important;
@@ -12,6 +12,16 @@ const HIDDEN_TEXTAREA_STYLE = `
   overflow:hidden !important;
   position:absolute !important;
   z-index:-1000 !important;
+  top:0 !important;
+  right:0 !important
+`;
+const HIDDEN_TEXTAREA_STYLE = `
+  min-height:0 !important;
+  max-height:none !important;
+  height:0 !important;
+  overflow:hidden !important;
+  position:absolute !important;
+  z-index:1000 !important;
   top:0 !important;
   right:0 !important
 `;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

fix #18111

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fix Textarea `autosize` still display scrollbar after resize.      |
| 🇨🇳 Chinese |     修复 Textarea `autosize` 在调整尺寸后仍然显示滚动条的问题。      |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
