### PR TITLE
fix: ResizeObserver should ignore shaking

### DIFF
--- a/components/__tests__/util/domHook.js
+++ b/components/__tests__/util/domHook.js
@@ -1,10 +1,12 @@
+const __NULL__ = { notExist: true };
+
 export function spyElementPrototypes(Element, properties) {
   const propNames = Object.keys(properties);
   const originDescriptors = {};
 
   propNames.forEach(propName => {
     const originDescriptor = Object.getOwnPropertyDescriptor(Element.prototype, propName);
-    originDescriptors[propName] = originDescriptor;
+    originDescriptors[propName] = originDescriptor || __NULL__;
 
     const spyProp = properties[propName];
 
@@ -37,7 +39,9 @@ export function spyElementPrototypes(Element, properties) {
     mockRestore() {
       propNames.forEach(propName => {
         const originDescriptor = originDescriptors[propName];
-        if (typeof originDescriptor === 'function') {
+        if (originDescriptor === __NULL__) {
+          delete Element.prototype[propName];
+        } else if (typeof originDescriptor === 'function') {
           Element.prototype[propName] = originDescriptor;
         } else {
           Object.defineProperty(Element.prototype, propName, originDescriptor);

--- a/components/_util/__tests__/util.test.js
+++ b/components/_util/__tests__/util.test.js
@@ -9,6 +9,8 @@ import triggerEvent from '../triggerEvent';
 import Wave from '../wave';
 import TransButton from '../transButton';
 import openAnimation from '../openAnimation';
+import ResizeObserver from '../resizeObserver';
+import { spyElementPrototype } from '../../__tests__/util/domHook';
 
 describe('Test utils function', () => {
   beforeAll(() => {
@@ -143,7 +145,9 @@ describe('Test utils function', () => {
     it('bindAnimationEvent should return when node is null', () => {
       const wrapper = mount(
         <Wave>
-          <button type="button" disabled>button</button>
+          <button type="button" disabled>
+            button
+          </button>
         </Wave>,
       ).instance();
       expect(wrapper.bindAnimationEvent()).toBe(undefined);
@@ -152,7 +156,9 @@ describe('Test utils function', () => {
     it('bindAnimationEvent.onClick should return when children is hidden', () => {
       const wrapper = mount(
         <Wave>
-          <button type="button" style={{ display: 'none' }}>button</button>
+          <button type="button" style={{ display: 'none' }}>
+            button
+          </button>
         </Wave>,
       ).instance();
       expect(wrapper.bindAnimationEvent()).toBe(undefined);
@@ -218,6 +224,49 @@ describe('Test utils function', () => {
       expect(typeof enter.stop).toBe('function');
       expect(typeof leave.stop).toBe('function');
       expect(done).toHaveBeenCalled();
+    });
+  });
+
+  describe('ResizeObserver', () => {
+    let domMock;
+
+    beforeAll(() => {
+      domMock = spyElementPrototype(HTMLDivElement, 'getBoundingClientRect', () => {
+        return {
+          width: 1128 + Math.random(),
+          height: 903 + Math.random(),
+        };
+      });
+    });
+
+    afterAll(() => {
+      domMock.mockRestore();
+    });
+
+    it('should not trigger `onResize` if size shaking', () => {
+      const onResize = jest.fn();
+      let divNode;
+
+      const wrapper = mount(
+        <ResizeObserver onResize={onResize}>
+          <div
+            ref={node => {
+              divNode = node;
+            }}
+          />
+        </ResizeObserver>,
+      );
+
+      // First trigger
+      wrapper.instance().onResize([{ target: divNode }]);
+      onResize.mockReset();
+
+      // Repeat trigger should not trigger outer `onResize` with shaking
+      for (let i = 0; i < 10; i += 1) {
+        wrapper.instance().onResize([{ target: divNode }]);
+      }
+
+      expect(onResize).not.toHaveBeenCalled();
     });
   });
 });

--- a/components/_util/resizeObserver.tsx
+++ b/components/_util/resizeObserver.tsx
@@ -10,8 +10,17 @@ interface ResizeObserverProps {
   onResize?: () => void;
 }
 
-class ReactResizeObserver extends React.Component<ResizeObserverProps, {}> {
+interface ResizeObserverState {
+  height: number;
+  width: number;
+}
+
+class ReactResizeObserver extends React.Component<ResizeObserverProps, ResizeObserverState> {
   resizeObserver: ResizeObserver | null = null;
+  state = {
+    width: 0,
+    height: 0,
+  };
 
   componentDidMount() {
     this.onComponentUpdated();
@@ -38,10 +47,30 @@ class ReactResizeObserver extends React.Component<ResizeObserverProps, {}> {
     }
   }
 
-  onResize = () => {
+  onResize: ResizeObserverCallback = (entries: ResizeObserverEntry[]) => {
     const { onResize } = this.props;
-    if (onResize) {
-      onResize();
+
+    const { target } = entries[0];
+
+    const { width, height } = target.getBoundingClientRect();
+
+    /**
+     * Resize observer trigger when content size changed.
+     * In most case we just care about element size,
+     * let's use `boundary` instead of `contentRect` here to avoid shaking.
+     */
+    const fixedWidth = Math.floor(width);
+    const fixedHeight = Math.floor(height);
+
+    if (this.state.width !== fixedWidth || this.state.height !== fixedHeight) {
+      this.setState({
+        width: fixedWidth,
+        height: fixedHeight,
+      });
+
+      if (onResize) {
+        onResize();
+      }
     }
   };
 

--- a/components/_util/resizeObserver.tsx
+++ b/components/_util/resizeObserver.tsx
@@ -17,6 +17,7 @@ interface ResizeObserverState {
 
 class ReactResizeObserver extends React.Component<ResizeObserverProps, ResizeObserverState> {
   resizeObserver: ResizeObserver | null = null;
+
   state = {
     width: 0,
     height: 0,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

fix #18216

### 💡 Background and solution

Measure fixed value before ResizeObserver trigger `onResize`

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Fix TextArea `autoresize` with `maxRows` cause scrollbar blink.        |
| 🇨🇳 Chinese |   修复 TextArea `autoresize` 使用 `maxRows` 时滚动条出现闪烁的问题。       |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
