### PR TITLE
fix: unused Descriptions parameter "border"

### DIFF
--- a/components/descriptions/demo/size.md
+++ b/components/descriptions/demo/size.md
@@ -38,7 +38,7 @@ class Demo extends React.Component {
         </Radio.Group>
         <br />
         <br />
-        <Descriptions bordered title="Custom Size" border size={this.state.size}>
+        <Descriptions bordered title="Custom Size" size={this.state.size}>
           <Descriptions.Item label="Product">Cloud Database</Descriptions.Item>
           <Descriptions.Item label="Billing">Prepaid</Descriptions.Item>
           <Descriptions.Item label="time">18:00:00</Descriptions.Item>
@@ -61,7 +61,7 @@ class Demo extends React.Component {
         </Descriptions>
         <br />
         <br />
-        <Descriptions title="Custom Size" border size={this.state.size}>
+        <Descriptions title="Custom Size" size={this.state.size}>
           <Descriptions.Item label="Product">Cloud Database</Descriptions.Item>
           <Descriptions.Item label="Billing">Prepaid</Descriptions.Item>
           <Descriptions.Item label="time">18:00:00</Descriptions.Item>


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

`border` parameter is no longer used in `Descriptions` component.

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      -     |
| 🇨🇳 Chinese |     -      |

### ☑️ Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed


-----
[View rendered components/descriptions/demo/size.md](https://github.com/AielloChan/ant-design/blob/patch-1/components/descriptions/demo/size.md)