### PR TITLE
feat(Progress): add new prop orientation to display vertically

### DIFF
--- a/components/config-provider/__tests__/__snapshots__/components.test.js.snap
+++ b/components/config-provider/__tests__/__snapshots__/components.test.js.snap
@@ -9599,7 +9599,7 @@ exports[`ConfigProvider components Popover prefixCls 1`] = `
 
 exports[`ConfigProvider components Progress configProvider 1`] = `
 <div
-  class="config-progress config-progress-line config-progress-status-normal config-progress-show-info config-progress-default config-progress-orientation-default"
+  class="config-progress config-progress-line config-progress-status-normal config-progress-show-info config-progress-default config-progress-orientation-horizontal"
 >
   <div>
     <div
@@ -9626,7 +9626,7 @@ exports[`ConfigProvider components Progress configProvider 1`] = `
 
 exports[`ConfigProvider components Progress normal 1`] = `
 <div
-  class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default ant-progress-orientation-default"
+  class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default ant-progress-orientation-horizontal"
 >
   <div>
     <div
@@ -9653,7 +9653,7 @@ exports[`ConfigProvider components Progress normal 1`] = `
 
 exports[`ConfigProvider components Progress prefixCls 1`] = `
 <div
-  class="prefix-Progress prefix-Progress-line prefix-Progress-status-normal prefix-Progress-show-info prefix-Progress-default prefix-Progress-orientation-default"
+  class="prefix-Progress prefix-Progress-line prefix-Progress-status-normal prefix-Progress-show-info prefix-Progress-default prefix-Progress-orientation-horizontal"
 >
   <div>
     <div

--- a/components/config-provider/__tests__/__snapshots__/components.test.js.snap
+++ b/components/config-provider/__tests__/__snapshots__/components.test.js.snap
@@ -9599,7 +9599,7 @@ exports[`ConfigProvider components Popover prefixCls 1`] = `
 
 exports[`ConfigProvider components Progress configProvider 1`] = `
 <div
-  class="config-progress config-progress-line config-progress-status-normal config-progress-show-info config-progress-default"
+  class="config-progress config-progress-line config-progress-status-normal config-progress-show-info config-progress-default config-progress-orientation-default"
 >
   <div>
     <div
@@ -9626,7 +9626,7 @@ exports[`ConfigProvider components Progress configProvider 1`] = `
 
 exports[`ConfigProvider components Progress normal 1`] = `
 <div
-  class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default"
+  class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default ant-progress-orientation-default"
 >
   <div>
     <div
@@ -9653,7 +9653,7 @@ exports[`ConfigProvider components Progress normal 1`] = `
 
 exports[`ConfigProvider components Progress prefixCls 1`] = `
 <div
-  class="prefix-Progress prefix-Progress-line prefix-Progress-status-normal prefix-Progress-show-info prefix-Progress-default"
+  class="prefix-Progress prefix-Progress-line prefix-Progress-status-normal prefix-Progress-show-info prefix-Progress-default prefix-Progress-orientation-default"
 >
   <div>
     <div

--- a/components/progress/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/progress/__tests__/__snapshots__/demo.test.js.snap
@@ -1244,9 +1244,11 @@ exports[`renders ./components/progress/demo/linecap.md correctly 1`] = `
 `;
 
 exports[`renders ./components/progress/demo/orientation.md correctly 1`] = `
-<div>
+<div
+  style="width:170px;height:130px;padding-top:45px"
+>
   <div
-    class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-small ant-progress-orientation-vertical"
+    class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-small ant-progress-orientation-vertical"
   >
     <div>
       <div
@@ -1257,10 +1259,17 @@ exports[`renders ./components/progress/demo/orientation.md correctly 1`] = `
         >
           <div
             class="ant-progress-bg"
-            style="width:30%;height:6px;border-radius:"
+            style="width:70%;height:6px;border-radius:"
           />
         </div>
       </div>
+      <span
+        class="ant-progress-text"
+        style="transform:rotate(90deg)"
+        title="70%"
+      >
+        70%
+      </span>
     </div>
   </div>
 </div>

--- a/components/progress/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/progress/__tests__/__snapshots__/demo.test.js.snap
@@ -1246,7 +1246,7 @@ exports[`renders ./components/progress/demo/linecap.md correctly 1`] = `
 exports[`renders ./components/progress/demo/orientation.md correctly 1`] = `
 <div>
   <div
-    class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default ant-progress-orientation-vertical"
+    class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-small ant-progress-orientation-vertical"
   >
     <div>
       <div
@@ -1257,57 +1257,10 @@ exports[`renders ./components/progress/demo/orientation.md correctly 1`] = `
         >
           <div
             class="ant-progress-bg"
-            style="width:30%;height:8px;border-radius:"
+            style="width:30%;height:6px;border-radius:"
           />
         </div>
       </div>
-      <span
-        class="ant-progress-text"
-        title="30%"
-      >
-        30%
-      </span>
-    </div>
-  </div>
-  <div
-    class="ant-progress ant-progress-line ant-progress-status-success ant-progress-show-info ant-progress-small ant-progress-orientation-vertical"
-  >
-    <div>
-      <div
-        class="ant-progress-outer"
-      >
-        <div
-          class="ant-progress-inner"
-        >
-          <div
-            class="ant-progress-bg"
-            style="width:100%;height:6px;border-radius:"
-          />
-        </div>
-      </div>
-      <span
-        class="ant-progress-text"
-      >
-        <i
-          aria-label="icon: check-circle"
-          class="anticon anticon-check-circle"
-        >
-          <svg
-            aria-hidden="true"
-            class=""
-            data-icon="check-circle"
-            fill="currentColor"
-            focusable="false"
-            height="1em"
-            viewBox="64 64 896 896"
-            width="1em"
-          >
-            <path
-              d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm193.5 301.7l-210.6 292a31.8 31.8 0 0 1-51.7 0L318.5 484.9c-3.8-5.3 0-12.7 6.5-12.7h46.9c10.2 0 19.9 4.9 25.9 13.3l71.2 98.8 157.2-218c6-8.3 15.6-13.3 25.9-13.3H699c6.5 0 10.3 7.4 6.5 12.7z"
-            />
-          </svg>
-        </i>
-      </span>
     </div>
   </div>
 </div>

--- a/components/progress/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/progress/__tests__/__snapshots__/demo.test.js.snap
@@ -3,7 +3,7 @@
 exports[`renders ./components/progress/demo/circle.md correctly 1`] = `
 <div>
   <div
-    class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default ant-progress-orientation-default"
+    class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default ant-progress-orientation-horizontal"
   >
     <div
       class="ant-progress-inner"
@@ -45,7 +45,7 @@ exports[`renders ./components/progress/demo/circle.md correctly 1`] = `
     </div>
   </div>
   <div
-    class="ant-progress ant-progress-circle ant-progress-status-exception ant-progress-show-info ant-progress-default ant-progress-orientation-default"
+    class="ant-progress ant-progress-circle ant-progress-status-exception ant-progress-show-info ant-progress-default ant-progress-orientation-horizontal"
   >
     <div
       class="ant-progress-inner"
@@ -104,7 +104,7 @@ exports[`renders ./components/progress/demo/circle.md correctly 1`] = `
     </div>
   </div>
   <div
-    class="ant-progress ant-progress-circle ant-progress-status-success ant-progress-show-info ant-progress-default ant-progress-orientation-default"
+    class="ant-progress ant-progress-circle ant-progress-status-success ant-progress-show-info ant-progress-default ant-progress-orientation-horizontal"
   >
     <div
       class="ant-progress-inner"
@@ -168,7 +168,7 @@ exports[`renders ./components/progress/demo/circle.md correctly 1`] = `
 exports[`renders ./components/progress/demo/circle-dynamic.md correctly 1`] = `
 <div>
   <div
-    class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default ant-progress-orientation-default"
+    class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default ant-progress-orientation-horizontal"
   >
     <div
       class="ant-progress-inner"
