### PR TITLE
docs: Responsive fixes for examples pages

### DIFF
--- a/components/cascader/index.en-US.md
+++ b/components/cascader/index.en-US.md
@@ -72,9 +72,3 @@ interface Option {
 | ------- | ------------ | ------- |
 | blur()  | remove focus |         |
 | focus() | get focus    |         |
-
-<style>
-.ant-cascader-picker {
-  width: 300px;
-}
-</style>

--- a/components/cascader/index.zh-CN.md
+++ b/components/cascader/index.zh-CN.md
@@ -74,10 +74,4 @@ interface Option {
 | blur()  | 移除焦点 |      |
 | focus() | 获取焦点 |      |
 
-<style>
-.ant-cascader-picker {
-  width: 300px;
-}
-</style>
-
 > 注意，如果需要获得中国省市区数据，可以参考 [china-division](https://gist.github.com/afc163/7582f35654fd03d5be7009444345ea17)。

--- a/components/slider/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/slider/__tests__/__snapshots__/demo.test.js.snap
@@ -1034,7 +1034,7 @@ exports[`renders ./components/slider/demo/tip-formatter.md correctly 1`] = `
 exports[`renders ./components/slider/demo/vertical.md correctly 1`] = `
 <div>
   <div
-    style="float:left;height:300px;margin-left:70px"
+    style="display:inline-block;height:300px;margin-left:70px"
   >
     <div
       class="ant-slider ant-slider-vertical"
@@ -1065,7 +1065,7 @@ exports[`renders ./components/slider/demo/vertical.md correctly 1`] = `
     </div>
   </div>
   <div
-    style="float:left;height:300px;margin-left:70px"
+    style="display:inline-block;height:300px;margin-left:70px"
   >
     <div
       class="ant-slider ant-slider-vertical"
@@ -1106,7 +1106,7 @@ exports[`renders ./components/slider/demo/vertical.md correctly 1`] = `
     </div>
   </div>
   <div
-    style="float:left;height:300px;margin-left:70px"
+    style="display:inline-block;height:300px;margin-left:70px"
   >
     <div
       class="ant-slider ant-slider-with-marks ant-slider-vertical"
@@ -1190,8 +1190,5 @@ exports[`renders ./components/slider/demo/vertical.md correctly 1`] = `
       </div>
     </div>
   </div>
-  <div
-    class="clearfix"
-  />
 </div>
 `;

--- a/components/slider/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/slider/__tests__/__snapshots__/demo.test.js.snap
@@ -1032,9 +1032,7 @@ exports[`renders ./components/slider/demo/tip-formatter.md correctly 1`] = `
 `;
 
 exports[`renders ./components/slider/demo/vertical.md correctly 1`] = `
-<div
-  style="height:300px"
->
+<div>
   <div
     style="float:left;height:300px;margin-left:70px"
   >
@@ -1192,5 +1190,8 @@ exports[`renders ./components/slider/demo/vertical.md correctly 1`] = `
       </div>
     </div>
   </div>
+  <div
+    class="clearfix"
+  />
 </div>
 `;

--- a/components/slider/demo/vertical.md
+++ b/components/slider/demo/vertical.md
@@ -45,7 +45,7 @@ ReactDOM.render(
     <div style={style}>
       <Slider vertical range marks={marks} defaultValue={[26, 37]} />
     </div>
-    <div className="clearfix"></div>
+    <div className="clearfix" />
   </div>,
   mountNode,
 );

--- a/components/slider/demo/vertical.md
+++ b/components/slider/demo/vertical.md
@@ -35,7 +35,7 @@ const marks = {
 };
 
 ReactDOM.render(
-  <div style={{ height: 300 }}>
+  <div>
     <div style={style}>
       <Slider vertical defaultValue={30} />
     </div>
@@ -45,6 +45,7 @@ ReactDOM.render(
     <div style={style}>
       <Slider vertical range marks={marks} defaultValue={[26, 37]} />
     </div>
+    <div className="clearfix"></div>
   </div>,
   mountNode,
 );

--- a/components/slider/demo/vertical.md
+++ b/components/slider/demo/vertical.md
@@ -17,7 +17,7 @@ The vertical Slider.
 import { Slider } from 'antd';
 
 const style = {
-  float: 'left',
+  display: 'inline-block',
   height: 300,
   marginLeft: 70,
 };
@@ -45,7 +45,6 @@ ReactDOM.render(
     <div style={style}>
       <Slider vertical range marks={marks} defaultValue={[26, 37]} />
     </div>
-    <div className="clearfix" />
   </div>,
   mountNode,
 );

--- a/components/tree-select/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/tree-select/__tests__/__snapshots__/demo.test.js.snap
@@ -5,7 +5,7 @@ exports[`renders ./components/tree-select/demo/async.md correctly 1`] = `
   aria-haspopup="listbox"
   class="ant-select ant-select-enabled"
   role="combobox"
-  style="width:300px"
+  style="width:100%"
   tabindex="0"
 >
   <span
@@ -53,7 +53,7 @@ exports[`renders ./components/tree-select/demo/basic.md correctly 1`] = `
   aria-haspopup="listbox"
   class="ant-select ant-select-enabled ant-select-allow-clear"
   role="combobox"
-  style="width:300px"
+  style="width:100%"
   tabindex="0"
 >
   <span
@@ -101,7 +101,7 @@ exports[`renders ./components/tree-select/demo/checkable.md correctly 1`] = `
   aria-haspopup="listbox"
   class="ant-select ant-select-enabled"
   role="combobox"
-  style="width:300px"
+  style="width:100%"
   tabindex="-1"
 >
   <span
@@ -184,7 +184,7 @@ exports[`renders ./components/tree-select/demo/multiple.md correctly 1`] = `
   aria-haspopup="listbox"
   class="ant-select ant-select-enabled ant-select-allow-clear"
   role="combobox"
-  style="width:300px"
+  style="width:100%"
   tabindex="-1"
 >
   <span
@@ -231,7 +231,7 @@ exports[`renders ./components/tree-select/demo/suffix.md correctly 1`] = `
   aria-haspopup="listbox"
   class="ant-select ant-select-enabled ant-select-allow-clear"
   role="combobox"
-  style="width:300px"
+  style="width:100%"
   tabindex="0"
 >
   <span
@@ -279,7 +279,7 @@ exports[`renders ./components/tree-select/demo/treeData.md correctly 1`] = `
   aria-haspopup="listbox"
   class="ant-select ant-select-enabled"
   role="combobox"
-  style="width:300px"
+  style="width:100%"
   tabindex="0"
 >
   <span

--- a/components/tree-select/demo/async.md
+++ b/components/tree-select/demo/async.md
@@ -63,7 +63,7 @@ class Demo extends React.Component {
     return (
       <TreeSelect
         treeDataSimpleMode
-        style={{ width: 300 }}
+        style={{ width: '100%' }}
         value={this.state.value}
         dropdownStyle={{ maxHeight: 400, overflow: 'auto' }}
         placeholder="Please select"

--- a/components/tree-select/demo/basic.md
+++ b/components/tree-select/demo/basic.md
@@ -32,7 +32,7 @@ class Demo extends React.Component {
     return (
       <TreeSelect
         showSearch
-        style={{ width: 300 }}
+        style={{ width: '100%' }}
         value={this.state.value}
         dropdownStyle={{ maxHeight: 400, overflow: 'auto' }}
         placeholder="Please select"

--- a/components/tree-select/demo/checkable.md
+++ b/components/tree-select/demo/checkable.md
@@ -74,7 +74,7 @@ class Demo extends React.Component {
       showCheckedStrategy: SHOW_PARENT,
       searchPlaceholder: 'Please select',
       style: {
-        width: 300,
+        width: '100%',
       },
     };
     return <TreeSelect {...tProps} />;

--- a/components/tree-select/demo/multiple.md
+++ b/components/tree-select/demo/multiple.md
@@ -32,7 +32,7 @@ class Demo extends React.Component {
     return (
       <TreeSelect
         showSearch
-        style={{ width: 300 }}
+        style={{ width: '100%' }}
         value={this.state.value}
         dropdownStyle={{ maxHeight: 400, overflow: 'auto' }}
         placeholder="Please select"

--- a/components/tree-select/demo/suffix.md
+++ b/components/tree-select/demo/suffix.md
@@ -35,7 +35,7 @@ class Demo extends React.Component {
       <TreeSelect
         showSearch
         suffixIcon={icon}
-        style={{ width: 300 }}
+        style={{ width: '100%' }}
         value={this.state.value}
         dropdownStyle={{ maxHeight: 400, overflow: 'auto' }}
         placeholder="Please select"

--- a/components/tree-select/demo/treeData.md
+++ b/components/tree-select/demo/treeData.md
@@ -54,7 +54,7 @@ class Demo extends React.Component {
   render() {
     return (
       <TreeSelect
-        style={{ width: 300 }}
+        style={{ width: '100%' }}
         value={this.state.value}
         dropdownStyle={{ maxHeight: 400, overflow: 'auto' }}
         treeData={treeData}


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

N/A

### 💡 Background and solution

#### Remove Cascader fixed width:
*Before:*
![cascade_before](https://user-images.githubusercontent.com/14093913/67640906-62d03900-f8f5-11e9-8b4e-6a1ef33c9575.png)
*After:*
![cascade_after](https://user-images.githubusercontent.com/14093913/67640905-62d03900-f8f5-11e9-97fb-7304de8c37b2.png)

#### Add vertical Slider clearfix:
*Before:*
![slider_before](https://user-images.githubusercontent.com/14093913/67640908-6368cf80-f8f5-11e9-94c7-8cecd1529e45.png)
*After:*
![slider_after](https://user-images.githubusercontent.com/14093913/67640907-6368cf80-f8f5-11e9-98d4-e89fa1d4e608.png)

#### Remove TreeSelect fixed width:
*Before:*
![treeselect_before](https://user-images.githubusercontent.com/14093913/67640910-6368cf80-f8f5-11e9-945f-d65f2b005df7.png)
*After:*
![treeselect_after](https://user-images.githubusercontent.com/14093913/67640909-6368cf80-f8f5-11e9-8f5a-667a8a690739.png)



### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A          |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/cascader/index.en-US.md](https://github.com/broder/ant-design/blob/responsive-example-fixes/components/cascader/index.en-US.md)
[View rendered components/cascader/index.zh-CN.md](https://github.com/broder/ant-design/blob/responsive-example-fixes/components/cascader/index.zh-CN.md)
[View rendered components/slider/demo/vertical.md](https://github.com/broder/ant-design/blob/responsive-example-fixes/components/slider/demo/vertical.md)
[View rendered components/tree-select/demo/async.md](https://github.com/broder/ant-design/blob/responsive-example-fixes/components/tree-select/demo/async.md)
[View rendered components/tree-select/demo/basic.md](https://github.com/broder/ant-design/blob/responsive-example-fixes/components/tree-select/demo/basic.md)
[View rendered components/tree-select/demo/checkable.md](https://github.com/broder/ant-design/blob/responsive-example-fixes/components/tree-select/demo/checkable.md)
[View rendered components/tree-select/demo/multiple.md](https://github.com/broder/ant-design/blob/responsive-example-fixes/components/tree-select/demo/multiple.md)
[View rendered components/tree-select/demo/suffix.md](https://github.com/broder/ant-design/blob/responsive-example-fixes/components/tree-select/demo/suffix.md)
[View rendered components/tree-select/demo/treeData.md](https://github.com/broder/ant-design/blob/responsive-example-fixes/components/tree-select/demo/treeData.md)