### PR TITLE
fix: 🐛 Table filterIcon bugs

### DIFF
--- a/components/table/__tests__/Table.filter.test.js
+++ b/components/table/__tests__/Table.filter.test.js
@@ -3,6 +3,7 @@ import React from 'react';
 import { render, mount } from 'enzyme';
 import Table from '..';
 import Input from '../../input';
+import Tooltip from '../../tooltip';
 import Button from '../../button';
 import ConfigProvider from '../../config-provider';
 
@@ -653,6 +654,21 @@ describe('Table.filter', () => {
       .first()
       .simulate('click');
     expect(wrapper.find('.ant-table-filter-icon').render()).toMatchSnapshot();
+  });
+
+  it('renders custom filter icon as string correctly', () => {
+    const filterIcon = () => 'string';
+    const wrapper = mount(
+      createTable({
+        columns: [
+          {
+            ...column,
+            filterIcon,
+          },
+        ],
+      }),
+    );
+    expect(wrapper.render()).toMatchSnapshot();
   });
 
   // https://github.com/ant-design/ant-design/issues/13028

--- a/components/table/__tests__/Table.filter.test.js
+++ b/components/table/__tests__/Table.filter.test.js
@@ -671,6 +671,25 @@ describe('Table.filter', () => {
     expect(wrapper.render()).toMatchSnapshot();
   });
 