@@ -270,7 +270,7 @@ exports[`renders ./components/progress/demo/circle-dynamic.md correctly 1`] = `
 exports[`renders ./components/progress/demo/circle-mini.md correctly 1`] = `
 <div>
   <div
-    class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default ant-progress-orientation-default"
+    class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default ant-progress-orientation-horizontal"
   >
     <div
       class="ant-progress-inner"
@@ -312,7 +312,7 @@ exports[`renders ./components/progress/demo/circle-mini.md correctly 1`] = `
     </div>
   </div>
   <div
-    class="ant-progress ant-progress-circle ant-progress-status-exception ant-progress-show-info ant-progress-default ant-progress-orientation-default"
+    class="ant-progress ant-progress-circle ant-progress-status-exception ant-progress-show-info ant-progress-default ant-progress-orientation-horizontal"
   >
     <div
       class="ant-progress-inner"
@@ -371,7 +371,7 @@ exports[`renders ./components/progress/demo/circle-mini.md correctly 1`] = `
     </div>
   </div>
   <div
-    class="ant-progress ant-progress-circle ant-progress-status-success ant-progress-show-info ant-progress-default ant-progress-orientation-default"
+    class="ant-progress ant-progress-circle ant-progress-status-success ant-progress-show-info ant-progress-default ant-progress-orientation-horizontal"
   >
     <div
       class="ant-progress-inner"
@@ -434,7 +434,7 @@ exports[`renders ./components/progress/demo/circle-mini.md correctly 1`] = `
 
 exports[`renders ./components/progress/demo/dashboard.md correctly 1`] = `
 <div
-  class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default ant-progress-orientation-default"
+  class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default ant-progress-orientation-horizontal"
 >
   <div
     class="ant-progress-inner"
@@ -480,7 +480,7 @@ exports[`renders ./components/progress/demo/dashboard.md correctly 1`] = `
 exports[`renders ./components/progress/demo/dynamic.md correctly 1`] = `
 <div>
   <div
-    class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default ant-progress-orientation-default"
+    class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default ant-progress-orientation-horizontal"
   >
     <div>
       <div
@@ -564,7 +564,7 @@ exports[`renders ./components/progress/demo/dynamic.md correctly 1`] = `
 exports[`renders ./components/progress/demo/format.md correctly 1`] = `
 <div>
   <div
-    class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default ant-progress-orientation-default"
+    class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default ant-progress-orientation-horizontal"
   >
     <div
       class="ant-progress-inner"
@@ -606,7 +606,7 @@ exports[`renders ./components/progress/demo/format.md correctly 1`] = `
     </div>
   </div>
   <div
-    class="ant-progress ant-progress-circle ant-progress-status-success ant-progress-show-info ant-progress-default ant-progress-orientation-default"
+    class="ant-progress ant-progress-circle ant-progress-status-success ant-progress-show-info ant-progress-default ant-progress-orientation-horizontal"
   >
     <div
       class="ant-progress-inner"
@@ -653,7 +653,7 @@ exports[`renders ./components/progress/demo/format.md correctly 1`] = `
 exports[`renders ./components/progress/demo/gradient-line.md correctly 1`] = `
 <div>
   <div
-    class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default ant-progress-orientation-default"
+    class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default ant-progress-orientation-horizontal"
   >
     <div>
       <div
@@ -677,7 +677,7 @@ exports[`renders ./components/progress/demo/gradient-line.md correctly 1`] = `
     </div>
   </div>
   <div
-    class="ant-progress ant-progress-line ant-progress-status-active ant-progress-show-info ant-progress-default ant-progress-orientation-default"
+    class="ant-progress ant-progress-line ant-progress-status-active ant-progress-show-info ant-progress-default ant-progress-orientation-horizontal"
   >
     <div>
       <div
@@ -701,7 +701,7 @@ exports[`renders ./components/progress/demo/gradient-line.md correctly 1`] = `
     </div>
   </div>
   <div
-    class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default ant-progress-orientation-default"
+    class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default ant-progress-orientation-horizontal"
   >
     <div
       class="ant-progress-inner ant-progress-circle-gradient"
@@ -761,7 +761,7 @@ exports[`renders ./components/progress/demo/gradient-line.md correctly 1`] = `
     </div>
   </div>
   <div
-    class="ant-progress ant-progress-circle ant-progress-status-success ant-progress-show-info ant-progress-default ant-progress-orientation-default"
+    class="ant-progress ant-progress-circle ant-progress-status-success ant-progress-show-info ant-progress-default ant-progress-orientation-horizontal"
   >
     <div
       class="ant-progress-inner ant-progress-circle-gradient"
@@ -843,7 +843,7 @@ exports[`renders ./components/progress/demo/gradient-line.md correctly 1`] = `
 exports[`renders ./components/progress/demo/line.md correctly 1`] = `
 <div>
   <div
-    class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default ant-progress-orientation-default"
+    class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default ant-progress-orientation-horizontal"
   >
     <div>
       <div
@@ -867,7 +867,7 @@ exports[`renders ./components/progress/demo/line.md correctly 1`] = `
     </div>
   </div>
   <div
-    class="ant-progress ant-progress-line ant-progress-status-active ant-progress-show-info ant-progress-default ant-progress-orientation-default"
+    class="ant-progress ant-progress-line ant-progress-status-active ant-progress-show-info ant-progress-default ant-progress-orientation-horizontal"
   >
     <div>
       <div
@@ -891,7 +891,7 @@ exports[`renders ./components/progress/demo/line.md correctly 1`] = `
     </div>
   </div>
   <div
-    class="ant-progress ant-progress-line ant-progress-status-exception ant-progress-show-info ant-progress-default ant-progress-orientation-default"
+    class="ant-progress ant-progress-line ant-progress-status-exception ant-progress-show-info ant-progress-default ant-progress-orientation-horizontal"
   >
     <div>
       <div
@@ -932,7 +932,7 @@ exports[`renders ./components/progress/demo/line.md correctly 1`] = `
     </div>
   </div>
   <div
-    class="ant-progress ant-progress-line ant-progress-status-success ant-progress-show-info ant-progress-default ant-progress-orientation-default"
+    class="ant-progress ant-progress-line ant-progress-status-success ant-progress-show-info ant-progress-default ant-progress-orientation-horizontal"
   >
     <div>
       <div
@@ -973,7 +973,7 @@ exports[`renders ./components/progress/demo/line.md correctly 1`] = `
     </div>
   </div>
   <div
-    class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-default ant-progress-orientation-default"
+    class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-default ant-progress-orientation-horizontal"
   >
     <div>
       <div
@@ -998,7 +998,7 @@ exports[`renders ./components/progress/demo/line-mini.md correctly 1`] = `
   style="width:170px"
 >
   <div
-    class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-small ant-progress-orientation-default"
+    class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-small ant-progress-orientation-horizontal"
   >
     <div>
       <div
@@ -1022,7 +1022,7 @@ exports[`renders ./components/progress/demo/line-mini.md correctly 1`] = `
     </div>
   </div>
   <div
-    class="ant-progress ant-progress-line ant-progress-status-active ant-progress-show-info ant-progress-small ant-progress-orientation-default"
+    class="ant-progress ant-progress-line ant-progress-status-active ant-progress-show-info ant-progress-small ant-progress-orientation-horizontal"
   >
     <div>
       <div
@@ -1046,7 +1046,7 @@ exports[`renders ./components/progress/demo/line-mini.md correctly 1`] = `
     </div>
   </div>
   <div
-    class="ant-progress ant-progress-line ant-progress-status-exception ant-progress-show-info ant-progress-small ant-progress-orientation-default"
+    class="ant-progress ant-progress-line ant-progress-status-exception ant-progress-show-info ant-progress-small ant-progress-orientation-horizontal"
   >
     <div>
       <div
@@ -1087,7 +1087,7 @@ exports[`renders ./components/progress/demo/line-mini.md correctly 1`] = `
     </div>
   </div>
   <div
