### PR TITLE
feat(table): Add defaultFilteredValues to table columns

### DIFF
--- a/components/table/Table.tsx
+++ b/components/table/Table.tsx
@@ -271,7 +271,7 @@ class Table<T> extends React.Component<InternalTableProps<T>, TableState<T>> {
     this.state = {
       ...this.getDefaultSortOrder(columns || []),
       // 减少状态
-      filters: getFiltersFromColumns<T>(),
+      filters: this.getDefaultFilters(columns),
       pagination: this.getDefaultPagination(props),
       pivot: undefined,
       prevProps: props,
@@ -353,6 +353,26 @@ class Table<T> extends React.Component<InternalTableProps<T>, TableState<T>> {
       columns || (this.state || {}).columns || [],
       (column: ColumnProps<T>) => 'sortOrder' in column,
     );
+  }
+
+  getDefaultFilters(columns?: ColumnProps<T>[]) {
+    const definedFilters = getFiltersFromColumns(this.state, columns);
+
+    const defaultFilteredValueColumns = flatFilter(
+      columns || [],
+      (column: ColumnProps<T>) => typeof column.defaultFilteredValue !== 'undefined',
+    );
+
+    const defaultFilters = defaultFilteredValueColumns.reduce(
+      (soFar: { [s: string]: any }, col: ColumnProps<T>) => {
+        const colKey = getColumnKey(col) as string;
+        soFar[colKey] = col.defaultFilteredValue;
+        return soFar;
+      },
+      {},
+    );
+
+    return { ...defaultFilters, ...definedFilters };
   }
 
   getDefaultSortOrder(columns?: ColumnProps<T>[]) {

--- a/components/table/__tests__/Table.filter.test.js
+++ b/components/table/__tests__/Table.filter.test.js
@@ -286,6 +286,58 @@ describe('Table.filter', () => {
     expect(wrapper.find('tbody tr').length).toBe(4);
   });
 
+  it('can read defaults from defaultFilteredValue', () => {
+    const wrapper = mount(
+      createTable({
+        columns: [
+          {
+            ...column,
+            defaultFilteredValue: ['Lucy'],
+          },
+        ],
+      }),
+    );
+    expect(wrapper.find('tbody tr').length).toBe(1);
+    expect(wrapper.find('tbody tr').text()).toBe('Lucy');
+
+    // Should properly ignore further defaultFilteredValue changes
+    wrapper.setProps({
+      columns: [
+        {
+          ...column,
+          defaultFilteredValue: [],
+        },
+      ],
+    });
+    expect(wrapper.find('tbody tr').length).toBe(1);
+    expect(wrapper.find('tbody tr').text()).toBe('Lucy');
+
+    // Should properly be overidden by non-null filteredValue
+    wrapper.setProps({
+      columns: [
+        {
+          ...column,
+          defaultFilteredValue: ['Lucy'],
+          filteredValue: ['Tom'],
+        },
+      ],
+    });
+    expect(wrapper.find('tbody tr').length).toBe(1);
+    expect(wrapper.find('tbody tr').text()).toBe('Tom');
+
+    // Should properly be overidden by a null filteredValue
+    wrapper.setProps({
+      columns: [
+        {
+          ...column,
+          defaultFilteredValue: ['Lucy'],
+          filteredValue: null,
+        },
+      ],
+    });
+    expect(wrapper.find('tbody tr').length).toBe(4);
+  });
+
   it('fires change event', () => {
     const handleChange = jest.fn();
     const wrapper = mount(createTable({ onChange: handleChange }));

--- a/components/table/demo/head.md
+++ b/components/table/demo/head.md
@@ -19,6 +19,8 @@ title:
 
 Use `filters` to generate filter menu in columns, `onFilter` to determine filtered result, and `filterMultiple` to indicate whether it's multiple or single selection.
 
+Uses `defaultFilterValues` to make a column filtered by default.
+
 Use `sorter` to make a column sortable. `sorter` can be a function of the type `function(a, b) { ... }` for sorting data locally.
 
 `sortDirections: ['ascend' | 'descend']` defines available sort methods for each columns, effective for all columns when set on table props.
@@ -58,6 +60,7 @@ const columns = [
         ],
       },
     ],
+    defaultFilterValues: ['Jim'],
     // specify the condition of filtering result
     // here is that finding the name started with `value`
     onFilter: (value, record) => record.name.indexOf(value) === 0,

--- a/components/table/index.en-US.md
+++ b/components/table/index.en-US.md
@@ -124,6 +124,7 @@ One of the Table `columns` prop for describing the table's columns, Column has t
 | className | className of this column | string | - |  |
 | colSpan | Span of this column's title | number |  |  |
 | dataIndex | Display field of the data record, could be set like `a.b.c`, `a[0].b.c[1]` | string | - |  |
+| defaultFilteredValue | Default filtered values | string\[] | - |  |
 | defaultSortOrder | Default order of sorted values | 'ascend' \| 'descend' | - |  |
 | filterDropdown | Customized filter overlay | React.ReactNode \| (props: [FilterDropdownProps](https://git.io/fjP5h)) => React.ReactNode | - |
 | filterDropdownVisible | Whether `filterDropdown` is visible | boolean | - |  |

--- a/components/table/index.zh-CN.md
+++ b/components/table/index.zh-CN.md
@@ -129,6 +129,7 @@ const columns = [
 | className | 列样式类名 | string | - |  |
 | colSpan | 表头列合并,设置为 0 时，不渲染 | number |  |  |
 | dataIndex | 列数据在数据项中对应的 key，支持 `a.b.c`、`a[0].b.c[1]` 的嵌套写法 | string | - |  |
+| defaultFilteredValue | 默认筛选值 | string\[] | - |  |
 | defaultSortOrder | 默认排序顺序 | 'ascend' \| 'descend' | - | 3.9.3 |
 | filterDropdown | 可以自定义筛选菜单，此函数只负责渲染图层，需要自行编写各种交互 | React.ReactNode \| (props: [FilterDropdownProps](https://git.io/fjP5h)) => React.ReactNode | - |
 | filterDropdownVisible | 用于控制自定义筛选菜单是否可见 | boolean | - |  |

--- a/components/table/interface.tsx
+++ b/components/table/interface.tsx
@@ -56,6 +56,7 @@ export interface ColumnProps<T> {
   fixed?: boolean | (typeof ColumnFixedPlacements)[number];
   filterIcon?: React.ReactNode | ((filtered: boolean) => React.ReactNode);
   filteredValue?: any[];
+  defaultFilteredValue?: any[];
   sortOrder?: SortOrder | boolean;
   children?: ColumnProps<T>[];
   onCellClick?: (record: T, event: Event) => void;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [x] New feature

### 🔗 Related issue link

We have the ability to se a `defaultSortOrder` to a `<Table />` column. Being able to set a `defaultFilteredValue` seems to be missing and would be great to easily set defaults without having to maintain a state.

In my case, I'm restoring sorters/filters from localStorage.

### 💡 Background and solution

Basically cloned the existing codepath for defaultSortOrder to have minimal impact.

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Ability to use `defaultFilteredValue` as a new column prop to set a default filter |
| 🇨🇳 Chinese | 允许使用 `defaultFilteredValue` 作为列的默认筛选值 |

PR is missing Chinese translation too as I'm not fluent unfortunately :).

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/table/demo/head.md](https://github.com/mgcrea/ant-design/blob/feat-defaultFilteredValues/components/table/demo/head.md)
[View rendered components/table/index.en-US.md](https://github.com/mgcrea/ant-design/blob/feat-defaultFilteredValues/components/table/index.en-US.md)
[View rendered components/table/index.zh-CN.md](https://github.com/mgcrea/ant-design/blob/feat-defaultFilteredValues/components/table/index.zh-CN.md)