### PR TITLE
fix(button): button not round when using Icon as child

### DIFF
--- a/components/auto-complete/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/auto-complete/__tests__/__snapshots__/demo.test.js.snap
@@ -517,7 +517,7 @@ exports[`renders ./components/auto-complete/demo/uncertain-category.md correctly
                   class="ant-input-suffix"
                 >
                   <button
-                    class="ant-btn search-btn ant-btn-primary ant-btn-lg"
+                    class="ant-btn search-btn ant-btn-primary ant-btn-lg ant-btn-icon-only"
                     style="margin-right:-12px"
                     type="button"
                   >

--- a/components/badge/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/badge/__tests__/__snapshots__/demo.test.js.snap
@@ -396,7 +396,7 @@ exports[`renders ./components/badge/demo/change.md correctly 1`] = `
       class="ant-btn-group"
     >
       <button
-        class="ant-btn"
+        class="ant-btn ant-btn-icon-only"
         type="button"
       >
         <i
@@ -420,7 +420,7 @@ exports[`renders ./components/badge/demo/change.md correctly 1`] = `
         </i>
       </button>
       <button
-        class="ant-btn"
+        class="ant-btn ant-btn-icon-only"
         type="button"
       >
         <i

--- a/components/button/button.tsx
+++ b/components/button/button.tsx
@@ -259,7 +259,11 @@ class Button extends React.Component<ButtonProps, ButtonState> {
       [`${prefixCls}-${type}`]: type,
       [`${prefixCls}-${shape}`]: shape,
       [`${prefixCls}-${sizeCls}`]: sizeCls,
-      [`${prefixCls}-icon-only`]: !children && children !== 0 && iconType,
+      [`${prefixCls}-icon-only`]:
+        (!children && children !== 0 && iconType) ||
+        (React.Children.count(children) === 1 &&
+          React.isValidElement(children) &&
+          children.type === Icon),
       [`${prefixCls}-loading`]: loading,
       [`${prefixCls}-background-ghost`]: ghost,
       [`${prefixCls}-two-chinese-chars`]: hasTwoCNChar && autoInsertSpace,

--- a/components/config-provider/__tests__/__snapshots__/components.test.js.snap
+++ b/components/config-provider/__tests__/__snapshots__/components.test.js.snap
@@ -6961,7 +6961,7 @@ exports[`ConfigProvider components Dropdown configProvider 1`] = `
     </span>
   </button>
   <button
-    class="config-btn config-dropdown-trigger config-btn-default"
+    class="config-btn config-dropdown-trigger config-btn-default config-btn-icon-only"
     type="button"
   >
     <i
@@ -7000,7 +7000,7 @@ exports[`ConfigProvider components Dropdown normal 1`] = `
     </span>
   </button>
   <button
-    class="ant-btn ant-dropdown-trigger ant-btn-default"
+    class="ant-btn ant-dropdown-trigger ant-btn-default ant-btn-icon-only"
     type="button"
   >
     <i
@@ -7039,7 +7039,7 @@ exports[`ConfigProvider components Dropdown prefixCls 1`] = `
     </span>
   </button>
   <button
-    class="ant-btn ant-dropdown-trigger ant-btn-default"
+    class="ant-btn ant-dropdown-trigger ant-btn-default ant-btn-icon-only"
     type="button"
   >
     <i

--- a/components/dropdown/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/dropdown/__tests__/__snapshots__/demo.test.js.snap
@@ -53,7 +53,7 @@ exports[`renders ./components/dropdown/demo/dropdown-button.md correctly 1`] = `
       </span>
     </button>
     <button
-      class="ant-btn ant-dropdown-trigger ant-btn-default"
+      class="ant-btn ant-dropdown-trigger ant-btn-default ant-btn-icon-only"
       type="button"
     >
       <i
@@ -89,7 +89,7 @@ exports[`renders ./components/dropdown/demo/dropdown-button.md correctly 1`] = `
       </span>
     </button>
     <button
-      class="ant-btn ant-dropdown-trigger ant-btn-default"
+      class="ant-btn ant-dropdown-trigger ant-btn-default ant-btn-icon-only"
       type="button"
     >
       <i
@@ -126,7 +126,7 @@ exports[`renders ./components/dropdown/demo/dropdown-button.md correctly 1`] = `
       </span>
     </button>
     <button
-      class="ant-btn ant-dropdown-trigger ant-btn-default"
+      class="ant-btn ant-dropdown-trigger ant-btn-default ant-btn-icon-only"
       disabled=""
       type="button"
     >

--- a/components/dropdown/__tests__/__snapshots__/dropdown-button.test.js.snap
+++ b/components/dropdown/__tests__/__snapshots__/dropdown-button.test.js.snap
@@ -9,7 +9,7 @@ exports[`DropdownButton should support href like Button 1`] = `
     href="https://ant.design"
   />
   <button
-    class="ant-btn ant-dropdown-trigger ant-btn-default"
+    class="ant-btn ant-dropdown-trigger ant-btn-default ant-btn-icon-only"
     type="button"
   >
     <i

--- a/components/input/__tests__/__snapshots__/Search.test.js.snap
+++ b/components/input/__tests__/__snapshots__/Search.test.js.snap
@@ -67,7 +67,7 @@ exports[`Input.Search should support addonAfter 2`] = `
       class="ant-input-group-addon"
     >
       <button
-        class="ant-btn ant-input-search-button ant-btn-primary"
+        class="ant-btn ant-input-search-button ant-btn-primary ant-btn-icon-only"
         type="button"
       >
         <i

--- a/components/input/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/input/__tests__/__snapshots__/demo.test.js.snap
@@ -1131,7 +1131,7 @@ exports[`renders ./components/input/demo/search-input.md correctly 1`] = `
         class="ant-input-group-addon"
       >
         <button
-          class="ant-btn ant-input-search-button ant-btn-primary"
+          class="ant-btn ant-input-search-button ant-btn-primary ant-btn-icon-only"
           type="button"
         >
           <i

--- a/components/menu/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/menu/__tests__/__snapshots__/demo.test.js.snap
@@ -395,7 +395,7 @@ exports[`renders ./components/menu/demo/inline-collapsed.md correctly 1`] = `
   style="width:256px"
 >
   <button
-    class="ant-btn ant-btn-primary"
+    class="ant-btn ant-btn-primary ant-btn-icon-only"
     style="margin-bottom:16px"
     type="button"
   >


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

A recent change made it that when creating a `circle` button where the only child is an Ant Design `Icon`, the button will not get the `icon-only` class applied, hence making the icon appear not round.

Example:
```ts
       <Button
          type="primary"
          shape="circle"
        >
          <Icon type="phone" rotate={90} />
        </Button>
```

Before this fix:
<img width="65" alt="Screen Shot 2019-08-28 at 2 05 37 PM" src="https://user-images.githubusercontent.com/11432241/63881089-10c67200-c99d-11e9-8f2c-eab79374b66b.png">

After this fix:
<img width="60" alt="Screen Shot 2019-08-28 at 2 06 28 PM" src="https://user-images.githubusercontent.com/11432241/63881100-1623bc80-c99d-11e9-9ee8-7a9b17df9124.png">


### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | **button**: circle icon button not circular, when icon is specified as a react child           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed **needs chinese**
