### PR TITLE
fix: 🐛 Slider tooltip not aligned center

### DIFF
--- a/components/config-provider/__tests__/__snapshots__/components.test.js.snap
+++ b/components/config-provider/__tests__/__snapshots__/components.test.js.snap
@@ -11156,7 +11156,7 @@ exports[`ConfigProvider components Slider configProvider 1`] = `
   />
   <div>
     <div
-      class="config-tooltip  config-tooltip-placement-top "
+      class="config-tooltip config-slider-tooltip config-tooltip-placement-top "
     >
       <div
         class="config-tooltip-content"
@@ -11205,7 +11205,7 @@ exports[`ConfigProvider components Slider normal 1`] = `
   />
   <div>
     <div
-      class="ant-tooltip  ant-tooltip-placement-top "
+      class="ant-tooltip ant-slider-tooltip ant-tooltip-placement-top "
     >
       <div
         class="ant-tooltip-content"
@@ -11254,7 +11254,7 @@ exports[`ConfigProvider components Slider prefixCls 1`] = `
   />
   <div>
     <div
-      class="prefix-Slider-tooltip  prefix-Slider-tooltip-placement-top "
+      class="prefix-Slider-tooltip prefix-Slider-tooltip prefix-Slider-tooltip-placement-top "
     >
       <div
         class="prefix-Slider-tooltip-content"

--- a/components/slider/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/slider/__tests__/__snapshots__/demo.test.js.snap
@@ -949,7 +949,7 @@ exports[`renders ./components/slider/demo/show-tooltip.md correctly 1`] = `
   />
   <div>
     <div
-      class="ant-tooltip  ant-tooltip-placement-top "
+      class="ant-tooltip ant-slider-tooltip ant-tooltip-placement-top "
     >
       <div
         class="ant-tooltip-content"

--- a/components/slider/__tests__/__snapshots__/index.test.js.snap
+++ b/components/slider/__tests__/__snapshots__/index.test.js.snap
@@ -3,7 +3,7 @@
 exports[`Slider should show tooltip when hovering slider handler 1`] = `
 <div>
   <div
-    class="ant-tooltip  ant-tooltip-placement-top "
+    class="ant-tooltip ant-slider-tooltip ant-tooltip-placement-top "
   >
     <div
       class="ant-tooltip-content"
@@ -25,7 +25,7 @@ exports[`Slider should show tooltip when hovering slider handler 1`] = `
 exports[`Slider should show tooltip when hovering slider handler 2`] = `
 <div>
   <div
-    class="ant-tooltip  ant-tooltip-placement-top  ant-tooltip-hidden"
+    class="ant-tooltip ant-slider-tooltip ant-tooltip-placement-top  ant-tooltip-hidden"
   >
     <div
       class="ant-tooltip-content"

--- a/components/slider/index.tsx
+++ b/components/slider/index.tsx
@@ -22,10 +22,12 @@ interface HandleGeneratorInfo {
   index: number;
   rest: any[];
 }
-export type HandleGeneratorFn = (
-  tooltipPrefixCls: string,
-  info: HandleGeneratorInfo,
-) => React.ReactNode;
+
+export type HandleGeneratorFn = (config: {
+  tooltipPrefixCls?: string;
+  prefixCls?: string;
+  info: HandleGeneratorInfo;
+}) => React.ReactNode;
 
 export interface SliderProps {
   prefixCls?: string;
@@ -82,10 +84,11 @@ export default class Slider extends React.Component<SliderProps, SliderState> {
     }));
   };
 
-  handleWithTooltip: HandleGeneratorFn = (
-    tooltipPrefixCls: string,
-    { value, dragging, index, ...restProps },
-  ) => {
+  handleWithTooltip: HandleGeneratorFn = ({
+    tooltipPrefixCls,
+    prefixCls,
+    info: { value, dragging, index, ...restProps },
+  }) => {
     const { tipFormatter, tooltipVisible, tooltipPlacement, getTooltipPopupContainer } = this.props;
     const { visibles } = this.state;
     const isTipFormatter = tipFormatter ? visibles[index] || dragging : false;
@@ -98,6 +101,7 @@ export default class Slider extends React.Component<SliderProps, SliderState> {
         placement={tooltipPlacement || 'top'}
         transitionName="zoom-down"
         key={index}
+        overlayClassName={`${prefixCls}-tooltip`}
         getPopupContainer={getTooltipPopupContainer || (() => document.body)}
       >
         <RcHandle
@@ -136,7 +140,13 @@ export default class Slider extends React.Component<SliderProps, SliderState> {
         <RcRange
           {...restProps}
           ref={this.saveSlider}
-          handle={(info: HandleGeneratorInfo) => this.handleWithTooltip(tooltipPrefixCls, info)}
+          handle={(info: HandleGeneratorInfo) =>
+            this.handleWithTooltip({
+              tooltipPrefixCls,
+              prefixCls,
+              info,
+            })
+          }
           prefixCls={prefixCls}
           tooltipPrefixCls={tooltipPrefixCls}
         />
@@ -146,7 +156,13 @@ export default class Slider extends React.Component<SliderProps, SliderState> {
       <RcSlider
         {...restProps}
         ref={this.saveSlider}
-        handle={(info: HandleGeneratorInfo) => this.handleWithTooltip(tooltipPrefixCls, info)}
+        handle={(info: HandleGeneratorInfo) =>
+          this.handleWithTooltip({
+            tooltipPrefixCls,
+            prefixCls,
+            info,
+          })
+        }
         prefixCls={prefixCls}
         tooltipPrefixCls={tooltipPrefixCls}
       />

--- a/components/slider/style/index.less
+++ b/components/slider/style/index.less
@@ -187,4 +187,11 @@
       margin-bottom: -4px;
     }
   }
+
+  &-tooltip {
+    // https://github.com/ant-design/ant-design/issues/20014
+    .@{ant-prefix}-tooltip-inner {
+      min-width: unset;
+    }
+  }
 }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close #20014

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Slider tooltip text not align center. |
| 🇨🇳 Chinese | 修复 Slider 的 tooltip 内容没有居中的问题。 |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
