### PR TITLE
Timeline with fragment

### DIFF
--- a/components/timeline/Timeline.tsx
+++ b/components/timeline/Timeline.tsx
@@ -73,12 +73,25 @@ export default class Timeline extends React.Component<TimelineProps, any> {
     const truthyItems = timeLineItems.filter(item => !!item);
     const lastCls = `${prefixCls}-item-last`;
 
-    const fragmentLessTruthyItems = flatMapDeep(truthyItems, (node: React.ReactElement<any>) => {
-      if (node.type === React.Fragment) {
-        return node.props.children;
+    const flattenItems = (
+      reactNodes: Array<React.ReactElement<any>> & React.ReactElement<any>,
+    ): any => {
+      if (reactNodes.type === React.Fragment) {
+        return flattenItems(reactNodes.props.children);
       }
-      return node;
-    });
+      if (!Array.isArray(reactNodes)) {
+        return reactNodes;
+      }
+      return flatMapDeep(reactNodes, (node: React.ReactElement<any>) => {
+        if (node.type === React.Fragment) {
+          return flattenItems(node.props.children);
+        }
+        return node;
+      });
+    };
+
+    const fragmentLessTruthyItems = flattenItems(truthyItems as Array<React.ReactElement<any>> &
+      React.ReactElement<any>);
     const itemsCount = React.Children.count(fragmentLessTruthyItems);
     const items = React.Children.map(
       fragmentLessTruthyItems,

--- a/components/timeline/__tests__/index.test.js
+++ b/components/timeline/__tests__/index.test.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import { mount } from 'enzyme';
 import TimeLine from '..';
 import mountTest from '../../../tests/shared/mountTest';
@@ -137,10 +137,10 @@ describe('TimeLine', () => {
         const wrapper = mount(
           <TimeLine>
             <Item key="1">foo</Item>
-            <Fragment>
+            <>
               <Item key="2">bar</Item>
               <Item key="3">baz</Item>
-            </Fragment>
+            </>
           </TimeLine>,
         );
         expect(
@@ -154,12 +154,12 @@ describe('TimeLine', () => {
         const wrapper = mount(
           <TimeLine>
             <Item key="1">foo</Item>
-            <Fragment>
+            <>
               <Item key="2">bar</Item>
-              <Fragment>
+              <>
                 <Item key="3">baz</Item>
-              </Fragment>
-            </Fragment>
+              </>
+            </>
           </TimeLine>,
         );
         expect(
@@ -172,9 +172,9 @@ describe('TimeLine', () => {
       it('one item which wrapped in Fragment', () => {
         const wrapper = mount(
           <TimeLine>
-            <Fragment>
+            <>
               <Item key="1">foo</Item>
-            </Fragment>
+            </>
           </TimeLine>,
         );
         expect(

--- a/components/timeline/__tests__/index.test.js
+++ b/components/timeline/__tests__/index.test.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import { mount } from 'enzyme';
 import TimeLine from '..';
 import mountTest from '../../../tests/shared/mountTest';
@@ -131,6 +131,59 @@ describe('TimeLine', () => {
           .first()
           .hasClass('ant-timeline-item-pending'),
       ).toBe(true);
+    });
+    describe('renders items with fragment', () => {
+      it('wrapped in the Fragment', () => {
+        const wrapper = mount(
+          <TimeLine>
+            <Item key="1">foo</Item>
+            <Fragment>
+              <Item key="2">bar</Item>
+              <Item key="3">baz</Item>
+            </Fragment>
+          </TimeLine>,
+        );
+        expect(
+          wrapper
+            .find('li.ant-timeline-item')
+            .last()
+            .hasClass('ant-timeline-item-last'),
+        ).toBe(true);
+      });
+      it('wrapped in nested Fragments', () => {
+        const wrapper = mount(
+          <TimeLine>
+            <Item key="1">foo</Item>
+            <Fragment>
+              <Item key="2">bar</Item>
+              <Fragment>
+                <Item key="3">baz</Item>
+              </Fragment>
+            </Fragment>
+          </TimeLine>,
+        );
+        expect(
+          wrapper
+            .find('li.ant-timeline-item')
+            .last()
+            .hasClass('ant-timeline-item-last'),
+        ).toBe(true);
+      });
+      it('one item which wrapped in Fragment', () => {
+        const wrapper = mount(
+          <TimeLine>
+            <Fragment>
+              <Item key="1">foo</Item>
+            </Fragment>
+          </TimeLine>,
+        );
+        expect(
+          wrapper
+            .find('li.ant-timeline-item')
+            .last()
+            .hasClass('ant-timeline-item-last'),
+        ).toBe(true);
+      });
     });
   });
 });

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "@packtracker/webpack-plugin": "^2.0.1",
     "@sentry/browser": "^5.4.0",
     "@types/classnames": "^2.2.8",
+    "@types/lodash": "^4.14.137",
     "@types/gtag.js": "^0.0.3",
     "@types/prop-types": "^15.7.1",
     "@types/react": "^16.9.0",

--- a/typings/custom-typings.d.ts
+++ b/typings/custom-typings.d.ts
@@ -89,18 +89,6 @@ declare module '*.json' {
   export default value;
 }
 
-declare module 'lodash/debounce';
-
-declare module 'lodash/padStart';
-
-declare module 'lodash/padEnd';
-
-declare module 'lodash/repeat';
-
-declare module 'lodash/uniqBy';
-
-declare module 'lodash/findIndex';
-
 declare module 'raf';
 
 declare module 'react-lifecycles-compat';


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

If you wrap a last < Timeline.Item > with the < Fragment >, it won't add 'last class name' to the last item, because the last item is the < Fragment > and it will show a line after the last element (see attached screenshot)
https://codesandbox.io/s/priceless-bush-btnl4
![img](https://i.imgur.com/U2ULH15.png)

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
