### PR TITLE
fix(Steps): add subTitle propType declaration for Steps.Step component

### DIFF
--- a/components/steps/index.tsx
+++ b/components/steps/index.tsx
@@ -28,6 +28,7 @@ export interface StepProps {
   status?: 'wait' | 'process' | 'finish' | 'error';
   disabled?: boolean;
   title?: React.ReactNode;
+  subTitle?: React.ReactNode;
   style?: React.CSSProperties;
 }
 


### PR DESCRIPTION
### 🤔 This is a ...

- [x] TypeScript definition update

### 🔗 Related issue link

There is no link, just a issue find in usage that the &lt;Steps.Step> component dosen't have `subTitle` prop type declaration but it is supported by `rc-steps` and exposed by the [document](https://ant.design/components/steps-cn/#Steps.Step).

### 💡 Background and solution

Add `subTitle` prop in `StepProps` interface.

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fix <Steps.Step> component's `subTitle` prop types      |
| 🇨🇳 Chinese |    修复 <Steps.Step> 组件 `subTitle` 属性类型    |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
