### PR TITLE
docs: clean up version info in 4.0

### DIFF
--- a/components/input-number/index.en-US.md
+++ b/components/input-number/index.en-US.md
@@ -12,26 +12,26 @@ When a numeric value needs to be provided.
 
 ## API
 
-| Property | Description | Type | Default | Version |
-| --- | --- | --- | --- | --- |
-| autoFocus | get focus when component mounted | boolean | false | - |
-| defaultValue | initial value | number | - | - |
-| disabled | disable the input | boolean | false | - |
-| formatter | Specifies the format of the value presented | function(value: number \| string): string | - | - |
-| max | max value | number | Infinity | - |
-| min | min value | number | -Infinity | - |
-| parser | Specifies the value extracted from formatter | function( string): number | - | - |
-| precision | precision of input value | number | - | - |
-| decimalSeparator | decimal separator | string | - | - |
-| size | height of input box | string | - | - |
-| step | The number to which the current value is increased or decreased. It can be an integer or decimal. | number\|string | 1 | - |
-| value | current value | number | - | - |
-| onChange | The callback triggered when the value is changed. | function(value: number \| string) | - | - |
-| onPressEnter | The callback function that is triggered when Enter key is pressed. | function(e) | - | - |
+| Property | Description | Type | Default |
+| --- | --- | --- | --- |
+| autoFocus | get focus when component mounted | boolean | false |
+| defaultValue | initial value | number |  |
+| disabled | disable the input | boolean | false |
+| formatter | Specifies the format of the value presented | function(value: number \| string): string |  |
+| max | max value | number | Infinity |
+| min | min value | number | -Infinity |
+| parser | Specifies the value extracted from formatter | function( string): number |  |
+| precision | precision of input value | number |  |
+| decimalSeparator | decimal separator | string |  |
+| size | height of input box | string |  |
+| step | The number to which the current value is increased or decreased. It can be an integer or decimal. | number\|string | 1 |
+| value | current value | number |  |
+| onChange | The callback triggered when the value is changed. | function(value: number \| string) |  |
+| onPressEnter | The callback function that is triggered when Enter key is pressed. | function(e) |  |
 
 ## Methods
 
-| Name    | Description  | Version |
-| ------- | ------------ | ------- |
-| blur()  | remove focus | -       |
-| focus() | get focus    | -       |
+| Name    | Description  |
+| ------- | ------------ |
+| blur()  | remove focus |
+| focus() | get focus    |

--- a/components/input-number/index.en-US.md
+++ b/components/input-number/index.en-US.md
@@ -14,24 +14,24 @@ When a numeric value needs to be provided.
 
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
-| autoFocus | get focus when component mounted | boolean | false |  |
-| defaultValue | initial value | number |  |  |
-| disabled | disable the input | boolean | false |  |
-| formatter | Specifies the format of the value presented | function(value: number \| string): string | - |  |
-| max | max value | number | Infinity |  |
-| min | min value | number | -Infinity |  |
-| parser | Specifies the value extracted from formatter | function( string): number | - |  |
-| precision | precision of input value | number | - |  |
-| decimalSeparator | decimal separator | string | - | 3.10.1 |
-| size | height of input box | string | - |  |
-| step | The number to which the current value is increased or decreased. It can be an integer or decimal. | number\|string | 1 |  |
-| value | current value | number |  |  |
-| onChange | The callback triggered when the value is changed. | function(value: number \| string) |  |  |
-| onPressEnter | The callback function that is triggered when Enter key is pressed. | function(e) |  |  |
+| autoFocus | get focus when component mounted | boolean | false | - |
+| defaultValue | initial value | number | - | - |
+| disabled | disable the input | boolean | false | - |
+| formatter | Specifies the format of the value presented | function(value: number \| string): string | - | - |
+| max | max value | number | Infinity | - |
+| min | min value | number | -Infinity | - |
+| parser | Specifies the value extracted from formatter | function( string): number | - | - |
+| precision | precision of input value | number | - | - |
+| decimalSeparator | decimal separator | string | - | - |
+| size | height of input box | string | - | - |
+| step | The number to which the current value is increased or decreased. It can be an integer or decimal. | number\|string | 1 | - |
+| value | current value | number | - | - |
+| onChange | The callback triggered when the value is changed. | function(value: number \| string) | - | - |
+| onPressEnter | The callback function that is triggered when Enter key is pressed. | function(e) | - | - |
 
 ## Methods
 
 | Name    | Description  | Version |
 | ------- | ------------ | ------- |
-| blur()  | remove focus |         |
-| focus() | get focus    |         |
+| blur()  | remove focus | -       |
+| focus() | get focus    | -       |

--- a/components/input-number/index.zh-CN.md
+++ b/components/input-number/index.zh-CN.md
@@ -15,26 +15,26 @@ title: InputNumber
 
 属性如下
 
-| 成员 | 说明 | 类型 | 默认值 | 版本 |
-| --- | --- | --- | --- | --- |
-| autoFocus | 自动获取焦点 | boolean | false | - |
-| defaultValue | 初始值 | number | - | - |
-| disabled | 禁用 | boolean | false | - |
-| formatter | 指定输入框展示值的格式 | function(value: number \| string): string | - | - |
-| max | 最大值 | number | Infinity | - |
-| min | 最小值 | number | -Infinity | - |
-| parser | 指定从 formatter 里转换回数字的方式，和 formatter 搭配使用 | function( string): number | - | - |
-| precision | 数值精度 | number | - | - |
-| decimalSeparator | 小数点 | string | - | - |
-| size | 输入框大小 | string | 无 | - |
-| step | 每次改变步数，可以为小数 | number\|string | 1 | - |
-| value | 当前值 | number | - | - |
-| onChange | 变化回调 | Function(value: number \| string) | - | - |
-| onPressEnter | 按下回车的回调 | function(e) | - | - |
+| 成员 | 说明 | 类型 | 默认值 |
+| --- | --- | --- | --- |
+| autoFocus | 自动获取焦点 | boolean | false |
+| defaultValue | 初始值 | number |  |
+| disabled | 禁用 | boolean | false |
+| formatter | 指定输入框展示值的格式 | function(value: number \| string): string |  |
+| max | 最大值 | number | Infinity |
+| min | 最小值 | number | -Infinity |
+| parser | 指定从 formatter 里转换回数字的方式，和 formatter 搭配使用 | function( string): number |  |
+| precision | 数值精度 | number |  |
+| decimalSeparator | 小数点 | string |  |
+| size | 输入框大小 | string | 无 |
+| step | 每次改变步数，可以为小数 | number\|string | 1 |
+| value | 当前值 | number |  |
+| onChange | 变化回调 | Function(value: number \| string) |  |
+| onPressEnter | 按下回车的回调 | function(e) |  |
 
 ## 方法
 
-| 名称    | 描述     | 版本 |
-| ------- | -------- | ---- |
-| blur()  | 移除焦点 | -    |
-| focus() | 获取焦点 | -    |
+| 名称    | 描述     |
+| ------- | -------- |
+| blur()  | 移除焦点 |
+| focus() | 获取焦点 |

--- a/components/input-number/index.zh-CN.md
+++ b/components/input-number/index.zh-CN.md
@@ -17,24 +17,24 @@ title: InputNumber
 
 | 成员 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
-| autoFocus | 自动获取焦点 | boolean | false |  |
-| defaultValue | 初始值 | number |  |  |
-| disabled | 禁用 | boolean | false |  |
-| formatter | 指定输入框展示值的格式 | function(value: number \| string): string | - |  |
-| max | 最大值 | number | Infinity |  |
-| min | 最小值 | number | -Infinity |  |
-| parser | 指定从 formatter 里转换回数字的方式，和 formatter 搭配使用 | function( string): number | - |  |
-| precision | 数值精度 | number | - |  |
-| decimalSeparator | 小数点 | string | - | 3.10.0 |
-| size | 输入框大小 | string | 无 |  |
-| step | 每次改变步数，可以为小数 | number\|string | 1 |  |
-| value | 当前值 | number |  |  |
-| onChange | 变化回调 | Function(value: number \| string) |  |  |
-| onPressEnter | 按下回车的回调 | function(e) |  |  |
+| autoFocus | 自动获取焦点 | boolean | false | - |
+| defaultValue | 初始值 | number | - | - |
+| disabled | 禁用 | boolean | false | - |
+| formatter | 指定输入框展示值的格式 | function(value: number \| string): string | - | - |
+| max | 最大值 | number | Infinity | - |
+| min | 最小值 | number | -Infinity | - |
+| parser | 指定从 formatter 里转换回数字的方式，和 formatter 搭配使用 | function( string): number | - | - |
+| precision | 数值精度 | number | - | - |
+| decimalSeparator | 小数点 | string | - | - |
+| size | 输入框大小 | string | 无 | - |
+| step | 每次改变步数，可以为小数 | number\|string | 1 | - |
+| value | 当前值 | number | - | - |
+| onChange | 变化回调 | Function(value: number \| string) | - | - |
+| onPressEnter | 按下回车的回调 | function(e) | - | - |
 
 ## 方法
 
 | 名称    | 描述     | 版本 |
 | ------- | -------- | ---- |
-| blur()  | 移除焦点 |      |
-| focus() | 获取焦点 |      |
+| blur()  | 移除焦点 | -    |
+| focus() | 获取焦点 | -    |

--- a/components/input/demo/autosize-textarea.md
+++ b/components/input/demo/autosize-textarea.md
@@ -9,13 +9,9 @@ title:
 
 `autoSize` 属性适用于 `textarea` 节点，并且只有高度会自动变化。另外 `autoSize` 可以设定为一个对象，指定最小行数和最大行数。
 
-> `3.24.0` 后 `autosize` 被废弃，请使用 `autoSize`。
-
 ## en-US
 
 `autoSize` prop for a `textarea` type of `Input` makes the height to automatically adjust based on the content. An options object can be provided to `autoSize` to specify the minimum and maximum number of lines the textarea will automatically adjust.
-
-> `autosize` is deprecated after `3.24.0`, please use `autoSize`.
 
 ```jsx
 import { Input } from 'antd';

--- a/components/input/demo/password-input.md
+++ b/components/input/demo/password-input.md
@@ -7,11 +7,11 @@ title:
 
 ## zh-CN
 
-密码框，版本 3.12.0 中新增。
+密码框。
 
 ## en-US
 
-Input type of password and added in 3.12.0.
+Input type of password.
 
 ```jsx
 import { Input } from 'antd';

