### PR TITLE
fix: Modal icon position while no title

### DIFF
--- a/components/modal/__tests__/confirm.test.js
+++ b/components/modal/__tests__/confirm.test.js
@@ -27,6 +27,13 @@ describe('Modal.confirm triggers callbacks correctly', () => {
     });
   }
 
+  it('should not render title when title not defined', () => {
+    confirm({
+      content: 'some descriptions',
+    });
+    expect(document.querySelector('.ant-modal-confirm-title')).toBe(null);
+  });
+
   it('trigger onCancel once when click on cancel button', () => {
     const onCancel = jest.fn();
     const onOk = jest.fn();

--- a/components/modal/confirm.tsx
+++ b/components/modal/confirm.tsx
@@ -100,7 +100,9 @@ const ConfirmDialog = (props: ConfirmDialogProps) => {
       <div className={`${contentPrefixCls}-body-wrapper`}>
         <div className={`${contentPrefixCls}-body`}>
           {iconNode}
-          <span className={`${contentPrefixCls}-title`}>{props.title}</span>
+          {props.title === undefined ? null : (
+            <span className={`${contentPrefixCls}-title`}>{props.title}</span>
+          )}
           <div className={`${contentPrefixCls}-content`}>{props.content}</div>
         </div>
         <div className={`${contentPrefixCls}-btns`}>

--- a/components/modal/demo/info.md
+++ b/components/modal/demo/info.md
@@ -31,7 +31,6 @@ function info() {
 
 function success() {
   Modal.success({
-    title: 'This is a success message',
     content: 'some messages...some messages...',
   });
 }


### PR DESCRIPTION


<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
close #19389

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution
not render title when Modal title is undefined.
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  fix Modal icon position when not use title         |
| 🇨🇳 Chinese |   修复当没有标题时 Modal 中图标没对齐的问题    |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
