### PR TITLE
docs: Removed version column in 4.0

### DIFF
--- a/components/tooltip/index.en-US.md
+++ b/components/tooltip/index.en-US.md
@@ -13,29 +13,29 @@ A simple text popup tip.
 
 ## API
 
-| Property | Description | Type | Default | Version |
-| --- | --- | --- | --- | --- |
+| Property | Description | Type | Default |
+| --- | --- | --- | --- |
 | title | The text shown in the tooltip | string\|ReactNode\|() => ReactNode | - |  |
 
 ### Common API
 
 The following APIs are shared by Tooltip, Popconfirm, Popover.
 
-| Property | Description | Type | Default | Version |
-| --- | --- | --- | --- | --- |
-| arrowPointAtCenter | Whether the arrow is pointed at the center of target, supported after `antd@1.11+` | boolean | `false` |  |
-| autoAdjustOverflow | Whether to adjust popup placement automatically when popup is off screen | boolean | `true` |  |
-| defaultVisible | Whether the floating tooltip card is visible by default | boolean | `false` |  |
-| getPopupContainer | The DOM container of the tip, the default behavior is to create a `div` element in `body` | Function(triggerNode) | () => document.body |  |
-| mouseEnterDelay | Delay in seconds, before tooltip is shown on mouse enter | number | 0.1 |  |
-| mouseLeaveDelay | Delay in seconds, before tooltip is hidden on mouse leave | number | 0.1 |  |
-| overlayClassName | Class name of the tooltip card | string | - |  |
-| overlayStyle | Style of the tooltip card | object | - |  |
-| placement | The position of the tooltip relative to the target, which can be one of `top` `left` `right` `bottom` `topLeft` `topRight` `bottomLeft` `bottomRight` `leftTop` `leftBottom` `rightTop` `rightBottom` | string | `top` |  |
-| trigger | Tooltip trigger mode | `hover` \| `focus` \| `click` \| `contextMenu` | `hover` |  |
-| visible | Whether the floating tooltip card is visible or not | boolean | `false` |  |
-| onVisibleChange | Callback executed when visibility of the tooltip card is changed | (visible) => void | - |  |
-| align | this value will be merged into placement's config, please refer to the settings [rc-tooltip](https://github.com/react-component/tooltip) | Object | - |  |
+| Property | Description | Type | Default |
+| --- | --- | --- | --- |
+| arrowPointAtCenter | Whether the arrow is pointed at the center of target, supported after `antd@1.11+` | boolean | `false` |
+| autoAdjustOverflow | Whether to adjust popup placement automatically when popup is off screen | boolean | `true` |
+| defaultVisible | Whether the floating tooltip card is visible by default | boolean | `false` |
+| getPopupContainer | The DOM container of the tip, the default behavior is to create a `div` element in `body` | Function(triggerNode) | () => document.body |
+| mouseEnterDelay | Delay in seconds, before tooltip is shown on mouse enter | number | 0.1 |
+| mouseLeaveDelay | Delay in seconds, before tooltip is hidden on mouse leave | number | 0.1 |
+| overlayClassName | Class name of the tooltip card | string | - |
+| overlayStyle | Style of the tooltip card | object | - |
+| placement | The position of the tooltip relative to the target, which can be one of `top` `left` `right` `bottom` `topLeft` `topRight` `bottomLeft` `bottomRight` `leftTop` `leftBottom` `rightTop` `rightBottom` | string | `top` |
+| trigger | Tooltip trigger mode | `hover` \| `focus` \| `click` \| `contextMenu` | `hover` |
+| visible | Whether the floating tooltip card is visible or not | boolean | `false` |
+| onVisibleChange | Callback executed when visibility of the tooltip card is changed | (visible) => void | - |
+| align | this value will be merged into placement's config, please refer to the settings [rc-tooltip](https://github.com/react-component/tooltip) | Object | - |
 
 ## Note
 

--- a/components/tooltip/index.en-US.md
+++ b/components/tooltip/index.en-US.md
@@ -35,7 +35,7 @@ The following APIs are shared by Tooltip, Popconfirm, Popover.
 | trigger | Tooltip trigger mode | `hover` \| `focus` \| `click` \| `contextMenu` | `hover` |  |
 | visible | Whether the floating tooltip card is visible or not | boolean | `false` |  |
 | onVisibleChange | Callback executed when visibility of the tooltip card is changed | (visible) => void | - |  |
-| align | this value will be merged into placement's config, please refer to the settings [rc-tooltip](https://github.com/react-component/tooltip) | Object | - | 3.10.0 |
+| align | this value will be merged into placement's config, please refer to the settings [rc-tooltip](https://github.com/react-component/tooltip) | Object | - |  |
 
 ## Note
 

--- a/components/tooltip/index.en-US.md
+++ b/components/tooltip/index.en-US.md
@@ -15,7 +15,7 @@ A simple text popup tip.
 
 | Property | Description | Type | Default |
 | --- | --- | --- | --- |
-| title | The text shown in the tooltip | string\|ReactNode\|() => ReactNode | - |  |
+| title | The text shown in the tooltip | string\|ReactNode\|() => ReactNode | - |
 
 ### Common API
 

--- a/components/tooltip/index.zh-CN.md
+++ b/components/tooltip/index.zh-CN.md
@@ -15,29 +15,29 @@ title: Tooltip
 
 ## API
 
