### PR TITLE
fix: Typography function component use Ref console log warning

### DIFF
--- a/components/typography/Typography.tsx
+++ b/components/typography/Typography.tsx
@@ -16,32 +16,35 @@ interface InternalTypographyProps extends TypographyProps {
   setContentRef?: (node: HTMLElement) => void;
 }
 
-const Typography: React.SFC<InternalTypographyProps> = ({
-  prefixCls: customizePrefixCls,
-  component = 'article',
-  className,
-  'aria-label': ariaLabel,
-  setContentRef,
-  children,
-  ...restProps
-}) => (
-  <ConfigConsumer>
-    {({ getPrefixCls }: ConfigConsumerProps) => {
-      const Component = component as any;
-      const prefixCls = getPrefixCls('typography', customizePrefixCls);
+class Typography extends React.Component<InternalTypographyProps> {
+  renderTypography = ({ getPrefixCls }: ConfigConsumerProps) => {
+    const {
+      prefixCls: customizePrefixCls,
+      component = 'article',
+      className,
+      'aria-label': ariaLabel,
+      setContentRef,
+      children,
+      ...restProps
+    } = this.props;
+    const Component = component as any;
+    const prefixCls = getPrefixCls('typography', customizePrefixCls);
 
-      return (
-        <Component
-          className={classNames(prefixCls, className)}
-          aria-label={ariaLabel}
-          ref={setContentRef}
-          {...restProps}
-        >
-          {children}
-        </Component>
-      );
-    }}
-  </ConfigConsumer>
-);
+    return (
+      <Component
+        className={classNames(prefixCls, className)}
+        aria-label={ariaLabel}
+        ref={setContentRef}
+        {...restProps}
+      >
+        {children}
+      </Component>
+    );
+  };
+
+  render() {
+    return <ConfigConsumer>{this.renderTypography}</ConfigConsumer>;
+  }
+}
 
 export default Typography;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

Fixed #19064 

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  tweak Typography from function base to class base to avoid ref warning of React       |
| 🇨🇳 Chinese |   调整 Typography 为 class base 以避开 React 无法获得 ref 的警告        |

### ☑️ Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