-    class="ant-progress ant-progress-line ant-progress-status-success ant-progress-show-info ant-progress-small ant-progress-orientation-default"
+    class="ant-progress ant-progress-line ant-progress-status-success ant-progress-show-info ant-progress-small ant-progress-orientation-horizontal"
   >
     <div>
       <div
@@ -1133,7 +1133,7 @@ exports[`renders ./components/progress/demo/line-mini.md correctly 1`] = `
 exports[`renders ./components/progress/demo/linecap.md correctly 1`] = `
 <div>
   <div
-    class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default ant-progress-orientation-default"
+    class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default ant-progress-orientation-horizontal"
   >
     <div>
       <div
@@ -1157,7 +1157,7 @@ exports[`renders ./components/progress/demo/linecap.md correctly 1`] = `
     </div>
   </div>
   <div
-    class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default ant-progress-orientation-default"
+    class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default ant-progress-orientation-horizontal"
   >
     <div
       class="ant-progress-inner"
@@ -1199,7 +1199,7 @@ exports[`renders ./components/progress/demo/linecap.md correctly 1`] = `
     </div>
   </div>
   <div
-    class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default ant-progress-orientation-default"
+    class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default ant-progress-orientation-horizontal"
   >
     <div
       class="ant-progress-inner"
@@ -1278,7 +1278,7 @@ exports[`renders ./components/progress/demo/orientation.md correctly 1`] = `
 exports[`renders ./components/progress/demo/segment.md correctly 1`] = `
 <div>
   <div
-    class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default ant-progress-orientation-default"
+    class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default ant-progress-orientation-horizontal"
   >
     <div>
       <div
@@ -1306,7 +1306,7 @@ exports[`renders ./components/progress/demo/segment.md correctly 1`] = `
     </div>
   </div>
   <div
-    class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default ant-progress-orientation-default"
+    class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default ant-progress-orientation-horizontal"
   >
     <div
       class="ant-progress-inner"
@@ -1359,7 +1359,7 @@ exports[`renders ./components/progress/demo/segment.md correctly 1`] = `
     </div>
   </div>
   <div
-    class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default ant-progress-orientation-default"
+    class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default ant-progress-orientation-horizontal"
   >
     <div
       class="ant-progress-inner"

--- a/components/progress/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/progress/__tests__/__snapshots__/demo.test.js.snap
@@ -3,7 +3,7 @@
 exports[`renders ./components/progress/demo/circle.md correctly 1`] = `
 <div>
   <div
-    class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default"
+    class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default ant-progress-orientation-default"
   >
     <div
       class="ant-progress-inner"
@@ -45,7 +45,7 @@ exports[`renders ./components/progress/demo/circle.md correctly 1`] = `
     </div>
   </div>
   <div
-    class="ant-progress ant-progress-circle ant-progress-status-exception ant-progress-show-info ant-progress-default"
+    class="ant-progress ant-progress-circle ant-progress-status-exception ant-progress-show-info ant-progress-default ant-progress-orientation-default"
   >
     <div
       class="ant-progress-inner"
@@ -104,7 +104,7 @@ exports[`renders ./components/progress/demo/circle.md correctly 1`] = `
     </div>
   </div>
   <div
-    class="ant-progress ant-progress-circle ant-progress-status-success ant-progress-show-info ant-progress-default"
+    class="ant-progress ant-progress-circle ant-progress-status-success ant-progress-show-info ant-progress-default ant-progress-orientation-default"
   >
     <div
       class="ant-progress-inner"
@@ -168,7 +168,7 @@ exports[`renders ./components/progress/demo/circle.md correctly 1`] = `
 exports[`renders ./components/progress/demo/circle-dynamic.md correctly 1`] = `
 <div>
   <div
-    class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default"
+    class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default ant-progress-orientation-default"
   >
     <div
       class="ant-progress-inner"
@@ -270,7 +270,7 @@ exports[`renders ./components/progress/demo/circle-dynamic.md correctly 1`] = `
 exports[`renders ./components/progress/demo/circle-mini.md correctly 1`] = `
 <div>
   <div
-    class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default"
+    class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default ant-progress-orientation-default"
   >
     <div
       class="ant-progress-inner"
@@ -312,7 +312,7 @@ exports[`renders ./components/progress/demo/circle-mini.md correctly 1`] = `
     </div>
   </div>
   <div
-    class="ant-progress ant-progress-circle ant-progress-status-exception ant-progress-show-info ant-progress-default"
+    class="ant-progress ant-progress-circle ant-progress-status-exception ant-progress-show-info ant-progress-default ant-progress-orientation-default"
   >
     <div
       class="ant-progress-inner"
@@ -371,7 +371,7 @@ exports[`renders ./components/progress/demo/circle-mini.md correctly 1`] = `
     </div>
   </div>
   <div
-    class="ant-progress ant-progress-circle ant-progress-status-success ant-progress-show-info ant-progress-default"
+    class="ant-progress ant-progress-circle ant-progress-status-success ant-progress-show-info ant-progress-default ant-progress-orientation-default"
   >
     <div
       class="ant-progress-inner"
@@ -434,7 +434,7 @@ exports[`renders ./components/progress/demo/circle-mini.md correctly 1`] = `
 
 exports[`renders ./components/progress/demo/dashboard.md correctly 1`] = `
 <div
-  class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default"
+  class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default ant-progress-orientation-default"
 >
   <div
     class="ant-progress-inner"
@@ -480,7 +480,7 @@ exports[`renders ./components/progress/demo/dashboard.md correctly 1`] = `
 exports[`renders ./components/progress/demo/dynamic.md correctly 1`] = `
 <div>
   <div
-    class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default"
+    class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default ant-progress-orientation-default"
   >
     <div>
       <div
@@ -564,7 +564,7 @@ exports[`renders ./components/progress/demo/dynamic.md correctly 1`] = `
 exports[`renders ./components/progress/demo/format.md correctly 1`] = `
 <div>
   <div
-    class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default"
+    class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default ant-progress-orientation-default"
   >
     <div
       class="ant-progress-inner"
@@ -606,7 +606,7 @@ exports[`renders ./components/progress/demo/format.md correctly 1`] = `
     </div>
   </div>
   <div
-    class="ant-progress ant-progress-circle ant-progress-status-success ant-progress-show-info ant-progress-default"
+    class="ant-progress ant-progress-circle ant-progress-status-success ant-progress-show-info ant-progress-default ant-progress-orientation-default"
   >
     <div
       class="ant-progress-inner"
@@ -653,7 +653,7 @@ exports[`renders ./components/progress/demo/format.md correctly 1`] = `
 exports[`renders ./components/progress/demo/gradient-line.md correctly 1`] = `
 <div>
   <div
-    class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default"
+    class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default ant-progress-orientation-default"
   >
     <div>
       <div
@@ -677,7 +677,7 @@ exports[`renders ./components/progress/demo/gradient-line.md correctly 1`] = `
     </div>
   </div>
   <div
-    class="ant-progress ant-progress-line ant-progress-status-active ant-progress-show-info ant-progress-default"
+    class="ant-progress ant-progress-line ant-progress-status-active ant-progress-show-info ant-progress-default ant-progress-orientation-default"
   >
     <div>
       <div
@@ -701,7 +701,7 @@ exports[`renders ./components/progress/demo/gradient-line.md correctly 1`] = `
     </div>
   </div>
   <div
-    class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default"
+    class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default ant-progress-orientation-default"
   >
     <div
       class="ant-progress-inner ant-progress-circle-gradient"
