### PR TITLE
docs: Removed version column in 4.0

### DIFF
--- a/components/select/index.en-US.md
+++ b/components/select/index.en-US.md
@@ -24,14 +24,14 @@ Select component to select value from options.
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
 | allowClear | Show clear button. | boolean | false |  |
-| autoClearSearchValue | Whether the current search will be cleared on selecting an item. Only applies when `mode` is set to `multiple` or `tags`. | boolean | true | 3.10.0 |
+| autoClearSearchValue | Whether the current search will be cleared on selecting an item. Only applies when `mode` is set to `multiple` or `tags`. | boolean | true |  |
 | autoFocus | Get focus by default | boolean | false |  |
 | defaultActiveFirstOption | Whether active first option by default | boolean | true |  |
 | defaultValue | Initial selected option. | string\|string\[]<br />number\|number\[]<br />LabeledValue\|LabeledValue[] | - |  |
 | disabled | Whether disabled select | boolean | false |  |
 | dropdownClassName | className of dropdown menu | string | - |  |
 | dropdownMatchSelectWidth | Whether dropdown's width is same with select. | boolean | true |  |
-| dropdownRender | Customize dropdown content | (menuNode: ReactNode, props) => ReactNode | - | 3.11.0 |
+| dropdownRender | Customize dropdown content | (menuNode: ReactNode, props) => ReactNode | - |  |
 | dropdownStyle | style of dropdown menu | object | - |  |
 | dropdownMenuStyle | additional style applied to dropdown menu | object | - |  |
 | filterOption | If true, filter options by input, if function, filter options against it. The function will receive two arguments, `inputValue` and `option`, if the function returns `true`, the option will be included in the filtered set; Otherwise, it will be excluded. | boolean or function(inputValue, option) | true |  |
