### PR TITLE
fix: Select should auto width as v3

### DIFF
--- a/components/select/style/index.less
+++ b/components/select/style/index.less
@@ -71,6 +71,10 @@
   &-arrow {
     .iconfont-mixin();
 
+    > * {
+      line-height: 0;
+    }
+
     position: absolute;
     top: 53%;
     right: @control-padding-horizontal - 1px;
@@ -170,7 +174,7 @@
   }
 
   // ========================= Options =========================
-  &-item {
+  .item() {
     position: relative;
     display: block;
     min-height: 32px;
@@ -180,6 +184,14 @@
     line-height: 22px;
     cursor: pointer;
     transition: background 0.3s ease;
+  }
+
+  &-item-empty {
+    .item();
+  }
+
+  &-item {
+    .item();
 
     // =========== Group ============
     &-group {

--- a/components/select/style/single.less
+++ b/components/select/style/single.less
@@ -34,8 +34,8 @@
 
     &::after,
     .@{select-prefix-cls}-selection-placeholder::after {
-      content: '\a0';
       line-height: @select-height-without-border;
+      content: '\a0';
     }
   }
 

--- a/components/select/style/single.less
+++ b/components/select/style/single.less
@@ -6,7 +6,11 @@
     display: flex;
 
     .@{select-prefix-cls}-selection-search {
-      width: 100%;
+      position: absolute;
+      left: @input-padding-horizontal-base;
+      right: @input-padding-horizontal-base;
+      top: 0;
+      bottom: 0;
 
       &-input {
         width: 100%;
@@ -15,12 +19,7 @@
 
     .@{select-prefix-cls}-selection-item,
     .@{select-prefix-cls}-selection-placeholder {
-      position: absolute;
-      top: 0;
-      right: 0;
-      bottom: 0;
-      left: 0;
-      padding: 0 @input-padding-horizontal-base;
+      padding: 0;
       line-height: @input-height-base;
       transition: all 0.3s;
       pointer-events: none;
@@ -32,12 +31,22 @@
         }
       }
     }
+
+    .@{select-prefix-cls}-selection-placeholder {
+      &::after {
+        content: '\a0';
+      }
+    }
   }
 
   // With arrow should provides `padding-right` to show the arrow
-  &.@{select-prefix-cls}-show-arrow .@{select-prefix-cls}-selector,
-  &.@{select-prefix-cls}-show-arrow .@{select-prefix-cls}-selection-item {
-    padding-right: @control-padding-horizontal + @font-size-sm;
+  &.@{select-prefix-cls}-show-arrow .@{select-prefix-cls}-selection-search {
+    right: @input-padding-horizontal-base + @font-size-base;
+  }
+
+  &.@{select-prefix-cls}-show-arrow .@{select-prefix-cls}-selection-item,
+  &.@{select-prefix-cls}-show-arrow .@{select-prefix-cls}-selection-placeholder {
+    padding-right: @font-size-base;
   }
 
   // Opacity selection if open
@@ -95,12 +104,23 @@
   // Size small need additional set padding
   &.@{select-prefix-cls}-sm {
     &:not(.@{select-prefix-cls}-customize-input) {
+      .@{select-prefix-cls}-selection-search {
+        left: @input-padding-horizontal-sm;
+        right: @input-padding-horizontal-sm;
+      }
+
       .@{select-prefix-cls}-selector {
-        &,
-        .@{select-prefix-cls}-selection-item,
-        .@{select-prefix-cls}-selection-placeholder {
-          padding: 0 @input-padding-horizontal-sm;
-        }
+        padding: 0 @input-padding-horizontal-sm;
+      }
+
+      // With arrow should provides `padding-right` to show the arrow
+      &.@{select-prefix-cls}-show-arrow .@{select-prefix-cls}-selection-search {
+        right: @input-padding-horizontal-sm + @font-size-base * 1.5;
+      }
+
+      &.@{select-prefix-cls}-show-arrow .@{select-prefix-cls}-selection-item,
+      &.@{select-prefix-cls}-show-arrow .@{select-prefix-cls}-selection-placeholder {
+        padding-right: @font-size-base * 1.5;
       }
     }
   }

--- a/components/select/style/single.less
+++ b/components/select/style/single.less
@@ -7,10 +7,10 @@
 
     .@{select-prefix-cls}-selection-search {
       position: absolute;
-      left: @input-padding-horizontal-base;
-      right: @input-padding-horizontal-base;
       top: 0;
+      right: @input-padding-horizontal-base;
       bottom: 0;
+      left: @input-padding-horizontal-base;
 
       &-input {
         width: 100%;
@@ -105,8 +105,8 @@
   &.@{select-prefix-cls}-sm {
     &:not(.@{select-prefix-cls}-customize-input) {
       .@{select-prefix-cls}-selection-search {
-        left: @input-padding-horizontal-sm;
         right: @input-padding-horizontal-sm;
+        left: @input-padding-horizontal-sm;
       }
 
       .@{select-prefix-cls}-selector {

--- a/components/select/style/single.less
+++ b/components/select/style/single.less
@@ -20,7 +20,7 @@
     .@{select-prefix-cls}-selection-item,
     .@{select-prefix-cls}-selection-placeholder {
       padding: 0;
-      line-height: @input-height-base;
+      line-height: @select-height-without-border;
       transition: all 0.3s;
       pointer-events: none;
 
@@ -32,10 +32,10 @@
       }
     }
 
-    .@{select-prefix-cls}-selection-placeholder {
-      &::after {
-        content: '\a0';
-      }
+    &::after,
+    .@{select-prefix-cls}-selection-placeholder::after {
+      content: '\a0';
+      line-height: @select-height-without-border;
     }
   }
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

fix #20146
fix #19889

ref: https://github.com/react-component/select/pull/436#issuecomment-564985884

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fix Select not correct auto width when style not set `width`.      |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