@@ -761,7 +761,7 @@ exports[`renders ./components/progress/demo/gradient-line.md correctly 1`] = `
     </div>
   </div>
   <div
-    class="ant-progress ant-progress-circle ant-progress-status-success ant-progress-show-info ant-progress-default"
+    class="ant-progress ant-progress-circle ant-progress-status-success ant-progress-show-info ant-progress-default ant-progress-orientation-default"
   >
     <div
       class="ant-progress-inner ant-progress-circle-gradient"
@@ -843,7 +843,7 @@ exports[`renders ./components/progress/demo/gradient-line.md correctly 1`] = `
 exports[`renders ./components/progress/demo/line.md correctly 1`] = `
 <div>
   <div
-    class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default"
+    class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default ant-progress-orientation-default"
   >
     <div>
       <div
@@ -867,7 +867,7 @@ exports[`renders ./components/progress/demo/line.md correctly 1`] = `
     </div>
   </div>
   <div
-    class="ant-progress ant-progress-line ant-progress-status-active ant-progress-show-info ant-progress-default"
+    class="ant-progress ant-progress-line ant-progress-status-active ant-progress-show-info ant-progress-default ant-progress-orientation-default"
   >
     <div>
       <div
@@ -891,7 +891,7 @@ exports[`renders ./components/progress/demo/line.md correctly 1`] = `
     </div>
   </div>
   <div
-    class="ant-progress ant-progress-line ant-progress-status-exception ant-progress-show-info ant-progress-default"
+    class="ant-progress ant-progress-line ant-progress-status-exception ant-progress-show-info ant-progress-default ant-progress-orientation-default"
   >
     <div>
       <div
@@ -932,7 +932,7 @@ exports[`renders ./components/progress/demo/line.md correctly 1`] = `
     </div>
   </div>
   <div
-    class="ant-progress ant-progress-line ant-progress-status-success ant-progress-show-info ant-progress-default"
+    class="ant-progress ant-progress-line ant-progress-status-success ant-progress-show-info ant-progress-default ant-progress-orientation-default"
   >
     <div>
       <div
@@ -973,7 +973,7 @@ exports[`renders ./components/progress/demo/line.md correctly 1`] = `
     </div>
   </div>
   <div
-    class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-default"
+    class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-default ant-progress-orientation-default"
   >
     <div>
       <div
@@ -998,7 +998,7 @@ exports[`renders ./components/progress/demo/line-mini.md correctly 1`] = `
   style="width:170px"
 >
   <div
-    class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-small"
+    class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-small ant-progress-orientation-default"
   >
     <div>
       <div
@@ -1022,7 +1022,7 @@ exports[`renders ./components/progress/demo/line-mini.md correctly 1`] = `
     </div>
   </div>
   <div
-    class="ant-progress ant-progress-line ant-progress-status-active ant-progress-show-info ant-progress-small"
+    class="ant-progress ant-progress-line ant-progress-status-active ant-progress-show-info ant-progress-small ant-progress-orientation-default"
   >
     <div>
       <div
@@ -1046,7 +1046,7 @@ exports[`renders ./components/progress/demo/line-mini.md correctly 1`] = `
     </div>
   </div>
   <div
-    class="ant-progress ant-progress-line ant-progress-status-exception ant-progress-show-info ant-progress-small"
+    class="ant-progress ant-progress-line ant-progress-status-exception ant-progress-show-info ant-progress-small ant-progress-orientation-default"
   >
     <div>
       <div
@@ -1087,7 +1087,7 @@ exports[`renders ./components/progress/demo/line-mini.md correctly 1`] = `
     </div>
   </div>
   <div
-    class="ant-progress ant-progress-line ant-progress-status-success ant-progress-show-info ant-progress-small"
+    class="ant-progress ant-progress-line ant-progress-status-success ant-progress-show-info ant-progress-small ant-progress-orientation-default"
   >
     <div>
       <div
@@ -1133,7 +1133,7 @@ exports[`renders ./components/progress/demo/line-mini.md correctly 1`] = `
 exports[`renders ./components/progress/demo/linecap.md correctly 1`] = `
 <div>
   <div
-    class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default"
+    class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default ant-progress-orientation-default"
   >
     <div>
       <div
@@ -1157,7 +1157,7 @@ exports[`renders ./components/progress/demo/linecap.md correctly 1`] = `
     </div>
   </div>
   <div
-    class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default"
+    class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default ant-progress-orientation-default"
   >
     <div
       class="ant-progress-inner"
@@ -1199,7 +1199,7 @@ exports[`renders ./components/progress/demo/linecap.md correctly 1`] = `
     </div>
   </div>
   <div
-    class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default"
+    class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default ant-progress-orientation-default"
   >
     <div
       class="ant-progress-inner"
@@ -1243,10 +1243,80 @@ exports[`renders ./components/progress/demo/linecap.md correctly 1`] = `
 </div>
 `;
 
+exports[`renders ./components/progress/demo/orientation.md correctly 1`] = `
+<div>
+  <div
+    class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default ant-progress-orientation-vertical"
+  >
+    <div>
+      <div
+        class="ant-progress-outer"
+      >
+        <div
+          class="ant-progress-inner"
+        >
+          <div
+            class="ant-progress-bg"
+            style="width:30%;height:8px;border-radius:"
+          />
+        </div>
+      </div>
+      <span
+        class="ant-progress-text"
+        title="30%"
+      >
+        30%
+      </span>
+    </div>
+  </div>
+  <div
+    class="ant-progress ant-progress-line ant-progress-status-success ant-progress-show-info ant-progress-small ant-progress-orientation-vertical"
+  >
+    <div>
+      <div
+        class="ant-progress-outer"
+      >
+        <div
+          class="ant-progress-inner"
+        >
+          <div
+            class="ant-progress-bg"
+            style="width:100%;height:6px;border-radius:"
+          />
+        </div>
+      </div>
+      <span
+        class="ant-progress-text"
+      >
+        <i
+          aria-label="icon: check-circle"
+          class="anticon anticon-check-circle"
+        >
+          <svg
+            aria-hidden="true"
+            class=""
+            data-icon="check-circle"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm193.5 301.7l-210.6 292a31.8 31.8 0 0 1-51.7 0L318.5 484.9c-3.8-5.3 0-12.7 6.5-12.7h46.9c10.2 0 19.9 4.9 25.9 13.3l71.2 98.8 157.2-218c6-8.3 15.6-13.3 25.9-13.3H699c6.5 0 10.3 7.4 6.5 12.7z"
+            />
+          </svg>
+        </i>
+      </span>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`renders ./components/progress/demo/segment.md correctly 1`] = `
 <div>
   <div
-    class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default"
+    class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default ant-progress-orientation-default"
   >
     <div>
       <div
@@ -1274,7 +1344,7 @@ exports[`renders ./components/progress/demo/segment.md correctly 1`] = `
     </div>
   </div>
   <div
-    class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default"
+    class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default ant-progress-orientation-default"
   >
     <div
       class="ant-progress-inner"
@@ -1327,7 +1397,7 @@ exports[`renders ./components/progress/demo/segment.md correctly 1`] = `
     </div>
   </div>
   <div
-    class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default"
+    class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default ant-progress-orientation-default"
   >
     <div
       class="ant-progress-inner"

--- a/components/progress/__tests__/__snapshots__/index.test.js.snap
+++ b/components/progress/__tests__/__snapshots__/index.test.js.snap
@@ -418,3 +418,30 @@ exports[`Progress render strokeColor 3`] = `
   </div>
 </Progress>
 `;
+
+exports[`render orientation vertical 1`] = `
+<div
+  class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default"
+>
+  <div>
+    <div
+      class="ant-progress-outer"
+    >
+      <div
+        class="ant-progress-inner"
+      >
+        <div
+          class="ant-progress-bg"
+          style="width: 0%; height: 8px;"
+        />
+      </div>
+    </div>
+    <span
+      class="ant-progress-text"
+      title="0%"
+    >
+      0%
+    </span>
+  </div>
+</div>
+`;

--- a/components/progress/__tests__/__snapshots__/index.test.js.snap
+++ b/components/progress/__tests__/__snapshots__/index.test.js.snap
@@ -418,31 +418,3 @@ exports[`Progress render strokeColor 3`] = `
   </div>
 </Progress>
 `;
-
-exports[`render orientation vertical 1`] = `
-<div
-  class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default ant-progress-orientation-vertical"
->
-  <div>
-    <div
-      class="ant-progress-outer"
-    >
-      <div
-        class="ant-progress-inner"
-      >
-        <div
-          class="ant-progress-bg"
-          style="width: 0%; height: 8px;"
-        />
-      </div>
-    </div>
-    <span
-      class="ant-progress-text"
-      style="transform: rotate(90deg);"
-      title="0%"
-    >
-      0%
-    </span>
-  </div>
-</div>
-`;

--- a/components/progress/__tests__/__snapshots__/index.test.js.snap
+++ b/components/progress/__tests__/__snapshots__/index.test.js.snap
@@ -252,6 +252,7 @@ exports[`Progress render strokeColor 1`] = `
 exports[`Progress render strokeColor 2`] = `
 <Progress
   gapDegree={0}
+  orientation="default"
   percent={50}
   showInfo={true}
   size="default"
@@ -270,6 +271,7 @@ exports[`Progress render strokeColor 2`] = `
   >
     <Line
       gapDegree={0}
