### PR TITLE
feat(Table): The onChange sorter parameter always contains column info when the table is sorting/unsorting.

### DIFF
--- a/components/config-provider/__tests__/__snapshots__/components.test.js.snap
+++ b/components/config-provider/__tests__/__snapshots__/components.test.js.snap
@@ -7998,6 +7998,7 @@ exports[`ConfigProvider components Mention prefixCls 1`] = `
 exports[`ConfigProvider components Menu configProvider 1`] = `
 <ul
   class="config-menu config-menu-light config-menu-root config-menu-inline"
+  motion="[object Object]"
   role="menu"
 >
   <li
@@ -8018,7 +8019,7 @@ exports[`ConfigProvider components Menu configProvider 1`] = `
       />
     </div>
     <ul
-      class="config-menu config-menu-sub config-menu-inline"
+      class="config-menu  config-menu-sub config-menu-inline"
       id="bamboo$Menu"
       role="menu"
     >
@@ -8051,6 +8052,7 @@ exports[`ConfigProvider components Menu configProvider 1`] = `
 exports[`ConfigProvider components Menu normal 1`] = `
 <ul
   class="ant-menu ant-menu-light ant-menu-root ant-menu-inline"
+  motion="[object Object]"
   role="menu"
 >
   <li
@@ -8071,7 +8073,7 @@ exports[`ConfigProvider components Menu normal 1`] = `
       />
     </div>
     <ul
-      class="ant-menu ant-menu-sub ant-menu-inline"
+      class="ant-menu  ant-menu-sub ant-menu-inline"
       id="bamboo$Menu"
       role="menu"
     >
@@ -8104,6 +8106,7 @@ exports[`ConfigProvider components Menu normal 1`] = `
 exports[`ConfigProvider components Menu prefixCls 1`] = `
 <ul
   class="prefix-Menu prefix-Menu-light prefix-Menu-root prefix-Menu-inline"
+  motion="[object Object]"
   role="menu"
 >
   <li
@@ -8124,7 +8127,7 @@ exports[`ConfigProvider components Menu prefixCls 1`] = `
       />
     </div>
     <ul
-      class="prefix-Menu prefix-Menu-sub prefix-Menu-inline"
+      class="prefix-Menu  prefix-Menu-sub prefix-Menu-inline"
       id="bamboo$Menu"
       role="menu"
     >
@@ -11142,7 +11145,7 @@ exports[`ConfigProvider components Slider configProvider 1`] = `
   />
   <div
     class="config-slider-track"
-    style="left:0%;right:auto;width:0%"
+    style="left:0%;width:0%"
   />
   <div
     class="config-slider-step"
@@ -11154,7 +11157,7 @@ exports[`ConfigProvider components Slider configProvider 1`] = `
     aria-valuenow="0"
     class="config-slider-handle config-tooltip-open"
     role="slider"
-    style="left:0%;right:auto;transform:translateX(-50%)"
+    style="left:0%"
     tabindex="0"
   />
   <div>
@@ -11191,7 +11194,7 @@ exports[`ConfigProvider components Slider normal 1`] = `
   />
   <div
     class="ant-slider-track"
-    style="left:0%;right:auto;width:0%"
+    style="left:0%;width:0%"
   />
   <div
     class="ant-slider-step"
@@ -11203,7 +11206,7 @@ exports[`ConfigProvider components Slider normal 1`] = `
     aria-valuenow="0"
     class="ant-slider-handle ant-tooltip-open"
     role="slider"
-    style="left:0%;right:auto;transform:translateX(-50%)"
+    style="left:0%"
     tabindex="0"
   />
   <div>
@@ -11240,7 +11243,7 @@ exports[`ConfigProvider components Slider prefixCls 1`] = `
   />
   <div
     class="prefix-Slider-track"
-    style="left:0%;right:auto;width:0%"
+    style="left:0%;width:0%"
   />
   <div
     class="prefix-Slider-step"
@@ -11252,7 +11255,7 @@ exports[`ConfigProvider components Slider prefixCls 1`] = `
     aria-valuenow="0"
     class="prefix-Slider-handle prefix-Slider-tooltip-open"
     role="slider"
-    style="left:0%;right:auto;transform:translateX(-50%)"
+    style="left:0%"
     tabindex="0"
   />
   <div>

--- a/components/form/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/form/__tests__/__snapshots__/demo.test.js.snap
@@ -3343,7 +3343,7 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
             />
             <div
               class="ant-slider-track"
-              style="left:0%;right:auto;width:0%"
+              style="left:0%;width:0%"
             />
             <div
               class="ant-slider-step"
@@ -3380,7 +3380,7 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
               aria-valuenow="0"
               class="ant-slider-handle"
               role="slider"
-              style="left:0%;right:auto;transform:translateX(-50%)"
+              style="left:0%"
               tabindex="0"
             />
             <div
@@ -3388,37 +3388,37 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
             >
               <span
                 class="ant-slider-mark-text ant-slider-mark-text-active"
-                style="transform:translateX(-50%);-ms-transform:translateX(-50%);left:0%"
+                style="left:0%;transform:translateX(-50%);-ms-transform:translateX(-50%)"
               >
                 A
               </span>
               <span
                 class="ant-slider-mark-text"
-                style="transform:translateX(-50%);-ms-transform:translateX(-50%);left:20%"
+                style="left:20%;transform:translateX(-50%);-ms-transform:translateX(-50%)"
               >
                 B
               </span>
               <span
                 class="ant-slider-mark-text"
-                style="transform:translateX(-50%);-ms-transform:translateX(-50%);left:40%"
+                style="left:40%;transform:translateX(-50%);-ms-transform:translateX(-50%)"
               >
                 C
               </span>
               <span
                 class="ant-slider-mark-text"
-                style="transform:translateX(-50%);-ms-transform:translateX(-50%);left:60%"
+                style="left:60%;transform:translateX(-50%);-ms-transform:translateX(-50%)"
               >
                 D
               </span>
               <span
                 class="ant-slider-mark-text"
-                style="transform:translateX(-50%);-ms-transform:translateX(-50%);left:80%"
+                style="left:80%;transform:translateX(-50%);-ms-transform:translateX(-50%)"
               >
                 E
               </span>
               <span
                 class="ant-slider-mark-text"
-                style="transform:translateX(-50%);-ms-transform:translateX(-50%);left:100%"
+                style="left:100%;transform:translateX(-50%);-ms-transform:translateX(-50%)"
               >
                 F
               </span>

--- a/components/grid/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/grid/__tests__/__snapshots__/demo.test.js.snap
@@ -525,7 +525,7 @@ exports[`renders ./components/grid/demo/playground.md correctly 1`] = `
         />
         <div
           class="ant-slider-track"
-          style="left:0%;right:auto;width:20%"
+          style="left:0%;width:20%"
         />
         <div
           class="ant-slider-step"
@@ -562,7 +562,7 @@ exports[`renders ./components/grid/demo/playground.md correctly 1`] = `
           aria-valuenow="1"
           class="ant-slider-handle"
           role="slider"
-          style="left:20%;right:auto;transform:translateX(-50%)"
+          style="left:20%"
           tabindex="0"
         />
         <div
@@ -570,37 +570,37 @@ exports[`renders ./components/grid/demo/playground.md correctly 1`] = `
         >
           <span
             class="ant-slider-mark-text ant-slider-mark-text-active"
-            style="transform:translateX(-50%);-ms-transform:translateX(-50%);left:0%"
+            style="left:0%;transform:translateX(-50%);-ms-transform:translateX(-50%)"
           >
             8
           </span>
           <span
             class="ant-slider-mark-text ant-slider-mark-text-active"
-            style="transform:translateX(-50%);-ms-transform:translateX(-50%);left:20%"
+            style="left:20%;transform:translateX(-50%);-ms-transform:translateX(-50%)"
           >
             16
           </span>
           <span
             class="ant-slider-mark-text"
-            style="transform:translateX(-50%);-ms-transform:translateX(-50%);left:40%"
+            style="left:40%;transform:translateX(-50%);-ms-transform:translateX(-50%)"
           >
             24
           </span>
           <span
             class="ant-slider-mark-text"
-            style="transform:translateX(-50%);-ms-transform:translateX(-50%);left:60%"
+            style="left:60%;transform:translateX(-50%);-ms-transform:translateX(-50%)"
           >
             32
           </span>
           <span
             class="ant-slider-mark-text"
-            style="transform:translateX(-50%);-ms-transform:translateX(-50%);left:80%"
+            style="left:80%;transform:translateX(-50%);-ms-transform:translateX(-50%)"
           >
             40
           </span>
           <span
             class="ant-slider-mark-text"
-            style="transform:translateX(-50%);-ms-transform:translateX(-50%);left:100%"
+            style="left:100%;transform:translateX(-50%);-ms-transform:translateX(-50%)"
           >
             48
           </span>
@@ -623,7 +623,7 @@ exports[`renders ./components/grid/demo/playground.md correctly 1`] = `
         />
         <div
           class="ant-slider-track"
-          style="left:0%;right:auto;width:20%"
+          style="left:0%;width:20%"
         />
         <div
           class="ant-slider-step"
@@ -660,7 +660,7 @@ exports[`renders ./components/grid/demo/playground.md correctly 1`] = `
           aria-valuenow="1"
           class="ant-slider-handle"
           role="slider"
-          style="left:20%;right:auto;transform:translateX(-50%)"
+          style="left:20%"
           tabindex="0"
         />
         <div
@@ -668,37 +668,37 @@ exports[`renders ./components/grid/demo/playground.md correctly 1`] = `
         >
           <span
             class="ant-slider-mark-text ant-slider-mark-text-active"
-            style="transform:translateX(-50%);-ms-transform:translateX(-50%);left:0%"
+            style="left:0%;transform:translateX(-50%);-ms-transform:translateX(-50%)"
           >
             8
           </span>
           <span
             class="ant-slider-mark-text ant-slider-mark-text-active"
-            style="transform:translateX(-50%);-ms-transform:translateX(-50%);left:20%"
+            style="left:20%;transform:translateX(-50%);-ms-transform:translateX(-50%)"
           >
             16
           </span>
           <span
             class="ant-slider-mark-text"
-            style="transform:translateX(-50%);-ms-transform:translateX(-50%);left:40%"
+            style="left:40%;transform:translateX(-50%);-ms-transform:translateX(-50%)"
           >
             24
           </span>
           <span
             class="ant-slider-mark-text"
-            style="transform:translateX(-50%);-ms-transform:translateX(-50%);left:60%"
+            style="left:60%;transform:translateX(-50%);-ms-transform:translateX(-50%)"
           >
             32
           </span>
           <span
             class="ant-slider-mark-text"
-            style="transform:translateX(-50%);-ms-transform:translateX(-50%);left:80%"
+            style="left:80%;transform:translateX(-50%);-ms-transform:translateX(-50%)"
           >
             40
           </span>
           <span
             class="ant-slider-mark-text"
-            style="transform:translateX(-50%);-ms-transform:translateX(-50%);left:100%"
+            style="left:100%;transform:translateX(-50%);-ms-transform:translateX(-50%)"
           >
             48
           </span>
@@ -721,7 +721,7 @@ exports[`renders ./components/grid/demo/playground.md correctly 1`] = `
         />
         <div
           class="ant-slider-track"
-          style="left:0%;right:auto;width:40%"
+          style="left:0%;width:40%"
         />
         <div
           class="ant-slider-step"
@@ -758,7 +758,7 @@ exports[`renders ./components/grid/demo/playground.md correctly 1`] = `
           aria-valuenow="2"
           class="ant-slider-handle"
           role="slider"
-          style="left:40%;right:auto;transform:translateX(-50%)"
+          style="left:40%"
           tabindex="0"
         />
         <div
@@ -766,37 +766,37 @@ exports[`renders ./components/grid/demo/playground.md correctly 1`] = `
         >
           <span
             class="ant-slider-mark-text ant-slider-mark-text-active"
-            style="transform:translateX(-50%);-ms-transform:translateX(-50%);left:0%"
+            style="left:0%;transform:translateX(-50%);-ms-transform:translateX(-50%)"
           >
             2
           </span>
           <span
             class="ant-slider-mark-text ant-slider-mark-text-active"
-            style="transform:translateX(-50%);-ms-transform:translateX(-50%);left:20%"
+            style="left:20%;transform:translateX(-50%);-ms-transform:translateX(-50%)"
           >
             3
           </span>
           <span
             class="ant-slider-mark-text ant-slider-mark-text-active"
-            style="transform:translateX(-50%);-ms-transform:translateX(-50%);left:40%"
+            style="left:40%;transform:translateX(-50%);-ms-transform:translateX(-50%)"
           >
             4
           </span>
           <span
             class="ant-slider-mark-text"
-            style="transform:translateX(-50%);-ms-transform:translateX(-50%);left:60%"
+            style="left:60%;transform:translateX(-50%);-ms-transform:translateX(-50%)"
           >
             6
           </span>
           <span
             class="ant-slider-mark-text"
-            style="transform:translateX(-50%);-ms-transform:translateX(-50%);left:80%"
+            style="left:80%;transform:translateX(-50%);-ms-transform:translateX(-50%)"
           >
             8
           </span>
           <span
             class="ant-slider-mark-text"
-            style="transform:translateX(-50%);-ms-transform:translateX(-50%);left:100%"
+            style="left:100%;transform:translateX(-50%);-ms-transform:translateX(-50%)"
           >
             12
           </span>

--- a/components/layout/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/layout/__tests__/__snapshots__/demo.test.js.snap
@@ -139,6 +139,7 @@ exports[`renders ./components/layout/demo/custom-trigger.md correctly 1`] = `
       />
       <ul
         class="ant-menu ant-menu-dark ant-menu-root ant-menu-inline"
+        motion="[object Object]"
         role="menu"
       >
         <li
@@ -279,6 +280,7 @@ exports[`renders ./components/layout/demo/fixed.md correctly 1`] = `
     />
     <ul
       class="ant-menu ant-menu-dark ant-menu-root ant-menu-horizontal"
+      motion="[object Object]"
       role="menu"
       style="line-height:64px"
     >
@@ -450,6 +452,7 @@ exports[`renders ./components/layout/demo/fixed-sider.md correctly 1`] = `
       />
       <ul
         class="ant-menu ant-menu-dark ant-menu-root ant-menu-inline"
+        motion="[object Object]"
         role="menu"
       >
         <li
@@ -833,6 +836,7 @@ exports[`renders ./components/layout/demo/responsive.md correctly 1`] = `
       />
       <ul
         class="ant-menu ant-menu-dark ant-menu-root ant-menu-inline"
+        motion="[object Object]"
         role="menu"
       >
         <li
@@ -1002,6 +1006,7 @@ exports[`renders ./components/layout/demo/side.md correctly 1`] = `
       />
       <ul
         class="ant-menu ant-menu-dark ant-menu-root ant-menu-inline"
+        motion="[object Object]"
         role="menu"
       >
         <li
@@ -1263,6 +1268,7 @@ exports[`renders ./components/layout/demo/top.md correctly 1`] = `
     />
     <ul
       class="ant-menu ant-menu-dark ant-menu-root ant-menu-horizontal"
+      motion="[object Object]"
       role="menu"
       style="line-height:64px"
     >
@@ -1430,6 +1436,7 @@ exports[`renders ./components/layout/demo/top-side.md correctly 1`] = `
     />
     <ul
       class="ant-menu ant-menu-dark ant-menu-root ant-menu-horizontal"
+      motion="[object Object]"
       role="menu"
       style="line-height:64px"
     >
@@ -1583,6 +1590,7 @@ exports[`renders ./components/layout/demo/top-side.md correctly 1`] = `
         >
           <ul
             class="ant-menu ant-menu-light ant-menu-root ant-menu-inline"
+            motion="[object Object]"
             role="menu"
             style="height:100%"
           >
@@ -1624,7 +1632,7 @@ exports[`renders ./components/layout/demo/top-side.md correctly 1`] = `
                 />
               </div>
               <ul
-                class="ant-menu ant-menu-sub ant-menu-inline"
+                class="ant-menu  ant-menu-sub ant-menu-inline"
                 id="sub1$Menu"
                 role="menu"
               >
@@ -1766,6 +1774,7 @@ exports[`renders ./components/layout/demo/top-side-2.md correctly 1`] = `
     />
     <ul
       class="ant-menu ant-menu-dark ant-menu-root ant-menu-horizontal"
+      motion="[object Object]"
       role="menu"
       style="line-height:64px"
     >
@@ -1873,6 +1882,7 @@ exports[`renders ./components/layout/demo/top-side-2.md correctly 1`] = `
       >
         <ul
           class="ant-menu ant-menu-light ant-menu-root ant-menu-inline"
+          motion="[object Object]"
           role="menu"
           style="height:100%;border-right:0"
         >
@@ -1914,7 +1924,7 @@ exports[`renders ./components/layout/demo/top-side-2.md correctly 1`] = `
               />
             </div>
             <ul
-              class="ant-menu ant-menu-sub ant-menu-inline"
+              class="ant-menu  ant-menu-sub ant-menu-inline"
               id="sub1$Menu"
               role="menu"
             >

--- a/components/menu/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/menu/__tests__/__snapshots__/demo.test.js.snap
@@ -3,6 +3,7 @@
 exports[`renders ./components/menu/demo/horizontal.md correctly 1`] = `
 <ul
   class="ant-menu ant-menu-light ant-menu-root ant-menu-horizontal"
+  motion="[object Object]"
   role="menu"
 >
   <li
@@ -202,6 +203,7 @@ exports[`renders ./components/menu/demo/horizontal.md correctly 1`] = `
 exports[`renders ./components/menu/demo/inline.md correctly 1`] = `
 <ul
   class="ant-menu ant-menu-light ant-menu-root ant-menu-inline"
+  motion="[object Object]"
   role="menu"
   style="width:256px"
 >
@@ -245,7 +247,7 @@ exports[`renders ./components/menu/demo/inline.md correctly 1`] = `
       />
     </div>
     <ul
-      class="ant-menu ant-menu-sub ant-menu-inline"
+      class="ant-menu  ant-menu-sub ant-menu-inline"
       id="sub1$Menu"
       role="menu"
     >
