### PR TITLE
fix: 🗑 Remove useless prop `searchValue`

### DIFF
--- a/components/select/__tests__/index.test.js
+++ b/components/select/__tests__/index.test.js
@@ -4,7 +4,6 @@ import Select from '..';
 import Icon from '../../icon';
 import focusTest from '../../../tests/shared/focusTest';
 import mountTest from '../../../tests/shared/mountTest';
-import { resetWarned } from '../../_util/warning';
 
 const { Option } = Select;
 
@@ -132,17 +131,5 @@ describe('Select', () => {
       jest.runAllTimers();
       expect(wrapper.render()).toMatchSnapshot();
     });
-  });
-
-  it('warning if user use `inputValue`', () => {
-    resetWarned();
-    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-
-    mount(<Select inputValue="" />);
-    expect(errorSpy).toHaveBeenLastCalledWith(
-      'Warning: [antd: Select] `inputValue` is deprecated. Please use `searchValue` instead.',
-    );
-
-    errorSpy.mockRestore();
   });
 });

--- a/components/select/index.en-US.md
+++ b/components/select/index.en-US.md
@@ -46,7 +46,6 @@ Select component to select value from options.
 | optionFilterProp | Which prop value of option will be used for filter if filterOption is true | string | value |  |
 | optionLabelProp | Which prop value of option will render as content of select. [Example](https://codesandbox.io/s/antd-reproduction-template-tk678) | string | `value` for `combobox`, `children` for other modes |  |
 | placeholder | Placeholder of select | string\|ReactNode | - |  |
-| searchValue | Search input value | string | - | 3.23.2 |
 | showArrow | Whether to show the drop-down arrow | boolean | true | 3.2.1 |
 | showSearch | Whether show search input in single mode. | boolean | false |  |
 | size | Size of Select input. `default` `large` `small` | string | default |  |

--- a/components/select/index.tsx
+++ b/components/select/index.tsx
@@ -53,9 +53,6 @@ export type SelectValue = string | string[] | number | number[] | LabeledValue |
 
 export interface SelectProps<T = SelectValue> extends AbstractSelectProps {
   value?: T;
-  /** @deprecated Use `searchValue` instead. */
-  inputValue?: string;
-  searchValue?: string;
   defaultValue?: T;
   mode?: 'default' | 'multiple' | 'tags' | 'combobox' | string;
   optionLabelProp?: string;
@@ -139,12 +136,6 @@ export default class Select<T = SelectValue> extends React.Component<SelectProps
         'it will be removed in next major version, ' +
         'please use AutoComplete instead',
     );
-
-    warning(
-      !('inputValue' in props),
-      'Select',
-      '`inputValue` is deprecated. Please use `searchValue` instead.',
-    );
   }
 
   getNotFoundContent(renderEmpty: RenderEmptyHandler) {
@@ -207,8 +198,6 @@ export default class Select<T = SelectValue> extends React.Component<SelectProps
       clearIcon,
       menuItemSelectedIcon,
       showArrow,
-      inputValue,
-      searchValue,
       ...restProps
     } = this.props;
     const rest = omit(restProps, ['inputIcon']);
@@ -270,7 +259,6 @@ export default class Select<T = SelectValue> extends React.Component<SelectProps
         showArrow={showArrow}
         {...rest}
         {...modeConfig}
-        inputValue={searchValue || inputValue}
         prefixCls={prefixCls}
         className={cls}
         optionLabelProp={optionLabelProp || 'children'}

--- a/components/select/index.zh-CN.md
+++ b/components/select/index.zh-CN.md
@@ -47,7 +47,6 @@ title: Select
 | optionFilterProp | 搜索时过滤对应的 option 属性，如设置为 children 表示对内嵌内容进行搜索。[示例](https://codesandbox.io/s/antd-reproduction-template-tk678) | string | value |  |
 | optionLabelProp | 回填到选择框的 Option 的属性值，默认是 Option 的子元素。比如在子元素需要高亮效果时，此值可以设为 `value`。 | string | `children` （combobox 模式下为 `value`） |  |
 | placeholder | 选择框默认文字 | string | - |  |
-| searchValue | 搜索框文本 | string | - | 3.23.2 |
 | showArrow | 是否显示下拉小箭头 | boolean | true | 3.2.1 |
 | showSearch | 使单选模式可搜索 | boolean | false |  |
 | size | 选择框大小，可选 `large` `small` | string | default |  |


### PR DESCRIPTION


<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [x] Site / document update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close #18847

### 💡 Background and solution

https://github.com/ant-design/ant-design/pull/18584#issuecomment-534927550

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Remove Select useless prop `searchValue` which is a total misunderstanding. |
| 🇨🇳 Chinese | 移除实际上毫无作用的 Select `searchValue` 属性定义和文档。 |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/select/index.en-US.md](https://github.com/ant-design/ant-design/blob/remove-search-value/components/select/index.en-US.md)
[View rendered components/select/index.zh-CN.md](https://github.com/ant-design/ant-design/blob/remove-search-value/components/select/index.zh-CN.md)