### PR TITLE
feat: Custom Table sort icon feature

### DIFF
--- a/Untitled
+++ b/Untitled
@@ -1,0 +1,1 @@
+Table columns={columns} dataSource={data} onChange={onChange} />

--- a/components/config-provider/__tests__/__snapshots__/components.test.js.snap
+++ b/components/config-provider/__tests__/__snapshots__/components.test.js.snap
@@ -8153,9 +8153,7 @@ exports[`ConfigProvider components Menu prefixCls 1`] = `
 
 exports[`ConfigProvider components Modal configProvider 1`] = `
 <div>
-  <div
-    class="config-modal-root"
-  >
+  <div>
     <div
       class="config-modal-mask"
     />
@@ -8247,9 +8245,7 @@ exports[`ConfigProvider components Modal configProvider 1`] = `
 
 exports[`ConfigProvider components Modal normal 1`] = `
 <div>
-  <div
-    class="ant-modal-root"
-  >
+  <div>
     <div
       class="ant-modal-mask"
     />
@@ -8341,9 +8337,7 @@ exports[`ConfigProvider components Modal normal 1`] = `
 
 exports[`ConfigProvider components Modal prefixCls 1`] = `
 <div>
-  <div
-    class="prefix-Modal-root"
-  >
+  <div>
     <div
       class="prefix-Modal-mask"
     />

--- a/components/modal/__tests__/__snapshots__/Modal.test.js.snap
+++ b/components/modal/__tests__/__snapshots__/Modal.test.js.snap
@@ -4,9 +4,7 @@ exports[`Modal render correctly 1`] = `
 <div>
   <div>
     <div>
-      <div
-        class="ant-modal-root"
-      >
+      <div>
         <div
           class="ant-modal-mask fade-appear"
         />
@@ -102,9 +100,7 @@ exports[`Modal render without footer 1`] = `
 <div>
   <div>
     <div>
-      <div
-        class="ant-modal-root"
-      >
+      <div>
         <div
           class="ant-modal-mask fade-appear"
         />
