### PR TITLE
docs: Update ConfigProvider documentation grammar

### DIFF
--- a/components/config-provider/index.en-US.md
+++ b/components/config-provider/index.en-US.md
@@ -9,7 +9,7 @@ title: ConfigProvider
 
 ## Usage
 
-This component provides a configuration to all React components underneath itself via the [context API](https://facebook.github.io/react/docs/context.html), In the render tree all components will have access to the provided config.
+This component provides a configuration to all React components underneath itself via the [context API](https://facebook.github.io/react/docs/context.html). In the render tree all components will have access to the provided config.
 
 ```jsx
 import { ConfigProvider } from 'antd';
@@ -25,7 +25,7 @@ return (
 
 ### Content Security Policy
 
-Some component use dynamic style to support wave effect. You can config `csp` prop if Content Security Policy (CSP) is enabled:
+Some components use dynamic style to support wave effect. You can config `csp` prop if Content Security Policy (CSP) is enabled:
 
 ```jsx
 <ConfigProvider csp={{ nonce: 'YourNonceCode' }}>
@@ -47,6 +47,6 @@ Some component use dynamic style to support wave effect. You can config `csp` pr
 
 ## FAQ
 
-#### Locale problem is still existed in DatePicker even ConfigProvider `locale` is used?
+#### Does the locale problem still exist in DatePicker even if ConfigProvider `locale` is used?
 
-Please make sure you set moment locale by `moment.locale('zh-cn')`, or you don't have two moment of different version.
+Please make sure you set moment locale by `moment.locale('zh-cn')` or that you don't have two different versions of moment.


### PR DESCRIPTION
Improved the grammar of the documentation.

<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed


-----
[View rendered components/config-provider/index.en-US.md](https://github.com/JosiahRooney/ant-design/blob/patch-1/components/config-provider/index.en-US.md)