### PR TITLE
fix: Capitalize Text and PageHeader default locale strings

### DIFF
--- a/components/locale/default.tsx
+++ b/components/locale/default.tsx
@@ -50,12 +50,12 @@ export default {
     icon: 'icon',
   },
   Text: {
-    edit: 'edit',
-    copy: 'copy',
-    copied: 'copy success',
-    expand: 'expand',
+    edit: 'Edit',
+    copy: 'Copy',
+    copied: 'Copied',
+    expand: 'Expand',
   },
   PageHeader: {
-    back: 'back',
+    back: 'Back',
   },
 };

--- a/components/page-header/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/page-header/__tests__/__snapshots__/demo.test.js.snap
@@ -8,7 +8,7 @@ exports[`renders ./components/page-header/demo/actions.md correctly 1`] = `
     class="ant-page-header-back"
   >
     <div
-      aria-label="back"
+      aria-label="Back"
       class="ant-page-header-back-button"
       role="button"
       style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-block"
@@ -418,7 +418,7 @@ exports[`renders ./components/page-header/demo/basic.md correctly 1`] = `
     class="ant-page-header-back"
   >
     <div
-      aria-label="back"
+      aria-label="Back"
       class="ant-page-header-back-button"
       role="button"
       style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-block"

--- a/components/typography/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/typography/__tests__/__snapshots__/demo.test.js.snap
@@ -285,7 +285,7 @@ exports[`renders ./components/typography/demo/interactive.md correctly 1`] = `
   >
     This is an editable text.
     <div
-      aria-label="edit"
+      aria-label="Edit"
       class="ant-typography-edit"
       role="button"
       style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-block"
@@ -318,7 +318,7 @@ exports[`renders ./components/typography/demo/interactive.md correctly 1`] = `
   >
     This is a copyable text.
     <div
-      aria-label="copy"
+      aria-label="Copy"
       class="ant-typography-copy"
       role="button"
       style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-block"
@@ -351,7 +351,7 @@ exports[`renders ./components/typography/demo/interactive.md correctly 1`] = `
   >
     Replace copy text.
     <div
-      aria-label="copy"
+      aria-label="Copy"
       class="ant-typography-copy"
       role="button"
       style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-block"


### PR DESCRIPTION
Most of the locale strings in the default locale are capitalized. This
changeset makes `Text` and `PageHeader` locale strings consistent with
others. Also, "Copied" implies successfully so changing "copy success"
to "Copied" should be sufficient IMHO.

<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
