### PR TITLE
table: Correct onRow event handlers to receive a MouseEvent

### DIFF
--- a/components/table/interface.tsx
+++ b/components/table/interface.tsx
@@ -134,11 +134,11 @@ export interface TableCurrentDataSource<T> {
 }
 
 export interface TableEventListeners {
-  onClick?: (arg: React.SyntheticEvent) => void;
-  onDoubleClick?: (arg: React.SyntheticEvent) => void;
-  onContextMenu?: (arg: React.SyntheticEvent) => void;
-  onMouseEnter?: (arg: React.SyntheticEvent) => void;
-  onMouseLeave?: (arg: React.SyntheticEvent) => void;
+  onClick?: (arg: React.MouseEvent) => void;
+  onDoubleClick?: (arg: React.MouseEvent) => void;
+  onContextMenu?: (arg: React.MouseEvent) => void;
+  onMouseEnter?: (arg: React.MouseEvent) => void;
+  onMouseLeave?: (arg: React.MouseEvent) => void;
   [name: string]: any; // https://github.com/ant-design/ant-design/issues/17245#issuecomment-504807714
 }
 


### PR DESCRIPTION
... instead of a SyntheticEvent

<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [X] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->
The definition for the table events supplied in onRow is currently defined as a `SyntheticEvent`, but it can be more specific. All of those event handlers receive a `MouseEvent`. Can confirm that by viewing the React types and all of these event handlers show are typed as `MouseEventHandler` https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts#L1339. `MouseEvent` gives you access to things like `e.ctrlKey` and other mouse-specific fields. Our use-case that required this was opening a page in a new tab when a row is cmd-clicked.

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |Corrected the `TableEventListeners` type to receive `React.MouseEvent` instead of the more generic `React.SyntheticEvent` |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [X] Doc is updated/provided or not needed
- [X] Demo is updated/provided or not needed
- [X] TypeScript definition is updated/provided or not needed
- [] Changelog is provided or not needed
