### PR TITLE
fix: FormItem with  should support array

### DIFF
--- a/components/form/FormItem.tsx
+++ b/components/form/FormItem.tsx
@@ -198,7 +198,12 @@ const FormItem: React.FC<FormItemProps> = (props: FormItemProps) => {
         }
 
         if (noStyle) {
-          return childNode;
+          warning(
+            !!mergedName.length,
+            'Form.Item',
+            'No need to wrap with Form.Item when field not set `name` and `noStyle` is true.',
+          );
+          return Array.isArray(childNode) ? <>{childNode}</> : childNode;
         }
 
         return (

--- a/components/form/__tests__/index.test.js
+++ b/components/form/__tests__/index.test.js
@@ -211,9 +211,7 @@ describe('Form', () => {
   it('warning when use `noStyle` without `name`', () => {
     const wrapper = mount(
       <Form>
-        <Form.Item noStyle>
-          [<h1 />, <h2 />]
-        </Form.Item>
+        <Form.Item noStyle>{[<h1 key="h1">Light</h1>, <h2 key="h2">Bamboo</h2>]}</Form.Item>
       </Form>,
     );
     expect(wrapper.find('h1')).toHaveLength(1);

--- a/components/form/__tests__/index.test.js
+++ b/components/form/__tests__/index.test.js
@@ -207,4 +207,19 @@ describe('Form', () => {
       'Warning: [antd: Form.Item] `name` is only used for validate React element. If you are using Form.Item as layout display, please remove `name` instead.',
     );
   });
+
+  it('warning when use `noStyle` without `name`', () => {
+    const wrapper = mount(
+      <Form>
+        <Form.Item noStyle>
+          [<h1 />, <h2 />]
+        </Form.Item>
+      </Form>,
+    );
+    expect(wrapper.find('h1')).toHaveLength(1);
+    expect(wrapper.find('h2')).toHaveLength(1);
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Warning: [antd: Form.Item] No need to wrap with Form.Item when field not set `name` and `noStyle` is true.',
+    );
+  });
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

fix #20160

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    FormItem with `noStyle`  should support array elements.       |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
