### PR TITLE
feat: Add expandText to Typography ellipsis

### DIFF
--- a/components/typography/Base.tsx
+++ b/components/typography/Base.tsx
@@ -39,6 +39,7 @@ interface EllipsisConfig {
   rows?: number;
   expandable?: boolean;
   onExpand?: () => void;
+  expandText?: string;
 }
 
 export interface BlockProps extends TypographyProps {
@@ -311,9 +312,10 @@ class Base extends React.Component<InternalBlockProps & ConfigConsumerProps, Bas
   }
 
   renderExpand(forceRender?: boolean) {
-    const { expandable } = this.getEllipsis();
+    const { expandable, expandText } = this.getEllipsis();
     const { prefixCls } = this.props;
     const { expanded, isEllipsis } = this.state;
+    const text = expandText || this.expandStr;
 
     if (!expandable) return null;
 
@@ -325,9 +327,9 @@ class Base extends React.Component<InternalBlockProps & ConfigConsumerProps, Bas
         key="expand"
         className={`${prefixCls}-expand`}
         onClick={this.onExpandClick}
-        aria-label={this.expandStr}
+        aria-label={text}
       >
-        {this.expandStr}
+        {text}
       </a>
     );
   }

--- a/components/typography/__tests__/index.test.js
+++ b/components/typography/__tests__/index.test.js
@@ -132,6 +132,25 @@ describe('Typography', () => {
         expect(wrapper.find('p').text()).toEqual(fullStr);
       });
 
