### PR TITLE
Fix: keep className given to expandIcon in Collapse component

### DIFF
--- a/components/collapse/Collapse.tsx
+++ b/components/collapse/Collapse.tsx
@@ -45,14 +45,15 @@ export default class Collapse extends React.Component<CollapseProps, any> {
 
   renderExpandIcon = (panelProps: PanelProps = {}, prefixCls: string) => {
     const { expandIcon } = this.props;
-    const icon = expandIcon ? (
+    const icon = (expandIcon ? (
       expandIcon(panelProps)
     ) : (
       <Icon type="right" rotate={panelProps.isActive ? 90 : undefined} />
-    );
+    )) as React.ReactNode;
+
     return React.isValidElement(icon)
       ? React.cloneElement(icon as any, {
-          className: `${prefixCls}-arrow`,
+          className: classNames(icon.props.className, `${prefixCls}-arrow`),
         })
       : icon;
   };

--- a/components/collapse/__tests__/index.test.js
+++ b/components/collapse/__tests__/index.test.js
@@ -27,6 +27,22 @@ describe('Collapse', () => {
     expect(wrapper.render()).toMatchSnapshot();
   });
 
+  it('should keep the className of the expandIcon', () => {
+    const wrapper = mount(
+      <Collapse
+        expandIcon={() => (
+          <button type="button" className="custom-expandicon-classname">
+            action
+          </button>
+        )}
+      >
+        <Collapse.Panel header="header" />
+      </Collapse>,
+    );
+
+    expect(wrapper.find('.custom-expandicon-classname').exists()).toBe(true);
+  });
+
   it('should render extra node of panel', () => {
     const wrapper = mount(
       <Collapse>


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
fixes #19158

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

use `classNames` method to add the `` `${prefixCls}-arrow` `` to the existing classNames instead of overwriting them.

### 📝 Changelog

Class name given to the `expandIcon` of the `Collapse` component will be maintained so that might pose a change if users expected it to be lost.

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Keep `className` given to `expandIcon` in `Collapse` component         |
| 🇨🇳 Chinese | 保留  `Collapse` 组件中 `expandIcon` 自定义 `className` |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
