### PR TITLE
feat(Drawer): add closeIcon prop

### DIFF
--- a/components/config-provider/__tests__/__snapshots__/components.test.js.snap
+++ b/components/config-provider/__tests__/__snapshots__/components.test.js.snap
@@ -7410,14 +7410,14 @@ exports[`ConfigProvider components InputNumber configProvider 1`] = `
     </span>
   </div>
   <div
+    aria-valuemin="-9007199254740991"
     class="config-input-number-input-wrap"
+    role="spinbutton"
   >
     <input
-      aria-valuemin="-9007199254740991"
       autocomplete="off"
       class="config-input-number-input"
       min="-9007199254740991"
-      role="spinbutton"
       step="1"
       value=""
     />
@@ -7488,14 +7488,14 @@ exports[`ConfigProvider components InputNumber normal 1`] = `
     </span>
   </div>
   <div
+    aria-valuemin="-9007199254740991"
     class="ant-input-number-input-wrap"
+    role="spinbutton"
   >
     <input
-      aria-valuemin="-9007199254740991"
       autocomplete="off"
       class="ant-input-number-input"
       min="-9007199254740991"
-      role="spinbutton"
       step="1"
       value=""
     />
@@ -7566,14 +7566,14 @@ exports[`ConfigProvider components InputNumber prefixCls 1`] = `
     </span>
   </div>
   <div
+    aria-valuemin="-9007199254740991"
     class="prefix-InputNumber-input-wrap"
+    role="spinbutton"
   >
     <input
-      aria-valuemin="-9007199254740991"
       autocomplete="off"
       class="prefix-InputNumber-input"
       min="-9007199254740991"
-      role="spinbutton"
       step="1"
       value=""
     />

--- a/components/drawer/__tests__/Drawer.test.js
+++ b/components/drawer/__tests__/Drawer.test.js
@@ -78,4 +78,14 @@ describe('Drawer', () => {
     );
     expect(wrapper).toMatchSnapshot();
   });
+  
+  it('renders a custom close icon', () => {
+    const wrapper = render(
+      <Drawer visible closeIcon={<span>X</span>} getContainer={false}>
+        Content
+      </Drawer>,
+    );
+
+    expect(wrapper).toMatchSnapshot();
+  });
 });

--- a/components/drawer/__tests__/__snapshots__/Drawer.test.js.snap
+++ b/components/drawer/__tests__/__snapshots__/Drawer.test.js.snap
@@ -348,13 +348,20 @@ exports[`Drawer render top drawer 1`] = `
 </div>
 `;
 
+<<<<<<< HEAD
 exports[`Drawer style/drawerStyle/headerStyle/bodyStyle should work 1`] = `
+=======
+exports[`Drawer renders a custom close icon 1`] = `
+>>>>>>> feat(Drawer): add closeIcon prop
 <div
   class=""
 >
   <div
     class="ant-drawer ant-drawer-right"
+<<<<<<< HEAD
     style="background-color:#08c"
+=======
+>>>>>>> feat(Drawer): add closeIcon prop
     tabindex="-1"
   >
     <div
@@ -369,16 +376,24 @@ exports[`Drawer style/drawerStyle/headerStyle/bodyStyle should work 1`] = `
       >
         <div
           class="ant-drawer-wrapper-body"
+<<<<<<< HEAD
           style="overflow:auto;height:100%;background-color:#08c"
         >
           <div
             class="ant-drawer-header-no-title"
             style="background-color:#08c"
+=======
+          style="overflow:auto;height:100%"
+        >
+          <div
+            class="ant-drawer-header-no-title"
+>>>>>>> feat(Drawer): add closeIcon prop
           >
             <button
               aria-label="Close"
               class="ant-drawer-close"
             >
+<<<<<<< HEAD
               <i
                 aria-label="icon: close"
                 class="anticon anticon-close"
