### PR TITLE
fix: Anchor.Link target should not be required

### DIFF
--- a/components/anchor/AnchorLink.tsx
+++ b/components/anchor/AnchorLink.tsx
@@ -8,7 +8,7 @@ import { ConfigConsumer, ConfigConsumerProps } from '../config-provider';
 export interface AnchorLinkProps {
   prefixCls?: string;
   href: string;
-  target: string;
+  target?: string;
   title: React.ReactNode;
   children?: React.ReactNode;
   className?: string;


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

fix issue in pr https://github.com/ant-design/ant-design/pull/18335/files

### 💡 Background and solution

Anchor.Link target should not be required

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     fix: Anchor.Link `target` prop should not be required      |
| 🇨🇳 Chinese |   fix:  Anchor.Link 的 `target` 属性不应该是必须的   |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