-| 参数  | 说明     | 类型                               | 默认值 | 版本 |
-| ----- | -------- | ---------------------------------- | ------ | ---- |
-| title | 提示文字 | string\|ReactNode\|() => ReactNode | 无     |      |
+| 参数  | 说明     | 类型                               | 默认值 |
+| ----- | -------- | ---------------------------------- | ------ |
+| title | 提示文字 | string\|ReactNode\|() => ReactNode | 无     |
 
 ### 共同的 API
 
 以下 API 为 Tooltip、Popconfirm、Popover 共享的 API。
 
-| 参数 | 说明 | 类型 | 默认值 | 版本 |
-| --- | --- | --- | --- | --- |
-| arrowPointAtCenter | 箭头是否指向目标元素中心，`antd@1.11+` 支持 | boolean | `false` |  |
-| autoAdjustOverflow | 气泡被遮挡时自动调整位置 | boolean | `true` |  |
-| defaultVisible | 默认是否显隐 | boolean | false |  |
-| getPopupContainer | 浮层渲染父节点，默认渲染到 body 上 | Function(triggerNode) | () => document.body |  |
-| mouseEnterDelay | 鼠标移入后延时多少才显示 Tooltip，单位：秒 | number | 0.1 |  |
-| mouseLeaveDelay | 鼠标移出后延时多少才隐藏 Tooltip，单位：秒 | number | 0.1 |  |
-| overlayClassName | 卡片类名 | string | 无 |  |
-| overlayStyle | 卡片样式 | object | 无 |  |
-| placement | 气泡框位置，可选 `top` `left` `right` `bottom` `topLeft` `topRight` `bottomLeft` `bottomRight` `leftTop` `leftBottom` `rightTop` `rightBottom` | string | top |  |
-| trigger | 触发行为，可选 `hover/focus/click/contextMenu` | string | hover |  |
-| visible | 用于手动控制浮层显隐 | boolean | false |  |
-| onVisibleChange | 显示隐藏的回调 | (visible) => void | 无 |  |
-| align | 该值将合并到 placement 的配置中，设置参考 [rc-tooltip](https://github.com/react-component/tooltip) | Object | 无 |  |
+| 参数 | 说明 | 类型 | 默认值 |
+| --- | --- | --- | --- |
+| arrowPointAtCenter | 箭头是否指向目标元素中心，`antd@1.11+` 支持 | boolean | `false` |
+| autoAdjustOverflow | 气泡被遮挡时自动调整位置 | boolean | `true` |
+| defaultVisible | 默认是否显隐 | boolean | false |
+| getPopupContainer | 浮层渲染父节点，默认渲染到 body 上 | Function(triggerNode) | () => document.body |
+| mouseEnterDelay | 鼠标移入后延时多少才显示 Tooltip，单位：秒 | number | 0.1 |
+| mouseLeaveDelay | 鼠标移出后延时多少才隐藏 Tooltip，单位：秒 | number | 0.1 |
+| overlayClassName | 卡片类名 | string | 无 |
+| overlayStyle | 卡片样式 | object | 无 |
+| placement | 气泡框位置，可选 `top` `left` `right` `bottom` `topLeft` `topRight` `bottomLeft` `bottomRight` `leftTop` `leftBottom` `rightTop` `rightBottom` | string | top |
+| trigger | 触发行为，可选 `hover/focus/click/contextMenu` | string | hover |
+| visible | 用于手动控制浮层显隐 | boolean | false |
+| onVisibleChange | 显示隐藏的回调 | (visible) => void | 无 |
+| align | 该值将合并到 placement 的配置中，设置参考 [rc-tooltip](https://github.com/react-component/tooltip) | Object | 无 |
 
 ## 注意
 

--- a/components/tooltip/index.zh-CN.md
+++ b/components/tooltip/index.zh-CN.md
@@ -37,7 +37,7 @@ title: Tooltip
 | trigger | 触发行为，可选 `hover/focus/click/contextMenu` | string | hover |  |
 | visible | 用于手动控制浮层显隐 | boolean | false |  |
 | onVisibleChange | 显示隐藏的回调 | (visible) => void | 无 |  |
-| align | 该值将合并到 placement 的配置中，设置参考 [rc-tooltip](https://github.com/react-component/tooltip) | Object | 无 | 3.10.0 |
+| align | 该值将合并到 placement 的配置中，设置参考 [rc-tooltip](https://github.com/react-component/tooltip) | Object | 无 |  |
 
 ## 注意
 

--- a/components/tree/index.en-US.md
+++ b/components/tree/index.en-US.md
@@ -17,26 +17,26 @@ Almost anything can be represented in a tree structure. Examples include directo
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
 | autoExpandParent | Whether to automatically expand a parent treeNode | boolean | true |  |
-| blockNode | Whether treeNode fill remaining horizontal space | boolean | false | 3.15.0 |
+| blockNode | Whether treeNode fill remaining horizontal space | boolean | false |  |
 | checkable | Adds a `Checkbox` before the treeNodes | boolean | false |  |
 | checkedKeys | (Controlled) Specifies the keys of the checked treeNodes (PS: When this specifies the key of a treeNode which is also a parent treeNode, all the children treeNodes of will be checked; and vice versa, when it specifies the key of a treeNode which is a child treeNode, its parent treeNode will also be checked. When `checkable` and `checkStrictly` is true, its object has `checked` and `halfChecked` property. Regardless of whether the child or parent treeNode is checked, they won't impact each other. | string\[] \| {checked: string\[], halfChecked: string\[]} | \[] |  |
 | checkStrictly | Check treeNode precisely; parent treeNode and children treeNodes are not associated | boolean | false |  |
 | defaultCheckedKeys | Specifies the keys of the default checked treeNodes | string\[] | \[] |  |
 | defaultExpandAll | Whether to expand all treeNodes by default | boolean | false |  |
 | defaultExpandedKeys | Specify the keys of the default expanded treeNodes | string\[] | \[] |  |
-| defaultExpandParent | auto expand parent treeNodes when init | bool | true | 3.4.0 |
+| defaultExpandParent | auto expand parent treeNodes when init | bool | true |  |
 | defaultSelectedKeys | Specifies the keys of the default selected treeNodes | string\[] | \[] |  |
-| disabled | whether disabled the tree | bool | false | 3.4.0 |
+| disabled | whether disabled the tree | bool | false |  |
 | draggable | Specifies whether this Tree is draggable (IE > 8) | boolean | false |  |
 | expandedKeys | (Controlled) Specifies the keys of the expanded treeNodes | string\[] | \[] |  |
 | filterTreeNode | Defines a function to filter (highlight) treeNodes. When the function returns `true`, the corresponding treeNode will be highlighted | function(node) | - |  |
 | loadData | Load data asynchronously | function(node) | - |  |
-| loadedKeys | (Controlled) Set loaded tree nodes. Need work with `loadData` | string\[] | \[] | 3.7.0 |
+| loadedKeys | (Controlled) Set loaded tree nodes. Need work with `loadData` | string\[] | \[] |  |
 | multiple | Allows selecting multiple treeNodes | boolean | false |  |
 | selectable | whether can be selected | boolean | true |  |
 | selectedKeys | (Controlled) Specifies the keys of the selected treeNodes | string\[] | - |  |
 | showIcon | Shows the icon before a TreeNode's title. There is no default style; you must set a custom style for it if set to `true` | boolean | false |  |
-| switcherIcon | customize collapse/expand icon of tree node | React.ReactElement | - | 3.12.0 |
+| switcherIcon | customize collapse/expand icon of tree node | React.ReactElement | - |  |
 | showLine | Shows a connecting line | boolean | false |  |
 | onCheck | Callback function for when the onCheck event occurs | function(checkedKeys, e:{checked: bool, checkedNodes, node, event}) | - |  |
 | onDragEnd | Callback function for when the onDragEnd event occurs | function({event, node}) | - |  |
@@ -46,19 +46,19 @@ Almost anything can be represented in a tree structure. Examples include directo
 | onDragStart | Callback function for when the onDragStart event occurs | function({event, node}) | - |  |
 | onDrop | Callback function for when the onDrop event occurs | function({event, node, dragNode, dragNodesKeys}) | - |  |
 | onExpand | Callback function for when a treeNode is expanded or collapsed | function(expandedKeys, {expanded: bool, node}) | - |  |
-| onLoad | Callback function for when a treeNode is loaded | function(loadedKeys, {event, node}) | - | 3.7.0 |
+| onLoad | Callback function for when a treeNode is loaded | function(loadedKeys, {event, node}) | - |  |
 | onRightClick | Callback function for when the user right clicks a treeNode | function({event, node}) | - |  |
 | onSelect | Callback function for when the user clicks a treeNode | function(selectedKeys, e:{selected: bool, selectedNodes, node, event}) | - |  |
-| treeData | treeNodes data Array, if set it then you need not to construct children TreeNode. (key should be unique across the whole array) | array\<{ key, title, children, \[disabled, selectable] }> | - | 3.19.8 |
+| treeData | treeNodes data Array, if set it then you need not to construct children TreeNode. (key should be unique across the whole array) | array\<{ key, title, children, \[disabled, selectable] }> | - |  |
 
 ### TreeNode props
 
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
-| checkable | When Tree is checkable, set TreeNode display Checkbox or not | boolean | - | 3.17.0 |
+| checkable | When Tree is checkable, set TreeNode display Checkbox or not | boolean | - |  |
 | disableCheckbox | Disables the checkbox of the treeNode | boolean | false |  |  |
 | disabled | Disables the treeNode | boolean | false |  |  |
-| icon | customize icon. When you pass component, whose render will receive full TreeNode props as component props | ReactNode/Function(props):ReactNode | - |  | 3.4.0 |
+| icon | customize icon. When you pass component, whose render will receive full TreeNode props as component props | ReactNode/Function(props):ReactNode | - |  |  |
 | isLeaf | Determines if this is a leaf node(effective when `loadData` is specified) | boolean | false |  |  |
 | key | Used with (default)ExpandedKeys / (default)CheckedKeys / (default)SelectedKeys. P.S.: It must be unique in all of treeNodes of the tree! | string | internal calculated position of treeNode |  |  |
 | selectable | Set whether the treeNode can be selected | boolean | true |  |  |
@@ -68,7 +68,7 @@ Almost anything can be represented in a tree structure. Examples include directo
 
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
-| expandAction | Directory open logic, optional `false` `'click'` `'doubleClick'` | string | click | 3.7.0 |
+| expandAction | Directory open logic, optional `false` `'click'` `'doubleClick'` | string | click |  |
 
 ## Note
 

--- a/components/tree/index.en-US.md
+++ b/components/tree/index.en-US.md
@@ -14,61 +14,61 @@ Almost anything can be represented in a tree structure. Examples include directo
 
 ### Tree props
 
-| Property | Description | Type | Default | Version |
-| --- | --- | --- | --- | --- |
-| autoExpandParent | Whether to automatically expand a parent treeNode | boolean | true |  |
-| blockNode | Whether treeNode fill remaining horizontal space | boolean | false |  |
-| checkable | Adds a `Checkbox` before the treeNodes | boolean | false |  |
-| checkedKeys | (Controlled) Specifies the keys of the checked treeNodes (PS: When this specifies the key of a treeNode which is also a parent treeNode, all the children treeNodes of will be checked; and vice versa, when it specifies the key of a treeNode which is a child treeNode, its parent treeNode will also be checked. When `checkable` and `checkStrictly` is true, its object has `checked` and `halfChecked` property. Regardless of whether the child or parent treeNode is checked, they won't impact each other. | string\[] \| {checked: string\[], halfChecked: string\[]} | \[] |  |
-| checkStrictly | Check treeNode precisely; parent treeNode and children treeNodes are not associated | boolean | false |  |
-| defaultCheckedKeys | Specifies the keys of the default checked treeNodes | string\[] | \[] |  |
-| defaultExpandAll | Whether to expand all treeNodes by default | boolean | false |  |
-| defaultExpandedKeys | Specify the keys of the default expanded treeNodes | string\[] | \[] |  |
-| defaultExpandParent | auto expand parent treeNodes when init | bool | true |  |
-| defaultSelectedKeys | Specifies the keys of the default selected treeNodes | string\[] | \[] |  |
-| disabled | whether disabled the tree | bool | false |  |
-| draggable | Specifies whether this Tree is draggable (IE > 8) | boolean | false |  |
-| expandedKeys | (Controlled) Specifies the keys of the expanded treeNodes | string\[] | \[] |  |
-| filterTreeNode | Defines a function to filter (highlight) treeNodes. When the function returns `true`, the corresponding treeNode will be highlighted | function(node) | - |  |
-| loadData | Load data asynchronously | function(node) | - |  |
-| loadedKeys | (Controlled) Set loaded tree nodes. Need work with `loadData` | string\[] | \[] |  |
-| multiple | Allows selecting multiple treeNodes | boolean | false |  |
-| selectable | whether can be selected | boolean | true |  |
-| selectedKeys | (Controlled) Specifies the keys of the selected treeNodes | string\[] | - |  |
-| showIcon | Shows the icon before a TreeNode's title. There is no default style; you must set a custom style for it if set to `true` | boolean | false |  |
-| switcherIcon | customize collapse/expand icon of tree node | React.ReactElement | - |  |
-| showLine | Shows a connecting line | boolean | false |  |
-| onCheck | Callback function for when the onCheck event occurs | function(checkedKeys, e:{checked: bool, checkedNodes, node, event}) | - |  |
-| onDragEnd | Callback function for when the onDragEnd event occurs | function({event, node}) | - |  |
-| onDragEnter | Callback function for when the onDragEnter event occurs | function({event, node, expandedKeys}) | - |  |
-| onDragLeave | Callback function for when the onDragLeave event occurs | function({event, node}) | - |  |
-| onDragOver | Callback function for when the onDragOver event occurs | function({event, node}) | - |  |
-| onDragStart | Callback function for when the onDragStart event occurs | function({event, node}) | - |  |
-| onDrop | Callback function for when the onDrop event occurs | function({event, node, dragNode, dragNodesKeys}) | - |  |
-| onExpand | Callback function for when a treeNode is expanded or collapsed | function(expandedKeys, {expanded: bool, node}) | - |  |
-| onLoad | Callback function for when a treeNode is loaded | function(loadedKeys, {event, node}) | - |  |
-| onRightClick | Callback function for when the user right clicks a treeNode | function({event, node}) | - |  |
-| onSelect | Callback function for when the user clicks a treeNode | function(selectedKeys, e:{selected: bool, selectedNodes, node, event}) | - |  |
-| treeData | treeNodes data Array, if set it then you need not to construct children TreeNode. (key should be unique across the whole array) | array\<{ key, title, children, \[disabled, selectable] }> | - |  |
+| Property | Description | Type | Default |
+| --- | --- | --- | --- |
+| autoExpandParent | Whether to automatically expand a parent treeNode | boolean | true |
+| blockNode | Whether treeNode fill remaining horizontal space | boolean | false |
+| checkable | Adds a `Checkbox` before the treeNodes | boolean | false |
+| checkedKeys | (Controlled) Specifies the keys of the checked treeNodes (PS: When this specifies the key of a treeNode which is also a parent treeNode, all the children treeNodes of will be checked; and vice versa, when it specifies the key of a treeNode which is a child treeNode, its parent treeNode will also be checked. When `checkable` and `checkStrictly` is true, its object has `checked` and `halfChecked` property. Regardless of whether the child or parent treeNode is checked, they won't impact each other. | string\[] \| {checked: string\[], halfChecked: string\[]} | \[] |
+| checkStrictly | Check treeNode precisely; parent treeNode and children treeNodes are not associated | boolean | false |
+| defaultCheckedKeys | Specifies the keys of the default checked treeNodes | string\[] | \[] |
+| defaultExpandAll | Whether to expand all treeNodes by default | boolean | false |
+| defaultExpandedKeys | Specify the keys of the default expanded treeNodes | string\[] | \[] |
+| defaultExpandParent | auto expand parent treeNodes when init | bool | true |
+| defaultSelectedKeys | Specifies the keys of the default selected treeNodes | string\[] | \[] |
+| disabled | whether disabled the tree | bool | false |
+| draggable | Specifies whether this Tree is draggable (IE > 8) | boolean | false |
+| expandedKeys | (Controlled) Specifies the keys of the expanded treeNodes | string\[] | \[] |
+| filterTreeNode | Defines a function to filter (highlight) treeNodes. When the function returns `true`, the corresponding treeNode will be highlighted | function(node) | - |
+| loadData | Load data asynchronously | function(node) | - |
+| loadedKeys | (Controlled) Set loaded tree nodes. Need work with `loadData` | string\[] | \[] |
+| multiple | Allows selecting multiple treeNodes | boolean | false |
+| selectable | whether can be selected | boolean | true |
+| selectedKeys | (Controlled) Specifies the keys of the selected treeNodes | string\[] | - |
+| showIcon | Shows the icon before a TreeNode's title. There is no default style; you must set a custom style for it if set to `true` | boolean | false |
+| switcherIcon | customize collapse/expand icon of tree node | React.ReactElement | - |
+| showLine | Shows a connecting line | boolean | false |
+| onCheck | Callback function for when the onCheck event occurs | function(checkedKeys, e:{checked: bool, checkedNodes, node, event}) | - |
+| onDragEnd | Callback function for when the onDragEnd event occurs | function({event, node}) | - |
+| onDragEnter | Callback function for when the onDragEnter event occurs | function({event, node, expandedKeys}) | - |
+| onDragLeave | Callback function for when the onDragLeave event occurs | function({event, node}) | - |
+| onDragOver | Callback function for when the onDragOver event occurs | function({event, node}) | - |
+| onDragStart | Callback function for when the onDragStart event occurs | function({event, node}) | - |
+| onDrop | Callback function for when the onDrop event occurs | function({event, node, dragNode, dragNodesKeys}) | - |
+| onExpand | Callback function for when a treeNode is expanded or collapsed | function(expandedKeys, {expanded: bool, node}) | - |
+| onLoad | Callback function for when a treeNode is loaded | function(loadedKeys, {event, node}) | - |
+| onRightClick | Callback function for when the user right clicks a treeNode | function({event, node}) | - |
+| onSelect | Callback function for when the user clicks a treeNode | function(selectedKeys, e:{selected: bool, selectedNodes, node, event}) | - |
+| treeData | treeNodes data Array, if set it then you need not to construct children TreeNode. (key should be unique across the whole array) | array\<{ key, title, children, \[disabled, selectable] }> | - |
 
 ### TreeNode props
 
-| Property | Description | Type | Default | Version |
-| --- | --- | --- | --- | --- |
-| checkable | When Tree is checkable, set TreeNode display Checkbox or not | boolean | - |  |
-| disableCheckbox | Disables the checkbox of the treeNode | boolean | false |  |  |
-| disabled | Disables the treeNode | boolean | false |  |  |
-| icon | customize icon. When you pass component, whose render will receive full TreeNode props as component props | ReactNode/Function(props):ReactNode | - |  |  |
-| isLeaf | Determines if this is a leaf node(effective when `loadData` is specified) | boolean | false |  |  |
-| key | Used with (default)ExpandedKeys / (default)CheckedKeys / (default)SelectedKeys. P.S.: It must be unique in all of treeNodes of the tree! | string | internal calculated position of treeNode |  |  |
-| selectable | Set whether the treeNode can be selected | boolean | true |  |  |
-| title | Title | string\|ReactNode | '---' |  |  |
+| Property | Description | Type | Default |
+| --- | --- | --- | --- |
+| checkable | When Tree is checkable, set TreeNode display Checkbox or not | boolean | - |
+| disableCheckbox | Disables the checkbox of the treeNode | boolean | false |  |
+| disabled | Disables the treeNode | boolean | false |  |
+| icon | customize icon. When you pass component, whose render will receive full TreeNode props as component props | ReactNode/Function(props):ReactNode | - |  |
+| isLeaf | Determines if this is a leaf node(effective when `loadData` is specified) | boolean | false |  |
+| key | Used with (default)ExpandedKeys / (default)CheckedKeys / (default)SelectedKeys. P.S.: It must be unique in all of treeNodes of the tree! | string | internal calculated position of treeNode |  |
+| selectable | Set whether the treeNode can be selected | boolean | true |  |
+| title | Title | string\|ReactNode | '---' |  |
 
 ### DirectoryTree props
 
-| Property | Description | Type | Default | Version |
-| --- | --- | --- | --- | --- |
-| expandAction | Directory open logic, optional `false` `'click'` `'doubleClick'` | string | click |  |
+| Property | Description | Type | Default |
+| --- | --- | --- | --- |
+| expandAction | Directory open logic, optional `false` `'click'` `'doubleClick'` | string | click |
 
 ## Note
 

--- a/components/tree/index.zh-CN.md
+++ b/components/tree/index.zh-CN.md
@@ -15,61 +15,61 @@ subtitle: 树形控件
 
 ### Tree props
 
-| 参数 | 说明 | 类型 | 默认值 | 版本 |
-| --- | --- | --- | --- | --- |
-| autoExpandParent | 是否自动展开父节点 | boolean | true |  |
-| blockNode | 是否节点占据一行 | boolean | false |  |
-| checkable | 节点前添加 Checkbox 复选框 | boolean | false |  |
-| checkedKeys | （受控）选中复选框的树节点（注意：父子节点有关联，如果传入父节点 key，则子节点自动选中；相应当子节点 key 都传入，父节点也自动选中。当设置`checkable`和`checkStrictly`，它是一个有`checked`和`halfChecked`属性的对象，并且父子节点的选中与否不再关联 | string\[] \| {checked: string\[], halfChecked: string\[]} | \[] |  |
-| checkStrictly | checkable 状态下节点选择完全受控（父子节点选中状态不再关联） | boolean | false |  |
-| defaultCheckedKeys | 默认选中复选框的树节点 | string\[] | \[] |  |
-| defaultExpandAll | 默认展开所有树节点 | boolean | false |  |
-| defaultExpandedKeys | 默认展开指定的树节点 | string\[] | \[] |  |
-| defaultExpandParent | 默认展开父节点 | bool | true |  |
-| defaultSelectedKeys | 默认选中的树节点 | string\[] | \[] |  |
-| disabled | 将树禁用 | bool | false |  |
-| draggable | 设置节点可拖拽（IE>8） | boolean | false |  |
-| expandedKeys | （受控）展开指定的树节点 | string\[] | \[] |  |
-| filterTreeNode | 按需筛选树节点（高亮），返回 true | function(node) | - |  |
-| loadData | 异步加载数据 | function(node) | - |  |
-| loadedKeys | （受控）已经加载的节点，需要配合 `loadData` 使用 | string\[] | \[] |  |
-| multiple | 支持点选多个节点（节点本身） | boolean | false |  |
-| selectable | 是否可选中 | boolean | true |  |
-| selectedKeys | （受控）设置选中的树节点 | string\[] | - |  |
-| showIcon | 是否展示 TreeNode title 前的图标，没有默认样式，如设置为 true，需要自行定义图标相关样式 | boolean | false |  |
-| switcherIcon | 自定义树节点的展开/折叠图标 | React.ReactElement | - |  |
-| showLine | 是否展示连接线 | boolean | false |  |
-| onCheck | 点击复选框触发 | function(checkedKeys, e:{checked: bool, checkedNodes, node, event}) | - |  |
-| onDragEnd | dragend 触发时调用 | function({event, node}) | - |  |
-| onDragEnter | dragenter 触发时调用 | function({event, node, expandedKeys}) | - |  |
-| onDragLeave | dragleave 触发时调用 | function({event, node}) | - |  |
-| onDragOver | dragover 触发时调用 | function({event, node}) | - |  |
-| onDragStart | 开始拖拽时调用 | function({event, node}) | - |  |
-| onDrop | drop 触发时调用 | function({event, node, dragNode, dragNodesKeys}) | - |  |
-| onExpand | 展开/收起节点时触发 | function(expandedKeys, {expanded: bool, node}) | - |  |
-| onLoad | 节点加载完毕时触发 | function(loadedKeys, {event, node}) | - |  |
-| onRightClick | 响应右键点击 | function({event, node}) | - |  |
-| onSelect | 点击树节点触发 | function(selectedKeys, e:{selected: bool, selectedNodes, node, event}) | - |  |
-| treeData | treeNodes 数据，如果设置则不需要手动构造 TreeNode 节点（key 在整个树范围内唯一） | array\<{key, title, children, \[disabled, selectable]}> | - |  |
+| 参数 | 说明 | 类型 | 默认值 |
+| --- | --- | --- | --- |
+| autoExpandParent | 是否自动展开父节点 | boolean | true |
+| blockNode | 是否节点占据一行 | boolean | false |
+| checkable | 节点前添加 Checkbox 复选框 | boolean | false |
+| checkedKeys | （受控）选中复选框的树节点（注意：父子节点有关联，如果传入父节点 key，则子节点自动选中；相应当子节点 key 都传入，父节点也自动选中。当设置`checkable`和`checkStrictly`，它是一个有`checked`和`halfChecked`属性的对象，并且父子节点的选中与否不再关联 | string\[] \| {checked: string\[], halfChecked: string\[]} | \[] |
+| checkStrictly | checkable 状态下节点选择完全受控（父子节点选中状态不再关联） | boolean | false |
+| defaultCheckedKeys | 默认选中复选框的树节点 | string\[] | \[] |
+| defaultExpandAll | 默认展开所有树节点 | boolean | false |
+| defaultExpandedKeys | 默认展开指定的树节点 | string\[] | \[] |
+| defaultExpandParent | 默认展开父节点 | bool | true |
+| defaultSelectedKeys | 默认选中的树节点 | string\[] | \[] |
+| disabled | 将树禁用 | bool | false |
+| draggable | 设置节点可拖拽（IE>8） | boolean | false |
+| expandedKeys | （受控）展开指定的树节点 | string\[] | \[] |
+| filterTreeNode | 按需筛选树节点（高亮），返回 true | function(node) | - |
+| loadData | 异步加载数据 | function(node) | - |
+| loadedKeys | （受控）已经加载的节点，需要配合 `loadData` 使用 | string\[] | \[] |
+| multiple | 支持点选多个节点（节点本身） | boolean | false |
+| selectable | 是否可选中 | boolean | true |
+| selectedKeys | （受控）设置选中的树节点 | string\[] | - |
+| showIcon | 是否展示 TreeNode title 前的图标，没有默认样式，如设置为 true，需要自行定义图标相关样式 | boolean | false |
+| switcherIcon | 自定义树节点的展开/折叠图标 | React.ReactElement | - |
+| showLine | 是否展示连接线 | boolean | false |
+| onCheck | 点击复选框触发 | function(checkedKeys, e:{checked: bool, checkedNodes, node, event}) | - |
+| onDragEnd | dragend 触发时调用 | function({event, node}) | - |
+| onDragEnter | dragenter 触发时调用 | function({event, node, expandedKeys}) | - |
+| onDragLeave | dragleave 触发时调用 | function({event, node}) | - |
+| onDragOver | dragover 触发时调用 | function({event, node}) | - |
+| onDragStart | 开始拖拽时调用 | function({event, node}) | - |
+| onDrop | drop 触发时调用 | function({event, node, dragNode, dragNodesKeys}) | - |
+| onExpand | 展开/收起节点时触发 | function(expandedKeys, {expanded: bool, node}) | - |
+| onLoad | 节点加载完毕时触发 | function(loadedKeys, {event, node}) | - |
+| onRightClick | 响应右键点击 | function({event, node}) | - |
+| onSelect | 点击树节点触发 | function(selectedKeys, e:{selected: bool, selectedNodes, node, event}) | - |
+| treeData | treeNodes 数据，如果设置则不需要手动构造 TreeNode 节点（key 在整个树范围内唯一） | array\<{key, title, children, \[disabled, selectable]}> | - |
 
 ### TreeNode props
 
-| 参数 | 说明 | 类型 | 默认值 | 版本 |
-| --- | --- | --- | --- | --- |
-| checkable | 当树为 checkable 时，设置独立节点是否展示 Checkbox | boolean | - |  |
-| disableCheckbox | 禁掉 checkbox | boolean | false |  |
-| disabled | 禁掉响应 | boolean | false |  |
-| icon | 自定义图标。可接收组件，props 为当前节点 props | ReactNode/Function(props):ReactNode | - |  |
-| isLeaf | 设置为叶子节点(设置了`loadData`时有效) | boolean | false |  |
-| key | 被树的 (default)ExpandedKeys / (default)CheckedKeys / (default)SelectedKeys 属性所用。注意：整个树范围内的所有节点的 key 值不能重复！ | string | 内部计算出的节点位置 |  |
-| selectable | 设置节点是否可被选中 | boolean | true |  |
-| title | 标题 | string\|ReactNode | '---' |  |
+| 参数 | 说明 | 类型 | 默认值 |
+| --- | --- | --- | --- |
+| checkable | 当树为 checkable 时，设置独立节点是否展示 Checkbox | boolean | - |
+| disableCheckbox | 禁掉 checkbox | boolean | false |
+| disabled | 禁掉响应 | boolean | false |
+| icon | 自定义图标。可接收组件，props 为当前节点 props | ReactNode/Function(props):ReactNode | - |
+| isLeaf | 设置为叶子节点(设置了`loadData`时有效) | boolean | false |
+| key | 被树的 (default)ExpandedKeys / (default)CheckedKeys / (default)SelectedKeys 属性所用。注意：整个树范围内的所有节点的 key 值不能重复！ | string | 内部计算出的节点位置 |
+| selectable | 设置节点是否可被选中 | boolean | true |
+| title | 标题 | string\|ReactNode | '---' |
 
 ### DirectoryTree props
 
-| 参数         | 说明                                                 | 类型   | 默认值 | 版本  |
-| ------------ | ---------------------------------------------------- | ------ | ------ | ----- |
-| expandAction | 目录展开逻辑，可选 `false` `'click'` `'doubleClick'` | string | click  |  |
+| 参数         | 说明                                                 | 类型   | 默认值 |
+| ------------ | ---------------------------------------------------- | ------ | ------ |
+| expandAction | 目录展开逻辑，可选 `false` `'click'` `'doubleClick'` | string | click  |
 
 ## 注意
 

--- a/components/tree/index.zh-CN.md
+++ b/components/tree/index.zh-CN.md
@@ -18,26 +18,26 @@ subtitle: 树形控件
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
 | autoExpandParent | 是否自动展开父节点 | boolean | true |  |
-| blockNode | 是否节点占据一行 | boolean | false | 3.15.0 |
+| blockNode | 是否节点占据一行 | boolean | false |  |
 | checkable | 节点前添加 Checkbox 复选框 | boolean | false |  |
 | checkedKeys | （受控）选中复选框的树节点（注意：父子节点有关联，如果传入父节点 key，则子节点自动选中；相应当子节点 key 都传入，父节点也自动选中。当设置`checkable`和`checkStrictly`，它是一个有`checked`和`halfChecked`属性的对象，并且父子节点的选中与否不再关联 | string\[] \| {checked: string\[], halfChecked: string\[]} | \[] |  |
 | checkStrictly | checkable 状态下节点选择完全受控（父子节点选中状态不再关联） | boolean | false |  |
 | defaultCheckedKeys | 默认选中复选框的树节点 | string\[] | \[] |  |
 | defaultExpandAll | 默认展开所有树节点 | boolean | false |  |
 | defaultExpandedKeys | 默认展开指定的树节点 | string\[] | \[] |  |
-| defaultExpandParent | 默认展开父节点 | bool | true | 3.4.0 |
+| defaultExpandParent | 默认展开父节点 | bool | true |  |
 | defaultSelectedKeys | 默认选中的树节点 | string\[] | \[] |  |
-| disabled | 将树禁用 | bool | false | 3.4.0 |
+| disabled | 将树禁用 | bool | false |  |
 | draggable | 设置节点可拖拽（IE>8） | boolean | false |  |
 | expandedKeys | （受控）展开指定的树节点 | string\[] | \[] |  |
 | filterTreeNode | 按需筛选树节点（高亮），返回 true | function(node) | - |  |
 | loadData | 异步加载数据 | function(node) | - |  |
-| loadedKeys | （受控）已经加载的节点，需要配合 `loadData` 使用 | string\[] | \[] | 3.7.0 |
+| loadedKeys | （受控）已经加载的节点，需要配合 `loadData` 使用 | string\[] | \[] |  |
 | multiple | 支持点选多个节点（节点本身） | boolean | false |  |
 | selectable | 是否可选中 | boolean | true |  |
 | selectedKeys | （受控）设置选中的树节点 | string\[] | - |  |
 | showIcon | 是否展示 TreeNode title 前的图标，没有默认样式，如设置为 true，需要自行定义图标相关样式 | boolean | false |  |
-| switcherIcon | 自定义树节点的展开/折叠图标 | React.ReactElement | - | 3.12.0 |
+| switcherIcon | 自定义树节点的展开/折叠图标 | React.ReactElement | - |  |
 | showLine | 是否展示连接线 | boolean | false |  |
 | onCheck | 点击复选框触发 | function(checkedKeys, e:{checked: bool, checkedNodes, node, event}) | - |  |
 | onDragEnd | dragend 触发时调用 | function({event, node}) | - |  |
@@ -47,19 +47,19 @@ subtitle: 树形控件
 | onDragStart | 开始拖拽时调用 | function({event, node}) | - |  |
 | onDrop | drop 触发时调用 | function({event, node, dragNode, dragNodesKeys}) | - |  |
 | onExpand | 展开/收起节点时触发 | function(expandedKeys, {expanded: bool, node}) | - |  |
-| onLoad | 节点加载完毕时触发 | function(loadedKeys, {event, node}) | - | 3.7.0 |
+| onLoad | 节点加载完毕时触发 | function(loadedKeys, {event, node}) | - |  |
 | onRightClick | 响应右键点击 | function({event, node}) | - |  |
 | onSelect | 点击树节点触发 | function(selectedKeys, e:{selected: bool, selectedNodes, node, event}) | - |  |
-| treeData | treeNodes 数据，如果设置则不需要手动构造 TreeNode 节点（key 在整个树范围内唯一） | array\<{key, title, children, \[disabled, selectable]}> | - | 3.19.8 |
+| treeData | treeNodes 数据，如果设置则不需要手动构造 TreeNode 节点（key 在整个树范围内唯一） | array\<{key, title, children, \[disabled, selectable]}> | - |  |
 
 ### TreeNode props
 
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
-| checkable | 当树为 checkable 时，设置独立节点是否展示 Checkbox | boolean | - | 3.17.0 |
+| checkable | 当树为 checkable 时，设置独立节点是否展示 Checkbox | boolean | - |  |
 | disableCheckbox | 禁掉 checkbox | boolean | false |  |
 | disabled | 禁掉响应 | boolean | false |  |
-| icon | 自定义图标。可接收组件，props 为当前节点 props | ReactNode/Function(props):ReactNode | - | 3.4.0 |
+| icon | 自定义图标。可接收组件，props 为当前节点 props | ReactNode/Function(props):ReactNode | - |  |
 | isLeaf | 设置为叶子节点(设置了`loadData`时有效) | boolean | false |  |
 | key | 被树的 (default)ExpandedKeys / (default)CheckedKeys / (default)SelectedKeys 属性所用。注意：整个树范围内的所有节点的 key 值不能重复！ | string | 内部计算出的节点位置 |  |
 | selectable | 设置节点是否可被选中 | boolean | true |  |
@@ -69,7 +69,7 @@ subtitle: 树形控件
 
 | 参数         | 说明                                                 | 类型   | 默认值 | 版本  |
 | ------------ | ---------------------------------------------------- | ------ | ------ | ----- |
-| expandAction | 目录展开逻辑，可选 `false` `'click'` `'doubleClick'` | string | click  | 3.7.0 |
+| expandAction | 目录展开逻辑，可选 `false` `'click'` `'doubleClick'` | string | click  |  |
 
 ## 注意
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
ref: [#19815](https://github.com/ant-design/ant-design/issues/19815)
<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution
ref: [#19815](https://github.com/ant-design/ant-design/issues/19815)
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Removed version column in 4.0     |
| 🇨🇳 Chinese |      删除相关版本号     |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/tooltip/index.en-US.md](https://github.com/zhangxiuling/ant-design/blob/version-remove/components/tooltip/index.en-US.md)
[View rendered components/tooltip/index.zh-CN.md](https://github.com/zhangxiuling/ant-design/blob/version-remove/components/tooltip/index.zh-CN.md)
[View rendered components/tree/index.en-US.md](https://github.com/zhangxiuling/ant-design/blob/version-remove/components/tree/index.en-US.md)
[View rendered components/tree/index.zh-CN.md](https://github.com/zhangxiuling/ant-design/blob/version-remove/components/tree/index.zh-CN.md)