### PR TITLE
feat(Layout): add prop zeroWidthTriggerStyle

### DIFF
--- a/components/layout/Sider.tsx
+++ b/components/layout/Sider.tsx
@@ -52,7 +52,7 @@ export interface SiderProps extends React.HTMLAttributes<HTMLDivElement> {
   defaultCollapsed?: boolean;
   reverseArrow?: boolean;
   onCollapse?: (collapsed: boolean, type: CollapseType) => void;
-  specialTriggerStyle?: React.CSSProperties;
+  zeroWidthTriggerStyle?: React.CSSProperties;
   trigger?: React.ReactNode;
   width?: number | string;
   collapsedWidth?: number | string;
@@ -187,7 +187,7 @@ class InternalSider extends React.Component<InternalSideProps, SiderState> {
       style,
       width,
       collapsedWidth,
-      specialTriggerStyle,
+      zeroWidthTriggerStyle,
       ...others
     } = this.props;
     const prefixCls = getPrefixCls('layout-sider', customizePrefixCls);
@@ -198,7 +198,7 @@ class InternalSider extends React.Component<InternalSideProps, SiderState> {
       'breakpoint',
       'onBreakpoint',
       'siderHook',
-      'specialTriggerStyle',
+      'zeroWidthTriggerStyle',
     ]);
     const rawWidth = this.state.collapsed ? collapsedWidth : width;
     // use "px" as fallback unit for width
