### PR TITLE
[WIP]: TextArea add support onResize

### DIFF
--- a/components/input/ResizableTextArea.tsx
+++ b/components/input/ResizableTextArea.tsx
@@ -49,6 +49,17 @@ class ResizableTextArea extends React.Component<TextAreaProps, TextAreaState> {
     }
   }
 
+  handleResize = (size: { width: number; height: number }) => {
+    const { autoSize, autosize, onResize } = this.props;
+    if (typeof onResize === 'function') {
+      onResize(size);
+    }
+    if (!(autoSize || autosize)) {
+      return;
+    }
+    this.resizeOnNextFrame();
+  };
+
   resizeOnNextFrame = () => {
     raf.cancel(this.nextFrameActionId);
     this.nextFrameActionId = raf(this.resizeTextarea);
@@ -75,7 +86,7 @@ class ResizableTextArea extends React.Component<TextAreaProps, TextAreaState> {
   }
 
   renderTextArea = () => {
-    const { prefixCls, autoSize, autosize, className, disabled } = this.props;
+    const { prefixCls, autosize, className, disabled } = this.props;
     const { textareaStyles, resizing } = this.state;
     warning(
       autosize === undefined,
@@ -89,6 +100,7 @@ class ResizableTextArea extends React.Component<TextAreaProps, TextAreaState> {
       'autosize',
       'defaultValue',
       'allowClear',
+      'onResize',
     ]);
     const cls = classNames(prefixCls, className, {
       [`${prefixCls}-disabled`]: disabled,
@@ -104,7 +116,7 @@ class ResizableTextArea extends React.Component<TextAreaProps, TextAreaState> {
       ...(resizing ? { overflow: 'hidden' } : null),
     };
     return (
-      <ResizeObserver onResize={this.resizeOnNextFrame} disabled={!(autoSize || autosize)}>
+      <ResizeObserver onResize={this.handleResize}>
         <textarea {...otherProps} className={cls} style={style} ref={this.saveTextArea} />
       </ResizeObserver>
     );

--- a/components/input/TextArea.tsx
+++ b/components/input/TextArea.tsx
@@ -14,6 +14,7 @@ export interface TextAreaProps extends HTMLTextareaProps {
   autoSize?: boolean | AutoSizeType;
   onPressEnter?: React.KeyboardEventHandler<HTMLTextAreaElement>;
   allowClear?: boolean;
+  onResize?: (size: { width: number; height: number }) => void;
 }
 
 export interface TextAreaState {

--- a/components/input/__tests__/__snapshots__/index.test.js.snap
+++ b/components/input/__tests__/__snapshots__/index.test.js.snap
@@ -545,7 +545,6 @@ exports[`TextArea allowClear should change type when click 1`] = `
         value="111"
       >
         <ResizeObserver
-          disabled={true}
           onResize={[Function]}
         >
           <textarea
@@ -634,7 +633,6 @@ exports[`TextArea allowClear should change type when click 2`] = `
         value=""
       >
         <ResizeObserver
-          disabled={true}
           onResize={[Function]}
         >
           <textarea
@@ -686,7 +684,6 @@ exports[`TextArea allowClear should not show icon if defaultValue is undefined, 
         value=""
       >
         <ResizeObserver
-          disabled={true}
           onResize={[Function]}
         >
           <textarea
@@ -734,7 +731,6 @@ exports[`TextArea allowClear should not show icon if defaultValue is undefined, 
         value=""
       >
         <ResizeObserver
-          disabled={true}
           onResize={[Function]}
         >
           <textarea
@@ -786,7 +782,6 @@ exports[`TextArea allowClear should not show icon if defaultValue is undefined, 
         value=""
       >
         <ResizeObserver
-          disabled={true}
           onResize={[Function]}
         >
           <textarea
@@ -836,7 +831,6 @@ exports[`TextArea allowClear should not show icon if value is undefined, null or
         value=""
       >
         <ResizeObserver
-          disabled={true}
           onResize={[Function]}
         >
           <textarea
@@ -884,7 +878,6 @@ exports[`TextArea allowClear should not show icon if value is undefined, null or
         value=""
       >
         <ResizeObserver
-          disabled={true}
           onResize={[Function]}
         >
           <textarea
@@ -934,7 +927,6 @@ exports[`TextArea allowClear should not show icon if value is undefined, null or
         value=""
       >
         <ResizeObserver
-          disabled={true}
           onResize={[Function]}
         >
           <textarea
@@ -978,7 +970,6 @@ exports[`TextArea should support disabled 1`] = `
       value=""
     >
       <ResizeObserver
-        disabled={true}
         onResize={[Function]}
       >
         <textarea
@@ -1022,7 +1013,6 @@ exports[`TextArea should support maxLength 1`] = `
       value=""
     >
       <ResizeObserver
-        disabled={true}
         onResize={[Function]}
       >
         <textarea

--- a/components/input/index.en-US.md
+++ b/components/input/index.en-US.md
@@ -47,6 +47,7 @@ The rest of the props of Input are exactly the same as the original [input](http
 | value | The input content value | string |  |  |
 | onPressEnter | The callback function that is triggered when Enter key is pressed. | function(e) |  |  |
 | allowClear | allow to remove input content with clear icon | boolean |  | 3.25.0 |
+| onResize | The callback function that is triggered when resize | function(size) |  | 3.26.4 |
 
 The rest of the props of `Input.TextArea` are the same as the original [textarea](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea).
 

--- a/components/input/index.zh-CN.md
+++ b/components/input/index.zh-CN.md
@@ -48,6 +48,7 @@ Input 的其他属性和 React 自带的 [input](https://facebook.github.io/reac
 | value | 输入框内容 | string |  |  |
 | onPressEnter | 按下回车的回调 | function(e) |  |  |
 | allowClear | 可以点击清除图标删除内容 | boolean |  | 3.25.0 |
+| onResize | resize 回调 | function(size) |  | 3.26.4 |
 
 `Input.TextArea` 的其他属性和浏览器自带的 [textarea](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea) 一致。
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
close #20244
<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   The callback function that is triggered when resize        |
| 🇨🇳 Chinese |    resize 回调       |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed


-----
[View rendered components/input/index.en-US.md](https://github.com/ant-design/ant-design/blob/textarea-support-onresize/components/input/index.en-US.md)
[View rendered components/input/index.zh-CN.md](https://github.com/ant-design/ant-design/blob/textarea-support-onresize/components/input/index.zh-CN.md)