### PR TITLE
fix: Allow to use TableProps without Store

### DIFF
--- a/components/table/interface.tsx
+++ b/components/table/interface.tsx
@@ -161,7 +161,7 @@ export interface WithStore {
   setCheckboxPropsCache: (cache: CheckboxPropsCache) => void;
 }
 
-export interface TableProps<T> extends WithStore {
+export interface TablePropsWithoutStore<T> {
   prefixCls?: string;
   dropdownPrefixCls?: string;
   rowSelection?: TableRowSelection<T>;
@@ -218,6 +218,8 @@ export interface TableProps<T> extends WithStore {
   sortDirections?: SortOrder[];
   getPopupContainer?: (triggerNode: HTMLElement) => HTMLElement;
 }
+
+export type TableProps<T> =<WithStore & TablePropsWithoutStore;
 
 export interface TableStateFilters {
   [key: string]: string[];

--- a/components/table/interface.tsx
+++ b/components/table/interface.tsx
@@ -219,7 +219,7 @@ export interface TablePropsWithoutStore<T> {
   getPopupContainer?: (triggerNode: HTMLElement) => HTMLElement;
 }
 
-export type TableProps<T> =<WithStore & TablePropsWithoutStore;
+export type TableProps<T> = WithStore & TablePropsWithoutStore<T>;
 
 export interface TableStateFilters {
   [key: string]: string[];


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

A little bit with #19249 but not exactly

### 💡 Background and solution

When you have a Custom Component which use the Table component and you want to pass all prop of the Custom Component to Table. The definition of the Custom Component must be without the store.

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Add TablePropsWithoutStore interface |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
