### PR TITLE
feat: add in disableAnimation option for configProvider and components

### DIFF
--- a/components/auto-complete/index.en-US.md
+++ b/components/auto-complete/index.en-US.md
@@ -30,6 +30,7 @@ const dataSource = ['12345', '23456', '34567'];
 | defaultActiveFirstOption | Whether active first option by default | boolean | true |  |
 | defaultValue | Initial selected option. | string\|string\[] | - |  |
 | disabled | Whether disabled select | boolean | false |  |
+| disableAnimation | Whether the dropdown animation is disabled | boolean | false |  |
 | filterOption | If true, filter options by input, if function, filter options against it. The function will receive two arguments, `inputValue` and `option`, if the function returns `true`, the option will be included in the filtered set; Otherwise, it will be excluded. | boolean or function(inputValue, option) | true |  |
 | optionLabelProp | Which prop value of option will render as content of select. | string | `children` |  |
 | placeholder | placeholder of input | string | - |  |

--- a/components/auto-complete/index.tsx
+++ b/components/auto-complete/index.tsx
@@ -44,6 +44,7 @@ export interface AutoCompleteProps extends Omit<AbstractSelectProps, 'loading'> 
     | React.ReactElement<InputProps>
     | React.ReactElement<OptionProps>
     | Array<React.ReactElement<OptionProps>>;
+  disableAnimation?: boolean;
 }
 
 function isSelectOptionOrSelectOptGroup(child: any): Boolean {
@@ -57,8 +58,8 @@ export default class AutoComplete extends React.Component<AutoCompleteProps, {}>
 
   static defaultProps = {
     transitionName: 'slide-up',
-    optionLabelProp: 'children',
     choiceTransitionName: 'zoom',
+    optionLabelProp: 'children',
     showSearch: false,
     filterOption: false,
   };
@@ -91,7 +92,10 @@ export default class AutoComplete extends React.Component<AutoCompleteProps, {}>
     this.select.blur();
   }
 
