### PR TITLE
fix: Add editable? to Table ColumnProps typescript interface

### DIFF
--- a/components/table/index.en-US.md
+++ b/components/table/index.en-US.md
@@ -126,6 +126,7 @@ One of the Table `columns` prop for describing the table's columns, Column has t
 | dataIndex | Display field of the data record, could be set like `a.b.c`, `a[0].b.c[1]` | string | - |  |
 | defaultFilteredValue | Default filtered values | string\[] | - |  |
 | defaultSortOrder | Default order of sorted values | 'ascend' \| 'descend' | - |  |
+| editable | Whether the column is `editable` | boolean | `false` |  |
 | filterDropdown | Customized filter overlay | React.ReactNode \| (props: [FilterDropdownProps](https://git.io/fjP5h)) => React.ReactNode | - |
 | filterDropdownVisible | Whether `filterDropdown` is visible | boolean | - |  |
 | filtered | Whether the `dataSource` is filtered | boolean | `false` |  |

--- a/components/table/interface.tsx
+++ b/components/table/interface.tsx
@@ -42,6 +42,7 @@ export interface ColumnProps<T> {
   render?: (text: any, record: T, index: number) => React.ReactNode;
   align?: 'left' | 'right' | 'center';
   ellipsis?: boolean;
+  editable?: boolean;
   filters?: ColumnFilterItem[];
   onFilter?: (value: any, record: T) => boolean;
   filterMultiple?: boolean;


### PR DESCRIPTION


### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / document update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

### 💡 Background and solution

Property `editable` was missing in the `ColumnProps` interface definition (which caused a Typescript error) and also in the API docs for the component. This PR extends the interface and the docs.

### 📝 Changelog

 Language   | Changelog |
| 🇺🇸 English |   Add missing property `editable`  to `ColumnProps` interface definition      |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/table/index.en-US.md](https://github.com/icaroponce/ant-design/blob/fix-columnprops-interface/components/table/index.en-US.md)