### PR TITLE
chore: Put origin img size to fill the box

### DIFF
--- a/components/upload/style/index.less
+++ b/components/upload/style/index.less
@@ -161,6 +161,8 @@
 
       > span {
         display: block;
+        width: 100%;
+        height: 100%;
       }
 
       .@{iconfont-css-prefix}-loading,
@@ -378,6 +380,7 @@
       display: block;
       width: 100%;
       height: 100%;
+      object-fit: cover;
     }
 
     .@{upload-item}-name {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close #18989

### 💡 Background and solution

Default setting the img of file will not cut before:

Form
<img width="346" alt="屏幕快照 2019-09-25 上午11 05 03" src="https://user-images.githubusercontent.com/5378891/65566150-9a5d6580-df84-11e9-969a-80255902fe5b.png">

To
![屏幕快照 2019-09-25 上午11 05 14](https://user-images.githubusercontent.com/5378891/65566162-9e898300-df84-11e9-95e6-3537e8fd1f08.png)



### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     💄 Adjust Upload `picture-card` mode picture display style to fill the picture box.     |
| 🇨🇳 Chinese |     💄 调整 Upload `picture-card` 模式下，图片展示样式为填充整个图片框。    |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
