### PR TITLE
fix: add missing null option type

### DIFF
--- a/components/table/interface.tsx
+++ b/components/table/interface.tsx
@@ -55,7 +55,7 @@ export interface ColumnProps<T> {
   className?: string;
   fixed?: boolean | typeof ColumnFixedPlacements[number];
   filterIcon?: React.ReactNode | ((filtered: boolean) => React.ReactNode);
-  filteredValue?: any[];
+  filteredValue?: any[] | null;
   sortOrder?: SortOrder | boolean;
   children?: ColumnProps<T>[];
   onCellClick?: (record: T, event: Event) => void;


### PR DESCRIPTION
See-also: https://ant.design/components/table/#components-table-demo-reset-filter

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 💡 Background and solution

Providing `null` for `filteredValue` is for cleaning the selected filter. (demo code works, this pr fixes ts type warnings.)

```
Type 'string[] | null' is not assignable to type 'any[] | undefined'.
Type 'null' is not assignable to type 'any[] | undefined'.ts(2322)
```

Providing `undefined` for `filteredValue` won't clean up the selected filter. (bug here?)

### ☑️ Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
