### PR TITLE
style: descriptions style update

### DIFF
--- a/components/calendar/locale/ro_RO.tsx
+++ b/components/calendar/locale/ro_RO.tsx
@@ -1,2 +1,3 @@
 import ro_RO from '../../date-picker/locale/ro_RO';
+
 export default ro_RO;

--- a/components/descriptions/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/descriptions/__tests__/__snapshots__/demo.test.js.snap
@@ -579,6 +579,123 @@ exports[`renders ./components/descriptions/demo/size.md correctly 1`] = `
       </table>
     </div>
   </div>
+  <br />
+  <br />
+  <div
+    class="ant-descriptions"
+  >
+    <div
+      class="ant-descriptions-title"
+    >
+      Custom Size
+    </div>
+    <div
+      class="ant-descriptions-view"
+    >
+      <table>
+        <tbody>
+          <tr
+            class="ant-descriptions-row"
+          >
+            <td
+              class="ant-descriptions-item"
+              colspan="1"
+            >
+              <span
+                class="ant-descriptions-item-label ant-descriptions-item-colon"
+              >
+                Product
+              </span>
+              <span
+                class="ant-descriptions-item-content"
+              >
+                Cloud Database
+              </span>
+            </td>
+            <td
+              class="ant-descriptions-item"
+              colspan="1"
+            >
+              <span
+                class="ant-descriptions-item-label ant-descriptions-item-colon"
+              >
+                Billing
+              </span>
+              <span
+                class="ant-descriptions-item-content"
+              >
+                Prepaid
+              </span>
+            </td>
+            <td
+              class="ant-descriptions-item"
+              colspan="1"
+            >
+              <span
+                class="ant-descriptions-item-label ant-descriptions-item-colon"
+              >
+                time
+              </span>
+              <span
+                class="ant-descriptions-item-content"
+              >
+                18:00:00
+              </span>
+            </td>
+          </tr>
+          <tr
+            class="ant-descriptions-row"
+          >
+            <td
+              class="ant-descriptions-item"
+              colspan="1"
+            >
+              <span
+                class="ant-descriptions-item-label ant-descriptions-item-colon"
+              >
+                Amount
+              </span>
+              <span
+                class="ant-descriptions-item-content"
+              >
+                $80.00
+              </span>
+            </td>
+            <td
+              class="ant-descriptions-item"
+              colspan="1"
+            >
+              <span
+                class="ant-descriptions-item-label ant-descriptions-item-colon"
+              >
+                Discount
+              </span>
+              <span
+                class="ant-descriptions-item-content"
+              >
+                $20.00
+              </span>
+            </td>
+            <td
+              class="ant-descriptions-item"
+              colspan="1"
+            >
+              <span
+                class="ant-descriptions-item-label ant-descriptions-item-colon"
+              >
+                Official
+              </span>
+              <span
+                class="ant-descriptions-item-content"
+              >
+                $60.00
+              </span>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
 </div>
 `;
 

--- a/components/descriptions/demo/size.md
+++ b/components/descriptions/demo/size.md
@@ -59,6 +59,16 @@ class Demo extends React.Component {
             Region: East China 1<br />
           </Descriptions.Item>
         </Descriptions>
+        <br />
+        <br />
+        <Descriptions title="Custom Size" border size={this.state.size}>
+          <Descriptions.Item label="Product">Cloud Database</Descriptions.Item>
+          <Descriptions.Item label="Billing">Prepaid</Descriptions.Item>
+          <Descriptions.Item label="time">18:00:00</Descriptions.Item>
+          <Descriptions.Item label="Amount">$80.00</Descriptions.Item>
+          <Descriptions.Item label="Discount">$20.00</Descriptions.Item>
+          <Descriptions.Item label="Official">$60.00</Descriptions.Item>
+        </Descriptions>
       </div>
     );
   }

--- a/components/descriptions/index.en-US.md
+++ b/components/descriptions/index.en-US.md
@@ -30,3 +30,5 @@ Commonly displayed on the details page.
 | -------- | ------------------------------ | --------- | ------- | ------- |
 | label    | description of the content     | ReactNode | -       | 3.19.0  |
 | span     | The number of columns included | number    | 1       | 3.19.0  |
+
+> The number of span Description.Item. Span={2} takes up the width of two DescriptionItems.

--- a/components/descriptions/index.zh-CN.md
+++ b/components/descriptions/index.zh-CN.md
@@ -31,3 +31,5 @@ cols: 1
 | ----- | ------------ | --------- | ------ | ------ |
 | label | 内容的描述   | ReactNode | -      | 3.19.0 |
 | span  | 包含列的数量 | number    | 1      | 3.19.0 |
+
+> span Description.Item 的数量。 span={2} 会占用两个 DescriptionItem 的宽度。

--- a/components/descriptions/style/index.less
+++ b/components/descriptions/style/index.less
@@ -78,6 +78,24 @@
     }
   }
 
+  &-middle {
+    .@{descriptions-prefix-cls}-row {
+      > th,
+      > td {
+        padding-bottom: 12px;
+      }
+    }
+  }
+
+  &-small {
+    .@{descriptions-prefix-cls}-row {
+      > th,
+      > td {
+        padding-bottom: 8px;
+      }
+    }
+  }
+
   &-bordered {
     .@{descriptions-prefix-cls}-view {
       border: 1px solid @border-color-split;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

descriptions 非 border 模式下 的 padding 不会跟着 size 走。在 pageheader 中 16 有点大。但是不能用 border 模式。这个 pr 修复了这个问题

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     The size of Descriptions now controls the padding-bottom of Descriptions.Item  |
| 🇨🇳 Chinese |    Descriptions 的 size 现在会控制 Descriptions.Item 的 padding-bottom  |

### ☑️ Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed


-----
[View rendered components/steps/demo/nav.md](https://github.com/ant-design/ant-design/blob/descript-style/components/steps/demo/nav.md)
[View rendered components/steps/demo/simple.md](https://github.com/ant-design/ant-design/blob/descript-style/components/steps/demo/simple.md)
[View rendered components/steps/index.en-US.md](https://github.com/ant-design/ant-design/blob/descript-style/components/steps/index.en-US.md)
[View rendered components/steps/index.zh-CN.md](https://github.com/ant-design/ant-design/blob/descript-style/components/steps/index.zh-CN.md)
[View rendered docs/react/i18n.en-US.md](https://github.com/ant-design/ant-design/blob/descript-style/docs/react/i18n.en-US.md)
[View rendered docs/react/i18n.zh-CN.md](https://github.com/ant-design/ant-design/blob/descript-style/docs/react/i18n.zh-CN.md)