### PR TITLE
fix(#19579): the textarea clear icon covered by textarea's scroll bar

### DIFF
--- a/components/input/ClearableLabeledInput.tsx
+++ b/components/input/ClearableLabeledInput.tsx
@@ -162,8 +162,9 @@ class ClearableLabeledInput extends React.Component<ClearableInputProps | Cleara
     const affixWrapperCls = classNames(
       className,
       `${prefixCls}-affix-wrapper`,
-      `${prefixCls}-affix-wrapper-textarea-with-clear-btn`,
-      { [`${prefixCls}-affix-wrapper-textarea-scroll-bar-with-clear-btn`]: hasVerticalScrollBar },
+      hasVerticalScrollBar
+        ? `${prefixCls}-affix-wrapper-textarea-scroll-bar-with-clear-btn`
+        : `${prefixCls}-affix-wrapper-textarea-with-clear-btn`,
     );
     return (
       <span className={affixWrapperCls} style={style}>

--- a/components/input/ClearableLabeledInput.tsx
+++ b/components/input/ClearableLabeledInput.tsx
@@ -44,16 +44,21 @@ interface ClearableTextAreaProps extends BasicProps {
   hasVerticalScrollBar: boolean;
 }
 
-class ClearableLabeledInput extends React.Component<ClearableInputProps & ClearableTextAreaProps> {
+class ClearableLabeledInput extends React.Component<ClearableInputProps | ClearableTextAreaProps> {
   renderClearIcon(prefixCls: string) {
-    const { allowClear, value, disabled, inputType, handleReset } = this.props;
+    const { allowClear, value, disabled, inputType, handleReset, hasVerticalScrollBar } = this
+      .props as ClearableInputProps & ClearableTextAreaProps;
     if (!allowClear || disabled || value === undefined || value === null || value === '') {
       return null;
     }
-    const className =
-      inputType === ClearableInputType[0]
-        ? `${prefixCls}-textarea-clear-icon`
-        : `${prefixCls}-clear-icon`;
+    let className;
+    if (inputType === ClearableInputType[0] && hasVerticalScrollBar) {
+      className = `${prefixCls}-textarea-scroll-bar-clear-icon`;
+    } else if (inputType === ClearableInputType[0]) {
+      className = `${prefixCls}-textarea-clear-icon`;
+    } else {
+      className = `${prefixCls}-clear-icon`;
+    }
     return (
       <Icon
         type="close-circle"
@@ -66,7 +71,7 @@ class ClearableLabeledInput extends React.Component<ClearableInputProps & Cleara
   }
 
   renderSuffix(prefixCls: string) {
-    const { suffix, allowClear } = this.props;
+    const { suffix, allowClear } = this.props as ClearableInputProps;
     if (suffix || allowClear) {
       return (
         <span className={`${prefixCls}-suffix`}>
@@ -79,7 +84,7 @@ class ClearableLabeledInput extends React.Component<ClearableInputProps & Cleara
   }
 
   renderLabeledIcon(prefixCls: string, element: React.ReactElement<any>) {
-    const props = this.props;
+    const props = this.props as ClearableInputProps;
     const suffix = this.renderSuffix(prefixCls);
     if (!hasPrefixSuffix(props)) {
       return React.cloneElement(element, {
@@ -111,7 +116,7 @@ class ClearableLabeledInput extends React.Component<ClearableInputProps & Cleara
   }
 
   renderInputWithLabel(prefixCls: string, labeledElement: React.ReactElement<any>) {
-    const { addonBefore, addonAfter, style, size, className } = this.props;
+    const { addonBefore, addonAfter, style, size, className } = this.props as ClearableInputProps;
     // Not wrap when there is not addons
     if (!addonBefore && !addonAfter) {
       return labeledElement;
@@ -147,7 +152,8 @@ class ClearableLabeledInput extends React.Component<ClearableInputProps & Cleara
   }
 
   renderTextAreaWithClearIcon(prefixCls: string, element: React.ReactElement<any>) {
-    const { value, allowClear, className, style } = this.props;
+    const { value, allowClear, className, style, hasVerticalScrollBar } = this
+      .props as ClearableTextAreaProps;
     if (!allowClear) {
       return React.cloneElement(element, {
         value,
@@ -157,6 +163,7 @@ class ClearableLabeledInput extends React.Component<ClearableInputProps & Cleara
       className,
       `${prefixCls}-affix-wrapper`,
       `${prefixCls}-affix-wrapper-textarea-with-clear-btn`,
+      { [`${prefixCls}-affix-wrapper-textarea-scroll-bar-with-clear-btn`]: hasVerticalScrollBar },
     );
     return (
       <span className={affixWrapperCls} style={style}>

--- a/components/input/ClearableLabeledInput.tsx
+++ b/components/input/ClearableLabeledInput.tsx
@@ -16,7 +16,7 @@ export function hasPrefixSuffix(props: InputProps | ClearableInputProps) {
  */
 interface BasicProps {
   prefixCls: string;
-  inputType: (typeof ClearableInputType)[number];
+  inputType: typeof ClearableInputType[number];
   value?: any;
   defaultValue?: any;
   allowClear?: boolean;
@@ -31,14 +31,20 @@ interface BasicProps {
  * This props only for input.
  */
 interface ClearableInputProps extends BasicProps {
-  size?: (typeof InputSizes)[number];
+  size?: typeof InputSizes[number];
   suffix?: React.ReactNode;
   prefix?: React.ReactNode;
   addonBefore?: React.ReactNode;
   addonAfter?: React.ReactNode;
 }
+/**
+ * This props only for textarea.
+ */
+interface ClearableTextAreaProps extends BasicProps {
+  hasVerticalScrollBar: boolean;
+}
 
-class ClearableLabeledInput extends React.Component<ClearableInputProps> {
+class ClearableLabeledInput extends React.Component<ClearableInputProps & ClearableTextAreaProps> {
   renderClearIcon(prefixCls: string) {
     const { allowClear, value, disabled, inputType, handleReset } = this.props;
     if (!allowClear || disabled || value === undefined || value === null || value === '') {

--- a/components/input/TextArea.tsx
+++ b/components/input/TextArea.tsx
@@ -68,11 +68,13 @@ class TextArea extends React.Component<TextAreaProps, TextAreaState> {
 
   handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     const { textArea } = this.resizableTextArea;
-    if (textArea.scrollWidth > textArea.clientWidth) {
+
+    if (textArea.scrollHeight > textArea.clientHeight) {
       this.setState({ hasVerticalScrollBar: true });
     } else {
       this.setState({ hasVerticalScrollBar: false });
     }
+
     this.setValue(e.target.value, () => {
       this.resizableTextArea.resizeTextarea();
     });

--- a/components/input/TextArea.tsx
+++ b/components/input/TextArea.tsx
@@ -18,6 +18,7 @@ export interface TextAreaProps extends HTMLTextareaProps {
 
 export interface TextAreaState {
   value: any;
+  hasVerticalScrollBar: boolean;
 }
 
 class TextArea extends React.Component<TextAreaProps, TextAreaState> {
@@ -30,6 +31,7 @@ class TextArea extends React.Component<TextAreaProps, TextAreaState> {
     const value = typeof props.value === 'undefined' ? props.defaultValue : props.value;
     this.state = {
       value,
+      hasVerticalScrollBar: false,
     };
   }
 
@@ -65,6 +67,10 @@ class TextArea extends React.Component<TextAreaProps, TextAreaState> {
   };
 
   handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const { textArea } = this.resizableTextArea;
+    if (textArea.scrollWidth > textArea.clientWidth) {
+      this.setState({ hasVerticalScrollBar: true });
+    }
     this.setValue(e.target.value, () => {
       this.resizableTextArea.resizeTextarea();
     });
@@ -102,7 +108,7 @@ class TextArea extends React.Component<TextAreaProps, TextAreaState> {
   };
 
   renderComponent = ({ getPrefixCls }: ConfigConsumerProps) => {
-    const { value } = this.state;
+    const { value, hasVerticalScrollBar } = this.state;
     const { prefixCls: customizePrefixCls } = this.props;
     const prefixCls = getPrefixCls('input', customizePrefixCls);
     return (
@@ -110,6 +116,7 @@ class TextArea extends React.Component<TextAreaProps, TextAreaState> {
         {...this.props}
         prefixCls={prefixCls}
         inputType="text"
+        hasVerticalScrollBar={hasVerticalScrollBar}
         value={fixControlledValue(value)}
         element={this.renderTextArea(prefixCls)}
         handleReset={this.handleReset}

--- a/components/input/TextArea.tsx
+++ b/components/input/TextArea.tsx
@@ -70,6 +70,8 @@ class TextArea extends React.Component<TextAreaProps, TextAreaState> {
     const { textArea } = this.resizableTextArea;
     if (textArea.scrollWidth > textArea.clientWidth) {
       this.setState({ hasVerticalScrollBar: true });
+    } else {
+      this.setState({ hasVerticalScrollBar: false });
     }
     this.setValue(e.target.value, () => {
       this.resizableTextArea.resizeTextarea();

--- a/components/input/TextArea.tsx
+++ b/components/input/TextArea.tsx
@@ -69,11 +69,7 @@ class TextArea extends React.Component<TextAreaProps, TextAreaState> {
   handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     const { textArea } = this.resizableTextArea;
 
-    if (textArea.scrollHeight > textArea.clientHeight) {
-      this.setState({ hasVerticalScrollBar: true });
-    } else {
-      this.setState({ hasVerticalScrollBar: false });
-    }
+    this.setState({ hasVerticalScrollBar: textArea.scrollHeight > textArea.clientHeight });
 
     this.setValue(e.target.value, () => {
       this.resizableTextArea.resizeTextarea();

--- a/components/input/style/index.less
+++ b/components/input/style/index.less
@@ -47,11 +47,13 @@
 }
 
 .@{ant-prefix}-input-textarea-clear-icon {
-  .clear-icon;
-  position: absolute;
-  top: 0;
-  right: 0;
+  .textarea-clear-icon;
   margin: 8px 8px 0 0;
 }
 
+.@{ant-prefix}-input-textarea-scroll-bar-clear-icon {
+  .textarea-clear-icon();
+  // https://github.com/ant-design/ant-design/issues/19579
+  margin: 8px 18px 0 0;
+}
 @import './search-input';

--- a/components/input/style/mixin.less
+++ b/components/input/style/mixin.less
@@ -425,6 +425,9 @@
   &.@{inputClass}-affix-wrapper-textarea-with-clear-btn .@{inputClass} {
     padding-right: 22px;
   }
+  &.@{inputClass}-affix-wrapper-textarea-scroll-bar-with-clear-btn .@{inputClass} {
+    padding-right: 32px;
+  }
 }
 
 .clear-icon() {
@@ -446,4 +449,10 @@
   + i {
     margin-left: 6px;
   }
+}
+.textarea-clear-icon() {
+  .clear-icon;
+  position: absolute;
+  top: 0;
+  right: 0;
 }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->
#19579 
### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->
If the textarea has a scroll bar, we set the margin-right of the clear button to 18px and the textarea padding-right to 32px.
### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |fix the textarea clear icon covered by textarea's scroll bar bug |
| 🇨🇳 Chinese |修复文本框清除按钮被文本框滚动条遮挡问题|

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
