### PR TITLE
fix: 4.0 table filters value may be previous

### DIFF
--- a/components/table/__tests__/Table.filter.test.js
+++ b/components/table/__tests__/Table.filter.test.js
@@ -123,6 +123,15 @@ describe('Table.filter', () => {
         <span onClick={() => clearFilters()} id="reset">
           Reset
         </span>
+        <span
+          onClick={() => {
+            setSelectedKeys([43]);
+            confirm();
+          }}
+          id="simulateOnSelect"
+        >
+          SimulateOnSelect
+        </span>
       </div>
     );
 
@@ -170,6 +179,11 @@ describe('Table.filter', () => {
         .first()
         .props().visible,
     ).toBeFalsy();
+
+    // Simulate onSelect, setSelectedKeys & confirm
+    wrapper.find('span.ant-dropdown-trigger').simulate('click', nativeEvent);
+    wrapper.find('#simulateOnSelect').simulate('click');
+    expect(getFilterMenu().props().filterState.filteredKeys).toEqual([43]);
   });
 
   it('can be controlled by filterDropdownVisible', () => {

--- a/components/table/__tests__/__snapshots__/Table.filter.test.js.snap
+++ b/components/table/__tests__/__snapshots__/Table.filter.test.js.snap
@@ -23,6 +23,12 @@ exports[`Table.filter override custom filter correctly 1`] = `
   >
     Reset
   </span>
+  <span
+    id="simulateOnSelect"
+    onClick={[Function]}
+  >
+    SimulateOnSelect
+  </span>
 </div>
 `;
 

--- a/components/table/hooks/useFilter/FilterDropdown.tsx
+++ b/components/table/hooks/useFilter/FilterDropdown.tsx
@@ -92,12 +92,10 @@ function FilterDropdown<RecordType>(props: FilterDropdownProps<RecordType>) {
   const [propFilteredKeys, setPropFilteredKeys] = React.useState(
     filterState && filterState.filteredKeys,
   );
-  const [filteredKeys, setFilteredKeys] = React.useState(propFilteredKeys || []);
   const [getFilteredKeysSync, setFilteredKeysSync] = useSyncState(propFilteredKeys || []);
 
   const onSelectKeys = ({ selectedKeys }: { selectedKeys: Key[] }) => {
     setFilteredKeysSync(selectedKeys);
-    setFilteredKeys(selectedKeys);
   };
 
   React.useEffect(() => {
@@ -170,7 +168,7 @@ function FilterDropdown<RecordType>(props: FilterDropdownProps<RecordType>) {
     dropdownContent = column.filterDropdown({
       prefixCls: `${dropdownPrefixCls}-custom`,
       setSelectedKeys: (selectedKeys: Key[]) => onSelectKeys({ selectedKeys }),
-      selectedKeys: filteredKeys,
+      selectedKeys: getFilteredKeysSync(),
       confirm: onConfirm,
       clearFilters: onReset,
       filters: column.filters,
@@ -188,12 +186,12 @@ function FilterDropdown<RecordType>(props: FilterDropdownProps<RecordType>) {
           onClick={onMenuClick}
           onSelect={onSelectKeys}
           onDeselect={onSelectKeys}
-          selectedKeys={(filteredKeys || []) as any}
+          selectedKeys={getFilteredKeysSync() as any}
           getPopupContainer={getPopupContainer}
           openKeys={openKeys}
           onOpenChange={onOpenChange}
         >
-          {renderFilterItems(column.filters!, prefixCls, filteredKeys, filterMultiple)}
+          {renderFilterItems(column.filters!, prefixCls, getFilteredKeysSync(), filterMultiple)}
         </Menu>
         <div className={`${prefixCls}-dropdown-btns`}>
           <a className={`${prefixCls}-dropdown-link confirm`} onClick={onConfirm}>

--- a/components/table/hooks/useFilter/FilterDropdown.tsx
+++ b/components/table/hooks/useFilter/FilterDropdown.tsx
@@ -92,12 +92,11 @@ function FilterDropdown<RecordType>(props: FilterDropdownProps<RecordType>) {
     filterState && filterState.filteredKeys,
   );
   const [filteredKeys, setFilteredKeys] = React.useState(propFilteredKeys || []);
-  // Use it to fix 'setFilteredKeys' is async
-  const filteredKeysRef = React.useRef(filteredKeys);
+  let filteredKeysLast = filteredKeys;
 
   const onSelectKeys = ({ selectedKeys }: { selectedKeys: Key[] }) => {
+    filteredKeysLast = selectedKeys;
     setFilteredKeys(selectedKeys);
-    filteredKeysRef.current = selectedKeys;
   };
 
   React.useEffect(() => {
@@ -105,7 +104,7 @@ function FilterDropdown<RecordType>(props: FilterDropdownProps<RecordType>) {
     const newFilteredKeys = filterState && filterState.filteredKeys;
     if (!shallowEqual(propFilteredKeys, newFilteredKeys)) {
       setPropFilteredKeys(newFilteredKeys);
-      onSelectKeys({selectedKeys: newFilteredKeys || []});
+      onSelectKeys({ selectedKeys: newFilteredKeys || [] });
     }
   }, [filterState]);
 
@@ -143,7 +142,7 @@ function FilterDropdown<RecordType>(props: FilterDropdownProps<RecordType>) {
   };
 
   const onConfirm = () => {
-    internalTriggerFilter(filteredKeysRef.current);
+    internalTriggerFilter(filteredKeysLast);
   };
 
   const onReset = () => {

--- a/components/table/hooks/useFilter/FilterDropdown.tsx
+++ b/components/table/hooks/useFilter/FilterDropdown.tsx
@@ -186,7 +186,7 @@ function FilterDropdown<RecordType>(props: FilterDropdownProps<RecordType>) {
           onClick={onMenuClick}
           onSelect={onSelectKeys}
           onDeselect={onSelectKeys}
-          selectedKeys={getFilteredKeysSync() as any}
+          selectedKeys={(getFilteredKeysSync() || []) as any}
           getPopupContainer={getPopupContainer}
           openKeys={openKeys}
           onOpenChange={onOpenChange}

--- a/components/table/hooks/useFilter/FilterDropdown.tsx
+++ b/components/table/hooks/useFilter/FilterDropdown.tsx
@@ -92,19 +92,22 @@ function FilterDropdown<RecordType>(props: FilterDropdownProps<RecordType>) {
     filterState && filterState.filteredKeys,
   );
   const [filteredKeys, setFilteredKeys] = React.useState(propFilteredKeys || []);
+  // Use it to fix 'setFilteredKeys' is async
+  const filteredKeysRef = React.useRef(filteredKeys);
+
+  const onSelectKeys = ({ selectedKeys }: { selectedKeys: Key[] }) => {
+    setFilteredKeys(selectedKeys);
+    filteredKeysRef.current = selectedKeys;
+  };
 
   React.useEffect(() => {
     // Sync internal filtered keys when props key changed
     const newFilteredKeys = filterState && filterState.filteredKeys;
     if (!shallowEqual(propFilteredKeys, newFilteredKeys)) {
       setPropFilteredKeys(newFilteredKeys);
-      setFilteredKeys(newFilteredKeys || []);
+      onSelectKeys({selectedKeys: newFilteredKeys || []});
     }
   }, [filterState]);
-
-  const onSelectKeys = ({ selectedKeys }: { selectedKeys: Key[] }) => {
-    setFilteredKeys(selectedKeys);
-  };
 
   // ====================== Open Keys ======================
   const [openKeys, setOpenKeys] = React.useState<string[]>([]);
@@ -140,7 +143,7 @@ function FilterDropdown<RecordType>(props: FilterDropdownProps<RecordType>) {
   };
 
   const onConfirm = () => {
-    internalTriggerFilter(filteredKeys);
+    internalTriggerFilter(filteredKeysRef.current);
   };
 
   const onReset = () => {

--- a/components/table/hooks/useFilter/FilterDropdown.tsx
+++ b/components/table/hooks/useFilter/FilterDropdown.tsx
@@ -9,6 +9,7 @@ import Dropdown from '../../../dropdown';
 import { ColumnType, ColumnFilterItem, Key, TableLocale, GetPopupContainer } from '../../interface';
 import FilterDropdownMenuWrapper from './FilterWrapper';
 import { FilterState } from '.';
+import useSyncState from '../useSyncState';
 
 const { SubMenu, Item: MenuItem } = Menu;
 
@@ -92,10 +93,10 @@ function FilterDropdown<RecordType>(props: FilterDropdownProps<RecordType>) {
     filterState && filterState.filteredKeys,
   );
   const [filteredKeys, setFilteredKeys] = React.useState(propFilteredKeys || []);
-  let filteredKeysLast = filteredKeys;
+  const [getFilteredKeysSync, setFilteredKeysSync] = useSyncState(propFilteredKeys || []);
 
   const onSelectKeys = ({ selectedKeys }: { selectedKeys: Key[] }) => {
-    filteredKeysLast = selectedKeys;
+    setFilteredKeysSync(selectedKeys);
     setFilteredKeys(selectedKeys);
   };
 
@@ -142,7 +143,7 @@ function FilterDropdown<RecordType>(props: FilterDropdownProps<RecordType>) {
   };
 
   const onConfirm = () => {
-    internalTriggerFilter(filteredKeysLast);
+    internalTriggerFilter(getFilteredKeysSync());
   };
 
   const onReset = () => {

--- a/components/table/hooks/useSyncState.ts
+++ b/components/table/hooks/useSyncState.ts
@@ -7,6 +7,6 @@ export default function useSyncState<T>(filteredKeys: T): UseSyncStateProps<T> {
 
   return [
     () => filteredKeysRef.current,
-    (newValue: T) => (filteredKeysRef.current = newValue)
+    (newValue: T) => (filteredKeysRef.current = newValue),
   ];
 }

--- a/components/table/hooks/useSyncState.ts
+++ b/components/table/hooks/useSyncState.ts
@@ -5,5 +5,8 @@ type UseSyncStateProps<T> = [() => T, (newValue: T) => void];
 export default function useSyncState<T>(filteredKeys: T): UseSyncStateProps<T> {
   const filteredKeysRef = React.useRef<T>(filteredKeys);
 
-  return [() => filteredKeysRef.current, (newValue: T) => (filteredKeysRef.current = newValue)];
+  return [
+    () => filteredKeysRef.current,
+    (newValue: T) => (filteredKeysRef.current = newValue)
+  ];
 }

--- a/components/table/hooks/useSyncState.ts
+++ b/components/table/hooks/useSyncState.ts
@@ -4,9 +4,14 @@ type UseSyncStateProps<T> = [() => T, (newValue: T) => void];
 
 export default function useSyncState<T>(filteredKeys: T): UseSyncStateProps<T> {
   const filteredKeysRef = React.useRef<T>(filteredKeys);
+  const [, forceUpdate] = React.useState<T>();
 
   return [
     () => filteredKeysRef.current,
-    (newValue: T) => (filteredKeysRef.current = newValue),
+    (newValue: T) => {
+      filteredKeysRef.current = newValue;
+      // re-render
+      forceUpdate(filteredKeys);
+    },
   ];
 }

--- a/components/table/hooks/useSyncState.ts
+++ b/components/table/hooks/useSyncState.ts
@@ -1,0 +1,9 @@
+import * as React from 'react';
+
+type UseSyncStateProps<T> = [() => T, (newValue: T) => void];
+
+export default function useSyncState<T>(filteredKeys: T): UseSyncStateProps<T> {
+  const filteredKeysRef = React.useRef<T>(filteredKeys);
+
+  return [() => filteredKeysRef.current, (newValue: T) => (filteredKeysRef.current = newValue)];
+}


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->
example:
https://codesandbox.io/s/elated-mendeleev-64277
### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  4.0 table filters value may be previous when use select, becanse of 'setFilteredKeys' is async  |
| 🇨🇳 Chinese | select选中一个option, 触发的搜索是前一个值 ,因’setFilteredKeys‘是异步的 |

### ☑️ Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