@@ -211,7 +211,7 @@ class InternalSider extends React.Component<InternalSideProps, SiderState> {
           className={`${prefixCls}-zero-width-trigger ${prefixCls}-zero-width-trigger-${
             reverseArrow ? 'right' : 'left'
           }`}
-          style={specialTriggerStyle}
+          style={zeroWidthTriggerStyle}
         >
           <Icon type="bars" />
         </span>

--- a/components/layout/Sider.tsx
+++ b/components/layout/Sider.tsx
@@ -52,6 +52,7 @@ export interface SiderProps extends React.HTMLAttributes<HTMLDivElement> {
   defaultCollapsed?: boolean;
   reverseArrow?: boolean;
   onCollapse?: (collapsed: boolean, type: CollapseType) => void;
+  specialTriggerStyle?: React.CSSProperties;
   trigger?: React.ReactNode;
   width?: number | string;
   collapsedWidth?: number | string;
@@ -186,6 +187,7 @@ class InternalSider extends React.Component<InternalSideProps, SiderState> {
       style,
       width,
       collapsedWidth,
+      specialTriggerStyle,
       ...others
     } = this.props;
     const prefixCls = getPrefixCls('layout-sider', customizePrefixCls);
@@ -196,6 +198,7 @@ class InternalSider extends React.Component<InternalSideProps, SiderState> {
       'breakpoint',
       'onBreakpoint',
       'siderHook',
+      'specialTriggerStyle',
     ]);
     const rawWidth = this.state.collapsed ? collapsedWidth : width;
     // use "px" as fallback unit for width
@@ -208,6 +211,7 @@ class InternalSider extends React.Component<InternalSideProps, SiderState> {
           className={`${prefixCls}-zero-width-trigger ${prefixCls}-zero-width-trigger-${
             reverseArrow ? 'right' : 'left'
           }`}
+          style={specialTriggerStyle}
         >
           <Icon type="bars" />
         </span>

--- a/components/layout/__tests__/index.test.js
+++ b/components/layout/__tests__/index.test.js
@@ -186,9 +186,9 @@ describe('Sider', () => {
     );
   });
 
-  it('specialTriggerStyle should work', () => {
+  it('zeroWidthTriggerStyle should work', () => {
     const wrapper = mount(
-      <Sider collapsedWidth={0} collapsible specialTriggerStyle={{ background: '#F96' }}>
+      <Sider collapsedWidth={0} collapsible zeroWidthTriggerStyle={{ background: '#F96' }}>
         <Menu theme="dark" mode="inline" defaultSelectedKeys={['1']}>
           <Menu.Item key="1">
             <Icon type="user" />

--- a/components/layout/__tests__/index.test.js
+++ b/components/layout/__tests__/index.test.js
@@ -185,4 +185,20 @@ describe('Sider', () => {
       'Warning: [antd: Menu] `inlineCollapsed` not control Menu under Sider. Should set `collapsed` on Sider instead.',
     );
   });
+
+  it('specialTriggerStyle should work', () => {
+    const wrapper = mount(
+      <Sider collapsedWidth={0} collapsible specialTriggerStyle={{ background: '#F96' }}>
+        <Menu theme="dark" mode="inline" defaultSelectedKeys={['1']}>
+          <Menu.Item key="1">
+            <Icon type="user" />
+            <span>nav 1</span>
+          </Menu.Item>
+        </Menu>
+      </Sider>,
+    );
+    expect(wrapper.find('.ant-layout-sider-zero-width-trigger').props().style).toEqual({
+      background: '#F96',
+    });
+  });
 });

--- a/components/layout/index.en-US.md
+++ b/components/layout/index.en-US.md
@@ -95,6 +95,7 @@ The sidebar.
 | defaultCollapsed | to set the initial status | boolean | false |  |
 | reverseArrow | reverse direction of arrow, for a sider that expands from the right | boolean | false |  |
 | style | to customize the styles | object | - |  |
+| specialTriggerStyle | to customize the styles of the special trigger that appears when collapsedWidth is 0 | object | - | 3.24.0 |
 | theme | color theme of the sidebar | string: `light` `dark` | `dark` | 3.6.0 |
 | trigger | specify the customized trigger, set to null to hide the trigger | string\|ReactNode | - |  |
 | width | width of the sidebar | number\|string | 200 |  |

--- a/components/layout/index.en-US.md
+++ b/components/layout/index.en-US.md
@@ -95,12 +95,12 @@ The sidebar.
 | defaultCollapsed | to set the initial status | boolean | false |  |
 | reverseArrow | reverse direction of arrow, for a sider that expands from the right | boolean | false |  |
 | style | to customize the styles | object | - |  |
-| specialTriggerStyle | to customize the styles of the special trigger that appears when collapsedWidth is 0 | object | - | 3.24.0 |
 | theme | color theme of the sidebar | string: `light` `dark` | `dark` | 3.6.0 |
 | trigger | specify the customized trigger, set to null to hide the trigger | string\|ReactNode | - |  |
 | width | width of the sidebar | number\|string | 200 |  |
 | onCollapse | the callback function, executed by clicking the trigger or activating the responsive layout | (collapsed, type) => {} | - |  |
 | onBreakpoint | the callback function, executed when [breakpoints](/components/grid#api) changed | (broken) => {} | - | 3.7.0 |
+| zeroWidthTriggerStyle | to customize the styles of the special trigger that appears when `collapsedWidth` is 0 | object | - | 3.24.0 |
 
 #### breakpoint width
 

--- a/components/layout/index.zh-CN.md
+++ b/components/layout/index.zh-CN.md
@@ -96,6 +96,7 @@ title: Layout
 | defaultCollapsed | 是否默认收起 | boolean | false |  |
 | reverseArrow | 翻转折叠提示箭头的方向，当 Sider 在右边时可以使用 | boolean | false |  |
 | style | 指定样式 | object | - |  |
+| specialTriggerStyle | 指定当 `collapsedWidth` 为 0 时出现的特殊 trigger 的样式 | object | - | 3.24.0 |
 | theme | 主题颜色 | string: `light` `dark` | `dark` | 3.6.0 |
 | trigger | 自定义 trigger，设置为 null 时隐藏 trigger | string\|ReactNode | - |  |
 | width | 宽度 | number\|string | 200 |  |

--- a/components/layout/index.zh-CN.md
+++ b/components/layout/index.zh-CN.md
@@ -96,12 +96,12 @@ title: Layout
 | defaultCollapsed | 是否默认收起 | boolean | false |  |
 | reverseArrow | 翻转折叠提示箭头的方向，当 Sider 在右边时可以使用 | boolean | false |  |
 | style | 指定样式 | object | - |  |
-| specialTriggerStyle | 指定当 `collapsedWidth` 为 0 时出现的特殊 trigger 的样式 | object | - | 3.24.0 |
 | theme | 主题颜色 | string: `light` `dark` | `dark` | 3.6.0 |
 | trigger | 自定义 trigger，设置为 null 时隐藏 trigger | string\|ReactNode | - |  |
 | width | 宽度 | number\|string | 200 |  |
 | onCollapse | 展开-收起时的回调函数，有点击 trigger 以及响应式反馈两种方式可以触发 | (collapsed, type) => {} | - |  |
 | onBreakpoint | 触发响应式布局[断点](/components/grid#api)时的回调 | (broken) => {} | - | 3.7.0 |
+| zeroWidthTriggerStyle | 指定当 `collapsedWidth` 为 0 时出现的特殊 trigger 的样式 | object | - | 3.24.0 |
 
 #### breakpoint width
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    add prop `specialTriggerStyle` to controll the style of the special trigger that appears when `collapsedWidth` is 0. |
| 🇨🇳 Chinese |    新增属性 `specialTriggerStyle` 以控制当 `collapsedWidth` 为 0 时，出现的特殊 trigger 的样式。      |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
