### PR TITLE
The background for the disabled menu item is made important, so that it does not change when hover

### DIFF
--- a/components/menu/style/index.less
+++ b/components/menu/style/index.less
@@ -484,7 +484,7 @@
   &-item-disabled,
   &-submenu-disabled {
     color: @disabled-color !important;
-    background: none;
+    background: none !important;
     border-color: transparent !important;
     cursor: not-allowed;
     > a {


### PR DESCRIPTION
…ed on hover

<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [x] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

Problem: menu item in disabled state when hover changes its background
the background of the disabled menu item should not change when you hover over it
Solution: make background for disabled-item !important

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
