### PR TITLE
docs(Tag): remove version column in 4.0

### DIFF
--- a/components/tag/index.en-US.md
+++ b/components/tag/index.en-US.md
@@ -16,17 +16,17 @@ Tag for categorizing or markup.
 
 ### Tag
 
-| Property | Description | Type | Default | Version |
-| --- | --- | --- | --- | --- |
-| afterClose | Callback executed when close animation is completed, please use `onClose`, we will remove this in the next version | () => void | - |  |
-| closable | Whether the Tag can be closed | boolean | `false` |  |
-| color | Color of the Tag | string | - |  |
-| onClose | Callback executed when tag is closed | (e) => void | - |  |
-| visible | Whether the Tag is closed or not | boolean | `true` | 3.7.0 |
+| Property | Description | Type | Default |
+| --- | --- | --- | --- |
+| afterClose | Callback executed when close animation is completed, please use `onClose`, we will remove this in the next version | () => void | - |
+| closable | Whether the Tag can be closed | boolean | `false` |
+| color | Color of the Tag | string | - |
+| onClose | Callback executed when tag is closed | (e) => void | - |
+| visible | Whether the Tag is closed or not | boolean | `true` |
 
 ### Tag.CheckableTag
 
-| Property | Description | Type | Default | Version |
-| --- | --- | --- | --- | --- |
-| checked | Checked status of Tag | boolean | `false` |  |
-| onChange | Callback executed when Tag is checked/unchecked | (checked) => void | - |  |
+| Property | Description | Type | Default |
+| --- | --- | --- | --- |
+| checked | Checked status of Tag | boolean | `false` |
+| onChange | Callback executed when Tag is checked/unchecked | (checked) => void | - |

--- a/components/tag/index.zh-CN.md
+++ b/components/tag/index.zh-CN.md
@@ -16,17 +16,17 @@ title: Tag
 
 ### Tag
 
-| 参数 | 说明 | 类型 | 默认值 | 版本 |
-| --- | --- | --- | --- | --- |
-| afterClose | 关闭动画完成后的回调，请使用 `onClose`, 我们将在下个版本删除此项 | () => void | - |  |
-| closable | 标签是否可以关闭 | boolean | false |  |
-| color | 标签色 | string | - |  |
-| onClose | 关闭时的回调 | (e) => void | - |  |
-| visible | 是否显示标签 | boolean | `true` | 3.7.0 |
+| 参数 | 说明 | 类型 | 默认值 |
+| --- | --- | --- | --- |
+| afterClose | 关闭动画完成后的回调，请使用 `onClose`, 我们将在下个版本删除此项 | () => void | - |
+| closable | 标签是否可以关闭 | boolean | false |
+| color | 标签色 | string | - |
+| onClose | 关闭时的回调 | (e) => void | - |
+| visible | 是否显示标签 | boolean | `true` |
 
 ### Tag.CheckableTag
 
-| 参数     | 说明                 | 类型              | 默认值 | 版本 |
-| -------- | -------------------- | ----------------- | ------ | ---- |
-| checked  | 设置标签的选中状态   | boolean           | false  |      |
-| onChange | 点击标签时触发的回调 | (checked) => void | -      |      |
+| 参数     | 说明                 | 类型              | 默认值 |
+| -------- | -------------------- | ----------------- | ------ |
+| checked  | 设置标签的选中状态   | boolean           | false  |
+| onChange | 点击标签时触发的回调 | (checked) => void | -      |


### PR DESCRIPTION
I'm not sure why i'm tagged to do this, but sure, I'll help out =)

### 🤔 This is a ...

- [x] Site / document update

### 🔗 Related issue link

ref: https://github.com/ant-design/ant-design/issues/19815


### 💡 Background and solution

ref: https://github.com/ant-design/ant-design/issues/19815

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Removed version column in 4.0  |
| 🇨🇳 Chinese |  删除相关版本号  |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

[view rendered components/tag/index.zh-CN.md](https://github.com/jhsu/ant-design/blob/4.0-prepare-tag/components/tag/index.zh-CN.md)
[view rendered components/tag/index.en-US.md](https://github.com/jhsu/ant-design/blob/4.0-prepare-tag/components/tag/index.en-US.md)

-----
[View rendered components/tag/index.en-US.md](https://github.com/jhsu/ant-design/blob/4.0-prepare-tag/components/tag/index.en-US.md)
[View rendered components/tag/index.zh-CN.md](https://github.com/jhsu/ant-design/blob/4.0-prepare-tag/components/tag/index.zh-CN.md)