### PR TITLE
fix: detect antd button by children.type.[staticProperty] instead of the same class

### DIFF
--- a/components/input/Search.tsx
+++ b/components/input/Search.tsx
@@ -92,7 +92,10 @@ export default class Search extends React.Component<SearchProps, any> {
 
     let button: React.ReactNode;
     const enterButtonAsElement = enterButton as React.ReactElement<any>;
-    if (enterButtonAsElement.type === Button || enterButtonAsElement.type === 'button') {
+    const isAntdButton =
+      enterButtonAsElement.type &&
+      (enterButtonAsElement.type as typeof Button).__ANT_BUTTON === true;
+    if (isAntdButton || enterButtonAsElement.type === 'button') {
       button = React.cloneElement(enterButtonAsElement, {
         onClick: this.onSearch,
         key: 'enterButton',


### PR DESCRIPTION


<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [x] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

It's hard(actually impossible) to keep the same class for component in HOC cases, but it's easier to assign all the static properties to each wrapped HOC component, such as

```
const BrandnewButton = someHOC(AntdButton);
BrandnewButton.__ANT_BUTTON = AntdButton.__ANT_BUTTON;
```

Generally antd can keep this rule that detecting component by static property and the other developers use https://github.com/mridgway/hoist-non-react-statics to do this automatically in HOC

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  fix: detect antd button by children.type.[staticProperty] instead of the same class         |
| 🇨🇳 Chinese |    fix: 使用静态属性替代 class 类型来判断子组件是一个 antd button       |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
