### PR TITLE
fix: revert Table return first page after sort

### DIFF
--- a/components/table/Table.tsx
+++ b/components/table/Table.tsx
@@ -868,7 +868,6 @@ class Table<T> extends React.Component<InternalTableProps<T>, TableState<T>> {
   };
 
   toggleSortOrder(column: ColumnProps<T>) {
-    const pagination = { ...this.state.pagination };
     const sortDirections = column.sortDirections || (this.props.sortDirections as SortOrder[]);
     const { sortOrder, sortColumn } = this.state;
     // 只同时允许一列进行排序，否则会导致排序顺序的逻辑问题
@@ -883,14 +882,7 @@ class Table<T> extends React.Component<InternalTableProps<T>, TableState<T>> {
       newSortOrder = sortDirections[0];
     }
 
-    if (this.props.pagination) {
-      // Reset current prop
-      pagination.current = 1;
-      pagination.onChange!(pagination.current);
-    }
-
     const newState = {
-      pagination,
       sortOrder: newSortOrder,
       sortColumn: newSortOrder ? column : null,
     };

--- a/components/table/__tests__/Table.sorter.test.js
+++ b/components/table/__tests__/Table.sorter.test.js
@@ -613,6 +613,7 @@ describe('Table.sorter', () => {
       createTable({
         pagination: {
           pageSize: 2,
+          defaultCurrent: 2,
           onChange: onPageChange,
         },
         onChange,
@@ -620,8 +621,8 @@ describe('Table.sorter', () => {
     );
 
     wrapper.find('.ant-table-column-sorters').simulate('click');
-    expect(onChange.mock.calls[0][0].current).toBe(1);
-    expect(onPageChange.mock.calls[0][0]).toBe(1);
+    expect(onChange.mock.calls[0][0].current).toBe(2);
+    expect(onPageChange).not.toHaveBeenCalled();
   });
 
   it('should support onHeaderCell in sort column', () => {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close #16978
close #17770
close #17648
close #18099
close #17075
close #19369

### 💡 Background and solution

#17020 之后的相关反馈太多，需要再权衡一下：https://github.com/ant-design/ant-design/issues/16978#issuecomment-569287404

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Revert Table return fisrt page after sort. |
| 🇨🇳 Chinese | 回滚 Table 排序之后回到第一页的行为。 |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
