### PR TITLE
fix doc.  

### DIFF
--- a/components/card/index.en-US.md
+++ b/components/card/index.en-US.md
@@ -13,7 +13,7 @@ A card can be used to display content related to a single subject. The content c
 
 ## API
 
-```html
+```jsx
 <Card title="Card title">Card content</Card>
 ```
 

--- a/components/card/index.zh-CN.md
+++ b/components/card/index.zh-CN.md
@@ -14,7 +14,7 @@ cols: 1
 
 ## API
 
-```html
+```jsx
 <Card title="卡片标题">卡片内容</Card>
 ```
 

--- a/components/input/index.en-US.md
+++ b/components/input/index.en-US.md
@@ -69,7 +69,7 @@ Supports all props of `Input`.
 | compact | Whether use compact style | boolean | false |  |
 | size | The size of `Input.Group` specifies the size of the included `Input` fields. Available: `large` `default` `small` | string | `default` |  |
 
-```html
+```jsx
 <Input.Group>
   <input />
   <input />

--- a/components/input/index.zh-CN.md
+++ b/components/input/index.zh-CN.md
@@ -68,7 +68,7 @@ Input 的其他属性和 React 自带的 [input](https://facebook.github.io/reac
 | compact | 是否用紧凑模式 | boolean | false |  |
 | size | `Input.Group` 中所有的 `Input` 的大小，可选 `large` `default` `small` | string | `default` |  |
 
-```html
+```jsx
 <Input.Group>
   <input />
   <input />

--- a/components/menu/index.en-US.md
+++ b/components/menu/index.en-US.md
@@ -15,7 +15,7 @@ More layouts with navigation: [Layout](/components/layout).
 
 ## API
 
-```html
+```jsx
 <Menu>
   <Menu.Item>Menu</Menu.Item>
   <SubMenu title="SubMenu">
@@ -26,27 +26,27 @@ More layouts with navigation: [Layout](/components/layout).
 
 ### Menu
 
-| Param               | Description                                                | Type                                                     | Default value | Version |
-| ------------------- | ---------------------------------------------------------- | -------------------------------------------------------- | ------------- | ------- |
-| defaultOpenKeys     | Array with the keys of default opened sub menus            | string\[]                                                |               |         |
-| defaultSelectedKeys | Array with the keys of default selected menu items         | string\[]                                                |               |         |
-| forceSubMenuRender  | Render submenu into DOM before it becomes visible          | boolean                                                  | false         |         |
-| inlineCollapsed     | Specifies the collapsed status when menu is inline mode    | boolean                                                  | -             |         |
-| inlineIndent        | Indent (in pixels) of inline menu items on each level      | number                                                   | 24            |         |
-| mode                | Type of menu; `vertical`, `horizontal`, or `inline`        | string: `vertical` \| `horizontal` \| `inline`           | `vertical`    |         |
-| multiple            | Allows selection of multiple items                         | boolean                                                  | false         |         |  
-| openKeys            | Array with the keys of currently opened sub-menus          | string\[]                                                |               |         |
-| selectable          | Allows selecting menu items                                | boolean                                                  | true          |         |
-| selectedKeys        | Array with the keys of currently selected menu items       | string\[]                                                |               |         |
-| style               | Style of the root node                                     | object                                                   |               |         |
-| subMenuCloseDelay   | Delay time to hide submenu when mouse leaves (in seconds)  | number                                                   | 0.1           |         |
-| subMenuOpenDelay    | Delay time to show submenu when mouse enters, (in seconds) | number                                                   | 0             |         |
-| theme               | Color theme of the menu                                    | string: `light` \| `dark`                                | `light`       |         |
-| onClick             | Called when a menu item is clicked                         | function({ item, key, keyPath, domEvent })               | -             |         |
-| onDeselect          | Called when a menu item is deselected (multiple mode only) | function({ item, key, keyPath, selectedKeys, domEvent }) | -             |         |
-| onOpenChange        | Called when sub-menus are opened or closed                 | function(openKeys: string\[])                            | noop          |         |
-| onSelect            | Called when a menu item is selected                        | function({ item, key, keyPath, selectedKeys, domEvent }) | none          |         |
-| overflowedIndicator | Customized icon when menu is collapsed                     | ReactNode                                                | -             | 3.16.0  |
+| Param | Description | Type | Default value | Version |
+| --- | --- | --- | --- | --- |
+| defaultOpenKeys | Array with the keys of default opened sub menus | string\[] |  |  |
+| defaultSelectedKeys | Array with the keys of default selected menu items | string\[] |  |  |
+| forceSubMenuRender | Render submenu into DOM before it becomes visible | boolean | false |  |
+| inlineCollapsed | Specifies the collapsed status when menu is inline mode | boolean | - |  |
+| inlineIndent | Indent (in pixels) of inline menu items on each level | number | 24 |  |
+| mode | Type of menu; `vertical`, `horizontal`, or `inline` | string: `vertical` \| `horizontal` \| `inline` | `vertical` |  |
+| multiple | Allows selection of multiple items | boolean | false |  |
+| openKeys | Array with the keys of currently opened sub-menus | string\[] |  |  |
+| selectable | Allows selecting menu items | boolean | true |  |
+| selectedKeys | Array with the keys of currently selected menu items | string\[] |  |  |
+| style | Style of the root node | object |  |  |
+| subMenuCloseDelay | Delay time to hide submenu when mouse leaves (in seconds) | number | 0.1 |  |
+| subMenuOpenDelay | Delay time to show submenu when mouse enters, (in seconds) | number | 0 |  |
+| theme | Color theme of the menu | string: `light` \| `dark` | `light` |  |
+| onClick | Called when a menu item is clicked | function({ item, key, keyPath, domEvent }) | - |  |
+| onDeselect | Called when a menu item is deselected (multiple mode only) | function({ item, key, keyPath, selectedKeys, domEvent }) | - |  |
+| onOpenChange | Called when sub-menus are opened or closed | function(openKeys: string\[]) | noop |  |
+| onSelect | Called when a menu item is selected | function({ item, key, keyPath, selectedKeys, domEvent }) | none |  |
+| overflowedIndicator | Customized icon when menu is collapsed | ReactNode | - | 3.16.0 |
 
 > More options in [rc-menu](https://github.com/react-component/menu#api)
 
@@ -60,14 +60,14 @@ More layouts with navigation: [Layout](/components/layout).
 
 ### Menu.SubMenu
 
-| Param          | Description                                          | Type                        | Default value | Version |
-| -------------- | ---------------------------------------------------- | --------------------------- | ------------- | ------- |
-| popupClassName | Sub-menu class name                                  | string                      |               | 3.22.0  |
-| children       | Sub-menus or sub-menu items                          | Array&lt;MenuItem\|SubMenu> |               |         |
-| disabled       | Whether sub-menu is disabled                         | boolean                     | false         |         |
-| key            | Unique ID of the sub-menu                            | string                      |               |         |
-| title          | Title of the sub-menu                                | string\|ReactNode           |               |         |
-| onTitleClick   | Callback executed when the sub-menu title is clicked | function({ key, domEvent }) |               |         |
+| Param | Description | Type | Default value | Version |
+| --- | --- | --- | --- | --- |
+| popupClassName | Sub-menu class name | string |  | 3.22.0 |
+| children | Sub-menus or sub-menu items | Array&lt;MenuItem\|SubMenu> |  |  |
+| disabled | Whether sub-menu is disabled | boolean | false |  |
+| key | Unique ID of the sub-menu | string |  |  |
+| title | Title of the sub-menu | string\|ReactNode |  |  |
+| onTitleClick | Callback executed when the sub-menu title is clicked | function({ key, domEvent }) |  |  |
 
 ### Menu.ItemGroup
 

--- a/components/menu/index.zh-CN.md
+++ b/components/menu/index.zh-CN.md
@@ -16,7 +16,7 @@ subtitle: 导航菜单
 
 ## API
 
-```html
+```jsx
 <Menu>
   <Menu.Item>菜单项</Menu.Item>
   <SubMenu title="子菜单">

--- a/components/pagination/index.en-US.md
+++ b/components/pagination/index.en-US.md
@@ -14,8 +14,8 @@ A long list can be divided into several pages using `Pagination`, and only one p
 
 ## API
 
-```html
-<Pagination onChange="{onChange}" total="{50}" />
+```jsx
+<Pagination onChange={onChange} total={50} />
 ```
 
 | Property | Description | Type | Default | Version |

--- a/components/pagination/index.zh-CN.md
+++ b/components/pagination/index.zh-CN.md
@@ -15,8 +15,8 @@ cols: 1
 
 ## API
 
-```html
-<Pagination onChange="{onChange}" total="{50}" />
+```jsx
+<Pagination onChange={onChange} total={50} />
 ```
 
 | 参数 | 说明 | 类型 | 默认值 | 版本 |

--- a/components/select/index.en-US.md
+++ b/components/select/index.en-US.md
@@ -13,7 +13,7 @@ Select component to select value from options.
 
 ## API
 
-```html
+```jsx
 <select>
   <option value="lucy">lucy</option>
 </select>


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution
markdown with `html` tag will be format error by perttier. it should be `jsx` tag
eg: 

```html
<Pagination onChange="{onChange}" total="{50}" />
```
to 
```jsx
<Pagination onChange={onChange} total={50} />
```


<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  fix the flies which format error by perttier because of the `html` tag not `jsx` tag   |
| 🇨🇳 Chinese | 修复md文档中因`html`标签导致的prettier格式化错误 |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/card/index.en-US.md](https://github.com/dr2009/ant-design/blob/master/components/card/index.en-US.md)
[View rendered components/card/index.zh-CN.md](https://github.com/dr2009/ant-design/blob/master/components/card/index.zh-CN.md)
[View rendered components/input/index.en-US.md](https://github.com/dr2009/ant-design/blob/master/components/input/index.en-US.md)
[View rendered components/input/index.zh-CN.md](https://github.com/dr2009/ant-design/blob/master/components/input/index.zh-CN.md)
[View rendered components/menu/index.en-US.md](https://github.com/dr2009/ant-design/blob/master/components/menu/index.en-US.md)
[View rendered components/menu/index.zh-CN.md](https://github.com/dr2009/ant-design/blob/master/components/menu/index.zh-CN.md)
[View rendered components/pagination/index.en-US.md](https://github.com/dr2009/ant-design/blob/master/components/pagination/index.en-US.md)
[View rendered components/pagination/index.zh-CN.md](https://github.com/dr2009/ant-design/blob/master/components/pagination/index.zh-CN.md)
[View rendered components/select/index.en-US.md](https://github.com/dr2009/ant-design/blob/master/components/select/index.en-US.md)