+  it('renders custom filter icon with right Tooltip title', () => {
+    const filterIcon = () => (
+      <Tooltip title="title" visible>
+        Tooltip
+      </Tooltip>
+    );
+    const wrapper = mount(
+      createTable({
+        columns: [
+          {
+            ...column,
+            filterIcon,
+          },
+        ],
+      }),
+    );
+    expect(wrapper.render()).toMatchSnapshot();
+  });
+
   // https://github.com/ant-design/ant-design/issues/13028
   it('reset dropdown filter correctly', () => {
     class Demo extends React.Component {

--- a/components/table/__tests__/__snapshots__/Table.filter.test.js.snap
+++ b/components/table/__tests__/__snapshots__/Table.filter.test.js.snap
@@ -44,6 +44,113 @@ exports[`Table.filter renders custom content correctly 1`] = `
 </div>
 `;
 
+exports[`Table.filter renders custom filter icon as string correctly 1`] = `
+<div
+  class="ant-table-wrapper"
+>
+  <div
+    class="ant-spin-nested-loading"
+  >
+    <div
+      class="ant-spin-container"
+    >
+      <div
+        class="ant-table ant-table-default ant-table-scroll-position-left"
+      >
+        <div
+          class="ant-table-content"
+        >
+          <div
+            class="ant-table-body"
+          >
+            <table
+              class=""
+            >
+              <colgroup>
+                <col />
+              </colgroup>
+              <thead
+                class="ant-table-thead"
+              >
+                <tr>
+                  <th
+                    class="ant-table-column-has-actions ant-table-column-has-filters ant-table-row-cell-last"
+                  >
+                    <span
+                      class="ant-table-header-column"
+                    >
+                      <div>
+                        <span
+                          class="ant-table-column-title"
+                        >
+                          Name
+                        </span>
+                        <span
+                          class="ant-table-column-sorter"
+                        />
+                      </div>
+                    </span>
+                    <span
+                      class="ant-table-filter-icon ant-dropdown-trigger"
+                    >
+                      string
+                    </span>
+                  </th>
+                </tr>
+              </thead>
+              <tbody
+                class="ant-table-tbody"
+              >
+                <tr
+                  class="ant-table-row ant-table-row-level-0"
+                  data-row-key="0"
+                >
+                  <td
+                    class="ant-table-column-has-actions ant-table-column-has-filters"
+                  >
+                    Jack
+                  </td>
+                </tr>
+                <tr
+                  class="ant-table-row ant-table-row-level-0"
+                  data-row-key="1"
+                >
+                  <td
+                    class="ant-table-column-has-actions ant-table-column-has-filters"
+                  >
+                    Lucy
+                  </td>
+                </tr>
+                <tr
+                  class="ant-table-row ant-table-row-level-0"
+                  data-row-key="2"
+                >
+                  <td
+                    class="ant-table-column-has-actions ant-table-column-has-filters"
+                  >
+                    Tom
+                  </td>
+                </tr>
+                <tr
+                  class="ant-table-row ant-table-row-level-0"
+                  data-row-key="3"
+                >
+                  <td
+                    class="ant-table-column-has-actions ant-table-column-has-filters"
+                  >
+                    Jerry
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Table.filter renders custom filter icon correctly 1`] = `
 <span
   class="ant-table-filter-icon ant-table-filter-selected ant-dropdown-trigger"
@@ -62,6 +169,134 @@ exports[`Table.filter renders custom filter icon correctly 2`] = `
 >
   unfiltered
 </span>
+`;
+
+exports[`Table.filter renders custom filter icon with right Tooltip title 1`] = `
+<div
+  class="ant-table-wrapper"
+>
+  <div
+    class="ant-spin-nested-loading"
+  >
+    <div
+      class="ant-spin-container"
+    >
+      <div
+        class="ant-table ant-table-default ant-table-scroll-position-left"
+      >
+        <div
+          class="ant-table-content"
+        >
+          <div
+            class="ant-table-body"
+          >
+            <table
+              class=""
+            >
+              <colgroup>
+                <col />
+              </colgroup>
+              <thead
+                class="ant-table-thead"
+              >
+                <tr>
+                  <th
+                    class="ant-table-column-has-actions ant-table-column-has-filters ant-table-row-cell-last"
+                  >
+                    <span
+                      class="ant-table-header-column"
+                    >
+                      <div>
+                        <span
+                          class="ant-table-column-title"
+                        >
+                          Name
+                        </span>
+                        <span
+                          class="ant-table-column-sorter"
+                        />
+                      </div>
+                    </span>
+                    <span
+                      class="ant-tooltip-open ant-table-filter-icon ant-dropdown-trigger"
+                      style=""
+                    >
+                      Tooltip
+                    </span>
+                    <div>
+                      <div
+                        class="ant-tooltip ant-tooltip-placement-top zoom-big-fast-appear"
+                        style="left: -999px; top: -1003px; transform-origin: 50% 4px;"
+                      >
+                        <div
+                          class="ant-tooltip-content"
+                        >
+                          <div
+                            class="ant-tooltip-arrow"
+                          />
+                          <div
+                            class="ant-tooltip-inner"
+                            role="tooltip"
+                          >
+                            title
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </th>
+                </tr>
+              </thead>
+              <tbody
+                class="ant-table-tbody"
+              >
+                <tr
+                  class="ant-table-row ant-table-row-level-0"
+                  data-row-key="0"
+                >
+                  <td
+                    class="ant-table-column-has-actions ant-table-column-has-filters"
+                  >
+                    Jack
+                  </td>
+                </tr>
+                <tr
+                  class="ant-table-row ant-table-row-level-0"
+                  data-row-key="1"
+                >
+                  <td
+                    class="ant-table-column-has-actions ant-table-column-has-filters"
+                  >
+                    Lucy
+                  </td>
+                </tr>
+                <tr
+                  class="ant-table-row ant-table-row-level-0"
+                  data-row-key="2"
+                >
+                  <td
+                    class="ant-table-column-has-actions ant-table-column-has-filters"
+                  >
+                    Tom
+                  </td>
+                </tr>
+                <tr
+                  class="ant-table-row ant-table-row-level-0"
+                  data-row-key="3"
+                >
+                  <td
+                    class="ant-table-column-has-actions ant-table-column-has-filters"
+                  >
+                    Jerry
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
 `;
 
 exports[`Table.filter renders filter correctly 1`] = `

--- a/components/table/demo/custom-filter-panel.md
+++ b/components/table/demo/custom-filter-panel.md
@@ -90,24 +90,25 @@ class App extends React.Component {
         setTimeout(() => this.searchInput.select());
       }
     },
-    render: text => (
-    (this.state.searchedColumn === dataIndex) ?
-      <Highlighter
-        highlightStyle={{ backgroundColor: '#ffc069', padding: 0 }}
-        searchWords={[this.state.searchText]}
-        autoEscape
-        textToHighlight={text.toString()}
-      />
-      : text
-    ),
+    render: text =>
+      this.state.searchedColumn === dataIndex ? (
+        <Highlighter
+          highlightStyle={{ backgroundColor: '#ffc069', padding: 0 }}
+          searchWords={[this.state.searchText]}
+          autoEscape
+          textToHighlight={text.toString()}
+        />
+      ) : (
+        text
+      ),
   });
 
   handleSearch = (selectedKeys, confirm, dataIndex) => {
     confirm();
-    this.setState({ 
+    this.setState({
       searchText: selectedKeys[0],
       searchedColumn: dataIndex,
-      });
+    });
   };
 
   handleReset = clearFilters => {

--- a/components/table/filterDropdown.tsx
+++ b/components/table/filterDropdown.tsx
@@ -200,7 +200,7 @@ class FilterMenu<T> extends React.Component<FilterMenuProps<T>, FilterMenuState<
   renderFilterIcon = () => {
     const { column, locale, prefixCls, selectedKeys } = this.props;
     const filtered = selectedKeys && selectedKeys.length > 0;
-    let filterIcon = column.filterIcon as any;
+    let filterIcon = column.filterIcon;
     if (typeof filterIcon === 'function') {
       filterIcon = filterIcon(filtered);
     }
@@ -210,21 +210,27 @@ class FilterMenu<T> extends React.Component<FilterMenuProps<T>, FilterMenuState<
       [`${prefixCls}-open`]: this.getDropdownVisible(),
     });
 
