### PR TITLE
fix: Export tooltip helper interfaces

### DIFF
--- a/components/tooltip/index.tsx
+++ b/components/tooltip/index.tsx
@@ -65,12 +65,12 @@ export interface AbstractTooltipProps {
 
 export type RenderFunction = () => React.ReactNode;
 
-interface TooltipPropsWithOverlay extends AbstractTooltipProps {
+export interface TooltipPropsWithOverlay extends AbstractTooltipProps {
   title?: React.ReactNode | RenderFunction;
   overlay: React.ReactNode | RenderFunction;
 }
 
-interface TooltipPropsWithTitle extends AbstractTooltipProps {
+export interface TooltipPropsWithTitle extends AbstractTooltipProps {
   title: React.ReactNode | RenderFunction;
   overlay?: React.ReactNode | RenderFunction;
 }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

We have a library that re-exports a few ant-design components. Following an upgrade from antd 3.20.0 to 3.25.0, we noticed a typescript error in this code:

```ts
// CustomTooltip.tsx
import "antd/lib/tooltip/style"
import "./CustomTooltip.less"

import AntdTooltip, { TooltipPlacement, TooltipProps } from "antd/lib/tooltip"
import classnames from "classnames"
import React from "react"

const CustomTooltip: React.RefForwardingComponent<AntdTooltip, TooltipProps> = (
  { overlayClassName, ...rest },
  ref,
) => {
  return (
    <AntdTooltip
      ref={ref}
      overlayClassName={classnames("custom-tooltip-overlay", overlayClassName)}
      {...rest}
    />
  )
}
export default React.forwardRef(CustomTooltip)
// ⬆
// ❌ Default export of the module has or is using private name 'TooltipPropsWithTitle'.ts(4082)
// ❌ Default export of the module has or is using private name 'TooltipPropsWithOverlay'.ts(4082)
export { TooltipProps, TooltipPlacement }
``` 
This seems to happen only when we have this option in our `tsconfig.json`:

```json
{
  "compilerOptions": {
    "declaration": true,
  },
}
``` 

After adding `export` in front of `TooltipPropsWithTitle` and `TooltipPropsWithOverlay` things work perfectly!

Seems like the problem was introduced in https://github.com/ant-design/ant-design/pull/18515 /cc @laysent

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Export tooltop helper interfaces to fix an issue with generating TypeScript declarations         |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
       _need help with Chinese_
