### PR TITLE
feat: Preset status color into Tag

### DIFF
--- a/components/_util/colors.ts
+++ b/components/_util/colors.ts
@@ -1,5 +1,7 @@
 import { tuple } from './type';
 
+// 预设的状态颜色类型
+export const PresetStatusColorTypes = tuple('success', 'processing', 'error', 'default', 'warning');
 // eslint-disable-next-line import/prefer-default-export
 export const PresetColorTypes = tuple(
   'pink',
@@ -18,3 +20,4 @@ export const PresetColorTypes = tuple(
 );
 
 export type PresetColorType = (typeof PresetColorTypes)[number];
+export type PresetStatusColorType = (typeof PresetStatusColorTypes)[number];

--- a/components/_util/colors.ts
+++ b/components/_util/colors.ts
@@ -1,6 +1,5 @@
 import { tuple } from './type';
 
-// 预设的状态颜色类型
 export const PresetStatusColorTypes = tuple('success', 'processing', 'error', 'default', 'warning');
 // eslint-disable-next-line import/prefer-default-export
 export const PresetColorTypes = tuple(

--- a/components/tag/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/tag/__tests__/__snapshots__/demo.test.js.snap
@@ -481,3 +481,33 @@ exports[`renders ./components/tag/demo/hot-tags.md correctly 1`] = `
   </span>
 </div>
 `;
+
+exports[`renders ./components/tag/demo/status.md correctly 1`] = `
+<div>
+  <span
+    class="ant-tag ant-tag-success"
+  >
+    成功
+  </span>
+  <span
+    class="ant-tag ant-tag-processing"
+  >
+    进行中
+  </span>
+  <span
+    class="ant-tag ant-tag-error"
+  >
+    失败
+  </span>
+  <span
+    class="ant-tag ant-tag-default"
+  >
+    未开始
+  </span>
+  <span
+    class="ant-tag ant-tag-warning"
+  >
+    警告
+  </span>
+</div>
+`;

--- a/components/tag/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/tag/__tests__/__snapshots__/demo.test.js.snap
@@ -487,27 +487,27 @@ exports[`renders ./components/tag/demo/status.md correctly 1`] = `
   <span
     class="ant-tag ant-tag-success"
   >
-    成功
+    success
   </span>
   <span
     class="ant-tag ant-tag-processing"
   >
-    进行中
+    processing
   </span>
   <span
     class="ant-tag ant-tag-error"
   >
-    失败
+    error
   </span>
   <span
     class="ant-tag ant-tag-default"
   >
-    未开始
+    not start
   </span>
   <span
     class="ant-tag ant-tag-warning"
   >
-    警告
+    warning
   </span>
 </div>
 `;

--- a/components/tag/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/tag/__tests__/__snapshots__/demo.test.js.snap
@@ -502,7 +502,7 @@ exports[`renders ./components/tag/demo/status.md correctly 1`] = `
   <span
     class="ant-tag ant-tag-default"
   >
-    not start
+    default
   </span>
   <span
     class="ant-tag ant-tag-warning"

--- a/components/tag/demo/status.md
+++ b/components/tag/demo/status.md
@@ -1,28 +1,28 @@
 ---
 order: 7
 title:
-  zh-CN: 状态Tag
+  zh-CN: 预设状态的标签
   en-US: Status Tag
 ---
 
 ## zh-CN
 
-可以通过添加 `status` 变为状态标签。
+预设五种状态颜色，可以通过设置 `color` 为`success`、 `processing`、`error`、`default`、`warning`来代表不同的状态。
 
 ## en-US
 
-Usage of status Tag, and it could be status tag by set `status` property.
+We preset five different colors, you can set color property such as `success`,`processing`,`error`,`default` and `warning` to indicate specific status.
 
 ```jsx
 import { Tag } from 'antd';
 
 ReactDOM.render(
   <div>
-    <Tag status="success">成功</Tag>
-    <Tag status="processing">进行中</Tag>
-    <Tag status="error">失败</Tag>
-    <Tag status="default">未开始</Tag>
-    <Tag status="warning">警告</Tag>
+    <Tag color="success">成功</Tag>
+    <Tag color="processing">进行中</Tag>
+    <Tag color="error">失败</Tag>
+    <Tag color="default">未开始</Tag>
+    <Tag color="warning">警告</Tag>
   </div>,
   mountNode,
 );

--- a/components/tag/demo/status.md
+++ b/components/tag/demo/status.md
@@ -21,7 +21,7 @@ ReactDOM.render(
     <Tag color="success">success</Tag>
     <Tag color="processing">processing</Tag>
     <Tag color="error">error</Tag>
-    <Tag color="default">not start</Tag>
+    <Tag color="default">default</Tag>
     <Tag color="warning">warning</Tag>
   </div>,
   mountNode,

--- a/components/tag/demo/status.md
+++ b/components/tag/demo/status.md
@@ -1,0 +1,29 @@
+---
+order: 7
+title:
+  zh-CN: 状态Tag
+  en-US: Status Tag
+---
+
+## zh-CN
+
+可以通过添加 `status` 变为状态标签。
+
+## en-US
+
+Usage of status Tag, and it could be status tag by set `status` property.
+
+```jsx
+import { Tag } from 'antd';
+
+ReactDOM.render(
+  <div>
+    <Tag status="success">成功</Tag>
+    <Tag status="processing">进行中</Tag>
+    <Tag status="error">失败</Tag>
+    <Tag status="default">未开始</Tag>
+    <Tag status="warning">警告</Tag>
+  </div>,
+  mountNode,
+);
+```

--- a/components/tag/demo/status.md
+++ b/components/tag/demo/status.md
@@ -7,7 +7,7 @@ title:
 
 ## zh-CN
 
-预设五种状态颜色，可以通过设置 `color` 为`success`、 `processing`、`error`、`default`、`warning`来代表不同的状态。
+预设五种状态颜色，可以通过设置 `color` 为 `success`、 `processing`、`error`、`default`、`warning` 来代表不同的状态。
 
 ## en-US
 
@@ -18,11 +18,11 @@ import { Tag } from 'antd';
 
 ReactDOM.render(
   <div>
-    <Tag color="success">成功</Tag>
-    <Tag color="processing">进行中</Tag>
-    <Tag color="error">失败</Tag>
-    <Tag color="default">未开始</Tag>
-    <Tag color="warning">警告</Tag>
+    <Tag color="success">success</Tag>
+    <Tag color="processing">processing</Tag>
+    <Tag color="error">error</Tag>
+    <Tag color="default">not start</Tag>
+    <Tag color="warning">warning</Tag>
   </div>,
   mountNode,
 );

--- a/components/tag/index.tsx
+++ b/components/tag/index.tsx
@@ -6,7 +6,7 @@ import { Close } from '@ant-design/icons';
 
 import CheckableTag from './CheckableTag';
 import { ConfigConsumer, ConfigConsumerProps } from '../config-provider';
-import { PresetColorTypes } from '../_util/colors';
+import { PresetColorTypes, PresetStatusColorTypes } from '../_util/colors';
 import Wave from '../_util/wave';
 
 export { CheckableTagProps } from './CheckableTag';
@@ -17,7 +17,6 @@ export interface TagProps extends React.HTMLAttributes<HTMLSpanElement> {
   color?: string;
   closable?: boolean;
   visible?: boolean;
-  status?: 'success' | 'processing' | 'default' | 'error' | 'warning';
   onClose?: Function;
   style?: React.CSSProperties;
 }
@@ -27,6 +26,7 @@ interface TagState {
 }
 
 const PresetColorRegex = new RegExp(`^(${PresetColorTypes.join('|')})(-inverse)?$`);
+const PresetStatusColorRegex = new RegExp(`^(${PresetStatusColorTypes.join('|')})$`);
 
 class Tag extends React.Component<TagProps, TagState> {
   static CheckableTag = CheckableTag;
@@ -58,7 +58,7 @@ class Tag extends React.Component<TagProps, TagState> {
   }
 
   getTagClassName({ getPrefixCls }: ConfigConsumerProps) {
-    const { prefixCls: customizePrefixCls, className, color, status } = this.props;
+    const { prefixCls: customizePrefixCls, className, color } = this.props;
     const { visible } = this.state;
     const isPresetColor = this.isPresetColor();
     const prefixCls = getPrefixCls('tag', customizePrefixCls);
@@ -68,7 +68,6 @@ class Tag extends React.Component<TagProps, TagState> {
         [`${prefixCls}-${color}`]: isPresetColor,
         [`${prefixCls}-has-color`]: color && !isPresetColor,
         [`${prefixCls}-hidden`]: !visible,
-        [`${prefixCls}-status-${status}`]: !!status,
       },
       className,
     );
@@ -97,7 +96,7 @@ class Tag extends React.Component<TagProps, TagState> {
     if (!color) {
       return false;
     }
-    return PresetColorRegex.test(color);
+    return PresetColorRegex.test(color) || PresetStatusColorRegex.test(color);
   }
 
   renderCloseIcon() {

--- a/components/tag/index.tsx
+++ b/components/tag/index.tsx
@@ -17,6 +17,7 @@ export interface TagProps extends React.HTMLAttributes<HTMLSpanElement> {
   color?: string;
   closable?: boolean;
   visible?: boolean;
+  status?: 'success' | 'processing' | 'default' | 'error' | 'warning';
   onClose?: Function;
   style?: React.CSSProperties;
 }
@@ -57,7 +58,7 @@ class Tag extends React.Component<TagProps, TagState> {
   }
 
   getTagClassName({ getPrefixCls }: ConfigConsumerProps) {
-    const { prefixCls: customizePrefixCls, className, color } = this.props;
+    const { prefixCls: customizePrefixCls, className, color, status } = this.props;
     const { visible } = this.state;
     const isPresetColor = this.isPresetColor();
     const prefixCls = getPrefixCls('tag', customizePrefixCls);
@@ -67,6 +68,7 @@ class Tag extends React.Component<TagProps, TagState> {
         [`${prefixCls}-${color}`]: isPresetColor,
         [`${prefixCls}-has-color`]: color && !isPresetColor,
         [`${prefixCls}-hidden`]: !visible,
+        [`${prefixCls}-status-${status}`]: !!status,
       },
       className,
     );

--- a/components/tag/index.zh-CN.md
+++ b/components/tag/index.zh-CN.md
@@ -21,7 +21,6 @@ title: Tag
 | afterClose | 关闭动画完成后的回调，请使用 `onClose`, 我们将在下个版本删除此项 | () => void | - |  |
 | closable | 标签是否可以关闭 | boolean | false |  |
 | color | 标签色 | string | - |  |
-| status | 状态 | Enum{ 'success', 'processing, 'default', 'error', 'warning' } | - | 4.0 |
 | onClose | 关闭时的回调 | (e) => void | - |  |
 | visible | 是否显示标签 | boolean | `true` | 3.7.0 |
 

--- a/components/tag/index.zh-CN.md
+++ b/components/tag/index.zh-CN.md
@@ -21,6 +21,7 @@ title: Tag
 | afterClose | 关闭动画完成后的回调，请使用 `onClose`, 我们将在下个版本删除此项 | () => void | - |  |
 | closable | 标签是否可以关闭 | boolean | false |  |
 | color | 标签色 | string | - |  |
+| status | 状态 | Enum{ 'success', 'processing, 'default', 'error', 'warning' } | - | 4.0 |
 | onClose | 关闭时的回调 | (e) => void | - |  |
 | visible | 是否显示标签 | boolean | `true` | 3.7.0 |
 

--- a/components/tag/style/index.less
+++ b/components/tag/style/index.less
@@ -102,5 +102,21 @@
     }
   }
 
+  .make-status-color-classes(@color, @status) {
+    @lightColor: '@{color}-1';
+    @lightBorderColor: '@{color}-3';
+    @darkColor: '@{color}-6';
+    &-status-@{status} {
+      color: @@darkColor;
+      background: @@lightColor;
+      border-color: @@lightBorderColor;
+    }
+  }
+
   .make-color-classes();
+
+  .make-status-color-classes('green', success);
+  .make-status-color-classes('cyan', processing);
+  .make-status-color-classes('red', error);
+  .make-status-color-classes('orange', warning);
 }

--- a/components/tag/style/index.less
+++ b/components/tag/style/index.less
@@ -106,7 +106,7 @@
     @lightColor: '@{color}-1';
     @lightBorderColor: '@{color}-3';
     @darkColor: '@{color}-6';
-    &-status-@{status} {
+    &-@{status} {
       color: @@darkColor;
       background: @@lightColor;
       border-color: @@lightBorderColor;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution
Sometimes tag component can be used to indicate status. The existing tag cannot be set by color property to achieve the design below. so preset status color to enhance tag component. We preset five different colors, you can set color property such as `success`,`processing`,`error`,`default` and `warning` to indicate specific status.

![image](https://user-images.githubusercontent.com/12150416/67481864-43d36c00-f695-11e9-9a5d-2858386d1f36.png)

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     preset status color into Tag       |
| 🇨🇳 Chinese |      Tag组件预设状态颜色     |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/tag/demo/status.md](https://github.com/QingLance/ant-design/blob/4.0-prepare/components/tag/demo/status.md)
[View rendered components/tag/index.zh-CN.md](https://github.com/QingLance/ant-design/blob/4.0-prepare/components/tag/index.zh-CN.md)