### PR TITLE
fix: Descriptions warning with key

### DIFF
--- a/components/descriptions/__tests__/__snapshots__/index.test.js.snap
+++ b/components/descriptions/__tests__/__snapshots__/index.test.js.snap
@@ -39,7 +39,7 @@ exports[`Descriptions Descriptions support colon 1`] = `
                 </DescriptionsItem>
               }
               colon={false}
-              key="0"
+              key="label-0"
               layout="horizontal"
               type="label"
             >
@@ -116,7 +116,7 @@ exports[`Descriptions Descriptions support style 1`] = `
                 </DescriptionsItem>
               }
               colon={true}
-              key="0"
+              key="label-0"
               layout="horizontal"
               type="label"
             >
@@ -183,7 +183,7 @@ exports[`Descriptions Descriptions.Item support className 1`] = `
                 </DescriptionsItem>
               }
               colon={true}
-              key="0"
+              key="label-0"
               layout="horizontal"
               type="label"
             >
@@ -241,7 +241,7 @@ exports[`Descriptions column is number 1`] = `
                 </DescriptionsItem>
               }
               colon={true}
-              key="0"
+              key="label-0"
               layout="horizontal"
               type="label"
             >
@@ -274,7 +274,7 @@ exports[`Descriptions column is number 1`] = `
                 </DescriptionsItem>
               }
               colon={true}
-              key="1"
+              key="label-1"
               layout="horizontal"
               type="label"
             >
@@ -307,7 +307,7 @@ exports[`Descriptions column is number 1`] = `
                 </DescriptionsItem>
               }
               colon={true}
-              key="2"
+              key="label-2"
               layout="horizontal"
               type="label"
             >
@@ -346,7 +346,7 @@ exports[`Descriptions column is number 1`] = `
                 </DescriptionsItem>
               }
               colon={true}
-              key="0"
+              key="label-0"
               layout="horizontal"
               type="label"
             >
@@ -414,7 +414,7 @@ exports[`Descriptions vertical layout 1`] = `
                 </DescriptionsItem>
               }
               colon={true}
-              key="0"
+              key="label-0"
               layout="vertical"
               type="label"
             >
@@ -446,7 +446,7 @@ exports[`Descriptions vertical layout 1`] = `
                 </DescriptionsItem>
               }
               colon={true}
-              key="0"
+              key="content-0"
               layout="vertical"
               type="content"
             >
@@ -478,7 +478,7 @@ exports[`Descriptions vertical layout 1`] = `
                 </DescriptionsItem>
               }
               colon={true}
-              key="0"
+              key="label-0"
               layout="vertical"
               type="label"
             >
@@ -510,7 +510,7 @@ exports[`Descriptions vertical layout 1`] = `
                 </DescriptionsItem>
               }
               colon={true}
-              key="0"
+              key="content-0"
               layout="vertical"
               type="content"
             >
@@ -542,7 +542,7 @@ exports[`Descriptions vertical layout 1`] = `
                 </DescriptionsItem>
               }
               colon={true}
-              key="0"
+              key="label-0"
               layout="vertical"
               type="label"
             >
@@ -574,7 +574,7 @@ exports[`Descriptions vertical layout 1`] = `
                 </DescriptionsItem>
               }
               colon={true}
-              key="0"
+              key="content-0"
               layout="vertical"
               type="content"
             >
@@ -607,7 +607,7 @@ exports[`Descriptions vertical layout 1`] = `
                 </DescriptionsItem>
               }
               colon={true}
-              key="0"
+              key="label-0"
               layout="vertical"
               type="label"
             >
@@ -640,7 +640,7 @@ exports[`Descriptions vertical layout 1`] = `
                 </DescriptionsItem>
               }
               colon={true}
-              key="0"
+              key="content-0"
               layout="vertical"
               type="content"
             >
@@ -701,7 +701,7 @@ exports[`Descriptions when item is rendered conditionally 1`] = `
                 </DescriptionsItem>
               }
               colon={true}
-              key="0"
+              key="label-0"
               layout="horizontal"
               type="label"
             >
@@ -739,7 +739,7 @@ exports[`Descriptions when item is rendered conditionally 1`] = `
                 </DescriptionsItem>
               }
               colon={true}
-              key="0"
+              key="label-0"
               layout="horizontal"
               type="label"
             >
@@ -777,7 +777,7 @@ exports[`Descriptions when item is rendered conditionally 1`] = `
                 </DescriptionsItem>
               }
               colon={true}
-              key="0"
+              key="label-0"
               layout="horizontal"
               type="label"
             >
@@ -816,7 +816,7 @@ exports[`Descriptions when item is rendered conditionally 1`] = `
                 </DescriptionsItem>
               }
               colon={true}
-              key="0"
+              key="label-0"
               layout="horizontal"
               type="label"
             >

--- a/components/descriptions/__tests__/index.test.js
+++ b/components/descriptions/__tests__/index.test.js
@@ -183,6 +183,6 @@ describe('Descriptions', () => {
       </Descriptions>,
     );
 
-    expect(wrapper.find('Col').key()).toBe('bamboo');
+    expect(wrapper.find('Col').key()).toBe('label-bamboo');
   });
 });

--- a/components/descriptions/index.tsx
+++ b/components/descriptions/index.tsx
@@ -105,7 +105,7 @@ const renderRow = (
         bordered={bordered}
         colon={colon}
         type={type}
-        key={colItem.key || idx}
+        key={`${type}-${colItem.key || idx}`}
         layout={layout}
       />
     );


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

fix #18633

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Fix Descriptions warning with same key when `bordered` is `true`.       |
| 🇨🇳 Chinese |     修复 Descriptions 在 `bordered` 为 `true` 时会报 key 相同的警告信息。      |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
