### PR TITLE
fix: pageHeader default background bg

### DIFF
--- a/components/page-header/style/index.less
+++ b/components/page-header/style/index.less
@@ -8,6 +8,7 @@
 
   position: relative;
   padding: @page-header-padding;
+  background: @component-background;
 
   &.has-breadcrumb {
     padding-top: @page-header-padding-breadcrumb;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->



### 💡 Background and solution

https://github.com/ant-design/ant-design/pull/18128/files#diff-b57e44af5f70de4dbd3e6959b2b2cd5dL11

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    fix PageHeader hasn't a default background color       |
| 🇨🇳 Chinese |  修复 PageHeader 默认背景色缺失 |

### ☑️ Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