+      orientation="default"
       percent={50}
       prefixCls="ant-progress"
       showInfo={true}
@@ -319,6 +321,7 @@ exports[`Progress render strokeColor 2`] = `
 exports[`Progress render strokeColor 3`] = `
 <Progress
   gapDegree={0}
+  orientation="default"
   percent={50}
   showInfo={true}
   size="default"
@@ -337,6 +340,7 @@ exports[`Progress render strokeColor 3`] = `
   >
     <Line
       gapDegree={0}
+      orientation="default"
       percent={50}
       prefixCls="ant-progress"
       showInfo={true}

--- a/components/progress/__tests__/__snapshots__/index.test.js.snap
+++ b/components/progress/__tests__/__snapshots__/index.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Progress render format 1`] = `
 <div
-  class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default"
+  class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default ant-progress-orientation-default"
 >
   <div>
     <div
@@ -31,9 +31,9 @@ exports[`Progress render format 1`] = `
 </div>
 `;
 
-exports[`Progress render negetive progress 1`] = `
+exports[`Progress render negative progress 1`] = `
 <div
-  class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default"
+  class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default ant-progress-orientation-default"
 >
   <div>
     <div
@@ -60,7 +60,7 @@ exports[`Progress render negetive progress 1`] = `
 
 exports[`Progress render negetive successPercent 1`] = `
 <div
-  class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default"
+  class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default ant-progress-orientation-default"
 >
   <div>
     <div
@@ -91,7 +91,7 @@ exports[`Progress render negetive successPercent 1`] = `
 
 exports[`Progress render normal progress 1`] = `
 <div
-  class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default"
+  class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default ant-progress-orientation-default"
 >
   <div>
     <div
@@ -116,9 +116,40 @@ exports[`Progress render normal progress 1`] = `
 </div>
 `;
 
+exports[`Progress render orientation vertical 1`] = `
+<div
+  class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default ant-progress-orientation-vertical"
+>
+  <div>
+    <div
+      class="ant-progress-outer"
+    >
+      <div
+        class="ant-progress-inner"
+      >
+        <div
+          class="ant-progress-bg"
+          style="width: 50%; height: 8px;"
+        />
+        <div
+          class="ant-progress-success-bg"
+          style="width: 10%; height: 8px;"
+        />
+      </div>
+    </div>
+    <span
+      class="ant-progress-text"
+      title="50%"
+    >
+      50%
+    </span>
+  </div>
+</div>
+`;
+
 exports[`Progress render out-of-range progress 1`] = `
 <div
-  class="ant-progress ant-progress-line ant-progress-status-success ant-progress-show-info ant-progress-default"
+  class="ant-progress ant-progress-line ant-progress-status-success ant-progress-show-info ant-progress-default ant-progress-orientation-default"
 >
   <div>
     <div
@@ -162,7 +193,7 @@ exports[`Progress render out-of-range progress 1`] = `
 
 exports[`Progress render out-of-range progress with info 1`] = `
 <div
-  class="ant-progress ant-progress-line ant-progress-status-success ant-progress-show-info ant-progress-default"
+  class="ant-progress ant-progress-line ant-progress-status-success ant-progress-show-info ant-progress-default ant-progress-orientation-default"
 >
   <div>
     <div
@@ -206,7 +237,7 @@ exports[`Progress render out-of-range progress with info 1`] = `
 
 exports[`Progress render strokeColor 1`] = `
 <div
-  class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default"
+  class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default ant-progress-orientation-default"
 >
   <div
     class="ant-progress-inner"
@@ -267,7 +298,7 @@ exports[`Progress render strokeColor 2`] = `
   type="line"
 >
   <div
-    className="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default"
+    className="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default ant-progress-orientation-default"
   >
     <Line
       gapDegree={0}
@@ -336,7 +367,7 @@ exports[`Progress render strokeColor 3`] = `
   type="line"
 >
   <div
-    className="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default"
+    className="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default ant-progress-orientation-default"
   >
     <Line
       gapDegree={0}
@@ -385,31 +416,4 @@ exports[`Progress render strokeColor 3`] = `
     </Line>
   </div>
 </Progress>
-`;
-
-exports[`render orientation vertical 1`] = `
-<div
-  class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default"
->
-  <div>
-    <div
-      class="ant-progress-outer"
-    >
-      <div
-        class="ant-progress-inner"
-      >
-        <div
-          class="ant-progress-bg"
-          style="width: 0%; height: 8px;"
-        />
-      </div>
-    </div>
-    <span
-      class="ant-progress-text"
-      title="0%"
-    >
-      0%
-    </span>
-  </div>
-</div>
 `;

--- a/components/progress/__tests__/__snapshots__/index.test.js.snap
+++ b/components/progress/__tests__/__snapshots__/index.test.js.snap
@@ -421,7 +421,7 @@ exports[`Progress render strokeColor 3`] = `
 
 exports[`render orientation vertical 1`] = `
 <div
-  class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default"
+  class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default ant-progress-orientation-vertical"
 >
   <div>
     <div
