### PR TITLE
feat: upgrade rc-mentions

### DIFF
--- a/components/mentions/index.en-US.md
+++ b/components/mentions/index.en-US.md
@@ -38,7 +38,7 @@ When need to mention someone or something.
 | onSearch | Trigger when prefix hit | (text: string, prefix: string) => void | - | 3.19.0 |
 | onFocus | Trigger when mentions get focus | () => void | - | 3.19.0 |
 | onBlur | Trigger when mentions lose focus | () => void | - | 3.19.0 |
-| getPopupContainer | DOM Container for suggestions | () => HTMLElement | - | 3.22.0 |
+| getPopupContainer | Set the mount HTML node for suggestions | () => HTMLElement | - | 3.22.0 |
 
 ### Mention methods
 

--- a/components/mentions/index.en-US.md
+++ b/components/mentions/index.en-US.md
@@ -38,6 +38,7 @@ When need to mention someone or something.
 | onSearch | Trigger when prefix hit | (text: string, prefix: string) => void | - | 3.19.0 |
 | onFocus | Trigger when mentions get focus | () => void | - | 3.19.0 |
 | onBlur | Trigger when mentions lose focus | () => void | - | 3.19.0 |
+| getPopupContainer | DOM Container for suggestions | () => HTMLElement | - | 3.22.0 |
 
 ### Mention methods
 

--- a/components/mentions/index.zh-CN.md
+++ b/components/mentions/index.zh-CN.md
@@ -48,7 +48,7 @@ title: Mentions
 | onSearch | 搜索时触发 | (text: string, prefix: string) => void | - | 3.19.0 |
 | onFocus | 获得焦点时触发 | () => void | - | 3.19.0 |
 | onBlur | 失去焦点时触发 | () => void | - | 3.19.0 |
-| getPopupContainer | 建议的容器 | () => HTMLElement | - | 3.22.0 |
+| getPopupContainer | 指定建议框挂载的 HTML 节点 | () => HTMLElement | - | 3.22.0 |
 
 ### Mention 方法
 

--- a/components/mentions/index.zh-CN.md
+++ b/components/mentions/index.zh-CN.md
@@ -48,6 +48,7 @@ title: Mentions
 | onSearch | 搜索时触发 | (text: string, prefix: string) => void | - | 3.19.0 |
 | onFocus | 获得焦点时触发 | () => void | - | 3.19.0 |
 | onBlur | 失去焦点时触发 | () => void | - | 3.19.0 |
+| getPopupContainer | 建议的容器 | () => HTMLElement | - | 3.22.0 |
 
 ### Mention 方法
 

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "rc-editor-mention": "^1.1.13",
     "rc-form": "^2.4.5",
     "rc-input-number": "~4.4.5",
-    "rc-mentions": "~0.3.1",
+    "rc-mentions": "~0.4.0",
     "rc-menu": "~7.4.23",
     "rc-notification": "~3.3.1",
     "rc-pagination": "~1.20.5",


### PR DESCRIPTION
### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

https://github.com/react-component/mentions/issues/9

### 💡 Background and solution

The new Mentions component does not have `getPopupContainer` prop. Added it to rc-mentions. Now upgrading the rc-mentions reference to 0.4 to take advantage of the new prop.

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Upgrade rc-mentions  |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
