### PR TITLE
fix(#18792): fix RangePicker & WeekPicker, add props 'name' for them

### DIFF
--- a/components/date-picker/RangePicker.tsx
+++ b/components/date-picker/RangePicker.tsx
@@ -286,6 +286,7 @@ class RangePicker extends React.Component<any, RangePickerState> {
       onCalendarChange,
       suffixIcon,
       separator,
+      name,
     } = props;
 
     const prefixCls = getPrefixCls('calendar', customizePrefixCls);
@@ -380,6 +381,7 @@ class RangePicker extends React.Component<any, RangePickerState> {
       return (
         <span className={props.pickerInputClass}>
           <input
+            name={name}
             disabled={props.disabled}
             readOnly
             value={formatDate(start, props.format)}
@@ -389,6 +391,7 @@ class RangePicker extends React.Component<any, RangePickerState> {
           />
           <span className={`${prefixCls}-range-picker-separator`}> {separator} </span>
           <input
+            name={name}
             disabled={props.disabled}
             readOnly
             value={formatDate(end, props.format)}

--- a/components/date-picker/WeekPicker.tsx
+++ b/components/date-picker/WeekPicker.tsx
@@ -143,6 +143,7 @@ class WeekPicker extends React.Component<any, WeekPickerState> {
       onBlur,
       id,
       suffixIcon,
+      name,
     } = this.props;
 
     const prefixCls = getPrefixCls('calendar', customizePrefixCls);
@@ -187,6 +188,7 @@ class WeekPicker extends React.Component<any, WeekPickerState> {
     const input = ({ value }: { value: moment.Moment | undefined }) => (
       <span style={{ display: 'inline-block', width: '100%' }}>
         <input
+          name={name}
           ref={this.saveInput}
           disabled={disabled}
           readOnly


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close #18792

### 💡 Background and solution

<!--
1. Components RangerPicker and WeekPicker don't receive prop 'name', so I did it.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix RangerPicker and WeekPicker can receive name |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
