### PR TITLE
feat/add warning for icon props

### DIFF
--- a/components/avatar/__tests__/Avatar.test.js
+++ b/components/avatar/__tests__/Avatar.test.js
@@ -133,4 +133,15 @@ describe('Avatar Render', () => {
     wrapper.setProps({ children: 'xx' });
     expect(wrapper.state().scale).toBe(0.32);
   });
+
+  it('should warning when pass a string as icon props', () => {
+    const warnSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    mount(<Avatar size={64} icon="aa" />);
+    expect(warnSpy).not.toHaveBeenCalled();
+    mount(<Avatar size={64} icon="user" />);
+    expect(warnSpy).toHaveBeenCalledWith(
+      `Warning: [antd: Avatar] \`icon\` is using ReactNode instead of string naming in v4. Please check \`user\` at https://ant.design/components/icon`,
+    );
+    warnSpy.mockRestore();
+  });
 });

--- a/components/avatar/index.tsx
+++ b/components/avatar/index.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import classNames from 'classnames';
 
 import { ConfigConsumer, ConfigConsumerProps } from '../config-provider';
+import warning from '../_util/warning';
 
 export interface AvatarProps {
   /** Shape of avatar, options:`circle`, `square` */
@@ -107,6 +108,12 @@ export default class Avatar extends React.Component<AvatarProps, AvatarState> {
       alt,
       ...others
     } = this.props;
+
+    warning(
+      !(typeof icon === 'string' && icon.length > 2),
+      'Avatar',
+      `\`icon\` is using ReactNode instead of string naming in v4. Please check \`${icon}\` at https://ant.design/components/icon`,
+    );
 
     const { isImgExist, scale, mounted } = this.state;
 

--- a/components/button/__tests__/index.test.js
+++ b/components/button/__tests__/index.test.js
@@ -233,4 +233,15 @@ describe('Button', () => {
       wrapper.unmount();
     }).not.toThrow();
   });
+
+  it('should warning when pass a string as icon props', () => {
+    const warnSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    mount(<Button type="primary" icon="ab" />);
+    expect(warnSpy).not.toHaveBeenCalled();
+    mount(<Button type="primary" icon="search" />);
+    expect(warnSpy).toHaveBeenCalledWith(
+      `Warning: [antd: Button] \`icon\` is using ReactNode instead of string naming in v4. Please check \`search\` at https://ant.design/components/icon`,
+    );
+    warnSpy.mockRestore();
+  });
 });

--- a/components/button/button.tsx
+++ b/components/button/button.tsx
@@ -10,6 +10,7 @@ import Group from './button-group';
 import { ConfigConsumer, ConfigConsumerProps } from '../config-provider';
 import Wave from '../_util/wave';
 import { Omit, tuple } from '../_util/type';
+import warning from '../_util/warning';
 
 const rxTwoCNChar = /^[\u4e00-\u9fa5]{2}$/;
 const isTwoCNChar = rxTwoCNChar.test.bind(rxTwoCNChar);
@@ -230,6 +231,12 @@ class Button extends React.Component<ButtonProps, ButtonState> {
       ...rest
     } = this.props;
     const { loading, hasTwoCNChar } = this.state;
+
+    warning(
+      !(typeof icon === 'string' && icon.length > 2),
+      'Button',
+      `\`icon\` is using ReactNode instead of string naming in v4. Please check \`${icon}\` at https://ant.design/components/icon`,
+    );
 
     const prefixCls = getPrefixCls('btn', customizePrefixCls);
     const autoInsertSpace = autoInsertSpaceInButton !== false;

--- a/components/modal/__tests__/confirm.test.js
+++ b/components/modal/__tests__/confirm.test.js
@@ -214,4 +214,21 @@ describe('Modal.confirm triggers callbacks correctly', () => {
     });
     jest.useRealTimers();
   });
+
+  it('should warning when pass a string as icon props', () => {
+    const warnSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    confirm({
+      content: 'some descriptions',
+      icon: 'ab',
+    });
+    expect(warnSpy).not.toHaveBeenCalled();
+    confirm({
+      content: 'some descriptions',
+      icon: 'question',
+    });
+    expect(warnSpy).toHaveBeenCalledWith(
+      `Warning: [antd: Modal] \`icon\` is using ReactNode instead of string naming in v4. Please check \`question\` at https://ant.design/components/icon`,
+    );
+    warnSpy.mockRestore();
+  });
 });

--- a/components/modal/confirm.tsx
+++ b/components/modal/confirm.tsx
@@ -5,6 +5,7 @@ import classNames from 'classnames';
 import Dialog, { ModalFuncProps, destroyFns } from './Modal';
 import ActionButton from './ActionButton';
 import { getConfirmLocale } from './locale';
