### PR TITLE
fix: Adjust Descriptions column calcuation logic

### DIFF
--- a/components/descriptions/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/descriptions/__tests__/__snapshots__/demo.test.js.snap
@@ -786,16 +786,6 @@ exports[`renders ./components/descriptions/demo/vertical.md correctly 1`] = `
         >
           <td
             class="ant-descriptions-item"
-            colspan="1"
-          >
-            <span
-              class="ant-descriptions-item-label ant-descriptions-item-colon"
-            >
-              Remark
-            </span>
-          </td>
-          <td
-            class="ant-descriptions-item"
             colspan="2"
           >
             <span
@@ -804,20 +794,20 @@ exports[`renders ./components/descriptions/demo/vertical.md correctly 1`] = `
               Address
             </span>
           </td>
-        </tr>
-        <tr
-          class="ant-descriptions-row"
-        >
           <td
             class="ant-descriptions-item"
             colspan="1"
           >
             <span
-              class="ant-descriptions-item-content"
+              class="ant-descriptions-item-label ant-descriptions-item-colon"
             >
-              empty
+              Remark
             </span>
           </td>
+        </tr>
+        <tr
+          class="ant-descriptions-row"
+        >
           <td
             class="ant-descriptions-item"
             colspan="2"
@@ -826,6 +816,16 @@ exports[`renders ./components/descriptions/demo/vertical.md correctly 1`] = `
               class="ant-descriptions-item-content"
             >
               No. 18, Wantang Road, Xihu District, Hangzhou, Zhejiang, China
+            </span>
+          </td>
+          <td
+            class="ant-descriptions-item"
+            colspan="1"
+          >
+            <span
+              class="ant-descriptions-item-content"
+            >
+              empty
             </span>
           </td>
         </tr>

--- a/components/descriptions/__tests__/index.test.js
+++ b/components/descriptions/__tests__/index.test.js
@@ -3,6 +3,7 @@ import MockDate from 'mockdate';
 import { mount } from 'enzyme';
 import Descriptions from '..';
 import mountTest from '../../../tests/shared/mountTest';
+import { resetWarned } from '../../_util/warning';
 
 jest.mock('enquire.js', () => {
   let that;
@@ -100,6 +101,8 @@ describe('Descriptions', () => {
   });
 
   it('warning if ecceed the row span', () => {
+    resetWarned();
+
     mount(
       <Descriptions column={3}>
         <Descriptions.Item label="Product" span={2}>

--- a/components/descriptions/demo/vertical.md
+++ b/components/descriptions/demo/vertical.md
@@ -21,10 +21,10 @@ ReactDOM.render(
     <Descriptions.Item label="UserName">Zhou Maomao</Descriptions.Item>
     <Descriptions.Item label="Telephone">1810000000</Descriptions.Item>
     <Descriptions.Item label="Live">Hangzhou, Zhejiang</Descriptions.Item>
-    <Descriptions.Item label="Remark">empty</Descriptions.Item>
-    <Descriptions.Item label="Address">
+    <Descriptions.Item label="Address" span={2}>
       No. 18, Wantang Road, Xihu District, Hangzhou, Zhejiang, China
     </Descriptions.Item>
+    <Descriptions.Item label="Remark">empty</Descriptions.Item>
   </Descriptions>,
   mountNode,
 );

--- a/components/descriptions/index.tsx
+++ b/components/descriptions/index.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import classNames from 'classnames';
+import toArray from 'rc-util/lib/Children/toArray';
 import warning from '../_util/warning';
 import ResponsiveObserve, {
   Breakpoint,
@@ -35,61 +36,61 @@ export interface DescriptionsProps {
 
 /**
  * Convert children into `column` groups.
- * @param cloneChildren: DescriptionsItem
+ * @param children: DescriptionsItem
  * @param column: number
  */
 const generateChildrenRows = (
-  cloneChildren: React.ReactNode,
+  children: React.ReactNode,
   column: number,
 ): React.ReactElement<DescriptionsItemProps>[][] => {
-  const childrenArray: React.ReactElement<DescriptionsItemProps>[][] = [];
-  let columnArray: React.ReactElement<DescriptionsItemProps>[] = [];
-  let totalRowSpan = 0;
-  React.Children.forEach(cloneChildren, (node: React.ReactElement<DescriptionsItemProps>) => {
-    columnArray.push(node);
-    if (node.props.span) {
-      totalRowSpan += node.props.span;
-    } else {
-      totalRowSpan += 1;
+  const rows: React.ReactElement<DescriptionsItemProps>[][] = [];
+  let columns: React.ReactElement<DescriptionsItemProps>[] | null = null;
+  let leftSpans: number;
+
+  const itemNodes = toArray(children);
+  itemNodes.forEach((node: React.ReactElement<DescriptionsItemProps>, index: number) => {
+    let itemNode = node;
+
+    if (!columns) {
+      leftSpans = column;
+      columns = [];
+      rows.push(columns);
     }
-    if (totalRowSpan >= column) {
+
+    // Always set last span to align the end of Descriptions
+    if (index === itemNodes.length - 1) {
+      itemNode = React.cloneElement(itemNode, {
+        span: leftSpans,
+      });
+    }
+
+    // Calculate left fill span
+    const { span = 1 } = itemNode.props;
+    columns.push(itemNode);
+    leftSpans -= span;
+
+    if (leftSpans <= 0) {
+      columns = null;
+
       warning(
-        totalRowSpan <= column,
+        leftSpans === 0,
         'Descriptions',
         'Sum of column `span` in a line exceeds `column` of Descriptions.',
       );
-
-      childrenArray.push(columnArray);
-      columnArray = [];
-      totalRowSpan = 0;
     }
   });
-  if (columnArray.length > 0) {
-    childrenArray.push(columnArray);
-    columnArray = [];
-  }
-  return childrenArray;
+
+  return rows;
 };
 
 const renderRow = (
   children: React.ReactElement<DescriptionsItemProps>[],
   index: number,
-  { prefixCls, column, isLast }: { prefixCls: string; column: number; isLast: boolean },
+  { prefixCls }: { prefixCls: string },
   bordered: boolean,
   layout: 'horizontal' | 'vertical',
   colon: boolean,
 ) => {
-  // copy children,prevent changes to incoming parameters
-  const childrenArray = [...children];
-  let lastChildren = childrenArray.pop() as React.ReactElement<DescriptionsItemProps>;
-  const span = column - childrenArray.length;
-  if (isLast) {
-    lastChildren = React.cloneElement(lastChildren as React.ReactElement<DescriptionsItemProps>, {
-      span,
-    });
-  }
-  childrenArray.push(lastChildren);
-
   const renderCol = (
     childrenItem: React.ReactElement<DescriptionsItemProps>,
     type: 'label' | 'content',
@@ -108,7 +109,7 @@ const renderRow = (
   const cloneChildren: JSX.Element[] = [];
   const cloneContentChildren: JSX.Element[] = [];
   React.Children.forEach(
-    childrenArray,
+    children,
     (childrenItem: React.ReactElement<DescriptionsItemProps>, idx: number) => {
       cloneChildren.push(renderCol(childrenItem, 'label', idx));
       if (layout === 'vertical') {
@@ -253,8 +254,6 @@ class Descriptions extends React.Component<
                         index,
                         {
                           prefixCls,
-                          column,
-                          isLast: index + 1 === childrenArray.length,
                         },
                         bordered,
                         layout,

--- a/components/descriptions/index.tsx
+++ b/components/descriptions/index.tsx
@@ -58,7 +58,10 @@ const generateChildrenRows = (
     }
 
     // Always set last span to align the end of Descriptions
-    if (index === itemNodes.length - 1) {
+    const lastItem = index === itemNodes.length - 1;
+    let lastSpanSame = true;
+    if (lastItem) {
+      lastSpanSame = (itemNode.props.span || 1) === leftSpans;
       itemNode = React.cloneElement(itemNode, {
         span: leftSpans,
       });
@@ -73,7 +76,7 @@ const generateChildrenRows = (
       columns = null;
 
       warning(
-        leftSpans === 0,
+        leftSpans === 0 && lastSpanSame,
         'Descriptions',
         'Sum of column `span` in a line exceeds `column` of Descriptions.',
       );


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

fix #18527

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Fix Descriptions last Item has wrong calculated width issue.   |
| 🇨🇳 Chinese |     修复 Descriptions Item 最后个宽度计算不正确的问题。      |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/descriptions/demo/vertical.md](https://github.com/ant-design/ant-design/blob/descs/components/descriptions/demo/vertical.md)