### PR TITLE
docs: using dayjs instead of moment

### DIFF
--- a/components/calendar/index.en-US.md
+++ b/components/calendar/index.en-US.md
@@ -46,3 +46,34 @@ When data is in the form of dates, such as schedules, timetables, prices calenda
 | onSelect | Callback for when a date is selected | function(date: moment） | - |  |
 | onChange | Callback for when date changes | function(date: moment） | - |  |
 | headerRender | render custom header in panel | function(object:{value: moment, type: string, onChange: f(), onTypeChange: f()}) | - |  |
+
+## FAQ
+
+### How to use dayjs instead of moment
+
+custom component `Calendar`
+
+```tsx
+import { Dayjs } from 'dayjs';
+import dayjsGenerateConfig from 'rc-picker/lib/generate/dayjs';
+import generateCalendar from 'antd/es/calendar/generateCalendar';
+import 'antd/es/calendar/style';
+
+const Calendar = generateCalendar<Dayjs>(dayjsGenerateConfig);
+
+export default Calendar;
+```
+
+using custom component `Calendar` instead of antd's `Calendar`
+
+```js
+import { Calendar } from '@/components';
+import format from 'dayjs';
+```
+
+instead
+
+```js
+import { Calendar } from 'antd';
+import format from 'moment';
+```

--- a/components/calendar/index.zh-CN.md
+++ b/components/calendar/index.zh-CN.md
@@ -47,3 +47,34 @@ title: Calendar
 | onSelect | 点击选择日期回调 | function(date: moment） | 无 |  |
 | onChange | 日期变化回调 | function(date: moment） | 无 |  |
 | headerRender | 自定义头部内容 | function(object:{value: moment, type: string, onChange: f(), onTypeChange: f()}) | 无 |  |
+
+## FAQ
+
+### 如何使用 dayjs 替代 moment
+
+自定义组件 `Calendar`
+
+```tsx
+import { Dayjs } from 'dayjs';
+import dayjsGenerateConfig from 'rc-picker/lib/generate/dayjs';
+import generateCalendar from 'antd/es/calendar/generateCalendar';
+import 'antd/es/calendar/style';
+
+const Calendar = generateCalendar<Dayjs>(dayjsGenerateConfig);
+
+export default Calendar;
+```
+
+使用自定义的 Calendar 组件替换 antd 的 `Calendar`
+
+```js
+import { Calendar } from '@/components';
+import format from 'dayjs';
+```
+
+替换
+
+```js
+import { Calendar } from 'antd';
+import format from 'moment';
+```

--- a/components/date-picker/index.en-US.md
+++ b/components/date-picker/index.en-US.md
@@ -151,3 +151,32 @@ The following APIs are shared by DatePicker, YearPicker, MonthPicker, RangePicke
 ## FAQ
 
 - [When set mode to DatePicker/RangePicker, cannot select year or month anymore?](/docs/react/faq#When-set-mode-to-DatePicker/RangePicker,-cannot-select-year-or-month-anymore?)
+
+### How to use dayjs instead of moment
+
+custom component `DatePicker`
+
+```tsx
+import { Dayjs } from 'dayjs';
+import dayjsGenerateConfig from 'rc-picker/lib/generate/dayjs';
+import generatePicker from 'antd/es/date-picker/generatePicker';
+import 'antd/es/date-picker/style/index';
+
+const DatePicker = generatePicker<Dayjs>(dayjsGenerateConfig);
+
+export default DatePicker;
+```
+
+using custom component `DatePicker` instead of antd's `DatePicker`
+
+```js
+import { DatePicker } from '@/components';
+import format from 'dayjs';
+```
+
+instead
+
+```js
+import { DatePicker } from 'antd';
+import format from 'moment';
+```

--- a/components/date-picker/index.zh-CN.md
+++ b/components/date-picker/index.zh-CN.md
@@ -152,4 +152,33 @@ import 'moment/locale/zh-cn';
 
 ## FAQ
 
-- [当我指定了 DatePicker/RangePicker 的 mode 属性后，点击后无法选择年份/月份？](/docs/react/faq#当我指定了-DatePicker/RangePicker-的-mode-属性后，点击后无法选择年份/月份？)
+- [当我指定了 DatePicker/RangePicker 的 mode 属性后，点击后无法选择年份/月份？](/docs/react/faq#当我指定了-DatePicker/RangePicker-的-mode-属性后，点击后无法选择年份/月份？) akdnsakldnsa
+
+### 如何使用 dayjs 替代 moment
+
+自定义组件 `DatePicker`
+
+```tsx
+import { Dayjs } from 'dayjs';
+import dayjsGenerateConfig from 'rc-picker/lib/generate/dayjs';
+import generatePicker from 'antd/es/date-picker/generatePicker';
+import 'antd/es/date-picker/style/index';
+
+const DatePicker = generatePicker<Dayjs>(dayjsGenerateConfig);
+
+export default DatePicker;
+```
+
+使用自定义的 DatePicker 组件替换 antd 的 `DatePicker`
+
+```js
+import { DatePicker } from '@/components';
+import format from 'dayjs';
+```
+
+替换
+
+```js
+import { DatePicker } from 'antd';
+import format from 'moment';
+```

--- a/components/time-picker/index.en-US.md
+++ b/components/time-picker/index.en-US.md
@@ -60,3 +60,83 @@ import moment from 'moment';
 | focus() | get focus    |         |
 
 <style>.code-box-demo .ant-picker { margin: 0 8px 12px 0; }</style>
+
+## FAQ
+
+### How to use dayjs instead of moment
+
+custom component `TimePicker`
+
+```tsx
+import { Dayjs } from 'dayjs';
+
+import * as React from 'react';
+import DatePicker from './DatePicker';
+import { PickerTimeProps, RangePickerTimeProps } from 'antd/es/date-picker/generatePicker';
+import warning from 'antd/es/_util/warning';
+import { Omit } from 'antd/es/_util/type';
+
+const { TimePicker: InternalTimePicker, RangePicker: InternalRangePicker } = DatePicker;
+
+export interface TimeRangePickerProps extends RangePickerTimeProps<Dayjs> {}
+
+const RangePicker = React.forwardRef<any, TimeRangePickerProps>((props, ref) => {
+  return <InternalRangePicker {...props} picker="time" mode={undefined} ref={ref} />;
+});
+
+export interface TimePickerProps extends Omit<PickerTimeProps<Dayjs>, 'picker'> {
+  addon?: () => React.ReactNode;
+}
+
+const TimePicker = React.forwardRef<any, TimePickerProps>(
+  ({ addon, renderExtraFooter, ...restProps }, ref) => {
+    const internalRenderExtraFooter = React.useMemo(() => {
+      if (renderExtraFooter) {
+        return renderExtraFooter;
+      }
+      if (addon) {
+        warning(
+          false,
+          'TimePicker',
+          '`addon` is deprecated. Please use `renderExtraFooter` instead.',
+        );
+        return addon;
+      }
+      return undefined;
+    }, [addon, renderExtraFooter]);
+
+    return (
+      <InternalTimePicker
+        {...restProps}
+        mode={undefined}
+        ref={ref}
+        renderExtraFooter={internalRenderExtraFooter}
+      />
+    );
+  },
+);
+
+TimePicker.displayName = 'TimePicker';
+
+type MergedTimePicker = typeof TimePicker & {
+  RangePicker: typeof RangePicker;
+};
+
+(TimePicker as MergedTimePicker).RangePicker = RangePicker;
+
+export default TimePicker as MergedTimePicker;
+```
+
+using custom component `TimePicker` instead of antd's `TimePicker`
+
+```js
+import { TimePicker } from '@/components';
+import format from 'dayjs';
+```
+
+instead
+
+```js
+import { TimePicker } from 'antd';
+import format from 'moment';
+```

--- a/components/time-picker/index.zh-CN.md
+++ b/components/time-picker/index.zh-CN.md
@@ -61,3 +61,83 @@ import moment from 'moment';
 | focus() | 获取焦点 |      |
 
 <style>.code-box-demo .ant-picker { margin: 0 8px 12px 0; }</style>
+
+## FAQ
+
+### 如何使用 dayjs 替代 moment
+
+自定义组件 `TimePicker`
+
+```tsx
+import { Dayjs } from 'dayjs';
+
+import * as React from 'react';
+import DatePicker from './DatePicker';
+import { PickerTimeProps, RangePickerTimeProps } from 'antd/es/date-picker/generatePicker';
+import warning from 'antd/es/_util/warning';
+import { Omit } from 'antd/es/_util/type';
+
+const { TimePicker: InternalTimePicker, RangePicker: InternalRangePicker } = DatePicker;
+
+export interface TimeRangePickerProps extends RangePickerTimeProps<Dayjs> {}
+
+const RangePicker = React.forwardRef<any, TimeRangePickerProps>((props, ref) => {
+  return <InternalRangePicker {...props} picker="time" mode={undefined} ref={ref} />;
+});
+
+export interface TimePickerProps extends Omit<PickerTimeProps<Dayjs>, 'picker'> {
+  addon?: () => React.ReactNode;
+}
+
+const TimePicker = React.forwardRef<any, TimePickerProps>(
+  ({ addon, renderExtraFooter, ...restProps }, ref) => {
+    const internalRenderExtraFooter = React.useMemo(() => {
+      if (renderExtraFooter) {
+        return renderExtraFooter;
+      }
+      if (addon) {
+        warning(
+          false,
+          'TimePicker',
+          '`addon` is deprecated. Please use `renderExtraFooter` instead.',
+        );
+        return addon;
+      }
+      return undefined;
+    }, [addon, renderExtraFooter]);
+
+    return (
+      <InternalTimePicker
+        {...restProps}
+        mode={undefined}
+        ref={ref}
+        renderExtraFooter={internalRenderExtraFooter}
+      />
+    );
+  },
+);
+
+TimePicker.displayName = 'TimePicker';
+
+type MergedTimePicker = typeof TimePicker & {
+  RangePicker: typeof RangePicker;
+};
+
+(TimePicker as MergedTimePicker).RangePicker = RangePicker;
+
+export default TimePicker as MergedTimePicker;
+```
+
+使用自定义的 TimePicker 组件替换 antd 的 `TimePicker`
+
+```js
+import { TimePicker } from '@/components';
+import format from 'dayjs';
+```
+
+替换
+
+```js
+import { TimePicker } from 'antd';
+import format from 'moment';
+```


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [x] FAQ

### 🔗 Related issue link

https://github.com/ant-design/ant-design/issues/20446
<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/calendar/index.en-US.md](https://github.com/ant-design/ant-design/blob/using-dayjs-instead-of-moment/components/calendar/index.en-US.md)
[View rendered components/calendar/index.zh-CN.md](https://github.com/ant-design/ant-design/blob/using-dayjs-instead-of-moment/components/calendar/index.zh-CN.md)
[View rendered components/date-picker/index.en-US.md](https://github.com/ant-design/ant-design/blob/using-dayjs-instead-of-moment/components/date-picker/index.en-US.md)
[View rendered components/date-picker/index.zh-CN.md](https://github.com/ant-design/ant-design/blob/using-dayjs-instead-of-moment/components/date-picker/index.zh-CN.md)
[View rendered components/time-picker/index.en-US.md](https://github.com/ant-design/ant-design/blob/using-dayjs-instead-of-moment/components/time-picker/index.en-US.md)
[View rendered components/time-picker/index.zh-CN.md](https://github.com/ant-design/ant-design/blob/using-dayjs-instead-of-moment/components/time-picker/index.zh-CN.md)