### PR TITLE
docs: correct maxTagTextLength description in Select.

### DIFF
--- a/components/select/index.en-US.md
+++ b/components/select/index.en-US.md
@@ -39,7 +39,7 @@ Select component to select value from options.
 | getPopupContainer | Parent Node which the selector should be rendered to. Default to `body`. When position issues happen, try to modify it into scrollable content and position it relative. [Example](https://codesandbox.io/s/4j168r7jw0) | function(triggerNode) | () => document.body |  |
 | labelInValue | whether to embed label in value, turn the format of value from `string` to `{key: string, label: ReactNode}` | boolean | false |  |
 | maxTagCount | Max tag count to show | number | - |  |
-| maxTagTextLength | Max tag count to show | number | - | 3.18.0 |
+| maxTagTextLength | Max tag text length to show | number | - | 3.18.0 |
 | maxTagPlaceholder | Placeholder for not showing tags | ReactNode/function(omittedValues) | - |  |
 | mode | Set mode of Select | 'default' \| 'multiple' \| 'tags' | 'default' |  |
 | notFoundContent | Specify content to show when no result matches.. | string | 'Not Found' |  |


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     correct maxTagTextLength description in Select.      |
| 🇨🇳 Chinese |     修复select组件中`maxTagTextLength `的描述     |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed


-----
[View rendered components/select/index.en-US.md](https://github.com/cwj0417/ant-design/blob/patch-1/components/select/index.en-US.md)