### PR TITLE
fix: remove unwanted vertical space at the top of Tabs

### DIFF
--- a/components/tabs/style/index.less
+++ b/components/tabs/style/index.less
@@ -245,7 +245,7 @@
   // Create a empty element to aovid margin merge
   // https://github.com/ant-design/ant-design/issues/18103
   &-content::before {
-    display: inline-block;
+    display: table;
     content: '';
   }
 

--- a/components/tabs/style/index.less
+++ b/components/tabs/style/index.less
@@ -242,7 +242,7 @@
     }
   }
 
-  // Create a empty element to aovid margin merge
+  // Create an empty element to avoid margin collapsing
   // https://github.com/ant-design/ant-design/issues/18103
   &-content::before {
     display: table;


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [x] Other (language improvement)

### 🔗 Related issue link

resolves #18103 

### 💡 Background and solution

This is a small improvement over d33a001, which has the unintended effect of introducing a small vertical space at the top of each Tabs element.
https://github.com/ant-design/ant-design/blob/d33a0019222d26084d538a4e14d7f6e3f1ef74f0/components/tabs/style/index.less#L245-L250
It would be better to do away with this vertical space because:
1. It serves no purpose.
2. This type of small gap is hard to reason about – it is doesn't fit anywhere in the _Box Model_ and therefore doesn't show up on the Box Model interactive diagram in the _Styles tab_ of the Chrome DevTools.

To remove this type of space after inline-block elements, one common solution is to set the `font-size` property of the parent element to `0`, Obviously, that'd be hardly ideal in our case, so I went ahead and changed the `display` property from `inline-block` to `table`, which has the similar effect of creating a new [_block formatting context_](//developer.mozilla.org/en-US/docs/Web/Guide/CSS/Block_formatting_context), and thus prevents [_margin collapsing_](//developer.mozilla.org/en-US/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing).

As a side note, I've slightly tweaked the language used in the comments along the way (e.g. corrected some minor misspellings). Probably just nitpicking :stuck_out_tongue_winking_eye:.

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Remove unwanted vertical space at the top of Tabs |
| 🇨🇳 Chinese | 去除Tabs顶部多余空隙 |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
