### PR TITLE
fix: add missing typescript inputValue to Select to enable placeholder to display for type string

### DIFF
--- a/components/select/index.en-US.md
+++ b/components/select/index.en-US.md
@@ -54,6 +54,7 @@ Select component to select value from options.
 | menuItemSelectedIcon | The custom menuItemSelected icon with multiple options | ReactNode | - | 3.11.0 |
 | tokenSeparators | Separator used to tokenize on tag/multiple mode | string\[] |  |  |
 | value | Current selected option. | string\|string\[]\<br />number\|number\[]\<br />LabeledValue\|LabeledValue[] | - |  |
+| inputValue | Current search text | string | - |  |
 | onBlur | Called when blur | function | - |  |
 | onChange | Called when select an option or input value change, or value of input is changed in combobox mode | function(value, option:Option/Array&lt;Option>) | - |  |
 | onDeselect | Called when a option is deselected, param is the selected option's value. Only called for multiple or tags, effective in multiple or tags mode only. | function(string\|number\|LabeledValue) | - |  |

--- a/components/select/index.tsx
+++ b/components/select/index.tsx
@@ -53,6 +53,7 @@ export type SelectValue = string | string[] | number | number[] | LabeledValue |
 
 export interface SelectProps<T = SelectValue> extends AbstractSelectProps {
   value?: T;
+  inputValue?: string;
   defaultValue?: T;
   mode?: 'default' | 'multiple' | 'tags' | 'combobox' | string;
   optionLabelProp?: string;


### PR DESCRIPTION
Reason: RC-Select has this parameter to accept string value and it will
        be a quick-fix to enable Typescript to acept inputValue.

<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
https://stackoverflow.com/questions/45546300/antd-design-select-placeholder-issues

I have created a demo:
https://codesandbox.io/s/hardcore-thunder-4qe7f?fontsize=14

### 💡 Background and solution

##### Problem
1. When using Select as a search input, an empty value string will hide placeholder.
Issue from rc-select: https://github.com/react-component/select/issues/335
Summary of the issue: when value is a string default empty,  ie.`value=""` together with `placeholder` will hide the placeholder because it always convert a string into `[value]` and thus checking length of value is always **> 0**.

2. What typescript throws:
<img width="586" alt="Screen Shot 2019-08-31 at 2 27 43 AM" src="https://user-images.githubusercontent.com/35248123/64043488-2901e100-cb97-11e9-9f1b-3301cf29b98f.png">

3. https://github.com/react-component/select/blob/master/src/Select.tsx

##### has props inputValue
```javascript
export interface ISelectState {
  ...
  value?: valueType;
  inputValue?: string;
  ...
}
```

##### placeholder in rc-select takes either inputValue or value to hide the placeholder
```javascript
  public getPlaceholderElement = () => {
    ...
    let hidden = false;
    if (state.inputValue) {
      hidden = true;
    }
    const value = state.value as string[];
    if (value.length) {
      hidden = true;
    }
    ...
          style={{
            display: hidden ? 'none' : 'block',
            ...UNSELECTABLE_STYLE,
          }}
    ...
```

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->
nothing to change

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | x |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [x] Doc is _updated_
- [x] Demo is not needed
- [x] TypeScript definition is updated
- [x] Changelog is not needed

-----
[View rendered components/select/index.en-US.md](https://github.com/daphne-jr/ant-design/blob/bugfix-missing-typescript-param-inputvalue-select/components/select/index.en-US.md)