### PR TITLE
fix: Upload.Dragger should work with multiple is false

### DIFF
--- a/components/upload/Upload.tsx
+++ b/components/upload/Upload.tsx
@@ -81,6 +81,12 @@ class Upload extends React.Component<UploadProps, UploadState> {
 
   onStart = (file: RcFile) => {
     const { fileList } = this.state;
+    const { multiple } = this.props;
+
+    if (!multiple && fileList.length > 0) {
+      return;
+    }
+
     const targetItem = fileToObject(file);
     targetItem.status = 'uploading';
 

--- a/components/upload/__tests__/upload.test.js
+++ b/components/upload/__tests__/upload.test.js
@@ -484,4 +484,28 @@ describe('Upload', () => {
     );
     errorSpy.mockRestore();
   });
+
+  it('not allow multiple upload when multiple is false', done => {
+    const onChange = jest.fn();
+
+    const wrapper = mount(
+      <Upload
+        fileList={[{ uid: '903', file: 'bamboo.png' }]}
+        action="http://upload.com"
+        onChange={onChange}
+        multiple={false}
+      />,
+    );
+
+    wrapper.find('input').simulate('change', {
+      target: {
+        files: [{ file: 'light.png' }],
+      },
+    });
+
+    setTimeout(() => {
+      expect(onChange).not.toHaveBeenCalled();
+      done();
+    });
+  });
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

fix #17397

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇨🇳 Chinese |     修复 Upload.Dragger 在 `multiple` 为 `false` 时，仍然可以上传多份文件的问题。      |
| 🇺🇸 English |    Fix Upload.Dragger can upload multiple files when `multiple` is `false`.       |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
