### PR TITLE
fix: 🐛 Tag onClick triggered when close

### DIFF
--- a/components/tag/__tests__/index.test.js
+++ b/components/tag/__tests__/index.test.js
@@ -39,6 +39,16 @@ describe('Tag', () => {
     expect(wrapper.find('.ant-tag:not(.ant-tag-hidden)').length).toBe(1);
   });
 
+  // https://github.com/ant-design/ant-design/issues/20344
+  it('should not trigger onClick when click close icon', () => {
+    const onClose = jest.fn();
+    const onClick = jest.fn();
+    const wrapper = mount(<Tag closable onClose={onClose} onClick={onClick} />);
+    wrapper.find('.anticon-close').simulate('click');
+    expect(onClose).toHaveBeenCalled();
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
   describe('visibility', () => {
     it('can be controlled by visible with visible as initial value', () => {
       const wrapper = mount(<Tag visible />);

--- a/components/tag/index.tsx
+++ b/components/tag/index.tsx
@@ -100,6 +100,7 @@ class Tag extends React.Component<TagProps, TagState> {
   }
 
   handleIconClick = (e: React.MouseEvent<HTMLElement>) => {
+    e.stopPropagation();
     this.setVisible(false, e);
   };
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close #20344

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Tag `onClick` been triggered when close it. |
| 🇨🇳 Chinese | 修复 Tag 关闭时 `onClick` 被触发的问题。 |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
