### PR TITLE
feat: pass props.id as id to Form.Item

### DIFF
--- a/components/form/FormItem.tsx
+++ b/components/form/FormItem.tsx
@@ -399,7 +399,7 @@ export default class FormItem extends React.Component<FormItemProps, any> {
   }
 
   renderFormItem = ({ getPrefixCls }: ConfigConsumerProps) => {
-    const { prefixCls: customizePrefixCls, style, className } = this.props;
+    const { prefixCls: customizePrefixCls, style, className, id } = this.props;
     const prefixCls = getPrefixCls('form', customizePrefixCls);
     const children = this.renderChildren(prefixCls);
     const itemClassName = {
@@ -409,7 +409,7 @@ export default class FormItem extends React.Component<FormItemProps, any> {
     };
 
     return (
-      <Row className={classNames(itemClassName)} style={style} key="row">
+      <Row className={classNames(itemClassName)} id={id} style={style} key="row">
         {children}
       </Row>
     );

--- a/components/form/__tests__/item.test.js
+++ b/components/form/__tests__/item.test.js
@@ -1,0 +1,11 @@
+/* eslint-disable react/prefer-stateless-function */
+import React from 'react';
+import { mount } from 'enzyme';
+import Form from '..';
+
+describe('Form.Item', () => {
+  it('passes id as a prop', () => {
+    const wrapper = mount(<Form.Item id="id">Test</Form.Item>);
+    expect(wrapper.find('div#id.ant-form-item').text()).toBe('Test');
+  });
+});

--- a/components/mention/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/mention/__tests__/__snapshots__/demo.test.js.snap
@@ -255,6 +255,7 @@ exports[`renders ./components/mention/demo/controlled.md correctly 1`] = `
 >
   <div
     class="ant-row ant-form-item"
+    id="control-mention"
   >
     <div
       class="ant-col ant-col-6 ant-form-item-label"


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [☑️ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link https://github.com/ant-design/ant-design/issues/18127

<!--
1. Describe the source of requirement, like related issue link.
-->
You already have id as a prop given to the Form.Item component but id is not actually passed to the rendered row that gets returned. 

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
Not allowing Form.Item to take an id makes finding specific Form.Items impossible. My particular use case involves truncating Form.Item error messages to one line and then adding an onClick callback to the div.ant-form-explain to pop up the full error in a notification. I cannot make sure I add the onClick to the right div.ant-form-explain without having an id on Form.Item.

2. GIF or snapshot should be provided if includes UI/interactive modification.
n/a

3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.

```js
renderFormItem = ({ getPrefixCls }: ConfigConsumerProps) => {
    const { prefixCls: customizePrefixCls, style, className, id } = this.props;
    const prefixCls = getPrefixCls('form', customizePrefixCls);
    const children = this.renderChildren(prefixCls);
    const itemClassName = {
      [`${prefixCls}-item`]: true,
      [`${prefixCls}-item-with-help`]: this.helpShow,
      [`${className}`]: !!className,
    };

    return (
      <Row className={classNames(itemClassName)} id={id} style={style} key="row">
        {children}
      </Row>
    );
  };
```
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Passes id to Form.Item|
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [☑️] Doc is updated/provided or not needed
- [☑️] Demo is updated/provided or not needed
- [☑️] TypeScript definition is updated/provided or not needed
- [☑️] Changelog is provided or not needed