### PR TITLE
docs: Search icon by image

### DIFF
--- a/site/theme/en-US.js
+++ b/site/theme/en-US.js
@@ -111,5 +111,8 @@ module.exports = {
     'app.docs.components.icon.category.data': 'Data Icons',
     'app.docs.components.icon.category.other': 'Application Icons',
     'app.docs.components.icon.category.logo': 'Brand and Logos',
+    'app.docs.components.icon.pic-searcher.title': 'Search by image',
+    'app.docs.components.icon.pic-searcher.placeholder':
+      'Click or drag or paste file to this area to upload',
   },
 };

--- a/site/theme/en-US.js
+++ b/site/theme/en-US.js
@@ -114,8 +114,10 @@ module.exports = {
     'app.docs.components.icon.pic-searcher.intro':
       'AI Search by image is online, welcome to use! 🎉',
     'app.docs.components.icon.pic-searcher.title': 'Search by image',
-    'app.docs.components.icon.pic-searcher.placeholder':
+    'app.docs.components.icon.pic-searcher.upload-text':
       'Click or drag or paste file to this area to upload',
+    'app.docs.components.icon.pic-searcher.upload-hint':
+      'We will find the most matching icon based on the image',
     'app.docs.components.icon.pic-searcher.server-error':
       'Predict service is temporarily unavailable',
     'app.docs.components.icon.pic-searcher.matching': 'Matching...',

--- a/site/theme/en-US.js
+++ b/site/theme/en-US.js
@@ -118,5 +118,9 @@ module.exports = {
       'Click or drag or paste file to this area to upload',
     'app.docs.components.icon.pic-searcher.server-error':
       'Predict service is temporarily unavailable',
+    'app.docs.components.icon.pic-searcher.matching': 'Matching...',
+    'app.docs.components.icon.pic-searcher.result-tip': 'Match the following icons for you:',
+    'app.docs.components.icon.pic-searcher.th-icon': 'Icon',
+    'app.docs.components.icon.pic-searcher.th-score': 'Probability',
   },
 };

--- a/site/theme/en-US.js
+++ b/site/theme/en-US.js
@@ -114,5 +114,7 @@ module.exports = {
     'app.docs.components.icon.pic-searcher.title': 'Search by image',
     'app.docs.components.icon.pic-searcher.placeholder':
       'Click or drag or paste file to this area to upload',
+    'app.docs.components.icon.pic-searcher.server-error':
+      'Predict service is temporarily unavailable',
   },
 };

