### PR TITLE
fix: icon innerNode render

### DIFF
--- a/components/icon/__tests__/__snapshots__/index.test.js.snap
+++ b/components/icon/__tests__/__snapshots__/index.test.js.snap
@@ -12,12 +12,20 @@ exports[`Icon \`component\` prop can access to svg defs if has children 1`] = `
     height="1em"
     width="1em"
   >
-    <title>
-      Cool Home
-    </title>
-    <path
-      d="'M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z'"
-    />
+    <defs>
+      <linearGradient
+        id="gradient"
+      >
+        <stop
+          offset="20%"
+          stop-color="#39F"
+        />
+        <stop
+          offset="90%"
+          stop-color="#F3F"
+        />
+      </linearGradient>
+    </defs>
   </svg>
 </i>
 `;
@@ -298,13 +306,14 @@ exports[`Icon should support svg react component 1`] = `
     fill="currentColor"
     focusable="false"
     height="1em"
+    viewBox="0 0 24 24"
     width="1em"
   >
     <title>
-      Cool Home
+      Custom Svg
     </title>
     <path
-      d="'M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z'"
+      d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z"
     />
   </svg>
 </i>

--- a/components/icon/__tests__/__snapshots__/index.test.js.snap
+++ b/components/icon/__tests__/__snapshots__/index.test.js.snap
@@ -26,6 +26,13 @@ exports[`Icon \`component\` prop can access to svg defs if has children 1`] = `
         />
       </linearGradient>
     </defs>
+    <title>
+      Cool Home
+    </title>
+    <path
+      d="'M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z'"
+      fill="scriptUrl(#gradient)"
+    />
   </svg>
 </i>
 `;