@@ -398,13 +413,23 @@ exports[`Drawer style/drawerStyle/headerStyle/bodyStyle should work 1`] = `
                   />
                 </svg>
               </i>
+=======
+              <span>
+                X
+              </span>
+>>>>>>> feat(Drawer): add closeIcon prop
             </button>
           </div>
           <div
             class="ant-drawer-body"
+<<<<<<< HEAD
             style="background-color:#08c"
           >
             Here is content of Drawer
+=======
+          >
+            Content
+>>>>>>> feat(Drawer): add closeIcon prop
           </div>
         </div>
       </div>

--- a/components/drawer/__tests__/__snapshots__/Drawer.test.js.snap
+++ b/components/drawer/__tests__/__snapshots__/Drawer.test.js.snap
@@ -348,20 +348,12 @@ exports[`Drawer render top drawer 1`] = `
 </div>
 `;
 
-<<<<<<< HEAD
-exports[`Drawer style/drawerStyle/headerStyle/bodyStyle should work 1`] = `
-=======
 exports[`Drawer renders a custom close icon 1`] = `
->>>>>>> feat(Drawer): add closeIcon prop
 <div
   class=""
 >
   <div
     class="ant-drawer ant-drawer-right"
-<<<<<<< HEAD
-    style="background-color:#08c"
-=======
->>>>>>> feat(Drawer): add closeIcon prop
     tabindex="-1"
   >
     <div
@@ -376,24 +368,63 @@ exports[`Drawer renders a custom close icon 1`] = `
       >
         <div
           class="ant-drawer-wrapper-body"
-<<<<<<< HEAD
-          style="overflow:auto;height:100%;background-color:#08c"
-        >
-          <div
-            class="ant-drawer-header-no-title"
-            style="background-color:#08c"
-=======
           style="overflow:auto;height:100%"
         >
           <div
             class="ant-drawer-header-no-title"
->>>>>>> feat(Drawer): add closeIcon prop
           >
             <button
               aria-label="Close"
               class="ant-drawer-close"
             >
-<<<<<<< HEAD
+              <span>
+                X
+              </span>
+            </button>
+          </div>
+          <div
+            class="ant-drawer-body"
+          >
+            Content
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Drawer style/drawerStyle/headerStyle/bodyStyle should work 1`] = `
+<div
+  class=""
+>
+  <div
+    class="ant-drawer ant-drawer-right"
+    style="background-color:#08c"
+    tabindex="-1"
+  >
+    <div
+      class="ant-drawer-mask"
+    />
+    <div
+      class="ant-drawer-content-wrapper"
+      style="transform:translateX(100%);-ms-transform:translateX(100%);width:256px"
+    >
+      <div
+        class="ant-drawer-content"
+      >
+        <div
+          class="ant-drawer-wrapper-body"
+          style="overflow:auto;height:100%;background-color:#08c"
+        >
+          <div
+            class="ant-drawer-header-no-title"
+            style="background-color:#08c"
+          >
+            <button
+              aria-label="Close"
+              class="ant-drawer-close"
+            >
               <i
                 aria-label="icon: close"
                 class="anticon anticon-close"
@@ -413,23 +444,13 @@ exports[`Drawer renders a custom close icon 1`] = `
                   />
                 </svg>
               </i>
-=======
-              <span>
-                X
-              </span>
->>>>>>> feat(Drawer): add closeIcon prop
             </button>
           </div>
           <div
             class="ant-drawer-body"
-<<<<<<< HEAD
             style="background-color:#08c"
           >
             Here is content of Drawer
-=======
-          >
-            Content
->>>>>>> feat(Drawer): add closeIcon prop
           </div>
         </div>
       </div>

--- a/components/drawer/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/drawer/__tests__/__snapshots__/demo.test.js.snap
@@ -13,6 +13,19 @@ exports[`renders ./components/drawer/demo/basic-right.md correctly 1`] = `
 </div>
 `;
 
+exports[`renders ./components/drawer/demo/custom-close-icon.md correctly 1`] = `
+<div>
+  <button
+    class="ant-btn ant-btn-primary"
+    type="button"
+  >
+    <span>
+      Open
+    </span>
+  </button>
+</div>
+`;
+
 exports[`renders ./components/drawer/demo/form-in-drawer.md correctly 1`] = `
 <div>
   <button

--- a/components/drawer/demo/custom-close-icon.md
+++ b/components/drawer/demo/custom-close-icon.md
@@ -1,11 +1,12 @@
 ---
 order: 6
 title:
