### PR TITLE
fix: Editable Typography flush in Firefox 

### DIFF
--- a/components/typography/Editable.tsx
+++ b/components/typography/Editable.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import KeyCode from 'rc-util/lib/KeyCode';
+import classNames from 'classnames';
 import { polyfill } from 'react-lifecycles-compat';
 import Icon from '../icon';
 import TextArea from '../input/TextArea';
@@ -114,7 +115,7 @@ class Editable extends React.Component<EditableProps, EditableState> {
     const { prefixCls, 'aria-label': ariaLabel, className, style } = this.props;
 
     return (
-      <div className={`${prefixCls} ${prefixCls}-edit-content ${className}`} style={style}>
+      <div className={classNames(prefixCls, `${prefixCls}-edit-content`, className)} style={style}>
         <TextArea
           ref={this.setTextarea}
           value={current}

--- a/components/typography/demo/interactive.md
+++ b/components/typography/demo/interactive.md
@@ -7,11 +7,11 @@ title:
 
 ## zh-CN
 
-提供额外的交互能力。
+提供可编辑和可复制等额外的交互能力。
 
 ## en-US
 
-Provide additional interactive capacity.
+Provide additional interactive capacity of editable and copyable.
 
 ```jsx
 import { Typography } from 'antd';

--- a/components/typography/style/index.less
+++ b/components/typography/style/index.less
@@ -156,6 +156,11 @@
       color: @text-color-secondary;
       pointer-events: none;
     }
+
+    // Fix Editable Textarea flash in Firefox
+    textarea {
+      -moz-transition: none;
+    }
   }
 
   // list


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

none

### 💡 Background and solution

在 Firefox 下 Editable Typography 点击会闪一下，这里把 `-moz-transition` 干掉修复。

<img width="230" alt="image" src="https://user-images.githubusercontent.com/507615/70294388-3b3a8d80-181e-11ea-951a-ee55b46f1853.png">

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Editable Typography flush in Firefox.  |
| 🇨🇳 Chinese | 修复 Typography 可编辑组件在 Firefox 下闪动的问题。 |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/typography/demo/interactive.md](https://github.com/ant-design/ant-design/blob/fix-typography-style/components/typography/demo/interactive.md)