@@ -438,6 +438,7 @@ exports[`render orientation vertical 1`] = `
     </div>
     <span
       class="ant-progress-text"
+      style="transform: rotate(90deg);"
       title="0%"
     >
       0%

--- a/components/progress/__tests__/__snapshots__/index.test.js.snap
+++ b/components/progress/__tests__/__snapshots__/index.test.js.snap
@@ -386,3 +386,30 @@ exports[`Progress render strokeColor 3`] = `
   </div>
 </Progress>
 `;
+
+exports[`render orientation vertical 1`] = `
+<div
+  class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default"
+>
+  <div>
+    <div
+      class="ant-progress-outer"
+    >
+      <div
+        class="ant-progress-inner"
+      >
+        <div
+          class="ant-progress-bg"
+          style="width: 0%; height: 8px;"
+        />
+      </div>
+    </div>
+    <span
+      class="ant-progress-text"
+      title="0%"
+    >
+      0%
+    </span>
+  </div>
+</div>
+`;

--- a/components/progress/__tests__/__snapshots__/index.test.js.snap
+++ b/components/progress/__tests__/__snapshots__/index.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Progress render format 1`] = `
 <div
-  class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default ant-progress-orientation-default"
+  class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default ant-progress-orientation-horizontal"
 >
   <div>
     <div
@@ -33,7 +33,7 @@ exports[`Progress render format 1`] = `
 
 exports[`Progress render negative progress 1`] = `
 <div
-  class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default ant-progress-orientation-default"
+  class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default ant-progress-orientation-horizontal"
 >
   <div>
     <div
@@ -60,7 +60,7 @@ exports[`Progress render negative progress 1`] = `
 
 exports[`Progress render negetive successPercent 1`] = `
 <div
-  class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default ant-progress-orientation-default"
+  class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default ant-progress-orientation-horizontal"
 >
   <div>
     <div
@@ -91,7 +91,7 @@ exports[`Progress render negetive successPercent 1`] = `
 
 exports[`Progress render normal progress 1`] = `
 <div
-  class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default ant-progress-orientation-default"
+  class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default ant-progress-orientation-horizontal"
 >
   <div>
     <div
@@ -150,7 +150,7 @@ exports[`Progress render orientation vertical 1`] = `
 
 exports[`Progress render out-of-range progress 1`] = `
 <div
-  class="ant-progress ant-progress-line ant-progress-status-success ant-progress-show-info ant-progress-default ant-progress-orientation-default"
+  class="ant-progress ant-progress-line ant-progress-status-success ant-progress-show-info ant-progress-default ant-progress-orientation-horizontal"
 >
   <div>
     <div
@@ -194,7 +194,7 @@ exports[`Progress render out-of-range progress 1`] = `
 
 exports[`Progress render out-of-range progress with info 1`] = `
 <div
-  class="ant-progress ant-progress-line ant-progress-status-success ant-progress-show-info ant-progress-default ant-progress-orientation-default"
+  class="ant-progress ant-progress-line ant-progress-status-success ant-progress-show-info ant-progress-default ant-progress-orientation-horizontal"
 >
   <div>
     <div
@@ -238,7 +238,7 @@ exports[`Progress render out-of-range progress with info 1`] = `
 
 exports[`Progress render strokeColor 1`] = `
 <div
-  class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default ant-progress-orientation-default"
+  class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default ant-progress-orientation-horizontal"
 >
   <div
     class="ant-progress-inner"
@@ -284,7 +284,7 @@ exports[`Progress render strokeColor 1`] = `
 exports[`Progress render strokeColor 2`] = `
 <Progress
   gapDegree={0}
-  orientation="default"
+  orientation="horizontal"
   percent={50}
   showInfo={true}
   size="default"
@@ -299,11 +299,11 @@ exports[`Progress render strokeColor 2`] = `
   type="line"
 >
   <div
-    className="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default ant-progress-orientation-default"
+    className="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default ant-progress-orientation-horizontal"
   >
     <Line
       gapDegree={0}
-      orientation="default"
+      orientation="horizontal"
       percent={50}
       prefixCls="ant-progress"
       showInfo={true}
@@ -353,7 +353,7 @@ exports[`Progress render strokeColor 2`] = `
 exports[`Progress render strokeColor 3`] = `
 <Progress
   gapDegree={0}
-  orientation="default"
+  orientation="horizontal"
   percent={50}
   showInfo={true}
   size="default"
@@ -368,11 +368,11 @@ exports[`Progress render strokeColor 3`] = `
   type="line"
 >
   <div
-    className="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default ant-progress-orientation-default"
+    className="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default ant-progress-orientation-horizontal"
   >
     <Line
       gapDegree={0}
-      orientation="default"
+      orientation="horizontal"
       percent={50}
       prefixCls="ant-progress"
       showInfo={true}

--- a/components/progress/__tests__/__snapshots__/index.test.js.snap
+++ b/components/progress/__tests__/__snapshots__/index.test.js.snap
@@ -139,6 +139,7 @@ exports[`Progress render orientation vertical 1`] = `
     </div>
     <span
       class="ant-progress-text"
+      style="transform: rotate(90deg);"
       title="50%"
     >
       50%

--- a/components/progress/__tests__/index.test.js
+++ b/components/progress/__tests__/index.test.js
@@ -114,3 +114,11 @@ describe('Progress', () => {
     errorSpy.mockRestore();
   });
 });
+
+it('render orientation vertical', () => {
+  const wrapper = mount(<Progress status="normal" orientation="vertical" />);
+  expect(wrapper.render()).toMatchSnapshot();
+  wrapper.setProps({
+    orientation: 'vertical',
+  });
+});

--- a/components/progress/__tests__/index.test.js
+++ b/components/progress/__tests__/index.test.js
@@ -18,6 +18,11 @@ describe('Progress', () => {
     expect(wrapper.find('.ant-progress-status-success')).toHaveLength(0);
   });
 
+  it('render orientation vertical', () => {
+    const wrapper = mount(<Progress percent={50} successPercent={10} orientation="vertical" />);
+    expect(wrapper.render()).toMatchSnapshot();
+  });
+
   it('render out-of-range progress', () => {
     const wrapper = mount(<Progress percent={120} />);
     expect(wrapper.render()).toMatchSnapshot();
@@ -107,13 +112,5 @@ describe('Progress', () => {
     const wrapper = mount(<Progress percent={100} status="invalid" />);
     expect(wrapper.find('.ant-progress-status-success')).toHaveLength(1);
     errorSpy.mockRestore();
-  });
-});
-
-it('render orientation vertical', () => {
-  const wrapper = mount(<Progress status="normal" orientation="vertical" />);
-  expect(wrapper.render()).toMatchSnapshot();
-  wrapper.setProps({
-    orientation: 'vertical',
   });
 });

--- a/components/progress/__tests__/index.test.js
+++ b/components/progress/__tests__/index.test.js
@@ -114,11 +114,3 @@ describe('Progress', () => {
     errorSpy.mockRestore();
   });
 });
-
-it('render orientation vertical', () => {
-  const wrapper = mount(<Progress status="normal" orientation="vertical" />);
-  expect(wrapper.render()).toMatchSnapshot();
-  wrapper.setProps({
-    orientation: 'vertical',
-  });
-});

--- a/components/progress/__tests__/index.test.js
+++ b/components/progress/__tests__/index.test.js
@@ -28,7 +28,7 @@ describe('Progress', () => {
     expect(wrapper.render()).toMatchSnapshot();
   });
 
-  it('render negetive progress', () => {
+  it('render negative progress', () => {
     const wrapper = mount(<Progress percent={-20} />);
     expect(wrapper.render()).toMatchSnapshot();
   });
@@ -107,5 +107,13 @@ describe('Progress', () => {
     const wrapper = mount(<Progress percent={100} status="invalid" />);
     expect(wrapper.find('.ant-progress-status-success')).toHaveLength(1);
     errorSpy.mockRestore();
+  });
+});
+
+it('render orientation vertical', () => {
+  const wrapper = mount(<Progress status="normal" orientation="vertical" />);
+  expect(wrapper.render()).toMatchSnapshot();
+  wrapper.setProps({
+    orientation: 'vertical',
   });
 });

--- a/components/progress/demo/orientation.md
+++ b/components/progress/demo/orientation.md
@@ -17,8 +17,8 @@ By setting `orientaton="vertical"`, you can change the orientantion from horizon
 import { Progress } from 'antd';
 
 ReactDOM.render(
-  <div>
-    <Progress percent={30} size="small" orientation="vertical" showInfo={false} />
+  <div style={{ width: 170, height: 130, paddingTop: 45 }}>
+    <Progress percent={70} size="small" orientation="vertical" showInfo />
   </div>,
   mountNode,
 );

--- a/components/progress/demo/orientation.md
+++ b/components/progress/demo/orientation.md
@@ -1,0 +1,26 @@
+---
+order: 0
+title:
+  zh-CN: 进度条
+  en-US: Orientation
+---
+
+## zh-CN
+
+标准的进度条。
+
+## en-US
+
+By setting `orientaton="vertical"`, you can change the orientantion from horizontal to vertical.
+
+```jsx
+import { Progress } from 'antd';
+
+ReactDOM.render(
+  <div>
+    <Progress percent={30} orientation="vertical" />
+    <Progress percent={100} size="small" orientation="vertical" />
+  </div>,
+  mountNode,
+);
+```

--- a/components/progress/demo/orientation.md
+++ b/components/progress/demo/orientation.md
@@ -1,7 +1,7 @@
 ---
 order: 0
 title:
-  zh-CN: 进度条
+  zh-CN: 取向
   en-US: Orientation
 ---
 

--- a/components/progress/demo/orientation.md
+++ b/components/progress/demo/orientation.md
@@ -1,17 +1,17 @@
 ---
