### PR TITLE
fix: FormItem errors should show in diff line

### DIFF
--- a/components/config-provider/__tests__/__snapshots__/components.test.js.snap
+++ b/components/config-provider/__tests__/__snapshots__/components.test.js.snap
@@ -6763,7 +6763,9 @@ exports[`ConfigProvider components Form configProvider 1`] = `
       <div
         class="config-form-item-explain"
       >
-        Bamboo is Light
+        <div>
+          Bamboo is Light
+        </div>
       </div>
     </div>
   </div>
@@ -6792,7 +6794,9 @@ exports[`ConfigProvider components Form normal 1`] = `
       <div
         class="ant-form-item-explain"
       >
-        Bamboo is Light
+        <div>
+          Bamboo is Light
+        </div>
       </div>
     </div>
   </div>
@@ -6821,7 +6825,9 @@ exports[`ConfigProvider components Form prefixCls 1`] = `
       <div
         class="prefix-Form-item-explain"
       >
-        Bamboo is Light
+        <div>
+          Bamboo is Light
+        </div>
       </div>
     </div>
   </div>

--- a/components/form/FormItemInput.tsx
+++ b/components/form/FormItemInput.tsx
@@ -104,7 +104,10 @@ const FormItemInput: React.FC<FormItemInputProps & FormItemInputMiscProps> = ({
           {({ className: motionClassName }: { className: string }) => {
             return (
               <div className={classNames(`${baseClassName}-explain`, motionClassName)} key="help">
-                {memoErrors}
+                {memoErrors.map((error, index) => (
+                  // eslint-disable-next-line react/no-array-index-key
+                  <div key={index}>{error}</div>
+                ))}
               </div>
             );
           }}

--- a/components/form/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/form/__tests__/__snapshots__/demo.test.js.snap
@@ -4232,7 +4232,9 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
       <div
         class="ant-form-item-explain"
       >
-        Should be combination of numbers & alphabets
+        <div>
+          Should be combination of numbers & alphabets
+        </div>
       </div>
     </div>
   </div>
@@ -4319,7 +4321,9 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
       <div
         class="ant-form-item-explain"
       >
-        The information is being validated...
+        <div>
+          The information is being validated...
+        </div>
       </div>
     </div>
   </div>
@@ -4483,7 +4487,9 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
       <div
         class="ant-form-item-explain"
       >
-        Should be combination of numbers & alphabets
+        <div>
+          Should be combination of numbers & alphabets
+        </div>
       </div>
     </div>
   </div>
@@ -4867,7 +4873,9 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
       <div
         class="ant-form-item-explain"
       >
-        The information is being validated...
+        <div>
+          The information is being validated...
+        </div>
       </div>
     </div>
   </div>
@@ -4943,7 +4951,9 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
             <div
               class="ant-form-item-explain"
             >
-              Please select the correct date
+              <div>
+                Please select the correct date
+              </div>
             </div>
           </div>
         </div>
@@ -5469,7 +5479,9 @@ exports[`renders ./components/form/demo/without-form-create.md correctly 1`] = `
       <div
         class="ant-form-item-explain"
       >
-        A prime is a natural number greater than 1 that has no positive divisors other than 1 and itself.
+        <div>
+          A prime is a natural number greater than 1 that has no positive divisors other than 1 and itself.
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

fix #20494

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Fix FormItem multiple errors shows in the same line.       |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
