### PR TITLE
feat: improve prop def for tooltip

### DIFF
--- a/components/menu/MenuItem.tsx
+++ b/components/menu/MenuItem.tsx
@@ -42,11 +42,12 @@ export default class MenuItem extends React.Component<MenuItemProps> {
     return (
       <MenuContext.Consumer>
         {({ inlineCollapsed }: MenuContextProps) => {
-          const tooltipProps: TooltipProps = {};
+          const tooltipProps: TooltipProps = {
+            title: title || (level === 1 ? children : ''),
+          };
 
-          let titleNode = title || (level === 1 ? children : '');
           if (!siderCollapsed && !inlineCollapsed) {
-            titleNode = null;
+            tooltipProps.title = null;
             // Reset `visible` to fix control mode tooltip display not correct
             // ref: https://github.com/ant-design/ant-design/issues/16742
             tooltipProps.visible = false;
@@ -55,7 +56,6 @@ export default class MenuItem extends React.Component<MenuItemProps> {
           return (
             <Tooltip
               {...tooltipProps}
-              title={titleNode}
               placement="right"
               overlayClassName={`${rootPrefixCls}-inline-collapsed-tooltip`}
             >

--- a/components/tooltip/index.tsx
+++ b/components/tooltip/index.tsx
@@ -64,10 +64,17 @@ export interface AbstractTooltipProps {
 
 export type RenderFunction = () => React.ReactNode;
 
-export interface TooltipProps extends AbstractTooltipProps {
+interface TooltipPropsWithOverlay extends AbstractTooltipProps {
   title?: React.ReactNode | RenderFunction;
+  overlay: React.ReactNode | RenderFunction;
+}
+
+interface TooltipPropsWithTitle extends AbstractTooltipProps {
+  title: React.ReactNode | RenderFunction;
   overlay?: React.ReactNode | RenderFunction;
 }
+
+export declare type TooltipProps = TooltipPropsWithTitle | TooltipPropsWithOverlay;
 
 const splitObject = (obj: any, keys: string[]) => {
   const picked: any = {};


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->
(none)

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

Tooltip component does not require to pass either `title` or `overlay`. However, when not passing the any of them, the component itself does not work (not rendering tooltip).

The solution is to improve the type definition, so that at least one of `title` and `overlay` is provided.

Please notice that `React.ReactNode` includes falsy values such as `undefined`, `null` and `false`, thus following works:

```jsx
<Tooltip title={undefined} />
```

However, following should consider type error and TypeScript should warn about it:

```jsx
<Tooltip />
```

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  fix: ensure `title` or `overlay` is required in Tooltip props definition         |
| 🇨🇳 Chinese |  fix: 确保 Tooltip props 定义中，`title` 或 `overlay` 至少有一个是必填的         |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