-order: 0
+order: 11
 title:
-  zh-CN: 取向
+  zh-CN: 方向
   en-US: Orientation
 ---
 
 ## zh-CN
 
-通过设置`orientaton =“ vertical”`，可以将方向从水平更改为垂直。
+通过设置`orientaton=“vertical”`，可以将方向从水平更改为垂直。
 
 ## en-US
 
-By setting `orientaton="vertical"`, you can change the orientantion from horizontal to vertical.
+By setting `orientation="vertical"`, you can change the orientation from horizontal to vertical.
 
 ```jsx
 import { Progress } from 'antd';

--- a/components/progress/demo/orientation.md
+++ b/components/progress/demo/orientation.md
@@ -7,7 +7,7 @@ title:
 
 ## zh-CN
 
-标准的进度条。
+通过设置`orientaton =“ vertical”`，可以将方向从水平更改为垂直。
 
 ## en-US
 

--- a/components/progress/demo/orientation.md
+++ b/components/progress/demo/orientation.md
@@ -18,8 +18,7 @@ import { Progress } from 'antd';
 
 ReactDOM.render(
   <div>
-    <Progress percent={30} orientation="vertical" />
-    <Progress percent={100} size="small" orientation="vertical" />
+    <Progress percent={30} size="small" orientation="vertical" showInfo={false} />
   </div>,
   mountNode,
 );

--- a/components/progress/index.en-US.md
+++ b/components/progress/index.en-US.md
@@ -24,6 +24,7 @@ Properties that shared by all types.
 | percent | to set the completion percentage | number | 0 |  |
 | showInfo | whether to display the progress value and the status icon | boolean | true |  |
 | status | to set the status of the Progress, options: `success` `exception` `normal` `active`(line only) | string | - |  |
+| orientation | to set the orientation from horizontal to vertical, options: `default` `vertical` | string | - |  |
 | strokeLinecap | to set the style of the progress linecap | Enum{ 'round', 'square' } | `round` | 3.8.0 |
 | strokeColor | color of progress bar | string | - | 3.7.0 |
 | successPercent | segmented success percent | number | 0 | 3.2.0 |

--- a/components/progress/index.en-US.md
+++ b/components/progress/index.en-US.md
@@ -24,7 +24,7 @@ Properties that shared by all types.
 | percent | to set the completion percentage | number | 0 |  |
 | showInfo | whether to display the progress value and the status icon | boolean | true |  |
 | status | to set the status of the Progress, options: `success` `exception` `normal` `active`(line only) | string | - |  |
-| orientation | to set the orientation from horizontal to vertical, options: `default` `vertical` | string | - |  |
+| orientation | to set the orientation from horizontal to vertical, options: `horizontal` `vertical` | string | - |  |
 | strokeLinecap | to set the style of the progress linecap | Enum{ 'round', 'square' } | `round` | 3.8.0 |
 | strokeColor | color of progress bar | string | - | 3.7.0 |
 | successPercent | segmented success percent | number | 0 | 3.2.0 |

--- a/components/progress/index.tsx
+++ b/components/progress/index.tsx
@@ -1,5 +1,4 @@
 import Progress from './progress';
 
 export { ProgressProps } from './progress';
-
 export default Progress;

--- a/components/progress/index.zh-CN.md
+++ b/components/progress/index.zh-CN.md
@@ -25,7 +25,7 @@ title: Progress
 | percent | 百分比 | number | 0 |  |
 | showInfo | 是否显示进度数值或状态图标 | boolean | true |  |
 | status | 状态，可选：`success` `exception` `normal` `active`(仅限 line) | string | - |  |
-| orientation | 将方向从水平设置为垂直, 可选: `default` `vertical` | string | - |  |
+| orientation | 将方向从水平设置为垂直, 可选: `horizontal` `vertical` | string | - |  |
 | strokeLinecap |  | Enum{ 'round', 'square' } | `round` | 3.8.0 |
 | strokeColor | 进度条的色彩 | string | - | 3.7.0 |
 | successPercent | 已完成的分段百分比 | number | 0 | 3.2.0 |

--- a/components/progress/index.zh-CN.md
+++ b/components/progress/index.zh-CN.md
@@ -25,6 +25,7 @@ title: Progress
 | percent | 百分比 | number | 0 |  |
 | showInfo | 是否显示进度数值或状态图标 | boolean | true |  |
 | status | 状态，可选：`success` `exception` `normal` `active`(仅限 line) | string | - |  |
+| orientation | 将方向从水平设置为垂直, 可选: `default` `vertical` | string | - |  |
 | strokeLinecap |  | Enum{ 'round', 'square' } | `round` | 3.8.0 |
 | strokeColor | 进度条的色彩 | string | - | 3.7.0 |
 | successPercent | 已完成的分段百分比 | number | 0 | 3.2.0 |

--- a/components/progress/progress.tsx
+++ b/components/progress/progress.tsx
@@ -12,6 +12,7 @@ import { validProgress } from './utils';
 const ProgressTypes = tuple('line', 'circle', 'dashboard');
 export type ProgressType = (typeof ProgressTypes)[number];
 const ProgressStatuses = tuple('normal', 'exception', 'active', 'success');
+export type ProgressOrientation = 'default' | 'vertical';
 export type ProgressSize = 'default' | 'small';
 export type StringGradients = { [percentage: string]: string };
 type FromToGradients = { from: string; to: string };
@@ -34,7 +35,7 @@ export interface ProgressProps {
   gapDegree?: number;
   gapPosition?: 'top' | 'bottom' | 'left' | 'right';
   size?: ProgressSize;
-  orientation?: 'default' | 'vertical';
+  orientation?: ProgressOrientation;
 }
 
 export default class Progress extends React.Component<ProgressProps> {
@@ -60,7 +61,7 @@ export default class Progress extends React.Component<ProgressProps> {
     strokeColor: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
     trailColor: PropTypes.string,
     format: PropTypes.func,
-    orientation: PropTypes.oneOf(['default', 'vertical']),
+    orientation: PropTypes.string,
     gapDegree: PropTypes.number,
   };
 
@@ -103,7 +104,15 @@ export default class Progress extends React.Component<ProgressProps> {
 
   renderProgress = ({ getPrefixCls }: ConfigConsumerProps) => {
     const { props } = this;
-    const { prefixCls: customizePrefixCls, className, size, type, showInfo, ...restProps } = props;
+    const {
+      prefixCls: customizePrefixCls,
+      className,
+      size,
+      type,
+      showInfo,
+      orientation,
+      ...restProps
+    } = props;
     const prefixCls = getPrefixCls('progress', customizePrefixCls);
     const progressStatus = this.getProgressStatus();
     const progressInfo = this.renderProcessInfo(prefixCls, progressStatus);
@@ -130,6 +139,7 @@ export default class Progress extends React.Component<ProgressProps> {
         [`${prefixCls}-status-${progressStatus}`]: true,
         [`${prefixCls}-show-info`]: showInfo,
         [`${prefixCls}-${size}`]: size,
+        [`${prefixCls}-orientation-${orientation}`]: orientation,
       },
       className,
     );

--- a/components/progress/progress.tsx
+++ b/components/progress/progress.tsx
@@ -12,7 +12,7 @@ import { validProgress } from './utils';
 const ProgressTypes = tuple('line', 'circle', 'dashboard');
 export type ProgressType = (typeof ProgressTypes)[number];
 const ProgressStatuses = tuple('normal', 'exception', 'active', 'success');
-export type ProgressOrientation = 'default' | 'vertical';
+export type ProgressOrientation = 'horizontal' | 'vertical';
 export type ProgressSize = 'default' | 'small';
 export type StringGradients = { [percentage: string]: string };
 type FromToGradients = { from: string; to: string };
@@ -47,7 +47,7 @@ export default class Progress extends React.Component<ProgressProps> {
     size: 'default',
     gapDegree: 0,
     strokeLinecap: 'round',
-    orientation: 'default',
+    orientation: 'horizontal',
   };
 
   static propTypes = {

--- a/components/progress/progress.tsx
+++ b/components/progress/progress.tsx
@@ -34,6 +34,7 @@ export interface ProgressProps {
   gapDegree?: number;
   gapPosition?: 'top' | 'bottom' | 'left' | 'right';
   size?: ProgressSize;
+  orientation?: 'default' | 'vertical';
 }
 
 export default class Progress extends React.Component<ProgressProps> {
@@ -45,6 +46,7 @@ export default class Progress extends React.Component<ProgressProps> {
     size: 'default',
     gapDegree: 0,
     strokeLinecap: 'round',
+    orientation: 'default',
   };
 
   static propTypes = {
@@ -58,6 +60,7 @@ export default class Progress extends React.Component<ProgressProps> {
     strokeColor: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
     trailColor: PropTypes.string,
     format: PropTypes.func,
+    orientation: PropTypes.oneOf(['default', 'vertical']),
     gapDegree: PropTypes.number,
   };
 
@@ -145,6 +148,7 @@ export default class Progress extends React.Component<ProgressProps> {
           'strokeColor',
           'strokeLinecap',
           'percent',
+          'orientation',
         ])}
         className={classString}
       >

--- a/components/progress/progress.tsx
+++ b/components/progress/progress.tsx
@@ -82,7 +82,7 @@ export default class Progress extends React.Component<ProgressProps> {
   }
 
   renderProcessInfo(prefixCls: string, progressStatus: (typeof ProgressStatuses)[number]) {
-    const { showInfo, format, type, percent, successPercent } = this.props;
+    const { showInfo, format, type, percent, successPercent, orientation } = this.props;
     if (!showInfo) return null;
 
     let text;
@@ -95,8 +95,13 @@ export default class Progress extends React.Component<ProgressProps> {
     } else if (progressStatus === 'success') {
       text = <Icon type={`check${iconType}`} theme={type === 'line' ? 'filled' : 'outlined'} />;
     }
+
     return (
-      <span className={`${prefixCls}-text`} title={typeof text === 'string' ? text : undefined}>
+      <span
+        className={`${prefixCls}-text`}
+        title={typeof text === 'string' ? text : undefined}
+        style={orientation === 'vertical' ? { transform: 'rotate(90deg)' } : undefined}
+      >
         {text}
       </span>
     );

--- a/components/progress/style/index.less
+++ b/components/progress/style/index.less
@@ -14,6 +14,10 @@
     font-size: @font-size-base;
   }
 
+  &-orientation-vertical {
+    transform: rotate(-90deg);
+  }
+
   &-small&-line,
   &-small&-line &-text .@{iconfont-css-prefix} {
     font-size: @font-size-sm;

--- a/components/progress/style/index.less
+++ b/components/progress/style/index.less
@@ -14,6 +14,12 @@
     font-size: @font-size-base;
   }
 
+  &-orientation-vertical {
+    .@{progress-prefix-cls}-outer {
+      transform: rotate(-90deg);
+    }
+  }
+
   &-small&-line,
   &-small&-line &-text .@{iconfont-css-prefix} {
     font-size: @font-size-sm;

--- a/components/progress/style/index.less
+++ b/components/progress/style/index.less
@@ -14,13 +14,13 @@
     font-size: @font-size-base;
   }
 
-  &-orientation-vertical {
-    transform: rotate(-90deg);
-  }
-
   &-small&-line,
   &-small&-line &-text .@{iconfont-css-prefix} {
     font-size: @font-size-sm;
+  }
+
+  &-orientation-vertical {
+    transform: rotate(-90deg);
   }
 
   &-outer {

--- a/components/progress/style/index.less
+++ b/components/progress/style/index.less
@@ -15,9 +15,7 @@
   }
 
   &-orientation-vertical {
-    .@{progress-prefix-cls}-outer {
-      transform: rotate(-90deg);
-    }
+    transform: rotate(-90deg);
   }
 
   &-small&-line,

--- a/components/progress/style/index.less
+++ b/components/progress/style/index.less
@@ -14,10 +14,6 @@
     font-size: @font-size-base;
   }
 
-  &-orientation-vertical {
-    transform: rotate(-90deg);
-  }
-
   &-small&-line,
   &-small&-line &-text .@{iconfont-css-prefix} {
     font-size: @font-size-sm;

--- a/components/upload/__tests__/__snapshots__/uploadlist.test.js.snap
+++ b/components/upload/__tests__/__snapshots__/uploadlist.test.js.snap
@@ -86,7 +86,7 @@ exports[`Upload List handle error 1`] = `
         class="ant-upload-list-item-progress fade-leave"
       >
         <div
