### PR TITLE
Gets the XMLHttpRequest Object in OnChange function

### DIFF
--- a/components/upload/Upload.tsx
+++ b/components/upload/Upload.tsx
@@ -103,7 +103,7 @@ class Upload extends React.Component<UploadProps, UploadState> {
     }
   };
 
-  onSuccess = (response: any, file: UploadFile) => {
+  onSuccess = (response: any, file: UploadFile, xhr: any) => {
     this.clearProgressTimer();
     try {
       if (typeof response === 'string') {
@@ -120,6 +120,7 @@ class Upload extends React.Component<UploadProps, UploadState> {
     }
     targetItem.status = 'done';
     targetItem.response = response;
+    targetItem.xhr = xhr;
     this.onChange({
       file: { ...targetItem },
       fileList,

--- a/components/upload/index.en-US.md
+++ b/components/upload/index.en-US.md
@@ -61,10 +61,11 @@ When uploading state change, it returns:
    ```js
    {
       uid: 'uid',      // unique identifier, negative is recommend, to prevent interference with internal generated id
-      name: 'xx.png'   // file name
+      name: 'xx.png',   // file name
       status: 'done', // options：uploading, done, error, removed
       response: '{"status": "success"}', // response from server
       linkProps: '{"download": "image"}', // additional html props of file link
+      xhr: 'XMLHttpRequest{ ... }', // XMLHttpRequest Header
    }
    ```
 

--- a/components/upload/interface.tsx
+++ b/components/upload/interface.tsx
@@ -41,6 +41,7 @@ export interface UploadFile<T = any> {
   linkProps?: any;
   type: string;
   preview?: string;
+  xhr?: T;
 }
 
 export interface UploadChangeParam<T extends object = UploadFile> {


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
Possibly fix the following issue (but not 100%)
https://github.com/ant-design/ant-design/issues/19386

### 💡 Background and solution
I noticed that in https://github.com/react-component/upload/blob/master/src/AjaxUploader.jsx#L177 , we are passing the XMLHttpRequest object to the OnSuccess function but we are not retrieiving it and exposing it to the user (via the onChange function). This PR aims to fix that but allowing the user to have access to it through the file parameter on the `onChange` function.

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/upload/index.en-US.md](https://github.com/hahmadia/ant-design/blob/GH19386/components/upload/index.en-US.md)