@@ -39,36 +39,36 @@ Select component to select value from options.
 | getPopupContainer | Parent Node which the selector should be rendered to. Default to `body`. When position issues happen, try to modify it into scrollable content and position it relative. [Example](https://codesandbox.io/s/4j168r7jw0) | function(triggerNode) | () => document.body |  |
 | labelInValue | whether to embed label in value, turn the format of value from `string` to `{key: string, label: ReactNode}` | boolean | false |  |
 | maxTagCount | Max tag count to show | number | - |  |
-| maxTagTextLength | Max tag count to show | number | - | 3.18.0 |
+| maxTagTextLength | Max tag count to show | number | - |  |
 | maxTagPlaceholder | Placeholder for not showing tags | ReactNode/function(omittedValues) | - |  |
 | mode | Set mode of Select | 'default' \| 'multiple' \| 'tags' | 'default' |  |
 | notFoundContent | Specify content to show when no result matches.. | string | 'Not Found' |  |
 | optionFilterProp | Which prop value of option will be used for filter if filterOption is true | string | value |  |
 | optionLabelProp | Which prop value of option will render as content of select. [Example](https://codesandbox.io/s/antd-reproduction-template-tk678) | string | `value` for `combobox`, `children` for other modes |  |
 | placeholder | Placeholder of select | string\|ReactNode | - |  |
-| showArrow | Whether to show the drop-down arrow | boolean | true | 3.2.1 |
+| showArrow | Whether to show the drop-down arrow | boolean | true |  |
 | showSearch | Whether show search input in single mode. | boolean | false |  |
 | size | Size of Select input. `default` `large` `small` | string | default |  |
-| suffixIcon | The custom suffix icon | ReactNode | - | 3.10.0 |
-| removeIcon | The custom remove icon | ReactNode | - | 3.11.0 |
-| clearIcon | The custom clear icon | ReactNode | - | 3.11.0 |
-| menuItemSelectedIcon | The custom menuItemSelected icon with multiple options | ReactNode | - | 3.11.0 |
+| suffixIcon | The custom suffix icon | ReactNode | - |  |
+| removeIcon | The custom remove icon | ReactNode | - |  |
+| clearIcon | The custom clear icon | ReactNode | - |  |
+| menuItemSelectedIcon | The custom menuItemSelected icon with multiple options | ReactNode | - |  |
 | tokenSeparators | Separator used to tokenize on tag/multiple mode | string\[] |  |  |
 | value | Current selected option. | string\|string\[]\<br />number\|number\[]\<br />LabeledValue\|LabeledValue[] | - |  |
 | onBlur | Called when blur | function | - |  |
 | onChange | Called when select an option or input value change, or value of input is changed in combobox mode | function(value, option:Option/Array&lt;Option>) | - |  |
 | onDeselect | Called when a option is deselected, param is the selected option's value. Only called for multiple or tags, effective in multiple or tags mode only. | function(string\|number\|LabeledValue) | - |  |
 | onFocus | Called when focus | function | - |  |
-| onInputKeyDown | Called when key pressed | function | - | 3.1.0 |
+| onInputKeyDown | Called when key pressed | function | - |  |
 | onMouseEnter | Called when mouse enter | function | - |  |
 | onMouseLeave | Called when mouse leave | function | - |  |
 | onPopupScroll | Called when dropdown scrolls | function | - |  |
 | onSearch | Callback function that is fired when input changed. | function(value: string) |  |  |
 | onSelect | Called when a option is selected, the params are option's value (or key) and option instance. | function(string\|number\|LabeledValue, option:Option) | - |  |
-| defaultOpen | Initial open state of dropdown | boolean | - | 3.9.3 |
-| open | Controlled open state of dropdown | boolean | - | 3.9.0 |
-| onDropdownVisibleChange | Call when dropdown open (Supported after version 3.9.0) | function(open) | - | 3.9.0 |
-| loading | indicate loading state | Boolean | false | 3.11.0 |
+| defaultOpen | Initial open state of dropdown | boolean | - |  |
+| open | Controlled open state of dropdown | boolean | - |  |
+| onDropdownVisibleChange | Call when dropdown open | function(open) | - |  |
+| loading | indicate loading state | Boolean | false |  |
 
 ### Select Methods
 
@@ -85,7 +85,7 @@ Select component to select value from options.
 | key | Same usage as `value`. If React request you to set this property, you can set it to value of option, and then omit value property. | string |  |  |
 | title | `title` of Select after select this Option | string | - |  |
 | value | default to filter with this property | string\|number | - |  |
-| className | additional class to option | string | - | 3.10.1 |
+| className | additional class to option | string | - |  |
 
 ### OptGroup props
 

--- a/components/select/index.zh-CN.md
+++ b/components/select/index.zh-CN.md
@@ -25,14 +25,14 @@ title: Select
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
 | allowClear | 支持清除 | boolean | false |  |
-| autoClearSearchValue | 是否在选中项后清空搜索框，只在 `mode` 为 `multiple` 或 `tags` 时有效。 | boolean | true | 3.10.0 |
+| autoClearSearchValue | 是否在选中项后清空搜索框，只在 `mode` 为 `multiple` 或 `tags` 时有效。 | boolean | true |  |
 | autoFocus | 默认获取焦点 | boolean | false |  |
 | defaultActiveFirstOption | 是否默认高亮第一个选项。 | boolean | true |  |
 | defaultValue | 指定默认选中的条目 | string\|string\[]\<br />number\|number\[]\<br />LabeledValue\|LabeledValue[] | - |  |
 | disabled | 是否禁用 | boolean | false |  |
 | dropdownClassName | 下拉菜单的 className 属性 | string | - |  |
 | dropdownMatchSelectWidth | 下拉菜单和选择器同宽 | boolean | true |  |
-| dropdownRender | 自定义下拉框内容 | (menuNode: ReactNode, props) => ReactNode | - | 3.11.0 |
+| dropdownRender | 自定义下拉框内容 | (menuNode: ReactNode, props) => ReactNode | - |  |
 | dropdownStyle | 下拉菜单的 style 属性 | object | - |  |
 | dropdownMenuStyle | dropdown 菜单自定义样式 | object | - |  |
 | filterOption | 是否根据输入项进行筛选。当其为一个函数时，会接收 `inputValue` `option` 两个参数，当 `option` 符合筛选条件时，应返回 `true`，反之则返回 `false`。 | boolean or function(inputValue, option) | true |  |
@@ -40,36 +40,36 @@ title: Select
 | getPopupContainer | 菜单渲染父节点。默认渲染到 body 上，如果你遇到菜单滚动定位问题，试试修改为滚动的区域，并相对其定位。[示例](https://codesandbox.io/s/4j168r7jw0) | Function(triggerNode) | () => document.body |  |
 | labelInValue | 是否把每个选项的 label 包装到 value 中，会把 Select 的 value 类型从 `string` 变为 `{key: string, label: ReactNode}` 的格式 | boolean | false |  |
 | maxTagCount | 最多显示多少个 tag | number | - |  |
-| maxTagTextLength | 最大显示的 tag 文本长度 | number | - | 3.18.0 |
+| maxTagTextLength | 最大显示的 tag 文本长度 | number | - |  |
 | maxTagPlaceholder | 隐藏 tag 时显示的内容 | ReactNode/function(omittedValues) | - |  |
 | mode | 设置 Select 的模式为多选或标签 | 'multiple' \| 'tags' | - |  |
 | notFoundContent | 当下拉列表为空时显示的内容 | string | 'Not Found' |  |
 | optionFilterProp | 搜索时过滤对应的 option 属性，如设置为 children 表示对内嵌内容进行搜索。[示例](https://codesandbox.io/s/antd-reproduction-template-tk678) | string | value |  |
 | optionLabelProp | 回填到选择框的 Option 的属性值，默认是 Option 的子元素。比如在子元素需要高亮效果时，此值可以设为 `value`。 | string | `children` （combobox 模式下为 `value`） |  |
 | placeholder | 选择框默认文字 | string | - |  |
-| showArrow | 是否显示下拉小箭头 | boolean | true | 3.2.1 |
+| showArrow | 是否显示下拉小箭头 | boolean | true |  |
 | showSearch | 使单选模式可搜索 | boolean | false |  |
 | size | 选择框大小，可选 `large` `small` | string | default |  |
-| suffixIcon | 自定义的选择框后缀图标 | ReactNode | - | 3.10.0 |
-| removeIcon | 自定义的多选框清除图标 | ReactNode | - | 3.11.0 |
-| clearIcon | 自定义的多选框清空图标 | ReactNode | - | 3.11.0 |
-| menuItemSelectedIcon | 自定义多选时当前选中的条目图标 | ReactNode | - | 3.11.0 |
+| suffixIcon | 自定义的选择框后缀图标 | ReactNode | - |  |
+| removeIcon | 自定义的多选框清除图标 | ReactNode | - |  |
+| clearIcon | 自定义的多选框清空图标 | ReactNode | - |  |
+| menuItemSelectedIcon | 自定义多选时当前选中的条目图标 | ReactNode | - |  |
 | tokenSeparators | 在 tags 和 multiple 模式下自动分词的分隔符 | string\[] |  |  |
 | value | 指定当前选中的条目 | string\|string\[]\<br />number\|number\[]\<br />LabeledValue\|LabeledValue[] | - |  |
 | onBlur | 失去焦点时回调 | function | - |  |
 | onChange | 选中 option，或 input 的 value 变化（combobox 模式下）时，调用此函数 | function(value, option:Option/Array&lt;Option>) | - |  |
 | onDeselect | 取消选中时调用，参数为选中项的 value (或 key) 值，仅在 multiple 或 tags 模式下生效 | function(string\|number\|LabeledValue) | - |  |
 | onFocus | 获得焦点时回调 | function | - |  |
-| onInputKeyDown | 按键按下时回调 | function | - | 3.1.0 |
+| onInputKeyDown | 按键按下时回调 | function | - |  |
 | onMouseEnter | 鼠标移入时回调 | function | - |  |
 | onMouseLeave | 鼠标移出时回调 | function | - |  |
 | onPopupScroll | 下拉列表滚动时的回调 | function | - |  |
 | onSearch | 文本框值变化时回调 | function(value: string) |  |  |
 | onSelect | 被选中时调用，参数为选中项的 value (或 key) 值 | function(string\|number\|LabeledValue, option:Option) | - |  |
-| defaultOpen | 是否默认展开下拉菜单 | boolean | - | 3.9.3 |
-| open | 是否展开下拉菜单 | boolean | - | 3.9.0 |
-| onDropdownVisibleChange | 展开下拉菜单的回调 (3.9.0 后支持) | function(open) | - | 3.9.0 |
-| loading | 加载中状态 | Boolean | false | 3.11.0 |
+| defaultOpen | 是否默认展开下拉菜单 | boolean | - |  |
+| open | 是否展开下拉菜单 | boolean | - |  |
+| onDropdownVisibleChange | 展开下拉菜单的回调 | function(open) | - |  |
+| loading | 加载中状态 | Boolean | false |  |
 
 > 注意，如果发现下拉菜单跟随页面滚动，或者需要在其他弹层中触发 Select，请尝试使用 `getPopupContainer={triggerNode => triggerNode.parentElement}` 将下拉弹层渲染节点固定在触发器的父元素中。
 
@@ -88,7 +88,7 @@ title: Select
 | key | 和 value 含义一致。如果 React 需要你设置此项，此项值与 value 的值相同，然后可以省略 value 设置 | string |  |  |
 | title | 选中该 Option 后，Select 的 title | string | - |  |
 | value | 默认根据此属性值进行筛选 | string\|number | - |  |
-| className | Option 器类名 | string | - | 3.10.1 |
+| className | Option 器类名 | string | - |  |
 
 ### OptGroup props
 

--- a/components/slider/index.en-US.md
+++ b/components/slider/index.en-US.md
@@ -23,16 +23,16 @@ To input a value in a range.
 | max | The maximum value the slider can slide to | number | 100 |  |
 | min | The minimum value the slider can slide to. | number | 0 |  |
 | range | dual thumb mode | boolean | false |  |
-| reverse | reverse the component | boolean | false | 3.24.0 |
+| reverse | reverse the component | boolean | false |  |
 | step | The granularity the slider can step through values. Must greater than 0, and be divided by (max - min) . When `marks` no null, `step` can be `null`. | number\|null | 1 |  |
 | tipFormatter | Slider will pass its value to `tipFormatter`, and display its value in Tooltip, and hide Tooltip when return value is null. | Function\|null | IDENTITY |  |
 | value | The value of slider. When `range` is `false`, use `number`, otherwise, use `[number, number]` | number\|number\[] |  |
 | vertical | If true, the slider will be vertical. | Boolean | false |  |
 | onAfterChange | Fire when `onmouseup` is fired. | Function(value) | NOOP |  |
 | onChange | Callback function that is fired when the user changes the slider's value. | Function(value) | NOOP |  |
-| tooltipPlacement | Set Tooltip display position. Ref [`Tooltip`](/components/tooltip/). | string |  | 3.19.0 |
-| tooltipVisible | If true, Tooltip will show always, or it will not show anyway, even if dragging or hovering. | Boolean |  | 3.11.0 |
-| getTooltipPopupContainer | The DOM container of the Tooltip, the default behavior is to create a div element in body. | Function | () => document.body | 3.19.0 |
+| tooltipPlacement | Set Tooltip display position. Ref [`Tooltip`](/components/tooltip/). | string |  |  |
+| tooltipVisible | If true, Tooltip will show always, or it will not show anyway, even if dragging or hovering. | Boolean |  |  |
+| getTooltipPopupContainer | The DOM container of the Tooltip, the default behavior is to create a div element in body. | Function | () => document.body |  |
 
 ## Methods
 

--- a/components/slider/index.zh-CN.md
+++ b/components/slider/index.zh-CN.md
@@ -24,16 +24,16 @@ title: Slider
 | max | 最大值 | number | 100 |  |
 | min | 最小值 | number | 0 |  |
 | range | 双滑块模式 | boolean | false |  |
-| reverse | 反向坐标轴 | boolean | false | 3.24.0 |
+| reverse | 反向坐标轴 | boolean | false |  |
 | step | 步长，取值必须大于 0，并且可被 (max - min) 整除。当 `marks` 不为空对象时，可以设置 `step` 为 `null`，此时 Slider 的可选值仅有 marks 标出来的部分。 | number\|null | 1 |  |
 | tipFormatter | Slider 会把当前值传给 `tipFormatter`，并在 Tooltip 中显示 `tipFormatter` 的返回值，若为 null，则隐藏 Tooltip。 | Function\|null | IDENTITY |  |
 | value | 设置当前取值。当 `range` 为 `false` 时，使用 `number`，否则用 `[number, number]` | number\|number\[] |  |  |
 | vertical | 值为 `true` 时，Slider 为垂直方向 | Boolean | false |  |
 | onAfterChange | 与 `onmouseup` 触发时机一致，把当前值作为参数传入。 | Function(value) | NOOP |  |
 | onChange | 当 Slider 的值发生改变时，会触发 onChange 事件，并把改变后的值作为参数传入。 | Function(value) | NOOP |  |
-| tooltipPlacement | 设置 Tooltip 展示位置。参考 [`Tooltip`](/components/tooltip/)。 | string |  | 3.19.0 |
-| tooltipVisible | 值为`true`时，Tooltip 将会始终显示；否则始终不显示，哪怕在拖拽及移入时。 | Boolean |  | 3.11.0 |
-| getTooltipPopupContainer | Tooltip 渲染父节点，默认渲染到 body 上。 | Function | () => document.body | 3.19.0 |
+| tooltipPlacement | 设置 Tooltip 展示位置。参考 [`Tooltip`](/components/tooltip/)。 | string |  |  |
+| tooltipVisible | 值为`true`时，Tooltip 将会始终显示；否则始终不显示，哪怕在拖拽及移入时。 | Boolean |  |  |
+| getTooltipPopupContainer | Tooltip 渲染父节点，默认渲染到 body 上。 | Function | () => document.body |  |
 
 ## 方法
 

--- a/components/time-picker/index.en-US.md
+++ b/components/time-picker/index.en-US.md
@@ -24,7 +24,7 @@ import moment from 'moment';
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
 | addon | called from timepicker panel to render some addon to its bottom | function | - |  |
-| allowClear | allow clearing text | boolean | true | 3.13.0 |
+| allowClear | allow clearing text | boolean | true |  |
 | autoFocus | get focus when component mounted | boolean | false |  |
 | className | className of picker | string | '' |  |
 | clearText | clear tooltip of icon | string | clear |  |
@@ -38,15 +38,15 @@ import moment from 'moment';
 | getPopupContainer | to set the container of the floating layer, while the default is to create a div element in body | function(trigger) | - |  |
 | hideDisabledOptions | hide the options that can not be selected | boolean | false |  |
 | hourStep | interval between hours in picker | number | 1 |  |
-| inputReadOnly | Set the `readonly` attribute of the input tag (avoids virtual keyboard on touch devices) | boolean | false | 3.3.0 |
+| inputReadOnly | Set the `readonly` attribute of the input tag (avoids virtual keyboard on touch devices) | boolean | false |  |
 | minuteStep | interval between minutes in picker | number | 1 |  |
 | open | whether to popup panel | boolean | false |  |
 | placeholder | display when there's no value | string | "Select a time" |  |
 | popupClassName | className of panel | string | '' |  |
-| popupStyle | style of panel | object | - | 3.12.0 |
+| popupStyle | style of panel | object | - |  |
 | secondStep | interval between seconds in picker | number | 1 |  |
-| suffixIcon | The custom suffix icon | ReactNode | - | 3.10.0 |
-| clearIcon | The custom clear icon | ReactNode | - | 3.14.0 |
+| suffixIcon | The custom suffix icon | ReactNode | - |  |
+| clearIcon | The custom clear icon | ReactNode | - |  |
 | use12Hours | display as 12 hours format, with default format `h:mm:ss a` | boolean | false |  |
 | value | to set time | [moment](http://momentjs.com/) | - |  |
 | onChange | a callback function, can be executed when the selected time is changing | function(time: moment, timeString: string): void | - |  |

--- a/components/time-picker/index.zh-CN.md
+++ b/components/time-picker/index.zh-CN.md
@@ -25,7 +25,7 @@ import moment from 'moment';
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
 | addon | 选择框底部显示自定义的内容 | function | 无 |  |
-| allowClear | 是否展示清除按钮 | boolean | true | 3.13.0 |
+| allowClear | 是否展示清除按钮 | boolean | true |  |
 | autoFocus | 自动获取焦点 | boolean | false |  |
 | className | 选择器类名 | string | '' |  |
 | clearText | 清除按钮的提示文案 | string | clear |  |
@@ -39,15 +39,15 @@ import moment from 'moment';
 | getPopupContainer | 定义浮层的容器，默认为 body 上新建 div | function(trigger) | 无 |  |
 | hideDisabledOptions | 隐藏禁止选择的选项 | boolean | false |  |
 | hourStep | 小时选项间隔 | number | 1 |  |
-| inputReadOnly | 设置输入框为只读（避免在移动设备上打开虚拟键盘） | boolean | false | 3.3.0 |
+| inputReadOnly | 设置输入框为只读（避免在移动设备上打开虚拟键盘） | boolean | false |  |
 | minuteStep | 分钟选项间隔 | number | 1 |  |
 | open | 面板是否打开 | boolean | false |  |
 | placeholder | 没有值的时候显示的内容 | string | "请选择时间" |  |
 | popupClassName | 弹出层类名 | string | '' |  |
-| popupStyle | 弹出层样式对象 | object | - | 3.12.0 |
+| popupStyle | 弹出层样式对象 | object | - |  |
 | secondStep | 秒选项间隔 | number | 1 |  |
-| suffixIcon | 自定义的选择框后缀图标 | ReactNode | - | 3.10.0 |
-| clearIcon | 自定义的清除图标 | ReactNode | - | 3.14.0 |
+| suffixIcon | 自定义的选择框后缀图标 | ReactNode | - |  |
+| clearIcon | 自定义的清除图标 | ReactNode | - |  |
 | use12Hours | 使用 12 小时制，为 true 时 `format` 默认为 `h:mm:ss a` | boolean | false |  |
 | value | 当前时间 | [moment](http://momentjs.com/) | 无 |  |
 | onChange | 时间发生变化的回调 | function(time: moment, timeString: string): void | 无 |  |

--- a/components/transfer/index.en-US.md
+++ b/components/transfer/index.en-US.md
@@ -22,38 +22,38 @@ One or more elements can be selected from either column, one click on the proper
 | --- | --- | --- | --- | --- |
 | className | A custom CSS class. | string | \['', ''] |  |
 | dataSource | Used for setting the source data. The elements that are part of this array will be present the left column. Except the elements whose keys are included in `targetKeys` prop. | [TransferItem](https://git.io/vMM64)\[] | \[] |  |
-| disabled | Whether disabled transfer | boolean | false | 3.10.0 |
+| disabled | Whether disabled transfer | boolean | false |  |
 | filterOption | A function to determine whether an item should show in search result list | (inputValue, option): boolean |  |  |
 | footer | A function used for rendering the footer. | (props) => ReactNode |  |  |
 | lazy | property of [react-lazy-load](https://github.com/loktar00/react-lazy-load) for lazy rendering items. Turn off it by set to `false`. | object\|boolean | `{ height: 32, offset: 32 }` |  |
 | listStyle | A custom CSS style used for rendering the transfer columns. | object\|({direction: 'left'\|'right'}) => object |  |  |
-| locale | i18n text including filter, empty text, item unit, etc | { itemUnit: string; itemsUnit: string; searchPlaceholder: string; notFoundContent: ReactNode; } | `{ itemUnit: 'item', itemsUnit: 'items', notFoundContent: 'The list is empty', searchPlaceholder: 'Search here' }` | 3.9.0 |
+| locale | i18n text including filter, empty text, item unit, etc | { itemUnit: string; itemsUnit: string; searchPlaceholder: string; notFoundContent: ReactNode; } | `{ itemUnit: 'item', itemsUnit: 'items', notFoundContent: 'The list is empty', searchPlaceholder: 'Search here' }` |  |
 | operations | A set of operations that are sorted from top to bottom. | string\[] | \['>', '<'] |  |
-| operationStyle | A custom CSS style used for rendering the operations column. | object |  | 3.6.0 |
+| operationStyle | A custom CSS style used for rendering the operations column. | object |  |  |
 | render | The function to generate the item shown on a column. Based on an record (element of the dataSource array), this function should return a React element which is generated from that record. Also, it can return a plain object with `value` and `label`, `label` is a React element and `value` is for title | (record) => ReactNode |  |  |
 | selectedKeys | A set of keys of selected items. | string\[] | \[] |  |
 | showSearch | If included, a search box is shown on each column. | boolean | false |  |
-| showSelectAll | Show select all checkbox on the header | boolean | true | 3.18.0 |
-| style | A custom CSS style used for rendering wrapper element. | object |  | 3.6.0 |
+| showSelectAll | Show select all checkbox on the header | boolean | true |  |
+| style | A custom CSS style used for rendering wrapper element. | object |  |  |
 | targetKeys | A set of keys of elements that are listed on the right column. | string\[] | \[] |  |
 | titles | A set of titles that are sorted from left to right. | ReactNode\[] | - |  |
 | onChange | A callback function that is executed when the transfer between columns is complete. | (targetKeys, direction, moveKeys): void |  |  |
 | onScroll | A callback function which is executed when scroll options list | (direction, event): void |  |  |
-| onSearch | A callback function which is executed when search field are changed | (direction: 'left'\|'right', value: string): void | - | 3.11.0 |
+| onSearch | A callback function which is executed when search field are changed | (direction: 'left'\|'right', value: string): void | - |  |
 | onSelectChange | A callback function which is executed when selected items are changed. | (sourceSelectedKeys, targetSelectedKeys): void |  |  |
 
 ### Render Props
 
-New in 3.18.0. Transfer accept `children` to customize render list, using follow props:
+Transfer accept `children` to customize render list, using follow props:
 
 | Property        | Description             | Type                                | Version |
 | --------------- | ----------------------- | ----------------------------------- | ------- |
-| direction       | List render direction   | 'left' \| 'right'                   | 3.18.0  |
-| disabled        | Disable list or not     | boolean                             | 3.18.0  |
-| filteredItems   | Filtered items          | TransferItem[]                      | 3.18.0  |
-| onItemSelect    | Select item             | (key: string, selected: boolean)    | 3.18.0  |
-| onItemSelectAll | Select a group of items | (keys: string[], selected: boolean) | 3.18.0  |
-| selectedKeys    | Selected items          | string[]                            | 3.18.0  |
+| direction       | List render direction   | 'left' \| 'right'                   |         |
+| disabled        | Disable list or not     | boolean                             |         |
+| filteredItems   | Filtered items          | TransferItem[]                      |         |
+| onItemSelect    | Select item             | (key: string, selected: boolean)    |         |
+| onItemSelectAll | Select a group of items | (keys: string[], selected: boolean) |         |
+| selectedKeys    | Selected items          | string[]                            |         |
 
 #### example
 

--- a/components/transfer/index.zh-CN.md
+++ b/components/transfer/index.zh-CN.md
@@ -25,37 +25,37 @@ title: Transfer
 | --- | --- | --- | --- | --- |
 | className | 自定义类 | string |  |  |
 | dataSource | 数据源，其中的数据将会被渲染到左边一栏中，`targetKeys` 中指定的除外。 | [TransferItem](https://git.io/vMM64)\[] | \[] |  |
-| disabled | 是否禁用 | boolean | false | 3.10.0 |
+| disabled | 是否禁用 | boolean | false |  |
 | filterOption | 接收 `inputValue` `option` 两个参数，当 `option` 符合筛选条件时，应返回 `true`，反之则返回 `false`。 |  | (inputValue, option): boolean |  |  |
 | footer | 底部渲染函数 | (props) => ReactNode |  |  |
 | lazy | Transfer 使用了 [react-lazy-load](https://github.com/loktar00/react-lazy-load) 优化性能，这里可以设置相关参数。设为 `false` 可以关闭懒加载。 | object\|boolean | `{ height: 32, offset: 32 }` |  |
 | listStyle | 两个穿梭框的自定义样式 | object\|({direction: 'left'\|'right'}) => object |  |  |
-| locale | 各种语言 | { itemUnit: string; itemsUnit: string; searchPlaceholder: string; notFoundContent: ReactNode; } | `{ itemUnit: '项', itemsUnit: '项', searchPlaceholder: '请输入搜索内容' }` | 3.9.0 |
+| locale | 各种语言 | { itemUnit: string; itemsUnit: string; searchPlaceholder: string; notFoundContent: ReactNode; } | `{ itemUnit: '项', itemsUnit: '项', searchPlaceholder: '请输入搜索内容' }` |  |
 | operations | 操作文案集合，顺序从上至下 | string\[] | \['>', '<'] |  |
 | render | 每行数据渲染函数，该函数的入参为 `dataSource` 中的项，返回值为 ReactElement。或者返回一个普通对象，其中 `label` 字段为 ReactElement，`value` 字段为 title | (record) => ReactNode |  |  |
 | selectedKeys | 设置哪些项应该被选中 | string\[] | \[] |  |
 | showSearch | 是否显示搜索框 | boolean | false |  |
-| showSelectAll | 是否展示全选勾选框 | boolean | true | 3.18.0 |
-| style | 容器的自定义样式 | object |  | 3.6.0 |
+| showSelectAll | 是否展示全选勾选框 | boolean | true |  |
+| style | 容器的自定义样式 | object |  |  |
 | targetKeys | 显示在右侧框数据的 key 集合 | string\[] | \[] |  |
 | titles | 标题集合，顺序从左至右 | ReactNode\[] | \['', ''] |  |
 | onChange | 选项在两栏之间转移时的回调函数 | (targetKeys, direction, moveKeys): void |  |  |
 | onScroll | 选项列表滚动时的回调函数 | (direction, event): void |  |  |
-| onSearch | 搜索框内容时改变时的回调函数 | (direction: 'left'\|'right', value: string): void | - | 3.11.0 |
+| onSearch | 搜索框内容时改变时的回调函数 | (direction: 'left'\|'right', value: string): void | - |  |
 | onSelectChange | 选中项发生改变时的回调函数 | (sourceSelectedKeys, targetSelectedKeys): void |  |  |
 
 ### Render Props
 
-3.18.0 新增。Transfer 支持接收 `children` 自定义渲染列表，并返回以下参数：
+Transfer 支持接收 `children` 自定义渲染列表，并返回以下参数：
 
-| 参数            | 说明           | 类型                                | 版本   |
-| --------------- | -------------- | ----------------------------------- | ------ |
-| direction       | 渲染列表的方向 | 'left' \| 'right'                   | 3.18.0 |
-| disabled        | 是否禁用列表   | boolean                             | 3.18.0 |
-| filteredItems   | 过滤后的数据   | TransferItem[]                      | 3.18.0 |
-| onItemSelect    | 勾选条目       | (key: string, selected: boolean)    | 3.18.0 |
-| onItemSelectAll | 勾选一组条目   | (keys: string[], selected: boolean) | 3.18.0 |
-| selectedKeys    | 选中的条目     | string[]                            | 3.18.0 |
+| 参数            | 说明           | 类型                                | 版本 |
+| --------------- | -------------- | ----------------------------------- | ---- |
+| direction       | 渲染列表的方向 | 'left' \| 'right'                   |      |
+| disabled        | 是否禁用列表   | boolean                             |      |
+| filteredItems   | 过滤后的数据   | TransferItem[]                      |      |
+| onItemSelect    | 勾选条目       | (key: string, selected: boolean)    |      |
+| onItemSelectAll | 勾选一组条目   | (keys: string[], selected: boolean) |      |
+| selectedKeys    | 选中的条目     | string[]                            |      |
 
 #### 参考示例
 

--- a/components/tree-select/index.en-US.md
+++ b/components/tree-select/index.en-US.md
@@ -17,41 +17,41 @@ Tree selection control.
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
 | allowClear | Whether allow clear | boolean | false |  |
-| autoClearSearchValue | auto clear search input value when multiple select is selected/deselected | boolean | true | 3.7.0 |
+| autoClearSearchValue | auto clear search input value when multiple select is selected/deselected | boolean | true |  |
 | defaultValue | To set the initial selected treeNode(s). | string\|string\[] | - |  |
 | disabled | Disabled or not | boolean | false |  |
-| dropdownClassName | className of dropdown menu | string | - | 3.3.0 |
+| dropdownClassName | className of dropdown menu | string | - |  |
 | dropdownMatchSelectWidth | Determine whether the dropdown menu and the select input are the same width. Default set `min-width` same as input. | boolean | true |  |
 | dropdownStyle | To set the style of the dropdown menu | object | - |  |
 | filterTreeNode | Whether to filter treeNodes by input value. The value of `treeNodeFilterProp` is used for filtering by default. | boolean\|Function(inputValue: string, treeNode: TreeNode) (should return boolean) | Function |  |
 | getPopupContainer | To set the container of the dropdown menu. The default is to create a `div` element in `body`, you can reset it to the scrolling area and make a relative reposition. [example](https://codepen.io/afc163/pen/zEjNOy?editors=0010) | Function(triggerNode) | () => document.body |  |
 | labelInValue | whether to embed label in value, turn the format of value from `string` to `{value: string, label: ReactNode, halfChecked: string[]}` | boolean | false |  |
 | loadData | Load data asynchronously. | function(node) | - |  |
-| maxTagCount | Max tag count to show | number | - | 3.7.0 |
-| maxTagPlaceholder | Placeholder for not showing tags | ReactNode/function(omittedValues) | - | 3.7.0 |
+| maxTagCount | Max tag count to show | number | - |  |
+| maxTagPlaceholder | Placeholder for not showing tags | ReactNode/function(omittedValues) | - |  |
 | multiple | Support multiple or not, will be `true` when enable `treeCheckable`. | boolean | false |  |
 | placeholder | Placeholder of the select input | string | - |  |
 | searchPlaceholder | Placeholder of the search input | string | - |  |
-| searchValue | work with `onSearch` to make search value controlled. | string | - | 3.7.0 |
-| treeIcon | Shows the icon before a TreeNode's title. There is no default style; you must set a custom style for it if set to `true` | boolean | false | 3.13.1 |
+| searchValue | work with `onSearch` to make search value controlled. | string | - |  |
+| treeIcon | Shows the icon before a TreeNode's title. There is no default style; you must set a custom style for it if set to `true` | boolean | false |  |
 | showCheckedStrategy | The way show selected item in box. **Default:** just show child nodes. **`TreeSelect.SHOW_ALL`:** show all checked treeNodes (include parent treeNode). **`TreeSelect.SHOW_PARENT`:** show checked treeNodes (just show parent treeNode). | enum { TreeSelect.SHOW_ALL, TreeSelect.SHOW_PARENT, TreeSelect.SHOW_CHILD } | TreeSelect.SHOW_CHILD |  |
 | showSearch | Support search or not | boolean | single: `false` \| multiple: `true` |  |
 | size | To set the size of the select input, options: `large` `small` | string | 'default' |  |
-| suffixIcon | The custom suffix icon | ReactNode | - | 3.10.0 |
+| suffixIcon | The custom suffix icon | ReactNode | - |  |
 | treeCheckable | Whether to show checkbox on the treeNodes | boolean | false |  |
 | treeCheckStrictly | Whether to check nodes precisely (in the `checkable` mode), means parent and child nodes are not associated, and it will make `labelInValue` be true | boolean | false |  |
 | treeData | Data of the treeNodes, manual construction work is no longer needed if this property has been set(ensure the Uniqueness of each value) | array\<{ value, title, children, \[disabled, disableCheckbox, selectable] }> | \[] |  |
 | treeDataSimpleMode | Enable simple mode of treeData. Changes the `treeData` schema to: \[{id:1, pId:0, value:'1', title:"test1",...},...] where pId is parent node's id). It is possible to replace the default `id` and `pId` keys by providing object to `treeDataSimpleMode` | false\|object\<{ id: string, pId: string, rootPId: string }> | false |  |
 | treeDefaultExpandAll | Whether to expand all treeNodes by default | boolean | false |  |
 | treeDefaultExpandedKeys | Default expanded treeNodes | string\[] | - |  |
-| treeExpandedKeys | Set expanded keys | string\[] | - | 3.10.0 |
+| treeExpandedKeys | Set expanded keys | string\[] | - |  |
 | treeNodeFilterProp | Will be used for filtering if `filterTreeNode` returns true | string | 'value' |  |
 | treeNodeLabelProp | Will render as content of select | string | 'title' |  |
 | value | To set the current selected treeNode(s). | string\|string\[] | - |  |
 | onChange | A callback function, can be executed when selected treeNodes or input value change | function(value, label, extra) | - |  |
 | onSearch | A callback function, can be executed when the search input changes. | function(value: string) | - |  |
 | onSelect | A callback function, can be executed when you select a treeNode. | function(value, node, extra) | - |  |
-| onTreeExpand | A callback function, can be executed when treeNode expanded | function(expandedKeys) | - | 3.10.0 |
+| onTreeExpand | A callback function, can be executed when treeNode expanded | function(expandedKeys) | - |  |
 
 ### Tree Methods
 
@@ -66,7 +66,7 @@ Tree selection control.
 
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
-| selectable | can be selected | boolean | true | 3.9.3 |
+| selectable | can be selected | boolean | true |  |
 | disableCheckbox | Disables the checkbox of the treeNode | boolean | false |  |
 | disabled | Disabled or not | boolean | false |  |
 | isLeaf | Leaf node or not | boolean | false |  |

--- a/components/tree-select/index.zh-CN.md
+++ b/components/tree-select/index.zh-CN.md
@@ -18,41 +18,41 @@ title: TreeSelect
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
 | allowClear | 显示清除按钮 | boolean | false |  |
-| autoClearSearchValue | 当多选模式下值被选择，自动清空搜索框 | boolean | true | 3.7.0 |
+| autoClearSearchValue | 当多选模式下值被选择，自动清空搜索框 | boolean | true |  |
 | defaultValue | 指定默认选中的条目 | string/string\[] | - |  |
 | disabled | 是否禁用 | boolean | false |  |
-| dropdownClassName | 下拉菜单的 className 属性 | string | - | 3.3.0 |
+| dropdownClassName | 下拉菜单的 className 属性 | string | - |  |
 | dropdownMatchSelectWidth | 下拉菜单和选择器同宽。默认将设置 `min-width`。 | boolean | true |  |
 | dropdownStyle | 下拉菜单的样式 | object | - |  |
 | filterTreeNode | 是否根据输入项进行筛选，默认用 treeNodeFilterProp 的值作为要筛选的 TreeNode 的属性值 | boolean\|Function(inputValue: string, treeNode: TreeNode) (函数需要返回 bool 值) | Function |  |
 | getPopupContainer | 菜单渲染父节点。默认渲染到 body 上，如果你遇到菜单滚动定位问题，试试修改为滚动的区域，并相对其定位。[示例](https://codepen.io/afc163/pen/zEjNOy?editors=0010) | Function(triggerNode) | () => document.body |  |
 | labelInValue | 是否把每个选项的 label 包装到 value 中，会把 value 类型从 `string` 变为 `{value: string, label: ReactNode, halfChecked(treeCheckStrictly 时有效): string[] }` 的格式 | boolean | false |  |
 | loadData | 异步加载数据 | function(node) | - |  |
-| maxTagCount | 最多显示多少个 tag | number | - | 3.7.0 |
-| maxTagPlaceholder | 隐藏 tag 时显示的内容 | ReactNode/function(omittedValues) | - | 3.7.0 |
+| maxTagCount | 最多显示多少个 tag | number | - |  |
+| maxTagPlaceholder | 隐藏 tag 时显示的内容 | ReactNode/function(omittedValues) | - |  |
 | multiple | 支持多选（当设置 treeCheckable 时自动变为 true） | boolean | false |  |
 | placeholder | 选择框默认文字 | string | - |  |
 | searchPlaceholder | 搜索框默认文字 | string | - |  |
-| searchValue | 搜索框的值，可以通过 `onSearch` 获取用户输入 | string | - | 3.7.0 |
-| treeIcon | 是否展示 TreeNode title 前的图标，没有默认样式，如设置为 true，需要自行定义图标相关样式 | boolean | false | 3.13.1 |
+| searchValue | 搜索框的值，可以通过 `onSearch` 获取用户输入 | string | - |  |
+| treeIcon | 是否展示 TreeNode title 前的图标，没有默认样式，如设置为 true，需要自行定义图标相关样式 | boolean | false |  |
 | showCheckedStrategy | 定义选中项回填的方式。`TreeSelect.SHOW_ALL`: 显示所有选中节点(包括父节点). `TreeSelect.SHOW_PARENT`: 只显示父节点(当父节点下所有子节点都选中时). 默认只显示子节点. | enum{TreeSelect.SHOW_ALL, TreeSelect.SHOW_PARENT, TreeSelect.SHOW_CHILD } | TreeSelect.SHOW_CHILD |  |
 | showSearch | 是否支持搜索框 | boolean | 单选：`false` \| 多选：`true` |  |
 | size | 选择框大小，可选 `large` `small` | string | 'default' |  |
-| suffixIcon | 自定义的选择框后缀图标 | ReactNode | - | 3.10.0 |
+| suffixIcon | 自定义的选择框后缀图标 | ReactNode | - |  |
 | treeCheckable | 显示 checkbox | boolean | false |  |
 | treeCheckStrictly | checkable 状态下节点选择完全受控（父子节点选中状态不再关联），会使得 `labelInValue` 强制为 true | boolean | false |  |
 | treeData | treeNodes 数据，如果设置则不需要手动构造 TreeNode 节点（value 在整个树范围内唯一） | array\<{value, title, children, \[disabled, disableCheckbox, selectable]}> | \[] |  |
 | treeDataSimpleMode | 使用简单格式的 treeData，具体设置参考可设置的类型 (此时 treeData 应变为这样的数据结构: \[{id:1, pId:0, value:'1', title:"test1",...},...], `pId` 是父节点的 id) | false\|object\<{ id: string, pId: string, rootPId: string }> | false |  |
 | treeDefaultExpandAll | 默认展开所有树节点 | boolean | false |  |
 | treeDefaultExpandedKeys | 默认展开的树节点 | string\[] | - |  |
-| treeExpandedKeys | 设置展开的树节点 | string\[] | - | 3.10.0 |
+| treeExpandedKeys | 设置展开的树节点 | string\[] | - |  |
 | treeNodeFilterProp | 输入项过滤对应的 treeNode 属性 | string | 'value' |  |
 | treeNodeLabelProp | 作为显示的 prop 设置 | string | 'title' |  |
 | value | 指定当前选中的条目 | string/string\[] | - |  |
 | onChange | 选中树节点时调用此函数 | function(value, label, extra) | - |  |
 | onSearch | 文本框值变化时回调 | function(value: string) | - |  |
 | onSelect | 被选中时调用 | function(value, node, extra) | - |  |
-| onTreeExpand | 展示节点时调用 | function(expandedKeys) | - | 3.10.0 |
+| onTreeExpand | 展示节点时调用 | function(expandedKeys) | - |  |
 
 ### Tree 方法
 
@@ -67,7 +67,7 @@ title: TreeSelect
 
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
-| selectable | 是否可选 | boolean | true | 3.9.3 |
+| selectable | 是否可选 | boolean | true |  |
 | disableCheckbox | 禁掉 checkbox | boolean | false |  |
 | disabled | 是否禁用 | boolean | false |  |
 | isLeaf | 是否是叶子节点 | boolean | false |  |

--- a/components/upload/index.en-US.md
+++ b/components/upload/index.en-US.md
@@ -20,8 +20,8 @@ Uploading is the process of publishing information (web pages, text, pictures, v
 | --- | --- | --- | --- | --- |
 | accept | File types that can be accepted. See [input accept Attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#accept) | string | - |  |
 | action | Uploading URL | string\|(file) => `Promise` | - |  |
-| method | http method of upload request | string | 'post' | 3.25.0 |
-| directory | support upload whole directory ([caniuse](https://caniuse.com/#feat=input-file-directory)) | boolean | false | 3.7.0 |
+| method | http method of upload request | string | 'post' |  |
+| directory | support upload whole directory ([caniuse](https://caniuse.com/#feat=input-file-directory)) | boolean | false |  |
 | beforeUpload | Hook function which will be executed before uploading. Uploading will be stopped with `false` or a rejected Promise returned. **Warning：this function is not supported in IE9**。 | (file, fileList) => `boolean | Promise` | - |  |
 | customRequest | override for the default xhr behavior allowing for additional customization and ability to implement your own XMLHttpRequest | Function | - |  |
 | data | Uploading extra params or function which can return uploading extra params. | object\|function(file) | - |  |
@@ -32,16 +32,16 @@ Uploading is the process of publishing information (web pages, text, pictures, v
 | listType | Built-in stylesheets, support for three types: `text`, `picture` or `picture-card` | string | 'text' |  |
 | multiple | Whether to support selected multiple file. `IE10+` supported. You can select multiple files with CTRL holding down while multiple is set to be true | boolean | false |  |
 | name | The name of uploading file | string | 'file' |  |
-| previewFile | Customize preview file logic | (file: File \| Blob) => Promise<dataURL: string> | - | 3.17.0 |
+| previewFile | Customize preview file logic | (file: File \| Blob) => Promise<dataURL: string> | - |  |
 | showUploadList | Whether to show default upload list, could be an object to specify `showPreviewIcon`, `showRemoveIcon` and `showDownloadIcon` individually | Boolean or { showPreviewIcon?: boolean, showDownloadIcon?: boolean, showRemoveIcon?: boolean } | true |  |
 | supportServerRender | Need to be turned on while the server side is rendering | boolean | false |  |
 | withCredentials | ajax upload with cookie sent | boolean | false |  |
-| openFileDialogOnClick | click open file dialog | boolean | true | 3.10.0 |
+| openFileDialogOnClick | click open file dialog | boolean | true |  |
 | onChange | A callback function, can be executed when uploading state is changing, see [onChange](#onChange) | Function | - |  |
 | onPreview | A callback function, will be executed when file link or preview icon is clicked | Function(file) | - |  |
 | onRemove | A callback function, will be executed when removing file button is clicked, remove event will be prevented when return value is `false` or a Promise which resolve(false) or reject | Function(file): `boolean | Promise` | - |  |
 | onDownload | Click the method to download the file, pass the method to perform the method logic, do not pass the default jump to the new TAB. | Function(file): void | Jump to new TAB |  |
-| transformFile   | Customize transform file before request | Function(file): `string | Blob | File | Promise<string | Blob | File>` | - | 3.21.0 |
+| transformFile   | Customize transform file before request | Function(file): `string | Blob | File | Promise<string | Blob | File>` | - |  |
 
 ### onChange
 

--- a/components/upload/index.zh-CN.md
+++ b/components/upload/index.zh-CN.md
@@ -21,8 +21,8 @@ title: Upload
 | --- | --- | --- | --- | --- |
 | accept | 接受上传的文件类型, 详见 [input accept Attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#accept) | string | 无 |  |
 | action | 上传的地址 | string\|(file) => `Promise` | 无 |  |
-| method | 上传请求的 http method | string | 'post' | 3.25.0 |
-| directory | 支持上传文件夹（[caniuse](https://caniuse.com/#feat=input-file-directory)） | boolean | false | 3.7.0 |
+| method | 上传请求的 http method | string | 'post' |  |
+| directory | 支持上传文件夹（[caniuse](https://caniuse.com/#feat=input-file-directory)） | boolean | false |  |
 | beforeUpload | 上传文件之前的钩子，参数为上传的文件，若返回 `false` 则停止上传。支持返回一个 Promise 对象，Promise 对象 reject 时则停止上传，resolve 时开始上传（ resolve 传入 `File` 或 `Blob` 对象则上传 resolve 传入对象）。**注意：IE9 不支持该方法**。 | (file, fileList) => `boolean | Promise` | 无 |  |
 | customRequest | 通过覆盖默认的上传行为，可以自定义自己的上传实现 | Function | 无 |  |
 | data | 上传所需额外参数或返回上传额外参数的方法 | object\|(file) => object | 无 |  |
@@ -33,16 +33,16 @@ title: Upload
 | listType | 上传列表的内建样式，支持三种基本样式 `text`, `picture` 和 `picture-card` | string | 'text' |  |
 | multiple | 是否支持多选文件，`ie10+` 支持。开启后按住 ctrl 可选择多个文件 | boolean | false |  |
 | name | 发到后台的文件参数名 | string | 'file' |  |
-| previewFile | 自定义文件预览逻辑 | (file: File \| Blob) => Promise<dataURL: string> | 无 | 3.17.0 |
+| previewFile | 自定义文件预览逻辑 | (file: File \| Blob) => Promise<dataURL: string> | 无 |  |
 | showUploadList | 是否展示文件列表, 可设为一个对象，用于单独设定 `showPreviewIcon`, `showRemoveIcon` 和 `showDownloadIcon` | Boolean or { showPreviewIcon?: boolean, showRemoveIcon?: boolean, showDownloadIcon?: boolean } | true |  |
 | supportServerRender | 服务端渲染时需要打开这个 | boolean | false |  |
 | withCredentials | 上传请求时是否携带 cookie | boolean | false |  |
-| openFileDialogOnClick | 点击打开文件对话框 | boolean | true | 3.10.0 |
+| openFileDialogOnClick | 点击打开文件对话框 | boolean | true |  |
 | onChange | 上传文件改变时的状态，详见 [onChange](#onChange) | Function | 无 |  |
 | onPreview | 点击文件链接或预览图标时的回调 | Function(file) | 无 |  |
 | onRemove   | 点击移除文件时的回调，返回值为 false 时不移除。支持返回一个 Promise 对象，Promise 对象 resolve(false) 或 reject 时不移除。               | Function(file): `boolean | Promise` | 无   |  |
 | onDownload | 点击下载文件时的回调，如果没有指定，则默认跳转到文件 url 对应的标签页。 | Function(file): void | 跳转新标签页 |  |
-| transformFile   | 在上传之前转换文件。支持返回一个 Promise 对象   | Function(file): `string | Blob | File | Promise<string | Blob | File>` | 无   | 3.21.0 |
+| transformFile   | 在上传之前转换文件。支持返回一个 Promise 对象   | Function(file): `string | Blob | File | Promise<string | Blob | File>` | 无   |  |
 
 ### onChange
 


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [X] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

ref: #19815

### 💡 Background and solution

ref: #19815

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Removed version column in 4.0  |
| 🇨🇳 Chinese | 删除相关版本号 |

### ☑️ Self Check before Merge

- [X] Doc is updated/provided or not needed
- [X] Demo is updated/provided or not needed
- [X] TypeScript definition is updated/provided or not needed
- [X] Changelog is provided or not needed


-----
[View rendered components/select/index.en-US.md](https://github.com/wangxingkang/ant-design/blob/4.0-remove-docs-version/components/select/index.en-US.md)
[View rendered components/select/index.zh-CN.md](https://github.com/wangxingkang/ant-design/blob/4.0-remove-docs-version/components/select/index.zh-CN.md)
[View rendered components/slider/index.en-US.md](https://github.com/wangxingkang/ant-design/blob/4.0-remove-docs-version/components/slider/index.en-US.md)
[View rendered components/slider/index.zh-CN.md](https://github.com/wangxingkang/ant-design/blob/4.0-remove-docs-version/components/slider/index.zh-CN.md)
[View rendered components/time-picker/index.en-US.md](https://github.com/wangxingkang/ant-design/blob/4.0-remove-docs-version/components/time-picker/index.en-US.md)
[View rendered components/time-picker/index.zh-CN.md](https://github.com/wangxingkang/ant-design/blob/4.0-remove-docs-version/components/time-picker/index.zh-CN.md)
[View rendered components/transfer/index.en-US.md](https://github.com/wangxingkang/ant-design/blob/4.0-remove-docs-version/components/transfer/index.en-US.md)
[View rendered components/transfer/index.zh-CN.md](https://github.com/wangxingkang/ant-design/blob/4.0-remove-docs-version/components/transfer/index.zh-CN.md)
[View rendered components/tree-select/index.en-US.md](https://github.com/wangxingkang/ant-design/blob/4.0-remove-docs-version/components/tree-select/index.en-US.md)
[View rendered components/tree-select/index.zh-CN.md](https://github.com/wangxingkang/ant-design/blob/4.0-remove-docs-version/components/tree-select/index.zh-CN.md)
[View rendered components/upload/index.en-US.md](https://github.com/wangxingkang/ant-design/blob/4.0-remove-docs-version/components/upload/index.en-US.md)
[View rendered components/upload/index.zh-CN.md](https://github.com/wangxingkang/ant-design/blob/4.0-remove-docs-version/components/upload/index.zh-CN.md)