### PR TITLE
feat: add footer property to Drawer

### DIFF
--- a/components/drawer/__tests__/Drawer.test.js
+++ b/components/drawer/__tests__/Drawer.test.js
@@ -78,4 +78,13 @@ describe('Drawer', () => {
     );
     expect(wrapper).toMatchSnapshot();
   });
+
+  it('have a footer', () => {
+    const wrapper = render(
+      <Drawer visible footer="Test Footer" getContainer={false}>
+        Here is content of Drawer
+      </Drawer>,
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
 });

--- a/components/drawer/__tests__/__snapshots__/Drawer.test.js.snap
+++ b/components/drawer/__tests__/__snapshots__/Drawer.test.js.snap
@@ -157,6 +157,73 @@ exports[`Drawer destroyOnClose is true 1`] = `
 </div>
 `;
 
+exports[`Drawer have a footer 1`] = `
+<div
+  class=""
+>
+  <div
+    class="ant-drawer ant-drawer-right"
+    footer="Test Footer"
+    tabindex="-1"
+  >
+    <div
+      class="ant-drawer-mask"
+    />
+    <div
+      class="ant-drawer-content-wrapper"
+      style="transform:translateX(100%);-ms-transform:translateX(100%);width:256px"
+    >
+      <div
+        class="ant-drawer-content"
+      >
+        <div
+          class="ant-drawer-wrapper-body"
+        >
+          <div
+            class="ant-drawer-header-no-title"
+          >
+            <button
+              aria-label="Close"
+              class="ant-drawer-close"
+            >
+              <i
+                aria-label="icon: close"
+                class="anticon anticon-close"
+              >
+                <svg
+                  aria-hidden="true"
+                  class=""
+                  data-icon="close"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M563.8 512l262.5-312.9c4.4-5.2.7-13.1-6.1-13.1h-79.8c-4.7 0-9.2 2.1-12.3 5.7L511.6 449.8 295.1 191.7c-3-3.6-7.5-5.7-12.3-5.7H203c-6.8 0-10.5 7.9-6.1 13.1L459.4 512 196.9 824.9A7.95 7.95 0 0 0 203 838h79.8c4.7 0 9.2-2.1 12.3-5.7l216.5-258.1 216.5 258.1c3 3.6 7.5 5.7 12.3 5.7h79.8c6.8 0 10.5-7.9 6.1-13.1L563.8 512z"
+                  />
+                </svg>
+              </i>
+            </button>
+          </div>
+          <div
+            class="ant-drawer-body"
+          >
+            Here is content of Drawer
+          </div>
+          <div
+            class="ant-drawer-footer"
+          >
+            Test Footer
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Drawer have a title 1`] = `
 <div
   class=""

--- a/components/drawer/demo/form-in-drawer.md
+++ b/components/drawer/demo/form-in-drawer.md
@@ -45,6 +45,23 @@ class DrawerForm extends React.Component {
           width={720}
           onClose={this.onClose}
           visible={this.state.visible}
+          footer={
+            <div
+              style={{
+                borderTop: '1px solid #e9e9e9',
+                padding: '10px 16px',
+                background: '#fff',
+                textAlign: 'right',
+              }}
+            >
+              <Button onClick={this.onClose} style={{ marginRight: 8 }}>
+                Cancel
+              </Button>
+              <Button onClick={this.onClose} type="primary">
+                Submit
+              </Button>
+            </div>
+          }
         >
           <Form layout="vertical" hideRequiredMark>
             <Row gutter={16}>
@@ -137,25 +154,6 @@ class DrawerForm extends React.Component {
               </Col>
             </Row>
           </Form>
-          <div
-            style={{
-              position: 'absolute',
-              left: 0,
-              bottom: 0,
-              width: '100%',
-              borderTop: '1px solid #e9e9e9',
-              padding: '10px 16px',
-              background: '#fff',
-              textAlign: 'right',
-            }}
-          >
-            <Button onClick={this.onClose} style={{ marginRight: 8 }}>
-              Cancel
-            </Button>
-            <Button onClick={this.onClose} type="primary">
-              Submit
-            </Button>
-          </div>
         </Drawer>
       </div>
     );

--- a/components/drawer/index.en-US.md
+++ b/components/drawer/index.en-US.md
@@ -39,6 +39,8 @@ A Drawer is a panel that is typically overlaid on top of a page and slides in fr
 | onClose | Specify a callback that will be called when a user clicks mask, close button or Cancel button. | function(e) | - | 3.7.0 |
 | afterVisibleChange | Callback after the animation ends when switching drawers. | function(visible) | - | 3.17.0 |
 | keyboard | Whether support press esc to close | Boolean | true | 3.19.8 |
+| footer | The footer for Drawer. | string\|ReactNode | - | 3.26.0 |
+| footerStyle | Style of the drawer footer part. | object | - | 3.26.0 |
 
 <style>
 #_hj_feedback_container {

--- a/components/drawer/index.tsx
+++ b/components/drawer/index.tsx
@@ -46,6 +46,8 @@ export interface DrawerProps {
   className?: string;
   handler?: React.ReactNode;
   keyboard?: boolean;
+  footer?: React.ReactNode;
+  footerStyle?: React.CSSProperties;
 }
 
 export interface IDrawerState {
@@ -160,6 +162,20 @@ class Drawer extends React.Component<DrawerProps & ConfigConsumerProps, IDrawerS
     );
   }
 
+  renderFooter() {
+    const { footer, footerStyle, prefixCls } = this.props;
+    if (!footer) {
+      return null;
+    }
+
+    const footerClassName = `${prefixCls}-footer`;
+    return (
+      <div className={footerClassName} style={footerStyle}>
+        {footer}
+      </div>
+    );
+  }
+
   renderCloseIcon() {
     const { closable, prefixCls, onClose } = this.props;
     return (
@@ -203,6 +219,7 @@ class Drawer extends React.Component<DrawerProps & ConfigConsumerProps, IDrawerS
         <div className={`${prefixCls}-body`} style={bodyStyle}>
           {this.props.children}
         </div>
+        {this.renderFooter()}
       </div>
     );
   };

--- a/components/drawer/index.zh-CN.md
+++ b/components/drawer/index.zh-CN.md
@@ -38,6 +38,8 @@ title: Drawer
 | onClose | 点击遮罩层或右上角叉或取消按钮的回调 | function(e) | 无 | 3.7.0 |
 | afterVisibleChange | 切换抽屉时动画结束后的回调 | function(visible) | 无 | 3.17.0 |
 | keyboard | 是否支持键盘 esc 关闭 | boolean | true | 3.19.8 |
+| footer | 抽屉的页脚 | string\|ReactNode | - | 3.26.0 |
+| footerStyle | 抽屉页脚部件的样式 | object | - | 3.26.0 |
 
 <style>
 #_hj_feedback_container {

--- a/components/drawer/style/drawer.less
+++ b/components/drawer/style/drawer.less
@@ -191,11 +191,25 @@
     background: @component-background;
   }
 
+  &-wrapper-body {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    flex-wrap: nowrap;
+  }
+
   &-body {
+    flex-grow: 1;
+    overflow: auto;
     padding: @drawer-body-padding;
     font-size: @font-size-base;
     line-height: @line-height-base;
     word-wrap: break-word;
+  }
+
+  &-footer {
+    flex-shrink: 0;
   }
 
   &-mask {

--- a/components/drawer/style/drawer.less
+++ b/components/drawer/style/drawer.less
@@ -192,17 +192,17 @@
   }
 
   &-wrapper-body {
-    width: 100%;
-    height: 100%;
     display: flex;
     flex-direction: column;
     flex-wrap: nowrap;
+    width: 100%;
+    height: 100%;
   }
 
   &-body {
     flex-grow: 1;
-    overflow: auto;
     padding: @drawer-body-padding;
+    overflow: auto;
     font-size: @font-size-base;
     line-height: @line-height-base;
     word-wrap: break-word;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [x] New feature
- [x] Bug fix
- [x] Site / document update

### 🔗 Related issue link

[feature request - Drawer footer support](https://github.com/ant-design/ant-design/issues/15204)

close #15204

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

Currently in the [demo](https://ant.design/components/drawer/) the `Drawer` footer is broken. See below.

![broken](https://user-images.githubusercontent.com/3798908/68780391-e6e92700-063e-11ea-971d-4e6378664003.gif)

I propose a solution to add a dedicated footer property on the `Drawer` component. This solution allows for a 'fixed' footer and title.

![fixed](https://user-images.githubusercontent.com/3798908/68781753-e8b3ea00-0640-11ea-803b-399a84ebd5e8.gif)

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->
- Add footer property to Drawer

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Add footer property to Drawer   |
| 🇨🇳 Chinese |  将页脚属性添加到抽屉  |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/drawer/demo/form-in-drawer.md](https://github.com/DeanVanNiekerk/ant-design/blob/feature/components/drawer/demo/form-in-drawer.md)
[View rendered components/drawer/index.en-US.md](https://github.com/DeanVanNiekerk/ant-design/blob/feature/components/drawer/index.en-US.md)
[View rendered components/drawer/index.zh-CN.md](https://github.com/DeanVanNiekerk/ant-design/blob/feature/components/drawer/index.zh-CN.md)