### PR TITLE
docs: Add link of "Install and Initialization" to Getting started

### DIFF
--- a/docs/react/getting-started.en-US.md
+++ b/docs/react/getting-started.en-US.md
@@ -5,6 +5,8 @@ title: Getting Started
 
 Ant Design React is dedicated to providing a **good development experience** for programmers. Make sure that you have installed [Node.js](https://nodejs.org/)(> 8.0.0) correctly.
 
+If you try in local environment, Please refer to [Install and Initialization](https://ant.design/docs/react/use-with-create-react-app#Install-and-Initialization) section of "Use in create-react-app".
+
 > Before delving into Ant Design React, a good knowledge base of [React](https://reactjs.org) and [JavaScript ES2015](http://babeljs.io/docs/learn-es2015/) is needed.
 
 ---
@@ -19,9 +21,12 @@ Here is a simple example to show usage of Ant Design React.
 
 Visit http://u.ant.design/codesandbox-repro to create a codesandbox. Don't forget to press the save button.
 
+
 ### 2. Using antd component
 
 Replace the content of `index.js` with the following code. As you can see, there is no difference between antd's components and typical React components.
+
+If you already set up by [Install and Initialization](https://ant.design/docs/react/use-with-create-react-app#Install-and-Initialization) section of "Use in create-react-app", Please replace the content of /src/index.js
 
 ```jsx
 import React from 'react';


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

https://ant.design/docs/react/getting-started

### 💡 Background and solution

- Notice to some users that want to try in a local environment
- User can use create-react-app instantly because almost user already installed node.js when they inspect the ant-design

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Add link of [Install and Initialization](https://ant.design/docs/react/use-with-create-react-app#Install-and-Initialization) to [Getting started](https://ant.design/docs/react/getting-started)       |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed


-----
[View rendered docs/react/getting-started.en-US.md](https://github.com/woodsand/ant-design/blob/patch-1/docs/react/getting-started.en-US.md)