### PR TITLE
fix: ConfigProvider locale not working with Modal in some situation

### DIFF
--- a/components/config-provider/__tests__/locale.test.js
+++ b/components/config-provider/__tests__/locale.test.js
@@ -2,10 +2,16 @@ import React from 'react';
 import { mount } from 'enzyme';
 import ConfigProvider from '..';
 import LocaleProvider from '../../locale-provider';
-import locale from '../../locale/zh_CN';
+import zhCN from '../../locale/zh_CN';
+import enUS from '../../locale/en_US';
 import TimePicker from '../../time-picker';
+import Modal from '../../modal';
 
 describe('ConfigProvider.Locale', () => {
+  function $$(className) {
+    return document.body.querySelectorAll(className);
+  }
+
   it('not throw', () => {
     if (process.env.REACT === '15') {
       return;
@@ -19,14 +25,54 @@ describe('ConfigProvider.Locale', () => {
     );
   });
 
+  // https://github.com/ant-design/ant-design/issues/18731
+  it('should not reset locale for Modal', () => {
+    class App extends React.Component {
+      state = {
+        showButton: false,
+      };
+
+      componentDidMount() {
+        this.setState({
+          showButton: true,
+        });
+      }
+
+      openConfirm = () => {
+        Modal.confirm({
+          title: 'title',
+          content: 'Some descriptions',
+        });
+      };
+
+      render() {
+        return (
+          <ConfigProvider locale={zhCN}>
+            {this.state.showButton ? (
+              <ConfigProvider locale={enUS}>
+                <button type="button" onClick={this.openConfirm}>
+                  open
+                </button>
+              </ConfigProvider>
+            ) : null}
+          </ConfigProvider>
+        );
+      }
+    }
+
+    const wrapper = mount(<App />);
+    wrapper.find('button').simulate('click');
+    expect($$('.ant-btn-primary')[0].textContent).toBe('OK');
+  });
+
   describe('support legacy LocaleProvider', () => {
     function testLocale(wrapper) {
-      expect(wrapper.find('input').props().placeholder).toBe(locale.TimePicker.placeholder);
+      expect(wrapper.find('input').props().placeholder).toBe(zhCN.TimePicker.placeholder);
     }
 
     it('LocaleProvider', () => {
       const wrapper = mount(
-        <LocaleProvider locale={locale}>
+        <LocaleProvider locale={zhCN}>
           <TimePicker />
         </LocaleProvider>,
       );
@@ -36,7 +82,7 @@ describe('ConfigProvider.Locale', () => {
 
     it('LocaleProvider > ConfigProvider', () => {
       const wrapper = mount(
-        <LocaleProvider locale={locale}>
+        <LocaleProvider locale={zhCN}>
           <ConfigProvider>
             <TimePicker />
           </ConfigProvider>
@@ -48,7 +94,7 @@ describe('ConfigProvider.Locale', () => {
 
     it('ConfigProvider > ConfigProvider', () => {
       const wrapper = mount(
-        <ConfigProvider locale={locale}>
+        <ConfigProvider locale={zhCN}>
           <ConfigProvider>
             <TimePicker />
           </ConfigProvider>

--- a/components/locale-provider/index.tsx
+++ b/components/locale-provider/index.tsx
@@ -73,8 +73,8 @@ export default class LocaleProvider extends React.Component<LocaleProviderProps,
     const { locale } = this.props;
     if (prevProps.locale !== locale) {
       setMomentLocale(locale);
+      changeConfirmLocale(locale && locale.Modal);
     }
-    changeConfirmLocale(locale && locale.Modal);
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close #18731

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix ConfigProvider `locale` not working with Modal in some situation. |
| 🇨🇳 Chinese | 修复 ConfigProvider `locale` 国际化在某些场景下对 `Modal` 不生效的问题。 |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