-    return filterIcon ? (
-      React.cloneElement(filterIcon as any, {
+    if (!filterIcon) {
+      return (
+        <Icon
+          title={locale.filterTitle}
+          type="filter"
+          theme="filled"
+          className={dropdownIconClass}
+          onClick={stopPropagation}
+        />
+      );
+    }
+
+    if (React.isValidElement(filterIcon)) {
+      return React.cloneElement(filterIcon, {
         title: locale.filterTitle,
         className: classNames(`${prefixCls}-icon`, dropdownIconClass, filterIcon.props.className),
         onClick: stopPropagation,
-      })
-    ) : (
-      <Icon
-        title={locale.filterTitle}
-        type="filter"
-        theme="filled"
-        className={dropdownIconClass}
-        onClick={stopPropagation}
-      />
-    );
+      });
+    }
+
+    return <span className={classNames(`${prefixCls}-icon`, dropdownIconClass)}>{filterIcon}</span>;
   };
 
   renderMenuItem(item: ColumnFilterItem) {

--- a/components/table/filterDropdown.tsx
+++ b/components/table/filterDropdown.tsx
@@ -224,7 +224,7 @@ class FilterMenu<T> extends React.Component<FilterMenuProps<T>, FilterMenuState<
 
     if (React.isValidElement(filterIcon)) {
       return React.cloneElement(filterIcon, {
-        title: locale.filterTitle,
+        title: filterIcon.props.title || locale.filterTitle,
         className: classNames(`${prefixCls}-icon`, dropdownIconClass, filterIcon.props.className),
         onClick: stopPropagation,
       });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close #20049

### 💡 Background and solution

1. Fix #20049
2. Fix filterIcon render string or number or null will throw error.

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | - Fix Table `filterIcon` throws error when render string or number.<br />- Fix Table `filterIcon` show wrong title when returns Tooltip. |
| 🇨🇳 Chinese | - 修复 Table `filterIcon` 返回字符串或数字时报错的问题。<br />- 修复 Table `filterIcon` 返回 Tooltip 时显示了错误的 `title`。 |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/table/demo/custom-filter-panel.md](https://github.com/ant-design/ant-design/blob/fix-filter-icon/components/table/demo/custom-filter-panel.md)