### PR TITLE
fix: submenu popupClassName and className chaos

### DIFF
--- a/components/menu/SubMenu.tsx
+++ b/components/menu/SubMenu.tsx
@@ -20,7 +20,7 @@ export interface SubMenuProps {
   onTitleMouseEnter?: (e: TitleEventEntity) => void;
   onTitleMouseLeave?: (e: TitleEventEntity) => void;
   popupOffset?: [number, number];
-  popupClassName?: stirng;
+  popupClassName?: string;
 }
 
 class SubMenu extends React.Component<SubMenuProps, any> {

--- a/components/menu/SubMenu.tsx
+++ b/components/menu/SubMenu.tsx
@@ -20,6 +20,7 @@ export interface SubMenuProps {
   onTitleMouseEnter?: (e: TitleEventEntity) => void;
   onTitleMouseLeave?: (e: TitleEventEntity) => void;
   popupOffset?: [number, number];
+  popupClassName?: stirng;
 }
 
 class SubMenu extends React.Component<SubMenuProps, any> {
@@ -41,14 +42,14 @@ class SubMenu extends React.Component<SubMenuProps, any> {
   };
 
   render() {
-    const { rootPrefixCls, className } = this.props;
+    const { rootPrefixCls, popupClassName } = this.props;
     return (
       <MenuContext.Consumer>
         {({ antdMenuTheme }: MenuContextProps) => (
           <RcSubMenu
             {...this.props}
             ref={this.saveSubMenu}
-            popupClassName={classNames(`${rootPrefixCls}-${antdMenuTheme}`, className)}
+            popupClassName={classNames(`${rootPrefixCls}-${antdMenuTheme}`, popupClassName)}
           />
         )}
       </MenuContext.Consumer>

--- a/components/menu/index.en-US.md
+++ b/components/menu/index.en-US.md
@@ -62,6 +62,7 @@ More layouts with navigation: [layout](/components/layout).
 
 | Param | Description | Type | Default value | Version |
 | --- | --- | --- | --- | --- |
+| popupClassName | sub menu class name | string |  | 3.21.5 |
 | children | sub menus or sub menu items | Array&lt;MenuItem\|SubMenu> |  |  |
 | disabled | whether sub menu is disabled or not | boolean | false |  |
 | key | unique id of the sub menu | string |  |  |

--- a/components/menu/index.zh-CN.md
+++ b/components/menu/index.zh-CN.md
@@ -61,13 +61,14 @@ subtitle: 导航菜单
 
 ### Menu.SubMenu
 
-| 参数         | 说明           | 类型                        | 默认值 | 版本 |
-| ------------ | -------------- | --------------------------- | ------ | ---- |
-| children     | 子菜单的菜单项 | Array&lt;MenuItem\|SubMenu> |        |      |
-| disabled     | 是否禁用       | boolean                     | false  |      |
-| key          | 唯一标志       | string                      |        |      |
-| title        | 子菜单项值     | string\|ReactNode           |        |      |
-| onTitleClick | 点击子菜单标题 | function({ key, domEvent }) |        |      |
+| 参数           | 说明           | 类型                        | 默认值 | 版本   |
+| -------------- | -------------- | --------------------------- | ------ | ------ |
+| popupClassName | 子菜单样式     | string                      |        | 3.21.5 |
+| children       | 子菜单的菜单项 | Array&lt;MenuItem\|SubMenu> |        |        |
+| disabled       | 是否禁用       | boolean                     | false  |        |
+| key            | 唯一标志       | string                      |        |        |
+| title          | 子菜单项值     | string\|ReactNode           |        |        |
+| onTitleClick   | 点击子菜单标题 | function({ key, domEvent }) |        |        |
 
 ### Menu.ItemGroup
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [X] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese | className 与 popupClassName 混乱， |

### ☑️ Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed


className 应该是 item li 的样式，不应该带到 popupMenu 上