### PR TITLE
fix: Change className to style in DemoBox component in Flex Alignment…

### DIFF
--- a/components/grid/demo/flex-align.md
+++ b/components/grid/demo/flex-align.md
@@ -16,7 +16,7 @@ Flex child elements vertically aligned.
 ```jsx
 import { Row, Col } from 'antd';
 
-const DemoBox = props => <p className={`height-${props.value}`}>{props.children}</p>;
+const DemoBox = props => <p style={{ height: props.value }}>{props.children}</p>;
 
 ReactDOM.render(
   <div>


### PR DESCRIPTION
🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
-  ☑️  Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)


💡 Background and solution

1. Describe the problem and the scenario.
    In the DemoBox component in **Flex child elements vertically aligned** section, the `value` passed is used to construct `className` prop which doesnt vertically align component. Instead, the value prop should be used to construct the `style` props.
2. GIF or snapshot should be provided if includes UI/interactive modification.
   [ documentation component](https://codesandbox.io/s/suspicious-diffie-k73vc)
    [fixed component](https://codesandbox.io/s/beautiful-fog-fo14i)


| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Change className prop to style prop in DemoBox      |
| 🇨🇳 Chinese |           |

 ☑️ Self Check before Merge

-  ☑️  Doc is updated/provided or not needed
-  ☑️  Demo is updated/provided or not needed
-  ☑️ TypeScript definition is updated/provided or not needed
-  ☑️  Changelog is provided or not needed


-----
[View rendered components/grid/demo/flex-align.md](https://github.com/udeepbahadur7/ant-design/blob/master/components/grid/demo/flex-align.md)