@@ -175,9 +171,7 @@ exports[`Modal render without footer 1`] = `
 `;
 
 exports[`Modal support closeIcon 1`] = `
-<div
-  class="ant-modal-root"
->
+<div>
   <div
     class="ant-modal-mask fade-appear"
   />

--- a/components/table/Table.tsx
+++ b/components/table/Table.tsx
@@ -1168,19 +1168,23 @@ class Table<T> extends React.Component<InternalTableProps<T>, TableState<T>> {
         const isAscend = isSortColumn && sortOrder === 'ascend';
         const isDescend = isSortColumn && sortOrder === 'descend';
 
+        const sortUpIcon = column.sortUpIcon !== undefined ? column.sortUpIcon : 'caret-up';
+        const themeUp = column.sortUpIcon !== undefined ? 'outlined' : 'filled';
         const ascend = sortDirections.indexOf('ascend') !== -1 && (
           <Icon
             className={`${prefixCls}-column-sorter-up ${isAscend ? 'on' : 'off'}`}
-            type="caret-up"
-            theme="filled"
+            type={sortUpIcon}
+            theme={themeUp}
           />
         );
 
+        const sortDownIcon = column.sortDownIcon !== undefined ? column.sortDownIcon : 'caret-down';
+        const themeDown = column.sortDownIcon !== undefined ? 'outlined' : 'filled';
         const descend = sortDirections.indexOf('descend') !== -1 && (
           <Icon
             className={`${prefixCls}-column-sorter-down ${isDescend ? 'on' : 'off'}`}
-            type="caret-down"
-            theme="filled"
+            type={sortDownIcon}
+            theme={themeDown}
           />
         );
 

--- a/components/table/__tests__/Table.sorterIcon.test.js
+++ b/components/table/__tests__/Table.sorterIcon.test.js
@@ -1,0 +1,710 @@
+/* eslint-disable react/no-multi-comp */
+import React from 'react';
+import { render, mount } from 'enzyme';
+import Table from '..';
+
+describe('Table.sorterIcon', () => {
+  const sorterFn = (a, b) => a.name[0].charCodeAt() - b.name[0].charCodeAt();
+
+  const column = {
+    title: 'Name',
+    dataIndex: 'name',
+    sorter: sorterFn,
+    sortUpIcon: 'arrow-up',
+    sortDownIcon: 'arrow-down',
+  };
+
+  const data = [
+    { key: 0, name: 'Jack' },
+    { key: 1, name: 'Lucy' },
+    { key: 2, name: 'Tom' },
+    { key: 3, name: 'Jerry' },
+  ];
+
+  function createTable(tableProps, columnProps = {}) {
+    return (
+      <Table
+        columns={[
+          {
+            ...column,
+            ...columnProps,
+          },
+        ]}
+        dataSource={data}
+        pagination={false}
+        {...tableProps}
+      />
+    );
+  }
+
+  function renderedNames(wrapper) {
+    return wrapper.find('TableRow').map(row => row.props().record.name);
+  }
+
+  it('renders sorter icon correctly', () => {
+    const wrapper = render(createTable());
+    expect(wrapper.find('thead')).toMatchSnapshot();
+  });
+
+  it('default sort order ascend', () => {
+    const wrapper = mount(
+      createTable(
+        {},
+        {
+          defaultSortOrder: 'ascend',
+        },
+      ),
+    );
+
+    expect(renderedNames(wrapper)).toEqual(['Jack', 'Jerry', 'Lucy', 'Tom']);
+  });
+
+  it('default sort order descend', () => {
+    const wrapper = mount(
+      createTable(
+        {},
+        {
+          defaultSortOrder: 'descend',
+        },
+      ),
+    );
+
+    expect(renderedNames(wrapper)).toEqual(['Tom', 'Lucy', 'Jack', 'Jerry']);
+  });
+
+  it('sort records', () => {
+    const wrapper = mount(createTable());
+
+    // ascend
+    wrapper.find('.ant-table-column-sorters').simulate('click');
+    expect(renderedNames(wrapper)).toEqual(['Jack', 'Jerry', 'Lucy', 'Tom']);
+
+    // descend
+    wrapper.find('.ant-table-column-sorters').simulate('click');
+    expect(renderedNames(wrapper)).toEqual(['Tom', 'Lucy', 'Jack', 'Jerry']);
+  });
+
+  it('can be controlled by sortOrder', () => {
+    const wrapper = mount(
+      createTable({
+        columns: [{ ...column, sortOrder: 'ascend' }],
+      }),
+    );
+    expect(renderedNames(wrapper)).toEqual(['Jack', 'Jerry', 'Lucy', 'Tom']);
+  });
+
+  it('provides sortOrder in the sorterFn', () => {
+    let actualSortOrder;
+    mount(
+      createTable(
+        {},
+        {
+          sortOrder: 'ascend',
+          sorter: (a, b, sortOrder) => {
+            actualSortOrder = sortOrder;
+            return sorterFn(a, b);
+          },
+        },
+      ),
+    );
+    expect(actualSortOrder).toEqual('ascend');
+  });
+
+  it('can update column sortOrder', () => {
+    const wrapper = mount(
+      createTable({
+        columns: [column],
+      }),
+    );
+    expect(renderedNames(wrapper)).toEqual(['Jack', 'Lucy', 'Tom', 'Jerry']);
+    wrapper.setProps({
+      columns: [{ ...column, sortOrder: 'ascend' }],
+    });
+    wrapper.update();
+    expect(renderedNames(wrapper)).toEqual(['Jack', 'Jerry', 'Lucy', 'Tom']);
+  });
+
+  it('fires change event', () => {
+    const handleChange = jest.fn();
+    const wrapper = mount(createTable({ onChange: handleChange }));
+
+    // ascent
+    wrapper.find('.ant-table-column-sorters').simulate('click');
+    const sorter1 = handleChange.mock.calls[0][2];
+    expect(sorter1.column.dataIndex).toBe('name');
+    expect(sorter1.order).toBe('ascend');
+    expect(sorter1.field).toBe('name');
+    expect(sorter1.columnKey).toBe('name');
+
+    wrapper.find('.ant-table-column-sorters').simulate('click');
+    const sorter2 = handleChange.mock.calls[1][2];
+    expect(sorter2.column.dataIndex).toBe('name');
+    expect(sorter2.order).toBe('descend');
+    expect(sorter2.field).toBe('name');
+    expect(sorter2.columnKey).toBe('name');
+
+    wrapper.find('.ant-table-column-sorters').simulate('click');
+    const sorter3 = handleChange.mock.calls[2][2];
+    expect(sorter3.column).toBe(undefined);
+    expect(sorter3.order).toBe(undefined);
+    expect(sorter3.field).toBe('name');
+    expect(sorter3.columnKey).toBe('name');
+  });
+
+  it('works with grouping columns in controlled mode', () => {
+    const columns = [
+      {
+        title: 'group',
+        key: 'group',
+        children: [
+          {
+            title: 'Name',
+            dataIndex: 'name',
+            key: 'name',
+            sorter: sorterFn,
+            sortOrder: 'descend',
+          },
+          {
+            title: 'Age',
+            dataIndex: 'age',
+            key: 'age',
+          },
+        ],
+      },
+    ];
+    const testData = [
+      { key: 0, name: 'Jack', age: 11 },
+      { key: 1, name: 'Lucy', age: 20 },
+      { key: 2, name: 'Tom', age: 21 },
+      { key: 3, name: 'Jerry', age: 22 },
+    ];
+    const wrapper = mount(<Table columns={columns} dataSource={testData} />);
+
+    expect(renderedNames(wrapper)).toEqual(['Tom', 'Lucy', 'Jack', 'Jerry']);
+  });
+
+  // https://github.com/ant-design/ant-design/issues/11246#issuecomment-405009167
+  it('Allow column title as render props with sortOrder argument', () => {
+    const title = ({ sortOrder }) => <div className="custom-title">{sortOrder}</div>;
+    const columns = [
+      {
+        title,
+        key: 'group',
+        sorter: true,
+      },
+    ];
+    const testData = [
+      { key: 0, name: 'Jack', age: 11 },
+      { key: 1, name: 'Lucy', age: 20 },
+      { key: 2, name: 'Tom', age: 21 },
+      { key: 3, name: 'Jerry', age: 22 },
+    ];
+    const wrapper = mount(<Table columns={columns} dataSource={testData} />);
+    expect(wrapper.find('.custom-title').text()).toEqual('');
+    wrapper.find('.ant-table-column-sorters').simulate('click');
+    expect(wrapper.find('.custom-title').text()).toEqual('ascend');
+    wrapper.find('.ant-table-column-sorters').simulate('click');
+    expect(wrapper.find('.custom-title').text()).toEqual('descend');
+  });
+
+  // https://github.com/ant-design/ant-design/pull/12264#discussion_r218053034
+  it('should sort from begining state when toggle from different columns', () => {
+    const columns = [
+      {
+        title: 'name',
+        dataIndex: 'name',
+        sorter: true,
+      },
+      {
+        title: 'age',
+        dataIndex: 'age',
+        sorter: true,
+      },
+    ];
+    const testData = [
+      { key: 0, name: 'Jack', age: 11 },
+      { key: 1, name: 'Lucy', age: 20 },
+      { key: 2, name: 'Tom', age: 21 },
+      { key: 3, name: 'Jerry', age: 22 },
+    ];
+    const wrapper = mount(<Table columns={columns} dataSource={testData} />);
+    const nameColumn = wrapper.find('.ant-table-column-sorters').at(0);
+    const ageColumn = wrapper.find('.ant-table-column-sorters').at(1);
+    // sort name
+    nameColumn.simulate('click');
+    expect(
+      nameColumn
+        .find('.ant-table-column-sorter-up')
+        .at(0)
+        .getDOMNode().className,
+    ).toContain(' on');
+    expect(
+      ageColumn
+        .find('.ant-table-column-sorter-up')
+        .at(0)
+        .getDOMNode().className,
+    ).toContain(' off');
+    // sort age
+    ageColumn.simulate('click');
+    expect(
+      nameColumn
+        .find('.ant-table-column-sorter-up')
+        .at(0)
+        .getDOMNode().className,
+    ).toContain(' off');
+    expect(
+      ageColumn
+        .find('.ant-table-column-sorter-up')
+        .at(0)
+        .getDOMNode().className,
+    ).toContain(' on');
+  });
+
+  // https://github.com/ant-design/ant-design/issues/12571
+  it('should toggle sort state when columns are put in render', () => {
+    const testData = [
+      { key: 0, name: 'Jack', age: 11 },
+      { key: 1, name: 'Lucy', age: 20 },
+      { key: 2, name: 'Tom', age: 21 },
+      { key: 3, name: 'Jerry', age: 22 },
+    ];
+    class TableTest extends React.Component {
+      state = {
+        pagination: {},
+      };
+
+      onChange = pagination => {
+        this.setState({ pagination });
+      };
+
+      render() {
+        const columns = [
+          {
+            title: 'name',
+            dataIndex: 'name',
+            sorter: true,
+          },
+        ];
+        const { pagination } = this.state;
+        return (
+          <Table
+            columns={columns}
+            pagination={pagination}
+            dataSource={testData}
+            onChange={this.onChange}
+          />
+        );
+      }
+    }
+
+    const wrapper = mount(<TableTest />);
+    const nameColumn = wrapper.find('.ant-table-column-sorters').at(0);
+    expect(
+      nameColumn
+        .find('.ant-table-column-sorter-up')
+        .at(0)
+        .getDOMNode().className,
+    ).toContain(' off');
+    expect(
+      nameColumn
+        .find('.ant-table-column-sorter-down')
+        .at(0)
+        .getDOMNode().className,
+    ).toContain(' off');
+    // sort name
+    nameColumn.simulate('click');
+    expect(
+      nameColumn
+        .find('.ant-table-column-sorter-up')
+        .at(0)
+        .getDOMNode().className,
+    ).toContain(' on');
+    expect(
+      nameColumn
+        .find('.ant-table-column-sorter-down')
+        .at(0)
+        .getDOMNode().className,
+    ).toContain(' off');
+    // sort name
+    nameColumn.simulate('click');
+    expect(
+      nameColumn
+        .find('.ant-table-column-sorter-up')
+        .at(0)
+        .getDOMNode().className,
+    ).toContain(' off');
+    expect(
+      nameColumn
+        .find('.ant-table-column-sorter-down')
+        .at(0)
+        .getDOMNode().className,
+    ).toContain(' on');
+    // sort name
+    nameColumn.simulate('click');
+    expect(
+      nameColumn
+        .find('.ant-table-column-sorter-up')
+        .at(0)
+        .getDOMNode().className,
+    ).toContain(' off');
+    expect(
+      nameColumn
+        .find('.ant-table-column-sorter-down')
+        .at(0)
+        .getDOMNode().className,
+    ).toContain(' off');
+  });
+
+  // https://github.com/ant-design/ant-design/issues/12737
+  // https://github.com/ant-design/ant-design/issues/19398
+  it('should toggle sort state when columns with non primitive properties are put in render', () => {
+    const testData = [
+      { key: 0, name: 'Jack', age: 11 },
+      { key: 1, name: 'Lucy', age: 20 },
+      { key: 2, name: 'Tom', age: 21 },
+      { key: 3, name: 'Jerry', age: 22 },
+    ];
+    class TableTest extends React.Component {
+      state = {
+        pagination: {},
+      };
+
+      onChange = pagination => {
+        this.setState({ pagination });
+      };
+
+      render() {
+        const columns = [
+          {
+            title: 'name',
+            dataIndex: 'name',
+            sorter: true,
+            render: text => text,
+            array: ['1', '2', 3],
+          },
+        ];
+        const { pagination } = this.state;
+        return (
+          <Table
+            columns={columns}
+            pagination={pagination}
+            dataSource={testData}
+            onChange={this.onChange}
+          />
+        );
+      }
+    }
+
+    const wrapper = mount(<TableTest />);
+    const nameColumn = wrapper.find('.ant-table-column-sorters').at(0);
+    expect(
+      nameColumn
+        .find('.ant-table-column-sorter-up')
+        .at(0)
+        .getDOMNode().className,
+    ).toContain(' off');
+    expect(
+      nameColumn
+        .find('.ant-table-column-sorter-down')
+        .at(0)
+        .getDOMNode().className,
+    ).toContain(' off');
+    // sort name
+    nameColumn.simulate('click');
+    expect(
+      nameColumn
+        .find('.ant-table-column-sorter-up')
+        .at(0)
+        .getDOMNode().className,
+    ).toContain(' on');
+    expect(
+      nameColumn
+        .find('.ant-table-column-sorter-down')
+        .at(0)
+        .getDOMNode().className,
+    ).toContain(' off');
+    // sort name
+    nameColumn.simulate('click');
+    expect(
+      nameColumn
+        .find('.ant-table-column-sorter-up')
+        .at(0)
+        .getDOMNode().className,
+    ).toContain(' off');
+    expect(
+      nameColumn
+        .find('.ant-table-column-sorter-down')
+        .at(0)
+        .getDOMNode().className,
+    ).toContain(' on');
+    // sort name
+    nameColumn.simulate('click');
+    expect(
+      nameColumn
+        .find('.ant-table-column-sorter-up')
+        .at(0)
+        .getDOMNode().className,
+    ).toContain(' off');
+    expect(
+      nameColumn
+        .find('.ant-table-column-sorter-down')
+        .at(0)
+        .getDOMNode().className,
+    ).toContain(' off');
+  });
+
+  // https://github.com/ant-design/ant-design/issues/12870
+  it('should toggle sort state when columns with key are put in render', () => {
+    const testData = [
+      { key: 0, name: 'Jack', age: 11 },
+      { key: 1, name: 'Lucy', age: 20 },
+      { key: 2, name: 'Tom', age: 21 },
+      { key: 3, name: 'Jerry', age: 22 },
+    ];
+    class TableTest extends React.Component {
+      state = {
+        pagination: {},
+      };
+
+      onChange = pagination => {
+        this.setState({ pagination });
+      };
+
+      render() {
+        const columns = [
+          {
+            title: 'name',
+            dataIndex: 'name',
+            sorter: true,
+            key: 'a',
+            style: {
+              fontSize: 18,
+            },
+          },
+        ];
+        const { pagination } = this.state;
+        return (
+          <Table
+            columns={columns}
+            pagination={pagination}
+            dataSource={testData}
+            onChange={this.onChange}
+          />
+        );
+      }
+    }
+
+    const wrapper = mount(<TableTest />);
+    const nameColumn = wrapper.find('.ant-table-column-sorters').at(0);
+    expect(
+      nameColumn
+        .find('.ant-table-column-sorter-up')
+        .at(0)
+        .getDOMNode().className,
+    ).toContain(' off');
+    expect(
+      nameColumn
+        .find('.ant-table-column-sorter-down')
+        .at(0)
+        .getDOMNode().className,
+    ).toContain(' off');
+    // sort name
+    nameColumn.simulate('click');
+    expect(
+      nameColumn
+        .find('.ant-table-column-sorter-up')
+        .at(0)
+        .getDOMNode().className,
+    ).toContain(' on');
+    expect(
+      nameColumn
+        .find('.ant-table-column-sorter-down')
+        .at(0)
+        .getDOMNode().className,
+    ).toContain(' off');
+    // sort name
+    nameColumn.simulate('click');
+    expect(
+      nameColumn
+        .find('.ant-table-column-sorter-up')
+        .at(0)
+        .getDOMNode().className,
+    ).toContain(' off');
+    expect(
+      nameColumn
+        .find('.ant-table-column-sorter-down')
+        .at(0)
+        .getDOMNode().className,
+    ).toContain(' on');
+    // sort name
+    nameColumn.simulate('click');
+    expect(
+      nameColumn
+        .find('.ant-table-column-sorter-up')
+        .at(0)
+        .getDOMNode().className,
+    ).toContain(' off');
+    expect(
+      nameColumn
+        .find('.ant-table-column-sorter-down')
+        .at(0)
+        .getDOMNode().className,
+    ).toContain(' off');
+  });
+
+  it('should first sort by descend, then ascend, then cancel sort', () => {
+    const wrapper = mount(
+      createTable({
+        sortDirections: ['descend', 'ascend'],
+      }),
+    );
+
+    // descend
+    wrapper.find('.ant-table-column-sorters').simulate('click');
+    expect(renderedNames(wrapper)).toEqual(['Tom', 'Lucy', 'Jack', 'Jerry']);
+
+    // ascend
+    wrapper.find('.ant-table-column-sorters').simulate('click');
+    expect(renderedNames(wrapper)).toEqual(['Jack', 'Jerry', 'Lucy', 'Tom']);
+
+    // cancel sort
+    wrapper.find('.ant-table-column-sorters').simulate('click');
+    expect(renderedNames(wrapper)).toEqual(['Jack', 'Lucy', 'Tom', 'Jerry']);
+  });
+
+  it('should first sort by descend, then cancel sort', () => {
+    const wrapper = mount(
+      createTable({
+        sortDirections: ['descend'],
+      }),
+    );
+
+    // descend
+    wrapper.find('.ant-table-column-sorters').simulate('click');
+    expect(renderedNames(wrapper)).toEqual(['Tom', 'Lucy', 'Jack', 'Jerry']);
+
+    // cancel sort
+    wrapper.find('.ant-table-column-sorters').simulate('click');
+    expect(renderedNames(wrapper)).toEqual(['Jack', 'Lucy', 'Tom', 'Jerry']);
+  });
+
+  it('should first sort by descend, then cancel sort. (column prop)', () => {
+    const wrapper = mount(
+      createTable(
+        {},
+        {
+          sortDirections: ['descend'],
+        },
+      ),
+    );
+
+    // descend
+    wrapper.find('.ant-table-column-sorters').simulate('click');
+    expect(renderedNames(wrapper)).toEqual(['Tom', 'Lucy', 'Jack', 'Jerry']);
+
+    // cancel sort
+    wrapper.find('.ant-table-column-sorters').simulate('click');
+    expect(renderedNames(wrapper)).toEqual(['Jack', 'Lucy', 'Tom', 'Jerry']);
+  });
+
+  it('pagination back', () => {
+    const onPageChange = jest.fn();
+    const onChange = jest.fn();
+
+    const wrapper = mount(
+      createTable({
+        pagination: {
+          pageSize: 2,
+          onChange: onPageChange,
+        },
+        onChange,
+      }),
+    );
+
+    wrapper.find('.ant-table-column-sorters').simulate('click');
+    expect(onChange.mock.calls[0][0].current).toBe(1);
+    expect(onPageChange.mock.calls[0][0]).toBe(1);
+  });
+
+  it('should support onHeaderCell in sort column', () => {
+    const onClick = jest.fn();
+    const wrapper = mount(
+      <Table columns={[{ title: 'title', onHeaderCell: () => ({ onClick }), sorter: true }]} />,
+    );
+    wrapper.find('th').simulate('click');
+    expect(onClick).toHaveBeenCalled();
+  });
+
+  it('could sort data with children', () => {
+    const wrapper = mount(
+      createTable(
+        {
+          dataSource: [
+            {
+              key: '1',
+              name: 'Brown',
+              children: [
+                {
+                  key: '2',
+                  name: 'Zoe',
+                },
+                {
+                  key: '3',
+                  name: 'Mike',
+                  children: [
+                    {
+                      key: '3-1',
+                      name: 'Petter',
+                    },
+                    {
+                      key: '3-2',
+                      name: 'Alex',
+                    },
+                  ],
+                },
+                {
+                  key: '4',
+                  name: 'Green',
+                },
+              ],
+            },
+          ],
+        },
+        {
+          defaultSortOrder: 'ascend',
+        },
+      ),
+    );
+
+    expect(renderedNames(wrapper)).toEqual(['Brown', 'Green', 'Mike', 'Alex', 'Petter', 'Zoe']);
+  });
+
+  // https://github.com/ant-design/ant-design/issues/19443
+  it('should not being inifinite loop when using Table.Column with sortOrder', () => {
+    class Demo extends React.Component {
+      componentDidMount() {
+        this.setState({});
+      }
+
+      render() {
+        return (
+          <Table dataSource={[]}>
+            <Table.Column title="Age" dataIndex="age" sorter sortOrder="ascend" key="age" />
+          </Table>
+        );
+      }
+    }
+    expect(() => {
+      mount(<Demo />);
+    }).not.toThrow();
+  });
+
+  it('should support defaultOrder in Column', () => {
+    const wrapper = mount(
+      <Table dataSource={[{ key: '1', age: 1 }]}>
+        <Table.Column title="Age" dataIndex="age" sorter defaultSortOrder="ascend" key="age" />
+      </Table>,
+    );
+    expect(wrapper.render()).toMatchSnapshot();
+  });
+});

--- a/components/table/__tests__/__snapshots__/Table.sorterIcon.test.js.snap
+++ b/components/table/__tests__/__snapshots__/Table.sorterIcon.test.js.snap
@@ -1,0 +1,264 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Table.sorterIcon renders sorter icon correctly 1`] = `
+<thead
+  class="ant-table-thead"
+>
+  <tr>
+    <th
+      class="ant-table-column-has-actions ant-table-column-has-sorters ant-table-row-cell-last"
+    >
+      <span
+        class="ant-table-header-column"
+      >
+        <div
+          class="ant-table-column-sorters"
+        >
+          <span
+            class="ant-table-column-title"
+          >
+            Name
+          </span>
+          <span
+            class="ant-table-column-sorter"
+          >
+            <div
+              class="ant-table-column-sorter-inner ant-table-column-sorter-inner-full"
+              title="Sort"
+            >
+              <i
+                aria-label="icon: arrow-up"
+                class="anticon anticon-arrow-up ant-table-column-sorter-up off"
+              >
+                <svg
+                  aria-hidden="true"
+                  class=""
+                  data-icon="arrow-up"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M868 545.5L536.1 163a31.96 31.96 0 0 0-48.3 0L156 545.5a7.97 7.97 0 0 0 6 13.2h81c4.6 0 9-2 12.1-5.5L474 300.9V864c0 4.4 3.6 8 8 8h60c4.4 0 8-3.6 8-8V300.9l218.9 252.3c3 3.5 7.4 5.5 12.1 5.5h81c6.8 0 10.5-8 6-13.2z"
+                  />
+                </svg>
+              </i>
+              <i
+                aria-label="icon: arrow-down"
+                class="anticon anticon-arrow-down ant-table-column-sorter-down off"
+              >
+                <svg
+                  aria-hidden="true"
+                  class=""
+                  data-icon="arrow-down"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M862 465.3h-81c-4.6 0-9 2-12.1 5.5L550 723.1V160c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v563.1L255.1 470.8c-3-3.5-7.4-5.5-12.1-5.5h-81c-6.8 0-10.5 8.1-6 13.2L487.9 861a31.96 31.96 0 0 0 48.3 0L868 478.5c4.5-5.2.8-13.2-6-13.2z"
+                  />
+                </svg>
+              </i>
+            </div>
+          </span>
+        </div>
+      </span>
+    </th>
+  </tr>
+</thead>
+`;
+
+exports[`Table.sorterIcon should support defaultOrder in Column 1`] = `
+<div
+  class="ant-table-wrapper"
+>
+  <div
+    class="ant-spin-nested-loading"
+  >
+    <div
+      class="ant-spin-container"
+    >
+      <div
+        class="ant-table ant-table-default ant-table-scroll-position-left"
+      >
+        <div
+          class="ant-table-content"
+        >
+          <div
+            class="ant-table-body"
+          >
+            <table
+              class=""
+            >
+              <colgroup>
+                <col />
+              </colgroup>
+              <thead
+                class="ant-table-thead"
+              >
+                <tr>
+                  <th
+                    class="ant-table-column-has-actions ant-table-column-has-sorters ant-table-column-sort ant-table-row-cell-last"
+                  >
+                    <span
+                      class="ant-table-header-column"
+                    >
+                      <div
+                        class="ant-table-column-sorters"
+                      >
+                        <span
+                          class="ant-table-column-title"
+                        >
+                          Age
+                        </span>
+                        <span
+                          class="ant-table-column-sorter"
+                        >
+                          <div
+                            class="ant-table-column-sorter-inner ant-table-column-sorter-inner-full"
+                            title="Sort"
+                          >
+                            <i
+                              aria-label="icon: caret-up"
+                              class="anticon anticon-caret-up ant-table-column-sorter-up on"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class=""
+                                data-icon="caret-up"
+                                fill="currentColor"
+                                focusable="false"
+                                height="1em"
+                                viewBox="0 0 1024 1024"
+                                width="1em"
+                              >
+                                <path
+                                  d="M858.9 689L530.5 308.2c-9.4-10.9-27.5-10.9-37 0L165.1 689c-12.2 14.2-1.2 35 18.5 35h656.8c19.7 0 30.7-20.8 18.5-35z"
+                                />
+                              </svg>
+                            </i>
+                            <i
+                              aria-label="icon: caret-down"
+                              class="anticon anticon-caret-down ant-table-column-sorter-down off"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class=""
+                                data-icon="caret-down"
+                                fill="currentColor"
+                                focusable="false"
+                                height="1em"
+                                viewBox="0 0 1024 1024"
+                                width="1em"
+                              >
+                                <path
+                                  d="M840.4 300H183.6c-19.7 0-30.7 20.8-18.5 35l328.4 380.8c9.4 10.9 27.5 10.9 37 0L858.9 335c12.2-14.2 1.2-35-18.5-35z"
+                                />
+                              </svg>
+                            </i>
+                          </div>
+                        </span>
+                      </div>
+                    </span>
+                  </th>
+                </tr>
+              </thead>
+              <tbody
+                class="ant-table-tbody"
+              >
+                <tr
+                  class="ant-table-row ant-table-row-level-0"
+                  data-row-key="1"
+                >
+                  <td
+                    class="ant-table-column-has-actions ant-table-column-has-sorters ant-table-column-sort"
+                  >
+                    1
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+      <ul
+        class="ant-pagination ant-table-pagination"
+        unselectable="unselectable"
+      >
+        <li
+          aria-disabled="true"
+          class="ant-pagination-disabled ant-pagination-prev"
+          title="Previous Page"
+        >
+          <a
+            class="ant-pagination-item-link"
+          >
+            <i
+              aria-label="icon: left"
+              class="anticon anticon-left"
+            >
+              <svg
+                aria-hidden="true"
+                class=""
+                data-icon="left"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M724 218.3V141c0-6.7-7.7-10.4-12.9-6.3L260.3 486.8a31.86 31.86 0 0 0 0 50.3l450.8 352.1c5.3 4.1 12.9.4 12.9-6.3v-77.3c0-4.9-2.3-9.6-6.1-12.6l-360-281 360-281.1c3.8-3 6.1-7.7 6.1-12.6z"
+                />
+              </svg>
+            </i>
+          </a>
+        </li>
+        <li
+          class="ant-pagination-item ant-pagination-item-1 ant-pagination-item-active"
+          tabindex="0"
+          title="1"
+        >
+          <a>
+            1
+          </a>
+        </li>
+        <li
+          aria-disabled="true"
+          class="ant-pagination-disabled ant-pagination-next"
+          title="Next Page"
+        >
+          <a
+            class="ant-pagination-item-link"
+          >
+            <i
+              aria-label="icon: right"
+              class="anticon anticon-right"
+            >
+              <svg
+                aria-hidden="true"
+                class=""
+                data-icon="right"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M765.7 486.8L314.9 134.7A7.97 7.97 0 0 0 302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 0 0 0-50.4z"
+                />
+              </svg>
+            </i>
+          </a>
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>
+`;