--- a/components/input/demo/search-input.md
+++ b/components/input/demo/search-input.md
@@ -7,11 +7,11 @@ title:
 
 ## zh-CN
 
-带有搜索按钮的输入框，`2.5.0` 时新增。
+带有搜索按钮的输入框。
 
 ## en-US
 
-Example of creating a search box by grouping a standard input with a search button, added in `2.5.0`.
+Example of creating a search box by grouping a standard input with a search button.
 
 ```jsx
 import { Input } from 'antd';

--- a/components/input/index.en-US.md
+++ b/components/input/index.en-US.md
@@ -17,20 +17,20 @@ A basic widget for getting the user input is a text field. Keyboard and mouse ca
 
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
-| addonAfter | The label text displayed after (on the right side of) the input field. | string\|ReactNode |  |  |
-| addonBefore | The label text displayed before (on the left side of) the input field. | string\|ReactNode |  |  |
-| defaultValue | The initial input content | string |  |  |
-| disabled | Whether the input is disabled. | boolean | false |  |
-| id | The ID for input | string |  |  |
-| maxLength | max length | number |  |  |
-| prefix | The prefix icon for the Input. | string\|ReactNode |  |  |
-| size | The size of the input box. Note: in the context of a form, the `large` size is used. Available: `large` `default` `small` | string | `default` |  |
-| suffix | The suffix icon for the Input. | string\|ReactNode |  |  |
-| type | The type of input, see: [MDN](https://developer.mozilla.org/docs/Web/HTML/Element/input#Form_%3Cinput%3E_types)(use `Input.TextArea` instead of `type="textarea"`) | string | `text` |  |
-| value | The input content value | string |  |  |
-| onChange | callback when user input | function(e) |  | 3.9.3 |
-| onPressEnter | The callback function that is triggered when Enter key is pressed. | function(e) |  |  |
-| allowClear | allow to remove input content with clear icon | boolean |  | 3.12.0 |
+| addonAfter | The label text displayed after (on the right side of) the input field. | string\|ReactNode | - | - |
+| addonBefore | The label text displayed before (on the left side of) the input field. | string\|ReactNode | - | - |
+| defaultValue | The initial input content | string | - | - |
+| disabled | Whether the input is disabled. | boolean | false | - |
+| id | The ID for input | string | - | - |
+| maxLength | max length | number | - | - |
+| prefix | The prefix icon for the Input. | string\|ReactNode | - | - |
+| size | The size of the input box. Note: in the context of a form, the `large` size is used. Available: `large` `default` `small` | string | `default` | - |
+| suffix | The suffix icon for the Input. | string\|ReactNode | - | - |
+| type | The type of input, see: [MDN](https://developer.mozilla.org/docs/Web/HTML/Element/input#Form_%3Cinput%3E_types)(use `Input.TextArea` instead of `type="textarea"`) | string | `text` | - |
+| value | The input content value | string | - | - |
+| onChange | callback when user input | function(e) | - | - |
+| onPressEnter | The callback function that is triggered when Enter key is pressed. | function(e) | - | - |
+| allowClear | allow to remove input content with clear icon | boolean | - | - |
 
 > When `Input` is used in a `Form.Item` context, if the `Form.Item` has the `id` and `options` props defined then `value`, `defaultValue`, and `id` props of `Input` are automatically set.
 
@@ -38,27 +38,23 @@ The rest of the props of Input are exactly the same as the original [input](http
 
 ### Input.TextArea
 
-> If you are using `antd@<2.12`, please use `Input[type=textarea]`.
-
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
-| autoSize | Height autosize feature, can be set to `true|false` or an object `{ minRows: 2, maxRows: 6 }`. `autosize` is deprecated after `3.24.0`, please use `autoSize`. | boolean\|object | false | 3.24.0 |
-| defaultValue | The initial input content | string |  |  |
-| value | The input content value | string |  |  |
-| onPressEnter | The callback function that is triggered when Enter key is pressed. | function(e) |  |  |
-| allowClear | allow to remove input content with clear icon | boolean |  | 3.25.0 |
+| autoSize | Height autosize feature, can be set to `true|false` or an object `{ minRows: 2, maxRows: 6 }`. | boolean\|object | false | - |
+| defaultValue | The initial input content | string | - | - |
+| value | The input content value | string | - | - |
+| onPressEnter | The callback function that is triggered when Enter key is pressed. | function(e) | - | - |
+| allowClear | allow to remove input content with clear icon | boolean | - | - |
 
 The rest of the props of `Input.TextArea` are the same as the original [textarea](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea).
 
 #### Input.Search
 
-`Added in 2.5.0`
-
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
-| enterButton | to show an enter button after input. This prop is conflict with addon. | boolean\|ReactNode | false |  |
-| onSearch | The callback function triggered when you click on the search-icon, the clear-icon or press the Enter key. | function(value, event) |  |  |
-| loading | Search box with loading. | boolean |  |  |
+| enterButton | to show an enter button after input. This prop is conflict with addon. | boolean\|ReactNode | false | - |
+| onSearch | The callback function triggered when you click on the search-icon, the clear-icon or press the Enter key. | function(value, event) | - | - |
+| loading | Search box with loading. | boolean | - | - |
 
 Supports all props of `Input`.
 
@@ -66,8 +62,8 @@ Supports all props of `Input`.
 
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
-| compact | Whether use compact style | boolean | false |  |
-| size | The size of `Input.Group` specifies the size of the included `Input` fields. Available: `large` `default` `small` | string | `default` |  |
+| compact | Whether use compact style | boolean | false | - |
+| size | The size of `Input.Group` specifies the size of the included `Input` fields. Available: `large` `default` `small` | string | `default` | - |
 
 ```html
 <Input.Group>
@@ -76,11 +72,11 @@ Supports all props of `Input`.
 </Input.Group>
 ```
 
-#### Input.Password (Added in 3.12.0)
+#### Input.Password
 
 | Property         | Description                | Type    | Default | Version |
 | ---------------- | -------------------------- | ------- | ------- | ------- |
-| visibilityToggle | Whether show toggle button | boolean | true    | 3.12.2  |
+| visibilityToggle | Whether show toggle button | boolean | true    | -       |
 
 ## FAQ
 

--- a/components/input/index.en-US.md
+++ b/components/input/index.en-US.md
@@ -15,22 +15,22 @@ A basic widget for getting the user input is a text field. Keyboard and mouse ca
 
 ### Input
 
-| Property | Description | Type | Default | Version |
-| --- | --- | --- | --- | --- |
-| addonAfter | The label text displayed after (on the right side of) the input field. | string\|ReactNode | - | - |
-| addonBefore | The label text displayed before (on the left side of) the input field. | string\|ReactNode | - | - |
-| defaultValue | The initial input content | string | - | - |
-| disabled | Whether the input is disabled. | boolean | false | - |
-| id | The ID for input | string | - | - |
-| maxLength | max length | number | - | - |
-| prefix | The prefix icon for the Input. | string\|ReactNode | - | - |
-| size | The size of the input box. Note: in the context of a form, the `large` size is used. Available: `large` `default` `small` | string | `default` | - |
-| suffix | The suffix icon for the Input. | string\|ReactNode | - | - |
-| type | The type of input, see: [MDN](https://developer.mozilla.org/docs/Web/HTML/Element/input#Form_%3Cinput%3E_types)(use `Input.TextArea` instead of `type="textarea"`) | string | `text` | - |
-| value | The input content value | string | - | - |
-| onChange | callback when user input | function(e) | - | - |
-| onPressEnter | The callback function that is triggered when Enter key is pressed. | function(e) | - | - |
-| allowClear | allow to remove input content with clear icon | boolean | - | - |
+| Property | Description | Type | Default |
+| --- | --- | --- | --- |
+| addonAfter | The label text displayed after (on the right side of) the input field. | string\|ReactNode |  |
+| addonBefore | The label text displayed before (on the left side of) the input field. | string\|ReactNode |  |
+| defaultValue | The initial input content | string |  |
+| disabled | Whether the input is disabled. | boolean | false |
+| id | The ID for input | string |  |
+| maxLength | max length | number |  |
+| prefix | The prefix icon for the Input. | string\|ReactNode |  |
+| size | The size of the input box. Note: in the context of a form, the `large` size is used. Available: `large` `default` `small` | string | `default` |
+| suffix | The suffix icon for the Input. | string\|ReactNode |  |
+| type | The type of input, see: [MDN](https://developer.mozilla.org/docs/Web/HTML/Element/input#Form_%3Cinput%3E_types)(use `Input.TextArea` instead of `type="textarea"`) | string | `text` |
+| value | The input content value | string |  |
+| onChange | callback when user input | function(e) |  |
+| onPressEnter | The callback function that is triggered when Enter key is pressed. | function(e) |  |
+| allowClear | allow to remove input content with clear icon | boolean |  |
 
 > When `Input` is used in a `Form.Item` context, if the `Form.Item` has the `id` and `options` props defined then `value`, `defaultValue`, and `id` props of `Input` are automatically set.
 
@@ -38,32 +38,32 @@ The rest of the props of Input are exactly the same as the original [input](http
 
 ### Input.TextArea
 
-| Property | Description | Type | Default | Version |
-| --- | --- | --- | --- | --- |
-| autoSize | Height autosize feature, can be set to `true|false` or an object `{ minRows: 2, maxRows: 6 }`. | boolean\|object | false | - |
-| defaultValue | The initial input content | string | - | - |
-| value | The input content value | string | - | - |
-| onPressEnter | The callback function that is triggered when Enter key is pressed. | function(e) | - | - |
-| allowClear | allow to remove input content with clear icon | boolean | - | - |
+| Property | Description | Type | Default |
+| --- | --- | --- | --- |
+| autoSize | Height autosize feature, can be set to `true|false` or an object `{ minRows: 2, maxRows: 6 }`. | boolean\|object | false |
+| defaultValue | The initial input content | string |  |
+| value | The input content value | string |  |
+| onPressEnter | The callback function that is triggered when Enter key is pressed. | function(e) |  |
+| allowClear | allow to remove input content with clear icon | boolean |  |
 
 The rest of the props of `Input.TextArea` are the same as the original [textarea](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea).
 
 #### Input.Search
 
-| Property | Description | Type | Default | Version |
-| --- | --- | --- | --- | --- |
-| enterButton | to show an enter button after input. This prop is conflict with addon. | boolean\|ReactNode | false | - |
-| onSearch | The callback function triggered when you click on the search-icon, the clear-icon or press the Enter key. | function(value, event) | - | - |
-| loading | Search box with loading. | boolean | - | - |
+| Property | Description | Type | Default |
+| --- | --- | --- | --- |
+| enterButton | to show an enter button after input. This prop is conflict with addon. | boolean\|ReactNode | false |
+| onSearch | The callback function triggered when you click on the search-icon, the clear-icon or press the Enter key. | function(value, event) |  |
+| loading | Search box with loading. | boolean |  |
 
 Supports all props of `Input`.
 
 #### Input.Group
 
-| Property | Description | Type | Default | Version |
-| --- | --- | --- | --- | --- |
-| compact | Whether use compact style | boolean | false | - |
-| size | The size of `Input.Group` specifies the size of the included `Input` fields. Available: `large` `default` `small` | string | `default` | - |
+| Property | Description | Type | Default |
+| --- | --- | --- | --- |
+| compact | Whether use compact style | boolean | false |
+| size | The size of `Input.Group` specifies the size of the included `Input` fields. Available: `large` `default` `small` | string | `default` |
 
 ```html
 <Input.Group>
