### PR TITLE
fix: table does not automatically scroll to the top when change page size

### DIFF
--- a/components/table/Table.tsx
+++ b/components/table/Table.tsx
@@ -807,7 +807,7 @@ class Table<T> extends React.Component<InternalTableProps<T>, TableState<T>> {
         current: this.state.pagination.current,
       };
     }
-    this.setState(newState, () => this.scrollToFirstRow());
+    this.setState(newState, this.scrollToFirstRow);
 
     this.props.store.setState({
       selectionDirty: false,
@@ -834,7 +834,7 @@ class Table<T> extends React.Component<InternalTableProps<T>, TableState<T>> {
       pageSize,
       current,
     };
-    this.setState({ pagination: nextPagination });
+    this.setState({ pagination: nextPagination }, this.scrollToFirstRow);
 
     const { onChange } = this.props;
     if (onChange) {
@@ -878,7 +878,7 @@ class Table<T> extends React.Component<InternalTableProps<T>, TableState<T>> {
 
     // Controlled
     if (this.getSortOrderColumns().length === 0) {
-      this.setState(newState, () => this.scrollToFirstRow());
+      this.setState(newState, this.scrollToFirstRow);
     }
 
     const { onChange } = this.props;

--- a/components/table/__tests__/Table.pagination.test.js
+++ b/components/table/__tests__/Table.pagination.test.js
@@ -98,7 +98,7 @@ describe('Table.pagination', () => {
       .simulate('click');
     expect(scrollToSpy).toHaveBeenCalledTimes(1);
 
-    wrapper.find('Trigger').simulate('click');
+    wrapper.find('.ant-select').simulate('click');
     wrapper
       .find('MenuItem')
       .find('li')

--- a/components/table/__tests__/Table.pagination.test.js
+++ b/components/table/__tests__/Table.pagination.test.js
@@ -79,14 +79,32 @@ describe('Table.pagination', () => {
     expect(wrapper.find('.ant-pagination.mini')).toHaveLength(1);
   });
 
-  // TODO
   it('should scroll to first row when page change', () => {
-    const wrapper = mount(createTable({ scroll: { y: 20 } }));
+    const wrapper = mount(
+      createTable({ scroll: { y: 20 }, pagination: { showSizeChanger: true, pageSize: 2 } }),
+    );
+    const scrollToSpy = jest.spyOn(
+      wrapper
+        .find('Table')
+        .first()
+        .instance(),
+      'scrollToFirstRow',
+    );
+    expect(scrollToSpy).toHaveBeenCalledTimes(0);
 
     wrapper
       .find('Pager')
       .last()
       .simulate('click');
+    expect(scrollToSpy).toHaveBeenCalledTimes(1);
+
+    wrapper.find('Trigger').simulate('click');
+    wrapper
+      .find('MenuItem')
+      .find('li')
+      .last()
+      .simulate('click');
+    expect(scrollToSpy).toHaveBeenCalledTimes(2);
   });
 
   it('fires change event', () => {


### PR DESCRIPTION



<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
close #19464
<!--
1. Describe the source of requirement, like related issue link.
-->


### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    fix table does not automatically scroll to the top when change page size       |
| 🇨🇳 Chinese |   修复当改变表格每页大小时不滚动到第一行的问题        |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