-  zh-CN:
+  zh-CN: 自定义Drawer关闭icon
   en-US: Custom close icon
 ---
 
 ## zh-CN
+
 自定义Drawer关闭icon
 
 ## en-US

--- a/components/drawer/demo/custom-close-icon.md
+++ b/components/drawer/demo/custom-close-icon.md
@@ -6,6 +6,7 @@ title:
 ---
 
 ## zh-CN
+自定义Drawer关闭icon
 
 ## en-US
 

--- a/components/drawer/demo/custom-close-icon.md
+++ b/components/drawer/demo/custom-close-icon.md
@@ -1,0 +1,55 @@
+---
+order: 6
+title:
+  zh-CN:
+  en-US: Custom close icon
+---
+
+## zh-CN
+
+## en-US
+
+Customize close icon of drawer
+
+```jsx
+import { Drawer, Button, Icon } from 'antd';
+
+class App extends React.Component {
+  state = { visible: false };
+
+  showDrawer = () => {
+    this.setState({
+      visible: true,
+    });
+  };
+
+  onClose = () => {
+    this.setState({
+      visible: false,
+    });
+  };
+
+  render() {
+    return (
+      <div>
+        <Button type="primary" onClick={this.showDrawer}>
+          Open
+        </Button>
+        <Drawer
+          title="Basic Drawer"
+          placement="right"
+          closeIcon={<Icon type="stop" />}
+          onClose={this.onClose}
+          visible={this.state.visible}
+        >
+          <p>Some contents...</p>
+          <p>Some contents...</p>
+          <p>Some contents...</p>
+        </Drawer>
+      </div>
+    );
+  }
+}
+
+ReactDOM.render(<App />, mountNode);
+```

--- a/components/drawer/index.en-US.md
+++ b/components/drawer/index.en-US.md
@@ -37,6 +37,7 @@ A Drawer is a panel that is typically overlaid on top of a page and slides in fr
 | zIndex | The `z-index` of the Drawer. | Number | 1000 | 3.7.0 |
 | placement | The placement of the Drawer. | 'top' \| 'right' \| 'bottom' \| 'left' | 'right' | 3.7.0 |
 | onClose | Specify a callback that will be called when a user clicks mask, close button or Cancel button. | function(e) | - | 3.7.0 |
+| closeIcon | Custom close icon | React.ReactElement | - |  |
 | afterVisibleChange | Callback after the animation ends when switching drawers. | function(visible) | - | 3.17.0 |
 | keyboard | Whether support press esc to close | Boolean | true | 3.19.8 |
 

--- a/components/drawer/index.tsx
+++ b/components/drawer/index.tsx
@@ -167,7 +167,7 @@ class Drawer extends React.Component<DrawerProps & ConfigConsumerProps, IDrawerS
       closable && (
         // eslint-disable-next-line react/button-has-type
         <button onClick={onClose} aria-label="Close" className={`${prefixCls}-close`}>
-          {closeIcon ? closeIcon : <Icon type="close" />}
+          {closeIcon || <Icon type="close" />}
         </button>
       )
     );

--- a/components/drawer/index.tsx
+++ b/components/drawer/index.tsx
@@ -46,6 +46,7 @@ export interface DrawerProps {
   className?: string;
   handler?: React.ReactNode;
   keyboard?: boolean;
+  closeIcon?: React.ReactElement<any>;
 }
 
 export interface IDrawerState {
@@ -161,12 +162,12 @@ class Drawer extends React.Component<DrawerProps & ConfigConsumerProps, IDrawerS
   }
 
   renderCloseIcon() {
-    const { closable, prefixCls, onClose } = this.props;
+    const { closable, prefixCls, onClose, closeIcon } = this.props;
     return (
       closable && (
         // eslint-disable-next-line react/button-has-type
         <button onClick={onClose} aria-label="Close" className={`${prefixCls}-close`}>
-          <Icon type="close" />
+          {closeIcon ? closeIcon : <Icon type="close" />}
         </button>
       )
     );
@@ -260,6 +261,7 @@ class Drawer extends React.Component<DrawerProps & ConfigConsumerProps, IDrawerS
             'csp',
             'pageHeader',
             'autoInsertSpaceInButton',
+            'closeIcon',
           ])}
           {...offsetStyle}
           prefixCls={prefixCls}

