### PR TITLE
fix: fix type of OptionProps

### DIFF
--- a/components/select/index.tsx
+++ b/components/select/index.tsx
@@ -92,6 +92,7 @@ export interface OptionProps {
   disabled?: boolean;
   value?: string | number;
   title?: string;
+  label?: React.ReactNode;
   children?: React.ReactNode;
   className?: string;
   style?: React.CSSProperties;


### PR DESCRIPTION
 [x] Bug fix
rc-select#Option could accept "label" props, but it was lose in type def OptionProps

https://github.com/react-component/select/blob/9ad3b02c82177db36d8e73f432192f34b9e04e17/src/interface/index.ts#L11