### PR TITLE
fix: Table inifinite loop and defaultSortOrder

### DIFF
--- a/components/table/Table.tsx
+++ b/components/table/Table.tsx
@@ -284,7 +284,7 @@ class Table<T> extends React.Component<InternalTableProps<T>, TableState<T>> {
     const { columns, sortColumn, sortOrder } = this.state;
     if (this.getSortOrderColumns(columns).length > 0) {
       const sortState = this.getSortStateFromColumns(columns);
-      if (sortState.sortColumn !== sortColumn || sortState.sortOrder !== sortOrder) {
+      if (!isSameColumn(sortState.sortColumn, sortColumn) || sortState.sortOrder !== sortOrder) {
         this.setState(sortState);
       }
     }

--- a/components/table/Table.tsx
+++ b/components/table/Table.tsx
@@ -249,7 +249,7 @@ class Table<T> extends React.Component<InternalTableProps<T>, TableState<T>> {
   constructor(props: InternalTableProps<T>) {
     super(props);
 
-    const { expandedRowRender, columns: columnsProp = [] } = props;
+    const { expandedRowRender, columns: columnsProp } = props;
 
     warning(
       !('columnsPageRange' in props || 'columnsPageSize' in props),
@@ -258,7 +258,7 @@ class Table<T> extends React.Component<InternalTableProps<T>, TableState<T>> {
         'fixed columns instead, see: https://u.ant.design/fixed-columns.',
     );
 
-    if (expandedRowRender && columnsProp.some(({ fixed }) => !!fixed)) {
+    if (expandedRowRender && (columnsProp || []).some(({ fixed }) => !!fixed)) {
       warning(
         false,
         'Table',
@@ -269,7 +269,7 @@ class Table<T> extends React.Component<InternalTableProps<T>, TableState<T>> {
     const columns = columnsProp || normalizeColumns(props.children as React.ReactChildren);
 
     this.state = {
-      ...this.getDefaultSortOrder(columns),
+      ...this.getDefaultSortOrder(columns || []),
       // 减少状态
       filters: getFiltersFromColumns<T>(),
       pagination: this.getDefaultPagination(props),
@@ -358,10 +358,9 @@ class Table<T> extends React.Component<InternalTableProps<T>, TableState<T>> {
   getDefaultSortOrder(columns?: ColumnProps<T>[]) {
     const definedSortState = this.getSortStateFromColumns(columns);
 
-    const defaultSortedColumn = flatFilter(
-      columns || [],
-      (column: ColumnProps<T>) => column.defaultSortOrder != null,
-    )[0];
+    const defaultSortedColumn = flatFilter(columns || [], (column: ColumnProps<T>) => {
+      return column.defaultSortOrder != null;
+    })[0];
 
     if (defaultSortedColumn && !definedSortState.sortColumn) {
       return {

--- a/components/table/__tests__/Table.sorter.test.js
+++ b/components/table/__tests__/Table.sorter.test.js
@@ -696,4 +696,13 @@ describe('Table.sorter', () => {
       mount(<Demo />);
     }).not.toThrow();
   });
+
+  it('should support defaultOrder in Column', () => {
+    const wrapper = mount(
+      <Table dataSource={[{ key: '1', age: 1 }]}>
+        <Table.Column title="Age" dataIndex="age" sorter defaultSortOrder="ascend" key="age" />
+      </Table>,
+    );
+    expect(wrapper.render()).toMatchSnapshot();
+  });
 });

--- a/components/table/__tests__/Table.sorter.test.js
+++ b/components/table/__tests__/Table.sorter.test.js
@@ -676,4 +676,24 @@ describe('Table.sorter', () => {
 
     expect(renderedNames(wrapper)).toEqual(['Brown', 'Green', 'Mike', 'Alex', 'Petter', 'Zoe']);
   });
+
+  // https://github.com/ant-design/ant-design/issues/19443
+  it('should not being inifinite loop when using Table.Column with sortOrder', () => {
+    class Demo extends React.Component {
+      componentDidMount() {
+        this.setState({});
+      }
+
+      render() {
+        return (
+          <Table dataSource={[]}>
+            <Table.Column title="Age" dataIndex="age" sorter sortOrder="ascend" key="age" />
+          </Table>
+        );
+      }
+    }
+    expect(() => {
+      mount(<Demo />);
+    }).not.toThrow();
+  });
 });

--- a/components/table/__tests__/__snapshots__/Table.sorter.test.js.snap
+++ b/components/table/__tests__/__snapshots__/Table.sorter.test.js.snap
@@ -72,3 +72,193 @@ exports[`Table.sorter renders sorter icon correctly 1`] = `
   </tr>
 </thead>
 `;
+
+exports[`Table.sorter should support defaultOrder in Column 1`] = `
+<div
+  class="ant-table-wrapper"
+>
+  <div
+    class="ant-spin-nested-loading"
+  >
+    <div
+      class="ant-spin-container"
+    >
+      <div
+        class="ant-table ant-table-default ant-table-scroll-position-left"
+      >
+        <div
+          class="ant-table-content"
+        >
+          <div
+            class="ant-table-body"
+          >
+            <table
+              class=""
+            >
+              <colgroup>
+                <col />
+              </colgroup>
+              <thead
+                class="ant-table-thead"
+              >
+                <tr>
+                  <th
+                    class="ant-table-column-has-actions ant-table-column-has-sorters ant-table-column-sort"
+                  >
+                    <span
+                      class="ant-table-header-column"
+                    >
+                      <div
+                        class="ant-table-column-sorters"
+                      >
+                        <span
+                          class="ant-table-column-title"
+                        >
+                          Age
+                        </span>
+                        <span
+                          class="ant-table-column-sorter"
+                        >
+                          <div
+                            class="ant-table-column-sorter-inner ant-table-column-sorter-inner-full"
+                            title="Sort"
+                          >
+                            <i
+                              aria-label="icon: caret-up"
+                              class="anticon anticon-caret-up ant-table-column-sorter-up on"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class=""
+                                data-icon="caret-up"
+                                fill="currentColor"
+                                focusable="false"
+                                height="1em"
+                                viewBox="0 0 1024 1024"
+                                width="1em"
+                              >
+                                <path
+                                  d="M858.9 689L530.5 308.2c-9.4-10.9-27.5-10.9-37 0L165.1 689c-12.2 14.2-1.2 35 18.5 35h656.8c19.7 0 30.7-20.8 18.5-35z"
+                                />
+                              </svg>
+                            </i>
+                            <i
+                              aria-label="icon: caret-down"
+                              class="anticon anticon-caret-down ant-table-column-sorter-down off"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class=""
+                                data-icon="caret-down"
+                                fill="currentColor"
+                                focusable="false"
+                                height="1em"
+                                viewBox="0 0 1024 1024"
+                                width="1em"
+                              >
+                                <path
+                                  d="M840.4 300H183.6c-19.7 0-30.7 20.8-18.5 35l328.4 380.8c9.4 10.9 27.5 10.9 37 0L858.9 335c12.2-14.2 1.2-35-18.5-35z"
+                                />
+                              </svg>
+                            </i>
+                          </div>
+                        </span>
+                      </div>
+                    </span>
+                  </th>
+                </tr>
+              </thead>
+              <tbody
+                class="ant-table-tbody"
+              >
+                <tr
+                  class="ant-table-row ant-table-row-level-0"
+                  data-row-key="1"
+                >
+                  <td
+                    class="ant-table-column-has-actions ant-table-column-has-sorters ant-table-column-sort"
+                  >
+                    1
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+      <ul
+        class="ant-pagination ant-table-pagination"
+        unselectable="unselectable"
+      >
+        <li
+          aria-disabled="true"
+          class="ant-pagination-disabled ant-pagination-prev"
+          title="Previous Page"
+        >
+          <a
+            class="ant-pagination-item-link"
+          >
+            <i
+              aria-label="icon: left"
+              class="anticon anticon-left"
+            >
+              <svg
+                aria-hidden="true"
+                class=""
+                data-icon="left"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M724 218.3V141c0-6.7-7.7-10.4-12.9-6.3L260.3 486.8a31.86 31.86 0 0 0 0 50.3l450.8 352.1c5.3 4.1 12.9.4 12.9-6.3v-77.3c0-4.9-2.3-9.6-6.1-12.6l-360-281 360-281.1c3.8-3 6.1-7.7 6.1-12.6z"
+                />
+              </svg>
+            </i>
+          </a>
+        </li>
+        <li
+          class="ant-pagination-item ant-pagination-item-1 ant-pagination-item-active"
+          tabindex="0"
+          title="1"
+        >
+          <a>
+            1
+          </a>
+        </li>
+        <li
+          aria-disabled="true"
+          class="ant-pagination-disabled ant-pagination-next"
+          title="Next Page"
+        >
+          <a
+            class="ant-pagination-item-link"
+          >
+            <i
+              aria-label="icon: right"
+              class="anticon anticon-right"
+            >
+              <svg
+                aria-hidden="true"
+                class=""
+                data-icon="right"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M765.7 486.8L314.9 134.7A7.97 7.97 0 0 0 302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 0 0 0-50.4z"
+                />
+              </svg>
+            </i>
+          </a>
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>
+`;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close https://github.com/ant-design/ant-design/issues/19443

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Table inifinite loop when using Table.Column with `sortOrder`. <br />Fix Table `defaultSortOrder` not working on Table.Column.  |
| 🇨🇳 Chinese | 修复 Table 在 Column 上定义 `sortOrder` 导致死循环的问题。<br />修复 Table `defaultSortOrder` 在 Column 上不生效的问题。|

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