--- a/components/drawer/index.zh-CN.md
+++ b/components/drawer/index.zh-CN.md
@@ -36,6 +36,7 @@ title: Drawer
 | zIndex | 设置 Drawer 的 `z-index` | Number | 1000 | 3.7.0 |
 | placement | 抽屉的方向 | 'top' \| 'right' \| 'bottom' \| 'left' | 'right' | 3.7.0 |
 | onClose | 点击遮罩层或右上角叉或取消按钮的回调 | function(e) | 无 | 3.7.0 |
+| closeIcon |  | React.ReactElement | - |  |
 | afterVisibleChange | 切换抽屉时动画结束后的回调 | function(visible) | 无 | 3.17.0 |
 | keyboard | 是否支持键盘 esc 关闭 | boolean | true | 3.19.8 |
 

--- a/components/drawer/index.zh-CN.md
+++ b/components/drawer/index.zh-CN.md
@@ -36,7 +36,7 @@ title: Drawer
 | zIndex | 设置 Drawer 的 `z-index` | Number | 1000 | 3.7.0 |
 | placement | 抽屉的方向 | 'top' \| 'right' \| 'bottom' \| 'left' | 'right' | 3.7.0 |
 | onClose | 点击遮罩层或右上角叉或取消按钮的回调 | function(e) | 无 | 3.7.0 |
-| closeIcon |  | React.ReactElement | - |  |
+| closeIcon | 自定义关闭icon | React.ReactElement | - |  |
 | afterVisibleChange | 切换抽屉时动画结束后的回调 | function(visible) | 无 | 3.17.0 |
 | keyboard | 是否支持键盘 esc 关闭 | boolean | true | 3.19.8 |
 

--- a/components/form/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/form/__tests__/__snapshots__/demo.test.js.snap
@@ -2385,14 +2385,14 @@ exports[`renders ./components/form/demo/style-check-debug.md correctly 1`] = `
                     </span>
                   </div>
                   <div
+                    aria-valuemin="-9007199254740991"
                     class="ant-input-number-input-wrap"
+                    role="spinbutton"
                   >
                     <input
-                      aria-valuemin="-9007199254740991"
                       autocomplete="off"
                       class="ant-input-number-input"
                       min="-9007199254740991"
-                      role="spinbutton"
                       step="1"
                       value=""
                     />
@@ -3244,12 +3244,13 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
               </span>
             </div>
             <div
+              aria-valuemax="10"
+              aria-valuemin="1"
+              aria-valuenow="3"
               class="ant-input-number-input-wrap"
+              role="spinbutton"
             >
               <input
-                aria-valuemax="10"
-                aria-valuemin="1"
-                aria-valuenow="3"
                 autocomplete="off"
                 class="ant-input-number-input"
                 data-__field="[object Object]"
@@ -3257,7 +3258,6 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
                 id="validate_other_input-number"
                 max="10"
                 min="1"
-                role="spinbutton"
                 step="1"
                 value="3"
               />
@@ -5096,14 +5096,14 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
               </span>
             </div>
             <div
+              aria-valuemin="-9007199254740991"
               class="ant-input-number-input-wrap"
+              role="spinbutton"
             >
               <input
-                aria-valuemin="-9007199254740991"
                 autocomplete="off"
                 class="ant-input-number-input"
                 min="-9007199254740991"
-                role="spinbutton"
                 step="1"
                 value=""
               />
@@ -5227,17 +5227,17 @@ exports[`renders ./components/form/demo/without-form-create.md correctly 1`] = `
               </span>
             </div>
             <div
+              aria-valuemax="12"
+              aria-valuemin="8"
+              aria-valuenow="11"
               class="ant-input-number-input-wrap"
+              role="spinbutton"
             >
               <input
-                aria-valuemax="12"
-                aria-valuemin="8"
-                aria-valuenow="11"
                 autocomplete="off"
                 class="ant-input-number-input"
                 max="12"
                 min="8"