-          class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-default"
+          class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-default ant-progress-orientation-default"
         >
           <div>
             <div
@@ -195,7 +195,7 @@ exports[`Upload List should be uploading when upload a file 1`] = `
         class="ant-upload-list-item-progress"
       >
         <div
-          class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-default"
+          class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-default ant-progress-orientation-default"
         >
           <div>
             <div
@@ -304,7 +304,7 @@ exports[`Upload List should be uploading when upload a file 2`] = `
         class="ant-upload-list-item-progress fade-leave"
       >
         <div
-          class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-default"
+          class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-default ant-progress-orientation-default"
         >
           <div>
             <div

--- a/components/upload/__tests__/__snapshots__/uploadlist.test.js.snap
+++ b/components/upload/__tests__/__snapshots__/uploadlist.test.js.snap
@@ -86,7 +86,7 @@ exports[`Upload List handle error 1`] = `
         class="ant-upload-list-item-progress fade-leave"
       >
         <div
-          class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-default ant-progress-orientation-default"
+          class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-default ant-progress-orientation-horizontal"
         >
           <div>
             <div
@@ -195,7 +195,7 @@ exports[`Upload List should be uploading when upload a file 1`] = `
         class="ant-upload-list-item-progress"
       >
         <div
-          class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-default ant-progress-orientation-default"
+          class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-default ant-progress-orientation-horizontal"
         >
           <div>
             <div
@@ -304,7 +304,7 @@ exports[`Upload List should be uploading when upload a file 2`] = `
         class="ant-upload-list-item-progress fade-leave"
       >
         <div
-          class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-default ant-progress-orientation-default"
+          class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-default ant-progress-orientation-horizontal"
         >
           <div>
             <div


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->
Issue #18761 

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

Turned able the usage of Progress Bar component with vertical orientation like mentioned at isse #18761 

![Screen Shot 2019-09-20 at 15 28 57](https://user-images.githubusercontent.com/27821672/65351432-7bdf1f00-dbbe-11e9-8efd-b24e5e3fd816.png)


To use just set the property "orientation" with "vertical" value, like "orientation='vertical' " to the Progress component.

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Progress add new prop `orientation` to display vertically      |
| 🇨🇳 Chinese |     Progress 新增属性 `orientation` 以垂直显示      |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

Closes #18761 

-----
[View rendered README-zh_CN.md](https://github.com/Larissagilliane/ant-design/blob/verticalProgress/README-zh_CN.md)
[View rendered README.md](https://github.com/Larissagilliane/ant-design/blob/verticalProgress/README.md)
[View rendered components/progress/demo/orientation.md](https://github.com/Larissagilliane/ant-design/blob/verticalProgress/components/progress/demo/orientation.md)
[View rendered components/progress/index.en-US.md](https://github.com/Larissagilliane/ant-design/blob/verticalProgress/components/progress/index.en-US.md)
[View rendered components/progress/index.zh-CN.md](https://github.com/Larissagilliane/ant-design/blob/verticalProgress/components/progress/index.zh-CN.md)
[View rendered components/tooltip/index.en-US.md](https://github.com/Larissagilliane/ant-design/blob/verticalProgress/components/tooltip/index.en-US.md)
[View rendered components/tooltip/index.zh-CN.md](https://github.com/Larissagilliane/ant-design/blob/verticalProgress/components/tooltip/index.zh-CN.md)