### PR TITLE
Update link to latest ColumnProps

### DIFF
--- a/components/table/index.en-US.md
+++ b/components/table/index.en-US.md
@@ -62,7 +62,7 @@ const columns = [
 | tableLayout | [table-layout](https://developer.mozilla.org/en-US/docs/Web/CSS/table-layout) attribute of table element | - \| 'auto' \| 'fixed' | -<hr />`fixed` when header/columns are fixed, or using `column.ellipsis` | 3.24.0 |
 | bordered | Whether to show all table borders | boolean | `false` |  |
 | childrenColumnName | The column contains children to display | string\[] | children | 3.4.2 |
-| columns | Columns of table | [ColumnProps](https://git.io/vMMXC)\[] | - |  |
+| columns | Columns of table | [ColumnProps](https://git.io/JeKZW)\[] | - |  |
 | components | Override default table elements | [TableComponents](https://git.io/fANxz) | - |  |
 | dataSource | Data record array to be displayed | any\[] | - |  |
 | defaultExpandAllRows | Expand all rows initially | boolean | `false` |  |

--- a/components/table/index.zh-CN.md
+++ b/components/table/index.zh-CN.md
@@ -67,7 +67,7 @@ const columns = [
 | tableLayout | 表格元素的 [table-layout](https://developer.mozilla.org/zh-CN/docs/Web/CSS/table-layout) 属性，设为 `fixed` 表示内容不会影响列的布局 | - \| 'auto' \| 'fixed' | 无<hr />固定表头/列或使用了 `column.ellipsis` 时，默认值为 `fixed` | 3.24.0 |
 | bordered | 是否展示外边框和列边框 | boolean | false |  |
 | childrenColumnName | 指定树形结构的列名 | string\[] | children | 3.4.2 |
-| columns | 表格列的配置描述，具体项见下表 | [ColumnProps](https://git.io/vMMXC)\[] | - |  |
+| columns | 表格列的配置描述，具体项见下表 | [ColumnProps](https://git.io/JeKZW)\[] | - |  |
 | components | 覆盖默认的 table 元素 | [TableComponents](https://git.io/fANxz) | - |  |
 | dataSource | 数据数组 | any\[] |  |  |
 | defaultExpandAllRows | 初始时，是否展开所有行 | boolean | false |  |


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

Current link is pointing to extremely outdated ColumnProps

-----
[View rendered components/table/index.en-US.md](https://github.com/Kamahl19/ant-design/blob/patch-2/components/table/index.en-US.md)