### PR TITLE
fix: 😢 Fix Tree showLine and showIcon missing icon

### DIFF
--- a/components/tree/Tree.tsx
+++ b/components/tree/Tree.tsx
@@ -188,17 +188,11 @@ export default class Tree extends React.Component<TreeProps, any> {
   renderSwitcherIcon = (
     prefixCls: string,
     switcherIcon: React.ReactElement<any> | undefined,
-    { isLeaf, expanded, loading, icon }: AntTreeNodeProps,
+    { isLeaf, expanded, loading }: AntTreeNodeProps,
   ) => {
     const { showLine } = this.props;
     if (loading) {
       return <Icon type="loading" className={`${prefixCls}-switcher-loading-icon`} />;
-    }
-    if (isLeaf) {
-      if (showLine) {
-        return icon || <Icon type="file" className={`${prefixCls}-switcher-line-icon`} />;
-      }
-      return null;
     }
     const switcherCls = `${prefixCls}-switcher-icon`;
     if (switcherIcon) {
@@ -206,16 +200,18 @@ export default class Tree extends React.Component<TreeProps, any> {
         className: classNames(switcherIcon.props.className || '', switcherCls),
       });
     }
-    if (showLine) {
-      return icon || (
-        <Icon
-          type={expanded ? 'minus-square' : 'plus-square'}
-          className={`${prefixCls}-switcher-line-icon`}
-          theme="outlined"
-        />
-      );
+    if (isLeaf) {
+      return showLine ? <Icon type="file" className={`${prefixCls}-switcher-line-icon`} /> : null;
     }
-    return <Icon type="caret-down" className={switcherCls} theme="filled" />;
+    return showLine ? (
+      <Icon
+        type={expanded ? 'minus-square' : 'plus-square'}
+        className={`${prefixCls}-switcher-line-icon`}
+        theme="outlined"
+      />
+    ) : (
+      <Icon type="caret-down" className={switcherCls} theme="filled" />
+    );
   };
 
   setTreeRef = (node: any) => {
@@ -228,7 +224,6 @@ export default class Tree extends React.Component<TreeProps, any> {
       prefixCls: customizePrefixCls,
       className,
       showIcon,
-      showLine,
       switcherIcon,
       blockNode,
       children,
@@ -239,9 +234,6 @@ export default class Tree extends React.Component<TreeProps, any> {
       <RcTree
         ref={this.setTreeRef}
         {...props}
-        // Hide icon in node when showLine is true, show icon in line always
-        // https://github.com/ant-design/ant-design/issues/20090
-        showIcon={showLine ? false : showIcon}
         prefixCls={prefixCls}
         className={classNames(className, {
           [`${prefixCls}-icon-hide`]: !showIcon,

--- a/components/tree/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/tree/__tests__/__snapshots__/demo.test.js.snap
@@ -1538,302 +1538,462 @@ exports[`renders ./components/tree/demo/dynamic.md correctly 1`] = `
 `;
 
 exports[`renders ./components/tree/demo/line.md correctly 1`] = `
-<ul
-  class="ant-tree ant-tree-icon-hide ant-tree-show-line"
-  role="tree"
-  unselectable="on"
->
-  <li
-    class="ant-tree-treenode-switcher-open"
-    role="treeitem"
+<div>
+  <div
+    style="margin-bottom:16px"
   >
-    <span
-      class="ant-tree-switcher ant-tree-switcher_open"
-    >
-      <i
-        aria-label="icon: minus-square"
-        class="anticon anticon-minus-square ant-tree-switcher-line-icon"
-      >
-        <svg
-          aria-hidden="true"
-          class=""
-          data-icon="minus-square"
-          fill="currentColor"
-          focusable="false"
-          height="1em"
-          viewBox="64 64 896 896"
-          width="1em"
-        >
-          <path
-            d="M328 544h368c4.4 0 8-3.6 8-8v-48c0-4.4-3.6-8-8-8H328c-4.4 0-8 3.6-8 8v48c0 4.4 3.6 8 8 8z"
-          />
-          <path
-            d="M880 112H144c-17.7 0-32 14.3-32 32v736c0 17.7 14.3 32 32 32h736c17.7 0 32-14.3 32-32V144c0-17.7-14.3-32-32-32zm-40 728H184V184h656v656z"
-          />
-        </svg>
-      </i>
-    </span>
-    <span
-      class="ant-tree-node-content-wrapper ant-tree-node-content-wrapper-open"
-      title="parent 1"
+    showLine: 
+    <button
+      aria-checked="true"
+      checked=""
+      class="ant-switch ant-switch-checked"
+      role="switch"
+      type="button"
     >
       <span
-        class="ant-tree-title"
-      >
-        parent 1
-      </span>
-    </span>
-    <ul
-      class="ant-tree-child-tree ant-tree-child-tree-open"
-      data-expanded="true"
-      role="group"
+        class="ant-switch-inner"
+      />
+    </button>
+    <br />
+    <br />
+    showIcon: 
+    <button
+      aria-checked="false"
+      class="ant-switch"
+      role="switch"
+      type="button"
     >
-      <li
-        class="ant-tree-treenode-switcher-open"
-        role="treeitem"
+      <span
+        class="ant-switch-inner"
+      />
+    </button>
+  </div>
+  <ul
+    class="ant-tree ant-tree-icon-hide ant-tree-show-line"
+    role="tree"
+    unselectable="on"
+  >
+    <li
+      class="ant-tree-treenode-switcher-open"
+      role="treeitem"
+    >
+      <span
+        class="ant-tree-switcher ant-tree-switcher_open"
+      >
+        <i
+          aria-label="icon: minus-square"
+          class="anticon anticon-minus-square ant-tree-switcher-line-icon"
+        >
+          <svg
+            aria-hidden="true"
+            class=""
+            data-icon="minus-square"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M328 544h368c4.4 0 8-3.6 8-8v-48c0-4.4-3.6-8-8-8H328c-4.4 0-8 3.6-8 8v48c0 4.4 3.6 8 8 8z"
+            />
+            <path
+              d="M880 112H144c-17.7 0-32 14.3-32 32v736c0 17.7 14.3 32 32 32h736c17.7 0 32-14.3 32-32V144c0-17.7-14.3-32-32-32zm-40 728H184V184h656v656z"
+            />
+          </svg>
+        </i>
+      </span>
+      <span
+        class="ant-tree-node-content-wrapper ant-tree-node-content-wrapper-open"
+        title="parent 1"
       >
         <span
-          class="ant-tree-switcher ant-tree-switcher_open"
+          class="ant-tree-title"
         >
-          <i
-            aria-label="icon: minus-square"
-            class="anticon anticon-minus-square ant-tree-switcher-line-icon"
-          >
-            <svg
-              aria-hidden="true"
-              class=""
-              data-icon="minus-square"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M328 544h368c4.4 0 8-3.6 8-8v-48c0-4.4-3.6-8-8-8H328c-4.4 0-8 3.6-8 8v48c0 4.4 3.6 8 8 8z"
-              />
-              <path
-                d="M880 112H144c-17.7 0-32 14.3-32 32v736c0 17.7 14.3 32 32 32h736c17.7 0 32-14.3 32-32V144c0-17.7-14.3-32-32-32zm-40 728H184V184h656v656z"
-              />
-            </svg>
-          </i>
+          parent 1
         </span>
-        <span
-          class="ant-tree-node-content-wrapper ant-tree-node-content-wrapper-open"
-          title="parent 1-0"
-        >
-          <span
-            class="ant-tree-title"
-          >
-            parent 1-0
-          </span>
-        </span>
-        <ul
-          class="ant-tree-child-tree ant-tree-child-tree-open"
-          data-expanded="true"
-          role="group"
-        >
-          <li
-            class="ant-tree-treenode-switcher-close"
-            role="treeitem"
-          >
-            <span
-              class="ant-tree-switcher ant-tree-switcher-noop"
-            >
-              <i
-                aria-label="icon: file"
-                class="anticon anticon-file ant-tree-switcher-line-icon"
-              >
-                <svg
-                  aria-hidden="true"
-                  class=""
-                  data-icon="file"
-                  fill="currentColor"
-                  focusable="false"
-                  height="1em"
-                  viewBox="64 64 896 896"
-                  width="1em"
-                >
-                  <path
-                    d="M854.6 288.6L639.4 73.4c-6-6-14.1-9.4-22.6-9.4H192c-17.7 0-32 14.3-32 32v832c0 17.7 14.3 32 32 32h640c17.7 0 32-14.3 32-32V311.3c0-8.5-3.4-16.7-9.4-22.7zM790.2 326H602V137.8L790.2 326zm1.8 562H232V136h302v216a42 42 0 0 0 42 42h216v494z"
-                  />
-                </svg>
-              </i>
-            </span>
-            <span
-              class="ant-tree-node-content-wrapper ant-tree-node-content-wrapper-normal"
-              title="leaf"
-            >
-              <span
-                class="ant-tree-title"
-              >
-                leaf
-              </span>
-            </span>
-          </li>
-          <li
-            class="ant-tree-treenode-switcher-close"
-            role="treeitem"
-          >
-            <span
-              class="ant-tree-switcher ant-tree-switcher-noop"
-            >
-              <i
-                aria-label="icon: file"
-                class="anticon anticon-file ant-tree-switcher-line-icon"
-              >
-                <svg
-                  aria-hidden="true"
-                  class=""
-                  data-icon="file"
-                  fill="currentColor"
-                  focusable="false"
-                  height="1em"
-                  viewBox="64 64 896 896"
-                  width="1em"
-                >
-                  <path
-                    d="M854.6 288.6L639.4 73.4c-6-6-14.1-9.4-22.6-9.4H192c-17.7 0-32 14.3-32 32v832c0 17.7 14.3 32 32 32h640c17.7 0 32-14.3 32-32V311.3c0-8.5-3.4-16.7-9.4-22.7zM790.2 326H602V137.8L790.2 326zm1.8 562H232V136h302v216a42 42 0 0 0 42 42h216v494z"
-                  />
-                </svg>
-              </i>
-            </span>
-            <span
-              class="ant-tree-node-content-wrapper ant-tree-node-content-wrapper-normal"
-              title="leaf"
-            >
-              <span
-                class="ant-tree-title"
-              >
-                leaf
-              </span>
-            </span>
-          </li>
-          <li
-            class="ant-tree-treenode-switcher-close"
-            role="treeitem"
-          >
-            <span
-              class="ant-tree-switcher ant-tree-switcher-noop"
-            >
-              <i
-                aria-label="icon: file"
-                class="anticon anticon-file ant-tree-switcher-line-icon"
-              >
-                <svg
-                  aria-hidden="true"
-                  class=""
-                  data-icon="file"
-                  fill="currentColor"
-                  focusable="false"
-                  height="1em"
-                  viewBox="64 64 896 896"
-                  width="1em"
-                >
-                  <path
-                    d="M854.6 288.6L639.4 73.4c-6-6-14.1-9.4-22.6-9.4H192c-17.7 0-32 14.3-32 32v832c0 17.7 14.3 32 32 32h640c17.7 0 32-14.3 32-32V311.3c0-8.5-3.4-16.7-9.4-22.7zM790.2 326H602V137.8L790.2 326zm1.8 562H232V136h302v216a42 42 0 0 0 42 42h216v494z"
-                  />
-                </svg>
-              </i>
-            </span>
-            <span
-              class="ant-tree-node-content-wrapper ant-tree-node-content-wrapper-normal"
-              title="leaf"
-            >
-              <span
-                class="ant-tree-title"
-              >
-                leaf
-              </span>
-            </span>
-          </li>
-        </ul>
-      </li>
-      <li
-        class="ant-tree-treenode-switcher-close"
-        role="treeitem"
+      </span>
+      <ul
+        class="ant-tree-child-tree ant-tree-child-tree-open"
+        data-expanded="true"
+        role="group"
       >
-        <span
-          class="ant-tree-switcher ant-tree-switcher_close"
-        >
-          <i
-            aria-label="icon: plus-square"
-            class="anticon anticon-plus-square ant-tree-switcher-line-icon"
-          >
-            <svg
-              aria-hidden="true"
-              class=""
-              data-icon="plus-square"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M328 544h152v152c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8V544h152c4.4 0 8-3.6 8-8v-48c0-4.4-3.6-8-8-8H544V328c0-4.4-3.6-8-8-8h-48c-4.4 0-8 3.6-8 8v152H328c-4.4 0-8 3.6-8 8v48c0 4.4 3.6 8 8 8z"
-              />
-              <path
-                d="M880 112H144c-17.7 0-32 14.3-32 32v736c0 17.7 14.3 32 32 32h736c17.7 0 32-14.3 32-32V144c0-17.7-14.3-32-32-32zm-40 728H184V184h656v656z"
-              />
-            </svg>
-          </i>
-        </span>
-        <span
-          class="ant-tree-node-content-wrapper ant-tree-node-content-wrapper-close"
-          title="parent 1-1"
+        <li
+          class="ant-tree-treenode-switcher-open"
+          role="treeitem"
         >
           <span
-            class="ant-tree-title"
+            class="ant-tree-switcher ant-tree-switcher_open"
           >
-            parent 1-1
-          </span>
-        </span>
-      </li>
-      <li
-        class="ant-tree-treenode-switcher-close"
-        role="treeitem"
-      >
-        <span
-          class="ant-tree-switcher ant-tree-switcher_close"
-        >
-          <i
-            aria-label="icon: plus-square"
-            class="anticon anticon-plus-square ant-tree-switcher-line-icon"
-          >
-            <svg
-              aria-hidden="true"
-              class=""
-              data-icon="plus-square"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
+            <i
+              aria-label="icon: minus-square"
+              class="anticon anticon-minus-square ant-tree-switcher-line-icon"
             >
-              <path
-                d="M328 544h152v152c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8V544h152c4.4 0 8-3.6 8-8v-48c0-4.4-3.6-8-8-8H544V328c0-4.4-3.6-8-8-8h-48c-4.4 0-8 3.6-8 8v152H328c-4.4 0-8 3.6-8 8v48c0 4.4 3.6 8 8 8z"
-              />
-              <path
-                d="M880 112H144c-17.7 0-32 14.3-32 32v736c0 17.7 14.3 32 32 32h736c17.7 0 32-14.3 32-32V144c0-17.7-14.3-32-32-32zm-40 728H184V184h656v656z"
-              />
-            </svg>
-          </i>
-        </span>
-        <span
-          class="ant-tree-node-content-wrapper ant-tree-node-content-wrapper-close"
-          title="parent 1-2"
+              <svg
+                aria-hidden="true"
+                class=""
+                data-icon="minus-square"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M328 544h368c4.4 0 8-3.6 8-8v-48c0-4.4-3.6-8-8-8H328c-4.4 0-8 3.6-8 8v48c0 4.4 3.6 8 8 8z"
+                />
+                <path
+                  d="M880 112H144c-17.7 0-32 14.3-32 32v736c0 17.7 14.3 32 32 32h736c17.7 0 32-14.3 32-32V144c0-17.7-14.3-32-32-32zm-40 728H184V184h656v656z"
+                />
+              </svg>
+            </i>
+          </span>
+          <span
+            class="ant-tree-node-content-wrapper ant-tree-node-content-wrapper-open"
+            title="parent 1-0"
+          >
+            <span
+              class="ant-tree-title"
+            >
+              parent 1-0
+            </span>
+          </span>
+          <ul
+            class="ant-tree-child-tree ant-tree-child-tree-open"
+            data-expanded="true"
+            role="group"
+          >
+            <li
+              class="ant-tree-treenode-switcher-close"
+              role="treeitem"
+            >
+              <span
+                class="ant-tree-switcher ant-tree-switcher-noop"
+              >
+                <i
+                  aria-label="icon: file"
+                  class="anticon anticon-file ant-tree-switcher-line-icon"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class=""
+                    data-icon="file"
+                    fill="currentColor"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M854.6 288.6L639.4 73.4c-6-6-14.1-9.4-22.6-9.4H192c-17.7 0-32 14.3-32 32v832c0 17.7 14.3 32 32 32h640c17.7 0 32-14.3 32-32V311.3c0-8.5-3.4-16.7-9.4-22.7zM790.2 326H602V137.8L790.2 326zm1.8 562H232V136h302v216a42 42 0 0 0 42 42h216v494z"
+                    />
+                  </svg>
+                </i>
+              </span>
+              <span
+                class="ant-tree-node-content-wrapper ant-tree-node-content-wrapper-normal"
+                title="leaf"
+              >
+                <span
+                  class="ant-tree-title"
+                >
+                  leaf
+                </span>
+              </span>
+            </li>
+            <li
+              class="ant-tree-treenode-switcher-close"
+              role="treeitem"
+            >
+              <span
+                class="ant-tree-switcher ant-tree-switcher-noop"
+              >
+                <i
+                  aria-label="icon: file"
+                  class="anticon anticon-file ant-tree-switcher-line-icon"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class=""
+                    data-icon="file"
+                    fill="currentColor"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M854.6 288.6L639.4 73.4c-6-6-14.1-9.4-22.6-9.4H192c-17.7 0-32 14.3-32 32v832c0 17.7 14.3 32 32 32h640c17.7 0 32-14.3 32-32V311.3c0-8.5-3.4-16.7-9.4-22.7zM790.2 326H602V137.8L790.2 326zm1.8 562H232V136h302v216a42 42 0 0 0 42 42h216v494z"
+                    />
+                  </svg>
+                </i>
+              </span>
+              <span
+                class="ant-tree-node-content-wrapper ant-tree-node-content-wrapper-normal"
+                title="leaf"
+              >
+                <span
+                  class="ant-tree-title"
+                >
+                  leaf
+                </span>
+              </span>
+            </li>
+            <li
+              class="ant-tree-treenode-switcher-close"
+              role="treeitem"
+            >
+              <span
+                class="ant-tree-switcher ant-tree-switcher-noop"
+              >
+                <i
+                  aria-label="icon: file"
+                  class="anticon anticon-file ant-tree-switcher-line-icon"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class=""
+                    data-icon="file"
+                    fill="currentColor"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M854.6 288.6L639.4 73.4c-6-6-14.1-9.4-22.6-9.4H192c-17.7 0-32 14.3-32 32v832c0 17.7 14.3 32 32 32h640c17.7 0 32-14.3 32-32V311.3c0-8.5-3.4-16.7-9.4-22.7zM790.2 326H602V137.8L790.2 326zm1.8 562H232V136h302v216a42 42 0 0 0 42 42h216v494z"
+                    />
+                  </svg>
+                </i>
+              </span>
+              <span
+                class="ant-tree-node-content-wrapper ant-tree-node-content-wrapper-normal"
+                title="leaf"
+              >
+                <span
+                  class="ant-tree-title"
+                >
+                  leaf
+                </span>
+              </span>
+            </li>
+          </ul>
+        </li>
+        <li
+          class="ant-tree-treenode-switcher-open"
+          role="treeitem"
         >
           <span
-            class="ant-tree-title"
+            class="ant-tree-switcher ant-tree-switcher_open"
           >
-            parent 1-2
+            <i
+              aria-label="icon: minus-square"
+              class="anticon anticon-minus-square ant-tree-switcher-line-icon"
+            >
+              <svg
+                aria-hidden="true"
+                class=""
+                data-icon="minus-square"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M328 544h368c4.4 0 8-3.6 8-8v-48c0-4.4-3.6-8-8-8H328c-4.4 0-8 3.6-8 8v48c0 4.4 3.6 8 8 8z"
+                />
+                <path
+                  d="M880 112H144c-17.7 0-32 14.3-32 32v736c0 17.7 14.3 32 32 32h736c17.7 0 32-14.3 32-32V144c0-17.7-14.3-32-32-32zm-40 728H184V184h656v656z"
+                />
+              </svg>
+            </i>
           </span>
-        </span>
-      </li>
-    </ul>
-  </li>
-</ul>
+          <span
+            class="ant-tree-node-content-wrapper ant-tree-node-content-wrapper-open"
+            title="parent 1-1"
+          >
+            <span
+              class="ant-tree-title"
+            >
+              parent 1-1
+            </span>
+          </span>
+          <ul
+            class="ant-tree-child-tree ant-tree-child-tree-open"
+            data-expanded="true"
+            role="group"
+          >
+            <li
+              class="ant-tree-treenode-switcher-close"
+              role="treeitem"
+            >
+              <span
+                class="ant-tree-switcher ant-tree-switcher-noop"
+              >
+                <i
+                  aria-label="icon: file"
+                  class="anticon anticon-file ant-tree-switcher-line-icon"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class=""
+                    data-icon="file"
+                    fill="currentColor"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M854.6 288.6L639.4 73.4c-6-6-14.1-9.4-22.6-9.4H192c-17.7 0-32 14.3-32 32v832c0 17.7 14.3 32 32 32h640c17.7 0 32-14.3 32-32V311.3c0-8.5-3.4-16.7-9.4-22.7zM790.2 326H602V137.8L790.2 326zm1.8 562H232V136h302v216a42 42 0 0 0 42 42h216v494z"
+                    />
+                  </svg>
+                </i>
+              </span>
+              <span
+                class="ant-tree-node-content-wrapper ant-tree-node-content-wrapper-normal"
+                title="leaf"
+              >
+                <span
+                  class="ant-tree-title"
+                >
+                  leaf
+                </span>
+              </span>
+            </li>
+          </ul>
+        </li>
+        <li
+          class="ant-tree-treenode-switcher-open"
+          role="treeitem"
+        >
+          <span
+            class="ant-tree-switcher ant-tree-switcher_open"
+          >
+            <i
+              aria-label="icon: minus-square"
+              class="anticon anticon-minus-square ant-tree-switcher-line-icon"
+            >
+              <svg
+                aria-hidden="true"
+                class=""
+                data-icon="minus-square"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M328 544h368c4.4 0 8-3.6 8-8v-48c0-4.4-3.6-8-8-8H328c-4.4 0-8 3.6-8 8v48c0 4.4 3.6 8 8 8z"
+                />
+                <path
+                  d="M880 112H144c-17.7 0-32 14.3-32 32v736c0 17.7 14.3 32 32 32h736c17.7 0 32-14.3 32-32V144c0-17.7-14.3-32-32-32zm-40 728H184V184h656v656z"
+                />
+              </svg>
+            </i>
+          </span>
+          <span
+            class="ant-tree-node-content-wrapper ant-tree-node-content-wrapper-open"
+            title="parent 1-2"
+          >
+            <span
+              class="ant-tree-title"
+            >
+              parent 1-2
+            </span>
+          </span>
+          <ul
+            class="ant-tree-child-tree ant-tree-child-tree-open"
+            data-expanded="true"
+            role="group"
+          >
+            <li
+              class="ant-tree-treenode-switcher-close"
+              role="treeitem"
+            >
+              <span
+                class="ant-tree-switcher ant-tree-switcher-noop"
+              >
+                <i
+                  aria-label="icon: file"
+                  class="anticon anticon-file ant-tree-switcher-line-icon"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class=""
+                    data-icon="file"
+                    fill="currentColor"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M854.6 288.6L639.4 73.4c-6-6-14.1-9.4-22.6-9.4H192c-17.7 0-32 14.3-32 32v832c0 17.7 14.3 32 32 32h640c17.7 0 32-14.3 32-32V311.3c0-8.5-3.4-16.7-9.4-22.7zM790.2 326H602V137.8L790.2 326zm1.8 562H232V136h302v216a42 42 0 0 0 42 42h216v494z"
+                    />
+                  </svg>
+                </i>
+              </span>
+              <span
+                class="ant-tree-node-content-wrapper ant-tree-node-content-wrapper-normal"
+                title="leaf"
+              >
+                <span
+                  class="ant-tree-title"
+                >
+                  leaf
+                </span>
+              </span>
+            </li>
+            <li
+              class="ant-tree-treenode-switcher-close"
+              role="treeitem"
+            >
+              <span
+                class="ant-tree-switcher ant-tree-switcher-noop"
+              >
+                <i
+                  aria-label="icon: form"
+                  class="anticon anticon-form"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class=""
+                    data-icon="form"
+                    fill="currentColor"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M904 512h-56c-4.4 0-8 3.6-8 8v320H184V184h320c4.4 0 8-3.6 8-8v-56c0-4.4-3.6-8-8-8H144c-17.7 0-32 14.3-32 32v736c0 17.7 14.3 32 32 32h736c17.7 0 32-14.3 32-32V520c0-4.4-3.6-8-8-8z"
+                    />
+                    <path
+                      d="M355.9 534.9L354 653.8c-.1 8.9 7.1 16.2 16 16.2h.4l118-2.9c2-.1 4-.9 5.4-2.3l415.9-415c3.1-3.1 3.1-8.2 0-11.3L785.4 114.3c-1.6-1.6-3.6-2.3-5.7-2.3s-4.1.8-5.7 2.3l-415.8 415a8.3 8.3 0 0 0-2.3 5.6zm63.5 23.6L779.7 199l45.2 45.1-360.5 359.7-45.7 1.1.7-46.4z"
+                    />
+                  </svg>
+                </i>
+              </span>
+              <span
+                class="ant-tree-node-content-wrapper ant-tree-node-content-wrapper-normal"
+                title="leaf"
+              >
+                <span
+                  class="ant-tree-title"
+                >
+                  leaf
+                </span>
+              </span>
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </li>
+  </ul>
+</div>
 `;
 
 exports[`renders ./components/tree/demo/search.md correctly 1`] = `

--- a/components/tree/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/tree/__tests__/__snapshots__/demo.test.js.snap
@@ -725,7 +725,27 @@ exports[`renders ./components/tree/demo/customized-icon.md correctly 1`] = `
       >
         <span
           class="ant-tree-switcher ant-tree-switcher-noop"
-        />
+        >
+          <i
+            aria-label="icon: down"
+            class="anticon anticon-down ant-tree-switcher-icon"
+          >
+            <svg
+              aria-hidden="true"
+              class=""
+              data-icon="down"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+              />
+            </svg>
+          </i>
+        </span>
         <span
           class="ant-tree-node-content-wrapper ant-tree-node-content-wrapper-normal ant-tree-node-selected"
           title="leaf"
@@ -766,7 +786,27 @@ exports[`renders ./components/tree/demo/customized-icon.md correctly 1`] = `
       >
         <span
           class="ant-tree-switcher ant-tree-switcher-noop"
-        />
+        >
+          <i
+            aria-label="icon: down"
+            class="anticon anticon-down ant-tree-switcher-icon"
+          >
+            <svg
+              aria-hidden="true"
+              class=""
+              data-icon="down"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+              />
+            </svg>
+          </i>
+        </span>
         <span
           class="ant-tree-node-content-wrapper ant-tree-node-content-wrapper-normal"
           title="leaf"
@@ -2049,13 +2089,13 @@ exports[`renders ./components/tree/demo/switcher-icon.md correctly 1`] = `
               class="ant-tree-switcher ant-tree-switcher-noop"
             >
               <i
-                aria-label="icon: file"
-                class="anticon anticon-file ant-tree-switcher-line-icon"
+                aria-label="icon: down"
+                class="anticon anticon-down ant-tree-switcher-icon"
               >
                 <svg
                   aria-hidden="true"
                   class=""
-                  data-icon="file"
+                  data-icon="down"
                   fill="currentColor"
                   focusable="false"
                   height="1em"
@@ -2063,7 +2103,7 @@ exports[`renders ./components/tree/demo/switcher-icon.md correctly 1`] = `
                   width="1em"
                 >
                   <path
-                    d="M854.6 288.6L639.4 73.4c-6-6-14.1-9.4-22.6-9.4H192c-17.7 0-32 14.3-32 32v832c0 17.7 14.3 32 32 32h640c17.7 0 32-14.3 32-32V311.3c0-8.5-3.4-16.7-9.4-22.7zM790.2 326H602V137.8L790.2 326zm1.8 562H232V136h302v216a42 42 0 0 0 42 42h216v494z"
+                    d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
                   />
                 </svg>
               </i>
@@ -2087,13 +2127,13 @@ exports[`renders ./components/tree/demo/switcher-icon.md correctly 1`] = `
               class="ant-tree-switcher ant-tree-switcher-noop"
             >
               <i
-                aria-label="icon: file"
-                class="anticon anticon-file ant-tree-switcher-line-icon"
+                aria-label="icon: down"
+                class="anticon anticon-down ant-tree-switcher-icon"
               >
                 <svg
                   aria-hidden="true"
                   class=""
-                  data-icon="file"
+                  data-icon="down"
                   fill="currentColor"
                   focusable="false"
                   height="1em"
@@ -2101,7 +2141,7 @@ exports[`renders ./components/tree/demo/switcher-icon.md correctly 1`] = `
                   width="1em"
                 >
                   <path
-                    d="M854.6 288.6L639.4 73.4c-6-6-14.1-9.4-22.6-9.4H192c-17.7 0-32 14.3-32 32v832c0 17.7 14.3 32 32 32h640c17.7 0 32-14.3 32-32V311.3c0-8.5-3.4-16.7-9.4-22.7zM790.2 326H602V137.8L790.2 326zm1.8 562H232V136h302v216a42 42 0 0 0 42 42h216v494z"
+                    d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
                   />
                 </svg>
               </i>
@@ -2125,13 +2165,13 @@ exports[`renders ./components/tree/demo/switcher-icon.md correctly 1`] = `
               class="ant-tree-switcher ant-tree-switcher-noop"
             >
               <i
-                aria-label="icon: file"
-                class="anticon anticon-file ant-tree-switcher-line-icon"
+                aria-label="icon: down"
+                class="anticon anticon-down ant-tree-switcher-icon"
               >
                 <svg
                   aria-hidden="true"
                   class=""
-                  data-icon="file"
+                  data-icon="down"
                   fill="currentColor"
                   focusable="false"
                   height="1em"
@@ -2139,7 +2179,7 @@ exports[`renders ./components/tree/demo/switcher-icon.md correctly 1`] = `
                   width="1em"
                 >
                   <path
-                    d="M854.6 288.6L639.4 73.4c-6-6-14.1-9.4-22.6-9.4H192c-17.7 0-32 14.3-32 32v832c0 17.7 14.3 32 32 32h640c17.7 0 32-14.3 32-32V311.3c0-8.5-3.4-16.7-9.4-22.7zM790.2 326H602V137.8L790.2 326zm1.8 562H232V136h302v216a42 42 0 0 0 42 42h216v494z"
+                    d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
                   />
                 </svg>
               </i>

--- a/components/tree/__tests__/__snapshots__/index.test.js.snap
+++ b/components/tree/__tests__/__snapshots__/index.test.js.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Tree icon of TreeNode should put inside line when showLine is true 1`] = `
+exports[`Tree icon and switcherIcon of Tree with showLine should render correctly 1`] = `
 <ul
-  class="ant-tree ant-tree-icon-hide ant-tree-show-line"
+  class="ant-tree ant-tree-show-line"
   role="tree"
   unselectable="on"
 >
@@ -13,12 +13,84 @@ exports[`Tree icon of TreeNode should put inside line when showLine is true 1`] 
     <span
       class="ant-tree-switcher ant-tree-switcher_close"
     >
-      icon
+      switcherIcon
     </span>
     <span
       class="ant-tree-node-content-wrapper ant-tree-node-content-wrapper-close"
       title="---"
     >
+      <span
+        class="ant-tree-iconEle ant-tree-icon__customize"
+      >
+        icon
+      </span>
+      <span
+        class="ant-tree-title"
+      >
+        ---
+      </span>
+    </span>
+  </li>
+  <li
+    class="ant-tree-treenode-switcher-close"
+    role="treeitem"
+  >
+    <span
+      class="ant-tree-switcher ant-tree-switcher_close"
+    >
+      switcherIcon
+    </span>
+    <span
+      class="ant-tree-node-content-wrapper ant-tree-node-content-wrapper-close"
+      title="---"
+    >
+      <span
+        class="ant-tree-iconEle ant-tree-icon__close"
+      />
+      <span
+        class="ant-tree-title"
+      >
+        ---
+      </span>
+    </span>
+  </li>
+  <li
+    class="ant-tree-treenode-switcher-close"
+    role="treeitem"
+  >
+    <span
+      class="ant-tree-switcher ant-tree-switcher_close"
+    >
+      <i
+        aria-label="icon: plus-square"
+        class="anticon anticon-plus-square ant-tree-switcher-line-icon"
+      >
+        <svg
+          aria-hidden="true"
+          class=""
+          data-icon="plus-square"
+          fill="currentColor"
+          focusable="false"
+          height="1em"
+          viewBox="64 64 896 896"
+          width="1em"
+        >
+          <path
+            d="M328 544h152v152c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8V544h152c4.4 0 8-3.6 8-8v-48c0-4.4-3.6-8-8-8H544V328c0-4.4-3.6-8-8-8h-48c-4.4 0-8 3.6-8 8v152H328c-4.4 0-8 3.6-8 8v48c0 4.4 3.6 8 8 8z"
+          />
+          <path
+            d="M880 112H144c-17.7 0-32 14.3-32 32v736c0 17.7 14.3 32 32 32h736c17.7 0 32-14.3 32-32V144c0-17.7-14.3-32-32-32zm-40 728H184V184h656v656z"
+          />
+        </svg>
+      </i>
+    </span>
+    <span
+      class="ant-tree-node-content-wrapper ant-tree-node-content-wrapper-close"
+      title="---"
+    >
+      <span
+        class="ant-tree-iconEle ant-tree-icon__close"
+      />
       <span
         class="ant-tree-title"
       >

--- a/components/tree/__tests__/index.test.js
+++ b/components/tree/__tests__/index.test.js
@@ -5,12 +5,26 @@ import Tree from '../index';
 const { TreeNode } = Tree;
 
 describe('Tree', () => {
-  it('icon of TreeNode should put inside line when showLine is true', () => {
+  it('icon and switcherIcon of Tree with showLine should render correctly', () => {
     const wrapper = mount(
-      <Tree showLine>
-        <TreeNode icon="icon" key="0-0">
-          <TreeNode icon="icon" key="0-0-0" />
-          <TreeNode key="0-0-1" />
+      <Tree showLine showIcon>
+        <TreeNode icon="icon" switcherIcon="switcherIcon" key="0-0">
+          <TreeNode icon="icon" switcherIcon="switcherIcon" key="0-0-0" />
+          <TreeNode switcherIcon="switcherIcon" key="0-0-1" />
+          <TreeNode icon="icon" key="0-0-2" />
+          <TreeNode key="0-0-3" />
+        </TreeNode>
+        <TreeNode switcherIcon="switcherIcon" key="0-1">
+          <TreeNode icon="icon" switcherIcon="switcherIcon" key="0-0-0" />
+          <TreeNode switcherIcon="switcherIcon" key="0-0-1" />
+          <TreeNode icon="icon" key="0-0-2" />
+          <TreeNode key="0-0-3" />
+        </TreeNode>
+        <TreeNode key="0-2">
+          <TreeNode icon="icon" switcherIcon="switcherIcon" key="0-0-0" />
+          <TreeNode switcherIcon="switcherIcon" key="0-0-1" />
+          <TreeNode icon="icon" key="0-0-2" />
+          <TreeNode key="0-0-3" />
         </TreeNode>
       </Tree>,
     );

--- a/components/tree/demo/line.md
+++ b/components/tree/demo/line.md
@@ -7,40 +7,67 @@ title:
 
 ## zh-CN
 
-节点之间带连接线的树，常用于文件目录结构展示。
+节点之间带连接线的树，常用于文件目录结构展示。使用 `showLine` 开启，可以用 `switcherIcon` 修改默认图标。
 
 ## en-US
 
-Tree with connected line between nodes.
+Tree with connected line between nodes, turn on by `showLine`, customize the preseted icon by `switcherIcon`.
 
 ```jsx
-import { Tree, Icon } from 'antd';
+import { Tree, Icon, Switch } from 'antd';
 
 const { TreeNode } = Tree;
 
 class Demo extends React.Component {
-  onSelect = (selectedKeys, info) => {
-    console.log('selected', selectedKeys, info);
-  };
+  state = {
+    showLine: true,
+    showIcon: false,
+  }
+
+  onShowLineChange = showLine => {
+    this.setState({ showLine });
+  }
+
+  onShowIconChange = showIcon => {
+    this.setState({ showIcon });
+  }
 
   render() {
+    const { showIcon, showLine } = this.state;
     return (
-      <Tree showLine defaultExpandedKeys={['0-0-0']} onSelect={this.onSelect}>
-        <TreeNode title="parent 1" key="0-0">
-          <TreeNode title="parent 1-0" key="0-0-0">
-            <TreeNode title="leaf" key="0-0-0-0" />
-            <TreeNode title="leaf" key="0-0-0-1" />
-            <TreeNode title="leaf" key="0-0-0-2" />
+      <div>
+        <div style={{ marginBottom: 16 }}>
+          showLine: <Switch checked={showLine} onChange={this.onShowLineChange} />
+          <br />
+          <br />
+          showIcon: <Switch checked={showIcon} onChange={this.onShowIconChange} />
+        </div>
+        <Tree
+          showLine={showLine}
+          showIcon={showIcon}
+          defaultExpandedKeys={['0-0-0', '0-0-1', '0-0-2']}
+        >
+          <TreeNode icon={<Icon type="carry-out" />} title="parent 1" key="0-0">
+            <TreeNode icon={<Icon type="carry-out" />} title="parent 1-0" key="0-0-0">
+              <TreeNode icon={<Icon type="carry-out" />} title="leaf" key="0-0-0-0" />
+              <TreeNode icon={<Icon type="carry-out" />} title="leaf" key="0-0-0-1" />
+              <TreeNode icon={<Icon type="carry-out" />} title="leaf" key="0-0-0-2" />
+            </TreeNode>
+            <TreeNode icon={<Icon type="carry-out" />} title="parent 1-1" key="0-0-1">
+              <TreeNode icon={<Icon type="carry-out" />} title="leaf" key="0-0-1-0" />
+            </TreeNode>
+            <TreeNode icon={<Icon type="carry-out" />} title="parent 1-2" key="0-0-2">
+              <TreeNode icon={<Icon type="carry-out" />} title="leaf" key="0-0-2-0" />
+              <TreeNode
+                switcherIcon={<Icon type="form" />}
+                icon={<Icon type="carry-out" />}
+                title="leaf"
+                key="0-0-2-1"
+              />
+            </TreeNode>
           </TreeNode>
-          <TreeNode title="parent 1-1" key="0-0-1">
-            <TreeNode title="leaf" key="0-0-1-0" />
-          </TreeNode>
-          <TreeNode title="parent 1-2" key="0-0-2">
-            <TreeNode title="leaf" key="0-0-2-0" />
-            <TreeNode switcherIcon={<Icon type="form" />} title="leaf" key="0-0-2-1" />
-          </TreeNode>
-        </TreeNode>
-      </Tree>
+        </Tree>
+      </div>
     );
   }
 }

--- a/components/tree/demo/line.md
+++ b/components/tree/demo/line.md
@@ -37,7 +37,7 @@ class Demo extends React.Component {
           </TreeNode>
           <TreeNode title="parent 1-2" key="0-0-2">
             <TreeNode title="leaf" key="0-0-2-0" />
-            <TreeNode icon={<Icon type="form" />} title="leaf" key="0-0-2-1" />
+            <TreeNode switcherIcon={<Icon type="form" />} title="leaf" key="0-0-2-1" />
           </TreeNode>
         </TreeNode>
       </Tree>


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close #20192

### 💡 Background and solution

Caused by  https://github.com/ant-design/ant-design/pull/20102

<img width="222" alt="image" src="https://user-images.githubusercontent.com/507615/70218757-91f08a80-177e-11ea-8667-b26ae78a6af3.png">

fixed back to

<img width="199" alt="image" src="https://user-images.githubusercontent.com/507615/70218868-c7957380-177e-11ea-982d-6b16c924c760.png">

We should use `switcherIcon` instead of `icon` to customize icon in Tree `showLine` mode.

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Tree `showLine` and `showIcon` missing icon. |
| 🇨🇳 Chinese | 修复 Tree `showLine` 和 `showIcon` 同时开启时 `[+]` `[-]` 图标丢失的问题。 |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/tree/demo/line.md](https://github.com/ant-design/ant-design/blob/fix-tree-show-line-icon/components/tree/demo/line.md)