### PR TITLE
fix: menu style broken in dropdown

### DIFF
--- a/components/config-provider/__tests__/__snapshots__/components.test.js.snap
+++ b/components/config-provider/__tests__/__snapshots__/components.test.js.snap
@@ -7410,14 +7410,14 @@ exports[`ConfigProvider components InputNumber configProvider 1`] = `
     </span>
   </div>
   <div
-    aria-valuemin="-9007199254740991"
     class="config-input-number-input-wrap"
-    role="spinbutton"
   >
     <input
+      aria-valuemin="-9007199254740991"
       autocomplete="off"
       class="config-input-number-input"
       min="-9007199254740991"
+      role="spinbutton"
       step="1"
       value=""
     />
@@ -7488,14 +7488,14 @@ exports[`ConfigProvider components InputNumber normal 1`] = `
     </span>
   </div>
   <div
-    aria-valuemin="-9007199254740991"
     class="ant-input-number-input-wrap"
-    role="spinbutton"
   >
     <input
+      aria-valuemin="-9007199254740991"
       autocomplete="off"
       class="ant-input-number-input"
       min="-9007199254740991"
+      role="spinbutton"
       step="1"
       value=""
     />
@@ -7566,14 +7566,14 @@ exports[`ConfigProvider components InputNumber prefixCls 1`] = `
     </span>
   </div>
   <div
-    aria-valuemin="-9007199254740991"
     class="prefix-InputNumber-input-wrap"
-    role="spinbutton"
   >
     <input
+      aria-valuemin="-9007199254740991"
       autocomplete="off"
       class="prefix-InputNumber-input"
       min="-9007199254740991"
+      role="spinbutton"
       step="1"
       value=""
     />

--- a/components/dropdown/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/dropdown/__tests__/__snapshots__/demo.test.js.snap
@@ -237,6 +237,34 @@ exports[`renders ./components/dropdown/demo/item.md correctly 1`] = `
 </a>
 `;
 
+exports[`renders ./components/dropdown/demo/menu-full.md correctly 1`] = `
+<a
+  class="ant-dropdown-link ant-dropdown-trigger"
+  href="#"
+>
+  Hover to check menu style 
+  <i
+    aria-label="icon: down"
+    class="anticon anticon-down"
+  >
+    <svg
+      aria-hidden="true"
+      class=""
+      data-icon="down"
+      fill="currentColor"
+      focusable="false"
+      height="1em"
+      viewBox="64 64 896 896"
+      width="1em"
+    >
+      <path
+        d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+      />
+    </svg>
+  </i>
+</a>
+`;
+
 exports[`renders ./components/dropdown/demo/overlay-visible.md correctly 1`] = `
 <a
   class="ant-dropdown-link ant-dropdown-trigger"

