### PR TITLE
fix: dark css dist error caused by variables

### DIFF
--- a/index-dark.js
+++ b/index-dark.js
@@ -1,2 +1,0 @@
-require('./components/style/dark.less');
-require('./index');


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [x] Other (about what?)

### 🔗 Related issue link
None

### 💡 Background and solution
After #20117 , `antd.dark.css` stil contains a part of default styles that will make UI broken, so extract dark entry to a single webpack config and compile dark theme via the [official documentation way](https://github.com/ant-design/ant-design/blob/4.0-prepare/docs/react/customize-theme.en-US.md#customize-in-webpack).

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | --        |
| 🇨🇳 Chinese | --        |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
