### PR TITLE
fix: table should not show sorter when sorter is falsy

### DIFF
--- a/components/table/__tests__/Table.sorter.test.js
+++ b/components/table/__tests__/Table.sorter.test.js
@@ -639,4 +639,34 @@ describe('Table.sorter', () => {
     );
     expect(wrapper.render()).toMatchSnapshot();
   });
+
+  // https://github.com/ant-design/ant-design/issues/20096
+  it('invalidate sorter should not display sorter button', () => {
+    const wrapper = mount(
+      <Table
+        columns={[
+          {
+            title: 'Name',
+            dataIndex: 'name',
+            key: 'name',
+            sorter: false,
+          },
+          {
+            title: 'Age',
+            dataIndex: 'age',
+            key: 'age',
+            sorter: null,
+          },
+          {
+            title: 'Address',
+            dataIndex: 'address',
+            key: 'address',
+            sorter: undefined,
+          },
+        ]}
+      />,
+    );
+
+    expect(wrapper.find('.ant-table-column-sorter-inner')).toHaveLength(0);
+  });
 });

--- a/components/table/hooks/useSorter.tsx
+++ b/components/table/hooks/useSorter.tsx
@@ -59,7 +59,7 @@ function collectSortStates<RecordType>(
 
     if ('children' in column) {
       sortStates = [...sortStates, ...collectSortStates(column.children, init, columnPos)];
-    } else if ('sorter' in column) {
+    } else if (column.sorter) {
       if ('sortOrder' in column) {
         // Controlled
         sortStates.push({
@@ -95,7 +95,7 @@ function injectSorter<RecordType>(
     const columnPos = getColumnPos(index, pos);
     let newColumn: ColumnsType<RecordType>[number] = column;
 
-    if ('sorter' in newColumn) {
+    if (newColumn.sorter) {
       const sortDirections: SortOrder[] = newColumn.sortDirections || defaultSortDirections;
       const columnKey = getColumnKey(newColumn, columnPos);
       const sorterState = sorterSates.find(({ key }) => key === columnKey);


### PR DESCRIPTION
fix #20096

<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

fix #20096

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Fix Table still show sorter when `sorter` is falsy value.     |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
