### PR TITLE
fix: 🐛 TreeNode without icon white block

### DIFF
--- a/components/tree/style/index.less
+++ b/components/tree/style/index.less
@@ -147,6 +147,10 @@
         border: 0 none;
         outline: none;
         cursor: pointer;
+
+        &:empty {
+          display: none;
+        }
       }
 
       &.@{tree-prefix-cls}-switcher {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

Reproduce link: https://codesandbox.io/s/immutable-cdn-brx1h

### 💡 Background and solution

```jsx
  <Tree showLine showIcon defaultExpandAll>
    <TreeNode title="tree node" icon={<Icon type="setting" />}>
      <TreeNode title="No icon" key="0-1" />
      <TreeNode title="No icon" key="0-2" />
      <TreeNode title="No icon" key="0-1" />
    </TreeNode>
  </Tree>
```

wrong ui:

<img width="191" alt="image" src="https://user-images.githubusercontent.com/507615/70891056-6e043300-2021-11ea-9ca7-86f24c9d6245.png">

fixed to:

<img width="168" alt="image" src="https://user-images.githubusercontent.com/507615/70891129-98ee8700-2021-11ea-82bb-738de02f1fbc.png">


### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fix TreeNode without `icon` show white block in `showIcon` mode. |
| 🇨🇳 Chinese | 修复 TreeNode 不设置 `icon` 时会展示一个空白占位的问题。 |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
