### PR TITLE
fix: Input.Search should trigger onSearch when clear

### DIFF
--- a/components/input/Search.tsx
+++ b/components/input/Search.tsx
@@ -9,7 +9,10 @@ export interface SearchProps extends InputProps {
   inputPrefixCls?: string;
   onSearch?: (
     value: string,
-    event?: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLInputElement>,
+    event?:
+      | React.ChangeEvent<HTMLInputElement>
+      | React.MouseEvent<HTMLElement>
+      | React.KeyboardEvent<HTMLInputElement>,
   ) => void;
   enterButton?: boolean | React.ReactNode;
 }
@@ -23,6 +26,16 @@ export default class Search extends React.Component<SearchProps, any> {
 
   saveInput = (node: Input) => {
     this.input = node;
+  };
+
+  onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { onChange, onSearch } = this.props;
+    if (e && e.target && e.type === 'click' && onSearch) {
+      onSearch((e as React.ChangeEvent<HTMLInputElement>).target.value, e);
+    }
+    if (onChange) {
+      onChange(e);
+    }
   };
 
   onSearch = (e: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLInputElement>) => {
@@ -141,6 +154,7 @@ export default class Search extends React.Component<SearchProps, any> {
         prefixCls={inputPrefixCls}
         addonAfter={this.renderAddonAfter(prefixCls)}
         suffix={this.renderSuffix(prefixCls)}
+        onChange={this.onChange}
         ref={this.saveInput}
         className={inputClassName}
       />

--- a/components/input/__tests__/Search.test.js
+++ b/components/input/__tests__/Search.test.js
@@ -137,4 +137,18 @@ describe('Input.Search', () => {
     expect(wrapper.render()).toMatchSnapshot();
     expect(wrapperWithEnterButton.render()).toMatchSnapshot();
   });
+
+  // https://github.com/ant-design/ant-design/issues/18729
+  it('should trigger onSearch when click clear icon', () => {
+    const onSearch = jest.fn();
+    const wrapper = mount(<Search allowClear defaultValue="value" onSearch={onSearch} />);
+    wrapper
+      .find('.ant-input-clear-icon')
+      .at(0)
+      .simulate('click');
+    expect(onSearch).toHaveBeenLastCalledWith(
+      '',
+      expect.anything(),
+    );
+  });
 });

--- a/components/input/__tests__/Search.test.js
+++ b/components/input/__tests__/Search.test.js
@@ -141,14 +141,15 @@ describe('Input.Search', () => {
   // https://github.com/ant-design/ant-design/issues/18729
   it('should trigger onSearch when click clear icon', () => {
     const onSearch = jest.fn();
-    const wrapper = mount(<Search allowClear defaultValue="value" onSearch={onSearch} />);
+    const onChange = jest.fn();
+    const wrapper = mount(
+      <Search allowClear defaultValue="value" onSearch={onSearch} onChange={onChange} />,
+    );
     wrapper
       .find('.ant-input-clear-icon')
       .at(0)
       .simulate('click');
-    expect(onSearch).toHaveBeenLastCalledWith(
-      '',
-      expect.anything(),
-    );
+    expect(onSearch).toHaveBeenLastCalledWith('', expect.anything());
+    expect(onChange).toHaveBeenCalled();
   });
 });

--- a/components/input/__tests__/__snapshots__/index.test.js.snap
+++ b/components/input/__tests__/__snapshots__/index.test.js.snap
@@ -253,6 +253,7 @@ exports[`Input.Search should support suffix 1`] = `
 >
   <Input
     className="ant-input-search"
+    onChange={[Function]}
     onPressEnter={[Function]}
     prefixCls="ant-input"
     suffix={


### PR DESCRIPTION


<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close #18729

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Input.Search not trigger `onSearch` when click clear icon. |
| 🇨🇳 Chinese | 修复 Input.Search 点击清除图标时没有触发 `onSearch` 的问题。|

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
