### PR TITLE
Update `okText` documentation for `PopConfirm` Component

### DIFF
--- a/components/popconfirm/index.en-US.md
+++ b/components/popconfirm/index.en-US.md
@@ -17,7 +17,7 @@ The difference with the `confirm` modal dialog is that it's more lightweight tha
 | Param | Description | Type | Default value | Version |
 | --- | --- | --- | --- | --- |
 | cancelText | text of the Cancel button | string | `Cancel` |  |
-| okText | text of the Confirm button | string | `Confirm` |  |
+| okText | text of the Confirm button | string | `OK` |  |
 | okType | Button `type` of the Confirm button | string | `primary` |  |
 | title | title of the confirmation box | string\|ReactNode | - |  |
 | onCancel | callback of cancel | function(e) | - |  |


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [x] Site / document update

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->
N/A

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

According to the default locale text definition file, the `okText` should really be `OK` but not `Confirm`. 

https://github.com/ant-design/ant-design/blob/109bd4ecde8879b9a4cd4a3048041d350f265dcd/components/locale/default.tsx#L31

I tried to look back into the git history, but I don't think at any point in time the default `okText` is `Confirm`. 

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

According to locale definition 

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Slight update to `PopConfirm` documentation.    |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/popconfirm/index.en-US.md](https://github.com/GalenWong/ant-design/blob/master/components/popconfirm/index.en-US.md)