### PR TITLE
docs(Tree): Add onMouseEnter and onMouseLeave event typeScript definition

### DIFF
--- a/components/tree/Tree.tsx
+++ b/components/tree/Tree.tsx
@@ -154,6 +154,8 @@ export interface TreeProps {
   onDragOver?: (options: AntTreeNodeMouseEvent) => void;
   onDragLeave?: (options: AntTreeNodeMouseEvent) => void;
   onDragEnd?: (options: AntTreeNodeMouseEvent) => void;
+  onMouseEnter?: (options: AntTreeNodeMouseEvent) => void;
+  onMouseLeave?: (options: AntTreeNodeMouseEvent) => void;
   onDrop?: (options: AntTreeNodeDropEvent) => void;
   style?: React.CSSProperties;
   showIcon?: boolean;

--- a/components/tree/index.en-US.md
+++ b/components/tree/index.en-US.md
@@ -46,6 +46,8 @@ Almost anything can be represented in a tree structure. Examples include directo
 | onDrop | Callback function for when the onDrop event occurs | function({event, node, dragNode, dragNodesKeys}) | - |  |
 | onExpand | Callback function for when a treeNode is expanded or collapsed | function(expandedKeys, {expanded: bool, node}) | - |  |
 | onLoad | Callback function for when a treeNode is loaded | function(loadedKeys, {event, node}) | - | 3.7.0 |
+| onMouseEnter | Callback function for when the onMouseEnter event occurs | function({event, node}) | - | 3.24.0 |
+| onMouseLeave | Callback function for when the onMouseLeave event occurs | function({event, node}) | - | 3.24.0 |
 | onRightClick | Callback function for when the user right clicks a treeNode | function({event, node}) | - |  |
 | onSelect | Callback function for when the user clicks a treeNode | function(selectedKeys, e:{selected: bool, selectedNodes, node, event}) | - |  |
 | treeData | treeNodes data Array, if set it then you need not to construct children TreeNode. (key should be unique across the whole array) | array\<{ key, title, children, \[disabled, selectable] }> | - | 3.19.8 |

--- a/components/tree/index.en-US.md
+++ b/components/tree/index.en-US.md
@@ -46,8 +46,8 @@ Almost anything can be represented in a tree structure. Examples include directo
 | onDrop | Callback function for when the onDrop event occurs | function({event, node, dragNode, dragNodesKeys}) | - |  |
 | onExpand | Callback function for when a treeNode is expanded or collapsed | function(expandedKeys, {expanded: bool, node}) | - |  |
 | onLoad | Callback function for when a treeNode is loaded | function(loadedKeys, {event, node}) | - | 3.7.0 |
-| onMouseEnter | Callback function for when the onMouseEnter event occurs | function({event, node}) | - | 3.24.0 |
-| onMouseLeave | Callback function for when the onMouseLeave event occurs | function({event, node}) | - | 3.24.0 |
+| onMouseEnter | Callback function for when Entering TreeNode | function({event, node}) | - |  |
+| onMouseLeave | Callback function for when Leaving TreeNode | function({event, node}) | - |  |
 | onRightClick | Callback function for when the user right clicks a treeNode | function({event, node}) | - |  |
 | onSelect | Callback function for when the user clicks a treeNode | function(selectedKeys, e:{selected: bool, selectedNodes, node, event}) | - |  |
 | treeData | treeNodes data Array, if set it then you need not to construct children TreeNode. (key should be unique across the whole array) | array\<{ key, title, children, \[disabled, selectable] }> | - | 3.19.8 |

--- a/components/tree/index.zh-CN.md
+++ b/components/tree/index.zh-CN.md
@@ -47,6 +47,8 @@ subtitle: 树形控件
 | onDrop | drop 触发时调用 | function({event, node, dragNode, dragNodesKeys}) | - |  |
 | onExpand | 展开/收起节点时触发 | function(expandedKeys, {expanded: bool, node}) | - |  |
 | onLoad | 节点加载完毕时触发 | function(loadedKeys, {event, node}) | - | 3.7.0 |
+| onMouseEnter | mouseenter 触发时调用 | function({event, node}) | - | 3.24.0 |
+| onMouseLeave | mouseleave 触发时调用 | function({event, node}) | - | 3.24.0 |
 | onRightClick | 响应右键点击 | function({event, node}) | - |  |
 | onSelect | 点击树节点触发 | function(selectedKeys, e:{selected: bool, selectedNodes, node, event}) | - |  |
 | treeData | treeNodes 数据，如果设置则不需要手动构造 TreeNode 节点（key 在整个树范围内唯一） | array\<{key, title, children, \[disabled, selectable]}> | - | 3.19.8 |

--- a/components/tree/index.zh-CN.md
+++ b/components/tree/index.zh-CN.md
@@ -47,8 +47,8 @@ subtitle: 树形控件
 | onDrop | drop 触发时调用 | function({event, node, dragNode, dragNodesKeys}) | - |  |
 | onExpand | 展开/收起节点时触发 | function(expandedKeys, {expanded: bool, node}) | - |  |
 | onLoad | 节点加载完毕时触发 | function(loadedKeys, {event, node}) | - | 3.7.0 |
-| onMouseEnter | 进入 TreeNode 时调用 | function({event, node}) | - | 3.24.0 |
-| onMouseLeave | 离开 TreeNode 时调用 | function({event, node}) | - | 3.24.0 |
+| onMouseEnter | 进入 TreeNode 时调用 | function({event, node}) | - |  |
+| onMouseLeave | 离开 TreeNode 时调用 | function({event, node}) | - |  |
 | onRightClick | 响应右键点击 | function({event, node}) | - |  |
 | onSelect | 点击树节点触发 | function(selectedKeys, e:{selected: bool, selectedNodes, node, event}) | - |  |
 | treeData | treeNodes 数据，如果设置则不需要手动构造 TreeNode 节点（key 在整个树范围内唯一） | array\<{key, title, children, \[disabled, selectable]}> | - | 3.19.8 |

--- a/components/tree/index.zh-CN.md
+++ b/components/tree/index.zh-CN.md
@@ -47,8 +47,8 @@ subtitle: 树形控件
 | onDrop | drop 触发时调用 | function({event, node, dragNode, dragNodesKeys}) | - |  |
 | onExpand | 展开/收起节点时触发 | function(expandedKeys, {expanded: bool, node}) | - |  |
 | onLoad | 节点加载完毕时触发 | function(loadedKeys, {event, node}) | - | 3.7.0 |
-| onMouseEnter | mouseenter 触发时调用 | function({event, node}) | - | 3.24.0 |
-| onMouseLeave | mouseleave 触发时调用 | function({event, node}) | - | 3.24.0 |
+| onMouseEnter | 进入 TreeNode 时调用 | function({event, node}) | - | 3.24.0 |
+| onMouseLeave | 离开 TreeNode 时调用 | function({event, node}) | - | 3.24.0 |
 | onRightClick | 响应右键点击 | function({event, node}) | - |  |
 | onSelect | 点击树节点触发 | function(selectedKeys, e:{selected: bool, selectedNodes, node, event}) | - |  |
 | treeData | treeNodes 数据，如果设置则不需要手动构造 TreeNode 节点（key 在整个树范围内唯一） | array\<{key, title, children, \[disabled, selectable]}> | - | 3.19.8 |


### PR DESCRIPTION

<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
close #18786
<!--
1. Describe the source of requirement, like related issue link.
-->


### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    :sparkles: Add onMouseEnter and onMouseLeave event TypeScript definition|
| 🇨🇳 Chinese |     :sparkles: 为 Tree 新增 onMouseEnter 和 onMouseLeave 事件的 TypeScript 类型      |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/tree/index.en-US.md](https://github.com/MrHeer/ant-design/blob/add-onMouseEnter-and-onMouseLeave-for-Tree/components/tree/index.en-US.md)
[View rendered components/tree/index.zh-CN.md](https://github.com/MrHeer/ant-design/blob/add-onMouseEnter-and-onMouseLeave-for-Tree/components/tree/index.zh-CN.md)