-                role="spinbutton"
                 step="1"
                 value="11"
               />

--- a/components/input-number/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/input-number/__tests__/__snapshots__/demo.test.js.snap
@@ -63,17 +63,17 @@ exports[`renders ./components/input-number/demo/basic.md correctly 1`] = `
     </span>
   </div>
   <div
+    aria-valuemax="10"
+    aria-valuemin="1"
+    aria-valuenow="3"
     class="ant-input-number-input-wrap"
+    role="spinbutton"
   >
     <input
-      aria-valuemax="10"
-      aria-valuemin="1"
-      aria-valuenow="3"
       autocomplete="off"
       class="ant-input-number-input"
       max="10"
       min="1"
-      role="spinbutton"
       step="1"
       value="3"
     />
@@ -144,16 +144,16 @@ exports[`renders ./components/input-number/demo/digit.md correctly 1`] = `
     </span>
   </div>
   <div
+    aria-valuemax="10"
+    aria-valuemin="0"
     class="ant-input-number-input-wrap"
+    role="spinbutton"
   >
     <input
-      aria-valuemax="10"
-      aria-valuemin="0"
       autocomplete="off"
       class="ant-input-number-input"
       max="10"
       min="0"
-      role="spinbutton"
       step="0.1"
       value=""
     />
@@ -225,18 +225,18 @@ exports[`renders ./components/input-number/demo/disabled.md correctly 1`] = `
       </span>
     </div>
     <div
+      aria-valuemax="10"
+      aria-valuemin="1"
+      aria-valuenow="3"
       class="ant-input-number-input-wrap"
+      role="spinbutton"
     >
       <input
-        aria-valuemax="10"
-        aria-valuemin="1"
-        aria-valuenow="3"
         autocomplete="off"
         class="ant-input-number-input"
         disabled=""
         max="10"
         min="1"
-        role="spinbutton"
         step="1"
         value="3"
       />
@@ -321,15 +321,15 @@ exports[`renders ./components/input-number/demo/formatter.md correctly 1`] = `
       </span>
     </div>
     <div
+      aria-valuemin="-9007199254740991"
+      aria-valuenow="1000"
       class="ant-input-number-input-wrap"
+      role="spinbutton"
     >
       <input
-        aria-valuemin="-9007199254740991"
-        aria-valuenow="1000"
         autocomplete="off"
         class="ant-input-number-input"
         min="-9007199254740991"
-        role="spinbutton"
         step="1"
         value="$ 1,000"
       />
@@ -397,17 +397,17 @@ exports[`renders ./components/input-number/demo/formatter.md correctly 1`] = `
       </span>
     </div>
     <div
+      aria-valuemax="100"
+      aria-valuemin="0"
+      aria-valuenow="100"
       class="ant-input-number-input-wrap"
+      role="spinbutton"
     >
       <input
-        aria-valuemax="100"
-        aria-valuemin="0"
-        aria-valuenow="100"
         autocomplete="off"
         class="ant-input-number-input"
         max="100"
         min="0"
-        role="spinbutton"
         step="1"
         value="100%"
       />
@@ -480,17 +480,17 @@ exports[`renders ./components/input-number/demo/size.md correctly 1`] = `
       </span>
     </div>
     <div
+      aria-valuemax="100000"
+      aria-valuemin="1"
+      aria-valuenow="3"
       class="ant-input-number-input-wrap"
+      role="spinbutton"
     >
       <input
-        aria-valuemax="100000"
-        aria-valuemin="1"
-        aria-valuenow="3"
         autocomplete="off"
         class="ant-input-number-input"
         max="100000"
         min="1"
-        role="spinbutton"
         step="1"
         value="3"
       />
@@ -558,17 +558,17 @@ exports[`renders ./components/input-number/demo/size.md correctly 1`] = `
       </span>
     </div>
     <div
+      aria-valuemax="100000"
+      aria-valuemin="1"
+      aria-valuenow="3"
       class="ant-input-number-input-wrap"
+      role="spinbutton"
     >
       <input
-        aria-valuemax="100000"
-        aria-valuemin="1"
-        aria-valuenow="3"
         autocomplete="off"
         class="ant-input-number-input"
         max="100000"
         min="1"
-        role="spinbutton"
         step="1"
         value="3"
       />
@@ -636,17 +636,17 @@ exports[`renders ./components/input-number/demo/size.md correctly 1`] = `
       </span>
     </div>
     <div
