### PR TITLE
docs: corrected the typographical error of word 'case' to 'care'

### DIFF
--- a/docs/react/use-with-create-react-app.en-US.md
+++ b/docs/react/use-with-create-react-app.en-US.md
@@ -88,7 +88,7 @@ Ok, you should now see a blue primary button displayed on the page. Next you can
 
 ## Advanced Guides
 
-We are successfully running antd components now but in the real world, there are still lots of problems about antd-demo. For instance, we actually import styles of all components in the project which may be a css bundle size issue (It is OK then if you don't case the gzipped 60kb css file size).
+We are successfully running antd components now but in the real world, there are still lots of problems about antd-demo. For instance, we actually import styles of all components in the project which may be a css bundle size issue (It is OK then if you don't care the gzipped 60kb css file size).
 
 Now we need to customize the default webpack config. We can achieve that by using [react-app-rewired](https://github.com/timarney/react-app-rewired) which is one of create-react-app's custom config solutions.
 


### PR DESCRIPTION
I guess there  was a typo in the doc of  https://ant.design/docs/react/use-with-create-react-app documentation where the word "case" was used instead of "care"



-----
[View rendered docs/react/use-with-create-react-app.en-US.md](https://github.com/Niyiojeyinka/ant-design/blob/master/docs/react/use-with-create-react-app.en-US.md)