--- a/components/table/interface.tsx
+++ b/components/table/interface.tsx
@@ -63,6 +63,8 @@ export interface ColumnProps<T> {
   onCell?: (record: T, rowIndex: number) => TableEventListeners;
   onHeaderCell?: (props: ColumnProps<T>) => TableEventListeners;
   sortDirections?: SortOrder[];
+  sortUpIcon?: string;
+  sortDownIcon?: string;
 }
 
 export interface AdditionalCellProps {


### PR DESCRIPTION
### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
[https://github.com/ant-design/ant-design/issues/19561](url)


### 💡 Background and solution
Added sortUpIcon and sortDownIcon to the ColumnProps in interface.tsx for the Table component.
This will allow a user to indicate whether they would like an optional custom sort Icon in each column of a table. Example usage:
const columns = [
  {
    title: 'Name',
    dataIndex: 'name',
    sorter: (a, b) => a.name.length - b.name.length,
    sortDirections: ['descend'],
    sortUpIcon: 'arrow-up',
    sortDownIcon: 'arrow-down',
  },
  {
    title: 'Age',
    dataIndex: 'age',
    defaultSortOrder: 'descend',
    sorter: (a, b) => a.age - b.age,
    sortUpIcon: 'up-square',
    sortDownIcon: 'down-square',
  },
  {
    title: 'Address',
    dataIndex: 'address',
    sorter: (a, b) => a.address.length - b.address.length,
    sortDirections: ['descend', 'ascend'],
  },
];
### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [X] Doc is updated/provided or not needed
- [X] Demo is updated/provided or not needed
- [X] TypeScript definition is updated/provided or not needed
- [X] Changelog is provided or not needed


-----
[View rendered components/table/demo/custom-filter-panel.md](https://github.com/zjoshi/ant-design/blob/custom_sort_icon_feature/components/table/demo/custom-filter-panel.md)