@@ -421,6 +423,7 @@ exports[`renders ./components/menu/demo/inline-collapsed.md correctly 1`] = `
   </button>
   <ul
     class="ant-menu ant-menu-dark ant-menu-root ant-menu-inline"
+    motion="[object Object]"
     role="menu"
   >
     <li
@@ -547,7 +550,7 @@ exports[`renders ./components/menu/demo/inline-collapsed.md correctly 1`] = `
         />
       </div>
       <ul
-        class="ant-menu ant-menu-sub ant-menu-inline"
+        class="ant-menu  ant-menu-sub ant-menu-inline"
         id="sub1$Menu"
         role="menu"
       >
@@ -628,6 +631,7 @@ exports[`renders ./components/menu/demo/inline-collapsed.md correctly 1`] = `
 exports[`renders ./components/menu/demo/sider-current.md correctly 1`] = `
 <ul
   class="ant-menu ant-menu-light ant-menu-root ant-menu-inline"
+  motion="[object Object]"
   role="menu"
   style="width:256px"
 >
@@ -671,7 +675,7 @@ exports[`renders ./components/menu/demo/sider-current.md correctly 1`] = `
       />
     </div>
     <ul
-      class="ant-menu ant-menu-sub ant-menu-inline"
+      class="ant-menu  ant-menu-sub ant-menu-inline"
       id="sub1$Menu"
       role="menu"
     >
@@ -820,6 +824,7 @@ exports[`renders ./components/menu/demo/switch-mode.md correctly 1`] = `
   <br />
   <ul
     class="ant-menu ant-menu-light ant-menu-root ant-menu-inline"
+    motion="[object Object]"
     role="menu"
     style="width:256px"
   >
@@ -915,7 +920,7 @@ exports[`renders ./components/menu/demo/switch-mode.md correctly 1`] = `
         />
       </div>
       <ul
-        class="ant-menu ant-menu-sub ant-menu-inline"
+        class="ant-menu  ant-menu-sub ant-menu-inline"
         id="sub1$Menu"
         role="menu"
       >
@@ -1016,6 +1021,7 @@ exports[`renders ./components/menu/demo/theme.md correctly 1`] = `
   <br />
   <ul
     class="ant-menu ant-menu-dark ant-menu-root ant-menu-inline"
+    motion="[object Object]"
     role="menu"
     style="width:256px"
   >
@@ -1059,7 +1065,7 @@ exports[`renders ./components/menu/demo/theme.md correctly 1`] = `
         />
       </div>
       <ul
-        class="ant-menu ant-menu-sub ant-menu-inline"
+        class="ant-menu  ant-menu-sub ant-menu-inline"
         id="sub1$Menu"
         role="menu"
       >
@@ -1180,6 +1186,7 @@ exports[`renders ./components/menu/demo/theme.md correctly 1`] = `
 exports[`renders ./components/menu/demo/vertical.md correctly 1`] = `
 <ul
   class="ant-menu ant-menu-light ant-menu-root ant-menu-vertical"
+  motion="[object Object]"
   role="menu"
   style="width:256px"
 >

--- a/components/menu/__tests__/__snapshots__/index.test.js.snap
+++ b/components/menu/__tests__/__snapshots__/index.test.js.snap
@@ -3,6 +3,7 @@
 exports[`Menu should controlled collapse work 1`] = `
 <ul
   class="ant-menu ant-menu-light ant-menu-root ant-menu-inline"
+  motion="[object Object]"
   role="menu"
 >
   <li
@@ -39,6 +40,7 @@ exports[`Menu should controlled collapse work 1`] = `
 exports[`Menu should controlled collapse work 2`] = `
 <ul
   class="ant-menu ant-menu-light ant-menu-inline-collapsed ant-menu-root ant-menu-inline"
+  motion="[object Object]"
   role="menu"
 >
   <li

--- a/components/slider/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/slider/__tests__/__snapshots__/demo.test.js.snap
@@ -10,7 +10,7 @@ exports[`renders ./components/slider/demo/basic.md correctly 1`] = `
     />
     <div
       class="ant-slider-track"
-      style="left:0%;right:auto;width:30%"
+      style="left:0%;width:30%"
     />
     <div
       class="ant-slider-step"
@@ -22,7 +22,7 @@ exports[`renders ./components/slider/demo/basic.md correctly 1`] = `
       aria-valuenow="30"
       class="ant-slider-handle"
       role="slider"
-      style="left:30%;right:auto;transform:translateX(-50%)"
+      style="left:30%"
       tabindex="0"
     />
     <div
@@ -37,7 +37,7 @@ exports[`renders ./components/slider/demo/basic.md correctly 1`] = `
     />
     <div
       class="ant-slider-track ant-slider-track-1"
-      style="left:20%;right:auto;width:30%"
+      style="left:20%;width:30%"
     />
     <div
       class="ant-slider-step"
@@ -49,7 +49,7 @@ exports[`renders ./components/slider/demo/basic.md correctly 1`] = `
       aria-valuenow="20"
       class="ant-slider-handle ant-slider-handle-1"
       role="slider"
-      style="left:20%;right:auto;transform:translateX(-50%)"
+      style="left:20%"
       tabindex="0"
     />
     <div
@@ -59,7 +59,7 @@ exports[`renders ./components/slider/demo/basic.md correctly 1`] = `
       aria-valuenow="50"
       class="ant-slider-handle ant-slider-handle-2"
       role="slider"
-      style="left:50%;right:auto;transform:translateX(-50%)"
+      style="left:50%"
       tabindex="0"
     />
     <div
@@ -90,7 +90,7 @@ exports[`renders ./components/slider/demo/event.md correctly 1`] = `
     />
     <div
       class="ant-slider-track"
-      style="left:0%;right:auto;width:30%"
+      style="left:0%;width:30%"
     />
     <div
       class="ant-slider-step"
@@ -102,7 +102,7 @@ exports[`renders ./components/slider/demo/event.md correctly 1`] = `
       aria-valuenow="30"
       class="ant-slider-handle"
       role="slider"
-      style="left:30%;right:auto;transform:translateX(-50%)"
+      style="left:30%"
       tabindex="0"
     />
     <div
@@ -117,7 +117,7 @@ exports[`renders ./components/slider/demo/event.md correctly 1`] = `
     />
     <div
       class="ant-slider-track ant-slider-track-1"
-      style="left:20%;right:auto;width:30%"
+      style="left:20%;width:30%"
     />
     <div
       class="ant-slider-step"
@@ -129,7 +129,7 @@ exports[`renders ./components/slider/demo/event.md correctly 1`] = `
       aria-valuenow="20"
       class="ant-slider-handle ant-slider-handle-1"
       role="slider"
-      style="left:20%;right:auto;transform:translateX(-50%)"
+      style="left:20%"
       tabindex="0"
     />
     <div
@@ -139,7 +139,7 @@ exports[`renders ./components/slider/demo/event.md correctly 1`] = `
       aria-valuenow="50"
       class="ant-slider-handle ant-slider-handle-2"
       role="slider"
-      style="left:50%;right:auto;transform:translateX(-50%)"
+      style="left:50%"
       tabindex="0"
     />
     <div
@@ -181,7 +181,7 @@ exports[`renders ./components/slider/demo/icon-slider.md correctly 1`] = `
     />
     <div
       class="ant-slider-track"
-      style="left:0%;right:auto;width:0%"
+      style="left:0%;width:0%"
     />
     <div
       class="ant-slider-step"
@@ -193,7 +193,7 @@ exports[`renders ./components/slider/demo/icon-slider.md correctly 1`] = `
       aria-valuenow="0"
       class="ant-slider-handle"
       role="slider"
-      style="left:0%;right:auto;transform:translateX(-50%)"
+      style="left:0%"
       tabindex="0"
     />
     <div
@@ -239,7 +239,7 @@ exports[`renders ./components/slider/demo/input-number.md correctly 1`] = `
         />
         <div
           class="ant-slider-track"
-          style="left:0%;right:auto;width:0%"
+          style="left:0%;width:0%"
         />
         <div
           class="ant-slider-step"
@@ -251,7 +251,7 @@ exports[`renders ./components/slider/demo/input-number.md correctly 1`] = `
           aria-valuenow="1"
           class="ant-slider-handle"
           role="slider"
-          style="left:0%;right:auto;transform:translateX(-50%)"
+          style="left:0%"
           tabindex="0"
         />
         <div
@@ -357,7 +357,7 @@ exports[`renders ./components/slider/demo/input-number.md correctly 1`] = `
         />
         <div
           class="ant-slider-track"
-          style="left:0%;right:auto;width:0%"
+          style="left:0%;width:0%"
         />
         <div
           class="ant-slider-step"
@@ -369,7 +369,7 @@ exports[`renders ./components/slider/demo/input-number.md correctly 1`] = `
           aria-valuenow="0"
           class="ant-slider-handle"
           role="slider"
-          style="left:0%;right:auto;transform:translateX(-50%)"
+          style="left:0%"
           tabindex="0"
         />
         <div
@@ -477,7 +477,7 @@ exports[`renders ./components/slider/demo/mark.md correctly 1`] = `
     />
     <div
       class="ant-slider-track"
-      style="left:0%;right:auto;width:37%"
+      style="left:0%;width:37%"
     />
     <div
       class="ant-slider-step"
@@ -506,7 +506,7 @@ exports[`renders ./components/slider/demo/mark.md correctly 1`] = `
       aria-valuenow="37"
       class="ant-slider-handle"
       role="slider"
-      style="left:37%;right:auto;transform:translateX(-50%)"
+      style="left:37%"
       tabindex="0"
     />
     <div
@@ -514,25 +514,25 @@ exports[`renders ./components/slider/demo/mark.md correctly 1`] = `
     >
       <span
         class="ant-slider-mark-text ant-slider-mark-text-active"
-        style="transform:translateX(-50%);-ms-transform:translateX(-50%);left:0%"
+        style="left:0%;transform:translateX(-50%);-ms-transform:translateX(-50%)"
       >
         0°C
       </span>
       <span
         class="ant-slider-mark-text ant-slider-mark-text-active"
-        style="transform:translateX(-50%);-ms-transform:translateX(-50%);left:26%"
+        style="left:26%;transform:translateX(-50%);-ms-transform:translateX(-50%)"
       >
         26°C
       </span>
       <span
         class="ant-slider-mark-text ant-slider-mark-text-active"
-        style="transform:translateX(-50%);-ms-transform:translateX(-50%);left:37%"
+        style="left:37%;transform:translateX(-50%);-ms-transform:translateX(-50%)"
       >
         37°C
       </span>
       <span
         class="ant-slider-mark-text"
-        style="transform:translateX(-50%);-ms-transform:translateX(-50%);left:100%;color:#f50"
+        style="left:100%;transform:translateX(-50%);-ms-transform:translateX(-50%);color:#f50"
       >
         <strong>
           100°C
@@ -548,7 +548,7 @@ exports[`renders ./components/slider/demo/mark.md correctly 1`] = `
     />
     <div
       class="ant-slider-track ant-slider-track-1"
-      style="left:26%;right:auto;width:11%"
+      style="left:26%;width:11%"
     />
     <div
       class="ant-slider-step"
@@ -577,7 +577,7 @@ exports[`renders ./components/slider/demo/mark.md correctly 1`] = `
       aria-valuenow="26"
       class="ant-slider-handle ant-slider-handle-1"
       role="slider"
-      style="left:26%;right:auto;transform:translateX(-50%)"
+      style="left:26%"
       tabindex="0"
     />
     <div
@@ -587,7 +587,7 @@ exports[`renders ./components/slider/demo/mark.md correctly 1`] = `
       aria-valuenow="37"
       class="ant-slider-handle ant-slider-handle-2"
       role="slider"
-      style="left:37%;right:auto;transform:translateX(-50%)"
+      style="left:37%"
       tabindex="0"
     />
     <div
@@ -595,25 +595,25 @@ exports[`renders ./components/slider/demo/mark.md correctly 1`] = `
     >
       <span
         class="ant-slider-mark-text"
-        style="transform:translateX(-50%);-ms-transform:translateX(-50%);left:0%"
+        style="left:0%;transform:translateX(-50%);-ms-transform:translateX(-50%)"
       >
         0°C
       </span>
       <span
         class="ant-slider-mark-text ant-slider-mark-text-active"
-        style="transform:translateX(-50%);-ms-transform:translateX(-50%);left:26%"
+        style="left:26%;transform:translateX(-50%);-ms-transform:translateX(-50%)"
       >
         26°C
       </span>
       <span
         class="ant-slider-mark-text ant-slider-mark-text-active"
-        style="transform:translateX(-50%);-ms-transform:translateX(-50%);left:37%"
+        style="left:37%;transform:translateX(-50%);-ms-transform:translateX(-50%)"
       >
         37°C
       </span>
       <span
         class="ant-slider-mark-text"
-        style="transform:translateX(-50%);-ms-transform:translateX(-50%);left:100%;color:#f50"
+        style="left:100%;transform:translateX(-50%);-ms-transform:translateX(-50%);color:#f50"
       >
         <strong>
           100°C
@@ -657,7 +657,7 @@ exports[`renders ./components/slider/demo/mark.md correctly 1`] = `
       aria-valuenow="37"
       class="ant-slider-handle"
       role="slider"
-      style="left:37%;right:auto;transform:translateX(-50%)"
+      style="left:37%"
       tabindex="0"
     />
     <div
@@ -665,25 +665,25 @@ exports[`renders ./components/slider/demo/mark.md correctly 1`] = `
     >
       <span
         class="ant-slider-mark-text"
-        style="transform:translateX(-50%);-ms-transform:translateX(-50%);left:0%"
+        style="left:0%;transform:translateX(-50%);-ms-transform:translateX(-50%)"
       >
         0°C
       </span>
       <span
         class="ant-slider-mark-text"
-        style="transform:translateX(-50%);-ms-transform:translateX(-50%);left:26%"
+        style="left:26%;transform:translateX(-50%);-ms-transform:translateX(-50%)"
       >
         26°C
       </span>
       <span
         class="ant-slider-mark-text ant-slider-mark-text-active"
-        style="transform:translateX(-50%);-ms-transform:translateX(-50%);left:37%"
+        style="left:37%;transform:translateX(-50%);-ms-transform:translateX(-50%)"
       >
         37°C
       </span>
       <span
         class="ant-slider-mark-text"
-        style="transform:translateX(-50%);-ms-transform:translateX(-50%);left:100%;color:#f50"
+        style="left:100%;transform:translateX(-50%);-ms-transform:translateX(-50%);color:#f50"
       >
         <strong>
           100°C
@@ -702,7 +702,7 @@ exports[`renders ./components/slider/demo/mark.md correctly 1`] = `
     />
     <div
       class="ant-slider-track"
-      style="left:0%;right:auto;width:37%"
+      style="left:0%;width:37%"
     />
     <div
       class="ant-slider-step"
@@ -731,7 +731,7 @@ exports[`renders ./components/slider/demo/mark.md correctly 1`] = `
       aria-valuenow="37"
       class="ant-slider-handle"
       role="slider"
-      style="left:37%;right:auto;transform:translateX(-50%)"
+      style="left:37%"
       tabindex="0"
     />
     <div
@@ -739,25 +739,25 @@ exports[`renders ./components/slider/demo/mark.md correctly 1`] = `
     >
       <span
         class="ant-slider-mark-text ant-slider-mark-text-active"
-        style="transform:translateX(-50%);-ms-transform:translateX(-50%);left:0%"
+        style="left:0%;transform:translateX(-50%);-ms-transform:translateX(-50%)"
       >
         0°C
       </span>
       <span
         class="ant-slider-mark-text ant-slider-mark-text-active"
-        style="transform:translateX(-50%);-ms-transform:translateX(-50%);left:26%"
+        style="left:26%;transform:translateX(-50%);-ms-transform:translateX(-50%)"
       >
         26°C
       </span>
       <span
         class="ant-slider-mark-text ant-slider-mark-text-active"
-        style="transform:translateX(-50%);-ms-transform:translateX(-50%);left:37%"
+        style="left:37%;transform:translateX(-50%);-ms-transform:translateX(-50%)"
       >
         37°C
       </span>
       <span
         class="ant-slider-mark-text"
-        style="transform:translateX(-50%);-ms-transform:translateX(-50%);left:100%;color:#f50"
+        style="left:100%;transform:translateX(-50%);-ms-transform:translateX(-50%);color:#f50"
       >
         <strong>
           100°C
@@ -776,7 +776,7 @@ exports[`renders ./components/slider/demo/mark.md correctly 1`] = `
     />
     <div
       class="ant-slider-track"
-      style="left:0%;right:auto;width:37%"
+      style="left:0%;width:37%"
     />
     <div
       class="ant-slider-step"
@@ -805,7 +805,7 @@ exports[`renders ./components/slider/demo/mark.md correctly 1`] = `
       aria-valuenow="37"
       class="ant-slider-handle"
       role="slider"
-      style="left:37%;right:auto;transform:translateX(-50%)"
+      style="left:37%"
       tabindex="0"
     />
     <div
@@ -813,25 +813,25 @@ exports[`renders ./components/slider/demo/mark.md correctly 1`] = `
     >
       <span
         class="ant-slider-mark-text ant-slider-mark-text-active"
-        style="transform:translateX(-50%);-ms-transform:translateX(-50%);left:0%"
+        style="left:0%;transform:translateX(-50%);-ms-transform:translateX(-50%)"
       >
         0°C
       </span>
       <span
         class="ant-slider-mark-text ant-slider-mark-text-active"
-        style="transform:translateX(-50%);-ms-transform:translateX(-50%);left:26%"
+        style="left:26%;transform:translateX(-50%);-ms-transform:translateX(-50%)"
       >
         26°C
       </span>
       <span
         class="ant-slider-mark-text ant-slider-mark-text-active"
-        style="transform:translateX(-50%);-ms-transform:translateX(-50%);left:37%"
+        style="left:37%;transform:translateX(-50%);-ms-transform:translateX(-50%)"
       >
         37°C
       </span>
       <span
         class="ant-slider-mark-text"
-        style="transform:translateX(-50%);-ms-transform:translateX(-50%);left:100%;color:#f50"
+        style="left:100%;transform:translateX(-50%);-ms-transform:translateX(-50%);color:#f50"
       >
         <strong>
           100°C
@@ -852,7 +852,7 @@ exports[`renders ./components/slider/demo/reverse.md correctly 1`] = `
     />
     <div
       class="ant-slider-track"
