### PR TITLE
fix: Dropdown icon missing margin right

### DIFF
--- a/components/dropdown/style/index.less
+++ b/components/dropdown/style/index.less
@@ -98,6 +98,7 @@
       cursor: pointer;
       transition: all 0.3s;
 
+      > .anticon:first-child,
       > span > .anticon:first-child {
         min-width: 12px;
         margin-right: 8px;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close https://github.com/ant-design/ant-design/issues/19625

### 💡 Background and solution

![image](https://user-images.githubusercontent.com/507615/68475163-52f41580-0262-11ea-926f-82fe3251ff01.png)



### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Dropdown menu icon `margin-right` style is missing. |
| 🇨🇳 Chinese | 修复 Dropdown 内菜单图标丢失右边距的问题。 |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
