### PR TITLE
feat: Modal closeIcon

### DIFF
--- a/components/modal/Modal.tsx
+++ b/components/modal/Modal.tsx
@@ -76,6 +76,7 @@ export interface ModalProps {
   keyboard?: boolean;
   wrapProps?: any;
   prefixCls?: string;
+  closeIcon?: React.ReactNode;
 }
 
 type getContainerFunc = () => HTMLElement;
@@ -164,6 +165,7 @@ export default class Modal extends React.Component<ModalProps, {}> {
     footer: PropTypes.node,
     title: PropTypes.node,
     closable: PropTypes.bool,
+    closeIcon: PropTypes.node,
   };
 
   handleCancel = (e: React.MouseEvent<HTMLButtonElement>) => {
@@ -210,6 +212,7 @@ export default class Modal extends React.Component<ModalProps, {}> {
       wrapClassName,
       centered,
       getContainer,
+      closeIcon,
       ...restProps
     } = this.props;
 
@@ -220,7 +223,7 @@ export default class Modal extends React.Component<ModalProps, {}> {
       </LocaleReceiver>
     );
 
-    const closeIcon = (
+    const closeIconToRender = closeIcon || (
       <span className={`${prefixCls}-close-x`}>
         <Icon className={`${prefixCls}-close-icon`} type="close" />
       </span>
@@ -236,7 +239,7 @@ export default class Modal extends React.Component<ModalProps, {}> {
         visible={visible}
         mousePosition={mousePosition}
         onClose={this.handleCancel}
-        closeIcon={closeIcon}
+        closeIcon={closeIconToRender}
       />
     );
   };

--- a/components/modal/__tests__/Modal.test.js
+++ b/components/modal/__tests__/Modal.test.js
@@ -57,4 +57,9 @@ describe('Modal', () => {
     wrapper.handleOk();
     expect(onOk).toHaveBeenCalled();
   });
+
+  it('support closeIcon', () => {
+    const wrapper = mount(<Modal closeIcon={<a>closeIcon</a>} visible />);
+    expect(wrapper.render()).toMatchSnapshot();
+  });
 });

--- a/components/modal/__tests__/__snapshots__/Modal.test.js.snap
+++ b/components/modal/__tests__/__snapshots__/Modal.test.js.snap
@@ -169,3 +169,71 @@ exports[`Modal render without footer 1`] = `
   </div>
 </div>
 `;
+
+exports[`Modal support closeIcon 1`] = `
+<div>
+  <div
+    class="ant-modal-mask fade-appear"
+  />
+  <div
+    class="ant-modal-wrap "
+    role="dialog"
+    tabindex="-1"
+  >
+    <div
+      class="ant-modal zoom-appear"
+      role="document"
+      style="width: 520px;"
+    >
+      <div
+        aria-hidden="true"
+        style="width: 0px; height: 0px; overflow: hidden;"
+        tabindex="0"
+      />
+      <div
+        class="ant-modal-content"
+      >
+        <button
+          aria-label="Close"
+          class="ant-modal-close"
+          type="button"
+        >
+          <a>
+            closeIcon
+          </a>
+        </button>
+        <div
+          class="ant-modal-body"
+        />
+        <div
+          class="ant-modal-footer"
+        >
+          <div>
+            <button
+              class="ant-btn"
+              type="button"
+            >
+              <span>
+                Cancel
+              </span>
+            </button>
+            <button
+              class="ant-btn ant-btn-primary"
+              type="button"
+            >
+              <span>
+                OK
+              </span>
+            </button>
+          </div>
+        </div>
+      </div>
+      <div
+        aria-hidden="true"
+        style="width: 0px; height: 0px; overflow: hidden;"
+        tabindex="0"
+      />
+    </div>
+  </div>
+</div>
+`;

--- a/components/modal/index.en-US.md
+++ b/components/modal/index.en-US.md
@@ -19,6 +19,7 @@ When requiring users to interact with the application, but without jumping to a 
 | cancelText | Text of the Cancel button | string\|ReactNode | `Cancel` |  |
 | centered | Centered Modal | Boolean | `false` | 3.8.0 |
 | closable | Whether a close (x) button is visible on top right of the modal dialog or not | boolean | true |  |
+| closeIcon | custom close icon | ReactNode | - | 3.22.0 |
 | confirmLoading | Whether to apply loading visual effect for OK button or not | boolean | false |  |
 | destroyOnClose | Whether to unmount child components on onClose | boolean | false | 3.1.0 |
 | footer | Footer content, set as `footer={null}` when you don't need default buttons | string\|ReactNode | OK and Cancel buttons |  |

--- a/components/modal/index.zh-CN.md
+++ b/components/modal/index.zh-CN.md
@@ -22,6 +22,7 @@ title: Modal
 | cancelText | 取消按钮文字 | string\|ReactNode | 取消 |  |
 | centered | 垂直居中展示 Modal | Boolean | `false` | 3.8.0 |
 | closable | 是否显示右上角的关闭按钮 | boolean | true |  |
+| closeIcon | 自定义关闭图标 | ReactNode | - | 3.22.0 |
 | confirmLoading | 确定按钮 loading | boolean | 无 |  |
 | destroyOnClose | 关闭时销毁 Modal 里的子元素 | boolean | false | 3.1.0 |
 | footer | 底部内容，当不需要默认底部按钮时，可以设为 `footer={null}` | string\|ReactNode | 确定取消按钮 |  |


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

https://github.com/ant-design/ant-design/issues/18307

### 💡 Background and solution

```diff
<Modal
+ closeIcon={<Icon />}
/>
```

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Modal support custom `closeIcon`. |
| 🇨🇳 Chinese | Modal 新增 `closeIcon` 属性用于自定义关闭图标。 |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/anchor/demo/customizeHighlight.md](https://github.com/ant-design/ant-design/blob/feat-close-icon/components/anchor/demo/customizeHighlight.md)
[View rendered components/anchor/index.en-US.md](https://github.com/ant-design/ant-design/blob/feat-close-icon/components/anchor/index.en-US.md)
[View rendered components/anchor/index.zh-CN.md](https://github.com/ant-design/ant-design/blob/feat-close-icon/components/anchor/index.zh-CN.md)
[View rendered components/descriptions/demo/size.md](https://github.com/ant-design/ant-design/blob/feat-close-icon/components/descriptions/demo/size.md)
[View rendered components/descriptions/index.en-US.md](https://github.com/ant-design/ant-design/blob/feat-close-icon/components/descriptions/index.en-US.md)
[View rendered components/descriptions/index.zh-CN.md](https://github.com/ant-design/ant-design/blob/feat-close-icon/components/descriptions/index.zh-CN.md)
[View rendered components/modal/index.en-US.md](https://github.com/ant-design/ant-design/blob/feat-close-icon/components/modal/index.en-US.md)
[View rendered components/modal/index.zh-CN.md](https://github.com/ant-design/ant-design/blob/feat-close-icon/components/modal/index.zh-CN.md)
[View rendered components/steps/demo/nav.md](https://github.com/ant-design/ant-design/blob/feat-close-icon/components/steps/demo/nav.md)
[View rendered components/steps/demo/simple.md](https://github.com/ant-design/ant-design/blob/feat-close-icon/components/steps/demo/simple.md)
[View rendered components/steps/index.en-US.md](https://github.com/ant-design/ant-design/blob/feat-close-icon/components/steps/index.en-US.md)
[View rendered components/steps/index.zh-CN.md](https://github.com/ant-design/ant-design/blob/feat-close-icon/components/steps/index.zh-CN.md)