### PR TITLE
docs: Removed version column in 4.0

### DIFF
--- a/components/cascader/index.en-US.md
+++ b/components/cascader/index.en-US.md
@@ -28,7 +28,7 @@ Cascade selection box.
 | disabled | whether disabled select | boolean | false |  |
 | displayRender | render function of displaying selected options | `(label, selectedOptions) => ReactNode` | `label => label.join(' / ')` |  |
 | expandTrigger | expand current item when click or hover, one of 'click' 'hover' | string | 'click' |  |
-| fieldNames | custom field name for label and value and children (before 3.7.0 it calls `filedNames` which is typo）) | object | `{ label: 'label', value: 'value', children: 'children' }` | 3.7.0 |
+| fieldNames | custom field name for label and value and children | object | `{ label: 'label', value: 'value', children: 'children' }` |  |
 | getPopupContainer | Parent Node which the selector should be rendered to. Default to `body`. When position issues happen, try to modify it into scrollable content and position it relative.[example](https://codepen.io/afc163/pen/zEjNOy?editors=0010) | Function(triggerNode) | () => document.body |  |
 | loadData | To load option lazily, and it cannot work with `showSearch` | `(selectedOptions) => void` | - |  |
 | notFoundContent | Specify content to show when no result matches. | string | 'Not Found' |  |
@@ -40,7 +40,7 @@ Cascade selection box.
 | showSearch | Whether show search input in single mode. | boolean\|object | false |  |
 | size | input size, one of `large` `default` `small` | string | `default` |  |
 | style | additional style | string | - |  |
-| suffixIcon | The custom suffix icon | ReactNode | - | 3.10.0 |
+| suffixIcon | The custom suffix icon | ReactNode | - |  |
 | value | selected value | string\[] | - |  |
 | onChange | callback when finishing cascader select | `(value, selectedOptions) => void` | - |  |
 | onPopupVisibleChange | callback when popup shown or hidden | `(value) => void` | - |  |
@@ -50,7 +50,7 @@ Fields in `showSearch`:
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
 | filter | The function will receive two arguments, inputValue and option, if the function returns true, the option will be included in the filtered set; Otherwise, it will be excluded. | `function(inputValue, path): boolean` |  |  |
-| limit | Set the count of filtered items | number \| false | 50 | 3.11.0 |
+| limit | Set the count of filtered items | number \| false | 50 |  |
 | matchInputWidth | Whether the width of result list equals to input's | boolean |  |  |
 | render | Used to render filtered options. | `function(inputValue, path): ReactNode` |  |  |
 | sort | Used to sort filtered options. | `function(a, b, inputValue)` |  |  |

--- a/components/cascader/index.zh-CN.md
+++ b/components/cascader/index.zh-CN.md
@@ -29,7 +29,7 @@ subtitle: 级联选择
 | disabled | 禁用 | boolean | false |  |
 | displayRender | 选择后展示的渲染函数 | `(label, selectedOptions) => ReactNode` | `label => label.join(' / ')` |  |
 | expandTrigger | 次级菜单的展开方式，可选 'click' 和 'hover' | string | 'click' |  |
-| fieldNames | 自定义 options 中 label name children 的字段（注意，3.7.0 之前的版本为 `filedNames`） | object | `{ label: 'label', value: 'value', children: 'children' }` | 3.7.0 |
+| fieldNames | 自定义 options 中 label name children 的字段 | object | `{ label: 'label', value: 'value', children: 'children' }` |  |
 | getPopupContainer | 菜单渲染父节点。默认渲染到 body 上，如果你遇到菜单滚动定位问题，试试修改为滚动的区域，并相对其定位。[示例](https://codepen.io/afc163/pen/zEjNOy?editors=0010) | Function(triggerNode) | () => document.body |  |
 | loadData | 用于动态加载选项，无法与 `showSearch` 一起使用 | `(selectedOptions) => void` | - |  |
 | notFoundContent | 当下拉列表为空时显示的内容 | string | 'Not Found' |  |
@@ -41,7 +41,7 @@ subtitle: 级联选择
 | showSearch | 在选择框中显示搜索框 | boolean | false |  |
 | size | 输入框大小，可选 `large` `default` `small` | string | `default` |  |
 | style | 自定义样式 | string | - |  |
-| suffixIcon | 自定义的选择框后缀图标 | ReactNode | - | 3.10.0 |
+| suffixIcon | 自定义的选择框后缀图标 | ReactNode | - |  |
 | value | 指定选中项 | string\[] | - |  |
 | onChange | 选择完成后的回调 | `(value, selectedOptions) => void` | - |  |
 | onPopupVisibleChange | 显示/隐藏浮层的回调 | `(value) => void` | - |  |
@@ -51,7 +51,7 @@ subtitle: 级联选择
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
 | filter | 接收 `inputValue` `path` 两个参数，当 `path` 符合筛选条件时，应返回 true，反之则返回 false。 | `function(inputValue, path): boolean` |  |  |
-| limit | 搜索结果展示数量 | number \| false | 50 | 3.11.0 |
+| limit | 搜索结果展示数量 | number \| false | 50 |  |
 | matchInputWidth | 搜索结果列表是否与输入框同宽 | boolean |  |  |
 | render | 用于渲染 filter 后的选项 | `function(inputValue, path): ReactNode` |  |  |
 | sort | 用于排序 filter 后的选项 | `function(a, b, inputValue)` |  |  |

--- a/components/date-picker/index.en-US.md
+++ b/components/date-picker/index.en-US.md
@@ -53,7 +53,7 @@ The following APIs are shared by DatePicker, MonthPicker, RangePicker, WeekPicke
 | dateRender | custom rendering function for date cells | function(currentDate: moment, today: moment) => React.ReactNode | - |  |
 | disabled | determine whether the DatePicker is disabled | boolean | false |  |
 | disabledDate | specify the date that cannot be selected | (currentDate: moment) => boolean | - |  |
-| dropdownClassName | to customize the className of the popup calendar | string | - | 3.3.0 |
+| dropdownClassName | to customize the className of the popup calendar | string | - |  |
 | getCalendarContainer | to set the container of the floating layer, while the default is to create a `div` element in `body` | function(trigger) | - |  |
 | locale | localization configuration | object | [default](https://github.com/ant-design/ant-design/blob/master/components/date-picker/locale/example.json) |  |
 | mode | picker panel mode（[Cannot select year or month anymore?](/docs/react/faq#When-set-mode-to-DatePicker/RangePicker,-cannot-select-year-or-month-anymore?) | `time|date|month|year|decade` | 'date' |  |
@@ -61,10 +61,10 @@ The following APIs are shared by DatePicker, MonthPicker, RangePicker, WeekPicke
 | placeholder | placeholder of date input | string\|RangePicker\[] | - |  |
 | popupStyle | to customize the style of the popup calendar | object | {} |  |
 | size | determine the size of the input box, the height of `large` and `small`, are 40px and 24px respectively, while default size is 32px | string | - |  |
-| suffixIcon | The custom suffix icon | ReactNode | - | 3.10.0 |
+| suffixIcon | The custom suffix icon | ReactNode | - |  |
 | style | to customize the style of the input box | object | {} |  |
 | onOpenChange | a callback function, can be executed whether the popup calendar is popped up or closed | function(status) | - |  |
-| onPanelChange | callback when picker panel mode is changed | function(value, mode) | - | 3.5.0 |
+| onPanelChange | callback when picker panel mode is changed | function(value, mode) | - |  |
 
 ### Common Methods
 
@@ -78,7 +78,7 @@ The following APIs are shared by DatePicker, MonthPicker, RangePicker, WeekPicke
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
 | defaultValue | to set default date, if start time or end time is null or undefined, the date range will be an open interval | [moment](http://momentjs.com/) | - |  |
-| defaultPickerValue | to set default picker date | [moment](http://momentjs.com/) | - | 3.10.8 |
+| defaultPickerValue | to set default picker date | [moment](http://momentjs.com/) | - |  |
 | disabledTime | to specify the time that cannot be selected | function(date) | - |  |
 | format | to set the date format, refer to [moment.js](http://momentjs.com/). When an array is provided, all values are used for parsing and first value is used for formatting. | string \| string[] | "YYYY-MM-DD" |  |
 | renderExtraFooter | render extra footer in panel | (mode) => React.ReactNode | - |  |
@@ -88,14 +88,14 @@ The following APIs are shared by DatePicker, MonthPicker, RangePicker, WeekPicke
 | value | to set date | [moment](http://momentjs.com/) | - |  |
 | onChange | a callback function, can be executed when the selected time is changing | function(date: moment, dateString: string) | - |  |
 | onOk | callback when click ok button | function() | - |  |
-| onPanelChange | Callback function for panel changing | function(value, mode) | - | 3.19.8 |
+| onPanelChange | Callback function for panel changing | function(value, mode) | - |  |
 
 ### MonthPicker
 
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
 | defaultValue | to set default date | [moment](http://momentjs.com/) | - |  |
-| defaultPickerValue | to set default picker date | [moment](http://momentjs.com/) | - | 3.10.8 |
+| defaultPickerValue | to set default picker date | [moment](http://momentjs.com/) | - |  |
 | format | to set the date format, refer to [moment.js](http://momentjs.com/) | string | "YYYY-MM" |  |
 | monthCellContentRender | Custom month cell content render method | function(date, locale): ReactNode | - |  |
 | renderExtraFooter | render extra footer in panel | () => React.ReactNode | - |  |
@@ -107,27 +107,27 @@ The following APIs are shared by DatePicker, MonthPicker, RangePicker, WeekPicke
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
 | defaultValue | to set default date | [moment](http://momentjs.com/) | - |  |
-| defaultPickerValue | to set default picker date | [moment](http://momentjs.com/) | - | 3.10.8 |
+| defaultPickerValue | to set default picker date | [moment](http://momentjs.com/) | - |  |
 | format | to set the date format, refer to [moment.js](http://momentjs.com/) | string | "YYYY-wo" |  |
 | value | to set date | [moment](http://momentjs.com/) | - |  |
 | onChange | a callback function, can be executed when the selected time is changing | function(date: moment, dateString: string) | - |  |
-| renderExtraFooter | render extra footer in panel | (mode) => React.ReactNode | - | 3.12.0 |
+| renderExtraFooter | render extra footer in panel | (mode) => React.ReactNode | - |  |
 
 ### RangePicker
 
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
 | defaultValue | to set default date | \[[moment](http://momentjs.com/), [moment](http://momentjs.com/)] | - |  |
-| defaultPickerValue | to set default picker date | \[[moment](http://momentjs.com/), [moment](http://momentjs.com/)\] | - | 3.10.8 |
+| defaultPickerValue | to set default picker date | \[[moment](http://momentjs.com/), [moment](http://momentjs.com/)\] | - |  |
 | disabledTime | to specify the time that cannot be selected | function(dates: \[moment, moment], partial: `'start'|'end'`) | - |  |
 | format | to set the date format, refer to [moment.js](http://momentjs.com/). When an array is provided, all values are used for parsing and first value is used for formatting. | string \| string[] | "YYYY-MM-DD HH:mm:ss" |  |
 | ranges | preseted ranges for quick selection | { \[range: string]: [moment](http://momentjs.com/)\[] } \| { \[range: string]: () => [moment](http://momentjs.com/)\[] } | - |  |
 | renderExtraFooter | render extra footer in panel | () => React.ReactNode | - |  |
-| separator | set separator between inputs | string | '~' | 3.14.0 |
+| separator | set separator between inputs | string | '~' |  |
 | showTime | to provide an additional time selection | object\|boolean | [TimePicker Options](/components/time-picker/#API) |  |
 | showTime.defaultValue | to set default time of selected date, [demo](#components-date-picker-demo-disabled-date) | [moment](http://momentjs.com/)\[] | \[moment(), moment()] |  |
 | value | to set date | \[[moment](http://momentjs.com/), [moment](http://momentjs.com/)] | - |  |
-| onCalendarChange | a callback function, can be executed when the start time or the end time of the range is changing | function(dates: \[moment, moment], dateStrings: \[string, string]) | - | 3.10.9 |
+| onCalendarChange | a callback function, can be executed when the start time or the end time of the range is changing | function(dates: \[moment, moment], dateStrings: \[string, string]) | - |  |
 | onChange | a callback function, can be executed when the selected time is changing | function(dates: \[moment, moment], dateStrings: \[string, string]) | - |  |
 | onOk | callback when click ok button | function(dates: [moment](http://momentjs.com/)\[]) | - |  |
 

--- a/components/date-picker/index.zh-CN.md
+++ b/components/date-picker/index.zh-CN.md
@@ -55,7 +55,7 @@ moment.locale('zh-cn');
 | dateRender | 自定义日期单元格的内容 | function(currentDate: moment, today: moment) => React.ReactNode | - |  |
 | disabled | 禁用 | boolean | false |  |
 | disabledDate | 不可选择的日期 | (currentDate: moment) => boolean | 无 |  |
-| dropdownClassName | 额外的弹出日历 className | string | - | 3.3.0 |
+| dropdownClassName | 额外的弹出日历 className | string | - |  |
 | getCalendarContainer | 定义浮层的容器，默认为 body 上新建 div | function(trigger) | 无 |  |
 | locale | 国际化配置 | object | [默认配置](https://github.com/ant-design/ant-design/blob/master/components/date-picker/locale/example.json) |  |
 | mode | 日期面板的状态（[设置后无法选择年份/月份？](/docs/react/faq#当我指定了-DatePicker/RangePicker-的-mode-属性后，点击后无法选择年份/月份？)） | `time|date|month|year|decade` | 'date' |  |
@@ -63,10 +63,10 @@ moment.locale('zh-cn');
 | placeholder | 输入框提示文字 | string\|RangePicker\[] | - |  |
 | popupStyle | 额外的弹出日历样式 | object | {} |  |
 | size | 输入框大小，`large` 高度为 40px，`small` 为 24px，默认是 32px | string | 无 |  |
-| suffixIcon | 自定义的选择框后缀图标 | ReactNode | - | 3.10.0 |
+| suffixIcon | 自定义的选择框后缀图标 | ReactNode | - |  |
 | style | 自定义输入框样式 | object | {} |  |
 | onOpenChange | 弹出日历和关闭日历的回调 | function(status) | 无 |  |
-| onPanelChange | 日历面板切换的回调 | function(value, mode) | - | 3.12.0 |
+| onPanelChange | 日历面板切换的回调 | function(value, mode) | - |  |
 
 ### 共同的方法
 
@@ -80,7 +80,7 @@ moment.locale('zh-cn');
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
 | defaultValue | 默认日期，如果开始时间或结束时间为 `null` 或者 `undefined`，日期范围将是一个开区间 | [moment](http://momentjs.com/) | 无 |  |
-| defaultPickerValue | 默认面板日期 | [moment](http://momentjs.com/) | 无 | 3.10.8 |
+| defaultPickerValue | 默认面板日期 | [moment](http://momentjs.com/) | 无 |  |
 | disabledTime | 不可选择的时间 | function(date) | 无 |  |
 | format | 设置日期格式，为数组时支持多格式匹配，展示以第一个为准。配置参考 [moment.js](http://momentjs.com/) | string \| string[] | "YYYY-MM-DD" |  |
 | renderExtraFooter | 在面板中添加额外的页脚 | (mode) => React.ReactNode | - |  |
@@ -90,14 +90,14 @@ moment.locale('zh-cn');
 | value | 日期 | [moment](http://momentjs.com/) | 无 |  |
 | onChange | 时间发生变化的回调 | function(date: moment, dateString: string) | 无 |  |
 | onOk | 点击确定按钮的回调 | function() | - |  |
-| onPanelChange | 日期面板变化时的回调 | function(value, mode) | - | 3.5.0 |
+| onPanelChange | 日期面板变化时的回调 | function(value, mode) | - |  |
 
 ### MonthPicker
 
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
 | defaultValue | 默认日期 | [moment](http://momentjs.com/) | 无 |  |
-| defaultPickerValue | 默认面板日期 | [moment](http://momentjs.com/) | 无 | 3.10.8 |
+| defaultPickerValue | 默认面板日期 | [moment](http://momentjs.com/) | 无 |  |
 | format | 展示的日期格式，配置参考 [moment.js](http://momentjs.com/) | string | "YYYY-MM" |  |
 | monthCellContentRender | 自定义的月份内容渲染方法 | function(date, locale): ReactNode | - |  |
 | renderExtraFooter | 在面板中添加额外的页脚 | () => React.ReactNode | - |  |
@@ -109,23 +109,23 @@ moment.locale('zh-cn');
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
 | defaultValue | 默认日期 | [moment](http://momentjs.com/) | - |  |
-| defaultPickerValue | 默认面板日期 | [moment](http://momentjs.com/) | 无 | 3.10.8 |
+| defaultPickerValue | 默认面板日期 | [moment](http://momentjs.com/) | 无 |  |
 | format | 展示的日期格式，配置参考 [moment.js](http://momentjs.com/) | string | "YYYY-wo" |  |
 | value | 日期 | [moment](http://momentjs.com/) | - |  |
 | onChange | 时间发生变化的回调，发生在用户选择时间时 | function(date: moment, dateString: string) | - |  |
-| renderExtraFooter | 在面板中添加额外的页脚 | (mode) => React.ReactNode | - | 3.12.0 |
+| renderExtraFooter | 在面板中添加额外的页脚 | (mode) => React.ReactNode | - |  |
 
 ### RangePicker
 
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
 | defaultValue | 默认日期 | [moment](http://momentjs.com/)\[] | 无 |  |
-| defaultPickerValue | 默认面板日期 | [moment](http://momentjs.com/)\[] | 无 | 3.10.8 |
+| defaultPickerValue | 默认面板日期 | [moment](http://momentjs.com/)\[] | 无 |  |
 | disabledTime | 不可选择的时间 | function(dates: \[moment, moment\], partial: `'start'|'end'`) | 无 |  |
 | format | 展示的日期格式 | string | "YYYY-MM-DD HH:mm:ss" |  |
 | ranges | 预设时间范围快捷选择 | { \[range: string]: [moment](http://momentjs.com/)\[] } \| { \[range: string]: () => [moment](http://momentjs.com/)\[] } | 无 |  |
 | renderExtraFooter | 在面板中添加额外的页脚 | () => React.ReactNode | - |  |
-| separator | 设置分隔符 | string | '~' | 3.14.0 |
+| separator | 设置分隔符 | string | '~' |  |
 | showTime | 增加时间选择功能 | Object\|boolean | [TimePicker Options](/components/time-picker/#API) |  |
 | showTime.defaultValue | 设置用户选择日期时默认的时分秒，[例子](#components-date-picker-demo-disabled-date) | [moment](http://momentjs.com/)\[] | \[moment(), moment()] |  |
 | value | 日期 | [moment](http://momentjs.com/)\[] | 无 |  |


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
ref: #19815
<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution
ref: #19815
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Removed version column in 4.0  |
| 🇨🇳 Chinese |  删除相关版本号  |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/alert/demo/custom-icon.md](https://github.com/yehq/ant-design/blob/fix-doc/components/alert/demo/custom-icon.md)
[View rendered components/auto-complete/demo/basic.md](https://github.com/yehq/ant-design/blob/fix-doc/components/auto-complete/demo/basic.md)
[View rendered components/auto-complete/demo/certain-category.md](https://github.com/yehq/ant-design/blob/fix-doc/components/auto-complete/demo/certain-category.md)
[View rendered components/auto-complete/demo/custom.md](https://github.com/yehq/ant-design/blob/fix-doc/components/auto-complete/demo/custom.md)
[View rendered components/auto-complete/demo/form-debug.md](https://github.com/yehq/ant-design/blob/fix-doc/components/auto-complete/demo/form-debug.md)
[View rendered components/auto-complete/demo/non-case-sensitive.md](https://github.com/yehq/ant-design/blob/fix-doc/components/auto-complete/demo/non-case-sensitive.md)
[View rendered components/auto-complete/demo/options.md](https://github.com/yehq/ant-design/blob/fix-doc/components/auto-complete/demo/options.md)
[View rendered components/auto-complete/demo/uncertain-category.md](https://github.com/yehq/ant-design/blob/fix-doc/components/auto-complete/demo/uncertain-category.md)
[View rendered components/auto-complete/index.en-US.md](https://github.com/yehq/ant-design/blob/fix-doc/components/auto-complete/index.en-US.md)
[View rendered components/auto-complete/index.zh-CN.md](https://github.com/yehq/ant-design/blob/fix-doc/components/auto-complete/index.zh-CN.md)
[View rendered components/avatar/demo/badge.md](https://github.com/yehq/ant-design/blob/fix-doc/components/avatar/demo/badge.md)