### PR TITLE
fix(#19132): fix component tree defaultExpandAll does not work when u…

### DIFF
--- a/components/tree/DirectoryTree.tsx
+++ b/components/tree/DirectoryTree.tsx
@@ -13,7 +13,12 @@ import Tree, {
   AntTreeNodeSelectedEvent,
   AntTreeNode,
 } from './Tree';
-import { calcRangeKeys, getFullKeyList, convertDirectoryKeysToNodes } from './util';
+import {
+  calcRangeKeys,
+  getFullKeyList,
+  convertDirectoryKeysToNodes,
+  getFullKeyListByTreeData,
+} from './util';
 import Icon from '../icon';
 
 export type ExpandAction = false | 'click' | 'doubleClick';
@@ -82,7 +87,15 @@ class DirectoryTree extends React.Component<DirectoryTreeProps, DirectoryTreeSta
 
     // Expanded keys
     if (defaultExpandAll) {
-      this.state.expandedKeys = getFullKeyList(props.children);
+      const expandedKeysByChildren = getFullKeyList(props.children);
+      this.state.expandedKeys = expandedKeysByChildren;
+      if (
+        !!props.treeData &&
+        Array.isArray(expandedKeysByChildren) &&
+        expandedKeysByChildren.length === 0
+      ) {
+        this.state.expandedKeys = getFullKeyListByTreeData(props.treeData);
+      }
     } else if (defaultExpandParent) {
       this.state.expandedKeys = conductExpandParent(
         expandedKeys || defaultExpandedKeys,

--- a/components/tree/DirectoryTree.tsx
+++ b/components/tree/DirectoryTree.tsx
@@ -87,14 +87,11 @@ class DirectoryTree extends React.Component<DirectoryTreeProps, DirectoryTreeSta
 
     // Expanded keys
     if (defaultExpandAll) {
-      const expandedKeysByChildren = getFullKeyList(props.children);
-      this.state.expandedKeys = expandedKeysByChildren;
-      if (
-        !!props.treeData &&
-        Array.isArray(expandedKeysByChildren) &&
-        expandedKeysByChildren.length === 0
-      ) {
+      if (props.treeData) {
+        console.log(getFullKeyListByTreeData(props.treeData));
         this.state.expandedKeys = getFullKeyListByTreeData(props.treeData);
+      } else {
+        this.state.expandedKeys = getFullKeyList(props.children);
       }
     } else if (defaultExpandParent) {
       this.state.expandedKeys = conductExpandParent(

--- a/components/tree/DirectoryTree.tsx
+++ b/components/tree/DirectoryTree.tsx
@@ -88,7 +88,6 @@ class DirectoryTree extends React.Component<DirectoryTreeProps, DirectoryTreeSta
     // Expanded keys
     if (defaultExpandAll) {
       if (props.treeData) {
-        console.log(getFullKeyListByTreeData(props.treeData));
         this.state.expandedKeys = getFullKeyListByTreeData(props.treeData);
       } else {
         this.state.expandedKeys = getFullKeyList(props.children);

--- a/components/tree/__tests__/__snapshots__/directory.test.js.snap
+++ b/components/tree/__tests__/__snapshots__/directory.test.js.snap
@@ -1,5 +1,189 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Directory Tree DirectoryTree should expend all when use treeData and defaultExpandAll is true 1`] = `
+<ul
+  class="ant-tree ant-tree-directory"
+  role="tree"
+  unselectable="on"
+>
+  <li
+    class="ant-tree-treenode-switcher-open"
+    role="treeitem"
+  >
+    <span
+      class="ant-tree-switcher ant-tree-switcher_open"
+    >
+      <i
+        aria-label="icon: caret-down"
+        class="anticon anticon-caret-down ant-tree-switcher-icon"
+      >
+        <svg
+          aria-hidden="true"
+          class=""
+          data-icon="caret-down"
+          fill="currentColor"
+          focusable="false"
+          height="1em"
+          viewBox="0 0 1024 1024"
+          width="1em"
+        >
+          <path
+            d="M840.4 300H183.6c-19.7 0-30.7 20.8-18.5 35l328.4 380.8c9.4 10.9 27.5 10.9 37 0L858.9 335c12.2-14.2 1.2-35-18.5-35z"
+          />
+        </svg>
+      </i>
+    </span>
+    <span
+      class="ant-tree-node-content-wrapper ant-tree-node-content-wrapper-open"
+      title="Folder"
+    >
+      <span
+        class="ant-tree-iconEle ant-tree-icon__customize"
+      >
+        <i
+          aria-label="icon: folder-open"
+          class="anticon anticon-folder-open"
+        >
+          <svg
+            aria-hidden="true"
+            class=""
+            data-icon="folder-open"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M928 444H820V330.4c0-17.7-14.3-32-32-32H473L355.7 186.2a8.15 8.15 0 0 0-5.5-2.2H96c-17.7 0-32 14.3-32 32v592c0 17.7 14.3 32 32 32h698c13 0 24.8-7.9 29.7-20l134-332c1.5-3.8 2.3-7.9 2.3-12 0-17.7-14.3-32-32-32zM136 256h188.5l119.6 114.4H748V444H238c-13 0-24.8 7.9-29.7 20L136 643.2V256zm635.3 512H159l103.3-256h612.4L771.3 768z"
+            />
+          </svg>
+        </i>
+      </span>
+      <span
+        class="ant-tree-title"
+      >
+        Folder
+      </span>
+    </span>
+    <ul
+      class="ant-tree-child-tree ant-tree-child-tree-open"
+      data-expanded="true"
+      role="group"
+    >
+      <li
+        class="ant-tree-treenode-switcher-open"
+        role="treeitem"
+      >
+        <span
+          class="ant-tree-switcher ant-tree-switcher_open"
+        >
+          <i
+            aria-label="icon: caret-down"
+            class="anticon anticon-caret-down ant-tree-switcher-icon"
+          >
+            <svg
+              aria-hidden="true"
+              class=""
+              data-icon="caret-down"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="0 0 1024 1024"
+              width="1em"
+            >
+              <path
+                d="M840.4 300H183.6c-19.7 0-30.7 20.8-18.5 35l328.4 380.8c9.4 10.9 27.5 10.9 37 0L858.9 335c12.2-14.2 1.2-35-18.5-35z"
+              />
+            </svg>
+          </i>
+        </span>
+        <span
+          class="ant-tree-node-content-wrapper ant-tree-node-content-wrapper-open"
+          title="Folder2"
+        >
+          <span
+            class="ant-tree-iconEle ant-tree-icon__customize"
+          >
+            <i
+              aria-label="icon: folder-open"
+              class="anticon anticon-folder-open"
+            >
+              <svg
+                aria-hidden="true"
+                class=""
+                data-icon="folder-open"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M928 444H820V330.4c0-17.7-14.3-32-32-32H473L355.7 186.2a8.15 8.15 0 0 0-5.5-2.2H96c-17.7 0-32 14.3-32 32v592c0 17.7 14.3 32 32 32h698c13 0 24.8-7.9 29.7-20l134-332c1.5-3.8 2.3-7.9 2.3-12 0-17.7-14.3-32-32-32zM136 256h188.5l119.6 114.4H748V444H238c-13 0-24.8 7.9-29.7 20L136 643.2V256zm635.3 512H159l103.3-256h612.4L771.3 768z"
+                />
+              </svg>
+            </i>
+          </span>
+          <span
+            class="ant-tree-title"
+          >
+            Folder2
+          </span>
+        </span>
+        <ul
+          class="ant-tree-child-tree ant-tree-child-tree-open"
+          data-expanded="true"
+          role="group"
+        >
+          <li
+            class=""
+            role="treeitem"
+          >
+            <span
+              class="ant-tree-switcher ant-tree-switcher-noop"
+            />
+            <span
+              class="ant-tree-node-content-wrapper ant-tree-node-content-wrapper-normal"
+              title="File"
+            >
+              <span
+                class="ant-tree-iconEle ant-tree-icon__customize"
+              >
+                <i
+                  aria-label="icon: file"
+                  class="anticon anticon-file"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class=""
+                    data-icon="file"
+                    fill="currentColor"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M854.6 288.6L639.4 73.4c-6-6-14.1-9.4-22.6-9.4H192c-17.7 0-32 14.3-32 32v832c0 17.7 14.3 32 32 32h640c17.7 0 32-14.3 32-32V311.3c0-8.5-3.4-16.7-9.4-22.7zM790.2 326H602V137.8L790.2 326zm1.8 562H232V136h302v216a42 42 0 0 0 42 42h216v494z"
+                    />
+                  </svg>
+                </i>
+              </span>
+              <span
+                class="ant-tree-title"
+              >
+                File
+              </span>
+            </span>
+          </li>
+        </ul>
+      </li>
+    </ul>
+  </li>
+</ul>
+`;
+
 exports[`Directory Tree defaultExpandAll 1`] = `
 <ul
   class="ant-tree ant-tree-directory"

--- a/components/tree/__tests__/directory.test.js
+++ b/components/tree/__tests__/directory.test.js
@@ -119,6 +119,30 @@ describe('Directory Tree', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
+  it('DirectoryTree should expend all when use treeData and defaultExpandAll is true', () => {
+    const treeData = [
+      {
+        key: '0-0-0',
+        title: 'Folder',
+        children: [
+          {
+            title: 'Folder2',
+            key: '0-0-1',
+            children: [
+              {
+                title: 'File',
+                key: '0-0-2',
+                isLeaf: true,
+              },
+            ],
+          },
+        ],
+      },
+    ];
+    const wrapper = render(createTree({ defaultExpandAll: true, treeData }));
+    expect(wrapper).toMatchSnapshot();
+  });
+
   it('defaultExpandParent', () => {
     const wrapper = render(createTree({ defaultExpandParent: true }));
     expect(wrapper).toMatchSnapshot();

--- a/components/tree/__tests__/util.test.js
+++ b/components/tree/__tests__/util.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import Tree from '../index';
-import { calcRangeKeys, getFullKeyListByTreeData } from '../util';
+import { calcRangeKeys } from '../util';
 
 const { TreeNode } = Tree;
 
@@ -30,53 +30,6 @@ describe('Tree util', () => {
     const { children } = wrapper.find(Tree).props();
     const keys = calcRangeKeys(children, ['0-0', '0-2', '0-2-0'], '0-2-0-1', '0-0-0');
     const target = ['0-0-0', '0-0-1', '0-1', '0-2', '0-2-0', '0-2-0-0', '0-2-0-1'];
-    expect(keys.sort()).toEqual(target.sort());
-  });
-
-  it('calc range keys by treeData', () => {
-    const treeData = [
-      {
-        key: '0-0-0',
-        title: 'Folder',
-        children: [
-          {
-            title: 'Folder2',
-            key: '0-0-1',
-            children: [
-              {
-                title: 'File',
-                key: '0-0-2',
-                isLeaf: true,
-              },
-            ],
-          },
-        ],
-      },
-      {
-        key: '0-0-3',
-        title: 'Folder',
-        children: [
-          {
-            title: 'File',
-            key: '0-0-4',
-            isLeaf: true,
-          },
-          {
-            title: 'File',
-            key: '0-0-5',
-            isLeaf: true,
-          },
-          {
-            title: 'File',
-            key: '0-0-6',
-            isLeaf: true,
-          },
-        ],
-      },
-    ];
-
-    const keys = getFullKeyListByTreeData(treeData);
-    const target = ['0-0-0', '0-0-1', '0-0-2', '0-0-3', '0-0-4', '0-0-5', '0-0-6'];
     expect(keys.sort()).toEqual(target.sort());
   });
 });

--- a/components/tree/__tests__/util.test.js
+++ b/components/tree/__tests__/util.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import Tree from '../index';
-import { calcRangeKeys } from '../util';
+import { calcRangeKeys, getFullKeyListByTreeData } from '../util';
 
 const { TreeNode } = Tree;
 
@@ -30,6 +30,53 @@ describe('Tree util', () => {
     const { children } = wrapper.find(Tree).props();
     const keys = calcRangeKeys(children, ['0-0', '0-2', '0-2-0'], '0-2-0-1', '0-0-0');
     const target = ['0-0-0', '0-0-1', '0-1', '0-2', '0-2-0', '0-2-0-0', '0-2-0-1'];
+    expect(keys.sort()).toEqual(target.sort());
+  });
+
+  it('calc range keys by treeData', () => {
+    const treeData = [
+      {
+        key: '0-0-0',
+        title: 'Folder',
+        children: [
+          {
+            title: 'Folder2',
+            key: '0-0-1',
+            children: [
+              {
+                title: 'File',
+                key: '0-0-2',
+                isLeaf: true,
+              },
+            ],
+          },
+        ],
+      },
+      {
+        key: '0-0-3',
+        title: 'Folder',
+        children: [
+          {
+            title: 'File',
+            key: '0-0-4',
+            isLeaf: true,
+          },
+          {
+            title: 'File',
+            key: '0-0-5',
+            isLeaf: true,
+          },
+          {
+            title: 'File',
+            key: '0-0-6',
+            isLeaf: true,
+          },
+        ],
+      },
+    ];
+
+    const keys = getFullKeyListByTreeData(treeData);
+    const target = ['0-0-0', '0-0-1', '0-0-2', '0-0-3', '0-0-4', '0-0-5', '0-0-6'];
     expect(keys.sort()).toEqual(target.sort());
   });
 });

--- a/components/tree/util.ts
+++ b/components/tree/util.ts
@@ -103,10 +103,10 @@ export function convertDirectoryKeysToNodes(
 }
 
 export function getFullKeyListByTreeData(treeData: any[]): any {
-  for (const item of treeData) {
-    if (item.children) {
-      return getFullKeyListByTreeData(item.children).concat([item.key]);
+  for (let i = 0; i < treeData.length; i++) {
+    if (treeData[i].children) {
+      return getFullKeyListByTreeData(treeData[i].children).concat([treeData[i].key]);
     }
-    return [item.key];
+    return [treeData[i].key];
   }
 }

--- a/components/tree/util.ts
+++ b/components/tree/util.ts
@@ -102,11 +102,14 @@ export function convertDirectoryKeysToNodes(
   return nodes;
 }
 
-export function getFullKeyListByTreeData(treeData: any[]): any {
-  for (let i = 0; i < treeData.length; i++) {
-    if (treeData[i].children) {
-      return getFullKeyListByTreeData(treeData[i].children).concat([treeData[i].key]);
+export function getFullKeyListByTreeData(treeData: any[], keys: any = []): any[] {
+  (treeData || []).forEach(item => {
+    if (item.children) {
+      keys.push(item.key);
+      keys.concat(getFullKeyListByTreeData(item.children, keys));
+    } else {
+      keys.push(item.key);
     }
-    return [treeData[i].key];
-  }
+  });
+  return keys;
 }

--- a/components/tree/util.ts
+++ b/components/tree/util.ts
@@ -101,3 +101,12 @@ export function convertDirectoryKeysToNodes(
   });
   return nodes;
 }
+
+export function getFullKeyListByTreeData(treeData: any[]): any {
+  for (const item of treeData) {
+    if (item.children) {
+      return getFullKeyListByTreeData(item.children).concat([item.key]);
+    }
+    return [item.key];
+  }
+}


### PR DESCRIPTION
…sing treeData

<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. [issue #19132](https://github.com/ant-design/ant-design/issues/19132)
-->

### 💡 Background and solution

<!--
1. There is not get expendkeys when use treeData, so I make a function getFullKeyListByTreeData in util.ts.
-->

### 📝 Changelog

<!--
no risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |  修复 DirectoryTree 组件, 该 bug 导致当传入属性 treeData 导致时, defaultExpandAll 不生效   |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
