### PR TITLE
fix(PageHeader): Allow back icon to coexist with breadcrumb 

### DIFF
--- a/components/page-header/__tests__/index.test.js
+++ b/components/page-header/__tests__/index.test.js
@@ -67,7 +67,7 @@ describe('PageHeader', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
-  it('breadcrumbs and back icon can only have one', () => {
+  it('breadcrumbs and back icon can coexist', () => {
     const routes = [
       {
         path: 'index',
@@ -82,10 +82,10 @@ describe('PageHeader', () => {
         breadcrumbName: 'Third-level Menu',
       },
     ];
-    const wrapper = mount(<PageHeader title="Title" onBack={() => true} breadcrumb={{ routes }} />);
-    expect(wrapper.find('.ant-breadcrumb')).toHaveLength(0);
+    const wrapper = mount(<PageHeader title="Title" breadcrumb={{ routes }} />);
+    expect(wrapper.find('.ant-breadcrumb')).toHaveLength(1);
 
-    wrapper.setProps({ onBack: undefined });
+    wrapper.setProps({ onBack: () => {} });
     expect(wrapper.find('.ant-breadcrumb')).toHaveLength(1);
   });
 });

--- a/components/page-header/index.tsx
+++ b/components/page-header/index.tsx
@@ -8,7 +8,6 @@ import Breadcrumb, { BreadcrumbProps } from '../breadcrumb';
 import Avatar, { AvatarProps } from '../avatar';
 import TransButton from '../_util/transButton';
 import LocaleReceiver from '../locale-provider/LocaleReceiver';
-import warning from '../_util/warning';
 
 export interface PageHeaderProps {
   backIcon?: React.ReactNode;
@@ -58,23 +57,6 @@ const renderBreadcrumb = (breadcrumb: BreadcrumbProps) => {
   return <Breadcrumb {...breadcrumb} />;
 };
 
-const renderHeader = (
-  breadcrumb: PageHeaderProps['breadcrumb'],
-  { backIcon, onBack }: PageHeaderProps,
-) => {
-  // by design,Bread crumbs and back icon can only have one
-  if (backIcon && onBack) {
-    if (breadcrumb && breadcrumb.routes) {
-      warning(false, 'page-header', 'breadcrumbs and back icon can only have one');
-    }
-    return null;
-  }
-  if (breadcrumb && breadcrumb.routes) {
-    return renderBreadcrumb(breadcrumb);
-  }
-  return null;
-};
-
 const renderTitle = (prefixCls: string, props: PageHeaderProps) => {
   const { title, avatar, subTitle, tags, extra, backIcon, onBack } = props;
   const headingPrefixCls = `${prefixCls}-heading`;
@@ -118,7 +100,7 @@ const PageHeader: React.SFC<PageHeaderProps> = props => (
       } = props;
 
       const prefixCls = getPrefixCls('page-header', customizePrefixCls);
-      const breadcrumbDom = renderHeader(breadcrumb, props);
+      const breadcrumbDom = breadcrumb && breadcrumb.routes ? renderBreadcrumb(breadcrumb) : null;
       const className = classnames(prefixCls, customizeClassName, {
         'has-breadcrumb': breadcrumbDom,
         'has-footer': footer,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

- Close #18094.

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

- According to the latest design, it's allowed that back icon coexists with breadcrumb.
![image](https://user-images.githubusercontent.com/14918822/64333378-f75e9f00-d008-11e9-95b5-478ac713d08a.png)

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 🐞 Fix PageHeader that back icon can't coexist with breadcrumb. [#18094](https://github.com/ant-design/ant-design/issues/18094) |
| 🇨🇳 Chinese | 🐞 修复 PageHeader 中返回图标与面包屑无法共存的问题。[#18094](https://github.com/ant-design/ant-design/issues/18094) |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
