### PR TITLE
chore: add entry to dist css files for the dark theme

### DIFF
--- a/index-dark.js
+++ b/index-dark.js
@@ -1,0 +1,2 @@
+require('./components/style/dark.less');
+require('./index');

--- a/package.json
+++ b/package.json
@@ -196,6 +196,7 @@
     "glob": "^7.1.4",
     "http-server": "^0.12.0",
     "husky": "^3.0.2",
+    "ignore-emit-webpack-plugin": "^2.0.2",
     "immutability-helper": "^3.0.0",
     "intersection-observer": "^0.7.0",
     "jest": "^24.8.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,7 +23,7 @@ function addLocales(webpackConfig) {
 }
 
 function addDarkTheme(webpackConfig) {
-  let packageName = 'antd-dark';
+  let packageName = 'antd.dark';
   if (webpackConfig.entry['antd.min']) {
     packageName += '.min';
   }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,6 +2,7 @@
 // This config is for building dist files
 const getWebpackConfig = require('@ant-design/tools/lib/getWebpackConfig');
 const PacktrackerPlugin = require('@packtracker/webpack-plugin');
+const IgnoreEmitPlugin = require('ignore-emit-webpack-plugin');
 
 const { webpack } = getWebpackConfig;
 
@@ -21,6 +22,16 @@ function addLocales(webpackConfig) {
   webpackConfig.output.filename = '[name].js';
 }
 
+function addDarkTheme(webpackConfig) {
+  let packageName = 'antd-dark';
+  if (webpackConfig.entry['antd.min']) {
+    packageName += '.min';
+  }
+  webpackConfig.entry[packageName] = './index-dark.js';
+  webpackConfig.output.filename = '[name].js';
+  webpackConfig.plugins.push(new IgnoreEmitPlugin(/dark(.min)?\.js(\.map)?$/));
+}
+
 function externalMoment(config) {
   config.externals.moment = {
     root: 'moment',
@@ -36,6 +47,7 @@ if (process.env.RUN_ENV === 'PRODUCTION') {
     ignoreMomentLocale(config);
     externalMoment(config);
     addLocales(config);
+    addDarkTheme(config);
     // skip codesandbox ci
     if (!process.env.CSB_REPO) {
       // https://docs.packtracker.io/uploading-your-webpack-stats/webpack-plugin


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [x] Other (about what?)

### 🔗 Related issue link

None

### 💡 Background and solution

Add a new webpack entry to dist the CSS files for the dark theme, and ignore to emit js entry files for the dark theme.

For maintainability, dark theme entry require the default entry directly rather than require styles like default entry again, it means, the emit ignored file `antd-dark(.min).js` will include all js module, but don't worry, only 5s more time to compile, see below.

#### Compare self require & require default

Device Info:
- CPU: 2.3 GHz Intel Core i5 (8th)
- Mem: 16 GB
- OS: macOS Mojave

| 🚩                     | Self require | Require default |
| ---------------------- | ------------ | --------------- |
| Progress Bar Total     | 58.77s       | 1.06m (63.6s)   | 
| Normal Child Process   | 58770ms      | 63409ms         |
| Min Child Process      | 83156ms      | 73739ms         |

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | --        |
| 🇨🇳 Chinese | --        |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
