### PR TITLE
fix: Table header text align when colspan=1

### DIFF
--- a/components/table/style/index.less
+++ b/components/table/style/index.less
@@ -49,7 +49,7 @@
     border-bottom: @border-width-base @border-style-base @border-color-split;
     transition: background 0.3s ease;
 
-    &[colspan] {
+    &[colspan]:not([colspan='1']) {
       text-align: center;
     }
 


### PR DESCRIPTION


<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

https://github.com/ant-design/ant-design/issues/20126#issuecomment-563307001

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->
<img width="170" alt="image" src="https://user-images.githubusercontent.com/507615/71463773-78c58180-27f2-11ea-92aa-0c4de790b25f.png">

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Table header wrong text align when `colspan="1"`. |
| 🇨🇳 Chinese | 修复 Table 分组列头 `colspan="1"`时的一个文本对齐问题。  |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
