### PR TITLE
fix: Table scroll.x max-content not working in Chrome

### DIFF
--- a/components/table/__tests__/__snapshots__/Table.rowSelection.test.js.snap
+++ b/components/table/__tests__/__snapshots__/Table.rowSelection.test.js.snap
@@ -11,7 +11,7 @@ exports[`Table.rowSelection fix selection column on the left 1`] = `
       class="ant-spin-container"
     >
       <div
-        class="ant-table ant-table-default ant-table-scroll-position-left ant-table-layout-fixed"
+        class="ant-table ant-table-default ant-table-scroll-position-left"
       >
         <div
           class="ant-table-content"
@@ -484,7 +484,7 @@ exports[`Table.rowSelection fix selection column on the left when any other colu
       class="ant-spin-container"
     >
       <div
-        class="ant-table ant-table-default ant-table-scroll-position-left ant-table-layout-fixed"
+        class="ant-table ant-table-default ant-table-scroll-position-left"
       >
         <div
           class="ant-table-content"

--- a/components/table/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/table/__tests__/__snapshots__/demo.test.js.snap
@@ -8816,17 +8816,17 @@ exports[`renders ./components/table/demo/grouping-columns.md correctly 1`] = `
             >
               <table
                 class="ant-table-fixed"
-                style="width:130%"
+                style="width:calc(700px + 50%)"
               >
                 <colgroup>
                   <col
                     style="width:100px;min-width:100px"
                   />
                   <col
-                    style="width:200px;min-width:200px"
+                    style="width:150px;min-width:150px"
                   />
                   <col
-                    style="width:200px;min-width:200px"
+                    style="width:150px;min-width:150px"
                   />
                   <col
                     style="width:100px;min-width:100px"
@@ -9156,17 +9156,17 @@ exports[`renders ./components/table/demo/grouping-columns.md correctly 1`] = `
             >
               <table
                 class="ant-table-fixed"
-                style="width:130%"
+                style="width:calc(700px + 50%)"
               >
                 <colgroup>
                   <col
                     style="width:100px;min-width:100px"
                   />
                   <col
-                    style="width:200px;min-width:200px"
+                    style="width:150px;min-width:150px"
                   />
                   <col
-                    style="width:200px;min-width:200px"
+                    style="width:150px;min-width:150px"
                   />
                   <col
                     style="width:100px;min-width:100px"

--- a/components/table/__tests__/__snapshots__/empty.test.js.snap
+++ b/components/table/__tests__/__snapshots__/empty.test.js.snap
@@ -453,7 +453,7 @@ exports[`Table renders empty table with fixed columns 1`] = `
       class="ant-spin-container"
     >
       <div
-        class="ant-table ant-table-default ant-table-empty ant-table-scroll-position-left ant-table-layout-fixed"
+        class="ant-table ant-table-default ant-table-empty ant-table-scroll-position-left"
       >
         <div
           class="ant-table-content"

--- a/components/table/demo/grouping-columns.md
+++ b/components/table/demo/grouping-columns.md
@@ -42,7 +42,7 @@ const columns = [
         title: 'Age',
         dataIndex: 'age',
         key: 'age',
-        width: 200,
+        width: 150,
         sorter: (a, b) => a.age - b.age,
       },
       {
@@ -52,7 +52,7 @@ const columns = [
             title: 'Street',
             dataIndex: 'street',
             key: 'street',
-            width: 200,
+            width: 150,
           },
           {
             title: 'Block',
@@ -121,7 +121,7 @@ ReactDOM.render(
     dataSource={data}
     bordered
     size="middle"
-    scroll={{ x: '130%', y: 240 }}
+    scroll={{ x: 'calc(700px + 50%)', y: 240 }}
   />,
   mountNode,
 );

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "rc-slider": "~8.7.1",
     "rc-steps": "~3.5.0",
     "rc-switch": "~1.9.0",
-    "rc-table": "~6.8.6",
+    "rc-table": "~6.9.3",
     "rc-tabs": "~9.6.4",
     "rc-time-picker": "~3.7.1",
     "rc-tooltip": "~3.7.3",


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

https://github.com/react-component/table/pull/378

### 💡 Background and solution

Reproduce link: 

❌ 3.24.0：https://codesandbox.io/s/unruffled-pine-9q76y
✅ 3.23.6：https://codesandbox.io/s/crazy-water-vyiii

<img width="644" alt="image" src="https://user-images.githubusercontent.com/507615/67069103-8f29de00-f1ae-11e9-9bd5-89fbf73dfe73.png">

to 

<img width="651" alt="image" src="https://user-images.githubusercontent.com/507615/67069145-b1bbf700-f1ae-11e9-8bfb-0f32db5d4931.png">

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fix Table `scroll={{ x: 'max-content' }}` rendered without scrollbar problem in Chrome.  |
| 🇨🇳 Chinese | 修复 Table `scroll.x` 设置 `max-content` 失效导致横向滚动失效的问题。  |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/table/demo/grouping-columns.md](https://github.com/ant-design/ant-design/blob/fix-table-style/components/table/demo/grouping-columns.md)