### PR TITLE
fix: responsiveObserve init miss sizing

### DIFF
--- a/components/_util/responsiveObserve.ts
+++ b/components/_util/responsiveObserve.ts
@@ -77,6 +77,8 @@ const responsiveObserve = {
         mql,
         listener,
       };
+
+      listener(mql);
     });
   },
 };

--- a/components/descriptions/__tests__/index.test.js
+++ b/components/descriptions/__tests__/index.test.js
@@ -10,15 +10,6 @@ describe('Descriptions', () => {
 
   const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
 
-  jest.spyOn(window, 'matchMedia').mockImplementationOnce(query => ({
-    addListener: (listener) => {
-      if (query === '(max-width: 575px)') {
-        listener({ matches: true });
-      }
-    },
-    removeListener: jest.fn(),
-  }));
-
   afterEach(() => {
     MockDate.reset();
     errorSpy.mockReset();

--- a/components/grid/__tests__/index.test.js
+++ b/components/grid/__tests__/index.test.js
@@ -3,15 +3,6 @@ import { render, mount } from 'enzyme';
 import { Col, Row } from '..';
 import mountTest from '../../../tests/shared/mountTest';
 
-jest.spyOn(window, 'matchMedia').mockImplementationOnce(query => ({
-  addListener: (listener) => {
-    if (query === '(max-width: 575px)') {
-      listener({ matches: true });
-    }
-  },
-  removeListener: jest.fn(),
-}));
-
 describe('Grid', () => {
   mountTest(Row);
   mountTest(Col);

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -12,10 +12,10 @@ if (typeof window !== 'undefined') {
   };
   global.window.scrollTo = () => {};
   // ref: https://github.com/ant-design/ant-design/issues/18774
-  if (!global.window.matchMedia) {
+  if (!window.matchMedia) {
     Object.defineProperty(global.window, 'matchMedia', {
-      value: jest.fn(() => ({
-        matches: true,
+      value: jest.fn(query => ({
+        matches: query.includes('max-width'),
         addListener: () => {},
         removeListener: () => {},
       })),


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

ref #20356

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Fix responsive related component (like Grid) missing sizing when init.       |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
