### PR TITLE
fix: Drawer content overflow when placement is top or bottom

### DIFF
--- a/components/config-provider/__tests__/__snapshots__/components.test.js.snap
+++ b/components/config-provider/__tests__/__snapshots__/components.test.js.snap
@@ -6791,7 +6791,6 @@ exports[`ConfigProvider components Drawer configProvider 1`] = `
       >
         <div
           class="config-drawer-wrapper-body"
-          style="overflow:auto;height:100%"
         >
           <div
             class="config-drawer-header-no-title"
@@ -6851,7 +6850,6 @@ exports[`ConfigProvider components Drawer normal 1`] = `
       >
         <div
           class="ant-drawer-wrapper-body"
-          style="overflow:auto;height:100%"
         >
           <div
             class="ant-drawer-header-no-title"
@@ -6911,7 +6909,6 @@ exports[`ConfigProvider components Drawer prefixCls 1`] = `
       >
         <div
           class="prefix-Drawer-wrapper-body"
-          style="overflow:auto;height:100%"
         >
           <div
             class="prefix-Drawer-header-no-title"

--- a/components/drawer/__tests__/__snapshots__/Drawer.test.js.snap
+++ b/components/drawer/__tests__/__snapshots__/Drawer.test.js.snap
@@ -20,7 +20,7 @@ exports[`Drawer className is test_drawer 1`] = `
       >
         <div
           class="ant-drawer-wrapper-body"
-          style="overflow:auto;height:100%;opacity:0;transition:opacity .3s"
+          style="opacity:0;transition:opacity .3s"
         >
           <div
             class="ant-drawer-header-no-title"
@@ -82,7 +82,6 @@ exports[`Drawer closable is false 1`] = `
       >
         <div
           class="ant-drawer-wrapper-body"
-          style="overflow:auto;height:100%"
         >
           <div
             class="ant-drawer-body"
@@ -116,7 +115,7 @@ exports[`Drawer destroyOnClose is true 1`] = `
       >
         <div
           class="ant-drawer-wrapper-body"
-          style="overflow:auto;height:100%;opacity:0;transition:opacity .3s"
+          style="opacity:0;transition:opacity .3s"
         >
           <div
             class="ant-drawer-header-no-title"
@@ -178,7 +177,6 @@ exports[`Drawer have a title 1`] = `
       >
         <div
           class="ant-drawer-wrapper-body"
-          style="overflow:auto;height:100%"
         >
           <div
             class="ant-drawer-header"
@@ -245,7 +243,6 @@ exports[`Drawer render correctly 1`] = `
       >
         <div
           class="ant-drawer-wrapper-body"
-          style="overflow:auto;height:100%"
         >
           <div
             class="ant-drawer-header-no-title"
@@ -369,7 +366,7 @@ exports[`Drawer style/drawerStyle/headerStyle/bodyStyle should work 1`] = `
       >
         <div
           class="ant-drawer-wrapper-body"
-          style="overflow:auto;height:100%;background-color:#08c"
+          style="background-color:#08c"
         >
           <div
             class="ant-drawer-header-no-title"

--- a/components/drawer/__tests__/__snapshots__/DrawerEvent.test.js.snap
+++ b/components/drawer/__tests__/__snapshots__/DrawerEvent.test.js.snap
@@ -29,7 +29,6 @@ exports[`Drawer render correctly 1`] = `
         >
           <div
             class="ant-drawer-wrapper-body"
-            style="overflow: auto; height: 100%;"
           >
             <div
               class="ant-drawer-header-no-title"

--- a/components/drawer/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/drawer/__tests__/__snapshots__/demo.test.js.snap
@@ -193,7 +193,6 @@ exports[`renders ./components/drawer/demo/render-in-current.md correctly 1`] = `
         >
           <div
             class="ant-drawer-wrapper-body"
-            style="overflow:auto;height:100%"
           >
             <div
               class="ant-drawer-header"

--- a/components/drawer/index.tsx
+++ b/components/drawer/index.tsx
@@ -174,19 +174,13 @@ class Drawer extends React.Component<DrawerProps & ConfigConsumerProps, IDrawerS
 
   // render drawer body dom
   renderBody = () => {
-    const { bodyStyle, drawerStyle, placement, prefixCls, visible } = this.props;
+    const { bodyStyle, drawerStyle, prefixCls, visible } = this.props;
     if (this.destroyClose && !visible) {
       return null;
     }
     this.destroyClose = false;
 
-    const containerStyle: React.CSSProperties =
-      placement === 'left' || placement === 'right'
-        ? {
-            overflow: 'auto',
-            height: '100%',
-          }
-        : {};
+    const containerStyle: React.CSSProperties = {};
 
     const isDestroyOnClose = this.getDestroyOnClose();
 

--- a/components/drawer/style/drawer.less
+++ b/components/drawer/style/drawer.less
@@ -213,6 +213,10 @@
       box-shadow: @shadow-2;
     }
   }
+  &-wrapper-body {
+    height: 100%;
+    overflow: auto;
+  }
 }
 
 @keyframes antdDrawerFadeIn {

--- a/components/drawer/style/drawer.less
+++ b/components/drawer/style/drawer.less
@@ -140,6 +140,7 @@
   &-content {
     position: relative;
     z-index: 1;
+    overflow: auto;
     background-color: @component-background;
     background-clip: padding-box;
     border: 0;
@@ -212,10 +213,6 @@
     &-content {
       box-shadow: @shadow-2;
     }
-  }
-  &-wrapper-body {
-    height: 100%;
-    overflow: auto;
   }
 }
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
Fixed #19454 

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Fix Drawer content overflow when `placement` prop is `top` or `bottom`    |
| 🇨🇳 Chinese | 修复 Drawer 当 `placement` 属性为 `top` 或 `bottom` 时内容溢出   |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