+      aria-valuemax="100000"
+      aria-valuemin="1"
+      aria-valuenow="3"
       class="ant-input-number-input-wrap"
+      role="spinbutton"
     >
       <input
-        aria-valuemax="100000"
-        aria-valuemin="1"
-        aria-valuenow="3"
         autocomplete="off"
         class="ant-input-number-input"
         max="100000"
         min="1"
-        role="spinbutton"
         step="1"
         value="3"
       />

--- a/components/input/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/input/__tests__/__snapshots__/demo.test.js.snap
@@ -370,14 +370,14 @@ exports[`renders ./components/input/demo/align.md correctly 1`] = `
       </span>
     </div>
     <div
+      aria-valuemin="-9007199254740991"
       class="ant-input-number-input-wrap"
+      role="spinbutton"
     >
       <input
-        aria-valuemin="-9007199254740991"
         autocomplete="off"
         class="ant-input-number-input"
         min="-9007199254740991"
-        role="spinbutton"
         step="1"
         value=""
       />
@@ -1145,14 +1145,14 @@ exports[`renders ./components/input/demo/group.md correctly 1`] = `
         </span>
       </div>
       <div
+        aria-valuemin="-9007199254740991"
         class="ant-input-number-input-wrap"
+        role="spinbutton"
       >
         <input
-          aria-valuemin="-9007199254740991"
           autocomplete="off"
           class="ant-input-number-input"
           min="-9007199254740991"
-          role="spinbutton"
           step="1"
           value=""
         />

--- a/components/slider/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/slider/__tests__/__snapshots__/demo.test.js.snap
@@ -325,17 +325,17 @@ exports[`renders ./components/slider/demo/input-number.md correctly 1`] = `
           </span>
         </div>
         <div
+          aria-valuemax="20"
+          aria-valuemin="1"
+          aria-valuenow="1"
           class="ant-input-number-input-wrap"
+          role="spinbutton"
         >
           <input
-            aria-valuemax="20"
-            aria-valuemin="1"
-            aria-valuenow="1"
             autocomplete="off"
             class="ant-input-number-input"
             max="20"
             min="1"
-            role="spinbutton"
             step="1"
             value="1"
           />
@@ -443,17 +443,17 @@ exports[`renders ./components/slider/demo/input-number.md correctly 1`] = `
           </span>
         </div>
         <div
+          aria-valuemax="1"
+          aria-valuemin="0"
+          aria-valuenow="0"
           class="ant-input-number-input-wrap"
+          role="spinbutton"
         >
           <input
-            aria-valuemax="1"
-            aria-valuemin="0"
-            aria-valuenow="0"
             autocomplete="off"
             class="ant-input-number-input"
             max="1"
             min="0"
-            role="spinbutton"
             step="0.01"
             value="0.00"
           />


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
close #19153

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->
1. Users are currently unable to customize the Drawer close icon
2. Component in action
![Annotation 2019-10-17 222934](https://user-images.githubusercontent.com/5252089/67068070-a4125d00-f12d-11e9-8f5a-05fd6bdcb3f0.png)

3. New API
```jsx
<Drawer closeIcon={<Icon type="stop" />}>
  Content
</Drawer>
```

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    add closeIcon prop to Drawer component       |
| 🇨🇳 Chinese |      添加关闭图标支持关闭当前 Drawer    |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/drawer/demo/custom-close-icon.md](https://github.com/kyle-copeland/ant-design/blob/feature-drawer-icon/components/drawer/demo/custom-close-icon.md)
[View rendered components/drawer/index.en-US.md](https://github.com/kyle-copeland/ant-design/blob/feature-drawer-icon/components/drawer/index.en-US.md)
[View rendered components/drawer/index.zh-CN.md](https://github.com/kyle-copeland/ant-design/blob/feature-drawer-icon/components/drawer/index.zh-CN.md)