+import warning from '../_util/warning';
 
 interface ConfirmDialogProps extends ModalFuncProps {
   afterClose?: () => void;
@@ -30,6 +31,12 @@ const ConfirmDialog = (props: ConfirmDialogProps) => {
     okButtonProps,
     cancelButtonProps,
   } = props;
+
+  warning(
+    !(typeof icon === 'string' && icon.length > 2),
+    'Modal',
+    `\`icon\` is using ReactNode instead of string naming in v4. Please check \`${icon}\` at https://ant.design/components/icon`,
+  );
 
   // 支持传入{ icon: null }来隐藏`Modal.confirm`默认的Icon
   const okType = props.okType || 'primary';

--- a/components/result/__tests__/index.test.js
+++ b/components/result/__tests__/index.test.js
@@ -55,4 +55,15 @@ describe('Result', () => {
     const wrapper = mount(<Result status="404" title="404" className="my-result" />);
     expect(wrapper.find('.ant-result.my-result')).toHaveLength(1);
   });
+
+  it('should warning when pass a string as icon props', () => {
+    const warnSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    mount(<Result title="404" icon="ab" />);
+    expect(warnSpy).not.toHaveBeenCalled();
+    mount(<Result title="404" icon="smile" />);
+    expect(warnSpy).toHaveBeenCalledWith(
+      `Warning: [antd: Result] \`icon\` is using ReactNode instead of string naming in v4. Please check \`smile\` at https://ant.design/components/icon`,
+    );
+    warnSpy.mockRestore();
+  });
 });

--- a/components/result/index.tsx
+++ b/components/result/index.tsx
@@ -8,6 +8,7 @@ import {
 } from '@ant-design/icons';
 
 import { ConfigConsumerProps, ConfigConsumer } from '../config-provider';
+import warning from '../_util/warning';
 
 import noFound from './noFound';
 import serverError from './serverError';
@@ -52,6 +53,12 @@ const ExceptionStatus = Object.keys(ExceptionMap);
  */
 const renderIcon = (prefixCls: string, { status, icon }: ResultProps) => {
   const className = classnames(`${prefixCls}-icon`);
+
+  warning(
+    !(typeof icon === 'string' && icon.length > 2),
+    'Result',
+    `\`icon\` is using ReactNode instead of string naming in v4. Please check \`${icon}\` at https://ant.design/components/icon`,
+  );
 
   if (ExceptionStatus.includes(status as ResultStatusType)) {
     const SVGComponent = ExceptionMap[status as ExceptionStatusType];


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [x] Other (about what?)

### 🔗 Related issue link

related to https://github.com/ant-design/codemod-v4/issues/5

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

add some warning for string naming `icon` props in component Avatar, Button, Modal.method and Result

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  add warning for string naming `icon` props in component Avatar, Button, Modal.method and Result |
| 🇨🇳 Chinese |  给使用字符串作为 icon props 的四个组件(Avatar, Button, Modal.method and Result) 增加 warning |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered README.md](https://github.com/ant-design/ant-design/blob/feat/add-warning-for-icon-props/README.md)
[View rendered components/affix/index.en-US.md](https://github.com/ant-design/ant-design/blob/feat/add-warning-for-icon-props/components/affix/index.en-US.md)
[View rendered components/affix/index.zh-CN.md](https://github.com/ant-design/ant-design/blob/feat/add-warning-for-icon-props/components/affix/index.zh-CN.md)
[View rendered components/alert/demo/custom-icon.md](https://github.com/ant-design/ant-design/blob/feat/add-warning-for-icon-props/components/alert/demo/custom-icon.md)
[View rendered components/alert/demo/error-boundary.md](https://github.com/ant-design/ant-design/blob/feat/add-warning-for-icon-props/components/alert/demo/error-boundary.md)
[View rendered components/alert/index.en-US.md](https://github.com/ant-design/ant-design/blob/feat/add-warning-for-icon-props/components/alert/index.en-US.md)
[View rendered components/alert/index.zh-CN.md](https://github.com/ant-design/ant-design/blob/feat/add-warning-for-icon-props/components/alert/index.zh-CN.md)
[View rendered components/anchor/index.en-US.md](https://github.com/ant-design/ant-design/blob/feat/add-warning-for-icon-props/components/anchor/index.en-US.md)
[View rendered components/anchor/index.zh-CN.md](https://github.com/ant-design/ant-design/blob/feat/add-warning-for-icon-props/components/anchor/index.zh-CN.md)