### PR TITLE
feat:Paragraph endFix

### DIFF
--- a/components/typography/Base.tsx
+++ b/components/typography/Base.tsx
@@ -37,16 +37,17 @@ interface EditConfig {
 interface EllipsisConfig {
   rows?: number;
   expandable?: boolean;
+  suffix?: string;
   onExpand?: () => void;
 }
 
 export interface BlockProps extends TypographyProps {
+  title?: string;
   editable?: boolean | EditConfig;
   copyable?: boolean | CopyConfig;
   type?: BaseType;
   disabled?: boolean;
   ellipsis?: boolean | EllipsisConfig;
-  endFix?: string;
   // decorations
   code?: boolean;
   mark?: boolean;
@@ -284,8 +285,8 @@ class Base extends React.Component<InternalBlockProps & ConfigConsumerProps, Bas
 
   syncEllipsis() {
     const { ellipsisText, isEllipsis, expanded } = this.state;
-    const { rows } = this.getEllipsis();
-    const { children, endFix } = this.props;
+    const { rows, suffix } = this.getEllipsis();
+    const { children } = this.props;
     if (!rows || rows < 0 || !this.content || expanded) return;
 
     // Do not measure if css already support ellipsis
@@ -299,7 +300,7 @@ class Base extends React.Component<InternalBlockProps & ConfigConsumerProps, Bas
 
     const { content, text, ellipsis } = measure(
       findDOMNode(this.content),
-      { rows, endFix },
+      { rows, suffix },
       children,
       this.renderOperations(true),
       ELLIPSIS_STR,
@@ -398,10 +399,10 @@ class Base extends React.Component<InternalBlockProps & ConfigConsumerProps, Bas
       type,
       disabled,
       style,
-      endFix,
+      title,
       ...restProps
     } = this.props;
-    const { rows } = this.getEllipsis();
+    const { rows, suffix } = this.getEllipsis();
 
     const textProps = omit(restProps, [
       'prefixCls',
@@ -441,10 +442,10 @@ class Base extends React.Component<InternalBlockProps & ConfigConsumerProps, Bas
 
     // Only use js ellipsis when css ellipsis not support
     if (rows && isEllipsis && !expanded && !cssEllipsis) {
-      ariaLabel = getChildrenAllText(children) + endFix;
+      ariaLabel = title || null;
       // We move full content to outer element to avoid repeat read the content by accessibility
       textNode = (
-        <span title={getChildrenAllText(children) + endFix} aria-hidden="true">
+        <span title={title} aria-hidden="true">
           {ellipsisContent}
         </span>
       );
@@ -452,7 +453,7 @@ class Base extends React.Component<InternalBlockProps & ConfigConsumerProps, Bas
       textNode = (
         <span aria-hidden="true">
           {children}
-          {endFix}
+          {suffix}
         </span>
       );
     }

--- a/components/typography/demo/ellipsis-debug.md
+++ b/components/typography/demo/ellipsis-debug.md
@@ -48,11 +48,15 @@ class Demo extends React.Component {
         {longText ? (
           <Paragraph ellipsis={{ rows, expandable }} copyable={copyable} editable={editable}>
             Ant Design, a design language for background applications, is refined by Ant UED Team.
-            This is a nest sample <Text code strong delete>Test</Text> case.
-            Bnt Design, a design language for background applications, is refined by Ant UED Team.
-            Cnt Design, a design language for background applications, is refined by Ant UED Team.
-            Dnt Design, a design language for background applications, is refined by Ant UED Team.
-            Ent Design, a design language for background applications, is refined by Ant UED Team.
+            This is a nest sample{' '}
+            <Text code strong delete>
+              Test
+            </Text>{' '}
+            case. Bnt Design, a design language for background applications, is refined by Ant UED
+            Team. Cnt Design, a design language for background applications, is refined by Ant UED
+            Team. Dnt Design, a design language for background applications, is refined by Ant UED
+            Team. Ent Design, a design language for background applications, is refined by Ant UED
+            Team.
           </Paragraph>
         ) : (
           <Paragraph ellipsis={{ rows, expandable }} copyable={copyable} editable={editable}>

--- a/components/typography/demo/endFIx.md
+++ b/components/typography/demo/endFIx.md
@@ -1,0 +1,58 @@
+---
+order: 100
+title:
+  zh-CN: 后缀
+  en-US: endFix
+---
+
+## zh-CN
+
+含有后缀的省略。
+
+## en-US
+
+have endFix ellipsis support.
+
+```jsx
+import { Typography, Slider, Switch } from 'antd';
+
+const { Text, Paragraph, Title } = Typography;
+
+class Demo extends React.Component {
+  state = {
+    rows: 1,
+    songForDrinking: '--李白',
+    Hamlet: '--William Shakespeare',
+  };
+
+  onChange = rows => {
+    this.setState({ rows });
+  };
+
+  render() {
+    const { rows, songForDrinking, Hamlet } = this.state;
+    return (
+      <div>
+        <Slider value={rows} min={1} max={10} onChange={this.onChange} />
+        <div>
+          <Paragraph ellipsis={{ rows, expandable: true }} endFix={songForDrinking}>
+            <Text code strong>
+              将进酒
+            </Text>
+            君不见，黄河之水天上来，奔流到海不复回。君不见，高堂明镜悲白发，朝如青丝暮成雪。人生得意须尽欢，莫使金樽空对月。天生我材必有用，千金散尽还复来。
+          </Paragraph>
+          <Paragraph ellipsis={{ rows, expandable: true }} endFix={Hamlet}>
+            <Text code strong>
+              Hamlet
+            </Text>
+            To be, or not to be, that is a question: Whether 'tis nobler in the mind to sufferThe slings
+            and arrows of outrageous fortune.
+          </Paragraph>
+        </div>
+      </div>
+    );
+  }
+}
+
+ReactDOM.render(<Demo />, mountNode);
+```

--- a/components/typography/demo/suffix.md
+++ b/components/typography/demo/suffix.md
@@ -31,22 +31,28 @@ class Demo extends React.Component {
 
   render() {
     const { rows, songForDrinking, Hamlet } = this.state;
+    const poetry =
+      '君不见，黄河之水天上来，奔流到海不复回。君不见，高堂明镜悲白发，朝如青丝暮成雪。人生得意须尽欢，莫使金樽空对月。天生我材必有用，千金散尽还复来';
+    const article =
+      'To be, or not to be, that is a question: Whether it is nobler in the mind to sufferThe slings and arrows of outrageous fortune';
     return (
       <div>
         <Slider value={rows} min={1} max={10} onChange={this.onChange} />
         <div>
-          <Paragraph ellipsis={{ rows, expandable: true }} endFix={songForDrinking}>
+          <Paragraph
+            ellipsis={{ rows, expandable: true, suffix: songForDrinking }}
+            title={poetry + songForDrinking}
+          >
             <Text code strong>
               将进酒
             </Text>
-            君不见，黄河之水天上来，奔流到海不复回。君不见，高堂明镜悲白发，朝如青丝暮成雪。人生得意须尽欢，莫使金樽空对月。天生我材必有用，千金散尽还复来。
+            {poetry}
           </Paragraph>
-          <Paragraph ellipsis={{ rows, expandable: true }} endFix={Hamlet}>
+          <Paragraph ellipsis={{ rows, expandable: true, suffix: Hamlet }} title={article + Hamlet}>
             <Text code strong>
               Hamlet
             </Text>
-            To be, or not to be, that is a question: Whether 'tis nobler in the mind to sufferThe slings
-            and arrows of outrageous fortune.
+            {article}
           </Paragraph>
         </div>
       </div>

--- a/components/typography/index.en-US.md
+++ b/components/typography/index.en-US.md
@@ -55,8 +55,7 @@ Basic text writing, including headings, body text, lists, and more.
 | delete | delete line style | boolean | false | 3.14.0 |
 | disabled | Disable content | boolean | false | 3.14.0 |
 | editable | Editable. Can control edit state when is object | boolean \| { editing: boolean, onStart: Function, onChange: Function(string) } | false | 3.14.0 |
-| ellipsis | Display ellipsis when overflow. Can config rows and expandable by using object | boolean \| { rows: number, expandable: boolean, onExpand: Function } | false | 3.14.0 |
-| endFix | 添加后缀 | string | - | 3.14.0 |
+| ellipsis | Display ellipsis when overflow. Can config rows, expandable and suffix by using object | boolean \| { rows: number, expandable: boolean, suffix: string, onExpand: Function } | false | 3.14.0 |
 | mark | mark style | boolean | false | 3.14.0 |
 | underline | underline style | boolean | false | 3.14.0 |
 | onChange | Trigger when user edit the content | Function(string) | - | 3.14.0 |

--- a/components/typography/index.en-US.md
+++ b/components/typography/index.en-US.md
@@ -56,6 +56,7 @@ Basic text writing, including headings, body text, lists, and more.
 | disabled | Disable content | boolean | false | 3.14.0 |
 | editable | Editable. Can control edit state when is object | boolean \| { editing: boolean, onStart: Function, onChange: Function(string) } | false | 3.14.0 |
 | ellipsis | Display ellipsis when overflow. Can config rows and expandable by using object | boolean \| { rows: number, expandable: boolean, onExpand: Function } | false | 3.14.0 |
+| endFix | 添加后缀 | string | - | 3.14.0 |
 | mark | mark style | boolean | false | 3.14.0 |
 | underline | underline style | boolean | false | 3.14.0 |
 | onChange | Trigger when user edit the content | Function(string) | - | 3.14.0 |

--- a/components/typography/index.zh-CN.md
+++ b/components/typography/index.zh-CN.md
@@ -52,8 +52,7 @@ cols: 1
 | delete | 添加删除线样式 | boolean | false | 3.14.0 |
 | disabled | 禁用文本 | boolean | false | 3.14.0 |
 | editable | 是否可编辑，为对象时可对编辑进行控制 | boolean \| { editing: boolean, onStart: Function, onChange: Function(string) } | false | 3.14.0 |
-| ellipsis | 自动溢出省略，为对象时可设置省略行数与是否可展开等 | boolean \| { rows: number, expandable: boolean, onExpand: Function } | false | 3.14.0 |
-| endFix | 添加后缀 | string | - | 3.14.0 |
+| ellipsis | 自动溢出省略，为对象时可设置省略行数、是否可展开、添加后缀等 | boolean \| { rows: number, expandable: boolean, suffix: string, onExpand: Function } | false | 3.14.0 |
 | mark | 添加标记样式 | boolean | false | 3.14.0 |
 | underline | 添加下划线样式 | boolean | false | 3.14.0 |
 | onChange | 当用户提交编辑内容时触发 | Function(string) | - | 3.14.0 |

--- a/components/typography/index.zh-CN.md
+++ b/components/typography/index.zh-CN.md
@@ -53,6 +53,7 @@ cols: 1
 | disabled | 禁用文本 | boolean | false | 3.14.0 |
 | editable | 是否可编辑，为对象时可对编辑进行控制 | boolean \| { editing: boolean, onStart: Function, onChange: Function(string) } | false | 3.14.0 |
 | ellipsis | 自动溢出省略，为对象时可设置省略行数与是否可展开等 | boolean \| { rows: number, expandable: boolean, onExpand: Function } | false | 3.14.0 |
+| endFix | 添加后缀 | string | - | 3.14.0 |
 | mark | 添加标记样式 | boolean | false | 3.14.0 |
 | underline | 添加下划线样式 | boolean | false | 3.14.0 |
 | onChange | 当用户提交编辑内容时触发 | Function(string) | - | 3.14.0 |

--- a/components/typography/util.tsx
+++ b/components/typography/util.tsx
@@ -8,7 +8,7 @@ interface MeasureResult {
 }
 interface Option {
   rows: number;
-  endFix?: string;
+  suffix?: string;
 }
 
 // We only handle element & text node.
@@ -68,7 +68,7 @@ export default (
     document.body.appendChild(ellipsisContainer);
   }
 
-  const { rows, endFix = '' } = option;
+  const { rows, suffix = '' } = option;
   // Get origin style
   const originStyle = window.getComputedStyle(originEle);
   const originCSS = styleToString(originStyle);
@@ -104,7 +104,7 @@ export default (
   render(
     <div style={wrapperStyle}>
       <span style={wrapperStyle}>
-        {(ellipsisStr + endFix)
+        {(ellipsisStr + suffix)
           .split('')
           .reverse()
           .join('')}
@@ -114,13 +114,13 @@ export default (
     ellipsisContainer,
   );
 
-  // endFix if ellipsis
+  // suffix if ellipsis
   if (inRange()) {
     render(
       <div style={wrapperStyle}>
         <span style={wrapperStyle}>
           {contentList}
-          {endFix}
+          {suffix}
         </span>
         <span style={wrapperStyle}>{fixedContent}</span>
       </div>,
@@ -152,7 +152,7 @@ export default (
   const ellipsisContentHolder = document.createElement('span');
   ellipsisContainer.appendChild(ellipsisContentHolder);
   const ellipsisTextNode = document.createTextNode(
-    `${ellipsisStr}${isEllipsisEndFix ? '' : endFix}`,
+    `${ellipsisStr}${isEllipsisEndFix ? '' : suffix}`,
   );
   ellipsisContentHolder.appendChild(ellipsisTextNode);
 
@@ -259,7 +259,7 @@ export default (
   if (isEllipsisEndFix) {
     ellipsisChildren.unshift(ellipsisStr);
   } else {
-    ellipsisChildren.push(ellipsisStr, endFix);
+    ellipsisChildren.push(ellipsisStr, suffix);
   }
 
   return {


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 组件样式改进
- [ ] TypeScript 定义更新
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
#### 末端截断

1. 单行内容超过列宽，超出的用 '...' 省略；
2. 多行内容超过设置行数，超出的部分用 '...' 省略；

#### 中间截断
-->
1. 设置末端保留字符，在末端保留字符前显示 '...' ；
2. 开头保留字符数根据列宽以“显示尽量多的字符”的原则来确定（极端情况为开头不保留字符，即为“开头截断”的样式；或是保留字符仍超过列宽，则尽量多地保留末端字符）；

### 📝 更新日志怎么写？

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |          |
| 🇨🇳 中文 |          |

- 中文（可选）:

### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供

-----
[View rendered components/typography/demo/endFIx.md](https://github.com/zouxiaomingya/ant-design/blob/master/components/typography/demo/endFIx.md)
[View rendered components/typography/index.en-US.md](https://github.com/zouxiaomingya/ant-design/blob/master/components/typography/index.en-US.md)
[View rendered components/typography/index.zh-CN.md](https://github.com/zouxiaomingya/ant-design/blob/master/components/typography/index.zh-CN.md)