-      style="right:0%;left:auto;width:30%"
+      style="left:0%;width:30%"
     />
     <div
       class="ant-slider-step"
@@ -864,7 +864,7 @@ exports[`renders ./components/slider/demo/reverse.md correctly 1`] = `
       aria-valuenow="30"
       class="ant-slider-handle"
       role="slider"
-      style="right:30%;left:auto;transform:translateX(+50%)"
+      style="left:30%"
       tabindex="0"
     />
     <div
@@ -879,7 +879,7 @@ exports[`renders ./components/slider/demo/reverse.md correctly 1`] = `
     />
     <div
       class="ant-slider-track ant-slider-track-1"
-      style="right:20%;left:auto;width:30%"
+      style="left:20%;width:30%"
     />
     <div
       class="ant-slider-step"
@@ -891,7 +891,7 @@ exports[`renders ./components/slider/demo/reverse.md correctly 1`] = `
       aria-valuenow="20"
       class="ant-slider-handle ant-slider-handle-1"
       role="slider"
-      style="right:20%;left:auto;transform:translateX(+50%)"
+      style="left:20%"
       tabindex="0"
     />
     <div
@@ -901,7 +901,7 @@ exports[`renders ./components/slider/demo/reverse.md correctly 1`] = `
       aria-valuenow="50"
       class="ant-slider-handle ant-slider-handle-2"
       role="slider"
-      style="right:50%;left:auto;transform:translateX(+50%)"
+      style="left:50%"
       tabindex="0"
     />
     <div
@@ -932,7 +932,7 @@ exports[`renders ./components/slider/demo/show-tooltip.md correctly 1`] = `
   />
   <div
     class="ant-slider-track"
-    style="left:0%;right:auto;width:30%"
+    style="left:0%;width:30%"
   />
   <div
     class="ant-slider-step"
@@ -944,7 +944,7 @@ exports[`renders ./components/slider/demo/show-tooltip.md correctly 1`] = `
     aria-valuenow="30"
     class="ant-slider-handle ant-tooltip-open"
     role="slider"
-    style="left:30%;right:auto;transform:translateX(-50%)"
+    style="left:30%"
     tabindex="0"
   />
   <div>
@@ -982,7 +982,7 @@ exports[`renders ./components/slider/demo/tip-formatter.md correctly 1`] = `
     />
     <div
       class="ant-slider-track"
-      style="left:0%;right:auto;width:0%"
+      style="left:0%;width:0%"
     />
     <div
       class="ant-slider-step"
@@ -994,7 +994,7 @@ exports[`renders ./components/slider/demo/tip-formatter.md correctly 1`] = `
       aria-valuenow="0"
       class="ant-slider-handle"
       role="slider"
-      style="left:0%;right:auto;transform:translateX(-50%)"
+      style="left:0%"
       tabindex="0"
     />
     <div
@@ -1009,7 +1009,7 @@ exports[`renders ./components/slider/demo/tip-formatter.md correctly 1`] = `
     />
     <div
       class="ant-slider-track"
-      style="left:0%;right:auto;width:0%"
+      style="left:0%;width:0%"
     />
     <div
       class="ant-slider-step"
@@ -1021,7 +1021,7 @@ exports[`renders ./components/slider/demo/tip-formatter.md correctly 1`] = `
       aria-valuenow="0"
       class="ant-slider-handle"
       role="slider"
-      style="left:0%;right:auto;transform:translateX(-50%)"
+      style="left:0%"
       tabindex="0"
     />
     <div
@@ -1046,7 +1046,7 @@ exports[`renders ./components/slider/demo/vertical.md correctly 1`] = `
       />
       <div
         class="ant-slider-track"
-        style="bottom:0%;top:auto;height:30%"
+        style="bottom:0%;height:30%"
       />
       <div
         class="ant-slider-step"
@@ -1058,7 +1058,7 @@ exports[`renders ./components/slider/demo/vertical.md correctly 1`] = `
         aria-valuenow="30"
         class="ant-slider-handle"
         role="slider"
-        style="bottom:30%;top:auto;transform:translateY(+50%)"
+        style="bottom:30%"
         tabindex="0"
       />
       <div
@@ -1077,7 +1077,7 @@ exports[`renders ./components/slider/demo/vertical.md correctly 1`] = `
       />
       <div
         class="ant-slider-track ant-slider-track-1"
-        style="bottom:20%;top:auto;height:30%"
+        style="bottom:20%;height:30%"
       />
       <div
         class="ant-slider-step"
@@ -1089,7 +1089,7 @@ exports[`renders ./components/slider/demo/vertical.md correctly 1`] = `
         aria-valuenow="20"
         class="ant-slider-handle ant-slider-handle-1"
         role="slider"
-        style="bottom:20%;top:auto;transform:translateY(+50%)"
+        style="bottom:20%"
         tabindex="0"
       />
       <div
@@ -1099,7 +1099,7 @@ exports[`renders ./components/slider/demo/vertical.md correctly 1`] = `
         aria-valuenow="50"
         class="ant-slider-handle ant-slider-handle-2"
         role="slider"
-        style="bottom:50%;top:auto;transform:translateY(+50%)"
+        style="bottom:50%"
         tabindex="0"
       />
       <div
@@ -1118,7 +1118,7 @@ exports[`renders ./components/slider/demo/vertical.md correctly 1`] = `
       />
       <div
         class="ant-slider-track ant-slider-track-1"
-        style="bottom:26%;top:auto;height:11%"
+        style="bottom:26%;height:11%"
       />
       <div
         class="ant-slider-step"
@@ -1147,7 +1147,7 @@ exports[`renders ./components/slider/demo/vertical.md correctly 1`] = `
         aria-valuenow="26"
         class="ant-slider-handle ant-slider-handle-1"
         role="slider"
-        style="bottom:26%;top:auto;transform:translateY(+50%)"
+        style="bottom:26%"
         tabindex="0"
       />
       <div
@@ -1157,7 +1157,7 @@ exports[`renders ./components/slider/demo/vertical.md correctly 1`] = `
         aria-valuenow="37"
         class="ant-slider-handle ant-slider-handle-2"
         role="slider"
-        style="bottom:37%;top:auto;transform:translateY(+50%)"
+        style="bottom:37%"
         tabindex="0"
       />
       <div

--- a/components/table/Table.tsx
+++ b/components/table/Table.tsx
@@ -877,10 +877,13 @@ class Table<T> extends React.Component<TableProps<T>, TableState<T>> {
     if (onChange) {
       onChange.apply(
         null,
-        this.prepareParamsArguments({
-          ...this.state,
-          ...newState,
-        }),
+        this.prepareParamsArguments(
+          {
+            ...this.state,
+            ...newState,
+          },
+          column,
+        ),
       );
     }
   }
@@ -898,18 +901,23 @@ class Table<T> extends React.Component<TableProps<T>, TableState<T>> {
   }
 
   // Get pagination, filters, sorter
