### PR TITLE
docs: add "maxLength" property to Input Doc

### DIFF
--- a/components/input/index.en-US.md
+++ b/components/input/index.en-US.md
@@ -22,6 +22,7 @@ A basic widget for getting the user input is a text field. Keyboard and mouse ca
 | defaultValue | The initial input content | string |  |  |
 | disabled | Whether the input is disabled. | boolean | false |  |
 | id | The ID for input | string |  |  |
+| maxLength | max length | number |  |  |
 | prefix | The prefix icon for the Input. | string\|ReactNode |  |  |
 | size | The size of the input box. Note: in the context of a form, the `large` size is used. Available: `large` `default` `small` | string | `default` |  |
 | suffix | The suffix icon for the Input. | string\|ReactNode |  |  |

--- a/components/input/index.zh-CN.md
+++ b/components/input/index.zh-CN.md
@@ -23,6 +23,7 @@ title: Input
 | defaultValue | 输入框默认内容 | string |  |  |
 | disabled | 是否禁用状态，默认为 false | boolean | false |  |
 | id | 输入框的 id | string |  |  |
+| maxLength | 最大长度 | number |  |  |
 | prefix | 带有前缀图标的 input | string\|ReactNode |  |  |
 | size | 控件大小。注：标准表单内的输入框大小限制为 `large`。可选 `large` `default` `small` | string | `default` |  |
 | suffix | 带有后缀图标的 input | string\|ReactNode |  |  |


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

新特性请提交至 feature 分支，其余可提交至 master 分支。
在一个维护者审核通过后合并。
请确保填写以下 pull request 的信息，谢谢！~

[[English Template / 英文模板](?expand=1)]
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [ ] 日常 bug 修复
- [x] 站点、文档改进
- [ ] 组件样式改进
- [ ] TypeScript 定义更新
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
在 `Input` 组件中看到有提供 `maxLength` 属性，但文档 API 说明中没有这个属性，所以补充了一下。
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志怎么写？

<!--
> 从用户角度描述具体变化，以及可能的 breaking change 和其他风险？
-->

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |Input API DOC add maxLength Property|
| 🇨🇳 中文 |Input API 文档添加 maxLength 的属性|

- 中文（可选）:

### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供

-----
[View rendered components/input/index.en-US.md](https://github.com/nbhaohao/ant-design/blob/fix/inputApiDocError/components/input/index.en-US.md)
[View rendered components/input/index.zh-CN.md](https://github.com/nbhaohao/ant-design/blob/fix/inputApiDocError/components/input/index.zh-CN.md)