### PR TITLE
fix: fix cascader placeholder internationalization

### DIFF
--- a/components/cascader/__tests__/__snapshots__/index.test.js.snap
+++ b/components/cascader/__tests__/__snapshots__/index.test.js.snap
@@ -952,7 +952,6 @@ exports[`Cascader should highlight keyword and filter when search in Cascader 1`
                       },
                     ]
                   }
-                  placeholder="Please select"
                   popupClassName=""
                   popupPlacement="bottomLeft"
                   popupVisible={true}
@@ -1250,7 +1249,6 @@ exports[`Cascader should render not found content 1`] = `
                       },
                     ]
                   }
-                  placeholder="Please select"
                   popupClassName=""
                   popupPlacement="bottomLeft"
                   popupVisible={true}
@@ -1578,7 +1576,6 @@ exports[`Cascader should show not found content when options.length is 0 1`] = `
                       },
                     ]
                   }
-                  placeholder="Please select"
                   popupClassName=""
                   popupPlacement="bottomLeft"
                   popupVisible={true}

--- a/components/cascader/__tests__/index.test.js
+++ b/components/cascader/__tests__/index.test.js
@@ -491,4 +491,15 @@ describe('Cascader', () => {
     );
     expect(popupWrapper.render()).toMatchSnapshot();
   });
+
+  it('placeholder works correctly', () => {
+    const wrapper = mount(<Cascader options={[]} />);
+    expect(wrapper.find('input').prop('placeholder')).toBe('Please select');
+
+    const customPlaceholder = 'Custom placeholder';
+    wrapper.setProps({
+      placeholder: customPlaceholder,
+    });
+    expect(wrapper.find('input').prop('placeholder')).toBe(customPlaceholder);
+  });
 });

--- a/components/cascader/index.tsx
+++ b/components/cascader/index.tsx
@@ -429,7 +429,7 @@ class Cascader extends React.Component<CascaderProps, CascaderState> {
       prefixCls: customizePrefixCls,
       inputPrefixCls: customizeInputPrefixCls,
       children,
-      placeholder = locale.placeholder,
+      placeholder = locale.placeholder || 'Please select',
       size,
       disabled,
       className,

--- a/components/cascader/index.tsx
+++ b/components/cascader/index.tsx
@@ -216,7 +216,6 @@ function warningValueNotExist(list: CascaderOptionType[], fieldNames: FieldNames
 
 class Cascader extends React.Component<CascaderProps, CascaderState> {
   static defaultProps = {
-    placeholder: 'Please select',
     transitionName: 'slide-up',
     popupPlacement: 'bottomLeft',
     options: [],


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->
[latest website](https://ant.design/components/cascader-cn/)
https://codesandbox.io/s/infallible-mountain-pt2tj
### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->
`Cascader`'s prop `placeholder` works not correctly with `LocaleProvider`/`ConfigProvider`
https://github.com/ant-design/ant-design/blob/8ffaeb8cba3ec334e2180c6062884851aba5c15f/components/cascader/index.tsx#L219
https://github.com/ant-design/ant-design/blob/8ffaeb8cba3ec334e2180c6062884851aba5c15f/components/cascader/index.tsx#L433
because `placeholder` exists in `defaultProps`,  `locale.placeholder` will not work

remove `placeholder` from `defaultProps` works well

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    fix `Cascader` placeholder internationalization       |
| 🇨🇳 Chinese |     修复  `Cascader` 占位符国际化错误    |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