-  prepareParamsArguments(state: any): PrepareParamsArgumentsReturn<T> {
+  prepareParamsArguments(state: any, column?: ColumnProps<T>): PrepareParamsArgumentsReturn<T> {
     const pagination = { ...state.pagination };
     // remove useless handle function in Table.onChange
     delete pagination.onChange;
     delete pagination.onShowSizeChange;
     const filters = state.filters;
     const sorter: any = {};
+    let currentColumn = column;
     if (state.sortColumn && state.sortOrder) {
+      currentColumn = state.sortColumn;
       sorter.column = state.sortColumn;
       sorter.order = state.sortOrder;
-      sorter.field = state.sortColumn.dataIndex;
-      sorter.columnKey = getColumnKey(state.sortColumn);
+    }
+
+    if (currentColumn) {
+      sorter.field = currentColumn.dataIndex;
+      sorter.columnKey = getColumnKey(currentColumn);
     }
 
     const extra = {

--- a/components/table/__tests__/Table.sorter.test.js
+++ b/components/table/__tests__/Table.sorter.test.js
@@ -145,8 +145,8 @@ describe('Table.sorter', () => {
     const sorter3 = handleChange.mock.calls[2][2];
     expect(sorter3.column).toBe(undefined);
     expect(sorter3.order).toBe(undefined);
-    expect(sorter3.field).toBe(undefined);
-    expect(sorter3.columnKey).toBe(undefined);
+    expect(sorter3.field).toBe('name');
+    expect(sorter3.columnKey).toBe('name');
   });
 
   it('works with grouping columns in controlled mode', () => {

--- a/components/table/__tests__/__snapshots__/Table.rowSelection.test.js.snap
+++ b/components/table/__tests__/__snapshots__/Table.rowSelection.test.js.snap
@@ -11,7 +11,7 @@ exports[`Table.rowSelection fix selection column on the left 1`] = `
       class="ant-spin-container"
     >
       <div
-        class="ant-table ant-table-default ant-table-scroll-position-left ant-table-layout-fixed"
+        class="ant-table ant-table-default ant-table-scroll-position-left"
       >
         <div
           class="ant-table-content"
@@ -484,7 +484,7 @@ exports[`Table.rowSelection fix selection column on the left when any other colu
       class="ant-spin-container"
     >
       <div
-        class="ant-table ant-table-default ant-table-scroll-position-left ant-table-layout-fixed"
+        class="ant-table ant-table-default ant-table-scroll-position-left"
       >
         <div
           class="ant-table-content"
@@ -992,6 +992,7 @@ exports[`Table.rowSelection render with default selection correctly 1`] = `
   >
     <ul
       class="ant-dropdown-menu ant-table-selection-menu ant-dropdown-menu-light ant-dropdown-menu-root ant-dropdown-menu-vertical"
+      motion="[object Object]"
       role="menu"
       tabindex="0"
     >

--- a/components/table/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/table/__tests__/__snapshots__/demo.test.js.snap
@@ -36,7 +36,7 @@ exports[`renders ./components/table/demo/ajax.md correctly 1`] = `
               >
                 <tr>
                   <th
-                    class="ant-table-column-has-actions ant-table-column-has-sorters ant-table-row-cell-break-word"
+                    class="ant-table-column-has-actions ant-table-column-has-sorters"
                   >
                     <span
                       class="ant-table-header-column"
@@ -100,7 +100,7 @@ exports[`renders ./components/table/demo/ajax.md correctly 1`] = `
                     </span>
                   </th>
                   <th
-                    class="ant-table-column-has-actions ant-table-column-has-filters ant-table-row-cell-break-word"
+                    class="ant-table-column-has-actions ant-table-column-has-filters"
                   >
                     <span
                       class="ant-table-header-column"
@@ -1200,7 +1200,7 @@ exports[`renders ./components/table/demo/custom-filter-panel.md correctly 1`] = 
               >
                 <tr>
                   <th
-                    class="ant-table-column-has-actions ant-table-column-has-filters ant-table-row-cell-break-word"
+                    class="ant-table-column-has-actions ant-table-column-has-filters"
                   >
                     <span
                       class="ant-table-header-column"
@@ -1239,7 +1239,7 @@ exports[`renders ./components/table/demo/custom-filter-panel.md correctly 1`] = 
                     </i>
                   </th>
                   <th
-                    class="ant-table-column-has-actions ant-table-column-has-filters ant-table-row-cell-break-word"
+                    class="ant-table-column-has-actions ant-table-column-has-filters"
                   >
                     <span
                       class="ant-table-header-column"
@@ -1326,7 +1326,7 @@ exports[`renders ./components/table/demo/custom-filter-panel.md correctly 1`] = 
                   data-row-key="1"
                 >
                   <td
-                    class="ant-table-column-has-actions ant-table-column-has-filters ant-table-row-cell-break-word"
+                    class="ant-table-column-has-actions ant-table-column-has-filters"
                   >
                     <span>
                       <span
@@ -1337,7 +1337,7 @@ exports[`renders ./components/table/demo/custom-filter-panel.md correctly 1`] = 
                     </span>
                   </td>
                   <td
-                    class="ant-table-column-has-actions ant-table-column-has-filters ant-table-row-cell-break-word"
+                    class="ant-table-column-has-actions ant-table-column-has-filters"
                   >
                     <span>
                       <span
@@ -1364,7 +1364,7 @@ exports[`renders ./components/table/demo/custom-filter-panel.md correctly 1`] = 
                   data-row-key="2"
                 >
                   <td
-                    class="ant-table-column-has-actions ant-table-column-has-filters ant-table-row-cell-break-word"
+                    class="ant-table-column-has-actions ant-table-column-has-filters"
                   >
                     <span>
                       <span
@@ -1375,7 +1375,7 @@ exports[`renders ./components/table/demo/custom-filter-panel.md correctly 1`] = 
                     </span>
                   </td>
                   <td
-                    class="ant-table-column-has-actions ant-table-column-has-filters ant-table-row-cell-break-word"
+                    class="ant-table-column-has-actions ant-table-column-has-filters"
                   >
                     <span>
                       <span
@@ -1402,7 +1402,7 @@ exports[`renders ./components/table/demo/custom-filter-panel.md correctly 1`] = 
                   data-row-key="3"
                 >
                   <td
-                    class="ant-table-column-has-actions ant-table-column-has-filters ant-table-row-cell-break-word"
+                    class="ant-table-column-has-actions ant-table-column-has-filters"
                   >
                     <span>
                       <span
@@ -1413,7 +1413,7 @@ exports[`renders ./components/table/demo/custom-filter-panel.md correctly 1`] = 
                     </span>
                   </td>
                   <td
-                    class="ant-table-column-has-actions ant-table-column-has-filters ant-table-row-cell-break-word"
+                    class="ant-table-column-has-actions ant-table-column-has-filters"
                   >
                     <span>
                       <span
@@ -1440,7 +1440,7 @@ exports[`renders ./components/table/demo/custom-filter-panel.md correctly 1`] = 
                   data-row-key="4"
                 >
                   <td
-                    class="ant-table-column-has-actions ant-table-column-has-filters ant-table-row-cell-break-word"
+                    class="ant-table-column-has-actions ant-table-column-has-filters"
                   >
                     <span>
                       <span
@@ -1451,7 +1451,7 @@ exports[`renders ./components/table/demo/custom-filter-panel.md correctly 1`] = 
                     </span>
                   </td>
                   <td
-                    class="ant-table-column-has-actions ant-table-column-has-filters ant-table-row-cell-break-word"
+                    class="ant-table-column-has-actions ant-table-column-has-filters"
                   >
                     <span>
                       <span
@@ -3686,7 +3686,7 @@ exports[`renders ./components/table/demo/edit-cell.md correctly 1`] = `
                 >
                   <tr>
                     <th
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       <span
                         class="ant-table-header-column"
@@ -3767,7 +3767,7 @@ exports[`renders ./components/table/demo/edit-cell.md correctly 1`] = `
                     data-row-key="0"
                   >
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       <div
                         class="editable-cell-value-wrap"
@@ -3799,7 +3799,7 @@ exports[`renders ./components/table/demo/edit-cell.md correctly 1`] = `
                     data-row-key="1"
                   >
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       <div
                         class="editable-cell-value-wrap"
@@ -3948,7 +3948,7 @@ exports[`renders ./components/table/demo/edit-row.md correctly 1`] = `
               >
                 <tr>
                   <th
-                    class="ant-table-row-cell-break-word"
+                    class=""
                   >
                     <span
                       class="ant-table-header-column"
@@ -3966,7 +3966,7 @@ exports[`renders ./components/table/demo/edit-row.md correctly 1`] = `
                     </span>
                   </th>
                   <th
-                    class="ant-table-row-cell-break-word"
+                    class=""
                   >
                     <span
                       class="ant-table-header-column"
@@ -3984,7 +3984,7 @@ exports[`renders ./components/table/demo/edit-row.md correctly 1`] = `
                     </span>
                   </th>
                   <th
-                    class="ant-table-row-cell-break-word"
+                    class=""
                   >
                     <span
                       class="ant-table-header-column"
@@ -4029,17 +4029,17 @@ exports[`renders ./components/table/demo/edit-row.md correctly 1`] = `
                   data-row-key="0"
                 >
                   <td
-                    class="ant-table-row-cell-break-word"
+                    class=""
                   >
                     Edrward 0
                   </td>
                   <td
-                    class="ant-table-row-cell-break-word"
+                    class=""
                   >
                     32
                   </td>
                   <td
-                    class="ant-table-row-cell-break-word"
+                    class=""
                   >
                     London Park no. 0
                   </td>
@@ -4056,17 +4056,17 @@ exports[`renders ./components/table/demo/edit-row.md correctly 1`] = `
                   data-row-key="1"
                 >
                   <td
-                    class="ant-table-row-cell-break-word"
+                    class=""
                   >
                     Edrward 1
                   </td>
                   <td
-                    class="ant-table-row-cell-break-word"
+                    class=""
                   >
                     32
                   </td>
                   <td
-                    class="ant-table-row-cell-break-word"
+                    class=""
                   >
                     London Park no. 1
                   </td>
@@ -4083,17 +4083,17 @@ exports[`renders ./components/table/demo/edit-row.md correctly 1`] = `
                   data-row-key="2"
                 >
                   <td
-                    class="ant-table-row-cell-break-word"
+                    class=""
                   >
                     Edrward 2
                   </td>
                   <td
-                    class="ant-table-row-cell-break-word"
+                    class=""
                   >
                     32
                   </td>
                   <td
-                    class="ant-table-row-cell-break-word"
+                    class=""
                   >
                     London Park no. 2
                   </td>
@@ -4110,17 +4110,17 @@ exports[`renders ./components/table/demo/edit-row.md correctly 1`] = `
                   data-row-key="3"
                 >
                   <td
-                    class="ant-table-row-cell-break-word"
+                    class=""
                   >
                     Edrward 3
                   </td>
                   <td
-                    class="ant-table-row-cell-break-word"
+                    class=""
                   >
                     32
                   </td>
                   <td
-                    class="ant-table-row-cell-break-word"
+                    class=""
                   >
                     London Park no. 3
                   </td>
@@ -4137,17 +4137,17 @@ exports[`renders ./components/table/demo/edit-row.md correctly 1`] = `
                   data-row-key="4"
                 >
                   <td
-                    class="ant-table-row-cell-break-word"
+                    class=""
                   >
                     Edrward 4
                   </td>
                   <td
-                    class="ant-table-row-cell-break-word"
+                    class=""
                   >
                     32
                   </td>
                   <td
-                    class="ant-table-row-cell-break-word"
+                    class=""
                   >
                     London Park no. 4
                   </td>
@@ -4164,17 +4164,17 @@ exports[`renders ./components/table/demo/edit-row.md correctly 1`] = `
                   data-row-key="5"
                 >
                   <td
-                    class="ant-table-row-cell-break-word"
+                    class=""
                   >
                     Edrward 5
                   </td>
                   <td
-                    class="ant-table-row-cell-break-word"
+                    class=""
                   >
                     32
                   </td>
                   <td
-                    class="ant-table-row-cell-break-word"
+                    class=""
                   >
                     London Park no. 5
                   </td>
@@ -4191,17 +4191,17 @@ exports[`renders ./components/table/demo/edit-row.md correctly 1`] = `
                   data-row-key="6"
                 >
                   <td
-                    class="ant-table-row-cell-break-word"
+                    class=""
                   >
                     Edrward 6
                   </td>
                   <td
-                    class="ant-table-row-cell-break-word"
+                    class=""
                   >
                     32
                   </td>
                   <td
-                    class="ant-table-row-cell-break-word"
+                    class=""
                   >
                     London Park no. 6
                   </td>
@@ -4218,17 +4218,17 @@ exports[`renders ./components/table/demo/edit-row.md correctly 1`] = `
                   data-row-key="7"
                 >
                   <td
-                    class="ant-table-row-cell-break-word"
+                    class=""
                   >
                     Edrward 7
                   </td>
                   <td
-                    class="ant-table-row-cell-break-word"
+                    class=""
                   >
                     32
                   </td>
                   <td
-                    class="ant-table-row-cell-break-word"
+                    class=""
                   >
                     London Park no. 7
                   </td>
@@ -4245,17 +4245,17 @@ exports[`renders ./components/table/demo/edit-row.md correctly 1`] = `
                   data-row-key="8"
                 >
                   <td
-                    class="ant-table-row-cell-break-word"
+                    class=""
                   >
                     Edrward 8
                   </td>
                   <td
-                    class="ant-table-row-cell-break-word"
+                    class=""
                   >
                     32
                   </td>
                   <td
-                    class="ant-table-row-cell-break-word"
+                    class=""
                   >
                     London Park no. 8
                   </td>
@@ -4272,17 +4272,17 @@ exports[`renders ./components/table/demo/edit-row.md correctly 1`] = `
                   data-row-key="9"
                 >
                   <td
-                    class="ant-table-row-cell-break-word"
+                    class=""
                   >
                     Edrward 9
                   </td>
                   <td
-                    class="ant-table-row-cell-break-word"
+                    class=""
                   >
                     32
                   </td>
                   <td
-                    class="ant-table-row-cell-break-word"
+                    class=""
                   >
                     London Park no. 9
                   </td>
@@ -4471,7 +4471,7 @@ exports[`renders ./components/table/demo/ellipsis.md correctly 1`] = `
       class="ant-spin-container"
     >
       <div
-        class="ant-table ant-table-default ant-table-scroll-position-left ant-table-layout-fixed"
+        class="ant-table ant-table-default ant-table-scroll-position-left"
       >
         <div
           class="ant-table-content"
@@ -4499,7 +4499,7 @@ exports[`renders ./components/table/demo/ellipsis.md correctly 1`] = `
               >
                 <tr>
                   <th
-                    class="ant-table-row-cell-break-word"
+                    class=""
                   >
                     <span
                       class="ant-table-header-column"
@@ -4517,7 +4517,7 @@ exports[`renders ./components/table/demo/ellipsis.md correctly 1`] = `
                     </span>
                   </th>
                   <th
-                    class="ant-table-row-cell-break-word"
+                    class=""
                   >
                     <span
                       class="ant-table-header-column"
@@ -4535,7 +4535,7 @@ exports[`renders ./components/table/demo/ellipsis.md correctly 1`] = `
                     </span>
                   </th>
                   <th
-                    class="ant-table-row-cell-ellipsis"
+                    class=""
                   >
                     <span
                       class="ant-table-header-column"
@@ -4553,7 +4553,7 @@ exports[`renders ./components/table/demo/ellipsis.md correctly 1`] = `
                     </span>
                   </th>
                   <th
-                    class="ant-table-row-cell-ellipsis"
+                    class=""
                   >
                     <span
                       class="ant-table-header-column"
@@ -4571,7 +4571,7 @@ exports[`renders ./components/table/demo/ellipsis.md correctly 1`] = `
                     </span>
                   </th>
                   <th
-                    class="ant-table-row-cell-ellipsis"
+                    class=""
                   >
                     <span
                       class="ant-table-header-column"
@@ -4589,7 +4589,7 @@ exports[`renders ./components/table/demo/ellipsis.md correctly 1`] = `
                     </span>
                   </th>
                   <th
-                    class="ant-table-row-cell-ellipsis"
+                    class=""
                   >
                     <span
                       class="ant-table-header-column"
@@ -4616,34 +4616,34 @@ exports[`renders ./components/table/demo/ellipsis.md correctly 1`] = `
                   data-row-key="1"
                 >
                   <td
-                    class="ant-table-row-cell-break-word"
+                    class=""
                   >
                     <a>
                       John Brown
                     </a>
                   </td>
                   <td
-                    class="ant-table-row-cell-break-word"
+                    class=""
                   >
                     32
                   </td>
                   <td
-                    class="ant-table-row-cell-ellipsis"
+                    class=""
                   >
                     New York No. 1 Lake Park, New York No. 1 Lake Park
                   </td>
                   <td
-                    class="ant-table-row-cell-ellipsis"
+                    class=""
                   >
                     New York No. 1 Lake Park, New York No. 1 Lake Park
                   </td>
                   <td
-                    class="ant-table-row-cell-ellipsis"
+                    class=""
                   >
                     New York No. 1 Lake Park, New York No. 1 Lake Park
                   </td>
                   <td
-                    class="ant-table-row-cell-ellipsis"
+                    class=""
                   >
                     New York No. 1 Lake Park, New York No. 1 Lake Park
                   </td>
@@ -4653,34 +4653,34 @@ exports[`renders ./components/table/demo/ellipsis.md correctly 1`] = `
                   data-row-key="2"
                 >
                   <td
-                    class="ant-table-row-cell-break-word"
+                    class=""
                   >
                     <a>
                       Jim Green
                     </a>
                   </td>
                   <td
-                    class="ant-table-row-cell-break-word"
+                    class=""
                   >
                     42
                   </td>
                   <td
-                    class="ant-table-row-cell-ellipsis"
+                    class=""
                   >
                     London No. 2 Lake Park, London No. 2 Lake Park
                   </td>
                   <td
-                    class="ant-table-row-cell-ellipsis"
+                    class=""
                   >
                     London No. 2 Lake Park, London No. 2 Lake Park
                   </td>
                   <td
-                    class="ant-table-row-cell-ellipsis"
+                    class=""
                   >
                     London No. 2 Lake Park, London No. 2 Lake Park
                   </td>
                   <td
-                    class="ant-table-row-cell-ellipsis"
+                    class=""
                   >
                     London No. 2 Lake Park, London No. 2 Lake Park
                   </td>
@@ -4690,34 +4690,34 @@ exports[`renders ./components/table/demo/ellipsis.md correctly 1`] = `
                   data-row-key="3"
                 >
                   <td
-                    class="ant-table-row-cell-break-word"
+                    class=""
                   >
                     <a>
                       Joe Black
                     </a>
                   </td>
                   <td
-                    class="ant-table-row-cell-break-word"
+                    class=""
                   >
                     32
                   </td>
                   <td
-                    class="ant-table-row-cell-ellipsis"
+                    class=""
                   >
                     Sidney No. 1 Lake Park, Sidney No. 1 Lake Park
                   </td>
                   <td
-                    class="ant-table-row-cell-ellipsis"
+                    class=""
                   >
                     Sidney No. 1 Lake Park, Sidney No. 1 Lake Park
                   </td>
                   <td
-                    class="ant-table-row-cell-ellipsis"
+                    class=""
                   >
                     Sidney No. 1 Lake Park, Sidney No. 1 Lake Park
                   </td>
                   <td
-                    class="ant-table-row-cell-ellipsis"
+                    class=""
                   >
                     Sidney No. 1 Lake Park, Sidney No. 1 Lake Park
                   </td>
@@ -5207,7 +5207,7 @@ exports[`renders ./components/table/demo/expand-children.md correctly 1`] = `
                     </span>
                   </th>
                   <th
-                    class="ant-table-row-cell-break-word"
+                    class=""
                   >
                     <span
                       class="ant-table-header-column"
@@ -5225,7 +5225,7 @@ exports[`renders ./components/table/demo/expand-children.md correctly 1`] = `
                     </span>
                   </th>
                   <th
-                    class="ant-table-row-cell-break-word"
+                    class=""
                   >
                     <span
                       class="ant-table-header-column"
@@ -5288,12 +5288,12 @@ exports[`renders ./components/table/demo/expand-children.md correctly 1`] = `
                     John Brown sr.
                   </td>
                   <td
-                    class="ant-table-row-cell-break-word"
+                    class=""
                   >
                     60
                   </td>
                   <td
-                    class="ant-table-row-cell-break-word"
+                    class=""
                   >
                     New York No. 1 Lake Park
                   </td>
@@ -5336,12 +5336,12 @@ exports[`renders ./components/table/demo/expand-children.md correctly 1`] = `
                     Joe Black
                   </td>
                   <td
-                    class="ant-table-row-cell-break-word"
+                    class=""
                   >
                     32
                   </td>
                   <td
-                    class="ant-table-row-cell-break-word"
+                    class=""
                   >
                     Sidney No. 1 Lake Park
                   </td>
@@ -5439,7 +5439,7 @@ exports[`renders ./components/table/demo/fixed-columns.md correctly 1`] = `
       class="ant-spin-container"
     >
       <div
-        class="ant-table ant-table-default ant-table-scroll-position-left ant-table-layout-fixed"
+        class="ant-table ant-table-default ant-table-scroll-position-left"
       >
         <div
           class="ant-table-content"
@@ -5480,7 +5480,7 @@ exports[`renders ./components/table/demo/fixed-columns.md correctly 1`] = `
                 >
                   <tr>
                     <th
-                      class="ant-table-fixed-columns-in-body ant-table-row-cell-break-word"
+                      class="ant-table-fixed-columns-in-body"
                     >
                       <span
                         class="ant-table-header-column"
@@ -5498,7 +5498,7 @@ exports[`renders ./components/table/demo/fixed-columns.md correctly 1`] = `
                       </span>
                     </th>
                     <th
-                      class="ant-table-fixed-columns-in-body ant-table-row-cell-break-word"
+                      class="ant-table-fixed-columns-in-body"
                     >
                       <span
                         class="ant-table-header-column"
@@ -5660,7 +5660,7 @@ exports[`renders ./components/table/demo/fixed-columns.md correctly 1`] = `
                       </span>
                     </th>
                     <th
-                      class="ant-table-fixed-columns-in-body ant-table-row-cell-break-word"
+                      class="ant-table-fixed-columns-in-body"
                     >
                       <span
                         class="ant-table-header-column"
@@ -5687,12 +5687,12 @@ exports[`renders ./components/table/demo/fixed-columns.md correctly 1`] = `
                     data-row-key="1"
                   >
                     <td
-                      class="ant-table-fixed-columns-in-body ant-table-row-cell-break-word"
+                      class="ant-table-fixed-columns-in-body"
                     >
                       John Brown
                     </td>
                     <td
-                      class="ant-table-fixed-columns-in-body ant-table-row-cell-break-word"
+                      class="ant-table-fixed-columns-in-body"
                     >
                       32
                     </td>
@@ -5737,7 +5737,7 @@ exports[`renders ./components/table/demo/fixed-columns.md correctly 1`] = `
                       New York Park
                     </td>
                     <td
-                      class="ant-table-fixed-columns-in-body ant-table-row-cell-break-word"
+                      class="ant-table-fixed-columns-in-body"
                     >
                       <a>
                         action
@@ -5749,12 +5749,12 @@ exports[`renders ./components/table/demo/fixed-columns.md correctly 1`] = `
                     data-row-key="2"
                   >
                     <td
-                      class="ant-table-fixed-columns-in-body ant-table-row-cell-break-word"
+                      class="ant-table-fixed-columns-in-body"
                     >
                       Jim Green
                     </td>
                     <td
-                      class="ant-table-fixed-columns-in-body ant-table-row-cell-break-word"
+                      class="ant-table-fixed-columns-in-body"
                     >
                       40
                     </td>
@@ -5799,7 +5799,7 @@ exports[`renders ./components/table/demo/fixed-columns.md correctly 1`] = `
                       London Park
                     </td>
                     <td
-                      class="ant-table-fixed-columns-in-body ant-table-row-cell-break-word"
+                      class="ant-table-fixed-columns-in-body"
                     >
                       <a>
                         action
@@ -5836,7 +5836,7 @@ exports[`renders ./components/table/demo/fixed-columns.md correctly 1`] = `
                   >
                     <tr>
                       <th
-                        class="ant-table-row-cell-break-word"
+                        class=""
                       >
                         <span
                           class="ant-table-header-column"
@@ -5854,7 +5854,7 @@ exports[`renders ./components/table/demo/fixed-columns.md correctly 1`] = `
                         </span>
                       </th>
                       <th
-                        class="ant-table-row-cell-break-word"
+                        class=""
                       >
                         <span
                           class="ant-table-header-column"
@@ -5881,12 +5881,12 @@ exports[`renders ./components/table/demo/fixed-columns.md correctly 1`] = `
                       data-row-key="1"
                     >
                       <td
-                        class="ant-table-row-cell-break-word"
+                        class=""
                       >
                         John Brown
                       </td>
                       <td
-                        class="ant-table-row-cell-break-word"
+                        class=""
                       >
                         32
                       </td>
@@ -5896,12 +5896,12 @@ exports[`renders ./components/table/demo/fixed-columns.md correctly 1`] = `
                       data-row-key="2"
                     >
                       <td
-                        class="ant-table-row-cell-break-word"
+                        class=""
                       >
                         Jim Green
                       </td>
                       <td
-                        class="ant-table-row-cell-break-word"
+                        class=""
                       >
                         40
                       </td>
@@ -5934,7 +5934,7 @@ exports[`renders ./components/table/demo/fixed-columns.md correctly 1`] = `
                   >
                     <tr>
                       <th
-                        class="ant-table-row-cell-break-word"
+                        class=""
                       >
                         <span
                           class="ant-table-header-column"
@@ -5961,7 +5961,7 @@ exports[`renders ./components/table/demo/fixed-columns.md correctly 1`] = `
                       data-row-key="1"
                     >
                       <td
-                        class="ant-table-row-cell-break-word"
+                        class=""
                       >
                         <a>
                           action
@@ -5973,7 +5973,7 @@ exports[`renders ./components/table/demo/fixed-columns.md correctly 1`] = `
                       data-row-key="2"
                     >
                       <td
-                        class="ant-table-row-cell-break-word"
+                        class=""
                       >
                         <a>
                           action
@@ -6075,7 +6075,7 @@ exports[`renders ./components/table/demo/fixed-columns-header.md correctly 1`] =
       class="ant-spin-container"
     >
       <div
-        class="ant-table ant-table-default ant-table-fixed-header ant-table-scroll-position-left ant-table-layout-fixed"
+        class="ant-table ant-table-default ant-table-fixed-header ant-table-scroll-position-left"
       >
         <div
           class="ant-table-content"
@@ -6128,7 +6128,7 @@ exports[`renders ./components/table/demo/fixed-columns-header.md correctly 1`] =
                 >
                   <tr>
                     <th
-                      class="ant-table-fixed-columns-in-body ant-table-row-cell-break-word"
+                      class="ant-table-fixed-columns-in-body"
                     >
                       <span
                         class="ant-table-header-column"
@@ -6146,7 +6146,7 @@ exports[`renders ./components/table/demo/fixed-columns-header.md correctly 1`] =
                       </span>
                     </th>
                     <th
-                      class="ant-table-fixed-columns-in-body ant-table-row-cell-break-word"
+                      class="ant-table-fixed-columns-in-body"
                     >
                       <span
                         class="ant-table-header-column"
@@ -6164,7 +6164,7 @@ exports[`renders ./components/table/demo/fixed-columns-header.md correctly 1`] =
                       </span>
                     </th>
                     <th
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       <span
                         class="ant-table-header-column"
@@ -6182,7 +6182,7 @@ exports[`renders ./components/table/demo/fixed-columns-header.md correctly 1`] =
                       </span>
                     </th>
                     <th
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       <span
                         class="ant-table-header-column"
@@ -6200,7 +6200,7 @@ exports[`renders ./components/table/demo/fixed-columns-header.md correctly 1`] =
                       </span>
                     </th>
                     <th
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       <span
                         class="ant-table-header-column"
@@ -6218,7 +6218,7 @@ exports[`renders ./components/table/demo/fixed-columns-header.md correctly 1`] =
                       </span>
                     </th>
                     <th
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       <span
                         class="ant-table-header-column"
@@ -6236,7 +6236,7 @@ exports[`renders ./components/table/demo/fixed-columns-header.md correctly 1`] =
                       </span>
                     </th>
                     <th
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       <span
                         class="ant-table-header-column"
@@ -6254,7 +6254,7 @@ exports[`renders ./components/table/demo/fixed-columns-header.md correctly 1`] =
                       </span>
                     </th>
                     <th
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       <span
                         class="ant-table-header-column"
@@ -6272,7 +6272,7 @@ exports[`renders ./components/table/demo/fixed-columns-header.md correctly 1`] =
                       </span>
                     </th>
                     <th
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       <span
                         class="ant-table-header-column"
@@ -6308,7 +6308,7 @@ exports[`renders ./components/table/demo/fixed-columns-header.md correctly 1`] =
                       </span>
                     </th>
                     <th
-                      class="ant-table-fixed-columns-in-body ant-table-row-cell-break-word"
+                      class="ant-table-fixed-columns-in-body"
                     >
                       <span
                         class="ant-table-header-column"
@@ -6379,47 +6379,17 @@ exports[`renders ./components/table/demo/fixed-columns-header.md correctly 1`] =
                     data-row-key="0"
                   >
                     <td
-                      class="ant-table-fixed-columns-in-body ant-table-row-cell-break-word"
+                      class="ant-table-fixed-columns-in-body"
                     >
                       Edrward 0
                     </td>
                     <td
-                      class="ant-table-fixed-columns-in-body ant-table-row-cell-break-word"
+                      class="ant-table-fixed-columns-in-body"
                     >
                       32
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
-                    >
-                      London Park no. 0
-                    </td>
-                    <td
-                      class="ant-table-row-cell-break-word"
-                    >
-                      London Park no. 0
-                    </td>
-                    <td
-                      class="ant-table-row-cell-break-word"
-                    >
-                      London Park no. 0
-                    </td>
-                    <td
-                      class="ant-table-row-cell-break-word"
-                    >
-                      London Park no. 0
-                    </td>
-                    <td
-                      class="ant-table-row-cell-break-word"
-                    >
-                      London Park no. 0
-                    </td>
-                    <td
-                      class="ant-table-row-cell-break-word"
-                    >
-                      London Park no. 0
-                    </td>
-                    <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       London Park no. 0
                     </td>
@@ -6429,7 +6399,37 @@ exports[`renders ./components/table/demo/fixed-columns-header.md correctly 1`] =
                       London Park no. 0
                     </td>
                     <td
-                      class="ant-table-fixed-columns-in-body ant-table-row-cell-break-word"
+                      class=""
+                    >
+                      London Park no. 0
+                    </td>
+                    <td
+                      class=""
+                    >
+                      London Park no. 0
+                    </td>
+                    <td
+                      class=""
+                    >
+                      London Park no. 0
+                    </td>
+                    <td
+                      class=""
+                    >
+                      London Park no. 0
+                    </td>
+                    <td
+                      class=""
+                    >
+                      London Park no. 0
+                    </td>
+                    <td
+                      class=""
+                    >
+                      London Park no. 0
+                    </td>
+                    <td
+                      class="ant-table-fixed-columns-in-body"
                     >
                       <a>
                         action
@@ -6441,47 +6441,17 @@ exports[`renders ./components/table/demo/fixed-columns-header.md correctly 1`] =
                     data-row-key="1"
                   >
                     <td
-                      class="ant-table-fixed-columns-in-body ant-table-row-cell-break-word"
+                      class="ant-table-fixed-columns-in-body"
                     >
                       Edrward 1
                     </td>
                     <td
-                      class="ant-table-fixed-columns-in-body ant-table-row-cell-break-word"
+                      class="ant-table-fixed-columns-in-body"
                     >
                       32
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
-                    >
-                      London Park no. 1
-                    </td>
-                    <td
-                      class="ant-table-row-cell-break-word"
-                    >
-                      London Park no. 1
-                    </td>
-                    <td
-                      class="ant-table-row-cell-break-word"
-                    >
-                      London Park no. 1
-                    </td>
-                    <td
-                      class="ant-table-row-cell-break-word"
-                    >
-                      London Park no. 1
-                    </td>
-                    <td
-                      class="ant-table-row-cell-break-word"
-                    >
-                      London Park no. 1
-                    </td>
-                    <td
-                      class="ant-table-row-cell-break-word"
-                    >
-                      London Park no. 1
-                    </td>
-                    <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       London Park no. 1
                     </td>
@@ -6491,7 +6461,37 @@ exports[`renders ./components/table/demo/fixed-columns-header.md correctly 1`] =
                       London Park no. 1
                     </td>
                     <td
-                      class="ant-table-fixed-columns-in-body ant-table-row-cell-break-word"
+                      class=""
+                    >
+                      London Park no. 1
+                    </td>
+                    <td
+                      class=""
+                    >
+                      London Park no. 1
+                    </td>
+                    <td
+                      class=""
+                    >
+                      London Park no. 1
+                    </td>
+                    <td
+                      class=""
+                    >
+                      London Park no. 1
+                    </td>
+                    <td
+                      class=""
+                    >
+                      London Park no. 1
+                    </td>
+                    <td
+                      class=""
+                    >
+                      London Park no. 1
+                    </td>
+                    <td
+                      class="ant-table-fixed-columns-in-body"
                     >
                       <a>
                         action
@@ -6503,47 +6503,17 @@ exports[`renders ./components/table/demo/fixed-columns-header.md correctly 1`] =
                     data-row-key="2"
                   >
                     <td
-                      class="ant-table-fixed-columns-in-body ant-table-row-cell-break-word"
+                      class="ant-table-fixed-columns-in-body"
                     >
                       Edrward 2
                     </td>
                     <td
-                      class="ant-table-fixed-columns-in-body ant-table-row-cell-break-word"
+                      class="ant-table-fixed-columns-in-body"
                     >
                       32
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
-                    >
-                      London Park no. 2
-                    </td>
-                    <td
-                      class="ant-table-row-cell-break-word"
-                    >
-                      London Park no. 2
-                    </td>
-                    <td
-                      class="ant-table-row-cell-break-word"
-                    >
-                      London Park no. 2
-                    </td>
-                    <td
-                      class="ant-table-row-cell-break-word"
-                    >
-                      London Park no. 2
-                    </td>
-                    <td
-                      class="ant-table-row-cell-break-word"
-                    >
-                      London Park no. 2
-                    </td>
-                    <td
-                      class="ant-table-row-cell-break-word"
-                    >
-                      London Park no. 2
-                    </td>
-                    <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       London Park no. 2
                     </td>
@@ -6553,7 +6523,37 @@ exports[`renders ./components/table/demo/fixed-columns-header.md correctly 1`] =
                       London Park no. 2
                     </td>
                     <td
-                      class="ant-table-fixed-columns-in-body ant-table-row-cell-break-word"
+                      class=""
+                    >
+                      London Park no. 2
+                    </td>
+                    <td
+                      class=""
+                    >
+                      London Park no. 2
+                    </td>
+                    <td
+                      class=""
+                    >
+                      London Park no. 2
+                    </td>
+                    <td
+                      class=""
+                    >
+                      London Park no. 2
+                    </td>
+                    <td
+                      class=""
+                    >
+                      London Park no. 2
+                    </td>
+                    <td
+                      class=""
+                    >
+                      London Park no. 2
+                    </td>
+                    <td
+                      class="ant-table-fixed-columns-in-body"
                     >
                       <a>
                         action
@@ -6565,47 +6565,17 @@ exports[`renders ./components/table/demo/fixed-columns-header.md correctly 1`] =
                     data-row-key="3"
                   >
                     <td
-                      class="ant-table-fixed-columns-in-body ant-table-row-cell-break-word"
+                      class="ant-table-fixed-columns-in-body"
                     >
                       Edrward 3
                     </td>
                     <td
-                      class="ant-table-fixed-columns-in-body ant-table-row-cell-break-word"
+                      class="ant-table-fixed-columns-in-body"
                     >
                       32
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
-                    >
-                      London Park no. 3
-                    </td>
-                    <td
-                      class="ant-table-row-cell-break-word"
-                    >
-                      London Park no. 3
-                    </td>
-                    <td
-                      class="ant-table-row-cell-break-word"
-                    >
-                      London Park no. 3
-                    </td>
-                    <td
-                      class="ant-table-row-cell-break-word"
-                    >
-                      London Park no. 3
-                    </td>
-                    <td
-                      class="ant-table-row-cell-break-word"
-                    >
-                      London Park no. 3
-                    </td>
-                    <td
-                      class="ant-table-row-cell-break-word"
-                    >
-                      London Park no. 3
-                    </td>
-                    <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       London Park no. 3
                     </td>
@@ -6615,7 +6585,37 @@ exports[`renders ./components/table/demo/fixed-columns-header.md correctly 1`] =
                       London Park no. 3
                     </td>
                     <td
-                      class="ant-table-fixed-columns-in-body ant-table-row-cell-break-word"
+                      class=""
+                    >
+                      London Park no. 3
+                    </td>
+                    <td
+                      class=""
+                    >
+                      London Park no. 3
+                    </td>
+                    <td
+                      class=""
+                    >
+                      London Park no. 3
+                    </td>
+                    <td
+                      class=""
+                    >
+                      London Park no. 3
+                    </td>
+                    <td
+                      class=""
+                    >
+                      London Park no. 3
+                    </td>
+                    <td
+                      class=""
+                    >
+                      London Park no. 3
+                    </td>
+                    <td
+                      class="ant-table-fixed-columns-in-body"
                     >
                       <a>
                         action
@@ -6627,47 +6627,17 @@ exports[`renders ./components/table/demo/fixed-columns-header.md correctly 1`] =
                     data-row-key="4"
                   >
                     <td
-                      class="ant-table-fixed-columns-in-body ant-table-row-cell-break-word"
+                      class="ant-table-fixed-columns-in-body"
                     >
                       Edrward 4
                     </td>
                     <td
-                      class="ant-table-fixed-columns-in-body ant-table-row-cell-break-word"
+                      class="ant-table-fixed-columns-in-body"
                     >
                       32
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
-                    >
-                      London Park no. 4
-                    </td>
-                    <td
-                      class="ant-table-row-cell-break-word"
-                    >
-                      London Park no. 4
-                    </td>
-                    <td
-                      class="ant-table-row-cell-break-word"
-                    >
-                      London Park no. 4
-                    </td>
-                    <td
-                      class="ant-table-row-cell-break-word"
-                    >
-                      London Park no. 4
-                    </td>
-                    <td
-                      class="ant-table-row-cell-break-word"
-                    >
-                      London Park no. 4
-                    </td>
-                    <td
-                      class="ant-table-row-cell-break-word"
-                    >
-                      London Park no. 4
-                    </td>
-                    <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       London Park no. 4
                     </td>
@@ -6677,7 +6647,37 @@ exports[`renders ./components/table/demo/fixed-columns-header.md correctly 1`] =
                       London Park no. 4
                     </td>
                     <td
-                      class="ant-table-fixed-columns-in-body ant-table-row-cell-break-word"
+                      class=""
+                    >
+                      London Park no. 4
+                    </td>
+                    <td
+                      class=""
+                    >
+                      London Park no. 4
+                    </td>
+                    <td
+                      class=""
+                    >
+                      London Park no. 4
+                    </td>
+                    <td
+                      class=""
+                    >
+                      London Park no. 4
+                    </td>
+                    <td
+                      class=""
+                    >
+                      London Park no. 4
+                    </td>
+                    <td
+                      class=""
+                    >
+                      London Park no. 4
+                    </td>
+                    <td
+                      class="ant-table-fixed-columns-in-body"
                     >
                       <a>
                         action
@@ -6689,47 +6689,17 @@ exports[`renders ./components/table/demo/fixed-columns-header.md correctly 1`] =
                     data-row-key="5"
                   >
                     <td
-                      class="ant-table-fixed-columns-in-body ant-table-row-cell-break-word"
+                      class="ant-table-fixed-columns-in-body"
                     >
                       Edrward 5
                     </td>
                     <td
-                      class="ant-table-fixed-columns-in-body ant-table-row-cell-break-word"
+                      class="ant-table-fixed-columns-in-body"
                     >
                       32
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
-                    >
-                      London Park no. 5
-                    </td>
-                    <td
-                      class="ant-table-row-cell-break-word"
-                    >
-                      London Park no. 5
-                    </td>
-                    <td
-                      class="ant-table-row-cell-break-word"
-                    >
-                      London Park no. 5
-                    </td>
-                    <td
-                      class="ant-table-row-cell-break-word"
-                    >
-                      London Park no. 5
-                    </td>
-                    <td
-                      class="ant-table-row-cell-break-word"
-                    >
-                      London Park no. 5
-                    </td>
-                    <td
-                      class="ant-table-row-cell-break-word"
-                    >
-                      London Park no. 5
-                    </td>
-                    <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       London Park no. 5
                     </td>
@@ -6739,7 +6709,37 @@ exports[`renders ./components/table/demo/fixed-columns-header.md correctly 1`] =
                       London Park no. 5
                     </td>
                     <td
-                      class="ant-table-fixed-columns-in-body ant-table-row-cell-break-word"
+                      class=""
+                    >
+                      London Park no. 5
+                    </td>
+                    <td
+                      class=""
+                    >
+                      London Park no. 5
+                    </td>
+                    <td
+                      class=""
+                    >
+                      London Park no. 5
+                    </td>
+                    <td
+                      class=""
+                    >
+                      London Park no. 5
+                    </td>
+                    <td
+                      class=""
+                    >
+                      London Park no. 5
+                    </td>
+                    <td
+                      class=""
+                    >
+                      London Park no. 5
+                    </td>
+                    <td
+                      class="ant-table-fixed-columns-in-body"
                     >
                       <a>
                         action
@@ -6751,47 +6751,17 @@ exports[`renders ./components/table/demo/fixed-columns-header.md correctly 1`] =
                     data-row-key="6"
                   >
                     <td
-                      class="ant-table-fixed-columns-in-body ant-table-row-cell-break-word"
+                      class="ant-table-fixed-columns-in-body"
                     >
                       Edrward 6
                     </td>
                     <td
-                      class="ant-table-fixed-columns-in-body ant-table-row-cell-break-word"
+                      class="ant-table-fixed-columns-in-body"
                     >
                       32
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
-                    >
-                      London Park no. 6
-                    </td>
-                    <td
-                      class="ant-table-row-cell-break-word"
-                    >
-                      London Park no. 6
-                    </td>
-                    <td
-                      class="ant-table-row-cell-break-word"
-                    >
-                      London Park no. 6
-                    </td>
-                    <td
-                      class="ant-table-row-cell-break-word"
-                    >
-                      London Park no. 6
-                    </td>
-                    <td
-                      class="ant-table-row-cell-break-word"
-                    >
-                      London Park no. 6
-                    </td>
-                    <td
-                      class="ant-table-row-cell-break-word"
-                    >
-                      London Park no. 6
-                    </td>
-                    <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       London Park no. 6
                     </td>
@@ -6801,7 +6771,37 @@ exports[`renders ./components/table/demo/fixed-columns-header.md correctly 1`] =
                       London Park no. 6
                     </td>
                     <td
-                      class="ant-table-fixed-columns-in-body ant-table-row-cell-break-word"
+                      class=""
+                    >
+                      London Park no. 6
+                    </td>
+                    <td
+                      class=""
+                    >
+                      London Park no. 6
+                    </td>
+                    <td
+                      class=""
+                    >
+                      London Park no. 6
+                    </td>
+                    <td
+                      class=""
+                    >
+                      London Park no. 6
+                    </td>
+                    <td
+                      class=""
+                    >
+                      London Park no. 6
+                    </td>
+                    <td
+                      class=""
+                    >
+                      London Park no. 6
+                    </td>
+                    <td
+                      class="ant-table-fixed-columns-in-body"
                     >
                       <a>
                         action
@@ -6813,47 +6813,17 @@ exports[`renders ./components/table/demo/fixed-columns-header.md correctly 1`] =
                     data-row-key="7"
                   >
                     <td
-                      class="ant-table-fixed-columns-in-body ant-table-row-cell-break-word"
+                      class="ant-table-fixed-columns-in-body"
                     >
                       Edrward 7
                     </td>
                     <td
-                      class="ant-table-fixed-columns-in-body ant-table-row-cell-break-word"
+                      class="ant-table-fixed-columns-in-body"
                     >
                       32
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
-                    >
-                      London Park no. 7
-                    </td>
-                    <td
-                      class="ant-table-row-cell-break-word"
-                    >
-                      London Park no. 7
-                    </td>
-                    <td
-                      class="ant-table-row-cell-break-word"
-                    >
-                      London Park no. 7
-                    </td>
-                    <td
-                      class="ant-table-row-cell-break-word"
-                    >
-                      London Park no. 7
-                    </td>
-                    <td
-                      class="ant-table-row-cell-break-word"
-                    >
-                      London Park no. 7
-                    </td>
-                    <td
-                      class="ant-table-row-cell-break-word"
-                    >
-                      London Park no. 7
-                    </td>
-                    <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       London Park no. 7
                     </td>
@@ -6863,7 +6833,37 @@ exports[`renders ./components/table/demo/fixed-columns-header.md correctly 1`] =
                       London Park no. 7
                     </td>
                     <td
-                      class="ant-table-fixed-columns-in-body ant-table-row-cell-break-word"
+                      class=""
+                    >
+                      London Park no. 7
+                    </td>
+                    <td
+                      class=""
+                    >
+                      London Park no. 7
+                    </td>
+                    <td
+                      class=""
+                    >
+                      London Park no. 7
+                    </td>
+                    <td
+                      class=""
+                    >
+                      London Park no. 7
+                    </td>
+                    <td
+                      class=""
+                    >
+                      London Park no. 7
+                    </td>
+                    <td
+                      class=""
+                    >
+                      London Park no. 7
+                    </td>
+                    <td
+                      class="ant-table-fixed-columns-in-body"
                     >
                       <a>
                         action
@@ -6875,47 +6875,17 @@ exports[`renders ./components/table/demo/fixed-columns-header.md correctly 1`] =
                     data-row-key="8"
                   >
                     <td
-                      class="ant-table-fixed-columns-in-body ant-table-row-cell-break-word"
+                      class="ant-table-fixed-columns-in-body"
                     >
                       Edrward 8
                     </td>
                     <td
-                      class="ant-table-fixed-columns-in-body ant-table-row-cell-break-word"
+                      class="ant-table-fixed-columns-in-body"
                     >
                       32
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
-                    >
-                      London Park no. 8
-                    </td>
-                    <td
-                      class="ant-table-row-cell-break-word"
-                    >
-                      London Park no. 8
-                    </td>
-                    <td
-                      class="ant-table-row-cell-break-word"
-                    >
-                      London Park no. 8
-                    </td>
-                    <td
-                      class="ant-table-row-cell-break-word"
-                    >
-                      London Park no. 8
-                    </td>
-                    <td
-                      class="ant-table-row-cell-break-word"
-                    >
-                      London Park no. 8
-                    </td>
-                    <td
-                      class="ant-table-row-cell-break-word"
-                    >
-                      London Park no. 8
-                    </td>
-                    <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       London Park no. 8
                     </td>
@@ -6925,7 +6895,37 @@ exports[`renders ./components/table/demo/fixed-columns-header.md correctly 1`] =
                       London Park no. 8
                     </td>
                     <td
-                      class="ant-table-fixed-columns-in-body ant-table-row-cell-break-word"
+                      class=""
+                    >
+                      London Park no. 8
+                    </td>
+                    <td
+                      class=""
+                    >
+                      London Park no. 8
+                    </td>
+                    <td
+                      class=""
+                    >
+                      London Park no. 8
+                    </td>
+                    <td
+                      class=""
+                    >
+                      London Park no. 8
+                    </td>
+                    <td
+                      class=""
+                    >
+                      London Park no. 8
+                    </td>
+                    <td
+                      class=""
+                    >
+                      London Park no. 8
+                    </td>
+                    <td
+                      class="ant-table-fixed-columns-in-body"
                     >
                       <a>
                         action
@@ -6937,47 +6937,17 @@ exports[`renders ./components/table/demo/fixed-columns-header.md correctly 1`] =
                     data-row-key="9"
                   >
                     <td
-                      class="ant-table-fixed-columns-in-body ant-table-row-cell-break-word"
+                      class="ant-table-fixed-columns-in-body"
                     >
                       Edrward 9
                     </td>
                     <td
-                      class="ant-table-fixed-columns-in-body ant-table-row-cell-break-word"
+                      class="ant-table-fixed-columns-in-body"
                     >
                       32
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
-                    >
-                      London Park no. 9
-                    </td>
-                    <td
-                      class="ant-table-row-cell-break-word"
-                    >
-                      London Park no. 9
-                    </td>
-                    <td
-                      class="ant-table-row-cell-break-word"
-                    >
-                      London Park no. 9
-                    </td>
-                    <td
-                      class="ant-table-row-cell-break-word"
-                    >
-                      London Park no. 9
-                    </td>
-                    <td
-                      class="ant-table-row-cell-break-word"
-                    >
-                      London Park no. 9
-                    </td>
-                    <td
-                      class="ant-table-row-cell-break-word"
-                    >
-                      London Park no. 9
-                    </td>
-                    <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       London Park no. 9
                     </td>
@@ -6987,7 +6957,37 @@ exports[`renders ./components/table/demo/fixed-columns-header.md correctly 1`] =
                       London Park no. 9
                     </td>
                     <td
-                      class="ant-table-fixed-columns-in-body ant-table-row-cell-break-word"
+                      class=""
+                    >
+                      London Park no. 9
+                    </td>
+                    <td
+                      class=""
+                    >
+                      London Park no. 9
+                    </td>
+                    <td
+                      class=""
+                    >
+                      London Park no. 9
+                    </td>
+                    <td
+                      class=""
+                    >
+                      London Park no. 9
+                    </td>
+                    <td
+                      class=""
+                    >
+                      London Park no. 9
+                    </td>
+                    <td
+                      class=""
+                    >
+                      London Park no. 9
+                    </td>
+                    <td
+                      class="ant-table-fixed-columns-in-body"
                     >
                       <a>
                         action
@@ -7020,7 +7020,7 @@ exports[`renders ./components/table/demo/fixed-columns-header.md correctly 1`] =
                 >
                   <tr>
                     <th
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       <span
                         class="ant-table-header-column"
@@ -7038,7 +7038,7 @@ exports[`renders ./components/table/demo/fixed-columns-header.md correctly 1`] =
                       </span>
                     </th>
                     <th
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       <span
                         class="ant-table-header-column"
@@ -7086,12 +7086,12 @@ exports[`renders ./components/table/demo/fixed-columns-header.md correctly 1`] =
                       data-row-key="0"
                     >
                       <td
-                        class="ant-table-row-cell-break-word"
+                        class=""
                       >
                         Edrward 0
                       </td>
                       <td
-                        class="ant-table-row-cell-break-word"
+                        class=""
                       >
                         32
                       </td>
@@ -7101,12 +7101,12 @@ exports[`renders ./components/table/demo/fixed-columns-header.md correctly 1`] =
                       data-row-key="1"
                     >
                       <td
-                        class="ant-table-row-cell-break-word"
+                        class=""
                       >
                         Edrward 1
                       </td>
                       <td
-                        class="ant-table-row-cell-break-word"
+                        class=""
                       >
                         32
                       </td>
@@ -7116,12 +7116,12 @@ exports[`renders ./components/table/demo/fixed-columns-header.md correctly 1`] =
                       data-row-key="2"
                     >
                       <td
-                        class="ant-table-row-cell-break-word"
+                        class=""
                       >
                         Edrward 2
                       </td>
                       <td
-                        class="ant-table-row-cell-break-word"
+                        class=""
                       >
                         32
                       </td>
@@ -7131,12 +7131,12 @@ exports[`renders ./components/table/demo/fixed-columns-header.md correctly 1`] =
                       data-row-key="3"
                     >
                       <td
-                        class="ant-table-row-cell-break-word"
+                        class=""
                       >
                         Edrward 3
                       </td>
                       <td
-                        class="ant-table-row-cell-break-word"
+                        class=""
                       >
                         32
                       </td>
@@ -7146,12 +7146,12 @@ exports[`renders ./components/table/demo/fixed-columns-header.md correctly 1`] =
                       data-row-key="4"
                     >
                       <td
-                        class="ant-table-row-cell-break-word"
+                        class=""
                       >
                         Edrward 4
                       </td>
                       <td
-                        class="ant-table-row-cell-break-word"
+                        class=""
                       >
                         32
                       </td>
@@ -7161,12 +7161,12 @@ exports[`renders ./components/table/demo/fixed-columns-header.md correctly 1`] =
                       data-row-key="5"
                     >
                       <td
-                        class="ant-table-row-cell-break-word"
+                        class=""
                       >
                         Edrward 5
                       </td>
                       <td
-                        class="ant-table-row-cell-break-word"
+                        class=""
                       >
                         32
                       </td>
@@ -7176,12 +7176,12 @@ exports[`renders ./components/table/demo/fixed-columns-header.md correctly 1`] =
                       data-row-key="6"
                     >
                       <td
-                        class="ant-table-row-cell-break-word"
+                        class=""
                       >
                         Edrward 6
                       </td>
                       <td
-                        class="ant-table-row-cell-break-word"
+                        class=""
                       >
                         32
                       </td>
@@ -7191,12 +7191,12 @@ exports[`renders ./components/table/demo/fixed-columns-header.md correctly 1`] =
                       data-row-key="7"
                     >
                       <td
-                        class="ant-table-row-cell-break-word"
+                        class=""
                       >
                         Edrward 7
                       </td>
                       <td
-                        class="ant-table-row-cell-break-word"
+                        class=""
                       >
                         32
                       </td>
@@ -7206,12 +7206,12 @@ exports[`renders ./components/table/demo/fixed-columns-header.md correctly 1`] =
                       data-row-key="8"
                     >
                       <td
-                        class="ant-table-row-cell-break-word"
+                        class=""
                       >
                         Edrward 8
                       </td>
                       <td
-                        class="ant-table-row-cell-break-word"
+                        class=""
                       >
                         32
                       </td>
@@ -7221,12 +7221,12 @@ exports[`renders ./components/table/demo/fixed-columns-header.md correctly 1`] =
                       data-row-key="9"
                     >
                       <td
-                        class="ant-table-row-cell-break-word"
+                        class=""
                       >
                         Edrward 9
                       </td>
                       <td
-                        class="ant-table-row-cell-break-word"
+                        class=""
                       >
                         32
                       </td>
@@ -7255,7 +7255,7 @@ exports[`renders ./components/table/demo/fixed-columns-header.md correctly 1`] =
                 >
                   <tr>
                     <th
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       <span
                         class="ant-table-header-column"
@@ -7300,7 +7300,7 @@ exports[`renders ./components/table/demo/fixed-columns-header.md correctly 1`] =
                       data-row-key="0"
                     >
                       <td
-                        class="ant-table-row-cell-break-word"
+                        class=""
                       >
                         <a>
                           action
@@ -7312,7 +7312,7 @@ exports[`renders ./components/table/demo/fixed-columns-header.md correctly 1`] =
                       data-row-key="1"
                     >
                       <td
-                        class="ant-table-row-cell-break-word"
+                        class=""
                       >
                         <a>
                           action
@@ -7324,7 +7324,7 @@ exports[`renders ./components/table/demo/fixed-columns-header.md correctly 1`] =
                       data-row-key="2"
                     >
                       <td
-                        class="ant-table-row-cell-break-word"
+                        class=""
                       >
                         <a>
                           action
@@ -7336,7 +7336,7 @@ exports[`renders ./components/table/demo/fixed-columns-header.md correctly 1`] =
                       data-row-key="3"
                     >
                       <td
-                        class="ant-table-row-cell-break-word"
+                        class=""
                       >
                         <a>
                           action
@@ -7348,7 +7348,7 @@ exports[`renders ./components/table/demo/fixed-columns-header.md correctly 1`] =
                       data-row-key="4"
                     >
                       <td
-                        class="ant-table-row-cell-break-word"
+                        class=""
                       >
                         <a>
                           action
@@ -7360,7 +7360,7 @@ exports[`renders ./components/table/demo/fixed-columns-header.md correctly 1`] =
                       data-row-key="5"
                     >
                       <td
-                        class="ant-table-row-cell-break-word"
+                        class=""
                       >
                         <a>
                           action
@@ -7372,7 +7372,7 @@ exports[`renders ./components/table/demo/fixed-columns-header.md correctly 1`] =
                       data-row-key="6"
                     >
                       <td
-                        class="ant-table-row-cell-break-word"
+                        class=""
                       >
                         <a>
                           action
@@ -7384,7 +7384,7 @@ exports[`renders ./components/table/demo/fixed-columns-header.md correctly 1`] =
                       data-row-key="7"
                     >
                       <td
-                        class="ant-table-row-cell-break-word"
+                        class=""
                       >
                         <a>
                           action
@@ -7396,7 +7396,7 @@ exports[`renders ./components/table/demo/fixed-columns-header.md correctly 1`] =
                       data-row-key="8"
                     >
                       <td
-                        class="ant-table-row-cell-break-word"
+                        class=""
                       >
                         <a>
                           action
@@ -7408,7 +7408,7 @@ exports[`renders ./components/table/demo/fixed-columns-header.md correctly 1`] =
                       data-row-key="9"
                     >
                       <td
-                        class="ant-table-row-cell-break-word"
+                        class=""
                       >
                         <a>
                           action
@@ -7594,7 +7594,7 @@ exports[`renders ./components/table/demo/fixed-header.md correctly 1`] = `
       class="ant-spin-container"
     >
       <div
-        class="ant-table ant-table-default ant-table-fixed-header ant-table-scroll-position-left ant-table-layout-fixed"
+        class="ant-table ant-table-default ant-table-fixed-header ant-table-scroll-position-left"
       >
         <div
           class="ant-table-content"
@@ -7622,7 +7622,7 @@ exports[`renders ./components/table/demo/fixed-header.md correctly 1`] = `
                 >
                   <tr>
                     <th
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       <span
                         class="ant-table-header-column"
@@ -7640,7 +7640,7 @@ exports[`renders ./components/table/demo/fixed-header.md correctly 1`] = `
                       </span>
                     </th>
                     <th
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       <span
                         class="ant-table-header-column"
@@ -7704,12 +7704,12 @@ exports[`renders ./components/table/demo/fixed-header.md correctly 1`] = `
                     data-row-key="0"
                   >
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       Edward King 0
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       32
                     </td>
@@ -7724,12 +7724,12 @@ exports[`renders ./components/table/demo/fixed-header.md correctly 1`] = `
                     data-row-key="1"
                   >
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       Edward King 1
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       32
                     </td>
@@ -7744,12 +7744,12 @@ exports[`renders ./components/table/demo/fixed-header.md correctly 1`] = `
                     data-row-key="2"
                   >
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       Edward King 2
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       32
                     </td>
@@ -7764,12 +7764,12 @@ exports[`renders ./components/table/demo/fixed-header.md correctly 1`] = `
                     data-row-key="3"
                   >
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       Edward King 3
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       32
                     </td>
@@ -7784,12 +7784,12 @@ exports[`renders ./components/table/demo/fixed-header.md correctly 1`] = `
                     data-row-key="4"
                   >
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       Edward King 4
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       32
                     </td>
@@ -7804,12 +7804,12 @@ exports[`renders ./components/table/demo/fixed-header.md correctly 1`] = `
                     data-row-key="5"
                   >
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       Edward King 5
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       32
                     </td>
@@ -7824,12 +7824,12 @@ exports[`renders ./components/table/demo/fixed-header.md correctly 1`] = `
                     data-row-key="6"
                   >
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       Edward King 6
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       32
                     </td>
@@ -7844,12 +7844,12 @@ exports[`renders ./components/table/demo/fixed-header.md correctly 1`] = `
                     data-row-key="7"
                   >
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       Edward King 7
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       32
                     </td>
@@ -7864,12 +7864,12 @@ exports[`renders ./components/table/demo/fixed-header.md correctly 1`] = `
                     data-row-key="8"
                   >
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       Edward King 8
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       32
                     </td>
@@ -7884,12 +7884,12 @@ exports[`renders ./components/table/demo/fixed-header.md correctly 1`] = `
                     data-row-key="9"
                   >
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       Edward King 9
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       32
                     </td>
@@ -7904,12 +7904,12 @@ exports[`renders ./components/table/demo/fixed-header.md correctly 1`] = `
                     data-row-key="10"
                   >
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       Edward King 10
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       32
                     </td>
@@ -7924,12 +7924,12 @@ exports[`renders ./components/table/demo/fixed-header.md correctly 1`] = `
                     data-row-key="11"
                   >
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       Edward King 11
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       32
                     </td>
@@ -7944,12 +7944,12 @@ exports[`renders ./components/table/demo/fixed-header.md correctly 1`] = `
                     data-row-key="12"
                   >
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       Edward King 12
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       32
                     </td>
@@ -7964,12 +7964,12 @@ exports[`renders ./components/table/demo/fixed-header.md correctly 1`] = `
                     data-row-key="13"
                   >
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       Edward King 13
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       32
                     </td>
@@ -7984,12 +7984,12 @@ exports[`renders ./components/table/demo/fixed-header.md correctly 1`] = `
                     data-row-key="14"
                   >
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       Edward King 14
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       32
                     </td>
@@ -8004,12 +8004,12 @@ exports[`renders ./components/table/demo/fixed-header.md correctly 1`] = `
                     data-row-key="15"
                   >
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       Edward King 15
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       32
                     </td>
@@ -8024,12 +8024,12 @@ exports[`renders ./components/table/demo/fixed-header.md correctly 1`] = `
                     data-row-key="16"
                   >
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       Edward King 16
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       32
                     </td>
@@ -8044,12 +8044,12 @@ exports[`renders ./components/table/demo/fixed-header.md correctly 1`] = `
                     data-row-key="17"
                   >
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       Edward King 17
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       32
                     </td>
@@ -8064,12 +8064,12 @@ exports[`renders ./components/table/demo/fixed-header.md correctly 1`] = `
                     data-row-key="18"
                   >
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       Edward King 18
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       32
                     </td>
@@ -8084,12 +8084,12 @@ exports[`renders ./components/table/demo/fixed-header.md correctly 1`] = `
                     data-row-key="19"
                   >
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       Edward King 19
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       32
                     </td>
@@ -8104,12 +8104,12 @@ exports[`renders ./components/table/demo/fixed-header.md correctly 1`] = `
                     data-row-key="20"
                   >
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       Edward King 20
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       32
                     </td>
@@ -8124,12 +8124,12 @@ exports[`renders ./components/table/demo/fixed-header.md correctly 1`] = `
                     data-row-key="21"
                   >
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       Edward King 21
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       32
                     </td>
@@ -8144,12 +8144,12 @@ exports[`renders ./components/table/demo/fixed-header.md correctly 1`] = `
                     data-row-key="22"
                   >
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       Edward King 22
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       32
                     </td>
@@ -8164,12 +8164,12 @@ exports[`renders ./components/table/demo/fixed-header.md correctly 1`] = `
                     data-row-key="23"
                   >
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       Edward King 23
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       32
                     </td>
@@ -8184,12 +8184,12 @@ exports[`renders ./components/table/demo/fixed-header.md correctly 1`] = `
                     data-row-key="24"
                   >
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       Edward King 24
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       32
                     </td>
@@ -8204,12 +8204,12 @@ exports[`renders ./components/table/demo/fixed-header.md correctly 1`] = `
                     data-row-key="25"
                   >
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       Edward King 25
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       32
                     </td>
@@ -8224,12 +8224,12 @@ exports[`renders ./components/table/demo/fixed-header.md correctly 1`] = `
                     data-row-key="26"
                   >
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       Edward King 26
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       32
                     </td>
@@ -8244,12 +8244,12 @@ exports[`renders ./components/table/demo/fixed-header.md correctly 1`] = `
                     data-row-key="27"
                   >
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       Edward King 27
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       32
                     </td>
@@ -8264,12 +8264,12 @@ exports[`renders ./components/table/demo/fixed-header.md correctly 1`] = `
                     data-row-key="28"
                   >
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       Edward King 28
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       32
                     </td>
@@ -8284,12 +8284,12 @@ exports[`renders ./components/table/demo/fixed-header.md correctly 1`] = `
                     data-row-key="29"
                   >
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       Edward King 29
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       32
                     </td>
@@ -8304,12 +8304,12 @@ exports[`renders ./components/table/demo/fixed-header.md correctly 1`] = `
                     data-row-key="30"
                   >
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       Edward King 30
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       32
                     </td>
@@ -8324,12 +8324,12 @@ exports[`renders ./components/table/demo/fixed-header.md correctly 1`] = `
                     data-row-key="31"
                   >
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       Edward King 31
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       32
                     </td>
@@ -8344,12 +8344,12 @@ exports[`renders ./components/table/demo/fixed-header.md correctly 1`] = `
                     data-row-key="32"
                   >
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       Edward King 32
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       32
                     </td>
@@ -8364,12 +8364,12 @@ exports[`renders ./components/table/demo/fixed-header.md correctly 1`] = `
                     data-row-key="33"
                   >
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       Edward King 33
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       32
                     </td>
@@ -8384,12 +8384,12 @@ exports[`renders ./components/table/demo/fixed-header.md correctly 1`] = `
                     data-row-key="34"
                   >
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       Edward King 34
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       32
                     </td>
@@ -8404,12 +8404,12 @@ exports[`renders ./components/table/demo/fixed-header.md correctly 1`] = `
                     data-row-key="35"
                   >
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       Edward King 35
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       32
                     </td>
@@ -8424,12 +8424,12 @@ exports[`renders ./components/table/demo/fixed-header.md correctly 1`] = `
                     data-row-key="36"
                   >
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       Edward King 36
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       32
                     </td>
@@ -8444,12 +8444,12 @@ exports[`renders ./components/table/demo/fixed-header.md correctly 1`] = `
                     data-row-key="37"
                   >
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       Edward King 37
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       32
                     </td>
@@ -8464,12 +8464,12 @@ exports[`renders ./components/table/demo/fixed-header.md correctly 1`] = `
                     data-row-key="38"
                   >
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       Edward King 38
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       32
                     </td>
@@ -8484,12 +8484,12 @@ exports[`renders ./components/table/demo/fixed-header.md correctly 1`] = `
                     data-row-key="39"
                   >
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       Edward King 39
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       32
                     </td>
@@ -8504,12 +8504,12 @@ exports[`renders ./components/table/demo/fixed-header.md correctly 1`] = `
                     data-row-key="40"
                   >
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       Edward King 40
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       32
                     </td>
@@ -8524,12 +8524,12 @@ exports[`renders ./components/table/demo/fixed-header.md correctly 1`] = `
                     data-row-key="41"
                   >
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       Edward King 41
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       32
                     </td>
@@ -8544,12 +8544,12 @@ exports[`renders ./components/table/demo/fixed-header.md correctly 1`] = `
                     data-row-key="42"
                   >
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       Edward King 42
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       32
                     </td>
@@ -8564,12 +8564,12 @@ exports[`renders ./components/table/demo/fixed-header.md correctly 1`] = `
                     data-row-key="43"
                   >
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       Edward King 43
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       32
                     </td>
@@ -8584,12 +8584,12 @@ exports[`renders ./components/table/demo/fixed-header.md correctly 1`] = `
                     data-row-key="44"
                   >
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       Edward King 44
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       32
                     </td>
@@ -8604,12 +8604,12 @@ exports[`renders ./components/table/demo/fixed-header.md correctly 1`] = `
                     data-row-key="45"
                   >
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       Edward King 45
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       32
                     </td>
@@ -8624,12 +8624,12 @@ exports[`renders ./components/table/demo/fixed-header.md correctly 1`] = `
                     data-row-key="46"
                   >
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       Edward King 46
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       32
                     </td>
@@ -8644,12 +8644,12 @@ exports[`renders ./components/table/demo/fixed-header.md correctly 1`] = `
                     data-row-key="47"
                   >
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       Edward King 47
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       32
                     </td>
@@ -8664,12 +8664,12 @@ exports[`renders ./components/table/demo/fixed-header.md correctly 1`] = `
                     data-row-key="48"
                   >
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       Edward King 48
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       32
                     </td>
@@ -8684,12 +8684,12 @@ exports[`renders ./components/table/demo/fixed-header.md correctly 1`] = `
                     data-row-key="49"
                   >
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       Edward King 49
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       32
                     </td>
@@ -8803,7 +8803,7 @@ exports[`renders ./components/table/demo/grouping-columns.md correctly 1`] = `
       class="ant-spin-container"
     >
       <div
-        class="ant-table ant-table-middle ant-table-bordered ant-table-fixed-header ant-table-scroll-position-left ant-table-layout-fixed"
+        class="ant-table ant-table-middle ant-table-bordered ant-table-fixed-header ant-table-scroll-position-left"
       >
         <div
           class="ant-table-content"
@@ -8847,7 +8847,7 @@ exports[`renders ./components/table/demo/grouping-columns.md correctly 1`] = `
                 >
                   <tr>
                     <th
-                      class="ant-table-fixed-columns-in-body ant-table-column-has-actions ant-table-column-has-filters ant-table-row-cell-break-word"
+                      class="ant-table-fixed-columns-in-body ant-table-column-has-actions ant-table-column-has-filters"
                       rowspan="4"
                     >
                       <span
@@ -8925,7 +8925,7 @@ exports[`renders ./components/table/demo/grouping-columns.md correctly 1`] = `
                       </span>
                     </th>
                     <th
-                      class="ant-table-fixed-columns-in-body ant-table-row-cell-break-word"
+                      class="ant-table-fixed-columns-in-body"
                       rowspan="4"
                     >
                       <span
@@ -8946,7 +8946,7 @@ exports[`renders ./components/table/demo/grouping-columns.md correctly 1`] = `
                   </tr>
                   <tr>
                     <th
-                      class="ant-table-column-has-actions ant-table-column-has-sorters ant-table-row-cell-break-word"
+                      class="ant-table-column-has-actions ant-table-column-has-sorters"
                       rowspan="3"
                     >
                       <span
@@ -9030,7 +9030,7 @@ exports[`renders ./components/table/demo/grouping-columns.md correctly 1`] = `
                       </span>
                     </th>
                     <th
-                      class="ant-table-row-cell-break-word"
+                      class=""
                       rowspan="3"
                     >
                       <span
@@ -9070,7 +9070,7 @@ exports[`renders ./components/table/demo/grouping-columns.md correctly 1`] = `
                   </tr>
                   <tr>
                     <th
-                      class="ant-table-row-cell-break-word"
+                      class=""
                       rowspan="2"
                     >
                       <span
@@ -9110,7 +9110,7 @@ exports[`renders ./components/table/demo/grouping-columns.md correctly 1`] = `
                   </tr>
                   <tr>
                     <th
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       <span
                         class="ant-table-header-column"
@@ -9128,7 +9128,7 @@ exports[`renders ./components/table/demo/grouping-columns.md correctly 1`] = `
                       </span>
                     </th>
                     <th
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       <span
                         class="ant-table-header-column"
@@ -9190,32 +9190,32 @@ exports[`renders ./components/table/demo/grouping-columns.md correctly 1`] = `
                     data-row-key="0"
                   >
                     <td
-                      class="ant-table-fixed-columns-in-body ant-table-column-has-actions ant-table-column-has-filters ant-table-row-cell-break-word"
+                      class="ant-table-fixed-columns-in-body ant-table-column-has-actions ant-table-column-has-filters"
                     >
                       John Brown
                     </td>
                     <td
-                      class="ant-table-column-has-actions ant-table-column-has-sorters ant-table-row-cell-break-word"
+                      class="ant-table-column-has-actions ant-table-column-has-sorters"
                     >
                       1
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       Lake Park
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       C
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       2035
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       Lake Street 42
                     </td>
@@ -9225,7 +9225,7 @@ exports[`renders ./components/table/demo/grouping-columns.md correctly 1`] = `
                       SoftLake Co
                     </td>
                     <td
-                      class="ant-table-fixed-columns-in-body ant-table-row-cell-break-word"
+                      class="ant-table-fixed-columns-in-body"
                     >
                       M
                     </td>
@@ -9235,32 +9235,32 @@ exports[`renders ./components/table/demo/grouping-columns.md correctly 1`] = `
                     data-row-key="1"
                   >
                     <td
-                      class="ant-table-fixed-columns-in-body ant-table-column-has-actions ant-table-column-has-filters ant-table-row-cell-break-word"
+                      class="ant-table-fixed-columns-in-body ant-table-column-has-actions ant-table-column-has-filters"
                     >
                       John Brown
                     </td>
                     <td
-                      class="ant-table-column-has-actions ant-table-column-has-sorters ant-table-row-cell-break-word"
+                      class="ant-table-column-has-actions ant-table-column-has-sorters"
                     >
                       2
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       Lake Park
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       C
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       2035
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       Lake Street 42
                     </td>
@@ -9270,7 +9270,7 @@ exports[`renders ./components/table/demo/grouping-columns.md correctly 1`] = `
                       SoftLake Co
                     </td>
                     <td
-                      class="ant-table-fixed-columns-in-body ant-table-row-cell-break-word"
+                      class="ant-table-fixed-columns-in-body"
                     >
                       M
                     </td>
@@ -9280,32 +9280,32 @@ exports[`renders ./components/table/demo/grouping-columns.md correctly 1`] = `
                     data-row-key="2"
                   >
                     <td
-                      class="ant-table-fixed-columns-in-body ant-table-column-has-actions ant-table-column-has-filters ant-table-row-cell-break-word"
+                      class="ant-table-fixed-columns-in-body ant-table-column-has-actions ant-table-column-has-filters"
                     >
                       John Brown
                     </td>
                     <td
-                      class="ant-table-column-has-actions ant-table-column-has-sorters ant-table-row-cell-break-word"
+                      class="ant-table-column-has-actions ant-table-column-has-sorters"
                     >
                       3
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       Lake Park
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       C
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       2035
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       Lake Street 42
                     </td>
@@ -9315,7 +9315,7 @@ exports[`renders ./components/table/demo/grouping-columns.md correctly 1`] = `
                       SoftLake Co
                     </td>
                     <td
-                      class="ant-table-fixed-columns-in-body ant-table-row-cell-break-word"
+                      class="ant-table-fixed-columns-in-body"
                     >
                       M
                     </td>
@@ -9325,32 +9325,32 @@ exports[`renders ./components/table/demo/grouping-columns.md correctly 1`] = `
                     data-row-key="3"
                   >
                     <td
-                      class="ant-table-fixed-columns-in-body ant-table-column-has-actions ant-table-column-has-filters ant-table-row-cell-break-word"
+                      class="ant-table-fixed-columns-in-body ant-table-column-has-actions ant-table-column-has-filters"
                     >
                       John Brown
                     </td>
                     <td
-                      class="ant-table-column-has-actions ant-table-column-has-sorters ant-table-row-cell-break-word"
+                      class="ant-table-column-has-actions ant-table-column-has-sorters"
                     >
                       4
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       Lake Park
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       C
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       2035
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       Lake Street 42
                     </td>
@@ -9360,7 +9360,7 @@ exports[`renders ./components/table/demo/grouping-columns.md correctly 1`] = `
                       SoftLake Co
                     </td>
                     <td
-                      class="ant-table-fixed-columns-in-body ant-table-row-cell-break-word"
+                      class="ant-table-fixed-columns-in-body"
                     >
                       M
                     </td>
@@ -9370,32 +9370,32 @@ exports[`renders ./components/table/demo/grouping-columns.md correctly 1`] = `
                     data-row-key="4"
                   >
                     <td
-                      class="ant-table-fixed-columns-in-body ant-table-column-has-actions ant-table-column-has-filters ant-table-row-cell-break-word"
+                      class="ant-table-fixed-columns-in-body ant-table-column-has-actions ant-table-column-has-filters"
                     >
                       John Brown
                     </td>
                     <td
-                      class="ant-table-column-has-actions ant-table-column-has-sorters ant-table-row-cell-break-word"
+                      class="ant-table-column-has-actions ant-table-column-has-sorters"
                     >
                       5
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       Lake Park
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       C
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       2035
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       Lake Street 42
                     </td>
@@ -9405,7 +9405,7 @@ exports[`renders ./components/table/demo/grouping-columns.md correctly 1`] = `
                       SoftLake Co
                     </td>
                     <td
-                      class="ant-table-fixed-columns-in-body ant-table-row-cell-break-word"
+                      class="ant-table-fixed-columns-in-body"
                     >
                       M
                     </td>
@@ -9415,32 +9415,32 @@ exports[`renders ./components/table/demo/grouping-columns.md correctly 1`] = `
                     data-row-key="5"
                   >
                     <td
-                      class="ant-table-fixed-columns-in-body ant-table-column-has-actions ant-table-column-has-filters ant-table-row-cell-break-word"
+                      class="ant-table-fixed-columns-in-body ant-table-column-has-actions ant-table-column-has-filters"
                     >
                       John Brown
                     </td>
                     <td
-                      class="ant-table-column-has-actions ant-table-column-has-sorters ant-table-row-cell-break-word"
+                      class="ant-table-column-has-actions ant-table-column-has-sorters"
                     >
                       6
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       Lake Park
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       C
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       2035
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       Lake Street 42
                     </td>
@@ -9450,7 +9450,7 @@ exports[`renders ./components/table/demo/grouping-columns.md correctly 1`] = `
                       SoftLake Co
                     </td>
                     <td
-                      class="ant-table-fixed-columns-in-body ant-table-row-cell-break-word"
+                      class="ant-table-fixed-columns-in-body"
                     >
                       M
                     </td>
@@ -9460,32 +9460,32 @@ exports[`renders ./components/table/demo/grouping-columns.md correctly 1`] = `
                     data-row-key="6"
                   >
                     <td
-                      class="ant-table-fixed-columns-in-body ant-table-column-has-actions ant-table-column-has-filters ant-table-row-cell-break-word"
+                      class="ant-table-fixed-columns-in-body ant-table-column-has-actions ant-table-column-has-filters"
                     >
                       John Brown
                     </td>
                     <td
-                      class="ant-table-column-has-actions ant-table-column-has-sorters ant-table-row-cell-break-word"
+                      class="ant-table-column-has-actions ant-table-column-has-sorters"
                     >
                       7
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       Lake Park
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       C
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       2035
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       Lake Street 42
                     </td>
@@ -9495,7 +9495,7 @@ exports[`renders ./components/table/demo/grouping-columns.md correctly 1`] = `
                       SoftLake Co
                     </td>
                     <td
-                      class="ant-table-fixed-columns-in-body ant-table-row-cell-break-word"
+                      class="ant-table-fixed-columns-in-body"
                     >
                       M
                     </td>
@@ -9505,32 +9505,32 @@ exports[`renders ./components/table/demo/grouping-columns.md correctly 1`] = `
                     data-row-key="7"
                   >
                     <td
-                      class="ant-table-fixed-columns-in-body ant-table-column-has-actions ant-table-column-has-filters ant-table-row-cell-break-word"
+                      class="ant-table-fixed-columns-in-body ant-table-column-has-actions ant-table-column-has-filters"
                     >
                       John Brown
                     </td>
                     <td
-                      class="ant-table-column-has-actions ant-table-column-has-sorters ant-table-row-cell-break-word"
+                      class="ant-table-column-has-actions ant-table-column-has-sorters"
                     >
                       8
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       Lake Park
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       C
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       2035
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       Lake Street 42
                     </td>
@@ -9540,7 +9540,7 @@ exports[`renders ./components/table/demo/grouping-columns.md correctly 1`] = `
                       SoftLake Co
                     </td>
                     <td
-                      class="ant-table-fixed-columns-in-body ant-table-row-cell-break-word"
+                      class="ant-table-fixed-columns-in-body"
                     >
                       M
                     </td>
@@ -9550,32 +9550,32 @@ exports[`renders ./components/table/demo/grouping-columns.md correctly 1`] = `
                     data-row-key="8"
                   >
                     <td
-                      class="ant-table-fixed-columns-in-body ant-table-column-has-actions ant-table-column-has-filters ant-table-row-cell-break-word"
+                      class="ant-table-fixed-columns-in-body ant-table-column-has-actions ant-table-column-has-filters"
                     >
                       John Brown
                     </td>
                     <td
-                      class="ant-table-column-has-actions ant-table-column-has-sorters ant-table-row-cell-break-word"
+                      class="ant-table-column-has-actions ant-table-column-has-sorters"
                     >
                       9
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       Lake Park
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       C
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       2035
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       Lake Street 42
                     </td>
@@ -9585,7 +9585,7 @@ exports[`renders ./components/table/demo/grouping-columns.md correctly 1`] = `
                       SoftLake Co
                     </td>
                     <td
-                      class="ant-table-fixed-columns-in-body ant-table-row-cell-break-word"
+                      class="ant-table-fixed-columns-in-body"
                     >
                       M
                     </td>
@@ -9595,32 +9595,32 @@ exports[`renders ./components/table/demo/grouping-columns.md correctly 1`] = `
                     data-row-key="9"
                   >
                     <td
-                      class="ant-table-fixed-columns-in-body ant-table-column-has-actions ant-table-column-has-filters ant-table-row-cell-break-word"
+                      class="ant-table-fixed-columns-in-body ant-table-column-has-actions ant-table-column-has-filters"
                     >
                       John Brown
                     </td>
                     <td
-                      class="ant-table-column-has-actions ant-table-column-has-sorters ant-table-row-cell-break-word"
+                      class="ant-table-column-has-actions ant-table-column-has-sorters"
                     >
                       10
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       Lake Park
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       C
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       2035
                     </td>
                     <td
-                      class="ant-table-row-cell-break-word"
+                      class=""
                     >
                       Lake Street 42
                     </td>
@@ -9630,7 +9630,7 @@ exports[`renders ./components/table/demo/grouping-columns.md correctly 1`] = `
                       SoftLake Co
                     </td>
                     <td
-                      class="ant-table-fixed-columns-in-body ant-table-row-cell-break-word"
+                      class="ant-table-fixed-columns-in-body"
                     >
                       M
                     </td>
@@ -9658,7 +9658,7 @@ exports[`renders ./components/table/demo/grouping-columns.md correctly 1`] = `
                 >
                   <tr>
                     <th
-                      class="ant-table-column-has-actions ant-table-column-has-filters ant-table-row-cell-break-word"
+                      class="ant-table-column-has-actions ant-table-column-has-filters"
                       rowspan="4"
                     >
                       <span
@@ -9725,7 +9725,7 @@ exports[`renders ./components/table/demo/grouping-columns.md correctly 1`] = `
                       data-row-key="0"
                     >
                       <td
-                        class="ant-table-column-has-actions ant-table-column-has-filters ant-table-row-cell-break-word"
+                        class="ant-table-column-has-actions ant-table-column-has-filters"
                       >
                         John Brown
                       </td>
@@ -9735,7 +9735,7 @@ exports[`renders ./components/table/demo/grouping-columns.md correctly 1`] = `
                       data-row-key="1"
                     >
                       <td
-                        class="ant-table-column-has-actions ant-table-column-has-filters ant-table-row-cell-break-word"
+                        class="ant-table-column-has-actions ant-table-column-has-filters"
                       >
                         John Brown
                       </td>
@@ -9745,7 +9745,7 @@ exports[`renders ./components/table/demo/grouping-columns.md correctly 1`] = `
                       data-row-key="2"
                     >
                       <td
-                        class="ant-table-column-has-actions ant-table-column-has-filters ant-table-row-cell-break-word"
+                        class="ant-table-column-has-actions ant-table-column-has-filters"
                       >
                         John Brown
                       </td>
@@ -9755,7 +9755,7 @@ exports[`renders ./components/table/demo/grouping-columns.md correctly 1`] = `
                       data-row-key="3"
                     >
                       <td
-                        class="ant-table-column-has-actions ant-table-column-has-filters ant-table-row-cell-break-word"
+                        class="ant-table-column-has-actions ant-table-column-has-filters"
                       >
                         John Brown
                       </td>
@@ -9765,7 +9765,7 @@ exports[`renders ./components/table/demo/grouping-columns.md correctly 1`] = `
                       data-row-key="4"
                     >
                       <td
-                        class="ant-table-column-has-actions ant-table-column-has-filters ant-table-row-cell-break-word"
+                        class="ant-table-column-has-actions ant-table-column-has-filters"
                       >
                         John Brown
                       </td>
@@ -9775,7 +9775,7 @@ exports[`renders ./components/table/demo/grouping-columns.md correctly 1`] = `
                       data-row-key="5"
                     >
                       <td
-                        class="ant-table-column-has-actions ant-table-column-has-filters ant-table-row-cell-break-word"
+                        class="ant-table-column-has-actions ant-table-column-has-filters"
                       >
                         John Brown
                       </td>
@@ -9785,7 +9785,7 @@ exports[`renders ./components/table/demo/grouping-columns.md correctly 1`] = `
                       data-row-key="6"
                     >
                       <td
-                        class="ant-table-column-has-actions ant-table-column-has-filters ant-table-row-cell-break-word"
+                        class="ant-table-column-has-actions ant-table-column-has-filters"
                       >
                         John Brown
                       </td>
@@ -9795,7 +9795,7 @@ exports[`renders ./components/table/demo/grouping-columns.md correctly 1`] = `
                       data-row-key="7"
                     >
                       <td
-                        class="ant-table-column-has-actions ant-table-column-has-filters ant-table-row-cell-break-word"
+                        class="ant-table-column-has-actions ant-table-column-has-filters"
                       >
                         John Brown
                       </td>
@@ -9805,7 +9805,7 @@ exports[`renders ./components/table/demo/grouping-columns.md correctly 1`] = `
                       data-row-key="8"
                     >
                       <td
-                        class="ant-table-column-has-actions ant-table-column-has-filters ant-table-row-cell-break-word"
+                        class="ant-table-column-has-actions ant-table-column-has-filters"
                       >
                         John Brown
                       </td>
@@ -9815,7 +9815,7 @@ exports[`renders ./components/table/demo/grouping-columns.md correctly 1`] = `
                       data-row-key="9"
                     >
                       <td
-                        class="ant-table-column-has-actions ant-table-column-has-filters ant-table-row-cell-break-word"
+                        class="ant-table-column-has-actions ant-table-column-has-filters"
                       >
                         John Brown
                       </td>
@@ -9844,7 +9844,7 @@ exports[`renders ./components/table/demo/grouping-columns.md correctly 1`] = `
                 >
                   <tr>
                     <th
-                      class="ant-table-row-cell-break-word"
+                      class=""
                       rowspan="4"
                     >
                       <span
@@ -9890,7 +9890,7 @@ exports[`renders ./components/table/demo/grouping-columns.md correctly 1`] = `
                       data-row-key="0"
                     >
                       <td
-                        class="ant-table-row-cell-break-word"
+                        class=""
                       >
                         M
                       </td>
@@ -9900,7 +9900,7 @@ exports[`renders ./components/table/demo/grouping-columns.md correctly 1`] = `
                       data-row-key="1"
                     >
                       <td
-                        class="ant-table-row-cell-break-word"
+                        class=""
                       >
                         M
                       </td>
@@ -9910,7 +9910,7 @@ exports[`renders ./components/table/demo/grouping-columns.md correctly 1`] = `
                       data-row-key="2"
                     >
                       <td
-                        class="ant-table-row-cell-break-word"
+                        class=""
                       >
                         M
                       </td>
@@ -9920,7 +9920,7 @@ exports[`renders ./components/table/demo/grouping-columns.md correctly 1`] = `
                       data-row-key="3"
                     >
                       <td
-                        class="ant-table-row-cell-break-word"
+                        class=""
                       >
                         M
                       </td>
@@ -9930,7 +9930,7 @@ exports[`renders ./components/table/demo/grouping-columns.md correctly 1`] = `
                       data-row-key="4"
                     >
                       <td
-                        class="ant-table-row-cell-break-word"
+                        class=""
                       >
                         M
                       </td>
@@ -9940,7 +9940,7 @@ exports[`renders ./components/table/demo/grouping-columns.md correctly 1`] = `
                       data-row-key="5"
                     >
                       <td
-                        class="ant-table-row-cell-break-word"
+                        class=""
                       >
                         M
                       </td>
@@ -9950,7 +9950,7 @@ exports[`renders ./components/table/demo/grouping-columns.md correctly 1`] = `
                       data-row-key="6"
                     >
                       <td
-                        class="ant-table-row-cell-break-word"
+                        class=""
                       >
                         M
                       </td>
@@ -9960,7 +9960,7 @@ exports[`renders ./components/table/demo/grouping-columns.md correctly 1`] = `
                       data-row-key="7"
                     >
                       <td
-                        class="ant-table-row-cell-break-word"
+                        class=""
                       >
                         M
                       </td>
@@ -9970,7 +9970,7 @@ exports[`renders ./components/table/demo/grouping-columns.md correctly 1`] = `
                       data-row-key="8"
                     >
                       <td
-                        class="ant-table-row-cell-break-word"
+                        class=""
                       >
                         M
                       </td>
@@ -9980,7 +9980,7 @@ exports[`renders ./components/table/demo/grouping-columns.md correctly 1`] = `
                       data-row-key="9"
                     >
                       <td
-                        class="ant-table-row-cell-break-word"
+                        class=""
                       >
                         M
                       </td>
@@ -11438,7 +11438,7 @@ exports[`renders ./components/table/demo/reset-filter.md correctly 1`] = `
         class="ant-spin-container"
       >
         <div
-          class="ant-table ant-table-default ant-table-scroll-position-left ant-table-layout-fixed"
+          class="ant-table ant-table-default ant-table-scroll-position-left"
         >
           <div
             class="ant-table-content"
@@ -11459,7 +11459,7 @@ exports[`renders ./components/table/demo/reset-filter.md correctly 1`] = `
                 >
                   <tr>
                     <th
-                      class="ant-table-column-has-actions ant-table-column-has-filters ant-table-column-has-sorters ant-table-row-cell-ellipsis"
+                      class="ant-table-column-has-actions ant-table-column-has-filters ant-table-column-has-sorters"
                     >
                       <span
                         class="ant-table-header-column"
@@ -11544,7 +11544,7 @@ exports[`renders ./components/table/demo/reset-filter.md correctly 1`] = `
                       </i>
                     </th>
                     <th
-                      class="ant-table-column-has-actions ant-table-column-has-sorters ant-table-row-cell-ellipsis"
+                      class="ant-table-column-has-actions ant-table-column-has-sorters"
                     >
                       <span
                         class="ant-table-header-column"
@@ -11608,7 +11608,7 @@ exports[`renders ./components/table/demo/reset-filter.md correctly 1`] = `
                       </span>
                     </th>
                     <th
-                      class="ant-table-column-has-actions ant-table-column-has-filters ant-table-column-has-sorters ant-table-row-cell-ellipsis"
+                      class="ant-table-column-has-actions ant-table-column-has-filters ant-table-column-has-sorters"
                     >
                       <span
                         class="ant-table-header-column"
@@ -11702,17 +11702,17 @@ exports[`renders ./components/table/demo/reset-filter.md correctly 1`] = `
                     data-row-key="1"
                   >
                     <td
-                      class="ant-table-column-has-actions ant-table-column-has-filters ant-table-column-has-sorters ant-table-row-cell-ellipsis"
+                      class="ant-table-column-has-actions ant-table-column-has-filters ant-table-column-has-sorters"
                     >
                       John Brown
                     </td>
                     <td
-                      class="ant-table-column-has-actions ant-table-column-has-sorters ant-table-row-cell-ellipsis"
+                      class="ant-table-column-has-actions ant-table-column-has-sorters"
                     >
                       32
                     </td>
                     <td
-                      class="ant-table-column-has-actions ant-table-column-has-filters ant-table-column-has-sorters ant-table-row-cell-ellipsis"
+                      class="ant-table-column-has-actions ant-table-column-has-filters ant-table-column-has-sorters"
                     >
                       New York No. 1 Lake Park
                     </td>
@@ -11722,17 +11722,17 @@ exports[`renders ./components/table/demo/reset-filter.md correctly 1`] = `
                     data-row-key="2"
                   >
                     <td
-                      class="ant-table-column-has-actions ant-table-column-has-filters ant-table-column-has-sorters ant-table-row-cell-ellipsis"
+                      class="ant-table-column-has-actions ant-table-column-has-filters ant-table-column-has-sorters"
                     >
                       Jim Green
                     </td>
                     <td
-                      class="ant-table-column-has-actions ant-table-column-has-sorters ant-table-row-cell-ellipsis"
+                      class="ant-table-column-has-actions ant-table-column-has-sorters"
                     >
                       42
                     </td>
                     <td
-                      class="ant-table-column-has-actions ant-table-column-has-filters ant-table-column-has-sorters ant-table-row-cell-ellipsis"
+                      class="ant-table-column-has-actions ant-table-column-has-filters ant-table-column-has-sorters"
                     >
                       London No. 1 Lake Park
                     </td>
@@ -11742,17 +11742,17 @@ exports[`renders ./components/table/demo/reset-filter.md correctly 1`] = `
                     data-row-key="3"
                   >
                     <td
-                      class="ant-table-column-has-actions ant-table-column-has-filters ant-table-column-has-sorters ant-table-row-cell-ellipsis"
+                      class="ant-table-column-has-actions ant-table-column-has-filters ant-table-column-has-sorters"
                     >
                       Joe Black
                     </td>
                     <td
-                      class="ant-table-column-has-actions ant-table-column-has-sorters ant-table-row-cell-ellipsis"
+                      class="ant-table-column-has-actions ant-table-column-has-sorters"
                     >
                       32
                     </td>
                     <td
-                      class="ant-table-column-has-actions ant-table-column-has-filters ant-table-column-has-sorters ant-table-row-cell-ellipsis"
+                      class="ant-table-column-has-actions ant-table-column-has-filters ant-table-column-has-sorters"
                     >
                       Sidney No. 1 Lake Park
                     </td>
@@ -11762,17 +11762,17 @@ exports[`renders ./components/table/demo/reset-filter.md correctly 1`] = `
                     data-row-key="4"
                   >
                     <td
-                      class="ant-table-column-has-actions ant-table-column-has-filters ant-table-column-has-sorters ant-table-row-cell-ellipsis"
+                      class="ant-table-column-has-actions ant-table-column-has-filters ant-table-column-has-sorters"
                     >
                       Jim Red
                     </td>
                     <td
-                      class="ant-table-column-has-actions ant-table-column-has-sorters ant-table-row-cell-ellipsis"
+                      class="ant-table-column-has-actions ant-table-column-has-sorters"
                     >
                       32
                     </td>
                     <td
-                      class="ant-table-column-has-actions ant-table-column-has-filters ant-table-column-has-sorters ant-table-row-cell-ellipsis"
+                      class="ant-table-column-has-actions ant-table-column-has-filters ant-table-column-has-sorters"
                     >
                       London No. 2 Lake Park
                     </td>
@@ -11902,7 +11902,7 @@ exports[`renders ./components/table/demo/resizable-column.md correctly 1`] = `
               >
                 <tr>
                   <th
-                    class="ant-table-row-cell-break-word react-resizable"
+                    class="react-resizable"
                   >
                     <span
                       class="ant-table-header-column"
@@ -11924,7 +11924,7 @@ exports[`renders ./components/table/demo/resizable-column.md correctly 1`] = `
                     />
                   </th>
                   <th
-                    class="ant-table-row-cell-break-word react-resizable"
+                    class="react-resizable"
                   >
                     <span
                       class="ant-table-header-column"
@@ -11946,7 +11946,7 @@ exports[`renders ./components/table/demo/resizable-column.md correctly 1`] = `
                     />
                   </th>
                   <th
-                    class="ant-table-row-cell-break-word react-resizable"
+                    class="react-resizable"
                   >
                     <span
                       class="ant-table-header-column"
@@ -11968,7 +11968,7 @@ exports[`renders ./components/table/demo/resizable-column.md correctly 1`] = `
                     />
                   </th>
                   <th
-                    class="ant-table-row-cell-break-word react-resizable"
+                    class="react-resizable"
                   >
                     <span
                       class="ant-table-header-column"
@@ -12017,22 +12017,22 @@ exports[`renders ./components/table/demo/resizable-column.md correctly 1`] = `
                   data-row-key="0"
                 >
                   <td
-                    class="ant-table-row-cell-break-word"
+                    class=""
                   >
                     2018-02-11
                   </td>
                   <td
-                    class="ant-table-row-cell-break-word"
+                    class=""
                   >
                     120
                   </td>
                   <td
-                    class="ant-table-row-cell-break-word"
+                    class=""
                   >
                     income
                   </td>
                   <td
-                    class="ant-table-row-cell-break-word"
+                    class=""
                   >
                     transfer
                   </td>
@@ -12049,22 +12049,22 @@ exports[`renders ./components/table/demo/resizable-column.md correctly 1`] = `
                   data-row-key="1"
                 >
                   <td
-                    class="ant-table-row-cell-break-word"
+                    class=""
                   >
                     2018-03-11
                   </td>
                   <td
-                    class="ant-table-row-cell-break-word"
+                    class=""
                   >
                     243
                   </td>
                   <td
-                    class="ant-table-row-cell-break-word"
+                    class=""
                   >
                     income
                   </td>
                   <td
-                    class="ant-table-row-cell-break-word"
+                    class=""
                   >
                     transfer
                   </td>
@@ -12081,22 +12081,22 @@ exports[`renders ./components/table/demo/resizable-column.md correctly 1`] = `
                   data-row-key="2"
                 >
                   <td
-                    class="ant-table-row-cell-break-word"
+                    class=""
                   >
                     2018-04-11
                   </td>
                   <td
-                    class="ant-table-row-cell-break-word"
+                    class=""
                   >
                     98
                   </td>
                   <td
-                    class="ant-table-row-cell-break-word"
+                    class=""
                   >
                     income
                   </td>
                   <td
-                    class="ant-table-row-cell-break-word"
+                    class=""
                   >
                     transfer
                   </td>

--- a/components/table/__tests__/__snapshots__/empty.test.js.snap
+++ b/components/table/__tests__/__snapshots__/empty.test.js.snap
@@ -453,7 +453,7 @@ exports[`Table renders empty table with fixed columns 1`] = `
       class="ant-spin-container"
     >
       <div
-        class="ant-table ant-table-default ant-table-empty ant-table-scroll-position-left ant-table-layout-fixed"
+        class="ant-table ant-table-default ant-table-empty ant-table-scroll-position-left"
       >
         <div
           class="ant-table-content"
@@ -491,7 +491,7 @@ exports[`Table renders empty table with fixed columns 1`] = `
                 >
                   <tr>
                     <th
-                      class="ant-table-fixed-columns-in-body ant-table-row-cell-break-word"
+                      class="ant-table-fixed-columns-in-body"
                     >
                       <span
                         class="ant-table-header-column"
@@ -509,7 +509,7 @@ exports[`Table renders empty table with fixed columns 1`] = `
                       </span>
                     </th>
                     <th
-                      class="ant-table-fixed-columns-in-body ant-table-row-cell-break-word"
+                      class="ant-table-fixed-columns-in-body"
                     >
                       <span
                         class="ant-table-header-column"
@@ -671,7 +671,7 @@ exports[`Table renders empty table with fixed columns 1`] = `
                       </span>
                     </th>
                     <th
-                      class="ant-table-fixed-columns-in-body ant-table-row-cell-break-word"
+                      class="ant-table-fixed-columns-in-body"
                     >
                       <span
                         class="ant-table-header-column"
@@ -771,7 +771,7 @@ exports[`Table renders empty table with fixed columns 1`] = `
                   >
                     <tr>
                       <th
-                        class="ant-table-row-cell-break-word"
+                        class=""
                       >
                         <span
                           class="ant-table-header-column"
@@ -789,7 +789,7 @@ exports[`Table renders empty table with fixed columns 1`] = `
                         </span>
                       </th>
                       <th
-                        class="ant-table-row-cell-break-word"
+                        class=""
                       >
                         <span
                           class="ant-table-header-column"
@@ -838,7 +838,7 @@ exports[`Table renders empty table with fixed columns 1`] = `
                   >
                     <tr>
                       <th
-                        class="ant-table-row-cell-break-word"
+                        class=""
                       >
                         <span
                           class="ant-table-header-column"

--- a/components/typography/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/typography/__tests__/__snapshots__/demo.test.js.snap
@@ -239,7 +239,7 @@ exports[`renders ./components/typography/demo/ellipsis-debug.md correctly 1`] = 
     />
     <div
       class="ant-slider-track"
-      style="left:0%;right:auto;width:0%"
+      style="left:0%;width:0%"
     />
     <div
       class="ant-slider-step"
@@ -251,7 +251,7 @@ exports[`renders ./components/typography/demo/ellipsis-debug.md correctly 1`] = 
       aria-valuenow="1"
       class="ant-slider-handle"
       role="slider"
-      style="left:0%;right:auto;transform:translateX(-50%)"
+      style="left:0%"
       tabindex="0"
     />
     <div


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [x] Other (about what?)

### 🔗 Related issue link

close #19108

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      The `onChange` sorter parameter always contains column info when the table is sorting/unsorting.    |
| 🇨🇳 Chinese |     现在 Table 排序时 `onChange` `sorter` 参数始终包含 column 信息。      |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
