### PR TITLE
fix: Should also set className with customize `help`

### DIFF
--- a/components/config-provider/__tests__/__snapshots__/components.test.js.snap
+++ b/components/config-provider/__tests__/__snapshots__/components.test.js.snap
@@ -6746,7 +6746,7 @@ exports[`ConfigProvider components Form configProvider 1`] = `
   class="config-form config-form-horizontal"
 >
   <div
-    class="config-row config-form-item config-form-item-has-error"
+    class="config-row config-form-item config-form-item-with-help config-form-item-has-error"
   >
     <div
       class="config-col config-form-item-control"
@@ -6775,7 +6775,7 @@ exports[`ConfigProvider components Form normal 1`] = `
   class="ant-form ant-form-horizontal"
 >
   <div
-    class="ant-row ant-form-item ant-form-item-has-error"
+    class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-error"
   >
     <div
       class="ant-col ant-form-item-control"
@@ -6804,7 +6804,7 @@ exports[`ConfigProvider components Form prefixCls 1`] = `
   class="prefix-Form prefix-Form-horizontal"
 >
   <div
-    class="ant-row prefix-Form-item prefix-Form-item-has-error"
+    class="ant-row prefix-Form-item prefix-Form-item-with-help prefix-Form-item-has-error"
   >
     <div
       class="ant-col prefix-Form-item-control"

--- a/components/form/FormItem.tsx
+++ b/components/form/FormItem.tsx
@@ -135,7 +135,7 @@ const FormItem: React.FC<FormItemProps> = (props: FormItemProps) => {
         // ====================== Class Name ======================
         const itemClassName = {
           [`${prefixCls}-item`]: true,
-          [`${prefixCls}-item-with-help`]: domErrorVisible, // TODO: handle this
+          [`${prefixCls}-item-with-help`]: domErrorVisible || help,
           [`${className}`]: !!className,
 
           // Status

--- a/components/form/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/form/__tests__/__snapshots__/demo.test.js.snap
@@ -4203,7 +4203,7 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
   class="ant-form ant-form-horizontal"
 >
   <div
-    class="ant-row ant-form-item ant-form-item-has-error"
+    class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-error"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-5"
@@ -4266,7 +4266,7 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
     </div>
   </div>
   <div
-    class="ant-row ant-form-item ant-form-item-has-feedback ant-form-item-is-validating"
+    class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-feedback ant-form-item-is-validating"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-5"
@@ -4430,7 +4430,7 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
     </div>
   </div>
   <div
-    class="ant-row ant-form-item ant-form-item-has-feedback ant-form-item-has-error"
+    class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-feedback ant-form-item-has-error"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-5"
@@ -4764,7 +4764,7 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
     </div>
   </div>
   <div
-    class="ant-row ant-form-item ant-form-item-has-feedback ant-form-item-is-validating"
+    class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-feedback ant-form-item-is-validating"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-5"
@@ -4892,7 +4892,7 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
         class="ant-form-item-control-input"
       >
         <div
-          class="ant-row ant-form-item ant-form-item-has-error"
+          class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-error"
           style="display:inline-block;width:calc(50% - 12px)"
         >
           <div
@@ -5367,7 +5367,7 @@ exports[`renders ./components/form/demo/without-form-create.md correctly 1`] = `
   class="ant-form ant-form-horizontal"
 >
   <div
-    class="ant-row ant-form-item"
+    class="ant-row ant-form-item ant-form-item-with-help"
   >
     <div
       class="ant-col ant-col-7 ant-form-item-label"

--- a/components/form/__tests__/index.test.js
+++ b/components/form/__tests__/index.test.js
@@ -25,15 +25,12 @@ describe('Form', () => {
       .find(Input)
       .at(index)
       .simulate('change', { target: { value } });
-    await delay(20);
+    await delay(50);
     wrapper.update();
   }
 
-  beforeAll(() => {
-    jest.useRealTimers();
-  });
-
   beforeEach(() => {
+    jest.useRealTimers();
     scrollIntoView.mockReset();
   });
 
@@ -234,5 +231,17 @@ describe('Form', () => {
     wrapper.find('input[type="checkbox"]').simulate('change', { target: { checked: true } });
     wrapper.update();
     expect(wrapper.find('.ant-form-item-required')).toHaveLength(1);
+  });
+
+  it('should show related className when customize help', () => {
+    const wrapper = mount(
+      <Form>
+        <Form.Item help="good">
+          <input />
+        </Form.Item>
+      </Form>,
+    );
+
+    expect(wrapper.find('.ant-form-item-with-help').length).toBeTruthy();
   });
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

fix #20483

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Fix FormItem missing `className` when customize `help`.       |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
