### PR TITLE
QA: Button loading prop as object feature

### DIFF
--- a/components/button/__tests__/index.test.js
+++ b/components/button/__tests__/index.test.js
@@ -1,10 +1,12 @@
 import React, { Component } from 'react';
-import { render, mount } from 'enzyme';
+import { render, mount, shallow } from 'enzyme';
 import renderer from 'react-test-renderer';
 import Button from '..';
 import Icon from '../../icon';
 import mountTest from '../../../tests/shared/mountTest';
 import { sleep } from '../../../tests/utils';
+
+jest.useFakeTimers();
 
 describe('Button', () => {
   mountTest(Button);
@@ -129,7 +131,7 @@ describe('Button', () => {
     expect(wrapper.find('.ant-btn-loading').length).toBe(1);
   });
 
-  it('should change loading state with delay', () => {
+  fit('should change loading state with delay', () => {
     // eslint-disable-next-line
     class DefaultButton extends Component {
       state = {
@@ -142,6 +144,7 @@ describe('Button', () => {
 
       render() {
         const { loading } = this.state;
+        console.log(loading);
         return (
           <Button loading={loading} onClick={this.enterLoading}>
             Button
@@ -150,8 +153,11 @@ describe('Button', () => {
       }
     }
     const wrapper = mount(<DefaultButton />);
+    expect(wrapper.render().hasClass('ant-btn-loading')).toBe(false);
     wrapper.simulate('click');
-    expect(wrapper.hasClass('ant-btn-loading')).toBe(false);
+    expect(wrapper.render().hasClass('ant-btn-loading')).toBe(true);
+    jest.runOnlyPendingTimers();
+    expect(wrapper.render().hasClass('ant-btn-loading')).toBe(false);
   });
 
   it('should not clickable when button is loading', () => {


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [x] Explore Button component

### 🔗 Related issue link
nothing

### 💡 Background and solution

When i explore ant components i`m find loading.delay prop in Button component, but it i think is not usefully. And i went to unit tests to explain how it works correctly. But now i don't lnow this.
I`m suggest to delete this api sometime.
Help to explain pls.
If it`s really usefully i suggest to add usage example in next PR to ant. And i want improve unit-test because now without render i thing they is nit correct.

I make some example in codesandbox based on unit test wrapper component
https://codesandbox.io/embed/button-with-delay-loading-upyrs
![screen-capture-_1_](https://user-images.githubusercontent.com/3505959/66784085-1b53b100-eee2-11e9-8e3c-9c5b2dc45485.gif)


### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
