### PR TITLE
fix: small table headers missing border

### DIFF
--- a/components/table/style/size.less
+++ b/components/table/style/size.less
@@ -138,7 +138,7 @@
       border-left: 0;
     }
 
-    .@{table-prefix-cls}-thead > tr > th:last-child,
+    .@{table-prefix-cls}-thead > tr:only-child > th:last-child,
     .@{table-prefix-cls}-tbody > tr > td:last-child {
       border-right: none;
     }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close #18762

### 💡 Background and solution

<img width="642" alt="image" src="https://user-images.githubusercontent.com/507615/64936892-b0836b80-d88a-11e9-8b7a-5ed73bb5194a.png">

fixed to

<img width="679" alt="image" src="https://user-images.githubusercontent.com/507615/64936899-c1cc7800-d88a-11e9-93ea-8876f40fde49.png">

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix `size="small"` Table header missing right border. |
| 🇨🇳 Chinese | 修复 Table `size="small"` 时丢失列头右边框的问题。 |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
