### PR TITLE
chore: Move openAnimation out of defaultProps

### DIFF
--- a/components/collapse/Collapse.tsx
+++ b/components/collapse/Collapse.tsx
@@ -73,8 +73,8 @@ export default class Collapse extends React.Component<CollapseProps, any> {
     );
     return (
       <RcCollapse
-        {...this.props}
         openAnimation={{ ...animation, appear() {} }}
+        {...this.props}
         expandIcon={(panelProps: PanelProps) => this.renderExpandIcon(panelProps, prefixCls)}
         prefixCls={prefixCls}
         className={collapseClassName}

--- a/components/collapse/Collapse.tsx
+++ b/components/collapse/Collapse.tsx
@@ -39,7 +39,6 @@ export default class Collapse extends React.Component<CollapseProps, any> {
 
   static defaultProps = {
     bordered: true,
-    openAnimation: { ...animation, appear() {} },
     expandIconPosition: 'left',
   };
 
@@ -75,6 +74,7 @@ export default class Collapse extends React.Component<CollapseProps, any> {
     return (
       <RcCollapse
         {...this.props}
+        openAnimation={{ ...animation, appear() {} }}
         expandIcon={(panelProps: PanelProps) => this.renderExpandIcon(panelProps, prefixCls)}
         prefixCls={prefixCls}
         className={collapseClassName}


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

No issue reported.

### 💡 Background and solution

The `defaultProps` of the `<Collapse />` included the prop `openAnimation` which is not defined in the prop types `CollapseProps`.  This can lead to ts errors for anyone wanting to extend this component since `<Collapse />` does not satisfy the type definition of `React.ComponentType<CollapseProps>` due to `defaultProps` not satisfying `Partial<CollapseProps>`.

To fix this, I moved  `openAnimation` outside of `defaultProps` and applied it directly to `<RcCollapse />` in the render function.

### 📝 Changelog

No breaking changes.

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
