### PR TITLE
fix(Spin): should not be render default indicator when indicator value is null

### DIFF
--- a/components/spin/__tests__/__snapshots__/index.test.js.snap
+++ b/components/spin/__tests__/__snapshots__/index.test.js.snap
@@ -1,5 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Spin if indicator set null should not be render default indicator 1`] = `
+<Spin
+  indicator={null}
+  size="default"
+  spinning={true}
+  wrapperClassName=""
+>
+  <div
+    className="ant-spin ant-spin-spinning"
+  />
+</Spin>
+`;
+
 exports[`Spin should render custom indicator when it's set 1`] = `
 <div
   class="ant-spin ant-spin-spinning"

--- a/components/spin/__tests__/index.test.js
+++ b/components/spin/__tests__/index.test.js
@@ -38,4 +38,9 @@ describe('Spin', () => {
     wrapper.setProps({ spinning: true });
     expect(wrapper.instance().state.spinning).toBe(true);
   });
+
+  it('if indicator set null should not be render default indicator', () => {
+    const wrapper = mount(<Spin indicator={null} />);
+    expect(wrapper).toMatchSnapshot();
+  });
 });

--- a/components/spin/index.tsx
+++ b/components/spin/index.tsx
@@ -7,7 +7,7 @@ import { ConfigConsumer, ConfigConsumerProps } from '../config-provider';
 import { tuple } from '../_util/type';
 
 const SpinSizes = tuple('small', 'default', 'large');
-export type SpinSize = (typeof SpinSizes)[number];
+export type SpinSize = typeof SpinSizes[number];
 export type SpinIndicator = React.ReactElement<HTMLElement>;
 
 export interface SpinProps {
@@ -33,6 +33,12 @@ let defaultIndicator: React.ReactNode = null;
 function renderIndicator(prefixCls: string, props: SpinProps): React.ReactNode {
   const { indicator } = props;
   const dotClassName = `${prefixCls}-dot`;
+
+  // should not be render default indicator when indicator value is null
+  if (indicator === null) {
+    return null;
+  }
+
   if (React.isValidElement(indicator)) {
     return React.cloneElement(indicator, {
       className: classNames(indicator.props.className, dotClassName),


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
Fixes https://github.com/ant-design/ant-design/issues/19940

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Fix Spin render default `indicator` when it is null       |
| 🇨🇳 Chinese |修复 Spin 在 `indicator` 属性为 `null` 时，渲染默认的 `indicator` |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
