### PR TITLE
feat: change link button color

### DIFF
--- a/components/button/style/mixin.less
+++ b/components/button/style/mixin.less
@@ -227,7 +227,7 @@
 }
 // link button style
 .btn-link() {
-  .button-variant-other(@link-color, transparent, transparent);
+  .button-variant-other(@btn-default-color, transparent, transparent);
   box-shadow: none;
   &:hover,
   &:focus,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

none

### 💡 Background and solution

Before:

<img width="279" alt="image" src="https://user-images.githubusercontent.com/507615/69524377-dae75880-0fa0-11ea-9423-ebfddef05b68.png">

After:

<img width="305" alt="image" src="https://user-images.githubusercontent.com/507615/69524399-eaff3800-0fa0-11ea-9d53-b6b4d7e9753f.png">

---

Link type button is usually used as none-border button with primary button and default button. The neutral color of button text could be more fit to this situation. For instance, the more `...` button should not be primary color when dropdown is invisible:

<img width="288" alt="image" src="https://user-images.githubusercontent.com/507615/69524536-3580b480-0fa1-11ea-8735-02de7fa6d520.png">

<img width="369" alt="image" src="https://user-images.githubusercontent.com/507615/69524546-3c0f2c00-0fa1-11ea-9ac1-8daf48ebc440.png">

---

链接按钮 `<Button type="link" />` 常用于无边框的按钮，放在主按钮和次按钮背后。**原先的默认色是链接色，放在一起很不和谐**，这里修正为中性色，hover 后变成链接主色。一个常见的用例是 `...` 更多按钮，默认应为和次按钮一样的灰色为文字，hover 才变成主色，用于标记下拉菜单激活状态。

<img width="288" alt="image" src="https://user-images.githubusercontent.com/507615/69524536-3580b480-0fa1-11ea-8735-02de7fa6d520.png">

<img width="369" alt="image" src="https://user-images.githubusercontent.com/507615/69524546-3c0f2c00-0fa1-11ea-9ac1-8daf48ebc440.png">

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Optimize Button `type="link"` to neutral color defaultly. |
| 🇨🇳 Chinese | 更新链接按钮的默认色彩为灰色。 |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed