### PR TITLE
docs: Removed version column in 4.0

### DIFF
--- a/components/auto-complete/index.en-US.md
+++ b/components/auto-complete/index.en-US.md
@@ -27,14 +27,14 @@ When there is a need for autocomplete functionality.
 | optionLabelProp | Which prop value of option will render as content of select. | string | `children` |  |
 | placeholder | placeholder of input | string | - |  |
 | value | selected option | string\|string\[]\|{ key: string, label: string\|ReactNode }\|Array&lt;{ key: string, label: string\|ReactNode }> | - |  |
-| onBlur | Called when leaving the component. | function() | - | 3.6.5 |
+| onBlur | Called when leaving the component. | function() | - |  |
 | onChange | Called when select an option or input value change, or value of input is changed | function(value) | - |  |
-| onFocus | Called when entering the component | function() | - | 3.6.5 |
+| onFocus | Called when entering the component | function() | - |  |
 | onSearch | Called when searching items. | function(value) | - |  |
 | onSelect | Called when a option is selected. param is option's value and option instance. | function(value, option) | - |  |
-| defaultOpen | Initial open state of dropdown | boolean | - | 3.9.3 |
-| open | Controlled open state of dropdown | boolean | - | 3.9.3 |
-| onDropdownVisibleChange | Call when dropdown open | function(open) | - | 3.9.3 |
+| defaultOpen | Initial open state of dropdown | boolean | - |  |
+| open | Controlled open state of dropdown | boolean | - |  |
+| onDropdownVisibleChange | Call when dropdown open | function(open) | - |  |
 
 ## Methods
 

--- a/components/auto-complete/index.zh-CN.md
+++ b/components/auto-complete/index.zh-CN.md
@@ -25,18 +25,18 @@ title: AutoComplete
 | defaultValue | 指定默认选中的条目 | string\|string\[]\| 无 |  |
 | disabled | 是否禁用 | boolean | false |  |
 | filterOption | 是否根据输入项进行筛选。当其为一个函数时，会接收 `inputValue` `option` 两个参数，当 `option` 符合筛选条件时，应返回 `true`，反之则返回 `false`。 | boolean or function(inputValue, option) | true |  |
