### PR TITLE
fix: Not shaking with autosize of TextArea

### DIFF
--- a/components/input/TextArea.tsx
+++ b/components/input/TextArea.tsx
@@ -45,7 +45,7 @@ class TextArea extends React.Component<TextAreaProps, TextAreaState> {
   componentDidUpdate(prevProps: TextAreaProps) {
     // Re-render with the new content then recalculate the height as required.
     if (prevProps.value !== this.props.value) {
-      this.resizeOnNextFrame();
+      this.resizeTextarea();
     }
   }
 

--- a/components/input/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/input/__tests__/__snapshots__/demo.test.js.snap
@@ -230,6 +230,13 @@ exports[`renders ./components/input/demo/autosize-textarea.md correctly 1`] = `
     class="ant-input"
     placeholder="Autosize height with minimum and maximum number of lines"
   />
+  <div
+    style="margin:24px 0"
+  />
+  <textarea
+    class="ant-input"
+    placeholder="Controlled autosize"
+  />
 </div>
 `;
 

--- a/components/input/__tests__/index.test.js
+++ b/components/input/__tests__/index.test.js
@@ -79,6 +79,7 @@ describe('TextArea', () => {
     wrapper.setProps({ value: '1111' });
     jest.runAllTimers();
     expect(mockFunc).toHaveBeenCalledTimes(2);
+    wrapper.update();
     expect(wrapper.find('textarea').props().style.overflow).toBeFalsy();
   });
 

--- a/components/input/demo/autosize-textarea.md
+++ b/components/input/demo/autosize-textarea.md
@@ -41,7 +41,7 @@ class Demo extends React.Component {
         <div style={{ margin: '24px 0' }} />
         <TextArea
           value={value}
-          onChange={e => setValue(e.target.value)}
+          onChange={this.onChange}
           placeholder="Controlled autosize"
           autosize={{ minRows: 3, maxRows: 5 }}
         />

--- a/components/input/demo/autosize-textarea.md
+++ b/components/input/demo/autosize-textarea.md
@@ -28,6 +28,8 @@ class Demo extends React.Component {
   };
 
   render() {
+    const { value } = this.state;
+
     return (
       <div>
         <TextArea placeholder="Autosize height based on content lines" autosize />

--- a/components/input/demo/autosize-textarea.md
+++ b/components/input/demo/autosize-textarea.md
@@ -18,15 +18,27 @@ import { Input } from 'antd';
 
 const { TextArea } = Input;
 
-ReactDOM.render(
-  <div>
-    <TextArea placeholder="Autosize height based on content lines" autosize />
-    <div style={{ margin: '24px 0' }} />
-    <TextArea
-      placeholder="Autosize height with minimum and maximum number of lines"
-      autosize={{ minRows: 2, maxRows: 6 }}
-    />
-  </div>,
-  mountNode,
-);
+const Demo = () => {
+  const [value, setValue] = React.useState('');
+
+  return (
+    <div>
+      <TextArea placeholder="Autosize height based on content lines" autosize />
+      <div style={{ margin: '24px 0' }} />
+      <TextArea
+        placeholder="Autosize height with minimum and maximum number of lines"
+        autosize={{ minRows: 2, maxRows: 6 }}
+      />
+      <div style={{ margin: '24px 0' }} />
+      <TextArea
+        value={value}
+        onChange={e => setValue(e.target.value)}
+        placeholder="Controlled autosize"
+        autosize={{ minRows: 3, maxRows: 5 }}
+      />
+    </div>
+  );
+};
+
+ReactDOM.render(<Demo />, mountNode);
 ```

--- a/components/input/demo/autosize-textarea.md
+++ b/components/input/demo/autosize-textarea.md
@@ -20,7 +20,7 @@ const { TextArea } = Input;
 
 class Demo extends React.Component {
   state = {
-    value: '';
+    value: '',
   };
 
   onChange = ({ target: { value } }) => {
@@ -28,24 +28,25 @@ class Demo extends React.Component {
   };
 
   render() {
-    return <div>
-      <TextArea placeholder="Autosize height based on content lines" autosize />
-      <div style={{ margin: '24px 0' }} />
-      <TextArea
-        placeholder="Autosize height with minimum and maximum number of lines"
-        autosize={{ minRows: 2, maxRows: 6 }}
-      />
-      <div style={{ margin: '24px 0' }} />
-      <TextArea
-        value={value}
-        onChange={e => setValue(e.target.value)}
-        placeholder="Controlled autosize"
-        autosize={{ minRows: 3, maxRows: 5 }}
-      />
-    </div>
+    return (
+      <div>
+        <TextArea placeholder="Autosize height based on content lines" autosize />
+        <div style={{ margin: '24px 0' }} />
+        <TextArea
+          placeholder="Autosize height with minimum and maximum number of lines"
+          autosize={{ minRows: 2, maxRows: 6 }}
+        />
+        <div style={{ margin: '24px 0' }} />
+        <TextArea
+          value={value}
+          onChange={e => setValue(e.target.value)}
+          placeholder="Controlled autosize"
+          autosize={{ minRows: 3, maxRows: 5 }}
+        />
+      </div>
+    );
   }
 }
-
 
 ReactDOM.render(<Demo />, mountNode);
 ```

--- a/components/input/demo/autosize-textarea.md
+++ b/components/input/demo/autosize-textarea.md
@@ -18,11 +18,17 @@ import { Input } from 'antd';
 
 const { TextArea } = Input;
 
-const Demo = () => {
-  const [value, setValue] = React.useState('');
+class Demo extends React.Component {
+  state = {
+    value: '';
+  };
 
-  return (
-    <div>
+  onChange = ({ target: { value } }) => {
+    this.setState({ value });
+  };
+
+  render() {
+    return <div>
       <TextArea placeholder="Autosize height based on content lines" autosize />
       <div style={{ margin: '24px 0' }} />
       <TextArea
@@ -37,8 +43,9 @@ const Demo = () => {
         autosize={{ minRows: 3, maxRows: 5 }}
       />
     </div>
-  );
-};
+  }
+}
+
 
 ReactDOM.render(<Demo />, mountNode);
 ```


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

fix #18366

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Fix TextArea with `autosize` in controlled mode that scrollbar blink when typing.        |
| 🇨🇳 Chinese |    修复 TextArea 受控模式下配置 `autosize` 时，输入会导致滚动条闪烁的问题。       |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/input/demo/autosize-textarea.md](https://github.com/ant-design/ant-design/blob/autosize/components/input/demo/autosize-textarea.md)