### PR TITLE
feat: upload should not be aborted until handleRemove is resolved

### DIFF
--- a/components/upload/Upload.tsx
+++ b/components/upload/Upload.tsx
@@ -158,11 +158,31 @@ class Upload extends React.Component<UploadProps, UploadState> {
     });
   };
 
-  handleManualRemove = (file: UploadFile) => {
-    if (this.upload) {
-      this.upload.abort(file);
-    }
-    this.handleRemove(file);
+  handleRemove = (file: UploadFile) => {
+    const { onRemove } = this.props;
+    const { fileList } = this.state;
+
+    Promise.resolve(typeof onRemove === 'function' ? onRemove(file) : onRemove).then(ret => {
+      // Prevent removing file
+      if (ret === false) {
+        return;
+      }
+
+      const removedFileList = removeFileItem(file, fileList);
+
+      if (removedFileList) {
+        file.status = 'removed'; // eslint-disable-line
+
+        if (this.upload) {
+          this.upload.abort(file);
+        }
+
+        this.onChange({
+          file,
+          fileList: removedFileList,
+        });
+      }
+    });
   };
 
   onChange = (info: UploadChangeParam) => {
@@ -205,30 +225,6 @@ class Upload extends React.Component<UploadProps, UploadState> {
     return true;
   };
 
-  handleRemove(file: UploadFile) {
-    const { onRemove } = this.props;
-    const { fileList } = this.state;
-    const { status } = file;
-
-    file.status = 'removed'; // eslint-disable-line
-
-    Promise.resolve(typeof onRemove === 'function' ? onRemove(file) : onRemove).then(ret => {
-      // Prevent removing file
-      if (ret === false) {
-        file.status = status;
-        return;
-      }
-
-      const removedFileList = removeFileItem(file, fileList);
-      if (removedFileList) {
-        this.onChange({
-          file,
-          fileList: removedFileList,
-        });
-      }
-    });
-  }
-
   clearProgressTimer() {
     clearInterval(this.progressTimer);
   }
@@ -267,7 +263,7 @@ class Upload extends React.Component<UploadProps, UploadState> {
         previewFile={previewFile}
         onPreview={onPreview}
         onDownload={onDownload}
-        onRemove={this.handleManualRemove}
+        onRemove={this.handleRemove}
         showRemoveIcon={!disabled && showRemoveIcon}
         showPreviewIcon={showPreviewIcon}
         showDownloadIcon={showDownloadIcon}

--- a/components/upload/__tests__/upload.test.js
+++ b/components/upload/__tests__/upload.test.js
@@ -429,6 +429,42 @@ describe('Upload', () => {
     });
   });
 
+  // https://github.com/ant-design/ant-design/issues/18902
+  it('should not abort uploading until return value of onRemove is resolved as true', done => {
+    let wrapper;
+
+    const props = {
+      onRemove: () =>
+        new Promise(
+          resolve =>
+            setTimeout(() => {
+              wrapper.update();
+              expect(props.fileList).toHaveLength(1);
+              expect(props.fileList[0].status).toBe('uploading');
+              resolve(true);
+            }),
+          100,
+        ),
+      fileList: [
+        {
+          uid: '-1',
+          name: 'foo.png',
+          status: 'uploading',
+          url: 'http://www.baidu.com/xxx.png',
+        },
+      ],
+      onChange: () => {
+        expect(props.fileList).toHaveLength(1);
+        expect(props.fileList[0].status).toBe('removed');
+        done();
+      },
+    };
+
+    wrapper = mount(<Upload {...props} />);
+
+    wrapper.find('div.ant-upload-list-item i.anticon-delete').simulate('click');
+  });
+
   it('should not stop download when return use onDownload', done => {
     const mockRemove = jest.fn(() => false);
     const props = {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

https://github.com/ant-design/ant-design/issues/18902

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

status and uploading progress of files should be kept as they are before the value of onRemove is resolved.

the solution is to toggle the status and quit the uploading while onRemove is resolved.

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Upload prop `onRemove` determines upload aborting         |
| 🇨🇳 Chinese | Upload 支持 `onRemove` 对上传中断的控制        |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
