### PR TITLE
Update documentation (en-US) for Input.Search: Clicking clear-icon fires onSearch

### DIFF
--- a/components/input/index.en-US.md
+++ b/components/input/index.en-US.md
@@ -55,7 +55,7 @@ The rest of the props of `Input.TextArea` are the same as the original [textarea
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
 | enterButton | to show an enter button after input. This prop is conflict with addon. | boolean\|ReactNode | false |  |
-| onSearch | The callback function that is triggered when you click on the search-icon or press Enter key. | function(value, event) |  |  |
+| onSearch | The callback function triggered when you click on the search-icon, the clear-icon or press the Enter key. | function(value, event) |  |  |
 
 Supports all props of `Input`.
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
close https://github.com/ant-design/ant-design/issues/19137
<!--
1. Describe the source of requirement, like related issue link.
-->
### 💡 Background and solution
I was surprised that the `onSearch` event was fired for the clear-icon click. I learned that this was intended but missing in the documentation.
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog
<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Updated documentation sentence about `onSearch` event for `Input.Search`.      |
| 🇨🇳 Chinese |    -      |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/input/index.en-US.md](https://github.com/rodrigoehlers/ant-design/blob/fix/input-search-on-clear/components/input/index.en-US.md)