### PR TITLE
fix: use Object.prototype.toString to check object

### DIFF
--- a/components/message/__tests__/index.test.js
+++ b/components/message/__tests__/index.test.js
@@ -189,4 +189,8 @@ describe('message', () => {
     jest.advanceTimersByTime(1500);
     expect(document.querySelectorAll('.ant-message-notice').length).toBe(0);
   });
+
+  it('should not throw error when pass null', () => {
+    message.error(null);
+  });
 });

--- a/components/message/index.tsx
+++ b/components/message/index.tsx
@@ -114,7 +114,10 @@ type JointContent = ConfigContent | ArgsProps;
 export type ConfigOnClose = () => void;
 
 function isArgsProps(content: JointContent): content is ArgsProps {
-  return typeof content === 'object' && !!(content as ArgsProps).content;
+  return (
+    Object.prototype.toString.call(content) === '[object Object]' &&
+    !!(content as ArgsProps).content
+  );
 }
 
 export interface ConfigOptions {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close https://github.com/ant-design/ant-design/issues/20528

### 💡 Background and solution

use Object.prototype.toString instead of typeof

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
