### PR TITLE
fix: function and params name word error in badge component

### DIFF
--- a/components/badge/index.tsx
+++ b/components/badge/index.tsx
@@ -109,7 +109,7 @@ export default class Badge extends React.Component<BadgeProps, any> {
     return hidden || !text ? null : <span className={`${prefixCls}-status-text`}>{text}</span>;
   }
 
-  renderDispayComponent() {
+  renderDisplayComponent() {
     const { count } = this.props;
     const customNode = count as React.ReactElement<any>;
     if (!customNode || typeof customNode !== 'object') {
@@ -144,7 +144,7 @@ export default class Badge extends React.Component<BadgeProps, any> {
         data-show={!hidden}
         className={scrollNumberCls}
         count={displayCount}
-        displayComponent={this.getNumberedDisplayCount()} // <Badge status="success" count={<Icon type="xxx" />}></Badge>
+        displayComponent={this.renderDisplayComponent()} // <Badge status="success" count={<Icon type="xxx" />}></Badge>
         title={this.getScrollNumberTitle()}
         style={this.getStyleWithOffset()}
         key="scrollNumber"

--- a/components/badge/index.tsx
+++ b/components/badge/index.tsx
@@ -49,8 +49,8 @@ export default class Badge extends React.Component<BadgeProps, any> {
   }
 
   isZero() {
-    const numberedDispayCount = this.getNumberedDispayCount();
-    return numberedDispayCount === '0' || numberedDispayCount === 0;
+    const numberedDisplayCount = this.getNumberedDisplayCount();
+    return numberedDisplayCount === '0' || numberedDisplayCount === 0;
   }
 
   isDot() {
@@ -61,7 +61,7 @@ export default class Badge extends React.Component<BadgeProps, any> {
 
   isHidden() {
     const { showZero } = this.props;
-    const displayCount = this.getDispayCount();
+    const displayCount = this.getDisplayCount();
     const isZero = this.isZero();
     const isDot = this.isDot();
     const isEmpty = displayCount === null || displayCount === undefined || displayCount === '';
@@ -75,13 +75,13 @@ export default class Badge extends React.Component<BadgeProps, any> {
     return displayCount as string | number | null;
   }
 
-  getDispayCount() {
+  getDisplayCount() {
     const isDot = this.isDot();
     // dot mode don't need count
     if (isDot) {
       return '';
     }
-    return this.getNumberedDispayCount();
+    return this.getNumberedDisplayCount();
   }
 
   getScrollNumberTitle() {
@@ -126,7 +126,7 @@ export default class Badge extends React.Component<BadgeProps, any> {
   renderBadgeNumber(prefixCls: string, scrollNumberPrefixCls: string) {
     const { count, status } = this.props;
 
-    const displayCount = this.getDispayCount();
+    const displayCount = this.getDisplayCount();
     const isDot = this.isDot();
     const hidden = this.isHidden();
 

--- a/components/badge/index.tsx
+++ b/components/badge/index.tsx
@@ -68,7 +68,7 @@ export default class Badge extends React.Component<BadgeProps, any> {
     return (isEmpty || (isZero && !showZero)) && !isDot;
   }
 
-  getNumberedDispayCount() {
+  getNumberedDisplayCount() {
     const { count, overflowCount } = this.props;
     const displayCount =
       (count as number) > (overflowCount as number) ? `${overflowCount}+` : count;
@@ -144,7 +144,7 @@ export default class Badge extends React.Component<BadgeProps, any> {
         data-show={!hidden}
         className={scrollNumberCls}
         count={displayCount}
-        displayComponent={this.renderDispayComponent()} // <Badge status="success" count={<Icon type="xxx" />}></Badge>
+        displayComponent={this.getNumberedDisplayCount()} // <Badge status="success" count={<Icon type="xxx" />}></Badge>
         title={this.getScrollNumberTitle()}
         style={this.getStyleWithOffset()}
         key="scrollNumber"


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

Fix the functions and params name word error in badge component, here is an image about what I change.

![image](https://user-images.githubusercontent.com/20939839/70846934-76c9fd00-1e99-11ea-854b-a54ab64414df.png)
