### PR TITLE
feat: Add sortColumn to title render

### DIFF
--- a/components/table/Table.tsx
+++ b/components/table/Table.tsx
@@ -1189,12 +1189,13 @@ export default class Table<T> extends React.Component<TableProps<T>, TableState<
   }
 
   renderColumnTitle(title: ColumnProps<T>['title']) {
-    const { filters, sortOrder } = this.state;
+    const { filters, sortOrder, sortColumn } = this.state;
     // https://github.com/ant-design/ant-design/issues/11246#issuecomment-405009167
     if (title instanceof Function) {
       return title({
         filters,
         sortOrder,
+        sortColumn,
       });
     }
     return title;

--- a/components/table/index.en-US.md
+++ b/components/table/index.en-US.md
@@ -138,7 +138,7 @@ One of the Table `columns` prop for describing the table's columns, Column has t
 | sorter | Sort function for local sort, see [Array.sort](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort)'s compareFunction. If you need sort buttons only, set to `true` | Function\|boolean | - |  |
 | sortOrder | Order of sorted values: `'ascend'` `'descend'` `false` | boolean\|string | - |  |
 | sortDirections | supported sort way, could be `'ascend'`, `'descend'` | Array | `['ascend', 'descend']` | 3.15.2 |
-| title | Title of this column | ReactNode\|({ sortOrder, filters }) => ReactNode | - |  |
+| title | Title of this column | ReactNode\|({ sortOrder, sortColumn, filters }) => ReactNode | - |  |
 | width | Width of this column ([width not working?](https://github.com/ant-design/ant-design/issues/13825#issuecomment-449889241)) | string\|number | - |  |
 | onCell | Set props on per cell | Function(record, rowIndex) | - |  |
 | onFilter | Callback executed when the confirm filter button is clicked | Function | - |  |

--- a/components/table/index.zh-CN.md
+++ b/components/table/index.zh-CN.md
@@ -143,7 +143,7 @@ const columns = [
 | sorter | 排序函数，本地排序使用一个函数(参考 [Array.sort](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort) 的 compareFunction)，需要服务端排序可设为 true | Function\|boolean | - |  |
 | sortOrder | 排序的受控属性，外界可用此控制列的排序，可设置为 `'ascend'` `'descend'` `false` | boolean\|string | - |  |
 | sortDirections | 支持的排序方式，取值为 `'ascend'` `'descend'` | Array | `['ascend', 'descend']` | 3.15.2 |
-| title | 列头显示文字（函数用法 `3.10.0` 后支持） | ReactNode\|({ sortOrder, filters }) => ReactNode | - | |
+| title | 列头显示文字（函数用法 `3.10.0` 后支持） | ReactNode\|({ sortOrder, sortColumn, filters }) => ReactNode | - |  |
 | width | 列宽度（[指定了也不生效？](https://github.com/ant-design/ant-design/issues/13825#issuecomment-449889241)） | string\|number | - |  |
 | onCell | 设置单元格属性 | Function(record, rowIndex) | - |  |
 | onFilter | 本地模式下，确定筛选的运行函数 | Function | - |  |

--- a/components/table/interface.tsx
+++ b/components/table/interface.tsx
@@ -29,7 +29,11 @@ export interface FilterDropdownProps {
 export interface ColumnProps<T> {
   title?:
     | React.ReactNode
-    | ((options: { filters: TableStateFilters; sortOrder?: SortOrder }) => React.ReactNode);
+    | ((options: {
+        filters: TableStateFilters;
+        sortOrder?: SortOrder;
+        sortColumn?: ColumnProps<T> | null;
+      }) => React.ReactNode);
   key?: React.Key;
   dataIndex?: string; // Note: We can not use generic type here, since we need to support nested key, see #9393
   render?: (text: any, record: T, index: number) => React.ReactNode;


### PR DESCRIPTION
Fixes #19007

### 🤔 This is a ...

- [X] New feature
- [X] Bug fix
- [X] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

#19007

Title render function is missing information about exactly which column is currently sorted. This is limiting when trying to render a custom sorter.

### 💡 Background and solution

Solution is to send the sortColumn that is stored in the table state. This way the user can infer which column is currently sorted while implementing the title render function.

### 📝 Changelog

Title render function argument object now contains a new key, sortColumn.

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed


-----
[View rendered components/table/index.en-US.md](https://github.com/swillis12/ant-design/blob/feat/19007/components/table/index.en-US.md)
[View rendered components/table/index.zh-CN.md](https://github.com/swillis12/ant-design/blob/feat/19007/components/table/index.zh-CN.md)