+      it('should add expand text', () => {
+        const onExpand = jest.fn();
+        const expandText = 'show more';
+        const wrapper = mount(
+          <Base
+            ellipsis={{ expandable: true, onExpand, expandText }}
+            component="p"
+            copyable
+            editable
+          >
+            {fullStr}
+          </Base>,
+        );
+
+        jest.runAllTimers();
+        wrapper.update();
+        expect(wrapper.find('.ant-typography-expand').text()).toEqual(expandText);
+      });
+
       it('can use css ellipsis', () => {
         const wrapper = mount(<Base ellipsis component="p" />);
         expect(wrapper.find('.ant-typography-ellipsis-single-line').length).toBeTruthy();

--- a/components/typography/demo/ellipsis.md
+++ b/components/typography/demo/ellipsis.md
@@ -29,7 +29,7 @@ ReactDOM.render(
       language for background applications, is refined by Ant UED Team.
     </Paragraph>
 
-    <Paragraph ellipsis={{ rows: 3, expandable: true }}>
+    <Paragraph ellipsis={{ rows: 3, expandable: true, expandText: 'show more' }}>
       Ant Design, a design language for background applications, is refined by Ant UED Team. Ant
       Design, a design language for background applications, is refined by Ant UED Team. Ant Design,
       a design language for background applications, is refined by Ant UED Team. Ant Design, a

--- a/components/typography/index.en-US.md
+++ b/components/typography/index.en-US.md
@@ -39,7 +39,7 @@ Basic text writing, including headings, body text, lists, and more.
 | delete | Deleted line style | boolean | false | 3.14.0 |
 | disabled | Disabled content | boolean | false | 3.14.0 |
 | editable | Editable. Can control edit state when is object | boolean \| { editing: boolean, onStart: Function, onChange: Function(string) } | false | 3.14.0 |
-| ellipsis | Display ellipsis when text overflows. Can configure rows and expandable by using object | boolean \| { rows: number, expandable: boolean, onExpand: Function } | false | 3.14.0 |
+| ellipsis | Display ellipsis when text overflows. Can configure rows and expandable by using object | boolean \| { rows: number, expandable: boolean, onExpand: Function, expandText: string } | false | 3.14.0 |
 | level | Set content importance. Match with `h1`, `h2`, `h3`, `h4` | number: `1`, `2`, `3`, `4` | 1 | 3.14.0 |
 | mark | Marked style | boolean | false | 3.14.0 |
 | underline | Underlined style | boolean | false | 3.14.0 |
@@ -55,7 +55,7 @@ Basic text writing, including headings, body text, lists, and more.
 | delete | Deleted line style | boolean | false | 3.14.0 |
 | disabled | Disabled content | boolean | false | 3.14.0 |
 | editable | Editable. Can control edit state when is object | boolean \| { editing: boolean, onStart: Function, onChange: Function(string) } | false | 3.14.0 |
-| ellipsis | Display ellipsis when text overflows. Can configure rows and expandable by using object | boolean \| { rows: number, expandable: boolean, onExpand: Function } | false | 3.14.0 |
+| ellipsis | Display ellipsis when text overflows. Can configure rows and expandable by using object | boolean \| { rows: number, expandable: boolean, onExpand: Function, expandText: string } | false | 3.14.0 |
 | mark | Marked style | boolean | false | 3.14.0 |
 | underline | Underlined style | boolean | false | 3.14.0 |
 | onChange | Trigger when user edits the content | Function(string) | - | 3.14.0 |

--- a/components/typography/index.zh-CN.md
+++ b/components/typography/index.zh-CN.md
@@ -37,7 +37,7 @@ cols: 1
 | delete | 添加删除线样式 | boolean | false | 3.14.0 |
 | disabled | 禁用文本 | boolean | false | 3.14.0 |
 | editable | 是否可编辑，为对象时可对编辑进行控制 | boolean \| { editing: boolean, onStart: Function, onChange: Function(string) } | false | 3.14.0 |
-| ellipsis | 自动溢出省略，为对象时可设置省略行数与是否可展开等 | boolean \| { rows: number, expandable: boolean, onExpand: Function } | false | 3.14.0 |
+| ellipsis | 自动溢出省略，为对象时可设置省略行数与是否可展开等 | boolean \| { rows: number, expandable: boolean, onExpand: Function, expandText: string } | false | 3.14.0 |
 | level | 重要程度，相当于 `h1`、`h2`、`h3`、`h4` | number: `1`, `2`, `3`, `4` | 1 | 3.14.0 |
 | mark | 添加标记样式 | boolean | false | 3.14.0 |
 | underline | 添加下划线样式 | boolean | false | 3.14.0 |
@@ -52,7 +52,7 @@ cols: 1
 | delete | 添加删除线样式 | boolean | false | 3.14.0 |
 | disabled | 禁用文本 | boolean | false | 3.14.0 |
 | editable | 是否可编辑，为对象时可对编辑进行控制 | boolean \| { editing: boolean, onStart: Function, onChange: Function(string) } | false | 3.14.0 |
-| ellipsis | 自动溢出省略，为对象时可设置省略行数与是否可展开等 | boolean \| { rows: number, expandable: boolean, onExpand: Function } | false | 3.14.0 |
+| ellipsis | 自动溢出省略，为对象时可设置省略行数与是否可展开等 | boolean \| { rows: number, expandable: boolean, onExpand: Function, expandText: string } | false | 3.14.0 |
 | mark | 添加标记样式 | boolean | false | 3.14.0 |
 | underline | 添加下划线样式 | boolean | false | 3.14.0 |
 | onChange | 当用户提交编辑内容时触发 | Function(string) | - | 3.14.0 |


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

1. Today you cannot change the wording for the `expand` link in the typography component when you are using the expandable ellipsis feature.
2. 
<img width="709" alt="Screen Shot 2019-11-28 at 5 29 46 PM" src="https://user-images.githubusercontent.com/15618249/69879887-94427880-1296-11ea-92f2-7dd64a1617ee.png">

3. Fixed the issue by adding an optional property that can be passed to `ellipsis` called `expandText` which will override the expand text provided in the locale files.

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->
- No breaking changes.

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered CHANGELOG.en-US.md](https://github.com/rghattas/ant-design/blob/master/CHANGELOG.en-US.md)
[View rendered CHANGELOG.zh-CN.md](https://github.com/rghattas/ant-design/blob/master/CHANGELOG.zh-CN.md)
[View rendered README.md](https://github.com/rghattas/ant-design/blob/master/README.md)
[View rendered components/auto-complete/index.en-US.md](https://github.com/rghattas/ant-design/blob/master/components/auto-complete/index.en-US.md)
[View rendered components/config-provider/index.en-US.md](https://github.com/rghattas/ant-design/blob/master/components/config-provider/index.en-US.md)
[View rendered components/drawer/demo/form-in-drawer.md](https://github.com/rghattas/ant-design/blob/master/components/drawer/demo/form-in-drawer.md)
[View rendered components/form/index.en-US.md](https://github.com/rghattas/ant-design/blob/master/components/form/index.en-US.md)
[View rendered components/form/index.zh-CN.md](https://github.com/rghattas/ant-design/blob/master/components/form/index.zh-CN.md)
[View rendered components/menu/index.en-US.md](https://github.com/rghattas/ant-design/blob/master/components/menu/index.en-US.md)
[View rendered components/menu/index.zh-CN.md](https://github.com/rghattas/ant-design/blob/master/components/menu/index.zh-CN.md)
[View rendered components/message/demo/update.md](https://github.com/rghattas/ant-design/blob/master/components/message/demo/update.md)
[View rendered components/notification/demo/placement.md](https://github.com/rghattas/ant-design/blob/master/components/notification/demo/placement.md)
[View rendered components/select/index.en-US.md](https://github.com/rghattas/ant-design/blob/master/components/select/index.en-US.md)
[View rendered components/skeleton/index.zh-CN.md](https://github.com/rghattas/ant-design/blob/master/components/skeleton/index.zh-CN.md)

-----
[View rendered components/typography/demo/ellipsis.md](https://github.com/rghattas/ant-design/blob/feature/components/typography/demo/ellipsis.md)
[View rendered components/typography/index.en-US.md](https://github.com/rghattas/ant-design/blob/feature/components/typography/index.en-US.md)
[View rendered components/typography/index.zh-CN.md](https://github.com/rghattas/ant-design/blob/feature/components/typography/index.zh-CN.md)