@@ -74,9 +74,9 @@ Supports all props of `Input`.
 
 #### Input.Password
 
-| Property         | Description                | Type    | Default | Version |
-| ---------------- | -------------------------- | ------- | ------- | ------- |
-| visibilityToggle | Whether show toggle button | boolean | true    | -       |
+| Property         | Description                | Type    | Default |
+| ---------------- | -------------------------- | ------- | ------- |
+| visibilityToggle | Whether show toggle button | boolean | true    |
 
 ## FAQ
 

--- a/components/input/index.zh-CN.md
+++ b/components/input/index.zh-CN.md
@@ -16,22 +16,22 @@ title: Input
 
 ### Input
 
-| 参数 | 说明 | 类型 | 默认值 | 版本 |
-| --- | --- | --- | --- | --- |
-| addonAfter | 带标签的 input，设置后置标签 | string\|ReactNode | - | - |
-| addonBefore | 带标签的 input，设置前置标签 | string\|ReactNode | - | - |
-| defaultValue | 输入框默认内容 | string | - | - |
-| disabled | 是否禁用状态，默认为 false | boolean | false | - |
-| id | 输入框的 id | string | - | - |
-| maxLength | 最大长度 | number | - | - |
-| prefix | 带有前缀图标的 input | string\|ReactNode | - | - |
-| size | 控件大小。注：标准表单内的输入框大小限制为 `large`。可选 `large` `default` `small` | string | `default` | - |
-| suffix | 带有后缀图标的 input | string\|ReactNode | - | - |
-| type | 声明 input 类型，同原生 input 标签的 type 属性，见：[MDN](https://developer.mozilla.org/zh-CN/docs/Web/HTML/Element/input#属性)(请直接使用 `Input.TextArea` 代替 `type="textarea"`)。 | string | `text` | - |
-| value | 输入框内容 | string | - | - |
-| onChange | 输入框内容变化时的回调 | function(e) | - | - |
-| onPressEnter | 按下回车的回调 | function(e) | - | - |
-| allowClear | 可以点击清除图标删除内容 | boolean | - | - |
+| 参数 | 说明 | 类型 | 默认值 |
+| --- | --- | --- | --- |
+| addonAfter | 带标签的 input，设置后置标签 | string\|ReactNode |  |
+| addonBefore | 带标签的 input，设置前置标签 | string\|ReactNode |  |
+| defaultValue | 输入框默认内容 | string |  |
+| disabled | 是否禁用状态，默认为 false | boolean | false |
+| id | 输入框的 id | string |  |
+| maxLength | 最大长度 | number |  |
+| prefix | 带有前缀图标的 input | string\|ReactNode |  |
+| size | 控件大小。注：标准表单内的输入框大小限制为 `large`。可选 `large` `default` `small` | string | `default` |
+| suffix | 带有后缀图标的 input | string\|ReactNode |  |
+| type | 声明 input 类型，同原生 input 标签的 type 属性，见：[MDN](https://developer.mozilla.org/zh-CN/docs/Web/HTML/Element/input#属性)(请直接使用 `Input.TextArea` 代替 `type="textarea"`)。 | string | `text` |
+| value | 输入框内容 | string |  |
+| onChange | 输入框内容变化时的回调 | function(e) |  |
+| onPressEnter | 按下回车的回调 | function(e) |  |
+| allowClear | 可以点击清除图标删除内容 | boolean |  |
 
 > 如果 `Input` 在 `Form.Item` 内，并且 `Form.Item` 设置了 `id` 和 `options` 属性，则 `value` `defaultValue` 和 `id` 属性会被自动设置。
 
@@ -39,32 +39,32 @@ Input 的其他属性和 React 自带的 [input](https://facebook.github.io/reac
 
 ### Input.TextArea
 
-| 参数 | 说明 | 类型 | 默认值 | 版本 |
-| --- | --- | --- | --- | --- |
-| autoSize | 自适应内容高度，可设置为 `true|false` 或对象：`{ minRows: 2, maxRows: 6 }`。 | boolean\|object | false | - |
-| defaultValue | 输入框默认内容 | string | - | - |
-| value | 输入框内容 | string | - | - |
-| onPressEnter | 按下回车的回调 | function(e) | - | - |
-| allowClear | 可以点击清除图标删除内容 | boolean | - | - |
+| 参数 | 说明 | 类型 | 默认值 |
+| --- | --- | --- | --- |
+| autoSize | 自适应内容高度，可设置为 `true|false` 或对象：`{ minRows: 2, maxRows: 6 }`。 | boolean\|object | false |
+| defaultValue | 输入框默认内容 | string |  |
+| value | 输入框内容 | string |  |
+| onPressEnter | 按下回车的回调 | function(e) |  |
+| allowClear | 可以点击清除图标删除内容 | boolean |  |
 
 `Input.TextArea` 的其他属性和浏览器自带的 [textarea](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea) 一致。
 
 #### Input.Search
 
-| 参数 | 说明 | 类型 | 默认值 | 版本 |
-| --- | --- | --- | --- | --- |
-| enterButton | 是否有确认按钮，可设为按钮文字。该属性会与 addon 冲突。 | boolean\|ReactNode | false | - |
-| onSearch | 点击搜索或按下回车键时的回调 | function(value, event) | - | - |
-| loading | 搜索 loading | boolean | - | - |
+| 参数 | 说明 | 类型 | 默认值 |
+| --- | --- | --- | --- |
+| enterButton | 是否有确认按钮，可设为按钮文字。该属性会与 addon 冲突。 | boolean\|ReactNode | false |
+| onSearch | 点击搜索或按下回车键时的回调 | function(value, event) |  |
+| loading | 搜索 loading | boolean |  |
 
 其余属性和 Input 一致。
 
 #### Input.Group
 
-| 参数 | 说明 | 类型 | 默认值 | 版本 |
-| --- | --- | --- | --- | --- |
-| compact | 是否用紧凑模式 | boolean | false | - |
-| size | `Input.Group` 中所有的 `Input` 的大小，可选 `large` `default` `small` | string | `default` | - |
+| 参数 | 说明 | 类型 | 默认值 |
+| --- | --- | --- | --- |
+| compact | 是否用紧凑模式 | boolean | false |
+| size | `Input.Group` 中所有的 `Input` 的大小，可选 `large` `default` `small` | string | `default` |
 
 ```html
 <Input.Group>
@@ -75,9 +75,9 @@ Input 的其他属性和 React 自带的 [input](https://facebook.github.io/reac
 
 #### Input.Password
 
-| 参数             | 说明             | 类型    | 默认值 | 版本 |
-| ---------------- | ---------------- | ------- | ------ | ---- |
-| visibilityToggle | 是否显示切换按钮 | boolean | true   | -    |
+| 参数             | 说明             | 类型    | 默认值 |
+| ---------------- | ---------------- | ------- | ------ |
+| visibilityToggle | 是否显示切换按钮 | boolean | true   |
 
 ## FAQ
 

--- a/components/input/index.zh-CN.md
+++ b/components/input/index.zh-CN.md
@@ -18,20 +18,20 @@ title: Input
 
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
-| addonAfter | 带标签的 input，设置后置标签 | string\|ReactNode |  |  |
-| addonBefore | 带标签的 input，设置前置标签 | string\|ReactNode |  |  |
-| defaultValue | 输入框默认内容 | string |  |  |
-| disabled | 是否禁用状态，默认为 false | boolean | false |  |
-| id | 输入框的 id | string |  |  |
-| maxLength | 最大长度 | number |  |  |
-| prefix | 带有前缀图标的 input | string\|ReactNode |  |  |
-| size | 控件大小。注：标准表单内的输入框大小限制为 `large`。可选 `large` `default` `small` | string | `default` |  |
-| suffix | 带有后缀图标的 input | string\|ReactNode |  |  |
-| type | 声明 input 类型，同原生 input 标签的 type 属性，见：[MDN](https://developer.mozilla.org/zh-CN/docs/Web/HTML/Element/input#属性)(请直接使用 `Input.TextArea` 代替 `type="textarea"`)。 | string | `text` |  |
-| value | 输入框内容 | string |  |  |
-| onChange | 输入框内容变化时的回调 | function(e) |  | 3.9.3 |
-| onPressEnter | 按下回车的回调 | function(e) |  |  |
-| allowClear | 可以点击清除图标删除内容 | boolean |  | 3.12.0 |
+| addonAfter | 带标签的 input，设置后置标签 | string\|ReactNode | - | - |
+| addonBefore | 带标签的 input，设置前置标签 | string\|ReactNode | - | - |
+| defaultValue | 输入框默认内容 | string | - | - |
+| disabled | 是否禁用状态，默认为 false | boolean | false | - |
+| id | 输入框的 id | string | - | - |
+| maxLength | 最大长度 | number | - | - |
+| prefix | 带有前缀图标的 input | string\|ReactNode | - | - |
+| size | 控件大小。注：标准表单内的输入框大小限制为 `large`。可选 `large` `default` `small` | string | `default` | - |
+| suffix | 带有后缀图标的 input | string\|ReactNode | - | - |
+| type | 声明 input 类型，同原生 input 标签的 type 属性，见：[MDN](https://developer.mozilla.org/zh-CN/docs/Web/HTML/Element/input#属性)(请直接使用 `Input.TextArea` 代替 `type="textarea"`)。 | string | `text` | - |
+| value | 输入框内容 | string | - | - |
+| onChange | 输入框内容变化时的回调 | function(e) | - | - |
+| onPressEnter | 按下回车的回调 | function(e) | - | - |
+| allowClear | 可以点击清除图标删除内容 | boolean | - | - |
 
 > 如果 `Input` 在 `Form.Item` 内，并且 `Form.Item` 设置了 `id` 和 `options` 属性，则 `value` `defaultValue` 和 `id` 属性会被自动设置。
 
@@ -39,15 +39,13 @@ Input 的其他属性和 React 自带的 [input](https://facebook.github.io/reac
 
 ### Input.TextArea
 
-> `2.12` 后新增的组件，旧版请使用 `Input[type=textarea]`。
-
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
-| autoSize | 自适应内容高度，可设置为 `true|false` 或对象：`{ minRows: 2, maxRows: 6 }`。`3.24.0` 后 `autosize` 被废弃，请使用 `autoSize`。 | boolean\|object | false | 3.24.0 |
-| defaultValue | 输入框默认内容 | string |  |  |
-| value | 输入框内容 | string |  |  |
-| onPressEnter | 按下回车的回调 | function(e) |  |  |
-| allowClear | 可以点击清除图标删除内容 | boolean |  | 3.25.0 |
+| autoSize | 自适应内容高度，可设置为 `true|false` 或对象：`{ minRows: 2, maxRows: 6 }`。 | boolean\|object | false | - |
+| defaultValue | 输入框默认内容 | string | - | - |
+| value | 输入框内容 | string | - | - |
+| onPressEnter | 按下回车的回调 | function(e) | - | - |
+| allowClear | 可以点击清除图标删除内容 | boolean | - | - |
 
 `Input.TextArea` 的其他属性和浏览器自带的 [textarea](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea) 一致。
 
@@ -55,9 +53,9 @@ Input 的其他属性和 React 自带的 [input](https://facebook.github.io/reac
 
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
-| enterButton | 是否有确认按钮，可设为按钮文字。该属性会与 addon 冲突。 | boolean\|ReactNode | false |  |
-| onSearch | 点击搜索或按下回车键时的回调 | function(value, event) |  |  |
-| loading | 搜索 loading | boolean |  |  |
+| enterButton | 是否有确认按钮，可设为按钮文字。该属性会与 addon 冲突。 | boolean\|ReactNode | false | - |
+| onSearch | 点击搜索或按下回车键时的回调 | function(value, event) | - | - |
+| loading | 搜索 loading | boolean | - | - |
 
 其余属性和 Input 一致。
 
@@ -65,8 +63,8 @@ Input 的其他属性和 React 自带的 [input](https://facebook.github.io/reac
 
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
-| compact | 是否用紧凑模式 | boolean | false |  |
-| size | `Input.Group` 中所有的 `Input` 的大小，可选 `large` `default` `small` | string | `default` |  |
+| compact | 是否用紧凑模式 | boolean | false | - |
+| size | `Input.Group` 中所有的 `Input` 的大小，可选 `large` `default` `small` | string | `default` | - |
 
 ```html
 <Input.Group>
@@ -75,11 +73,11 @@ Input 的其他属性和 React 自带的 [input](https://facebook.github.io/reac
 </Input.Group>
 ```
 
-#### Input.Password (3.12.0 中新增)
+#### Input.Password
 
-| 参数             | 说明             | 类型    | 默认值 | 版本   |
-| ---------------- | ---------------- | ------- | ------ | ------ |
-| visibilityToggle | 是否显示切换按钮 | boolean | true   | 3.12.2 |
+| 参数             | 说明             | 类型    | 默认值 | 版本 |
+| ---------------- | ---------------- | ------- | ------ | ---- |
+| visibilityToggle | 是否显示切换按钮 | boolean | true   | -    |
 
 ## FAQ
 

--- a/components/mentions/index.en-US.md
+++ b/components/mentions/index.en-US.md
@@ -22,34 +22,34 @@ When need to mention someone or something.
 
 ### Mention
 
-| Property | Description | Type | Default | Version |
-| --- | --- | --- | --- | --- |
-| autoFocus | Auto get focus when component mounted | boolean | `false` | - |
-| defaultValue | Default value | string | - | - |
-| filterOption | Customize filter option logic | false \| (input: string, option: OptionProps) => boolean | - | - |
-| notFoundContent | Set mentions content when not match | ReactNode | 'Not Found' | - |
-| placement | Set popup placement | 'top' \| 'bottom' | 'bottom' | - |
-| prefix | Set trigger prefix keyword | string \| string[] | '@' | - |
-| split | Set split string before and after selected mention | string | ' ' | - |
-| validateSearch | Customize trigger search logic | (text: string, props: MentionsProps) => void | - | - |
-| value | Set value of mentions | string | - | - |
-| onChange | Trigger when value changed | (text: string) => void | - | - |
-| onSelect | Trigger when user select the option | (option: OptionProps, prefix: string) => void | - | - |
-| onSearch | Trigger when prefix hit | (text: string, prefix: string) => void | - | - |
-| onFocus | Trigger when mentions get focus | () => void | - | - |
-| onBlur | Trigger when mentions lose focus | () => void | - | - |
-| getPopupContainer | Set the mount HTML node for suggestions | () => HTMLElement | - | - |
+| Property | Description | Type | Default |
+| --- | --- | --- | --- |
+| autoFocus | Auto get focus when component mounted | boolean | `false` |
+| defaultValue | Default value | string |  |
+| filterOption | Customize filter option logic | false \| (input: string, option: OptionProps) => boolean |  |
+| notFoundContent | Set mentions content when not match | ReactNode | 'Not Found' |
+| placement | Set popup placement | 'top' \| 'bottom' | 'bottom' |
+| prefix | Set trigger prefix keyword | string \| string[] | '@' |
+| split | Set split string before and after selected mention | string | ' ' |
+| validateSearch | Customize trigger search logic | (text: string, props: MentionsProps) => void |  |
+| value | Set value of mentions | string |  |
+| onChange | Trigger when value changed | (text: string) => void |  |
+| onSelect | Trigger when user select the option | (option: OptionProps, prefix: string) => void |  |
+| onSearch | Trigger when prefix hit | (text: string, prefix: string) => void |  |
+| onFocus | Trigger when mentions get focus | () => void |  |
+| onBlur | Trigger when mentions lose focus | () => void |  |
+| getPopupContainer | Set the mount HTML node for suggestions | () => HTMLElement |  |
 
 ### Mention methods
 
-| Name    | Description  | Version |
-| ------- | ------------ | ------- |
-| blur()  | remove focus | -       |
-| focus() | get focus    | -       |
+| Name    | Description  |
+| ------- | ------------ |
+| blur()  | remove focus |
+| focus() | get focus    |
 
 ### Option
 
-| Property | Description | Type | Default | Version |
-| --- | --- | --- | --- | --- |
-| children | suggestion content | ReactNode | - | - |
-| value | value of suggestion, the value will insert into input filed while selected | string | '' | - |
+| Property | Description | Type | Default |
+| --- | --- | --- | --- |
+| children | suggestion content | ReactNode |  |
+| value | value of suggestion, the value will insert into input filed while selected | string | '' |

--- a/components/mentions/index.en-US.md
+++ b/components/mentions/index.en-US.md
@@ -24,32 +24,32 @@ When need to mention someone or something.
 
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
-| autoFocus | Auto get focus when component mounted | boolean | `false` | 3.19.0 |
-| defaultValue | Default value | string | - | 3.19.0 |
-| filterOption | Customize filter option logic | false \| (input: string, option: OptionProps) => boolean | - | 3.19.0 |
-| notFoundContent | Set mentions content when not match | ReactNode | 'Not Found' | 3.19.0 |
-| placement | Set popup placement | 'top' \| 'bottom' | 'bottom' | 3.19.0 |
-| prefix | Set trigger prefix keyword | string \| string[] | '@' | 3.19.0 |
-| split | Set split string before and after selected mention | string | ' ' | 3.19.0 |
-| validateSearch | Customize trigger search logic | (text: string, props: MentionsProps) => void | - | 3.19.0 |
-| value | Set value of mentions | string | - | 3.19.0 |
-| onChange | Trigger when value changed | (text: string) => void | - | 3.19.0 |
-| onSelect | Trigger when user select the option | (option: OptionProps, prefix: string) => void | - | 3.19.0 |
-| onSearch | Trigger when prefix hit | (text: string, prefix: string) => void | - | 3.19.0 |
-| onFocus | Trigger when mentions get focus | () => void | - | 3.19.0 |
-| onBlur | Trigger when mentions lose focus | () => void | - | 3.19.0 |
-| getPopupContainer | Set the mount HTML node for suggestions | () => HTMLElement | - | 3.22.0 |
+| autoFocus | Auto get focus when component mounted | boolean | `false` | - |
+| defaultValue | Default value | string | - | - |
+| filterOption | Customize filter option logic | false \| (input: string, option: OptionProps) => boolean | - | - |
+| notFoundContent | Set mentions content when not match | ReactNode | 'Not Found' | - |
+| placement | Set popup placement | 'top' \| 'bottom' | 'bottom' | - |
+| prefix | Set trigger prefix keyword | string \| string[] | '@' | - |
+| split | Set split string before and after selected mention | string | ' ' | - |
+| validateSearch | Customize trigger search logic | (text: string, props: MentionsProps) => void | - | - |
+| value | Set value of mentions | string | - | - |
+| onChange | Trigger when value changed | (text: string) => void | - | - |
+| onSelect | Trigger when user select the option | (option: OptionProps, prefix: string) => void | - | - |
+| onSearch | Trigger when prefix hit | (text: string, prefix: string) => void | - | - |
+| onFocus | Trigger when mentions get focus | () => void | - | - |
+| onBlur | Trigger when mentions lose focus | () => void | - | - |
+| getPopupContainer | Set the mount HTML node for suggestions | () => HTMLElement | - | - |
 
 ### Mention methods
 
 | Name    | Description  | Version |
 | ------- | ------------ | ------- |
-| blur()  | remove focus | 3.19.0  |
-| focus() | get focus    | 3.19.0  |
+| blur()  | remove focus | -       |
+| focus() | get focus    | -       |
 
 ### Option
 
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
-| children | suggestion content | ReactNode | - | 3.19.0 |
-| value | value of suggestion, the value will insert into input filed while selected | string | '' | 3.19.0 |
+| children | suggestion content | ReactNode | - | - |
+| value | value of suggestion, the value will insert into input filed while selected | string | '' | - |

--- a/components/mentions/index.zh-CN.md
+++ b/components/mentions/index.zh-CN.md
@@ -25,32 +25,32 @@ title: Mentions
 
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
-| autoFocus | 自动获得焦点 | boolean | `false` | 3.19.0 |
-| defaultValue | 默认值 | string | - | 3.19.0 |
-| filterOption | 自定义过滤逻辑 | false \| (input: string, option: OptionProps) => boolean | - | 3.19.0 |
-| notFoundContent | 当下拉列表为空时显示的内容 | ReactNode | 'Not Found' | 3.19.0 |
-| placement | 弹出层展示位置 | 'top' \| 'bottom' | 'bottom' | 3.19.0 |
-| prefix | 设置触发关键字 | string \| string[] | '@' | 3.19.0 |
-| split | 设置选中项前后分隔符 | string | ' ' | 3.19.0 |
-| validateSearch | 自定义触发验证逻辑 | (text: string, props: MentionsProps) => void | - | 3.19.0 |
-| value | 设置值 | string | - | 3.19.0 |
-| onChange | 值改变时触发 | (text: string) => void | - | 3.19.0 |
-| onSelect | 选择选项时触发 | (option: OptionProps, prefix: string) => void | - | 3.19.0 |
-| onSearch | 搜索时触发 | (text: string, prefix: string) => void | - | 3.19.0 |
-| onFocus | 获得焦点时触发 | () => void | - | 3.19.0 |
-| onBlur | 失去焦点时触发 | () => void | - | 3.19.0 |
-| getPopupContainer | 指定建议框挂载的 HTML 节点 | () => HTMLElement | - | 3.22.0 |
+| autoFocus | 自动获得焦点 | boolean | `false` | - |
+| defaultValue | 默认值 | string | - | - |
+| filterOption | 自定义过滤逻辑 | false \| (input: string, option: OptionProps) => boolean | - | - |
+| notFoundContent | 当下拉列表为空时显示的内容 | ReactNode | 'Not Found' | - |
+| placement | 弹出层展示位置 | 'top' \| 'bottom' | 'bottom' | - |
+| prefix | 设置触发关键字 | string \| string[] | '@' | - |
+| split | 设置选中项前后分隔符 | string | ' ' | - |
+| validateSearch | 自定义触发验证逻辑 | (text: string, props: MentionsProps) => void | - | - |
+| value | 设置值 | string | - | - |
+| onChange | 值改变时触发 | (text: string) => void | - | - |
+| onSelect | 选择选项时触发 | (option: OptionProps, prefix: string) => void | - | - |
+| onSearch | 搜索时触发 | (text: string, prefix: string) => void | - | - |
+| onFocus | 获得焦点时触发 | () => void | - | - |
+| onBlur | 失去焦点时触发 | () => void | - | - |
+| getPopupContainer | 指定建议框挂载的 HTML 节点 | () => HTMLElement | - | - |
 
 ### Mentions 方法
 
-| 名称    | 描述     | 版本   |
-| ------- | -------- | ------ |
-| blur()  | 移除焦点 | 3.19.0 |
-| focus() | 获取焦点 | 3.19.0 |
+| 名称    | 描述     | 版本 |
+| ------- | -------- | ---- |
+| blur()  | 移除焦点 | -    |
+| focus() | 获取焦点 | -    |
 
 ### Option
 
-| 参数     | 说明           | 类型      | 默认值 | 版本   |
-| -------- | -------------- | --------- | ------ | ------ |
-| children | 选项内容       | ReactNode | -      | 3.19.0 |
-| value    | 选择时填充的值 | string    | ''     | 3.19.0 |
+| 参数     | 说明           | 类型      | 默认值 | 版本 |
+| -------- | -------------- | --------- | ------ | ---- |
+| children | 选项内容       | ReactNode | -      | -    |
+| value    | 选择时填充的值 | string    | ''     | -    |

--- a/components/mentions/index.zh-CN.md
+++ b/components/mentions/index.zh-CN.md
@@ -23,34 +23,34 @@ title: Mentions
 
 ### Mentions
 
-| 参数 | 说明 | 类型 | 默认值 | 版本 |
-| --- | --- | --- | --- | --- |
-| autoFocus | 自动获得焦点 | boolean | `false` | - |
-| defaultValue | 默认值 | string | - | - |
-| filterOption | 自定义过滤逻辑 | false \| (input: string, option: OptionProps) => boolean | - | - |
-| notFoundContent | 当下拉列表为空时显示的内容 | ReactNode | 'Not Found' | - |
-| placement | 弹出层展示位置 | 'top' \| 'bottom' | 'bottom' | - |
-| prefix | 设置触发关键字 | string \| string[] | '@' | - |
-| split | 设置选中项前后分隔符 | string | ' ' | - |
-| validateSearch | 自定义触发验证逻辑 | (text: string, props: MentionsProps) => void | - | - |
-| value | 设置值 | string | - | - |
-| onChange | 值改变时触发 | (text: string) => void | - | - |
-| onSelect | 选择选项时触发 | (option: OptionProps, prefix: string) => void | - | - |
-| onSearch | 搜索时触发 | (text: string, prefix: string) => void | - | - |
-| onFocus | 获得焦点时触发 | () => void | - | - |
-| onBlur | 失去焦点时触发 | () => void | - | - |
-| getPopupContainer | 指定建议框挂载的 HTML 节点 | () => HTMLElement | - | - |
+| 参数 | 说明 | 类型 | 默认值 |
+| --- | --- | --- | --- |
+| autoFocus | 自动获得焦点 | boolean | `false` |
+| defaultValue | 默认值 | string |  |
+| filterOption | 自定义过滤逻辑 | false \| (input: string, option: OptionProps) => boolean |  |
+| notFoundContent | 当下拉列表为空时显示的内容 | ReactNode | 'Not Found' |
+| placement | 弹出层展示位置 | 'top' \| 'bottom' | 'bottom' |
+| prefix | 设置触发关键字 | string \| string[] | '@' |
+| split | 设置选中项前后分隔符 | string | ' ' |
+| validateSearch | 自定义触发验证逻辑 | (text: string, props: MentionsProps) => void |  |
+| value | 设置值 | string |  |
+| onChange | 值改变时触发 | (text: string) => void |  |
+| onSelect | 选择选项时触发 | (option: OptionProps, prefix: string) => void |  |
+| onSearch | 搜索时触发 | (text: string, prefix: string) => void |  |
+| onFocus | 获得焦点时触发 | () => void |  |
+| onBlur | 失去焦点时触发 | () => void |  |
+| getPopupContainer | 指定建议框挂载的 HTML 节点 | () => HTMLElement |  |
 
 ### Mentions 方法
 
-| 名称    | 描述     | 版本 |
-| ------- | -------- | ---- |
-| blur()  | 移除焦点 | -    |
-| focus() | 获取焦点 | -    |
+| 名称    | 描述     |
+| ------- | -------- |
+| blur()  | 移除焦点 |
+| focus() | 获取焦点 |
 
 ### Option
 
-| 参数     | 说明           | 类型      | 默认值 | 版本 |
-| -------- | -------------- | --------- | ------ | ---- |
-| children | 选项内容       | ReactNode | -      | -    |
-| value    | 选择时填充的值 | string    | ''     | -    |
+| 参数     | 说明           | 类型      | 默认值 |
+| -------- | -------------- | --------- | ------ |
+| children | 选项内容       | ReactNode |        |
+| value    | 选择时填充的值 | string    | ''     |

--- a/components/radio/index.en-US.md
+++ b/components/radio/index.en-US.md
@@ -15,34 +15,34 @@ Radio.
 
 ### Radio
 
-| Property | Description | Type | Default | Version |
-| --- | --- | --- | --- | --- |
-| autoFocus | get focus when component mounted | boolean | false | - |
-| checked | Specifies whether the radio is selected. | boolean | - | - |
-| defaultChecked | Specifies the initial state: whether or not the radio is selected. | boolean | false | - |
-| disabled | Disable radio | boolean | false | - |
-| value | According to value for comparison, to determine whether the selected | any | - | - |
+| Property | Description | Type | Default |
+| --- | --- | --- | --- |
+| autoFocus | get focus when component mounted | boolean | false |
+| checked | Specifies whether the radio is selected. | boolean |  |
+| defaultChecked | Specifies the initial state: whether or not the radio is selected. | boolean | false |
+| disabled | Disable radio | boolean | false |
+| value | According to value for comparison, to determine whether the selected | any |  |
 
 ### RadioGroup
 
 Radio group can wrap a group of `Radio`。
 
-| Property | Description | Type | Default | Version |
-| --- | --- | --- | --- | --- |
-| defaultValue | Default selected value | any | - | - |
-| disabled | Disable all radio buttons | boolean | false | - |
-| name | The `name` property of all `input[type="radio"]` children | string | - | - |
-| options | set children optional | string\[] \| Array&lt;{ label: string value: string disabled?: boolean }> | - | - |
-| size | size for radio button style | `large` \| `default` \| `small` | `default` | - |
-| value | Used for setting the currently selected value. | any | - | - |
-| onChange | The callback function that is triggered when the state changes. | Function(e:Event) | - | - |
-| buttonStyle | style type of radio button | `outline` \| `solid` | `outline` | - |
+| Property | Description | Type | Default |
+| --- | --- | --- | --- |
+| defaultValue | Default selected value | any |  |
+| disabled | Disable all radio buttons | boolean | false |
+| name | The `name` property of all `input[type="radio"]` children | string |  |
+| options | set children optional | string\[] \| Array&lt;{ label: string value: string disabled?: boolean }> |  |
+| size | size for radio button style | `large` \| `default` \| `small` | `default` |
+| value | Used for setting the currently selected value. | any |  |
+| onChange | The callback function that is triggered when the state changes. | Function(e:Event) |  |
+| buttonStyle | style type of radio button | `outline` \| `solid` | `outline` |
 
 ## Methods
 
 ### Radio
 
-| Name    | Description  | Version |
-| ------- | ------------ | ------- |
-| blur()  | remove focus | -       |
-| focus() | get focus    | -       |
+| Name    | Description  |
+| ------- | ------------ |
+| blur()  | remove focus |
+| focus() | get focus    |

--- a/components/radio/index.en-US.md
+++ b/components/radio/index.en-US.md
@@ -17,11 +17,11 @@ Radio.
 
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
-| autoFocus | get focus when component mounted | boolean | false |  |
-| checked | Specifies whether the radio is selected. | boolean | - |  |
-| defaultChecked | Specifies the initial state: whether or not the radio is selected. | boolean | false |  |
-| disabled | Disable radio | boolean | false |  |
-| value | According to value for comparison, to determine whether the selected | any | - |  |
+| autoFocus | get focus when component mounted | boolean | false | - |
+| checked | Specifies whether the radio is selected. | boolean | - | - |
+| defaultChecked | Specifies the initial state: whether or not the radio is selected. | boolean | false | - |
+| disabled | Disable radio | boolean | false | - |
+| value | According to value for comparison, to determine whether the selected | any | - | - |
 
 ### RadioGroup
 
@@ -29,14 +29,14 @@ Radio group can wrap a group of `Radio`。
 
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
-| defaultValue | Default selected value | any | - |  |
-| disabled | Disable all radio buttons | boolean | false |  |
-| name | The `name` property of all `input[type="radio"]` children | string | - |  |
-| options | set children optional | string\[] \| Array&lt;{ label: string value: string disabled?: boolean }> | - |  |
-| size | size for radio button style | `large` \| `default` \| `small` | `default` |  |
-| value | Used for setting the currently selected value. | any | - |  |
-| onChange | The callback function that is triggered when the state changes. | Function(e:Event) | - |  |
-| buttonStyle | style type of radio button | `outline` \| `solid` | `outline` | 3.7.0 |
+| defaultValue | Default selected value | any | - | - |
+| disabled | Disable all radio buttons | boolean | false | - |
+| name | The `name` property of all `input[type="radio"]` children | string | - | - |
+| options | set children optional | string\[] \| Array&lt;{ label: string value: string disabled?: boolean }> | - | - |
+| size | size for radio button style | `large` \| `default` \| `small` | `default` | - |
+| value | Used for setting the currently selected value. | any | - | - |
+| onChange | The callback function that is triggered when the state changes. | Function(e:Event) | - | - |
+| buttonStyle | style type of radio button | `outline` \| `solid` | `outline` | - |
 
 ## Methods
 
@@ -44,5 +44,5 @@ Radio group can wrap a group of `Radio`。
 
 | Name    | Description  | Version |
 | ------- | ------------ | ------- |
-| blur()  | remove focus |         |
-| focus() | get focus    |         |
+| blur()  | remove focus | -       |
+| focus() | get focus    | -       |

--- a/components/radio/index.zh-CN.md
+++ b/components/radio/index.zh-CN.md
@@ -16,33 +16,33 @@ title: Radio
 
 ### Radio
 
-| 参数           | 说明                              | 类型    | 默认值 | 版本 |
-| -------------- | --------------------------------- | ------- | ------ | ---- |
-| autoFocus      | 自动获取焦点                      | boolean | false  | -    |
-| checked        | 指定当前是否选中                  | boolean | false  | -    |
-| defaultChecked | 初始是否选中                      | boolean | false  | -    |
-| value          | 根据 value 进行比较，判断是否选中 | any     | -      | -    |
+| 参数           | 说明                              | 类型    | 默认值 |
+| -------------- | --------------------------------- | ------- | ------ |
+| autoFocus      | 自动获取焦点                      | boolean | false  |
+| checked        | 指定当前是否选中                  | boolean | false  |
+| defaultChecked | 初始是否选中                      | boolean | false  |
+| value          | 根据 value 进行比较，判断是否选中 | any     |        |
 
 ### RadioGroup
 
 单选框组合，用于包裹一组 `Radio`。
 
-| 参数 | 说明 | 类型 | 默认值 | 版本 |
-| --- | --- | --- | --- | --- |
-| defaultValue | 默认选中的值 | any | - | - |
-| disabled | 禁选所有子单选器 | boolean | false | - |
-| name | RadioGroup 下所有 `input[type="radio"]` 的 `name` 属性 | string | - | - |
-| options | 以配置形式设置子元素 | string\[] \| Array&lt;{ label: string value: string disabled?: boolean }> | - | - |
-| size | 大小，只对按钮样式生效 | `large` \| `default` \| `small` | `default` | - |
-| value | 用于设置当前选中的值 | any | - | - |
-| onChange | 选项变化时的回调函数 | Function(e:Event) | - | - |
-| buttonStyle | RadioButton 的风格样式，目前有描边和填色两种风格 | `outline` \| `solid` | `outline` | - |
+| 参数 | 说明 | 类型 | 默认值 |
+| --- | --- | --- | --- |
+| defaultValue | 默认选中的值 | any |  |
+| disabled | 禁选所有子单选器 | boolean | false |
+| name | RadioGroup 下所有 `input[type="radio"]` 的 `name` 属性 | string |  |
+| options | 以配置形式设置子元素 | string\[] \| Array&lt;{ label: string value: string disabled?: boolean }> |  |
+| size | 大小，只对按钮样式生效 | `large` \| `default` \| `small` | `default` |
+| value | 用于设置当前选中的值 | any |  |
+| onChange | 选项变化时的回调函数 | Function(e:Event) |  |
+| buttonStyle | RadioButton 的风格样式，目前有描边和填色两种风格 | `outline` \| `solid` | `outline` |
 
 ## 方法
 
 ### Radio
 
-| 名称    | 描述     | 版本 |
-| ------- | -------- | ---- |
-| blur()  | 移除焦点 | -    |
-| focus() | 获取焦点 | -    |
+| 名称    | 描述     |
+| ------- | -------- |
+| blur()  | 移除焦点 |
+| focus() | 获取焦点 |

--- a/components/radio/index.zh-CN.md
+++ b/components/radio/index.zh-CN.md
@@ -18,10 +18,10 @@ title: Radio
 
 | 参数           | 说明                              | 类型    | 默认值 | 版本 |
 | -------------- | --------------------------------- | ------- | ------ | ---- |
-| autoFocus      | 自动获取焦点                      | boolean | false  |      |
-| checked        | 指定当前是否选中                  | boolean | false  |      |
-| defaultChecked | 初始是否选中                      | boolean | false  |      |
-| value          | 根据 value 进行比较，判断是否选中 | any     | -      |      |
+| autoFocus      | 自动获取焦点                      | boolean | false  | -    |
+| checked        | 指定当前是否选中                  | boolean | false  | -    |
+| defaultChecked | 初始是否选中                      | boolean | false  | -    |
+| value          | 根据 value 进行比较，判断是否选中 | any     | -      | -    |
 
 ### RadioGroup
 
@@ -29,14 +29,14 @@ title: Radio
 
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
-| defaultValue | 默认选中的值 | any | - |  |
-| disabled | 禁选所有子单选器 | boolean | false | 3.6.5 |
-| name | RadioGroup 下所有 `input[type="radio"]` 的 `name` 属性 | string | - |  |
-| options | 以配置形式设置子元素 | string\[] \| Array&lt;{ label: string value: string disabled?: boolean }> | - |  |
-| size | 大小，只对按钮样式生效 | `large` \| `default` \| `small` | `default` |  |
-| value | 用于设置当前选中的值 | any | - |  |
-| onChange | 选项变化时的回调函数 | Function(e:Event) | - |  |
-| buttonStyle | RadioButton 的风格样式，目前有描边和填色两种风格 | `outline` \| `solid` | `outline` | 3.7.0 |
+| defaultValue | 默认选中的值 | any | - | - |
+| disabled | 禁选所有子单选器 | boolean | false | - |
+| name | RadioGroup 下所有 `input[type="radio"]` 的 `name` 属性 | string | - | - |
+| options | 以配置形式设置子元素 | string\[] \| Array&lt;{ label: string value: string disabled?: boolean }> | - | - |
+| size | 大小，只对按钮样式生效 | `large` \| `default` \| `small` | `default` | - |
+| value | 用于设置当前选中的值 | any | - | - |
+| onChange | 选项变化时的回调函数 | Function(e:Event) | - | - |
+| buttonStyle | RadioButton 的风格样式，目前有描边和填色两种风格 | `outline` \| `solid` | `outline` | - |
 
 ## 方法
 
@@ -44,5 +44,5 @@ title: Radio
 
 | 名称    | 描述     | 版本 |
 | ------- | -------- | ---- |
-| blur()  | 移除焦点 |      |
-| focus() | 获取焦点 |      |
+| blur()  | 移除焦点 | -    |
+| focus() | 获取焦点 | -    |

--- a/components/rate/index.en-US.md
+++ b/components/rate/index.en-US.md
@@ -13,28 +13,28 @@ Rate component.
 
 ## API
 
-| Property | Description | type | Default | Version |
-| --- | --- | --- | --- | --- |
-| allowClear | whether to allow clear when click again | boolean | true | - |
-| allowHalf | whether to allow semi selection | boolean | false | - |
-| autoFocus | get focus when component mounted | boolean | false | - |
-| character | custom character of rate | ReactNode | `<Icon type="star" />` | - |
-| className | custom class name of rate | string | - | - |
-| count | star count | number | 5 | - |
-| defaultValue | default value | number | 0 | - |
-| disabled | read only, unable to interact | boolean | false | - |
-| style | custom style object of rate | object | - | - |
-| tooltips | Customize tooltip by each character | string\[] | - | - |
-| value | current value | number | - | - |
-| onBlur | callback when component lose focus | Function() | - | - |
-| onChange | callback when select value | Function(value: number) | - | - |
-| onFocus | callback when component get focus | Function() | - | - |
-| onHoverChange | callback when hover item | Function(value: number) | - | - |
-| onKeyDown | callback when keydown on component | Function(event) | - | - |
+| Property | Description | type | Default |
+| --- | --- | --- | --- |
+| allowClear | whether to allow clear when click again | boolean | true |
+| allowHalf | whether to allow semi selection | boolean | false |
+| autoFocus | get focus when component mounted | boolean | false |
+| character | custom character of rate | ReactNode | `<Icon type="star" />` |
+| className | custom class name of rate | string |  |
+| count | star count | number | 5 |
+| defaultValue | default value | number | 0 |
+| disabled | read only, unable to interact | boolean | false |
+| style | custom style object of rate | object |  |
+| tooltips | Customize tooltip by each character | string\[] |  |
+| value | current value | number |  |
+| onBlur | callback when component lose focus | Function() |  |
+| onChange | callback when select value | Function(value: number) |  |
+| onFocus | callback when component get focus | Function() |  |
+| onHoverChange | callback when hover item | Function(value: number) |  |
+| onKeyDown | callback when keydown on component | Function(event) |  |
 
 ## Methods
 
-| Name    | Description  | Version |
-| ------- | ------------ | ------- |
-| blur()  | remove focus | -       |
-| focus() | get focus    | -       |
+| Name    | Description  |
+| ------- | ------------ |
+| blur()  | remove focus |
+| focus() | get focus    |

--- a/components/rate/index.en-US.md
+++ b/components/rate/index.en-US.md
@@ -15,26 +15,26 @@ Rate component.
 
 | Property | Description | type | Default | Version |
 | --- | --- | --- | --- | --- |
-| allowClear | whether to allow clear when click again | boolean | true | 3.1.0 |
-| allowHalf | whether to allow semi selection | boolean | false |  |
-| autoFocus | get focus when component mounted | boolean | false |  |
-| character | custom character of rate | ReactNode | `<Icon type="star" />` |  |
-| className | custom class name of rate | string | - |  |
-| count | star count | number | 5 |  |
-| defaultValue | default value | number | 0 |  |
-| disabled | read only, unable to interact | boolean | false |  |
-| style | custom style object of rate | object | - |  |
-| tooltips | Customize tooltip by each character | string\[] | - | 3.12.0 |
-| value | current value | number | - |  |
-| onBlur | callback when component lose focus | Function() | - |  |
-| onChange | callback when select value | Function(value: number) | - |  |
-| onFocus | callback when component get focus | Function() | - |  |
-| onHoverChange | callback when hover item | Function(value: number) | - |  |
-| onKeyDown | callback when keydown on component | Function(event) | - |  |
+| allowClear | whether to allow clear when click again | boolean | true | - |
+| allowHalf | whether to allow semi selection | boolean | false | - |
+| autoFocus | get focus when component mounted | boolean | false | - |
+| character | custom character of rate | ReactNode | `<Icon type="star" />` | - |
+| className | custom class name of rate | string | - | - |
+| count | star count | number | 5 | - |
+| defaultValue | default value | number | 0 | - |
+| disabled | read only, unable to interact | boolean | false | - |
+| style | custom style object of rate | object | - | - |
+| tooltips | Customize tooltip by each character | string\[] | - | - |
+| value | current value | number | - | - |
+| onBlur | callback when component lose focus | Function() | - | - |
+| onChange | callback when select value | Function(value: number) | - | - |
+| onFocus | callback when component get focus | Function() | - | - |
+| onHoverChange | callback when hover item | Function(value: number) | - | - |
+| onKeyDown | callback when keydown on component | Function(event) | - | - |
 
 ## Methods
 
 | Name    | Description  | Version |
 | ------- | ------------ | ------- |
-| blur()  | remove focus |         |
-| focus() | get focus    |         |
+| blur()  | remove focus | -       |
+| focus() | get focus    | -       |

--- a/components/rate/index.zh-CN.md
+++ b/components/rate/index.zh-CN.md
@@ -14,28 +14,28 @@ title: Rate
 
 ## API
 
-| 属性 | 说明 | 类型 | 默认值 | 版本 |
-| --- | --- | --- | --- | --- |
-| allowClear | 是否允许再次点击后清除 | boolean | true | - |
-| allowHalf | 是否允许半选 | boolean | false | - |
-| autoFocus | 自动获取焦点 | boolean | false | - |
-| character | 自定义字符 | ReactNode | `<Icon type="star" />` | - |
-| className | 自定义样式类名 | string | - | - |
-| count | star 总数 | number | 5 | - |
-| defaultValue | 默认值 | number | 0 | - |
-| disabled | 只读，无法进行交互 | boolean | false | - |
-| style | 自定义样式对象 | object | - | - |
-| tooltips | 自定义每项的提示信息 | string\[] | - | - |
-| value | 当前数，受控值 | number | - | - |
-| onBlur | 失去焦点时的回调 | Function() | - | - |
-| onChange | 选择时的回调 | Function(value: number) | - | - |
-| onFocus | 获取焦点时的回调 | Function() | - | - |
-| onHoverChange | 鼠标经过时数值变化的回调 | Function(value: number) | - | - |
-| onKeyDown | 按键回调 | Function(event) | - | - |
+| 属性          | 说明                     | 类型                    | 默认值                 |
+| ------------- | ------------------------ | ----------------------- | ---------------------- |
+| allowClear    | 是否允许再次点击后清除   | boolean                 | true                   |
+| allowHalf     | 是否允许半选             | boolean                 | false                  |
+| autoFocus     | 自动获取焦点             | boolean                 | false                  |
+| character     | 自定义字符               | ReactNode               | `<Icon type="star" />` |
+| className     | 自定义样式类名           | string                  |                        |
+| count         | star 总数                | number                  | 5                      |
+| defaultValue  | 默认值                   | number                  | 0                      |
+| disabled      | 只读，无法进行交互       | boolean                 | false                  |
+| style         | 自定义样式对象           | object                  |                        |
+| tooltips      | 自定义每项的提示信息     | string\[]               |                        |
+| value         | 当前数，受控值           | number                  |                        |
+| onBlur        | 失去焦点时的回调         | Function()              |                        |
+| onChange      | 选择时的回调             | Function(value: number) |                        |
+| onFocus       | 获取焦点时的回调         | Function()              |                        |
+| onHoverChange | 鼠标经过时数值变化的回调 | Function(value: number) |                        |
+| onKeyDown     | 按键回调                 | Function(event)         |                        |
 
 ## 方法
 
-| 名称    | 描述     | 版本 |
-| ------- | -------- | ---- |
-| blur()  | 移除焦点 | -    |
-| focus() | 获取焦点 | -    |
+| 名称    | 描述     |
+| ------- | -------- |
+| blur()  | 移除焦点 |
+| focus() | 获取焦点 |

--- a/components/rate/index.zh-CN.md
+++ b/components/rate/index.zh-CN.md
@@ -16,26 +16,26 @@ title: Rate
 
 | 属性 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
-| allowClear | 是否允许再次点击后清除 | boolean | true | 3.1.0 |
-| allowHalf | 是否允许半选 | boolean | false |  |
-| autoFocus | 自动获取焦点 | boolean | false |  |
-| character | 自定义字符 | ReactNode | `<Icon type="star" />` |  |
-| className | 自定义样式类名 | string | - |  |
-| count | star 总数 | number | 5 |  |
-| defaultValue | 默认值 | number | 0 |  |
-| disabled | 只读，无法进行交互 | boolean | false |  |
-| style | 自定义样式对象 | object | - |  |
-| tooltips | 自定义每项的提示信息 | string\[] | - | 3.12.0 |
-| value | 当前数，受控值 | number | - |  |
-| onBlur | 失去焦点时的回调 | Function() | - |  |
-| onChange | 选择时的回调 | Function(value: number) | - |  |
-| onFocus | 获取焦点时的回调 | Function() | - |  |
-| onHoverChange | 鼠标经过时数值变化的回调 | Function(value: number) | - |  |
-| onKeyDown | 按键回调 | Function(event) | - |  |
+| allowClear | 是否允许再次点击后清除 | boolean | true | - |
+| allowHalf | 是否允许半选 | boolean | false | - |
+| autoFocus | 自动获取焦点 | boolean | false | - |
+| character | 自定义字符 | ReactNode | `<Icon type="star" />` | - |
+| className | 自定义样式类名 | string | - | - |
+| count | star 总数 | number | 5 | - |
+| defaultValue | 默认值 | number | 0 | - |
+| disabled | 只读，无法进行交互 | boolean | false | - |
+| style | 自定义样式对象 | object | - | - |
+| tooltips | 自定义每项的提示信息 | string\[] | - | - |
+| value | 当前数，受控值 | number | - | - |
+| onBlur | 失去焦点时的回调 | Function() | - | - |
+| onChange | 选择时的回调 | Function(value: number) | - | - |
+| onFocus | 获取焦点时的回调 | Function() | - | - |
+| onHoverChange | 鼠标经过时数值变化的回调 | Function(value: number) | - | - |
+| onKeyDown | 按键回调 | Function(event) | - | - |
 
 ## 方法
 
 | 名称    | 描述     | 版本 |
 | ------- | -------- | ---- |
-| blur()  | 移除焦点 |      |
-| focus() | 获取焦点 |      |
+| blur()  | 移除焦点 | -    |
+| focus() | 获取焦点 | -    |

--- a/components/switch/index.en-US.md
+++ b/components/switch/index.en-US.md
@@ -15,21 +15,21 @@ Switching Selector.
 
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
-| autoFocus | get focus when component mounted | boolean | false |  |
-| checked | determine whether the `Switch` is checked | boolean | false |  |
-| checkedChildren | content to be shown when the state is checked | string\|ReactNode |  |  |
-| defaultChecked | to set the initial state | boolean | false |  |
-| disabled | Disable switch | boolean | false |  |
-| loading | loading state of switch | boolean | false |  |
-| size | the size of the `Switch`, options: `default` `small` | string | default |  |
-| unCheckedChildren | content to be shown when the state is unchecked | string\|ReactNode |  |  |
-| onChange | trigger when the checked state is changing | Function(checked: boolean, event: Event) |  |  |
-| onClick | trigger when clicked | Function(checked: boolean, event: Event) |  | 3.13.0 |
-| className | additional class to Switch | string | - | 3.10.1 |
+| autoFocus | get focus when component mounted | boolean | false | - |
+| checked | determine whether the `Switch` is checked | boolean | false | - |
+| checkedChildren | content to be shown when the state is checked | string\|ReactNode | - | - |
+| defaultChecked | to set the initial state | boolean | false | - |
+| disabled | Disable switch | boolean | false | - |
+| loading | loading state of switch | boolean | false | - |
+| size | the size of the `Switch`, options: `default` `small` | string | default | - |
+| unCheckedChildren | content to be shown when the state is unchecked | string\|ReactNode | - | - |
+| onChange | trigger when the checked state is changing | Function(checked: boolean, event: Event) | - | - |
+| onClick | trigger when clicked | Function(checked: boolean, event: Event) | - | - |
+| className | additional class to Switch | string | - | - |
 
 ## Methods
 
 | Name    | Description  | Version |
 | ------- | ------------ | ------- |
-| blur()  | remove focus |         |
-| focus() | get focus    |         |
+| blur()  | remove focus | -       |
+| focus() | get focus    | -       |

--- a/components/switch/index.en-US.md
+++ b/components/switch/index.en-US.md
@@ -13,23 +13,23 @@ Switching Selector.
 
 ## API
 
-| Property | Description | Type | Default | Version |
-| --- | --- | --- | --- | --- |
-| autoFocus | get focus when component mounted | boolean | false | - |
-| checked | determine whether the `Switch` is checked | boolean | false | - |
-| checkedChildren | content to be shown when the state is checked | string\|ReactNode | - | - |
-| defaultChecked | to set the initial state | boolean | false | - |
-| disabled | Disable switch | boolean | false | - |
-| loading | loading state of switch | boolean | false | - |
-| size | the size of the `Switch`, options: `default` `small` | string | default | - |
-| unCheckedChildren | content to be shown when the state is unchecked | string\|ReactNode | - | - |
-| onChange | trigger when the checked state is changing | Function(checked: boolean, event: Event) | - | - |
-| onClick | trigger when clicked | Function(checked: boolean, event: Event) | - | - |
-| className | additional class to Switch | string | - | - |
+| Property | Description | Type | Default |
+| --- | --- | --- | --- |
+| autoFocus | get focus when component mounted | boolean | false |
+| checked | determine whether the `Switch` is checked | boolean | false |
+| checkedChildren | content to be shown when the state is checked | string\|ReactNode |  |
+| defaultChecked | to set the initial state | boolean | false |
+| disabled | Disable switch | boolean | false |
+| loading | loading state of switch | boolean | false |
+| size | the size of the `Switch`, options: `default` `small` | string | default |
+| unCheckedChildren | content to be shown when the state is unchecked | string\|ReactNode |  |
+| onChange | trigger when the checked state is changing | Function(checked: boolean, event: Event) |  |
+| onClick | trigger when clicked | Function(checked: boolean, event: Event) |  |
+| className | additional class to Switch | string |  |
 
 ## Methods
 
-| Name    | Description  | Version |
-| ------- | ------------ | ------- |
-| blur()  | remove focus | -       |
-| focus() | get focus    | -       |
+| Name    | Description  |
+| ------- | ------------ |
+| blur()  | remove focus |
+| focus() | get focus    |

--- a/components/switch/index.zh-CN.md
+++ b/components/switch/index.zh-CN.md
@@ -16,21 +16,21 @@ title: Switch
 
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
-| autoFocus | 组件自动获取焦点 | boolean | false | 3.2.2 |
-| checked | 指定当前是否选中 | boolean | false |  |
-| checkedChildren | 选中时的内容 | string\|ReactNode |  |  |
-| defaultChecked | 初始是否选中 | boolean | false |  |
-| disabled | 是否禁用 | boolean | false | 3.2.2 |
-| loading | 加载中的开关 | boolean | false |  |
-| size | 开关大小，可选值：`default` `small` | string | default |  |
-| unCheckedChildren | 非选中时的内容 | string\|ReactNode |  |  |
-| onChange | 变化时回调函数 | Function(checked: boolean, event: Event) |  |  |
-| onClick | 点击时回调函数 | Function(checked: boolean, event: Event) |  | 3.13.0 |
-| className | Switch 器类名 | string | - | 3.10.1 |
+| autoFocus | 组件自动获取焦点 | boolean | false | - |
+| checked | 指定当前是否选中 | boolean | false | - |
+| checkedChildren | 选中时的内容 | string\|ReactNode | - | - |
+| defaultChecked | 初始是否选中 | boolean | false | - |
+| disabled | 是否禁用 | boolean | false | - |
+| loading | 加载中的开关 | boolean | false | - |
+| size | 开关大小，可选值：`default` `small` | string | default | - |
+| unCheckedChildren | 非选中时的内容 | string\|ReactNode | - | - |
+| onChange | 变化时回调函数 | Function(checked: boolean, event: Event) | - | - |
+| onClick | 点击时回调函数 | Function(checked: boolean, event: Event) | - | - |
+| className | Switch 器类名 | string | - | - |
 
 ## 方法
 
 | 名称    | 描述     | 版本 |
 | ------- | -------- | ---- |
-| blur()  | 移除焦点 |      |
-| focus() | 获取焦点 |      |
+| blur()  | 移除焦点 | -    |
+| focus() | 获取焦点 | -    |

--- a/components/switch/index.zh-CN.md
+++ b/components/switch/index.zh-CN.md
@@ -14,23 +14,23 @@ title: Switch
 
 ## API
 
-| 参数 | 说明 | 类型 | 默认值 | 版本 |
-| --- | --- | --- | --- | --- |
-| autoFocus | 组件自动获取焦点 | boolean | false | - |
-| checked | 指定当前是否选中 | boolean | false | - |
-| checkedChildren | 选中时的内容 | string\|ReactNode | - | - |
-| defaultChecked | 初始是否选中 | boolean | false | - |
-| disabled | 是否禁用 | boolean | false | - |
-| loading | 加载中的开关 | boolean | false | - |
-| size | 开关大小，可选值：`default` `small` | string | default | - |
-| unCheckedChildren | 非选中时的内容 | string\|ReactNode | - | - |
-| onChange | 变化时回调函数 | Function(checked: boolean, event: Event) | - | - |
-| onClick | 点击时回调函数 | Function(checked: boolean, event: Event) | - | - |
-| className | Switch 器类名 | string | - | - |
+| 参数 | 说明 | 类型 | 默认值 |
+| --- | --- | --- | --- |
+| autoFocus | 组件自动获取焦点 | boolean | false |
+| checked | 指定当前是否选中 | boolean | false |
+| checkedChildren | 选中时的内容 | string\|ReactNode |  |
+| defaultChecked | 初始是否选中 | boolean | false |
+| disabled | 是否禁用 | boolean | false |
+| loading | 加载中的开关 | boolean | false |
+| size | 开关大小，可选值：`default` `small` | string | default |
+| unCheckedChildren | 非选中时的内容 | string\|ReactNode |  |
+| onChange | 变化时回调函数 | Function(checked: boolean, event: Event) |  |
+| onClick | 点击时回调函数 | Function(checked: boolean, event: Event) |  |
+| className | Switch 器类名 | string |  |
 
 ## 方法
 
-| 名称    | 描述     | 版本 |
-| ------- | -------- | ---- |
-| blur()  | 移除焦点 | -    |
-| focus() | 获取焦点 | -    |
+| 名称    | 描述     |
+| ------- | -------- |
+| blur()  | 移除焦点 |
+| focus() | 获取焦点 |


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue https://github.com/ant-design/ant-design/issues/19815

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed


-----
[View rendered components/input-number/index.en-US.md](https://github.com/qhanw/ant-design/blob/docs-clean-version/components/input-number/index.en-US.md)
[View rendered components/input-number/index.zh-CN.md](https://github.com/qhanw/ant-design/blob/docs-clean-version/components/input-number/index.zh-CN.md)
[View rendered components/input/demo/autosize-textarea.md](https://github.com/qhanw/ant-design/blob/docs-clean-version/components/input/demo/autosize-textarea.md)
[View rendered components/input/demo/password-input.md](https://github.com/qhanw/ant-design/blob/docs-clean-version/components/input/demo/password-input.md)
[View rendered components/input/demo/search-input.md](https://github.com/qhanw/ant-design/blob/docs-clean-version/components/input/demo/search-input.md)
[View rendered components/input/index.en-US.md](https://github.com/qhanw/ant-design/blob/docs-clean-version/components/input/index.en-US.md)
[View rendered components/mentions/index.en-US.md](https://github.com/qhanw/ant-design/blob/docs-clean-version/components/mentions/index.en-US.md)
[View rendered components/mentions/index.en-US.md](https://github.com/qhanw/ant-design/blob/docs-clean-version/components/mentions/index.en-US.md.md)
[View rendered components/mentions/index.zh-CN.md](https://github.com/qhanw/ant-design/blob/docs-clean-version/components/mentions/index.zh-CN.md)
[View rendered components/radio/index.en-US.md](https://github.com/qhanw/ant-design/blob/docs-clean-version/components/radio/index.en-US.md)
[View rendered components/radio/index.zh-CN.md](https://github.com/qhanw/ant-design/blob/docs-clean-version/components/radio/index.zh-CN.md)
[View rendered components/rate/index.en-US.md](https://github.com/qhanw/ant-design/blob/docs-clean-version/components/rate/index.en-US.md)
[View rendered components/rate/index.zh-CN.md](https://github.com/qhanw/ant-design/blob/docs-clean-version/components/rate/index.zh-CN.md)
[View rendered components/switch/index.en-US.md](https://github.com/qhanw/ant-design/blob/docs-clean-version/components/switch/index.en-US.md)
[View rendered components/switch/index.zh-CN.md](https://github.com/qhanw/ant-design/blob/docs-clean-version/components/switch/index.zh-CN.md)