### PR TITLE
fix: Input.Password unmount crash

### DIFF
--- a/components/input/Password.tsx
+++ b/components/input/Password.tsx
@@ -55,7 +55,9 @@ export default class Password extends React.Component<PasswordProps, PasswordSta
   }
 
   saveInput = (instance: Input) => {
-    this.input = instance.input;
+    if (instance && instance.input) {
+      this.input = instance.input;
+    }
   };
 
   focus() {

--- a/components/input/__tests__/Password.test.js
+++ b/components/input/__tests__/Password.test.js
@@ -61,4 +61,12 @@ describe('Input.Password', () => {
         .getDOMNode(),
     );
   });
+
+  // https://github.com/ant-design/ant-design/pull/18441
+  it('should unmount without error', () => {
+    const wrapper = mount(<Input.Password />);
+    expect(() => {
+      wrapper.unmount();
+    }).not.toThrow();
+  });
 });


### PR DESCRIPTION


<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close #18473

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Input.Password crash with `Cannot read property 'input' of null` when unmount.  |
| 🇨🇳 Chinese | 修复 Input.Password `unmount` 时报错 `Cannot read property 'input' of null`。 |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
