### PR TITLE
fix: Menu.ItemGroup styles inside Dropdown

### DIFF
--- a/components/dropdown/demo/menu-full.md
+++ b/components/dropdown/demo/menu-full.md
@@ -8,11 +8,15 @@ debug: true
 
 ## zh-CN
 
-此演示需要注意查看 Dropdown 内 Menu 的样式是否正常。[#19150](https://github.com/ant-design/ant-design/pull/19150)
+此演示需要注意去掉 Reset 样式后查看 Dropdown 内 Menu 的样式是否正常。
+
+[#19150](https://github.com/ant-design/ant-design/pull/19150)
 
 ## en-US
 
-This demo was created for debugging Menu styles inside Dropdown. [#19150](https://github.com/ant-design/ant-design/pull/19150)
+This demo was created for debugging Menu styles inside Dropdown.
+
+[#19150](https://github.com/ant-design/ant-design/pull/19150)
 
 ```jsx
 import { Menu, Dropdown, Icon } from 'antd';
@@ -21,6 +25,10 @@ const { SubMenu } = Menu;
 
 const menu = (
   <Menu selectedKeys={['1']} openKeys={['sub1']}>
+    <Menu.ItemGroup key="group" title="Item Group">
+      <Menu.Item key="01">Option 0</Menu.Item>
+      <Menu.Item key="02">Option 0</Menu.Item>
+    </Menu.ItemGroup>
     <SubMenu
       key="sub1"
       title={

--- a/components/dropdown/style/index.less
+++ b/components/dropdown/style/index.less
@@ -81,6 +81,7 @@
       ul {
         margin-right: 0.3em;
         margin-left: 0.3em;
+        padding: 0;
       }
     }
 
@@ -139,6 +140,7 @@
         line-height: 0;
         background-color: @border-color-split;
       }
+
       .@{dropdown-prefix-cls}-menu-submenu-arrow {
         position: absolute;
         right: @padding-xs;
@@ -148,6 +150,12 @@
           .iconfont-size-under-12px(10px);
         }
       }
+    }
+
+    &-item-group-list {
+      margin: 0 8px;
+      padding: 0;
+      list-style: none;
     }
 
     &-submenu-title {

--- a/site/theme/static/demo.less
+++ b/site/theme/static/demo.less
@@ -89,7 +89,6 @@
 
     h4,
     section& p {
-      width: 98%;
       margin: 0;
     }
 


### PR DESCRIPTION

<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close #19576
close #19145

### 💡 Background and solution

<img width="397" alt="截屏2019-11-05下午7 15 37" src="https://user-images.githubusercontent.com/507615/68204134-4e312680-0002-11ea-921c-73340ecb44c0.png">

to

<img width="524" alt="截屏2019-11-05下午7 22 42" src="https://user-images.githubusercontent.com/507615/68204147-52f5da80-0002-11ea-8820-ed11a68ca191.png">

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix broken Menu.ItemGroup style inside Dropdown again. |
| 🇨🇳 Chinese | 再次修复 Dropdown 下 Menu.ItemGroup 样式错乱的问题。 |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

-----
[View rendered components/dropdown/demo/menu-full.md](https://github.com/ant-design/ant-design/blob/fix-dropdown-style/components/dropdown/demo/menu-full.md)