--- a/components/icon/__tests__/index.test.js
+++ b/components/icon/__tests__/index.test.js
@@ -162,7 +162,7 @@ describe('Icon', () => {
   it('should support svg react component', () => {
     const SvgComponent = props => (
       <svg viewBox="0 0 24 24" {...props}>
-        <title>Cool Home</title>
+        <title>Custom Svg</title>
         <path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z" />
       </svg>
     );

--- a/components/icon/index.en-US.md
+++ b/components/icon/index.en-US.md
@@ -26,6 +26,8 @@ ReactDOM.render(<IconDisplay />, mountNode);
 | component | The component used for the root node. This will override the **`type`** property. | ComponentType<CustomIconComponentProps\> | - | 3.9.0 |
 | twoToneColor | Only supports the two-tone icon. Specify the primary color. | string (hex color) | - | 3.9.0 |
 
+> Note: the rendering priority of the Icon component is component > children > type. When props is passed, the priority is directly effective, and the lower priority would be invalid.
+
 ### SVG icons
 
 We introduced SVG icons in `3.9.0` version replacing font icons which brings benefits below:

--- a/components/icon/index.en-US.md
+++ b/components/icon/index.en-US.md
@@ -121,7 +121,7 @@ ReactDOM.render(<Icon component={MessageSvg} />, mountNode);
 
 The following properties are available for the component:
 
-| Property | Description | Type | Default | Version |
+| Property | Description | Type | Readonly | Version |
 | --- | --- | --- | --- | --- |
 | width | The width of the `svg` element | string \| number | '1em' | 3.10.0 |
 | height | The height of the `svg` element | string \| number | '1em' | 3.10.0 |

--- a/components/icon/index.en-US.md
+++ b/components/icon/index.en-US.md
@@ -26,7 +26,7 @@ ReactDOM.render(<IconDisplay />, mountNode);
 | component | The component used for the root node. This will override the **`type`** property. | ComponentType<CustomIconComponentProps\> | - | 3.9.0 |
 | twoToneColor | Only supports the two-tone icon. Specify the primary color. | string (hex color) | - | 3.9.0 |
 
-> Note: the rendering priority of the Icon component is component > children > type. When props is passed, the priority is directly effective, and the lower priority would be invalid.
+> Note: icon rendering priority of the Icon component is component > children > type. When props is passed, higher priority item will works, and lower priority item would be invalid.
 
 ### SVG icons
 

--- a/components/icon/index.tsx
+++ b/components/icon/index.tsx
@@ -128,8 +128,6 @@ const Icon: IconComponent<IconProps> = props => {
     [`anticon-spin`]: !!spin || type === 'loading',
   });
 
-  let innerNode: React.ReactNode;
-
   const svgStyle = rotate
     ? {
         msTransform: `rotate(${rotate}deg)`,
@@ -148,52 +146,54 @@ const Icon: IconComponent<IconProps> = props => {
     delete innerSvgProps.viewBox;
   }
 
-  // component > children > type
-  if (Component) {
-    innerNode = <Component {...innerSvgProps}>{children}</Component>;
-  }
+  const renderInnerNode = () => {
+    // component > children > type
+    if (Component) {
+      return <Component {...innerSvgProps}>{children}</Component>;
+    }
 
-  if (children) {
-    warning(
-      Boolean(viewBox) ||
-        (React.Children.count(children) === 1 &&
-          React.isValidElement(children) &&
-          React.Children.only(children).type === 'use'),
-      'Icon',
-      'Make sure that you provide correct `viewBox`' +
-        ' prop (default `0 0 1024 1024`) to the icon.',
-    );
-    innerNode = (
-      <svg {...innerSvgProps} viewBox={viewBox}>
-        {children}
-      </svg>
-    );
-  }
-
-  if (typeof type === 'string') {
-    let computedType = type;
-    if (theme) {
-      const themeInName = getThemeFromTypeName(type);
+    if (children) {
       warning(
-        !themeInName || theme === themeInName,
+        Boolean(viewBox) ||
+          (React.Children.count(children) === 1 &&
+            React.isValidElement(children) &&
+            React.Children.only(children).type === 'use'),
         'Icon',
-        `The icon name '${type}' already specify a theme '${themeInName}',` +
-          ` the 'theme' prop '${theme}' will be ignored.`,
+        'Make sure that you provide correct `viewBox`' +
+          ' prop (default `0 0 1024 1024`) to the icon.',
+      );
+      return (
+        <svg {...innerSvgProps} viewBox={viewBox}>
+          {children}
+        </svg>
       );
     }
-    computedType = withThemeSuffix(
-      removeTypeTheme(alias(computedType)),
-      dangerousTheme || theme || defaultTheme,
-    );
-    innerNode = (
-      <ReactIcon
-        className={svgClassString}
-        type={computedType}
-        primaryColor={twoToneColor}
-        style={svgStyle}
-      />
-    );
-  }
+
+    if (typeof type === 'string') {
+      let computedType = type;
+      if (theme) {
+        const themeInName = getThemeFromTypeName(type);
+        warning(
+          !themeInName || theme === themeInName,
+          'Icon',
+          `The icon name '${type}' already specify a theme '${themeInName}',` +
+            ` the 'theme' prop '${theme}' will be ignored.`,
+        );
+      }
+      computedType = withThemeSuffix(
+        removeTypeTheme(alias(computedType)),
+        dangerousTheme || theme || defaultTheme,
+      );
+      return (
+        <ReactIcon
+          className={svgClassString}
+          type={computedType}
+          primaryColor={twoToneColor}
+          style={svgStyle}
+        />
+      );
+    }
+  };
 
   let iconTabIndex = tabIndex;
   if (iconTabIndex === undefined && onClick) {
@@ -210,7 +210,7 @@ const Icon: IconComponent<IconProps> = props => {
           onClick={onClick}
           className={classString}
         >
-          {innerNode}
+          {renderInnerNode()}
         </i>
       )}
     </LocaleReceiver>

--- a/components/icon/index.tsx
+++ b/components/icon/index.tsx
@@ -149,7 +149,7 @@ const Icon: IconComponent<IconProps> = props => {
   const renderInnerNode = () => {
     // component > children > type
     if (Component) {
-      return <Component {...innerSvgProps}>{children}</Component>;
+      return <Component {...innerSvgProps} />;
     }
 
     if (children) {

--- a/components/icon/index.tsx
+++ b/components/icon/index.tsx
@@ -149,7 +149,7 @@ const Icon: IconComponent<IconProps> = props => {
   const renderInnerNode = () => {
     // component > children > type
     if (Component) {
-      return <Component {...innerSvgProps} />;
+      return <Component {...innerSvgProps}>{children}</Component>;
     }
 
     if (children) {

--- a/components/icon/index.zh-CN.md
+++ b/components/icon/index.zh-CN.md
@@ -31,6 +31,8 @@ ReactDOM.render(<IconDisplay />, mountNode);
 | component | 控制如何渲染图标，通常是一个渲染根标签为 `<svg>` 的 `React` 组件，**会使 `type` 属性失效** | ComponentType<CustomIconComponentProps\> | - | 3.9.0 |
 | twoToneColor | 仅适用双色图标。设置双色图标的主要颜色 | string (十六进制颜色) | - | 3.9.0 |
 
+> 注意：Icon 组件的渲染优先级为 component > children > type, 传入 props 时，优先级高的直接生效，优先级低的则失效
+
 ### SVG 图标
 
 在 `3.9.0` 之后，我们使用了 SVG 图标替换了原先的 font 图标，从而带来了以下优势：

--- a/components/icon/index.zh-CN.md
+++ b/components/icon/index.zh-CN.md
@@ -31,7 +31,7 @@ ReactDOM.render(<IconDisplay />, mountNode);
 | component | 控制如何渲染图标，通常是一个渲染根标签为 `<svg>` 的 `React` 组件，**会使 `type` 属性失效** | ComponentType<CustomIconComponentProps\> | - | 3.9.0 |
 | twoToneColor | 仅适用双色图标。设置双色图标的主要颜色 | string (十六进制颜色) | - | 3.9.0 |
 
-> 注意：Icon 组件的渲染优先级为 component > children > type, 传入 props 时，优先级高的直接生效，优先级低的则失效
+> 注意：Icon 组件中图标渲染的优先级为 component > children > type, 传入 props 时，优先级高的直接生效，优先级低的则失效。
 
 ### SVG 图标
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
#17962
<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution
Background：Icon组件并没有如文档里写的，compoent和type同时使用的话，type会失效，实际起作用的还是type。因为实际代码里，innerNode被反复修改，compoent、children、type，按顺序判断，只要后面的有值，都会覆盖前面的。
https://codesandbox.io/s/antd-reproduction-template-08w2u

另外文档里component 的props，英文文档里default，实际代码里是写死的，传了也不起作用，没有往component上传递。

solution: component、children、type, 按顺序判断，哪个有值，渲染时就直接返回；修改英文文档
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix rendering priority issue that props `component` and `children` is lower proiorty than props `type`  in the Icon component |
| 🇨🇳 Chinese | 修复 Icon 组件中 component 和 children 属性优先级低于 type 的问题 |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
