### PR TITLE
fix(style): form  field error border style for select

### DIFF
--- a/components/form/style/index.less
+++ b/components/form/style/index.less
@@ -295,6 +295,14 @@
       }
     }
 
+    // fixes https://github.com/ant-design/ant-design/issues/20482
+    .@{ant-prefix}-select {
+      &.@{ant-prefix}-select-single:not(.@{ant-prefix}-select-customize-input)
+        .@{ant-prefix}-select-selector {
+        border: 0;
+      }
+    }
+
     .@{ant-prefix}-select.@{ant-prefix}-select-auto-complete {
       .@{ant-prefix}-input:focus {
         border-color: @error-color;

--- a/components/form/style/index.less
+++ b/components/form/style/index.less
@@ -296,7 +296,7 @@
     }
 
     // fixes https://github.com/ant-design/ant-design/issues/20482
-    .@{ant-prefix}-select {
+    .@{ant-prefix}-input-group-addon .@{ant-prefix}-select {
       &.@{ant-prefix}-select-single:not(.@{ant-prefix}-select-customize-input)
         .@{ant-prefix}-select-selector {
         border: 0;

--- a/components/form/style/index.less
+++ b/components/form/style/index.less
@@ -309,13 +309,6 @@
       }
     }
 
-    .@{ant-prefix}-input-group-addon .@{ant-prefix}-select {
-      &-selector {
-        border-color: transparent;
-        box-shadow: none;
-      }
-    }
-
     //input-number, timepicker
     .@{ant-prefix}-input-number,
     .@{ant-prefix}-picker {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->
#20482 
### 💡 Background and solution

Another border was getting added due to some internal style of select. I had to override it to fix the issue.

![image](https://user-images.githubusercontent.com/22376783/71553662-55404800-2a39-11ea-8d7d-33eb89fedf2e.png)

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
