### PR TITLE
fix(Table): when table setting scroll, if tableNode == null, use default

### DIFF
--- a/components/table/Table.tsx
+++ b/components/table/Table.tsx
@@ -543,7 +543,9 @@ class Table<T> extends React.Component<TableProps<T>, TableState<T>> {
       return getPopupContainer;
     }
     // Use undefined to let rc component use default logic.
-    return scroll && table ? () => table.tableNode : undefined;
+    return scroll && table
+      ? (defaultNode: React.ReactNode) => table.tableNode || defaultNode
+      : undefined;
   };
 
   scrollToFirstRow = () => {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

fix #19274

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |     修复疑似table 在重新渲染时，tableNode未准备好的健壮性问题      |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