--- a/site/theme/en-US.js
+++ b/site/theme/en-US.js
@@ -111,6 +111,8 @@ module.exports = {
     'app.docs.components.icon.category.data': 'Data Icons',
     'app.docs.components.icon.category.other': 'Application Icons',
     'app.docs.components.icon.category.logo': 'Brand and Logos',
+    'app.docs.components.icon.pic-searcher.intro':
+      'AI Search by image is online, welcome to use! 🎉',
     'app.docs.components.icon.pic-searcher.title': 'Search by image',
     'app.docs.components.icon.pic-searcher.placeholder':
       'Click or drag or paste file to this area to upload',

--- a/site/theme/static/icon-pic-searcher.less
+++ b/site/theme/static/icon-pic-searcher.less
@@ -29,7 +29,7 @@
 }
 
 .icon-pic-search-result {
-  margin-top: 20px;
+  min-height: 50px;
   padding: 0 10px;
   > .result-tip {
     padding: 10px 0;

--- a/site/theme/static/icon-pic-searcher.less
+++ b/site/theme/static/icon-pic-searcher.less
@@ -1,0 +1,42 @@
+.icon-pic-searcher {
+  margin: 1px 8px;
+  display: inline-block;
+
+  .icon-pic-btn {
+    color: rgba(0, 0, 0, 0.45);
+    cursor: pointer;
+    transition: all 0.3s;
+
+    &:hover {
+      color: rgba(0, 0, 0, 0.8);
+    }
+  }
+}
+
+.icon-pic-preview {
+  width: 66px;
+  height: 66px;
+  padding: 8px;
+  margin-top: 10px;
+  text-align: center;
+  border: 1px solid #d9d9d9;
+  border-radius: 4px;
+  > img {
+    max-width: 50px;
+    max-height: 50px;
+  }
+}
+
+.icon-pic-search-result {
+  padding: 20px 10px 0px 0px;
+
+  > div {
+    display: flex;
+    align-items: center;
+
+    > i {
+      margin: 10px 20px 10px 0;
+      font-size: 30px;
+    }
+  }
+}

--- a/site/theme/static/icon-pic-searcher.less
+++ b/site/theme/static/icon-pic-searcher.less
@@ -29,18 +29,23 @@
 }
 
 .icon-pic-search-result {
-  margin-top: 10px;
+  margin-top: 20px;
+  padding: 0 10px;
+  > .result-tip {
+    padding: 10px 0;
+    color: @text-color-secondary;
+  }
+  > table {
+    width: 100%;
+    .col-icon {
+      width: 80px;
+      padding: 10px 0;
+      > i {
+        font-size: 30px;
 
-  > div {
-    display: flex;
-    align-items: center;
-
-    > i {
-      margin: 10px 20px 10px 0;
-      font-size: 30px;
-
-      :hover {
-        color: @link-hover-color;
+        :hover {
+          color: @link-hover-color;
+        }
       }
     }
   }

--- a/site/theme/static/icon-pic-searcher.less
+++ b/site/theme/static/icon-pic-searcher.less
@@ -19,7 +19,7 @@
   padding: 8px;
   margin-top: 10px;
   text-align: center;
-  border: 1px solid #d9d9d9;
+  border: 1px solid @border-color-base;
   border-radius: 4px;
   > img {
     max-width: 50px;
@@ -37,6 +37,9 @@
     > i {
       margin: 10px 20px 10px 0;
       font-size: 30px;
+      :hover {
+        color: @link-hover-color;
+      }
     }
   }
 }

--- a/site/theme/static/icon-pic-searcher.less
+++ b/site/theme/static/icon-pic-searcher.less
@@ -21,6 +21,7 @@
   text-align: center;
   border: 1px solid @border-color-base;
   border-radius: 4px;
+
   > img {
     max-width: 50px;
     max-height: 50px;
@@ -28,7 +29,7 @@
 }
 
 .icon-pic-search-result {
-  padding: 20px 10px 0px 0px;
+  margin-top: 10px;
 
   > div {
     display: flex;
@@ -37,6 +38,7 @@
     > i {
       margin: 10px 20px 10px 0;
       font-size: 30px;
+
       :hover {
         color: @link-hover-color;
       }

--- a/site/theme/static/index.less
+++ b/site/theme/static/index.less
@@ -14,6 +14,7 @@
 @import './demo';
 @import './colors';
 @import './icons';
+@import './icon-pic-searcher';
 @import './mock-browser';
 @import './new-version-info-modal';
 @import './motion';

--- a/site/theme/template/IconDisplay/IconPicSearcher.tsx
+++ b/site/theme/template/IconDisplay/IconPicSearcher.tsx
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { Upload, Popover, Icon, Modal, Progress, message, Spin } from 'antd';
+import { Upload, Tooltip, Popover, Icon, Modal, Progress, message, Spin } from 'antd';
 import CopyToClipboard from 'react-copy-to-clipboard';
 import { injectIntl } from 'react-intl';
 
@@ -139,7 +139,9 @@ class PicSearcher extends Component<PicSearcherProps, PicSearcherState> {
               {icons.map((icon: iconObject) => (
                 <div key={icon.type}>
                   <CopyToClipboard text={`<Icon type="${icon.type}" />`} onCopy={this.onCopied}>
-                    <Icon type={icon.type} />
+                    <Tooltip title={icon.type} placement="right">
+                      <Icon type={icon.type} />
+                    </Tooltip>
                   </CopyToClipboard>
                   <Progress percent={Math.ceil(icon.score * 100)} />
                 </div>

--- a/site/theme/template/IconDisplay/IconPicSearcher.tsx
+++ b/site/theme/template/IconDisplay/IconPicSearcher.tsx
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import { Upload, Tooltip, Icon, Modal, Progress, message } from 'antd';
+import CopyToClipboard from 'react-copy-to-clipboard';
 
 const { Dragger } = Upload;
 
@@ -9,12 +10,11 @@ interface PicSearcherState {
   loading: Boolean;
   modalVisible: Boolean;
   icons: Array<string>;
-  justCopied: string | null;
   fileList: Array<any>;
 }
 
 interface iconObject {
-  class_name: string;
+  type: string;
   score: number;
 }
 
@@ -25,7 +25,6 @@ class PicSearcher extends Component<PicSearcherProps, PicSearcherState> {
     loading: false,
     modalVisible: false,
     icons: [],
-    justCopied: null,
     fileList: [],
   };
 
@@ -38,17 +37,12 @@ class PicSearcher extends Component<PicSearcherProps, PicSearcherState> {
     window.clearTimeout(this.copyId);
   }
 
-  onCopied = (type: string, text: string) => {
+  onCopied = (text: string) => {
     message.success(
       <span>
         <code className="copied-code">{text}</code> copied 🎉
       </span>,
     );
-    this.setState({ justCopied: type }, () => {
-      this.copyId = window.setTimeout(() => {
-        this.setState({ justCopied: null });
-      }, 2000);
-    });
   };
 
   onPaste = (event: ClipboardEvent) => {
@@ -89,8 +83,8 @@ class PicSearcher extends Component<PicSearcherProps, PicSearcherState> {
         }),
       },
     );
-    const icons = await res.json();
-    console.log(icons);
+    let icons = await res.json();
+    icons = icons.map((i: any) => ({ score: i.score, type: i.class_name.replace(/\s/g, '-') }));
     this.setState(() => ({ icons, loading: false }));
   };
 
@@ -128,8 +122,11 @@ class PicSearcher extends Component<PicSearcherProps, PicSearcherState> {
           </Dragger>
           <div className="icon-pic-search-result">
             {icons.map((icon: iconObject) => (
-              <div key={icon.class_name}>
-                <Icon type={icon.class_name.replace(/\s/g, '-')} />
+              <div key={icon.type}>
+                <CopyToClipboard text={`<Icon type="${icon.type}" />`} onCopy={this.onCopied}>
+                  <Icon type={icon.type} />
+                </CopyToClipboard>
+
                 <Progress percent={Math.ceil(icon.score * 100)} />
               </div>
             ))}

--- a/site/theme/template/IconDisplay/IconPicSearcher.tsx
+++ b/site/theme/template/IconDisplay/IconPicSearcher.tsx
@@ -134,18 +134,37 @@ class PicSearcher extends Component<PicSearcherProps, PicSearcherState> {
               {messages['app.docs.components.icon.pic-searcher.placeholder']}
             </p>
           </Dragger>
-          <Spin spinning={loading}>
+          <Spin spinning={loading} tip={messages['app.docs.components.icon.pic-searcher.matching']}>
             <div className="icon-pic-search-result">
-              {icons.map((icon: iconObject) => (
-                <div key={icon.type}>
-                  <CopyToClipboard text={`<Icon type="${icon.type}" />`} onCopy={this.onCopied}>
-                    <Tooltip title={icon.type} placement="right">
-                      <Icon type={icon.type} />
-                    </Tooltip>
-                  </CopyToClipboard>
-                  <Progress percent={Math.ceil(icon.score * 100)} />
+              {icons.length > 0 && (
+                <div className="result-tip">
+                  {messages['app.docs.components.icon.pic-searcher.result-tip']}
                 </div>
-              ))}
+              )}
+              <table>
+                {icons.length > 0 && (
+                  <tr>
+                    <th className="col-icon">
+                      {messages['app.docs.components.icon.pic-searcher.th-icon']}
+                    </th>
+                    <th>{messages['app.docs.components.icon.pic-searcher.th-score']}</th>
+                  </tr>
+                )}
+                {icons.map((icon: iconObject) => (
+                  <tr key={icon.type}>
+                    <td className="col-icon">
+                      <CopyToClipboard text={`<Icon type="${icon.type}" />`} onCopy={this.onCopied}>
+                        <Tooltip title={icon.type} placement="right">
+                          <Icon type={icon.type} />
+                        </Tooltip>
+                      </CopyToClipboard>
+                    </td>
+                    <td>
+                      <Progress percent={Math.ceil(icon.score * 100)} />
+                    </td>
+                  </tr>
+                ))}
+              </table>
             </div>
           </Spin>
         </Modal>

--- a/site/theme/template/IconDisplay/IconPicSearcher.tsx
+++ b/site/theme/template/IconDisplay/IconPicSearcher.tsx
@@ -94,8 +94,8 @@ class PicSearcher extends Component<PicSearcherProps, PicSearcherState> {
       fileList: [],
       icons: [],
     }));
-    if (!localStorage.getItem('disableIconTip')) {
-      localStorage.setItem('disableIconTip', 'true');
+    if (!window.localStorage.getItem('disableIconTip')) {
+      window.localStorage.setItem('disableIconTip', 'true');
     }
   };
 
@@ -116,7 +116,7 @@ class PicSearcher extends Component<PicSearcherProps, PicSearcherState> {
       <div className="icon-pic-searcher">
         <Popover
           content={messages[`app.docs.components.icon.pic-searcher.intro`]}
-          visible={!localStorage.getItem('disableIconTip')}
+          visible={!window.localStorage.getItem('disableIconTip')}
         >
           <Icon type="camera" className="icon-pic-btn" onClick={this.toggleModal} />
         </Popover>

--- a/site/theme/template/IconDisplay/IconPicSearcher.tsx
+++ b/site/theme/template/IconDisplay/IconPicSearcher.tsx
@@ -1,0 +1,143 @@
+import React, { Component } from 'react';
+import { Upload, Tooltip, Icon, Modal, Progress, message } from 'antd';
+
+const { Dragger } = Upload;
+
+interface PicSearcherProps {}
+
+interface PicSearcherState {
+  loading: Boolean;
+  modalVisible: Boolean;
+  icons: Array<string>;
+  justCopied: string | null;
+  fileList: Array<any>;
+}
+
+interface iconObject {
+  class_name: string;
+  score: number;
+}
+
+class PicSearcher extends Component<PicSearcherProps, PicSearcherState> {
+  copyId?: number;
+
+  state = {
+    loading: false,
+    modalVisible: false,
+    icons: [],
+    justCopied: null,
+    fileList: [],
+  };
+
+  componentDidMount() {
+    document.addEventListener('paste', this.onPaste);
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener('paste', this.onPaste);
+    window.clearTimeout(this.copyId);
+  }
+
+  onCopied = (type: string, text: string) => {
+    message.success(
+      <span>
+        <code className="copied-code">{text}</code> copied 🎉
+      </span>,
+    );
+    this.setState({ justCopied: type }, () => {
+      this.copyId = window.setTimeout(() => {
+        this.setState({ justCopied: null });
+      }, 2000);
+    });
+  };
+
+  onPaste = (event: ClipboardEvent) => {
+    const items = event.clipboardData && event.clipboardData.items;
+    let file = null;
+    if (items && items.length) {
+      for (let i = 0; i < items.length; i += 1) {
+        if (items[i].type.indexOf('image') !== -1) {
+          file = items[i].getAsFile();
+          break;
+        }
+      }
+    }
+    if (file) this.uploadFile(file);
+  };
+
+  uploadFile = (file: File) => {
+    const reader: FileReader = new FileReader();
+    reader.onload = () => {
+      this.predict(reader.result);
+      this.setState(() => ({
+        fileList: [{ uid: 1, name: file.name, status: 'done', url: reader.result }],
+      }));
+    };
+    reader.readAsDataURL(file);
+  };
+
+  predict = async (imageBase64: any) => {
+    this.setState(() => ({ loading: true }));
+    const res = await fetch(
+      '//1647796581073291.cn-shanghai.fc.aliyuncs.com/2016-08-15/proxy/cr-sh.cr-fc-predict__stable/cr-fc-predict/',
+      {
+        method: 'post',
+        body: JSON.stringify({
+          modelId: 'data_icon',
+          type: 'ic',
+          imageBase64,
+        }),
+      },
+    );
+    const icons = await res.json();
+    console.log(icons);
+    this.setState(() => ({ icons, loading: false }));
+  };
+
+  toggleModal = () => {
+    this.setState(prev => ({ modalVisible: !prev.modalVisible }));
+  };
+
+  customRequest = (options: any) => {
+    this.uploadFile(options.file);
+  };
+
+  render() {
+    const { modalVisible, icons, fileList } = this.state;
+    return (
+      <div className="icon-pic-searcher">
+        <Tooltip title="截图搜索，支持 CTL+V 粘贴图片" visible>
+          <Icon type="camera" className="icon-pic-btn" onClick={this.toggleModal} />
+        </Tooltip>
+        <Modal
+          title="截图搜索"
+          visible={modalVisible}
+          onOk={this.toggleModal}
+          onCancel={this.toggleModal}
+        >
+          <Dragger
+            listType="picture"
+            customRequest={this.customRequest}
+            fileList={fileList}
+            showUploadList={{ showPreviewIcon: false, showRemoveIcon: false }}
+          >
+            <p className="ant-upload-drag-icon">
+              <Icon type="inbox" />
+            </p>
+            <p className="ant-upload-text">点击/拖拽/粘贴上传</p>
+          </Dragger>
+          <div className="icon-pic-search-result">
+            {icons.map((icon: iconObject) => (
+              <div key={icon.class_name}>
+                <Icon type={icon.class_name.replace(/\s/g, '-')} />
+                <Progress percent={Math.ceil(icon.score * 100)} />
+              </div>
+            ))}
+          </div>
+        </Modal>
+      </div>
+    );
+  }
+}
+
+export default PicSearcher;

--- a/site/theme/template/IconDisplay/IconPicSearcher.tsx
+++ b/site/theme/template/IconDisplay/IconPicSearcher.tsx
@@ -117,8 +117,8 @@ class PicSearcher extends Component<PicSearcherProps, PicSearcherState> {
         <Modal
           title={messages[`app.docs.components.icon.pic-searcher.title`]}
           visible={modalVisible}
-          onOk={this.toggleModal}
           onCancel={this.toggleModal}
+          footer={null}
         >
           <Dragger
             accept="image/jpeg, image/png"
@@ -131,7 +131,10 @@ class PicSearcher extends Component<PicSearcherProps, PicSearcherState> {
               <Icon type="inbox" />
             </p>
             <p className="ant-upload-text">
-              {messages['app.docs.components.icon.pic-searcher.placeholder']}
+              {messages['app.docs.components.icon.pic-searcher.upload-text']}
+            </p>
+            <p className="ant-upload-hint">
+              {messages['app.docs.components.icon.pic-searcher.upload-hint']}
             </p>
           </Dragger>
           <Spin spinning={loading} tip={messages['app.docs.components.icon.pic-searcher.matching']}>

--- a/site/theme/template/IconDisplay/IconPicSearcher.tsx
+++ b/site/theme/template/IconDisplay/IconPicSearcher.tsx
@@ -57,12 +57,30 @@ class PicSearcher extends Component<PicSearcherProps, PicSearcherState> {
   uploadFile = (file: File) => {
     const reader: FileReader = new FileReader();
     reader.onload = () => {
-      this.predict(reader.result);
+      this.downscaleImage(reader.result).then(this.predict);
       this.setState(() => ({
         fileList: [{ uid: 1, name: file.name, status: 'done', url: reader.result }],
       }));
     };
     reader.readAsDataURL(file);
+  };
+
+  downscaleImage = (url: any) => {
+    return new Promise(resolve => {
+      const img = new Image();
+      img.setAttribute('crossOrigin', 'anonymous');
+      img.src = url;
+      img.onload = function() {
+        const scale = Math.min(1, 300 / Math.max(img.width, img.height));
+        const canvas = document.createElement('canvas');
+        canvas.width = img.width * scale;
+        canvas.height = img.height * scale;
+        const ctx = canvas.getContext('2d');
+        (ctx as CanvasRenderingContext2D).drawImage(img, 0, 0, canvas.width, canvas.height);
+        const newDataUrl = canvas.toDataURL('image/jpeg');
+        resolve(newDataUrl);
+      };
+    });
   };
 
   predict = async (imageBase64: any) => {

--- a/site/theme/template/IconDisplay/IconPicSearcher.tsx
+++ b/site/theme/template/IconDisplay/IconPicSearcher.tsx
@@ -23,8 +23,6 @@ interface iconObject {
 }
 
 class PicSearcher extends Component<PicSearcherProps, PicSearcherState> {
-  copyId?: number;
-
   state = {
     loading: false,
     modalVisible: false,
@@ -39,7 +37,6 @@ class PicSearcher extends Component<PicSearcherProps, PicSearcherState> {
 
   componentWillUnmount() {
     document.removeEventListener('paste', this.onPaste);
-    window.clearTimeout(this.copyId);
   }
 
   onPaste = (event: ClipboardEvent) => {
@@ -118,7 +115,7 @@ class PicSearcher extends Component<PicSearcherProps, PicSearcherState> {
     return (
       <div className="icon-pic-searcher">
         <Popover
-          content={messages[`app.docs.components.icon.pic-searcher.title`]}
+          content={messages[`app.docs.components.icon.pic-searcher.intro`]}
           visible={popoverVisible}
         >
           <Icon type="camera" className="icon-pic-btn" onClick={this.toggleModal} />
@@ -130,6 +127,7 @@ class PicSearcher extends Component<PicSearcherProps, PicSearcherState> {
           onCancel={this.toggleModal}
         >
           <Dragger
+            accept="image/jpeg, image/png"
             listType="picture"
             customRequest={(o: any) => this.uploadFile(o.file)}
             fileList={fileList}

--- a/site/theme/template/IconDisplay/IconPicSearcher.tsx
+++ b/site/theme/template/IconDisplay/IconPicSearcher.tsx
@@ -1,14 +1,18 @@
 import React, { Component } from 'react';
-import { Upload, Tooltip, Icon, Modal, Progress, message } from 'antd';
+import { Upload, Popover, Icon, Modal, Progress, message, Spin } from 'antd';
 import CopyToClipboard from 'react-copy-to-clipboard';
+import { injectIntl } from 'react-intl';
 
 const { Dragger } = Upload;
 
-interface PicSearcherProps {}
+interface PicSearcherProps {
+  intl: any;
+}
 
 interface PicSearcherState {
   loading: Boolean;
   modalVisible: Boolean;
+  popoverVisible: Boolean;
   icons: Array<string>;
   fileList: Array<any>;
 }
@@ -24,6 +28,7 @@ class PicSearcher extends Component<PicSearcherProps, PicSearcherState> {
   state = {
     loading: false,
     modalVisible: false,
+    popoverVisible: true,
     icons: [],
     fileList: [],
   };
@@ -36,14 +41,6 @@ class PicSearcher extends Component<PicSearcherProps, PicSearcherState> {
     document.removeEventListener('paste', this.onPaste);
     window.clearTimeout(this.copyId);
   }
-
-  onCopied = (text: string) => {
-    message.success(
-      <span>
-        <code className="copied-code">{text}</code> copied 🎉
-      </span>,
-    );
-  };
 
   onPaste = (event: ClipboardEvent) => {
     const items = event.clipboardData && event.clipboardData.items;
@@ -89,52 +86,70 @@ class PicSearcher extends Component<PicSearcherProps, PicSearcherState> {
   };
 
   toggleModal = () => {
-    this.setState(prev => ({ modalVisible: !prev.modalVisible }));
+    this.setState(prev => ({
+      modalVisible: !prev.modalVisible,
+      popoverVisible: false,
+      fileList: [],
+      icons: [],
+    }));
   };
 
-  customRequest = (options: any) => {
-    this.uploadFile(options.file);
+  onCopied = (text: string) => {
+    message.success(
+      <span>
+        <code className="copied-code">{text}</code> copied 🎉
+      </span>,
+    );
   };
 
   render() {
-    const { modalVisible, icons, fileList } = this.state;
+    const {
+      intl: { messages },
+    } = this.props;
+    const { popoverVisible, modalVisible, icons, fileList, loading } = this.state;
     return (
       <div className="icon-pic-searcher">
-        <Tooltip title="截图搜索，支持 CTL+V 粘贴图片" visible>
+        <Popover
+          content={messages[`app.docs.components.icon.pic-searcher.title`]}
+          visible={popoverVisible}
+        >
           <Icon type="camera" className="icon-pic-btn" onClick={this.toggleModal} />
-        </Tooltip>
+        </Popover>
         <Modal
-          title="截图搜索"
+          title={messages[`app.docs.components.icon.pic-searcher.title`]}
           visible={modalVisible}
           onOk={this.toggleModal}
           onCancel={this.toggleModal}
         >
           <Dragger
             listType="picture"
-            customRequest={this.customRequest}
+            customRequest={(o: any) => this.uploadFile(o.file)}
             fileList={fileList}
             showUploadList={{ showPreviewIcon: false, showRemoveIcon: false }}
           >
             <p className="ant-upload-drag-icon">
               <Icon type="inbox" />
             </p>
-            <p className="ant-upload-text">点击/拖拽/粘贴上传</p>
+            <p className="ant-upload-text">
+              {messages['app.docs.components.icon.pic-searcher.placeholder']}
+            </p>
           </Dragger>
-          <div className="icon-pic-search-result">
-            {icons.map((icon: iconObject) => (
-              <div key={icon.type}>
-                <CopyToClipboard text={`<Icon type="${icon.type}" />`} onCopy={this.onCopied}>
-                  <Icon type={icon.type} />
-                </CopyToClipboard>
-
-                <Progress percent={Math.ceil(icon.score * 100)} />
-              </div>
-            ))}
-          </div>
+          <Spin spinning={loading}>
+            <div className="icon-pic-search-result">
+              {icons.map((icon: iconObject) => (
+                <div key={icon.type}>
+                  <CopyToClipboard text={`<Icon type="${icon.type}" />`} onCopy={this.onCopied}>
+                    <Icon type={icon.type} />
+                  </CopyToClipboard>
+                  <Progress percent={Math.ceil(icon.score * 100)} />
+                </div>
+              ))}
+            </div>
+          </Spin>
         </Modal>
       </div>
     );
   }
 }
 
-export default PicSearcher;
+export default injectIntl(PicSearcher);

--- a/site/theme/template/IconDisplay/IconPicSearcher.tsx
+++ b/site/theme/template/IconDisplay/IconPicSearcher.tsx
@@ -12,6 +12,7 @@ interface PicSearcherProps {
 interface PicSearcherState {
   loading: Boolean;
   modalVisible: Boolean;
+  popoverVisible: Boolean;
   icons: Array<string>;
   fileList: Array<any>;
 }
@@ -25,12 +26,14 @@ class PicSearcher extends Component<PicSearcherProps, PicSearcherState> {
   state = {
     loading: false,
     modalVisible: false,
+    popoverVisible: false,
     icons: [],
     fileList: [],
   };
 
   componentDidMount() {
     document.addEventListener('paste', this.onPaste);
+    this.setState({ popoverVisible: !localStorage.getItem('disableIconTip') });
   }
 
   componentWillUnmount() {
@@ -91,10 +94,11 @@ class PicSearcher extends Component<PicSearcherProps, PicSearcherState> {
   toggleModal = () => {
     this.setState(prev => ({
       modalVisible: !prev.modalVisible,
+      popoverVisible: false,
       fileList: [],
       icons: [],
     }));
-    if (localStorage && !localStorage.getItem('disableIconTip')) {
+    if (!localStorage.getItem('disableIconTip')) {
       localStorage.setItem('disableIconTip', 'true');
     }
   };
@@ -111,12 +115,12 @@ class PicSearcher extends Component<PicSearcherProps, PicSearcherState> {
     const {
       intl: { messages },
     } = this.props;
-    const { modalVisible, icons, fileList, loading } = this.state;
+    const { modalVisible, popoverVisible, icons, fileList, loading } = this.state;
     return (
       <div className="icon-pic-searcher">
         <Popover
           content={messages[`app.docs.components.icon.pic-searcher.intro`]}
-          visible={!(localStorage && localStorage.getItem('disableIconTip'))}
+          visible={popoverVisible}
         >
           <Icon type="camera" className="icon-pic-btn" onClick={this.toggleModal} />
         </Popover>
@@ -152,27 +156,34 @@ class PicSearcher extends Component<PicSearcherProps, PicSearcherState> {
               )}
               <table>
                 {icons.length > 0 && (
-                  <tr>
-                    <th className="col-icon">
-                      {messages['app.docs.components.icon.pic-searcher.th-icon']}
-                    </th>
-                    <th>{messages['app.docs.components.icon.pic-searcher.th-score']}</th>
-                  </tr>
+                  <thead>
+                    <tr>
+                      <th className="col-icon">
+                        {messages['app.docs.components.icon.pic-searcher.th-icon']}
+                      </th>
+                      <th>{messages['app.docs.components.icon.pic-searcher.th-score']}</th>
+                    </tr>
+                  </thead>
                 )}
-                {icons.map((icon: iconObject) => (
-                  <tr key={icon.type}>
-                    <td className="col-icon">
-                      <CopyToClipboard text={`<Icon type="${icon.type}" />`} onCopy={this.onCopied}>
-                        <Tooltip title={icon.type} placement="right">
-                          <Icon type={icon.type} />
-                        </Tooltip>
-                      </CopyToClipboard>
-                    </td>
-                    <td>
-                      <Progress percent={Math.ceil(icon.score * 100)} />
-                    </td>
-                  </tr>
-                ))}
+                <tbody>
+                  {icons.map((icon: iconObject) => (
+                    <tr key={icon.type}>
+                      <td className="col-icon">
+                        <CopyToClipboard
+                          text={`<Icon type="${icon.type}" />`}
+                          onCopy={this.onCopied}
+                        >
+                          <Tooltip title={icon.type} placement="right">
+                            <Icon type={icon.type} />
+                          </Tooltip>
+                        </CopyToClipboard>
+                      </td>
+                      <td>
+                        <Progress percent={Math.ceil(icon.score * 100)} />
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
               </table>
             </div>
           </Spin>

--- a/site/theme/template/IconDisplay/IconPicSearcher.tsx
+++ b/site/theme/template/IconDisplay/IconPicSearcher.tsx
@@ -12,7 +12,6 @@ interface PicSearcherProps {
 interface PicSearcherState {
   loading: Boolean;
   modalVisible: Boolean;
-  popoverVisible: Boolean;
   icons: Array<string>;
   fileList: Array<any>;
 }
@@ -26,7 +25,6 @@ class PicSearcher extends Component<PicSearcherProps, PicSearcherState> {
   state = {
     loading: false,
     modalVisible: false,
-    popoverVisible: true,
     icons: [],
     fileList: [],
   };
@@ -93,7 +91,6 @@ class PicSearcher extends Component<PicSearcherProps, PicSearcherState> {
   toggleModal = () => {
     this.setState(prev => ({
       modalVisible: !prev.modalVisible,
-      popoverVisible: false,
       fileList: [],
       icons: [],
     }));
@@ -111,13 +108,10 @@ class PicSearcher extends Component<PicSearcherProps, PicSearcherState> {
     const {
       intl: { messages },
     } = this.props;
-    const { popoverVisible, modalVisible, icons, fileList, loading } = this.state;
+    const { modalVisible, icons, fileList, loading } = this.state;
     return (
       <div className="icon-pic-searcher">
-        <Popover
-          content={messages[`app.docs.components.icon.pic-searcher.intro`]}
-          visible={popoverVisible}
-        >
+        <Popover content={messages[`app.docs.components.icon.pic-searcher.intro`]} visible>
           <Icon type="camera" className="icon-pic-btn" onClick={this.toggleModal} />
         </Popover>
         <Modal

--- a/site/theme/template/IconDisplay/IconPicSearcher.tsx
+++ b/site/theme/template/IconDisplay/IconPicSearcher.tsx
@@ -94,6 +94,9 @@ class PicSearcher extends Component<PicSearcherProps, PicSearcherState> {
       fileList: [],
       icons: [],
     }));
+    if (!localStorage.getItem('disableIconTip')) {
+      localStorage.setItem('disableIconTip', 'true');
+    }
   };
 
   onCopied = (text: string) => {
@@ -111,7 +114,10 @@ class PicSearcher extends Component<PicSearcherProps, PicSearcherState> {
     const { modalVisible, icons, fileList, loading } = this.state;
     return (
       <div className="icon-pic-searcher">
-        <Popover content={messages[`app.docs.components.icon.pic-searcher.intro`]} visible>
+        <Popover
+          content={messages[`app.docs.components.icon.pic-searcher.intro`]}
+          visible={!localStorage.getItem('disableIconTip')}
+        >
           <Icon type="camera" className="icon-pic-btn" onClick={this.toggleModal} />
         </Popover>
         <Modal

--- a/site/theme/template/IconDisplay/IconPicSearcher.tsx
+++ b/site/theme/template/IconDisplay/IconPicSearcher.tsx
@@ -94,8 +94,8 @@ class PicSearcher extends Component<PicSearcherProps, PicSearcherState> {
       fileList: [],
       icons: [],
     }));
-    if (!window.localStorage.getItem('disableIconTip')) {
-      window.localStorage.setItem('disableIconTip', 'true');
+    if (localStorage && !localStorage.getItem('disableIconTip')) {
+      localStorage.setItem('disableIconTip', 'true');
     }
   };
 
@@ -116,7 +116,7 @@ class PicSearcher extends Component<PicSearcherProps, PicSearcherState> {
       <div className="icon-pic-searcher">
         <Popover
           content={messages[`app.docs.components.icon.pic-searcher.intro`]}
-          visible={!window.localStorage.getItem('disableIconTip')}
+          visible={!(localStorage && localStorage.getItem('disableIconTip'))}
         >
           <Icon type="camera" className="icon-pic-btn" onClick={this.toggleModal} />
         </Popover>

--- a/site/theme/template/IconDisplay/IconPicSearcher.tsx
+++ b/site/theme/template/IconDisplay/IconPicSearcher.tsx
@@ -68,21 +68,29 @@ class PicSearcher extends Component<PicSearcherProps, PicSearcherState> {
   };
 
   predict = async (imageBase64: any) => {
+    const {
+      intl: { messages },
+    } = this.props;
     this.setState(() => ({ loading: true }));
-    const res = await fetch(
-      '//1647796581073291.cn-shanghai.fc.aliyuncs.com/2016-08-15/proxy/cr-sh.cr-fc-predict__stable/cr-fc-predict/',
-      {
-        method: 'post',
-        body: JSON.stringify({
-          modelId: 'data_icon',
-          type: 'ic',
-          imageBase64,
-        }),
-      },
-    );
-    let icons = await res.json();
-    icons = icons.map((i: any) => ({ score: i.score, type: i.class_name.replace(/\s/g, '-') }));
-    this.setState(() => ({ icons, loading: false }));
+    try {
+      const res = await fetch(
+        '//1647796581073291.cn-shanghai.fc.aliyuncs.com/2016-08-15/proxy/cr-sh.cr-fc-predict__stable/cr-fc-predict/',
+        {
+          method: 'post',
+          body: JSON.stringify({
+            modelId: 'data_icon',
+            type: 'ic',
+            imageBase64,
+          }),
+        },
+      );
+      let icons = await res.json();
+      icons = icons.map((i: any) => ({ score: i.score, type: i.class_name.replace(/\s/g, '-') }));
+      this.setState(() => ({ icons, loading: false }));
+    } catch (err) {
+      message.error(messages['app.docs.components.icon.pic-searcher.server-error']);
+      this.setState(() => ({ loading: false }));
+    }
   };
 
   toggleModal = () => {

--- a/site/theme/template/IconDisplay/IconPicSearcher.tsx
+++ b/site/theme/template/IconDisplay/IconPicSearcher.tsx
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { Upload, Tooltip, Popover, Icon, Modal, Progress, message, Spin } from 'antd';
+import { Upload, Tooltip, Popover, Icon, Modal, Progress, message, Spin, Result } from 'antd';
 import CopyToClipboard from 'react-copy-to-clipboard';
 import { injectIntl } from 'react-intl';
 
@@ -10,11 +10,12 @@ interface PicSearcherProps {
 }
 
 interface PicSearcherState {
-  loading: Boolean;
-  modalVisible: Boolean;
-  popoverVisible: Boolean;
+  loading: boolean;
+  modalVisible: boolean;
+  popoverVisible: boolean;
   icons: Array<string>;
   fileList: Array<any>;
+  error: boolean;
 }
 
 interface iconObject {
@@ -29,6 +30,7 @@ class PicSearcher extends Component<PicSearcherProps, PicSearcherState> {
     popoverVisible: false,
     icons: [],
     fileList: [],
+    error: false,
   };
 
   componentDidMount() {
@@ -84,9 +86,6 @@ class PicSearcher extends Component<PicSearcherProps, PicSearcherState> {
   };
 
   predict = async (imageBase64: any) => {
-    const {
-      intl: { messages },
-    } = this.props;
     this.setState(() => ({ loading: true }));
     try {
       const res = await fetch(
@@ -102,10 +101,9 @@ class PicSearcher extends Component<PicSearcherProps, PicSearcherState> {
       );
       let icons = await res.json();
       icons = icons.map((i: any) => ({ score: i.score, type: i.class_name.replace(/\s/g, '-') }));
-      this.setState(() => ({ icons, loading: false }));
+      this.setState(() => ({ icons, loading: false, error: false }));
     } catch (err) {
-      message.error(messages['app.docs.components.icon.pic-searcher.server-error']);
-      this.setState(() => ({ loading: false }));
+      this.setState(() => ({ loading: false, error: true }));
     }
   };
 
@@ -133,7 +131,7 @@ class PicSearcher extends Component<PicSearcherProps, PicSearcherState> {
     const {
       intl: { messages },
     } = this.props;
-    const { modalVisible, popoverVisible, icons, fileList, loading } = this.state;
+    const { modalVisible, popoverVisible, icons, fileList, loading, error } = this.state;
     return (
       <div className="icon-pic-searcher">
         <Popover
@@ -203,6 +201,13 @@ class PicSearcher extends Component<PicSearcherProps, PicSearcherState> {
                   ))}
                 </tbody>
               </table>
+              {error && (
+                <Result
+                  status="500"
+                  title="500"
+                  subTitle={messages['app.docs.components.icon.pic-searcher.server-error']}
+                />
+              )}
             </div>
           </Spin>
         </Modal>

--- a/site/theme/template/IconDisplay/IconPicSearcher.tsx
+++ b/site/theme/template/IconDisplay/IconPicSearcher.tsx
@@ -204,7 +204,7 @@ class PicSearcher extends Component<PicSearcherProps, PicSearcherState> {
               {error && (
                 <Result
                   status="500"
-                  title="500"
+                  title="503"
                   subTitle={messages['app.docs.components.icon.pic-searcher.server-error']}
                 />
               )}

--- a/site/theme/template/IconDisplay/index.tsx
+++ b/site/theme/template/IconDisplay/index.tsx
@@ -7,6 +7,7 @@ import { injectIntl } from 'react-intl';
 import debounce from 'lodash/debounce';
 import { ThemeType } from 'antd/es/icon';
 import Category from './Category';
+import IconPicSearcher from './IconPicSearcher';
 import { FilledIcon, OutlinedIcon, TwoToneIcon } from './themeIcons';
 import categories, { Categories, CategoriesKeys } from './fields';
 
@@ -124,6 +125,7 @@ class IconDisplay extends React.Component<IconDisplayProps, IconDisplayState> {
             onChange={e => this.handleSearchIcon(e.currentTarget.value)}
             size="large"
             autoFocus
+            suffix={<IconPicSearcher />}
           />
         </div>
         {this.renderCategories(list)}

--- a/site/theme/zh-CN.js
+++ b/site/theme/zh-CN.js
@@ -112,5 +112,9 @@ module.exports = {
     'app.docs.components.icon.pic-searcher.title': '按图片搜索',
     'app.docs.components.icon.pic-searcher.placeholder': '点击/拖拽/粘贴上传',
     'app.docs.components.icon.pic-searcher.server-error': '识别服务暂不可用',
+    'app.docs.components.icon.pic-searcher.matching': '匹配中...',
+    'app.docs.components.icon.pic-searcher.result-tip': '为您匹配到以下图标：',
+    'app.docs.components.icon.pic-searcher.th-icon': '图标',
+    'app.docs.components.icon.pic-searcher.th-score': '匹配度',
   },
 };

--- a/site/theme/zh-CN.js
+++ b/site/theme/zh-CN.js
@@ -109,8 +109,10 @@ module.exports = {
     'app.docs.components.icon.category.other': '网站通用图标',
     'app.docs.components.icon.category.logo': '品牌和标识',
     'app.docs.components.icon.pic-searcher.intro': 'AI 截图搜索上线了，快来体验吧！🎉',
-    'app.docs.components.icon.pic-searcher.title': '按图片搜索',
-    'app.docs.components.icon.pic-searcher.placeholder': '点击/拖拽/粘贴上传',
+    'app.docs.components.icon.pic-searcher.title': '上传图片搜索图标',
+    'app.docs.components.icon.pic-searcher.upload-text': '点击/拖拽/粘贴上传图片',
+    'app.docs.components.icon.pic-searcher.upload-hint':
+      '我们会通过上传的图片进行匹配，得到最相似的图标',
     'app.docs.components.icon.pic-searcher.server-error': '识别服务暂不可用',
     'app.docs.components.icon.pic-searcher.matching': '匹配中...',
     'app.docs.components.icon.pic-searcher.result-tip': '为您匹配到以下图标：',

--- a/site/theme/zh-CN.js
+++ b/site/theme/zh-CN.js
@@ -108,6 +108,7 @@ module.exports = {
     'app.docs.components.icon.category.data': '数据类图标',
     'app.docs.components.icon.category.other': '网站通用图标',
     'app.docs.components.icon.category.logo': '品牌和标识',
+    'app.docs.components.icon.pic-searcher.intro': 'AI 截图搜索上线了，快来体验吧！🎉',
     'app.docs.components.icon.pic-searcher.title': '按图片搜索',
     'app.docs.components.icon.pic-searcher.placeholder': '点击/拖拽/粘贴上传',
     'app.docs.components.icon.pic-searcher.server-error': '识别服务暂不可用',

--- a/site/theme/zh-CN.js
+++ b/site/theme/zh-CN.js
@@ -108,5 +108,7 @@ module.exports = {
     'app.docs.components.icon.category.data': '数据类图标',
     'app.docs.components.icon.category.other': '网站通用图标',
     'app.docs.components.icon.category.logo': '品牌和标识',
+    'app.docs.components.icon.pic-searcher.title': '按图片搜索',
+    'app.docs.components.icon.pic-searcher.placeholder': '点击/拖拽/粘贴上传',
   },
 };

--- a/site/theme/zh-CN.js
+++ b/site/theme/zh-CN.js
@@ -110,5 +110,6 @@ module.exports = {
     'app.docs.components.icon.category.logo': '品牌和标识',
     'app.docs.components.icon.pic-searcher.title': '按图片搜索',
     'app.docs.components.icon.pic-searcher.placeholder': '点击/拖拽/粘贴上传',
+    'app.docs.components.icon.pic-searcher.server-error': '识别服务暂不可用',
   },
 };


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [ ] 日常 bug 修复
- [x] 站点、文档改进
- [ ] 组件样式改进
- [ ] TypeScript 定义更新
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

无

### 💡 需求背景和解决方案


1. 要解决的具体问题：前端开发过程中，需要还原设计稿图片中的图标，大多时候设计稿中的图标没有对应的 type 字段，如果肉眼从几百个图标中寻找，用户体验非常差。
2. 列出最终的 API 实现和用法：所以本 PR 基于深度学习技术贡献了一个截图搜 icon 的功能，用户直接对设计稿或任意图片中的图标截图，点击或拖拽或粘贴上传，就可以搜索到匹配度最高的五个图标以及对应的匹配度。
3. 涉及UI/交互变动需要有截图或 GIF：![](https://img.alicdn.com/tfs/TB1rEyhdVT7gK0jSZFpXXaTkpXa-1271-677.gif)



### 📝 更新日志怎么写？

<!--
> 从用户角度描述具体变化，以及可能的 breaking change 和其他风险？
-->

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |    Search icon by image      |
| 🇨🇳 中文 |    通过截图搜索图标      |

- 中文（可选）:

### ☑️ 请求合并前的自查清单

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供