--- a/components/dropdown/demo/menu-full.md
+++ b/components/dropdown/demo/menu-full.md
@@ -1,0 +1,83 @@
+---
+order: 100
+title:
+  zh-CN: Menu 完整样式
+  en-US: Menu full styles
+debug: true
+---
+
+## zh-CN
+
+此演示需要注意查看 Dropdown 内 Menu 的样式是否正常。[#19150](https://github.com/ant-design/ant-design/pull/19150)
+
+## en-US
+
+This demo was created for debugging Menu styles inside Dropdown. [#19150](https://github.com/ant-design/ant-design/pull/19150)
+
+```jsx
+import { Menu, Dropdown, Icon } from 'antd';
+
+const { SubMenu } = Menu;
+
+const menu = (
+  <Menu selectedKeys={['1']} openKeys={['sub1']}>
+    <SubMenu
+      key="sub1"
+      title={
+        <span>
+          <Icon type="mail" />
+          <span>Navigation One</span>
+        </span>
+      }
+    >
+      <Menu.ItemGroup key="g1" title="Item 1">
+        <Menu.Item key="1">Option 1</Menu.Item>
+        <Menu.Item key="2">Option 2</Menu.Item>
+      </Menu.ItemGroup>
+      <Menu.ItemGroup key="g2" title="Item 2">
+        <Menu.Item key="3">Option 3</Menu.Item>
+        <Menu.Item key="4">Option 4</Menu.Item>
+      </Menu.ItemGroup>
+    </SubMenu>
+    <SubMenu
+      key="sub2"
+      title={
+        <span>
+          <Icon type="appstore" />
+          <span>Navigation Two</span>
+        </span>
+      }
+    >
+      <Menu.Item key="5">Option 5</Menu.Item>
+      <Menu.Item key="6">Option 6</Menu.Item>
+      <SubMenu key="sub3" title="Submenu">
+        <Menu.Item key="7">Option 7</Menu.Item>
+        <Menu.Item key="8">Option 8</Menu.Item>
+      </SubMenu>
+    </SubMenu>
+    <SubMenu
+      key="sub4"
+      title={
+        <span>
+          <Icon type="setting" />
+          <span>Navigation Three</span>
+        </span>
+      }
+    >
+      <Menu.Item key="9">Option 9</Menu.Item>
+      <Menu.Item key="10">Option 10</Menu.Item>
+      <Menu.Item key="11">Option 11</Menu.Item>
+      <Menu.Item key="12">Option 12</Menu.Item>
+    </SubMenu>
+  </Menu>
+);
+
+ReactDOM.render(
+  <Dropdown overlay={menu}>
+    <a className="ant-dropdown-link" href="#">
+      Hover to check menu style <Icon type="down" />
+    </a>
+  </Dropdown>,
+  mountNode,
+);
+```

--- a/components/dropdown/style/index.less
+++ b/components/dropdown/style/index.less
@@ -72,6 +72,16 @@
       > .@{dropdown-prefix-cls}-menu {
         transform-origin: 0 0;
       }
+
+      ul,
+      li {
+        list-style: none;
+      }
+
+      ul {
+        margin-right: 0.3em;
+        margin-left: 0.3em;
+      }
     }
 
     &-item,
@@ -87,9 +97,10 @@
       cursor: pointer;
       transition: all 0.3s;
 
-      > .anticon:first-child {
+      > span > .anticon:first-child {
         min-width: 12px;
         margin-right: 8px;
+        font-size: @font-size-sm;
       }
 
       > a {

--- a/components/form/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/form/__tests__/__snapshots__/demo.test.js.snap
@@ -2385,14 +2385,14 @@ exports[`renders ./components/form/demo/style-check-debug.md correctly 1`] = `
                     </span>
                   </div>
                   <div
-                    aria-valuemin="-9007199254740991"
                     class="ant-input-number-input-wrap"
-                    role="spinbutton"
                   >
                     <input
+                      aria-valuemin="-9007199254740991"
                       autocomplete="off"
                       class="ant-input-number-input"
                       min="-9007199254740991"
+                      role="spinbutton"
                       step="1"
                       value=""
                     />
@@ -3244,13 +3244,12 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
               </span>
             </div>
             <div
-              aria-valuemax="10"
-              aria-valuemin="1"
-              aria-valuenow="3"
               class="ant-input-number-input-wrap"
-              role="spinbutton"
             >
               <input
+                aria-valuemax="10"
+                aria-valuemin="1"
+                aria-valuenow="3"
                 autocomplete="off"
                 class="ant-input-number-input"
                 data-__field="[object Object]"
@@ -3258,6 +3257,7 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
                 id="validate_other_input-number"
                 max="10"
                 min="1"
+                role="spinbutton"
                 step="1"
                 value="3"
               />
@@ -5096,14 +5096,14 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
               </span>
             </div>
             <div
-              aria-valuemin="-9007199254740991"
               class="ant-input-number-input-wrap"
-              role="spinbutton"
             >
               <input
+                aria-valuemin="-9007199254740991"
                 autocomplete="off"
                 class="ant-input-number-input"
                 min="-9007199254740991"
+                role="spinbutton"
                 step="1"
                 value=""
               />
@@ -5227,17 +5227,17 @@ exports[`renders ./components/form/demo/without-form-create.md correctly 1`] = `
               </span>
             </div>
             <div
-              aria-valuemax="12"
-              aria-valuemin="8"
-              aria-valuenow="11"
               class="ant-input-number-input-wrap"
-              role="spinbutton"
             >
               <input
+                aria-valuemax="12"
+                aria-valuemin="8"
+                aria-valuenow="11"
                 autocomplete="off"
                 class="ant-input-number-input"
                 max="12"
                 min="8"
+                role="spinbutton"
                 step="1"
                 value="11"
               />

--- a/components/input-number/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/input-number/__tests__/__snapshots__/demo.test.js.snap
@@ -63,17 +63,17 @@ exports[`renders ./components/input-number/demo/basic.md correctly 1`] = `
     </span>
   </div>
   <div
-    aria-valuemax="10"
-    aria-valuemin="1"
-    aria-valuenow="3"
     class="ant-input-number-input-wrap"
-    role="spinbutton"
   >
     <input
+      aria-valuemax="10"
+      aria-valuemin="1"
+      aria-valuenow="3"
       autocomplete="off"
       class="ant-input-number-input"
       max="10"
       min="1"
+      role="spinbutton"
       step="1"
       value="3"
     />
@@ -144,16 +144,16 @@ exports[`renders ./components/input-number/demo/digit.md correctly 1`] = `
     </span>
   </div>
   <div
-    aria-valuemax="10"
-    aria-valuemin="0"
     class="ant-input-number-input-wrap"
-    role="spinbutton"
   >
     <input
+      aria-valuemax="10"
+      aria-valuemin="0"
       autocomplete="off"
       class="ant-input-number-input"
       max="10"
       min="0"
+      role="spinbutton"
       step="0.1"
       value=""
     />
@@ -225,18 +225,18 @@ exports[`renders ./components/input-number/demo/disabled.md correctly 1`] = `
       </span>
     </div>
     <div
-      aria-valuemax="10"
-      aria-valuemin="1"
-      aria-valuenow="3"
       class="ant-input-number-input-wrap"
-      role="spinbutton"
     >
       <input
+        aria-valuemax="10"
+        aria-valuemin="1"
+        aria-valuenow="3"
         autocomplete="off"
         class="ant-input-number-input"
         disabled=""
         max="10"
         min="1"
+        role="spinbutton"
         step="1"
         value="3"
       />
@@ -321,15 +321,15 @@ exports[`renders ./components/input-number/demo/formatter.md correctly 1`] = `
       </span>
     </div>
     <div
-      aria-valuemin="-9007199254740991"
-      aria-valuenow="1000"
       class="ant-input-number-input-wrap"
-      role="spinbutton"
     >
       <input
+        aria-valuemin="-9007199254740991"
+        aria-valuenow="1000"
         autocomplete="off"
         class="ant-input-number-input"
         min="-9007199254740991"
+        role="spinbutton"
         step="1"
         value="$ 1,000"
       />
@@ -397,17 +397,17 @@ exports[`renders ./components/input-number/demo/formatter.md correctly 1`] = `
       </span>
     </div>
     <div
-      aria-valuemax="100"
-      aria-valuemin="0"
-      aria-valuenow="100"
       class="ant-input-number-input-wrap"
-      role="spinbutton"
     >
       <input
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="100"
         autocomplete="off"
         class="ant-input-number-input"
         max="100"
         min="0"
+        role="spinbutton"
         step="1"
         value="100%"
       />
@@ -480,17 +480,17 @@ exports[`renders ./components/input-number/demo/size.md correctly 1`] = `
       </span>
     </div>
     <div
-      aria-valuemax="100000"
-      aria-valuemin="1"
-      aria-valuenow="3"
       class="ant-input-number-input-wrap"
-      role="spinbutton"
     >
       <input
+        aria-valuemax="100000"
+        aria-valuemin="1"
+        aria-valuenow="3"
         autocomplete="off"
         class="ant-input-number-input"
         max="100000"
         min="1"
+        role="spinbutton"
         step="1"
         value="3"
       />
@@ -558,17 +558,17 @@ exports[`renders ./components/input-number/demo/size.md correctly 1`] = `
       </span>
     </div>
     <div
-      aria-valuemax="100000"
-      aria-valuemin="1"
-      aria-valuenow="3"
       class="ant-input-number-input-wrap"
-      role="spinbutton"
     >
       <input
+        aria-valuemax="100000"
+        aria-valuemin="1"
+        aria-valuenow="3"
         autocomplete="off"
         class="ant-input-number-input"
         max="100000"
         min="1"
+        role="spinbutton"
         step="1"
         value="3"
       />
@@ -636,17 +636,17 @@ exports[`renders ./components/input-number/demo/size.md correctly 1`] = `
       </span>
     </div>
     <div
-      aria-valuemax="100000"
-      aria-valuemin="1"
-      aria-valuenow="3"
       class="ant-input-number-input-wrap"
-      role="spinbutton"
     >
       <input
+        aria-valuemax="100000"
+        aria-valuemin="1"
+        aria-valuenow="3"
         autocomplete="off"
         class="ant-input-number-input"
         max="100000"
         min="1"
+        role="spinbutton"
         step="1"
         value="3"
       />

--- a/components/input/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/input/__tests__/__snapshots__/demo.test.js.snap
@@ -342,14 +342,14 @@ exports[`renders ./components/input/demo/align.md correctly 1`] = `
       </span>
     </div>
     <div
-      aria-valuemin="-9007199254740991"
       class="ant-input-number-input-wrap"
-      role="spinbutton"
     >
       <input
+        aria-valuemin="-9007199254740991"
         autocomplete="off"
         class="ant-input-number-input"
         min="-9007199254740991"
+        role="spinbutton"
         step="1"
         value=""
       />
@@ -1105,14 +1105,14 @@ exports[`renders ./components/input/demo/group.md correctly 1`] = `
         </span>
       </div>
       <div
-        aria-valuemin="-9007199254740991"
         class="ant-input-number-input-wrap"
-        role="spinbutton"
       >
         <input
+          aria-valuemin="-9007199254740991"
           autocomplete="off"
           class="ant-input-number-input"
           min="-9007199254740991"
+          role="spinbutton"
           step="1"
           value=""
         />

--- a/components/slider/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/slider/__tests__/__snapshots__/demo.test.js.snap
@@ -325,17 +325,17 @@ exports[`renders ./components/slider/demo/input-number.md correctly 1`] = `
           </span>
         </div>
         <div
-          aria-valuemax="20"
-          aria-valuemin="1"
-          aria-valuenow="1"
           class="ant-input-number-input-wrap"
-          role="spinbutton"
         >
           <input
+            aria-valuemax="20"
+            aria-valuemin="1"
+            aria-valuenow="1"
             autocomplete="off"
             class="ant-input-number-input"
             max="20"
             min="1"
+            role="spinbutton"
             step="1"
             value="1"
           />
@@ -443,17 +443,17 @@ exports[`renders ./components/slider/demo/input-number.md correctly 1`] = `
           </span>
         </div>
         <div
-          aria-valuemax="1"
-          aria-valuemin="0"
-          aria-valuenow="0"
           class="ant-input-number-input-wrap"
-          role="spinbutton"
         >
           <input
+            aria-valuemax="1"
+            aria-valuemin="0"
+            aria-valuenow="0"
             autocomplete="off"
             class="ant-input-number-input"
             max="1"
             min="0"
+            role="spinbutton"
             step="0.01"
             value="0.00"
           />


### PR DESCRIPTION


<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close #19145

### 💡 Background and solution

<img width="412" alt="image" src="https://user-images.githubusercontent.com/507615/66537466-1b0a8d00-eb53-11e9-9bad-68cbb347fd75.png">

to

<img width="609" alt="截屏2019-10-10上午11 40 06" src="https://user-images.githubusercontent.com/507615/66537440-07f7bd00-eb53-11e9-8199-c1e5298b55dc.png">

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix broken menu style inside Dropdown. |
| 🇨🇳 Chinese | 修复 Dropdown 下部分 Menu 样式错乱的问题。 |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/dropdown/demo/menu-full.md](https://github.com/ant-design/ant-design/blob/fix-menu-style/components/dropdown/demo/menu-full.md)