-| getPopupContainer | 菜单渲染父节点。默认渲染到 body 上，如果你遇到菜单滚动定位问题，试试修改为滚动的区域，并相对其定位。[示例](https://codesandbox.io/s/4j168r7jw0) | Function(triggerNode) | () => document.body | 3.19.4 |
+| getPopupContainer | 菜单渲染父节点。默认渲染到 body 上，如果你遇到菜单滚动定位问题，试试修改为滚动的区域，并相对其定位。[示例](https://codesandbox.io/s/4j168r7jw0) | Function(triggerNode) | () => document.body |  |
 | optionLabelProp | 回填到选择框的 Option 的属性值，默认是 Option 的子元素。比如在子元素需要高亮效果时，此值可以设为 `value`。 | string | `children` |  |
 | placeholder | 输入框提示 | string | - |  |
 | value | 指定当前选中的条目 | string\|string\[]\|{ key: string, label: string\|ReactNode }\|Array&lt;{ key: string, label: string\|ReactNode }> | 无 |  |
-| onBlur | 失去焦点时的回调 | function() | - | 3.6.5 |
+| onBlur | 失去焦点时的回调 | function() | - |  |
 | onChange | 选中 option，或 input 的 value 变化时，调用此函数 | function(value) | 无 |  |
-| onFocus | 获得焦点时的回调 | function() | - | 3.6.5 |
+| onFocus | 获得焦点时的回调 | function() | - |  |
 | onSearch | 搜索补全项的时候调用 | function(value) | 无 |  |
 | onSelect | 被选中时调用，参数为选中项的 value 值 | function(value, option) | 无 |  |
-| defaultOpen | 是否默认展开下拉菜单 | boolean | - | 3.9.3 |
-| open | 是否展开下拉菜单 | boolean | - | 3.9.3 |
-| onDropdownVisibleChange | 展开下拉菜单的回调 | function(open) | - | 3.9.3 |
+| defaultOpen | 是否默认展开下拉菜单 | boolean | - |  |
+| open | 是否展开下拉菜单 | boolean | - |  |
+| onDropdownVisibleChange | 展开下拉菜单的回调 | function(open) | - |  |
 
 ## 方法
 

--- a/components/checkbox/index.en-US.md
+++ b/components/checkbox/index.en-US.md
@@ -19,23 +19,23 @@ Checkbox component.
 
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
-| autoFocus | get focus when component mounted | boolean | false | 3.6.2 |
-| checked | Specifies whether the checkbox is selected. | boolean | false | 3.6.2 |
-| defaultChecked | Specifies the initial state: whether or not the checkbox is selected. | boolean | false | 3.6.2 |
-| disabled | Disable checkbox | boolean | false | 3.6.2 |
-| indeterminate | indeterminate checked state of checkbox | boolean | false | 3.6.2 |
-| onChange | The callback function that is triggered when the state changes. | Function(e:Event) | - | 3.6.2 |
+| autoFocus | get focus when component mounted | boolean | false |  |
+| checked | Specifies whether the checkbox is selected. | boolean | false |  |
+| defaultChecked | Specifies the initial state: whether or not the checkbox is selected. | boolean | false |  |
+| disabled | Disable checkbox | boolean | false |  |
+| indeterminate | indeterminate checked state of checkbox | boolean | false |  |
+| onChange | The callback function that is triggered when the state changes. | Function(e:Event) | - |  |
 
 #### Checkbox Group
 
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
-| defaultValue | Default selected value | string\[] | \[] | 3.6.2 |
-| disabled | Disable all checkboxes | boolean | false | 3.6.2 |
-| name | The `name` property of all `input[type="checkbox"]` children | string | - | 3.16.0 |
-| options | Specifies options | string\[] | \[] | 3.6.2 |
-| value | Used for setting the currently selected value. | string\[] | \[] | 3.6.2 |
-| onChange | The callback function that is triggered when the state changes. | Function(checkedValue) | - | 3.6.2 |
+| defaultValue | Default selected value | string\[] | \[] |  |
+| disabled | Disable all checkboxes | boolean | false |  |
+| name | The `name` property of all `input[type="checkbox"]` children | string | - |  |
+| options | Specifies options | string\[] | \[] |  |
+| value | Used for setting the currently selected value. | string\[] | \[] |  |
+| onChange | The callback function that is triggered when the state changes. | Function(checkedValue) | - |  |
 
 ### Methods
 
@@ -43,5 +43,5 @@ Checkbox component.
 
 | Name    | Description  | Version |
 | ------- | ------------ | ------- |
-| blur()  | remove focus | 3.6.2   |
-| focus() | get focus    | 3.6.2   |
+| blur()  | remove focus |         |
+| focus() | get focus    |         |

--- a/components/checkbox/index.zh-CN.md
+++ b/components/checkbox/index.zh-CN.md
@@ -18,31 +18,31 @@ title: Checkbox
 
 #### Checkbox
 
-| 参数           | 说明                                    | 类型              | 默认值 | 版本  |
-| -------------- | --------------------------------------- | ----------------- | ------ | ----- |
-| autoFocus      | 自动获取焦点                            | boolean           | false  | 3.6.2 |
-| checked        | 指定当前是否选中                        | boolean           | false  | 3.6.2 |
-| defaultChecked | 初始是否选中                            | boolean           | false  | 3.6.2 |
-| disabled       | 失效状态                                | boolean           | false  | 3.6.2 |
-| indeterminate  | 设置 indeterminate 状态，只负责样式控制 | boolean           | false  | 3.6.2 |
-| onChange       | 变化时回调函数                          | Function(e:Event) | -      | 3.6.2 |
+| 参数           | 说明                                    | 类型              | 默认值 | 版本 |
+| -------------- | --------------------------------------- | ----------------- | ------ | ---- |
+| autoFocus      | 自动获取焦点                            | boolean           | false  |      |
+| checked        | 指定当前是否选中                        | boolean           | false  |      |
+| defaultChecked | 初始是否选中                            | boolean           | false  |      |
+| disabled       | 失效状态                                | boolean           | false  |      |
+| indeterminate  | 设置 indeterminate 状态，只负责样式控制 | boolean           | false  |      |
+| onChange       | 变化时回调函数                          | Function(e:Event) | -      |      |
 
 #### Checkbox Group
 
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
-| defaultValue | 默认选中的选项 | string\[] | \[] | 3.6.2 |
-| disabled | 整组失效 | boolean | false | 3.6.2 |
-| name | CheckboxGroup 下所有 `input[type="checkbox"]` 的 `name` 属性 | string | - | 3.16.0 |
-| options | 指定可选项 | string\[] | \[] | 3.6.2 |
-| value | 指定选中的选项 | string\[] | \[] | 3.6.2 |
-| onChange | 变化时回调函数 | Function(checkedValue) | - | 3.6.2 |
+| defaultValue | 默认选中的选项 | string\[] | \[] |  |
+| disabled | 整组失效 | boolean | false |  |
+| name | CheckboxGroup 下所有 `input[type="checkbox"]` 的 `name` 属性 | string | - |  |
+| options | 指定可选项 | string\[] | \[] |  |
+| value | 指定选中的选项 | string\[] | \[] |  |
+| onChange | 变化时回调函数 | Function(checkedValue) | - |  |
 
 ### 方法
 
 #### Checkbox
 
-| 名称    | 描述     | 版本  |
-| ------- | -------- | ----- |
-| blur()  | 移除焦点 | 3.6.2 |
-| focus() | 获取焦点 | 3.6.2 |
+| 名称    | 描述     | 版本 |
+| ------- | -------- | ---- |
+| blur()  | 移除焦点 |      |
+| focus() | 获取焦点 |      |


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
ref: #19815


### 💡 Background and solution

ref: #19815

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Removed version column in 4.0        |
| 🇨🇳 Chinese |     删除相关版本号      |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/auto-complete/index.en-US.md](https://github.com/577281375/ant-design/blob/midou/components/auto-complete/index.en-US.md)
[View rendered components/auto-complete/index.zh-CN.md](https://github.com/577281375/ant-design/blob/midou/components/auto-complete/index.zh-CN.md)
[View rendered components/checkbox/index.en-US.md](https://github.com/577281375/ant-design/blob/midou/components/checkbox/index.en-US.md)
[View rendered components/checkbox/index.zh-CN.md](https://github.com/577281375/ant-design/blob/midou/components/checkbox/index.zh-CN.md)