### PR TITLE
Update table column render typings

### DIFF
--- a/components/table/interface.tsx
+++ b/components/table/interface.tsx
@@ -18,6 +18,13 @@ export type ColumnFilterItem = {
   children?: ColumnFilterItem[];
 };
 
+export type TableColumnRenderFn = (text: any, record: T, index: number) => 
+  | React.ReactNode 
+  | {
+      children: React.ReactNode;
+      props: { rowSpan: number; colSpan: number };
+    };
+
 export interface FilterDropdownProps {
   prefixCls?: string;
   setSelectedKeys?: (selectedKeys: string[]) => void;
@@ -39,7 +46,7 @@ export interface ColumnProps<T> {
       }) => React.ReactNode);
   key?: React.Key;
   dataIndex?: string; // Note: We can not use generic type here, since we need to support nested key, see #9393
-  render?: (text: any, record: T, index: number) => React.ReactNode;
+  render?: TableColumnRenderFn;
   align?: 'left' | 'right' | 'center';
   ellipsis?: boolean;
   filters?: ColumnFilterItem[];


### PR DESCRIPTION
According to documentation:
```
Renderer of the table cell. The return value should be a ReactNode, or an object for colSpan/rowSpan config
```
This PR proposes an update to current renderer interface which can return only ReactNode.

<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

No related issue found
### 💡 Background and solution

Small update to Table cell renderer typing

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           -|
| 🇨🇳 Chinese |           -|

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x]  Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
