### PR TITLE
feat: make click area of steps more precise

### DIFF
--- a/components/steps/style/index.less
+++ b/components/steps/style/index.less
@@ -47,6 +47,7 @@
 
   &-container {
     outline: none;
+    pointer-events: none;
   }
 
   &:last-child {
@@ -62,6 +63,7 @@
   &-content {
     display: inline-block;
     vertical-align: top;
+    pointer-events: all;
   }
 
   &-icon {
@@ -115,6 +117,7 @@
       height: 1px;
       background: @wait-tail-color;
       content: '';
+      pointer-events: none;
     }
   }
   &-subtitle {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

When a step is clickable in the Steps component, the clicking area isn't precise enough ATM. This PR makes a step only clickable on its icon and content, not the connector line after it.

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
