### PR TITLE
fix: number controls overlap borders when active

### DIFF
--- a/components/input-number/style/index.less
+++ b/components/input-number/style/index.less
@@ -141,6 +141,7 @@
 
   &-handler-up {
     cursor: pointer;
+    border-top-right-radius: @border-radius-base;
     &-inner {
       top: 50%;
       margin-top: -5px;
@@ -154,6 +155,7 @@
   &-handler-down {
     top: 0;
     border-top: @border-width-base @border-style-base @border-color-base;
+    border-bottom-right-radius: @border-radius-base;
     cursor: pointer;
     &-inner {
       top: 50%;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

fix #18790

### 💡 Background and solution
Input border is overlapped by the control spans. Added the needed border-radius to the spans.

![image](https://user-images.githubusercontent.com/5127194/64775310-28355b80-d556-11e9-8ac1-1e4c66b96b4f.png)

![image](https://user-images.githubusercontent.com/5127194/64775494-92e69700-d556-11e9-8f5f-4f2b709b4a05.png)

Fixed demo:
https://codesandbox.io/s/compassionate-shape-pe2th

### 📝 Changelog

Neither changes from userside, nor potential break changes or other risks.

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
