### PR TITLE
Fixed grammatical errors in Button and Icon documentation.

### DIFF
--- a/components/button/demo/icon.md
+++ b/components/button/demo/icon.md
@@ -13,7 +13,7 @@ title:
 
 ## en-US
 
-`Button` components can contain an `Icon`. This is done by setting the `icon` property or placing an `Icon` component within the `Button`
+`Button` components can contain an `Icon`. This is done by setting the `icon` property or placing an `Icon` component within the `Button`.
 
 If you want specific control over the positioning and placement of the `Icon`, then that should be done by placing the `Icon` component within the `Button` rather than using the `icon` property.
 

--- a/components/icon/demo/basic.md
+++ b/components/icon/demo/basic.md
@@ -11,7 +11,7 @@ title:
 
 ## en-US
 
-Use tag `<Icon />` to create an icon and set its type in the `type` prop. Specific the `spin` property to show spinning animation and the `theme` property to switch different themes.
+Use tag `<Icon />` to create an icon and set its type in the `type` prop. Specify the `spin` property to show spinning animation and the `theme` property to switch between different themes.
 
 ```jsx
 import { Icon } from 'antd';

--- a/components/icon/demo/two-tone.md
+++ b/components/icon/demo/two-tone.md
@@ -11,7 +11,7 @@ title:
 
 ## en-US
 
-Specific them property `theme` to `twoTone` to render two-tone icons. You can also set the primary color.
+Specify the property `theme` to `twoTone` to render two-tone icons. You can also set the primary color.
 
 ```jsx
 import { Icon } from 'antd';

--- a/components/icon/index.en-US.md
+++ b/components/icon/index.en-US.md
@@ -24,13 +24,13 @@ ReactDOM.render(<IconDisplay />, mountNode);
 | spin | Rotate icon with animation | boolean | false |  |
 | rotate | Rotate degrees (added in 3.13.0, not working in IE9) | number | - | 3.13.0 |
 | component | The component used for the root node. This will override the **`type`** property. | ComponentType<CustomIconComponentProps\> | - | 3.9.0 |
-| twoToneColor | Only support the two-tone icon. Specific the primary color. | string (hex color) | - | 3.9.0 |
+| twoToneColor | Only supports the two-tone icon. Specify the primary color. | string (hex color) | - | 3.9.0 |
 
 ### SVG icons
 
 We introduced SVG icons in `3.9.0` version replacing font icons which brings benefits below:
 
-- Complete offline usage of icon, no dependency of CDN font icon file and no more empty square during downloading than no need to deploy icon font files locally either.
+- Complete offline usage of icon, no dependency of CDN font icon file. No more empty square during downloading and no need to deploy icon font files locally either.
 - Much more display accuracy in lower-level screens.
 - Support multiple colors for icon.
 - No need to change built-in icons with overriding styles by providing more props in component.
@@ -64,7 +64,7 @@ Icon.getTwoToneColor(); // #eb2f96
 
 ### Custom Font Icon
 
-We added a `createFromIconfontCN` function to help developer using their own icons deployed at [iconfont.cn](http://iconfont.cn/) in a convenient way.
+We added a `createFromIconfontCN` function to help developer use their own icons deployed at [iconfont.cn](http://iconfont.cn/) in a convenient way.
 
 > This method is specified for [iconfont.cn](http://iconfont.cn/).
 
@@ -76,7 +76,7 @@ const MyIcon = Icon.createFromIconfontCN({
 ReactDOM.render(<MyIcon type="icon-example" />, mountedNode);
 ```
 
-It create a component that uses SVG sprites in essence.
+It creates a component that uses SVG sprites in essence.
 
 The following options are available:
 
@@ -91,7 +91,7 @@ See [iconfont.cn documents](http://iconfont.cn/help/detail?spm=a313x.7781069.199
 
 ### Custom SVG Icon
 
-You can import SVG icon as an react component by using `webpack` and [`@svgr/webpack`](https://www.npmjs.com/package/@svgr/webpack). `@svgr/webpack`'s `options` [reference](https://github.com/smooth-code/svgr#options).
+You can import SVG icon as a react component by using `webpack` and [`@svgr/webpack`](https://www.npmjs.com/package/@svgr/webpack). `@svgr/webpack`'s `options` [reference](https://github.com/smooth-code/svgr#options).
 
 ```js
 // webpack.config.js


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [X] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed some grammatical errors in Button and Icon documentation. |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [X] Doc is updated/provided or not needed
- [X] Demo is updated/provided or not needed
- [X] TypeScript definition is updated/provided or not needed
- [X] Changelog is provided or not needed


-----
[View rendered components/button/demo/icon.md](https://github.com/RageBill/ant-design/blob/master/components/button/demo/icon.md)
[View rendered components/icon/demo/basic.md](https://github.com/RageBill/ant-design/blob/master/components/icon/demo/basic.md)
[View rendered components/icon/demo/two-tone.md](https://github.com/RageBill/ant-design/blob/master/components/icon/demo/two-tone.md)
[View rendered components/icon/index.en-US.md](https://github.com/RageBill/ant-design/blob/master/components/icon/index.en-US.md)