### PR TITLE
docs: Layout and Affix clean version

### DIFF
--- a/components/affix/index.en-US.md
+++ b/components/affix/index.en-US.md
@@ -14,12 +14,12 @@ Please note that Affix should not cover other content on the page, especially wh
 
 ## API
 
-| Property | Description | Type | Default | Version |
-| --- | --- | --- | --- | --- |
-| offsetBottom | Pixels to offset from bottom when calculating position of scroll | number | - |  |
-| offsetTop | Pixels to offset from top when calculating position of scroll | number | 0 |  |
-| target | specifies the scrollable area dom node | () => HTMLElement | () => window |  |
-| onChange | Callback for when affix state is changed | Function(affixed) | - |  |
+| Property | Description | Type | Default |
+| --- | --- | --- | --- |
+| offsetBottom | Pixels to offset from bottom when calculating position of scroll | number | - |
+| offsetTop | Pixels to offset from top when calculating position of scroll | number | 0 |
+| target | specifies the scrollable area dom node | () => HTMLElement | () => window |
+| onChange | Callback for when affix state is changed | Function(affixed) | - |
 
 **Note:** Children of `Affix` can not be `position: absolute`, but you can set `Affix` as `position: absolute`:
 

--- a/components/affix/index.zh-CN.md
+++ b/components/affix/index.zh-CN.md
@@ -17,10 +17,10 @@ title: Affix
 
 | 成员 | 说明 | 类型 | 默认值 |
 | --- | --- | --- | --- |
-| offsetBottom | 距离窗口底部达到指定偏移量后触发 | number |  |
-| offsetTop | 距离窗口顶部达到指定偏移量后触发 | number |  |
+| offsetBottom | 距离窗口底部达到指定偏移量后触发 | number | - |
+| offsetTop | 距离窗口顶部达到指定偏移量后触发 | number | - |
 | target | 设置 `Affix` 需要监听其滚动事件的元素，值为一个返回对应 DOM 元素的函数 | () => HTMLElement | () => window |
-| onChange | 固定状态改变时触发的回调函数 | Function(affixed) | 无 |
+| onChange | 固定状态改变时触发的回调函数 | Function(affixed) | - |
 
 **注意：**`Affix` 内的元素不要使用绝对定位，如需要绝对定位的效果，可以直接设置 `Affix` 为绝对定位：
 

--- a/components/affix/index.zh-CN.md
+++ b/components/affix/index.zh-CN.md
@@ -15,12 +15,12 @@ title: Affix
 
 ## API
 
-| 成员 | 说明 | 类型 | 默认值 | 版本 |
-| --- | --- | --- | --- | --- |
-| offsetBottom | 距离窗口底部达到指定偏移量后触发 | number |  |  |
-| offsetTop | 距离窗口顶部达到指定偏移量后触发 | number |  |  |
-| target | 设置 `Affix` 需要监听其滚动事件的元素，值为一个返回对应 DOM 元素的函数 | () => HTMLElement | () => window |  |
-| onChange | 固定状态改变时触发的回调函数 | Function(affixed) | 无 |  |
+| 成员 | 说明 | 类型 | 默认值 |
+| --- | --- | --- | --- |
+| offsetBottom | 距离窗口底部达到指定偏移量后触发 | number |  |
+| offsetTop | 距离窗口顶部达到指定偏移量后触发 | number |  |
+| target | 设置 `Affix` 需要监听其滚动事件的元素，值为一个返回对应 DOM 元素的函数 | () => HTMLElement | () => window |
+| onChange | 固定状态改变时触发的回调函数 | Function(affixed) | 无 |
 
 **注意：**`Affix` 内的元素不要使用绝对定位，如需要绝对定位的效果，可以直接设置 `Affix` 为绝对定位：
 

--- a/components/layout/index.en-US.md
+++ b/components/layout/index.en-US.md
@@ -73,11 +73,11 @@ Style of a navigation should conform to its level.
 
 The wrapper.
 
