### PR TITLE
style: Tweak Radio.Group inconsistant style

### DIFF
--- a/components/radio/style/index.less
+++ b/components/radio/style/index.less
@@ -11,7 +11,6 @@
   .reset-component;
 
   display: inline-block;
-  line-height: unset;
 }
 
 // 一般状态


### PR DESCRIPTION
Remove "line-height: unset;" from ".@{radio-group-prefix-cls}".
It causes inconsistance with Checkbox.Group.
See: https://codesandbox.io/s/antd-radio-line-height-8kt7u

<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution
See https://codesandbox.io/s/antd-radio-line-height-8kt7u

`Radio.Group` has the style below while `Checkbox.Group` doesn't have.
```css
line-height: unset;
```

So when the parent element is specified a `line-height`, `Radio.Group` will inherit it while `Checkbox.Group` won't. For example:
```javascript
const options = Array(50)
  .fill(1)
  .map((_, index) => ({
    label: index,
    value: index
  }));

function App() {
  return (
    <div
      style={{
        lineHeight: "40px"
      }}
    >
      <Checkbox.Group options={options} />
      <Radio.Group options={options} />
    </div>
  );
}
```
Render result:
<img width="795" alt="image" src="https://user-images.githubusercontent.com/24999464/71572423-fc94ac00-2b19-11ea-9d99-fd6e216701a3.png">

It's hard to say which side is right, but I think antd components should take responsibility of their own `line-height`, so I recommend removing the line.

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Remove `line-height: unset` from `Radio.Group` to prevent it from inheriting `line-height` from parent element. This may affect the code who was intending to use this mechanism. |
| 🇨🇳 Chinese | 移除了 `Radio.Group` 的 `line-height: unset;`，以免其从父元素继承 `line-height`。这也许会导致那些有意利用该机制的代码失效。 |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
