### PR TITLE
docs(Timeline, Tabs): removed version column in 4.0

### DIFF
--- a/components/tabs/index.en-US.md
+++ b/components/tabs/index.en-US.md
@@ -19,33 +19,33 @@ Ant Design has 3 types of Tabs for different situations.
 
 ### Tabs
 
-| Property | Description | Type | Default | Version |
-| --- | --- | --- | --- | --- |
-| activeKey | Current TabPane's key | string | - |  |
-| animated | Whether to change tabs with animation. Only works while `tabPosition="top"\|"bottom"` | boolean \| {inkBar:boolean, tabPane:boolean} | `true`, `false` when `type="card"` |  |
-| renderTabBar | replace the TabBar | (props: DefaultTabBarProps, DefaultTabBar: React.ComponentClass) => React.ReactElement | - | 3.9.0 |
-| defaultActiveKey | Initial active TabPane's key, if `activeKey` is not set. | string | - |  |
-| hideAdd | Hide plus icon or not. Only works while `type="editable-card"` | boolean | `false` |  |
-| size | preset tab bar size | `large` \| `default` \| `small` | `default` |  |
-| tabBarExtraContent | Extra content in tab bar | React.ReactNode | - |  |
-| tabBarGutter | The gap between tabs | number | - | 3.2.0 |
-| tabBarStyle | Tab bar style object | object | - |  |
-| tabPosition | Position of tabs | `top` \| `right` \| `bottom` \| `left` | `top` |  |
-| type | Basic style of tabs | `line` \| `card` \| `editable-card` | `line` |  |
-| onChange | Callback executed when active tab is changed | Function(activeKey) {} | - |  |
-| onEdit | Callback executed when tab is added or removed. Only works while `type="editable-card"` | (targetKey, action): void | - |  |
-| onNextClick | Callback executed when next button is clicked | Function | - |  |
-| onPrevClick | Callback executed when prev button is clicked | Function | - |  |
-| onTabClick | Callback executed when tab is clicked | Function(key: string, event: MouseEvent) | - |  |
+| Property | Description | Type | Default |
+| --- | --- | --- | --- |
+| activeKey | Current TabPane's key | string | - |
+| animated | Whether to change tabs with animation. Only works while `tabPosition="top"\|"bottom"` | boolean \| {inkBar:boolean, tabPane:boolean} | `true`, `false` when `type="card"` |
+| renderTabBar | replace the TabBar | (props: DefaultTabBarProps, DefaultTabBar: React.ComponentClass) => React.ReactElement | - |
+| defaultActiveKey | Initial active TabPane's key, if `activeKey` is not set. | string | - |
+| hideAdd | Hide plus icon or not. Only works while `type="editable-card"` | boolean | `false` |
+| size | preset tab bar size | `large` \| `default` \| `small` | `default` |
+| tabBarExtraContent | Extra content in tab bar | React.ReactNode | - |
+| tabBarGutter | The gap between tabs | number | - |
+| tabBarStyle | Tab bar style object | object | - |
+| tabPosition | Position of tabs | `top` \| `right` \| `bottom` \| `left` | `top` |
+| type | Basic style of tabs | `line` \| `card` \| `editable-card` | `line` |
+| onChange | Callback executed when active tab is changed | Function(activeKey) {} | - |
+| onEdit | Callback executed when tab is added or removed. Only works while `type="editable-card"` | (targetKey, action): void | - |
+| onNextClick | Callback executed when next button is clicked | Function | - |
+| onPrevClick | Callback executed when prev button is clicked | Function | - |
+| onTabClick | Callback executed when tab is clicked | Function(key: string, event: MouseEvent) | - |
 
 More option at [rc-tabs option](https://github.com/react-component/tabs#tabs)
 
 ### Tabs.TabPane
 
-| Property | Description | Type | Default | Version |
-| --- | --- | --- | --- | --- |
-| forceRender | Forced render of content in tabs, not lazy render after clicking on tabs | boolean | false |  |
-| key | TabPane's key | string | - |  |
-| tab | Show text in TabPane's head | string\|ReactNode | - |  |
+| Property | Description | Type | Default |
+| --- | --- | --- | --- |
+| forceRender | Forced render of content in tabs, not lazy render after clicking on tabs | boolean | false |
+| key | TabPane's key | string | - |
+| tab | Show text in TabPane's head | string\|ReactNode | - |
 
 More option at [rc-tabs option](https://github.com/react-component/tabs#tabpane)

--- a/components/tabs/index.zh-CN.md
+++ b/components/tabs/index.zh-CN.md
@@ -22,29 +22,29 @@ Ant Design 依次提供了三级选项卡，分别用于不同的场景。
 
 ### Tabs
 
-| 参数 | 说明 | 类型 | 默认值 | 版本 |
-| --- | --- | --- | --- | --- |
-| activeKey | 当前激活 tab 面板的 key | string | 无 |  |
-| animated | 是否使用动画切换 Tabs，在 `tabPosition=top|bottom` 时有效 | boolean \| {inkBar:boolean, tabPane:boolean} | true, 当 type="card" 时为 false |  |
-| renderTabBar | 替换 TabBar，用于二次封装标签头 | (props: DefaultTabBarProps, DefaultTabBar: React.ComponentClass) => React.ReactElement | 无 | 3.9.0 |
-| defaultActiveKey | 初始化选中面板的 key，如果没有设置 activeKey | string | 第一个面板 |  |
-| hideAdd | 是否隐藏加号图标，在 `type="editable-card"` 时有效 | boolean | false |  |
-| size | 大小，提供 `large` `default` 和 `small` 三种大小 | string | 'default' |  |
-| tabBarExtraContent | tab bar 上额外的元素 | React.ReactNode | 无 |  |
-| tabBarGutter | tabs 之间的间隙 | number | 无 | 3.2.0 |
-| tabBarStyle | tab bar 的样式对象 | object | - |  |
-| tabPosition | 页签位置，可选值有 `top` `right` `bottom` `left` | string | 'top' |  |
-| type | 页签的基本样式，可选 `line`、`card` `editable-card` 类型 | string | 'line' |  |
-| onChange | 切换面板的回调 | Function(activeKey) {} | 无 |  |
-| onEdit | 新增和删除页签的回调，在 `type="editable-card"` 时有效 | (targetKey, action): void | 无 |  |
-| onNextClick | next 按钮被点击的回调 | Function | 无 |  |
-| onPrevClick | prev 按钮被点击的回调 | Function | 无 |  |
-| onTabClick | tab 被点击的回调 | Function | 无 |  |
+| 参数 | 说明 | 类型 | 默认值 |
+| --- | --- | --- | --- |
+| activeKey | 当前激活 tab 面板的 key | string | 无 |
+| animated | 是否使用动画切换 Tabs，在 `tabPosition=top|bottom` 时有效 | boolean \| {inkBar:boolean, tabPane:boolean} | true, 当 type="card" 时为 false |
+| renderTabBar | 替换 TabBar，用于二次封装标签头 | (props: DefaultTabBarProps, DefaultTabBar: React.ComponentClass) => React.ReactElement | 无 |
+| defaultActiveKey | 初始化选中面板的 key，如果没有设置 activeKey | string | 第一个面板 |
+| hideAdd | 是否隐藏加号图标，在 `type="editable-card"` 时有效 | boolean | false |
+| size | 大小，提供 `large` `default` 和 `small` 三种大小 | string | 'default' |
+| tabBarExtraContent | tab bar 上额外的元素 | React.ReactNode | 无 |
+| tabBarGutter | tabs 之间的间隙 | number | 无 |
+| tabBarStyle | tab bar 的样式对象 | object | - |
+| tabPosition | 页签位置，可选值有 `top` `right` `bottom` `left` | string | 'top' |
+| type | 页签的基本样式，可选 `line`、`card` `editable-card` 类型 | string | 'line' |
+| onChange | 切换面板的回调 | Function(activeKey) {} | 无 |
+| onEdit | 新增和删除页签的回调，在 `type="editable-card"` 时有效 | (targetKey, action): void | 无 |
+| onNextClick | next 按钮被点击的回调 | Function | 无 |
+| onPrevClick | prev 按钮被点击的回调 | Function | 无 |
+| onTabClick | tab 被点击的回调 | Function | 无 |
 
 ### Tabs.TabPane
 
-| 参数        | 说明                      | 类型              | 默认值 | 版本 |
-| ----------- | ------------------------- | ----------------- | ------ | ---- |
-| forceRender | 被隐藏时是否渲染 DOM 结构 | boolean           | false  |      |
-| key         | 对应 activeKey            | string            | 无     |      |
-| tab         | 选项卡头显示文字          | string\|ReactNode | 无     |      |
+| 参数        | 说明                      | 类型              | 默认值 |
+| ----------- | ------------------------- | ----------------- | ------ |
+| forceRender | 被隐藏时是否渲染 DOM 结构 | boolean           | false  |
+| key         | 对应 activeKey            | string            | 无     |
+| tab         | 选项卡头显示文字          | string\|ReactNode | 无     |

--- a/components/timeline/index.en-US.md
+++ b/components/timeline/index.en-US.md
@@ -26,19 +26,19 @@ Vertical display timeline.
 
 Timeline
 
-| Property | Description | Type | Default | Version |
-| --- | --- | --- | --- | --- |
-| pending | Set the last ghost node's existence or its content | boolean\|string\|ReactNode | `false` |  |
-| pendingDot | Set the dot of the last ghost node when pending is true | string\|ReactNode | `<Icon type="loading" />` | 3.3.0 |
-| reverse | reverse nodes or not | boolean | false | 3.5.0 |
-| mode | By sending `alternate` the timeline will distribute the nodes to the left and right. | `left` \| `alternate` \| `right` | - | 3.8.0 |
+| Property | Description | Type | Default |
+| --- | --- | --- | --- |
+| pending | Set the last ghost node's existence or its content | boolean\|string\|ReactNode | `false` |
+| pendingDot | Set the dot of the last ghost node when pending is true | string\|ReactNode | `<Icon type="loading" />` |
+| reverse | reverse nodes or not | boolean | false |
+| mode | By sending `alternate` the timeline will distribute the nodes to the left and right. | `left` \| `alternate` \| `right` | - |
 
 ### Timeline.Item
 
 Node of timeline
 
-| Property | Description | Type | Default | Version |
-| --- | --- | --- | --- | --- |
-| color | Set the circle's color to `blue`, `red`, `green`, `gray` or other custom colors | string | `blue` |  |
-| dot | Customize timeline dot | string\|ReactNode | - |  |
-| position | Customize node position | `left` \| `right` | - | 3.17.0 |
+| Property | Description | Type | Default |
+| --- | --- | --- | --- |
+| color | Set the circle's color to `blue`, `red`, `green`, `gray` or other custom colors | string | `blue` |
+| dot | Customize timeline dot | string\|ReactNode | - |
+| position | Customize node position | `left` \| `right` | - |

--- a/components/timeline/index.zh-CN.md
+++ b/components/timeline/index.zh-CN.md
@@ -27,19 +27,19 @@ title: Timeline
 
 时间轴。
 
-| 参数 | 说明 | 类型 | 默认值 | 版本 |
-| --- | --- | --- | --- | --- |
-| pending | 指定最后一个幽灵节点是否存在或内容 | boolean\|string\|ReactNode | false |  |
-| pendingDot | 当最后一个幽灵节点存在時，指定其时间图点 | string\|ReactNode | `<Icon type="loading" />` | 3.3.0 |
-| reverse | 节点排序 | boolean | false | 3.5.0 |
-| mode | 通过设置 `mode` 可以改变时间轴和内容的相对位置 | `left` \| `alternate` \| `right` | - | 3.8.0 |
+| 参数 | 说明 | 类型 | 默认值 |
+| --- | --- | --- | --- |
+| pending | 指定最后一个幽灵节点是否存在或内容 | boolean\|string\|ReactNode | false |
+| pendingDot | 当最后一个幽灵节点存在時，指定其时间图点 | string\|ReactNode | `<Icon type="loading" />` |
+| reverse | 节点排序 | boolean | false |
+| mode | 通过设置 `mode` 可以改变时间轴和内容的相对位置 | `left` \| `alternate` \| `right` | - |
 
 ### Timeline.Item
 
 时间轴的每一个节点。
 
-| 参数 | 说明 | 类型 | 默认值 | 版本 |
-| --- | --- | --- | --- | --- |
-| color | 指定圆圈颜色 `blue, red, green, gray`，或自定义的色值 | string | blue |  |
-| dot | 自定义时间轴点 | string\|ReactNode | - |  |
-| position | 自定义节点位置 | `left` \| `right` | - | 3.17.0 |
+| 参数 | 说明 | 类型 | 默认值 |
+| --- | --- | --- | --- |
+| color | 指定圆圈颜色 `blue, red, green, gray`，或自定义的色值 | string | blue |
+| dot | 自定义时间轴点 | string\|ReactNode | - |
+| position | 自定义节点位置 | `left` \| `right` | - |


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->
ref: [#19815](https://github.com/ant-design/ant-design/issues/19815)

### 💡 Background and solution
ref: [#19815](https://github.com/ant-design/ant-design/issues/19815)
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   removed version column in 4.0  |
| 🇨🇳 Chinese |   删除相关版本号      |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed


-----
[View rendered components/tabs/index.en-US.md](https://github.com/chouchouovo/ant-design/blob/updateVersion/components/tabs/index.en-US.md)
[View rendered components/tabs/index.zh-CN.md](https://github.com/chouchouovo/ant-design/blob/updateVersion/components/tabs/index.zh-CN.md)
[View rendered components/timeline/index.en-US.md](https://github.com/chouchouovo/ant-design/blob/updateVersion/components/timeline/index.en-US.md)
[View rendered components/timeline/index.zh-CN.md](https://github.com/chouchouovo/ant-design/blob/updateVersion/components/timeline/index.zh-CN.md)