-  renderAutoComplete = ({ getPrefixCls }: ConfigConsumerProps) => {
+  renderAutoComplete = ({
+    getPrefixCls,
+    disableAnimation: disableAnimationGlobal,
+  }: ConfigConsumerProps) => {
     const {
       prefixCls: customizePrefixCls,
       size,
@@ -100,8 +104,14 @@ export default class AutoComplete extends React.Component<AutoCompleteProps, {}>
       optionLabelProp,
       dataSource,
       children,
+      disableAnimation: disableAnimationLocal,
     } = this.props;
     const prefixCls = getPrefixCls('select', customizePrefixCls);
+
+    // Give preference to the the prop if it alters the
+    // animation state of the component directly.
+    const disableAnimation =
+      typeof disableAnimationLocal !== 'undefined' ? disableAnimationLocal : disableAnimationGlobal;
 
     const cls = classNames({
       [`${prefixCls}-lg`]: size === 'large',
@@ -147,6 +157,7 @@ export default class AutoComplete extends React.Component<AutoCompleteProps, {}>
         optionLabelProp={optionLabelProp}
         getInputElement={this.getInputElement}
         notFoundContent={notFoundContent}
+        disableAnimation={disableAnimation}
         ref={this.saveSelect}
       >
         {options}

--- a/components/auto-complete/index.zh-CN.md
+++ b/components/auto-complete/index.zh-CN.md
@@ -31,6 +31,7 @@ const dataSource = ['12345', '23456', '34567'];
 | defaultActiveFirstOption | 是否默认高亮第一个选项。 | boolean | true |  |
 | defaultValue | 指定默认选中的条目 | string\|string\[]\| 无 |  |
 | disabled | 是否禁用 | boolean | false |  |
+| disableAnimation | 是否禁用下拉动画 | boolean | false |  |
 | filterOption | 是否根据输入项进行筛选。当其为一个函数时，会接收 `inputValue` `option` 两个参数，当 `option` 符合筛选条件时，应返回 `true`，反之则返回 `false`。 | boolean or function(inputValue, option) | true |  |
 | getPopupContainer | 菜单渲染父节点。默认渲染到 body 上，如果你遇到菜单滚动定位问题，试试修改为滚动的区域，并相对其定位。[示例](https://codesandbox.io/s/4j168r7jw0) | Function(triggerNode) | () => document.body | 3.19.4 |
 | optionLabelProp | 回填到选择框的 Option 的属性值，默认是 Option 的子元素。比如在子元素需要高亮效果时，此值可以设为 `value`。 | string | `children` |  |

--- a/components/button/button.tsx
+++ b/components/button/button.tsx
@@ -65,13 +65,13 @@ function spaceChildren(children: React.ReactNode, needInserted: boolean) {
 }
 
 const ButtonTypes = tuple('default', 'primary', 'ghost', 'dashed', 'danger', 'link');
-export type ButtonType = (typeof ButtonTypes)[number];
+export type ButtonType = typeof ButtonTypes[number];
 const ButtonShapes = tuple('circle', 'circle-outline', 'round');
-export type ButtonShape = (typeof ButtonShapes)[number];
+export type ButtonShape = typeof ButtonShapes[number];
 const ButtonSizes = tuple('large', 'default', 'small');
-export type ButtonSize = (typeof ButtonSizes)[number];
+export type ButtonSize = typeof ButtonSizes[number];
 const ButtonHTMLTypes = tuple('submit', 'button', 'reset');
-export type ButtonHTMLType = (typeof ButtonHTMLTypes)[number];
+export type ButtonHTMLType = typeof ButtonHTMLTypes[number];
 
 export interface BaseButtonProps {
   type?: ButtonType;
@@ -84,6 +84,7 @@ export interface BaseButtonProps {
   ghost?: boolean;
   block?: boolean;
   children?: React.ReactNode;
+  disableAnimation?: boolean;
 }
 
 // Typescript will make optional not optional if use Pick with union.
@@ -213,7 +214,11 @@ class Button extends React.Component<ButtonProps, ButtonState> {
     return React.Children.count(children) === 1 && !icon && type !== 'link';
   }
 
-  renderButton = ({ getPrefixCls, autoInsertSpaceInButton }: ConfigConsumerProps) => {
+  renderButton = ({
+    getPrefixCls,
+    autoInsertSpaceInButton,
+    disableAnimation: disableAnimationGlobal,
+  }: ConfigConsumerProps) => {
     const {
       prefixCls: customizePrefixCls,
       type,
@@ -224,12 +229,18 @@ class Button extends React.Component<ButtonProps, ButtonState> {
       icon,
       ghost,
       block,
+      disableAnimation: disableAnimationLocal,
       ...rest
     } = this.props;
     const { loading, hasTwoCNChar } = this.state;
 
     const prefixCls = getPrefixCls('btn', customizePrefixCls);
     const autoInsertSpace = autoInsertSpaceInButton !== false;
+
+    // Give preference to the the prop if it alters the
+    // animation state of the component directly.
+    const disableAnimation =
+      typeof disableAnimationLocal !== 'undefined' ? disableAnimationLocal : disableAnimationGlobal;
 
     // large => lg
     // small => sm
@@ -296,6 +307,10 @@ class Button extends React.Component<ButtonProps, ButtonState> {
     );
 
     if (type === 'link') {
+      return buttonNode;
+    }
+
+    if (disableAnimation) {
       return buttonNode;
     }
 

--- a/components/button/index.en-US.md
+++ b/components/button/index.en-US.md
@@ -17,6 +17,7 @@ To get a customized button, just set `type`/`shape`/`size`/`loading`/`disabled`.
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
 | disabled | disabled state of button | boolean | `false` | 3.5.1 |
+| disableAnimation | disable the wave animation | boolean | false |  |
 | ghost | make background transparent and invert text and border colors, added in 2.7 | boolean | `false` |  |
 | href | redirect url of link button | string | - |  |
 | htmlType | set the original html `type` of `button`, see: [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#attr-type) | string | `button` |  |

--- a/components/button/index.zh-CN.md
+++ b/components/button/index.zh-CN.md
@@ -20,6 +20,7 @@ subtitle: 按钮
 | 属性 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
 | disabled | 按钮失效状态 | boolean | `false` | 3.5.1 |
+| disableAnimation | 删除波浪动画 | boolean | false |  |
 | ghost | 幽灵属性，使按钮背景透明，版本 2.7 中增加 | boolean | false |  |
 | href | 点击跳转的地址，指定此属性 button 的行为和 a 链接一致 | string | - |  |
 | htmlType | 设置 `button` 原生的 `type` 值，可选值请参考 [HTML 标准](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#attr-type) | string | `button` |  |

--- a/components/config-provider/context.tsx
+++ b/components/config-provider/context.tsx
@@ -18,6 +18,7 @@ export interface ConfigConsumerProps {
   pageHeader?: {
     ghost: boolean;
   };
+  disableAnimation?: boolean;
 }
 
 export const ConfigContext = createReactContext<ConfigConsumerProps>({

--- a/components/config-provider/index.tsx
+++ b/components/config-provider/index.tsx
@@ -19,6 +19,7 @@ export const configConsumerProps = [
   'autoInsertSpaceInButton',
   'locale',
   'pageHeader',
+  'disableAnimation',
 ];
 
 export interface ConfigProviderProps {
@@ -32,6 +33,7 @@ export interface ConfigProviderProps {
   pageHeader?: {
     ghost: boolean;
   };
+  disableAnimation?: boolean;
 }
 
 class ConfigProvider extends React.Component<ConfigProviderProps> {
@@ -52,6 +54,7 @@ class ConfigProvider extends React.Component<ConfigProviderProps> {
       autoInsertSpaceInButton,
       locale,
       pageHeader,
+      disableAnimation,
     } = this.props;
 
     const config: ConfigConsumerProps = {
@@ -71,6 +74,10 @@ class ConfigProvider extends React.Component<ConfigProviderProps> {
 
     if (pageHeader) {
       config.pageHeader = pageHeader;
+    }
+
+    if (disableAnimation) {
+      config.disableAnimation = disableAnimation;
     }
 
     return (

--- a/components/dropdown/dropdown.tsx
+++ b/components/dropdown/dropdown.tsx
@@ -15,7 +15,7 @@ const Placements = tuple(
   'bottomCenter',
   'bottomRight',
 );
-type Placement = (typeof Placements)[number];
+type Placement = typeof Placements[number];
 
 type OverlayFunc = () => React.ReactNode;
 
@@ -50,6 +50,7 @@ export interface DropDownProps {
   mouseEnterDelay?: number;
   mouseLeaveDelay?: number;
   openClassName?: string;
+  disableAnimation?: boolean;
 }
 
 export default class Dropdown extends React.Component<DropDownProps, any> {
@@ -120,6 +121,7 @@ export default class Dropdown extends React.Component<DropDownProps, any> {
   renderDropDown = ({
     getPopupContainer: getContextPopupContainer,
     getPrefixCls,
+    disableAnimation: disableAnimationGlobal,
   }: ConfigConsumerProps) => {
     const {
       prefixCls: customizePrefixCls,
@@ -127,9 +129,16 @@ export default class Dropdown extends React.Component<DropDownProps, any> {
       trigger,
       disabled,
       getPopupContainer,
+      disableAnimation: disableAnimationLocal,
     } = this.props;
 
     const prefixCls = getPrefixCls('dropdown', customizePrefixCls);
+
+    // Give preference to the the prop if it alters the
+    // animation state of the component directly.
+    const disableAnimation =
+      typeof disableAnimationLocal !== 'undefined' ? disableAnimationLocal : disableAnimationGlobal;
+
     const child = React.Children.only(children) as React.ReactElement<any>;
 
     const dropdownTrigger = React.cloneElement(child, {
@@ -149,7 +158,7 @@ export default class Dropdown extends React.Component<DropDownProps, any> {
         {...this.props}
         prefixCls={prefixCls}
         getPopupContainer={getPopupContainer || getContextPopupContainer}
-        transitionName={this.getTransitionName()}
+        transitionName={disableAnimation ? null : this.getTransitionName()}
         trigger={triggerActions}
         overlay={() => this.renderOverlay(prefixCls)}
       >

--- a/components/dropdown/index.en-US.md
+++ b/components/dropdown/index.en-US.md
@@ -17,6 +17,7 @@ When there are more than a few options to choose from, you can wrap them in a `D
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
 | disabled | Whether the dropdown menu is disabled | boolean | - |  |
+| disableAnimation | Whether the dropdown animation is disabled | boolean | false |  |
 | getPopupContainer | To set the container of the dropdown menu. The default is to create a `div` element in `body`, but you can reset it to the scrolling area and make a relative reposition. [Example on CodePen](https://codepen.io/afc163/pen/zEjNOy?editors=0010). | Function(triggerNode) | `() => document.body` |  |
 | overlay | The dropdown menu | [Menu](/components/menu) \| () => Menu | - |  |
 | overlayClassName | Class name of the dropdown root element | string | - | 3.11.0 |

--- a/components/dropdown/index.zh-CN.md
+++ b/components/dropdown/index.zh-CN.md
@@ -18,6 +18,7 @@ title: Dropdown
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
 | disabled | 菜单是否禁用 | boolean | - |  |
+| disableAnimation | 是否禁用下拉动画 | boolean | false |  |
 | getPopupContainer | 菜单渲染父节点。默认渲染到 body 上，如果你遇到菜单滚动定位问题，试试修改为滚动的区域，并相对其定位。[示例](https://codepen.io/afc163/pen/zEjNOy?editors=0010) | Function(triggerNode) | `() => document.body` |  |
 | overlay | 菜单 | [Menu](/components/menu) \| () => Menu | - |  |
 | overlayClassName | 下拉根元素的类名称 | string | - | 3.11.0 |

--- a/components/menu/index.tsx
+++ b/components/menu/index.tsx
@@ -58,6 +58,7 @@ export interface MenuProps {
   getPopupContainer?: (triggerNode: HTMLElement) => HTMLElement;
   overflowedIndicator?: React.ReactNode;
   forceSubMenuRender?: boolean;
+  disableAnimation?: boolean;
 }
 
 type InternalMenuProps = MenuProps & SiderContextProps;
@@ -281,11 +282,27 @@ class InternalMenu extends React.Component<InternalMenuProps, MenuState> {
     }
   }
 
-  renderMenu = ({ getPopupContainer, getPrefixCls }: ConfigConsumerProps) => {
-    const { prefixCls: customizePrefixCls, className, theme, collapsedWidth } = this.props;
+  renderMenu = ({
+    getPopupContainer,
+    getPrefixCls,
+    disableAnimation: disableAnimationGlobal,
+  }: ConfigConsumerProps) => {
+    const {
+      prefixCls: customizePrefixCls,
+      className,
+      theme,
+      collapsedWidth,
+      disableAnimation: disableAnimationLocal,
+    } = this.props;
+
+    // Give preference to the the prop if it alters the
+    // animation state of the component directly.
+    const disableAnimation =
+      typeof disableAnimationLocal !== 'undefined' ? disableAnimationLocal : disableAnimationGlobal;
+
     const passProps = omit(this.props, ['collapsedWidth', 'siderCollapsed']);
     const menuMode = this.getRealMenuMode();
-    const menuOpenMotion = this.getOpenMotionProps(menuMode!);
+    const menuOpenMotion = disableAnimation ? null : this.getOpenMotionProps(menuMode!);
 
     const prefixCls = getPrefixCls('menu', customizePrefixCls);
     const menuClassName = classNames(className, `${prefixCls}-${theme}`, {

--- a/components/select/index.en-US.md
+++ b/components/select/index.en-US.md
@@ -29,6 +29,7 @@ Select component to select value from options.
 | defaultActiveFirstOption | Whether active first option by default | boolean | true |  |
 | defaultValue | Initial selected option. | string\|string\[]<br />number\|number\[]<br />LabeledValue\|LabeledValue[] | - |  |
 | disabled | Whether disabled select | boolean | false |  |
+| disableAnimation | Whether the dropdown animation is disabled | boolean | false |  |
 | dropdownClassName | className of dropdown menu | string | - |  |
 | dropdownMatchSelectWidth | Whether dropdown's width is same with select. | boolean | true |  |
 | dropdownRender | Customize dropdown content | (menuNode: ReactNode, props) => ReactNode | - | 3.11.0 |

--- a/components/select/index.tsx
+++ b/components/select/index.tsx
@@ -14,7 +14,7 @@ export interface AbstractSelectProps {
   prefixCls?: string;
   className?: string;
   showAction?: string | string[];
-  size?: (typeof SelectSizes)[number];
+  size?: typeof SelectSizes[number];
   notFoundContent?: React.ReactNode | null;
   transitionName?: string;
   choiceTransitionName?: string;
@@ -58,7 +58,7 @@ const ModeOptions = tuple(
   'combobox',
   'SECRET_COMBOBOX_MODE_DO_NOT_USE',
 );
-export type ModeOption = (typeof ModeOptions)[number];
+export type ModeOption = typeof ModeOptions[number];
 export interface SelectProps<T = SelectValue> extends AbstractSelectProps {
   value?: T;
   defaultValue?: T;
@@ -86,6 +86,7 @@ export interface SelectProps<T = SelectValue> extends AbstractSelectProps {
   removeIcon?: React.ReactNode;
   clearIcon?: React.ReactNode;
   menuItemSelectedIcon?: React.ReactNode;
+  disableAnimation?: boolean;
 }
 
 export interface OptionProps {
@@ -127,8 +128,6 @@ export default class Select<T = SelectValue> extends React.Component<SelectProps
 
   static defaultProps = {
     showSearch: false,
-    transitionName: 'slide-up',
-    choiceTransitionName: 'zoom',
   };
 
   static propTypes = SelectPropTypes;
@@ -196,6 +195,7 @@ export default class Select<T = SelectValue> extends React.Component<SelectProps
     getPopupContainer: getContextPopupContainer,
     getPrefixCls,
     renderEmpty,
+    disableAnimation: disableAnimationGlobal,
   }: ConfigConsumerProps) => {
     const {
       prefixCls: customizePrefixCls,
@@ -207,9 +207,15 @@ export default class Select<T = SelectValue> extends React.Component<SelectProps
       clearIcon,
       menuItemSelectedIcon,
       showArrow,
+      disableAnimation: disableAnimationLocal,
       ...restProps
     } = this.props;
     const rest = omit(restProps, ['inputIcon']);
+
+    // Give preference to the the prop if it alters the
+    // animation state of the component directly.
+    const disableAnimation =
+      typeof disableAnimationLocal !== 'undefined' ? disableAnimationLocal : disableAnimationGlobal;
 
     const prefixCls = getPrefixCls('select', customizePrefixCls);
     const cls = classNames(
@@ -268,6 +274,8 @@ export default class Select<T = SelectValue> extends React.Component<SelectProps
         showArrow={showArrow}
         {...rest}
         {...modeConfig}
+        transitionName={disableAnimation ? null : 'slide-up'}
+        choiceTransitionName={disableAnimation ? null : 'zoom'}
         prefixCls={prefixCls}
         className={cls}
         optionLabelProp={optionLabelProp || 'children'}

--- a/components/select/index.zh-CN.md
+++ b/components/select/index.zh-CN.md
@@ -30,6 +30,7 @@ title: Select
 | defaultActiveFirstOption | 是否默认高亮第一个选项。 | boolean | true |  |
 | defaultValue | 指定默认选中的条目 | string\|string\[]\<br />number\|number\[]\<br />LabeledValue\|LabeledValue[] | - |  |
 | disabled | 是否禁用 | boolean | false |  |
+| disableAnimation | 是否禁用下拉动画 | boolean | false |  |
 | dropdownClassName | 下拉菜单的 className 属性 | string | - |  |
 | dropdownMatchSelectWidth | 下拉菜单和选择器同宽 | boolean | true |  |
 | dropdownRender | 自定义下拉框内容 | (menuNode: ReactNode, props) => ReactNode | - | 3.11.0 |

--- a/components/switch/index.tsx
+++ b/components/switch/index.tsx
@@ -27,6 +27,7 @@ export interface SwitchProps {
   autoFocus?: boolean;
   style?: React.CSSProperties;
   title?: string;
+  disableAnimation?: boolean;
 }
 
 export default class Switch extends React.Component<SwitchProps, {}> {
@@ -66,9 +67,25 @@ export default class Switch extends React.Component<SwitchProps, {}> {
     this.rcSwitch.blur();
   }
 
-  renderSwitch = ({ getPrefixCls }: ConfigConsumerProps) => {
-    const { prefixCls: customizePrefixCls, size, loading, className = '', disabled } = this.props;
+  renderSwitch = ({
+    getPrefixCls,
+    disableAnimation: disableAnimationGlobal,
+  }: ConfigConsumerProps) => {
+    const {
+      prefixCls: customizePrefixCls,
+      size,
+      loading,
+      className = '',
+      disabled,
+      disableAnimation: disableAnimationLocal,
+    } = this.props;
     const prefixCls = getPrefixCls('switch', customizePrefixCls);
+
+    // Give preference to the the prop if it alters the
+    // animation state of the component directly.
+    const disableAnimation =
+      typeof disableAnimationLocal !== 'undefined' ? disableAnimationLocal : disableAnimationGlobal;
+
     const classes = classNames(className, {
       [`${prefixCls}-small`]: size === 'small',
       [`${prefixCls}-loading`]: loading,
@@ -76,18 +93,23 @@ export default class Switch extends React.Component<SwitchProps, {}> {
     const loadingIcon = loading ? (
       <Icon type="loading" className={`${prefixCls}-loading-icon`} />
     ) : null;
-    return (
-      <Wave insertExtraNode>
-        <RcSwitch
-          {...omit(this.props, ['loading'])}
-          prefixCls={prefixCls}
-          className={classes}
-          disabled={disabled || loading}
-          ref={this.saveSwitch}
-          loadingIcon={loadingIcon}
-        />
-      </Wave>
+
+    const switchNode = (
+      <RcSwitch
+        {...omit(this.props, ['loading'])}
+        prefixCls={prefixCls}
+        className={classes}
+        disabled={disabled || loading}
+        ref={this.saveSwitch}
+        loadingIcon={loadingIcon}
+      />
     );
+
+    if (disableAnimation) {
+      return switchNode;
+    }
+
+    return <Wave insertExtraNode>{switchNode}</Wave>;
   };
 
   render() {

--- a/components/tag/index.en-US.md
+++ b/components/tag/index.en-US.md
@@ -20,6 +20,7 @@ Tag for categorizing or markup.
 | --- | --- | --- | --- | --- |
 | afterClose | Callback executed when close animation is completed, please use `onClose`, we will remove this in the next version | () => void | - |  |
 | closable | Whether the Tag can be closed | boolean | `false` |  |
+| disableAnimation | disable the wave animation | boolean | false |  |
 | color | Color of the Tag | string | - |  |
 | onClose | Callback executed when tag is closed | (e) => void | - |  |
 | visible | Whether the Tag is closed or not | boolean | `true` | 3.7.0 |

--- a/components/tag/index.tsx
+++ b/components/tag/index.tsx
@@ -20,6 +20,7 @@ export interface TagProps extends React.HTMLAttributes<HTMLSpanElement> {
   onClose?: Function;
   afterClose?: Function;
   style?: React.CSSProperties;
+  disableAnimation?: boolean;
 }
 
 interface TagState {
@@ -117,7 +118,7 @@ class Tag extends React.Component<TagProps, TagState> {
   }
 
   renderTag = (configProps: ConfigConsumerProps) => {
-    const { children, ...otherProps } = this.props;
+    const { children, disableAnimation: disableAnimationLocal, ...otherProps } = this.props;
     const isNeedWave =
       'onClick' in otherProps || (children && (children as React.ReactElement<any>).type === 'a');
     const tagProps = omit(otherProps, [
@@ -128,23 +129,29 @@ class Tag extends React.Component<TagProps, TagState> {
       'closable',
       'prefixCls',
     ]);
-    return isNeedWave ? (
-      <Wave>
-        <span
-          {...tagProps}
-          className={this.getTagClassName(configProps)}
-          style={this.getTagStyle()}
-        >
-          {children}
-          {this.renderCloseIcon()}
-        </span>
-      </Wave>
-    ) : (
+
+    // Give preference to the the prop if it alters the
+    // animation state of the component directly.
+    const disableAnimation =
+      typeof disableAnimationLocal !== 'undefined'
+        ? disableAnimationLocal
+        : configProps.disableAnimation;
+
+    const tagNode = (
       <span {...tagProps} className={this.getTagClassName(configProps)} style={this.getTagStyle()}>
         {children}
         {this.renderCloseIcon()}
       </span>
     );
+
+    if (isNeedWave) {
+      if (disableAnimation) {
+        return tagNode;
+      }
+      return <Wave>{tagNode}</Wave>;
+    }
+
+    return tagNode;
   };
 
   render() {

--- a/components/tag/index.zh-CN.md
+++ b/components/tag/index.zh-CN.md
@@ -21,6 +21,7 @@ title: Tag
 | afterClose | 关闭动画完成后的回调，请使用 `onClose`, 我们将在下个版本删除此项 | () => void | - |  |
 | closable | 标签是否可以关闭 | boolean | false |  |
 | color | 标签色 | string | - |  |
+| disableAnimation | 删除波浪动画 | boolean | false |  |
 | onClose | 关闭时的回调 | (e) => void | - |  |
 | visible | 是否显示标签 | boolean | `true` | 3.7.0 |
 

--- a/components/tree-select/index.en-US.md
+++ b/components/tree-select/index.en-US.md
@@ -20,6 +20,7 @@ Tree selection control.
 | autoClearSearchValue | auto clear search input value when multiple select is selected/deselected | boolean | true | 3.7.0 |
 | defaultValue | To set the initial selected treeNode(s). | string\|string\[] | - |  |
 | disabled | Disabled or not | boolean | false |  |
+| disableAnimation | Whether the dropdown animation is disabled | boolean | false |  |
 | dropdownClassName | className of dropdown menu | string | - | 3.3.0 |
 | dropdownMatchSelectWidth | Determine whether the dropdown menu and the select input are the same width. Default set `min-width` same as input. | boolean | true |  |
 | dropdownStyle | To set the style of the dropdown menu | object | - |  |

--- a/components/tree-select/index.tsx
+++ b/components/tree-select/index.tsx
@@ -23,11 +23,6 @@ export default class TreeSelect<T extends TreeNodeValue> extends React.Component
 
   static SHOW_CHILD = SHOW_CHILD;
 
-  static defaultProps = {
-    transitionName: 'slide-up',
-    choiceTransitionName: 'zoom',
-  };
-
   private rcTreeSelect: any;
 
   constructor(props: TreeSelectProps<T>) {
@@ -66,6 +61,7 @@ export default class TreeSelect<T extends TreeNodeValue> extends React.Component
     getPopupContainer: getContextPopupContainer,
     getPrefixCls,
     renderEmpty,
+    disableAnimation: disableAnimationGlobal,
   }: ConfigConsumerProps) => {
     const {
       prefixCls: customizePrefixCls,
@@ -78,9 +74,15 @@ export default class TreeSelect<T extends TreeNodeValue> extends React.Component
       removeIcon,
       clearIcon,
       getPopupContainer,
+      disableAnimation: disableAnimationLocal,
       ...restProps
     } = this.props;
     const rest = omit(restProps, ['inputIcon', 'removeIcon', 'clearIcon', 'switcherIcon']);
+
+    // Give preference to the the prop if it alters the
+    // animation state of the component directly.
+    const disableAnimation =
+      typeof disableAnimationLocal !== 'undefined' ? disableAnimationLocal : disableAnimationGlobal;
 
     const prefixCls = getPrefixCls('select', customizePrefixCls);
     const cls = classNames(
@@ -134,6 +136,8 @@ export default class TreeSelect<T extends TreeNodeValue> extends React.Component
         dropdownClassName={classNames(dropdownClassName, `${prefixCls}-tree-dropdown`)}
         prefixCls={prefixCls}
         className={cls}
+        transitionName={disableAnimation ? null : 'slide-up'}
+        choiceTransitionName={disableAnimation ? null : 'zoom'}
         dropdownStyle={{ maxHeight: '100vh', overflow: 'auto', ...dropdownStyle }}
         treeCheckable={checkable}
         notFoundContent={notFoundContent || renderEmpty('Select')}

--- a/components/tree-select/index.zh-CN.md
+++ b/components/tree-select/index.zh-CN.md
@@ -21,6 +21,7 @@ title: TreeSelect
 | autoClearSearchValue | 当多选模式下值被选择，自动清空搜索框 | boolean | true | 3.7.0 |
 | defaultValue | 指定默认选中的条目 | string/string\[] | - |  |
 | disabled | 是否禁用 | boolean | false |  |
+| disableAnimation | 是否禁用下拉动画 | boolean | false |  |
 | dropdownClassName | 下拉菜单的 className 属性 | string | - | 3.3.0 |
 | dropdownMatchSelectWidth | 下拉菜单和选择器同宽。默认将设置 `min-width`。 | boolean | true |  |
 | dropdownStyle | 下拉菜单的样式 | object | - |  |

--- a/components/tree-select/interface.tsx
+++ b/components/tree-select/interface.tsx
@@ -65,4 +65,5 @@ export interface TreeSelectProps<T extends TreeNodeValue> extends AbstractSelect
   treeNodeFilterProp?: string;
   treeNodeLabelProp?: string;
   value?: T;
+  disableAnimation?: boolean;
 }


### PR DESCRIPTION

<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [x] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

#16943

### 💡 Background and solution

Some users may need/want to disable basic animations to load speed or design purposes. Adding in the prop ` disableAnimations` allows for the user to disable animations globally through configProvider, or through the component props. The component prop takes priority, meaning it will override what is defined in configProvider.

Components added so far: dropdown, menu, autocomplete, select, tree-select. There are still more components to be added, but this is a start. 

to disable an animation, just add the prop: `disableAnimation={false}`

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  add disableAnimation for dropdown/menu/autocomplete/select/tree-select components  |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/auto-complete/index.en-US.md](https://github.com/Satloff/ant-design/blob/disable-animation/components/auto-complete/index.en-US.md)
[View rendered components/auto-complete/index.zh-CN.md](https://github.com/Satloff/ant-design/blob/disable-animation/components/auto-complete/index.zh-CN.md)
[View rendered components/button/index.en-US.md](https://github.com/Satloff/ant-design/blob/disable-animation/components/button/index.en-US.md)
[View rendered components/button/index.zh-CN.md](https://github.com/Satloff/ant-design/blob/disable-animation/components/button/index.zh-CN.md)
[View rendered components/dropdown/index.en-US.md](https://github.com/Satloff/ant-design/blob/disable-animation/components/dropdown/index.en-US.md)
[View rendered components/dropdown/index.zh-CN.md](https://github.com/Satloff/ant-design/blob/disable-animation/components/dropdown/index.zh-CN.md)
[View rendered components/select/index.en-US.md](https://github.com/Satloff/ant-design/blob/disable-animation/components/select/index.en-US.md)
[View rendered components/select/index.zh-CN.md](https://github.com/Satloff/ant-design/blob/disable-animation/components/select/index.zh-CN.md)
[View rendered components/tag/index.en-US.md](https://github.com/Satloff/ant-design/blob/disable-animation/components/tag/index.en-US.md)
[View rendered components/tag/index.zh-CN.md](https://github.com/Satloff/ant-design/blob/disable-animation/components/tag/index.zh-CN.md)
[View rendered components/tree-select/index.en-US.md](https://github.com/Satloff/ant-design/blob/disable-animation/components/tree-select/index.en-US.md)
[View rendered components/tree-select/index.zh-CN.md](https://github.com/Satloff/ant-design/blob/disable-animation/components/tree-select/index.zh-CN.md)