### PR TITLE
fix: 💄 Remove Input.Password value attribute from dom

### DIFF
--- a/components/input/Input.tsx
+++ b/components/input/Input.tsx
@@ -133,6 +133,10 @@ class Input extends React.Component<InputProps, InputState> {
     return null;
   }
 
+  componentDidMount() {
+    this.clearPasswordValueAttribute();
+  }
+
   // Since polyfill `getSnapshotBeforeUpdate` need work with `componentDidUpdate`.
   // We keep an empty function here.
   componentDidUpdate() {}
@@ -217,19 +221,21 @@ class Input extends React.Component<InputProps, InputState> {
     );
   };
 
-  handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    this.setValue(e.target.value, () => {
-      // https://github.com/ant-design/ant-design/issues/20541
-      this.removePasswordTimeout = setTimeout(() => {
-        if (
-          this.input &&
-          this.input.getAttribute('type') === 'password' &&
-          this.input.hasAttribute('value')
-        ) {
-          this.input.removeAttribute('value');
-        }
-      });
+  clearPasswordValueAttribute = () => {
+    // https://github.com/ant-design/ant-design/issues/20541
+    this.removePasswordTimeout = setTimeout(() => {
+      if (
+        this.input &&
+        this.input.getAttribute('type') === 'password' &&
+        this.input.hasAttribute('value')
+      ) {
+        this.input.removeAttribute('value');
+      }
     });
+  };
+
+  handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    this.setValue(e.target.value, this.clearPasswordValueAttribute);
     resolveOnChange(this.input, e, this.props.onChange);
   };
 

--- a/components/input/Password.tsx
+++ b/components/input/Password.tsx
@@ -33,7 +33,7 @@ export default class Password extends React.Component<PasswordProps, PasswordSta
     visible: false,
   };
 
-  onChange = () => {
+  onVisibleChange = () => {
     const { disabled } = this.props;
     if (disabled) {
       return;
@@ -46,7 +46,7 @@ export default class Password extends React.Component<PasswordProps, PasswordSta
     const { prefixCls, action } = this.props;
     const iconTrigger = ActionMap[action!] || '';
     const iconProps = {
-      [iconTrigger]: this.onChange,
+      [iconTrigger]: this.onVisibleChange,
       className: `${prefixCls}-icon`,
       type: this.state.visible ? 'eye' : 'eye-invisible',
       key: 'passwordIcon',

--- a/components/input/__tests__/Password.test.js
+++ b/components/input/__tests__/Password.test.js
@@ -88,4 +88,17 @@ describe('Input.Password', () => {
         .getAttribute('value'),
     ).toBeFalsy();
   });
+  
+  
+  // https://github.com/ant-design/ant-design/issues/20541
+  it('could be unmount without errors', () => {
+    expect(() => {
+      const wrapper = mount(<Input.Password />);
+      wrapper
+        .find('input')
+        .at('0')
+        .simulate('change', { target: { value: 'value' } });
+      wrapper.unmount();
+    }).not.toThrow();
+  });
 });

--- a/components/input/__tests__/Password.test.js
+++ b/components/input/__tests__/Password.test.js
@@ -88,8 +88,7 @@ describe('Input.Password', () => {
         .getAttribute('value'),
     ).toBeFalsy();
   });
-  
-  
+
   // https://github.com/ant-design/ant-design/issues/20541
   it('could be unmount without errors', () => {
     expect(() => {
@@ -100,5 +99,18 @@ describe('Input.Password', () => {
         .simulate('change', { target: { value: 'value' } });
       wrapper.unmount();
     }).not.toThrow();
+  });
+
+  // https://github.com/ant-design/ant-design/pull/20544#issuecomment-569861679
+  it('should not contain value attribute in input element with defautValue', async () => {
+    const wrapper = mount(<Input.Password defaultValue="value" />);
+    await sleep();
+    expect(
+      wrapper
+        .find('input')
+        .at('0')
+        .getDOMNode()
+        .getAttribute('value'),
+    ).toBeFalsy();
   });
 });

--- a/components/input/__tests__/Password.test.js
+++ b/components/input/__tests__/Password.test.js
@@ -4,6 +4,7 @@ import { mount } from 'enzyme';
 import Input from '..';
 import focusTest from '../../../tests/shared/focusTest';
 import mountTest from '../../../tests/shared/mountTest';
+import { sleep } from '../../../tests/utils';
 
 describe('Input.Password', () => {
   focusTest(Input.Password);
@@ -69,5 +70,22 @@ describe('Input.Password', () => {
         .at(0)
         .getDOMNode(),
     );
+  });
+
+  // https://github.com/ant-design/ant-design/issues/20541
+  it('should not show value attribute in input element', async () => {
+    const wrapper = mount(<Input.Password />);
+    wrapper
+      .find('input')
+      .at('0')
+      .simulate('change', { target: { value: 'value' } });
+    await sleep();
+    expect(
+      wrapper
+        .find('input')
+        .at('0')
+        .getDOMNode()
+        .getAttribute('value'),
+    ).toBeFalsy();
   });
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close #20541
close #7761
close #19959
close #20536
close #12672
close #10952
close #14592

### 💡 Background and solution

Hack for `value` attruibute for `<input type="password" />`.

<img width="914" alt="image" src="https://user-images.githubusercontent.com/507615/71577779-6fa91d00-2b30-11ea-84fd-92a28585386a.png">

ref: https://github.com/facebook/react/issues/11896

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Remove Input.Password `value` attribute from dom. |
| 🇨🇳 Chinese | 优化 Input.Password 在 dom 中明文显示 `value` 属性的问题。 |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
