### PR TITLE
Improve typing of `UploadFile` interface

### DIFF
--- a/components/upload/interface.tsx
+++ b/components/upload/interface.tsx
@@ -24,7 +24,7 @@ export interface RcCustomRequestOptions {
   headers: object;
 }
 
-export interface UploadFile {
+export interface UploadFile<T = any> {
   uid: string;
   size: number;
   name: string;
@@ -36,7 +36,7 @@ export interface UploadFile {
   percent?: number;
   thumbUrl?: string;
   originFileObj?: File | Blob;
-  response?: any;
+  response?: T;
   error?: any;
   linkProps?: any;
   type: string;


### PR DESCRIPTION
UploadFile interface made generic type so that a user can define a strongly typed response object if needed

<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 💡 Background and solution

Upload component has an interface called `UploadFile` which returns a response object of `any` type. The typing of this interface can be improved by making it a generic type.
### ☑️ Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