-| Property | Description | Type | Default | Version |
-| --- | --- | --- | --- | --- |
-| className | container className | string | - |  |
-| hasSider | whether contain Sider in children, don't have to assign it normally. Useful in ssr avoid style flickering | boolean | - | 3.2.0 |
-| style | to customize the styles | object | - |  |
+| Property | Description | Type | Default |
+| --- | --- | --- | --- |
+| className | container className | string | - |
+| hasSider | whether contain Sider in children, don't have to assign it normally. Useful in ssr avoid style flickering | boolean | - |
+| style | to customize the styles | object | - |
 
 > APIs of `Layout.Header` `Layout.Footer` `Layout.Content` are the same as that of `Layout`.
 
@@ -85,21 +85,21 @@ The wrapper.
 
 The sidebar.
 
-| Property | Description | Type | Default | Version |
-| --- | --- | --- | --- | --- |
-| breakpoint | [breakpoints](/components/grid#api) of the responsive layout | Enum { 'xs', 'sm', 'md', 'lg', 'xl', 'xxl' } | - |  |
-| className | container className | string | - |  |
-| collapsed | to set the current status | boolean | - |  |
-| collapsedWidth | width of the collapsed sidebar, by setting to `0` a special trigger will appear | number | 80 |  |
-| collapsible | whether can be collapsed | boolean | false |  |
-| defaultCollapsed | to set the initial status | boolean | false |  |
-| reverseArrow | reverse direction of arrow, for a sider that expands from the right | boolean | false |  |
-| style | to customize the styles | object | - |  |
-| theme | color theme of the sidebar | string: `light` `dark` | `dark` | 3.6.0 |
-| trigger | specify the customized trigger, set to null to hide the trigger | string\|ReactNode | - |  |
-| width | width of the sidebar | number\|string | 200 |  |
-| onCollapse | the callback function, executed by clicking the trigger or activating the responsive layout | (collapsed, type) => {} | - |  |
-| onBreakpoint | the callback function, executed when [breakpoints](/components/grid#api) changed | (broken) => {} | - | 3.7.0 |
+| Property | Description | Type | Default |
+| --- | --- | --- | --- |
+| breakpoint | [breakpoints](/components/grid#api) of the responsive layout | Enum { 'xs', 'sm', 'md', 'lg', 'xl', 'xxl' } | - |
+| className | container className | string | - |
+| collapsed | to set the current status | boolean | - |
+| collapsedWidth | width of the collapsed sidebar, by setting to `0` a special trigger will appear | number | 80 |
+| collapsible | whether can be collapsed | boolean | false |
+| defaultCollapsed | to set the initial status | boolean | false |
+| reverseArrow | reverse direction of arrow, for a sider that expands from the right | boolean | false |
+| style | to customize the styles | object | - |
+| theme | color theme of the sidebar | string: `light` `dark` | `dark` |
+| trigger | specify the customized trigger, set to null to hide the trigger | string\|ReactNode | - |
+| width | width of the sidebar | number\|string | 200 |
+| onCollapse | the callback function, executed by clicking the trigger or activating the responsive layout | (collapsed, type) => {} | - |
+| onBreakpoint | the callback function, executed when [breakpoints](/components/grid#api) changed | (broken) => {} | - |
 
 #### breakpoint width
 

--- a/components/layout/index.zh-CN.md
+++ b/components/layout/index.zh-CN.md
@@ -74,11 +74,11 @@ title: Layout
 
 布局容器。
 
-| 参数 | 说明 | 类型 | 默认值 | 版本 |
-| --- | --- | --- | --- | --- |
-| className | 容器 className | string | - |  |
-| hasSider | 表示子元素里有 Sider，一般不用指定。可用于服务端渲染时避免样式闪动 | boolean | - | 3.2.0 |
-| style | 指定样式 | object | - |  |
+| 参数 | 说明 | 类型 | 默认值 |
+| --- | --- | --- | --- |
+| className | 容器 className | string | - |
+| hasSider | 表示子元素里有 Sider，一般不用指定。可用于服务端渲染时避免样式闪动 | boolean | - |
+| style | 指定样式 | object | - |
 
 > `Layout.Header` `Layout.Footer` `Layout.Content` API 与 `Layout` 相同
 
@@ -86,21 +86,21 @@ title: Layout
 
 侧边栏。
 
-| 参数 | 说明 | 类型 | 默认值 | 版本 |
-| --- | --- | --- | --- | --- |
-| breakpoint | 触发响应式布局的[断点](/components/grid#api) | Enum { 'xs', 'sm', 'md', 'lg', 'xl', 'xxl' } | - |  |
-| className | 容器 className | string | - |  |
-| collapsed | 当前收起状态 | boolean | - |  |
-| collapsedWidth | 收缩宽度，设置为 0 会出现特殊 trigger | number | 80 |  |
-| collapsible | 是否可收起 | boolean | false |  |
-| defaultCollapsed | 是否默认收起 | boolean | false |  |
-| reverseArrow | 翻转折叠提示箭头的方向，当 Sider 在右边时可以使用 | boolean | false |  |
-| style | 指定样式 | object | - |  |
-| theme | 主题颜色 | string: `light` `dark` | `dark` | 3.6.0 |
-| trigger | 自定义 trigger，设置为 null 时隐藏 trigger | string\|ReactNode | - |  |
-| width | 宽度 | number\|string | 200 |  |
-| onCollapse | 展开-收起时的回调函数，有点击 trigger 以及响应式反馈两种方式可以触发 | (collapsed, type) => {} | - |  |
-| onBreakpoint | 触发响应式布局[断点](/components/grid#api)时的回调 | (broken) => {} | - | 3.7.0 |
+| 参数 | 说明 | 类型 | 默认值 |
+| --- | --- | --- | --- |
+| breakpoint | 触发响应式布局的[断点](/components/grid#api) | Enum { 'xs', 'sm', 'md', 'lg', 'xl', 'xxl' } | - |
+| className | 容器 className | string | - |
+| collapsed | 当前收起状态 | boolean | - |
+| collapsedWidth | 收缩宽度，设置为 0 会出现特殊 trigger | number | 80 |
+| collapsible | 是否可收起 | boolean | false |
+| defaultCollapsed | 是否默认收起 | boolean | false |
+| reverseArrow | 翻转折叠提示箭头的方向，当 Sider 在右边时可以使用 | boolean | false |
+| style | 指定样式 | object | - |
+| theme | 主题颜色 | string: `light` `dark` | `dark` |
+| trigger | 自定义 trigger，设置为 null 时隐藏 trigger | string\|ReactNode | - |
+| width | 宽度 | number\|string | 200 |
+| onCollapse | 展开-收起时的回调函数，有点击 trigger 以及响应式反馈两种方式可以触发 | (collapsed, type) => {} | - |
+| onBreakpoint | 触发响应式布局[断点](/components/grid#api)时的回调 | (broken) => {} | - |
 
 #### breakpoint width
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
#19815 
<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->
1.删除 API 列 版本 (Version)
2.将表格中 空白值 替换成 -
3.将表格中中文 无 替换成 -

#### 涉及到的文档
##### Layout
- [x] Layout 
##### Navigation
- [x] Affix 

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed


-----
[View rendered components/affix/index.en-US.md](https://github.com/ShawDanon/ant-design/blob/4.0-prepare/components/affix/index.en-US.md)
[View rendered components/affix/index.zh-CN.md](https://github.com/ShawDanon/ant-design/blob/4.0-prepare/components/affix/index.zh-CN.md)
[View rendered components/layout/index.en-US.md](https://github.com/ShawDanon/ant-design/blob/4.0-prepare/components/layout/index.en-US.md)
[View rendered components/layout/index.zh-CN.md](https://github.com/ShawDanon/ant-design/blob/4.0-prepare/components/layout/index.zh-CN.md)