### PR TITLE
feat: Add a new prop breakpointMap in Sider to allow configuration of breakpoints

### DIFF
--- a/components/layout/Sider.tsx
+++ b/components/layout/Sider.tsx
@@ -45,6 +45,15 @@ export type CollapseType = 'clickTrigger' | 'responsive';
 
 export type SiderTheme = 'light' | 'dark';
 
+export type BreakpointMap = {
+  xs: string;
+  sm: string;
+  md: string;
+  lg: string;
+  xl: string;
+  xxl: string;
+};
+
 export interface SiderProps extends React.HTMLAttributes<HTMLDivElement> {
   prefixCls?: string;
   collapsible?: boolean;
@@ -57,6 +66,7 @@ export interface SiderProps extends React.HTMLAttributes<HTMLDivElement> {
   width?: number | string;
   collapsedWidth?: number | string;
   breakpoint?: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'xxl';
+  breakpointMap: BreakpointMap;
   theme?: SiderTheme;
   onBreakpoint?: (broken: boolean) => void;
 }
@@ -86,6 +96,7 @@ class InternalSider extends React.Component<InternalSideProps, SiderState> {
     collapsedWidth: 80,
     style: {},
     theme: 'dark' as SiderTheme,
+    breakpointMap: dimensionMaxMap,
   };
 
   static getDerivedStateFromProps(nextProps: InternalSideProps) {
@@ -108,8 +119,8 @@ class InternalSider extends React.Component<InternalSideProps, SiderState> {
     if (typeof window !== 'undefined') {
       matchMedia = window.matchMedia;
     }
-    if (matchMedia && props.breakpoint && props.breakpoint in dimensionMaxMap) {
-      this.mql = matchMedia(`(max-width: ${dimensionMaxMap[props.breakpoint]})`);
+    if (matchMedia && props.breakpoint && props.breakpoint in props.breakpointMap) {
+      this.mql = matchMedia(`(max-width: ${props.breakpointMap[props.breakpoint]})`);
     }
     let collapsed;
     if ('collapsed' in props) {
@@ -197,6 +208,7 @@ class InternalSider extends React.Component<InternalSideProps, SiderState> {
       'onCollapse',
       'breakpoint',
       'onBreakpoint',
+      'breakpointMap',
       'siderHook',
       'zeroWidthTriggerStyle',
     ]);

--- a/components/layout/Sider.tsx
+++ b/components/layout/Sider.tsx
@@ -115,12 +115,13 @@ class InternalSider extends React.Component<InternalSideProps, SiderState> {
   constructor(props: InternalSideProps) {
     super(props);
     this.uniqueId = generateId('ant-sider-');
+    const breakpointMap = props.breakpointMap ? props.breakpointMap : dimensionMaxMap;
     let matchMedia;
     if (typeof window !== 'undefined') {
       matchMedia = window.matchMedia;
     }
-    if (matchMedia && props.breakpoint && props.breakpoint in props.breakpointMap) {
-      this.mql = matchMedia(`(max-width: ${props.breakpointMap[props.breakpoint]})`);
+    if (matchMedia && props.breakpoint && props.breakpoint in breakpointMap) {
+      this.mql = matchMedia(`(max-width: ${breakpointMap[props.breakpoint]})`);
     }
     let collapsed;
     if ('collapsed' in props) {

--- a/components/layout/Sider.tsx
+++ b/components/layout/Sider.tsx
@@ -66,7 +66,7 @@ export interface SiderProps extends React.HTMLAttributes<HTMLDivElement> {
   width?: number | string;
   collapsedWidth?: number | string;
   breakpoint?: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'xxl';
-  breakpointMap: BreakpointMap;
+  breakpointMap?: BreakpointMap;
   theme?: SiderTheme;
   onBreakpoint?: (broken: boolean) => void;
 }

--- a/components/layout/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/layout/__tests__/__snapshots__/demo.test.js.snap
@@ -266,6 +266,174 @@ exports[`renders ./components/layout/demo/custom-trigger.md correctly 1`] = `
 </section>
 `;
 
+exports[`renders ./components/layout/demo/customBreakpoints.md correctly 1`] = `
+<section
+  class="ant-layout"
+>
+  <aside
+    class="ant-layout-sider ant-layout-sider-dark"
+    style="flex:0 0 200px;max-width:200px;min-width:200px;width:200px"
+  >
+    <div
+      class="ant-layout-sider-children"
+    >
+      <div
+        class="logo"
+      />
+      <ul
+        class="ant-menu ant-menu-dark ant-menu-root ant-menu-inline"
+        role="menu"
+      >
+        <li
+          class="ant-menu-item"
+          role="menuitem"
+          style="padding-left:24px"
+        >
+          <i
+            aria-label="icon: user"
+            class="anticon anticon-user"
+          >
+            <svg
+              aria-hidden="true"
+              class=""
+              data-icon="user"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M858.5 763.6a374 374 0 0 0-80.6-119.5 375.63 375.63 0 0 0-119.5-80.6c-.4-.2-.8-.3-1.2-.5C719.5 518 760 444.7 760 362c0-137-111-248-248-248S264 225 264 362c0 82.7 40.5 156 102.8 201.1-.4.2-.8.3-1.2.5-44.8 18.9-85 46-119.5 80.6a375.63 375.63 0 0 0-80.6 119.5A371.7 371.7 0 0 0 136 901.8a8 8 0 0 0 8 8.2h60c4.4 0 7.9-3.5 8-7.8 2-77.2 33-149.5 87.8-204.3 56.7-56.7 132-87.9 212.2-87.9s155.5 31.2 212.2 87.9C779 752.7 810 825 812 902.2c.1 4.4 3.6 7.8 8 7.8h60a8 8 0 0 0 8-8.2c-1-47.8-10.9-94.3-29.5-138.2zM512 534c-45.9 0-89.1-17.9-121.6-50.4S340 407.9 340 362c0-45.9 17.9-89.1 50.4-121.6S466.1 190 512 190s89.1 17.9 121.6 50.4S684 316.1 684 362c0 45.9-17.9 89.1-50.4 121.6S557.9 534 512 534z"
+              />
+            </svg>
+          </i>
+          <span
+            class="nav-text"
+          >
+            nav 1
+          </span>
+        </li>
+        <li
+          class="ant-menu-item"
+          role="menuitem"
+          style="padding-left:24px"
+        >
+          <i
+            aria-label="icon: video-camera"
+            class="anticon anticon-video-camera"
+          >
+            <svg
+              aria-hidden="true"
+              class=""
+              data-icon="video-camera"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M912 302.3L784 376V224c0-35.3-28.7-64-64-64H128c-35.3 0-64 28.7-64 64v576c0 35.3 28.7 64 64 64h592c35.3 0 64-28.7 64-64V648l128 73.7c21.3 12.3 48-3.1 48-27.6V330c0-24.6-26.7-40-48-27.7zM712 792H136V232h576v560zm176-167l-104-59.8V458.9L888 399v226zM208 360h112c4.4 0 8-3.6 8-8v-48c0-4.4-3.6-8-8-8H208c-4.4 0-8 3.6-8 8v48c0 4.4 3.6 8 8 8z"
+              />
+            </svg>
+          </i>
+          <span
+            class="nav-text"
+          >
+            nav 2
+          </span>
+        </li>
+        <li
+          class="ant-menu-item"
+          role="menuitem"
+          style="padding-left:24px"
+        >
+          <i
+            aria-label="icon: upload"
+            class="anticon anticon-upload"
+          >
+            <svg
+              aria-hidden="true"
+              class=""
+              data-icon="upload"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M400 317.7h73.9V656c0 4.4 3.6 8 8 8h60c4.4 0 8-3.6 8-8V317.7H624c6.7 0 10.4-7.7 6.3-12.9L518.3 163a8 8 0 0 0-12.6 0l-112 141.7c-4.1 5.3-.4 13 6.3 13zM878 626h-60c-4.4 0-8 3.6-8 8v154H214V634c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v198c0 17.7 14.3 32 32 32h684c17.7 0 32-14.3 32-32V634c0-4.4-3.6-8-8-8z"
+              />
+            </svg>
+          </i>
+          <span
+            class="nav-text"
+          >
+            nav 3
+          </span>
+        </li>
+        <li
+          class="ant-menu-item ant-menu-item-selected"
+          role="menuitem"
+          style="padding-left:24px"
+        >
+          <i
+            aria-label="icon: user"
+            class="anticon anticon-user"
+          >
+            <svg
+              aria-hidden="true"
+              class=""
+              data-icon="user"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M858.5 763.6a374 374 0 0 0-80.6-119.5 375.63 375.63 0 0 0-119.5-80.6c-.4-.2-.8-.3-1.2-.5C719.5 518 760 444.7 760 362c0-137-111-248-248-248S264 225 264 362c0 82.7 40.5 156 102.8 201.1-.4.2-.8.3-1.2.5-44.8 18.9-85 46-119.5 80.6a375.63 375.63 0 0 0-80.6 119.5A371.7 371.7 0 0 0 136 901.8a8 8 0 0 0 8 8.2h60c4.4 0 7.9-3.5 8-7.8 2-77.2 33-149.5 87.8-204.3 56.7-56.7 132-87.9 212.2-87.9s155.5 31.2 212.2 87.9C779 752.7 810 825 812 902.2c.1 4.4 3.6 7.8 8 7.8h60a8 8 0 0 0 8-8.2c-1-47.8-10.9-94.3-29.5-138.2zM512 534c-45.9 0-89.1-17.9-121.6-50.4S340 407.9 340 362c0-45.9 17.9-89.1 50.4-121.6S466.1 190 512 190s89.1 17.9 121.6 50.4S684 316.1 684 362c0 45.9-17.9 89.1-50.4 121.6S557.9 534 512 534z"
+              />
+            </svg>
+          </i>
+          <span
+            class="nav-text"
+          >
+            nav 4
+          </span>
+        </li>
+      </ul>
+    </div>
+  </aside>
+  <section
+    class="ant-layout"
+  >
+    <header
+      class="ant-layout-header"
+      style="background:#fff;padding:0"
+    />
+    <main
+      class="ant-layout-content"
+      style="margin:24px 16px 0"
+    >
+      <div
+        style="padding:24px;background:#fff;min-height:360px"
+      >
+        content
+      </div>
+    </main>
+    <footer
+      class="ant-layout-footer"
+      style="text-align:center"
+    >
+      Ant Design ©2018 Created by Ant UED
+    </footer>
+  </section>
+</section>
+`;
+
 exports[`renders ./components/layout/demo/fixed.md correctly 1`] = `
 <section
   class="ant-layout"

--- a/components/layout/demo/customBreakpoints.md
+++ b/components/layout/demo/customBreakpoints.md
@@ -1,0 +1,85 @@
+---
+order: 5
+title:
+  zh-CN: 响应式布局
+  en-US: Custom Breakpoint
+---
+
+## zh-CN
+
+<!-- Layout.Sider 支持响应式布局。
+
+> 说明：配置 `breakpoint` 属性即生效，视窗宽度小于 `breakpoint` 时 Sider 缩小为 `collapsedWidth` 宽度，若将 `collapsedWidth` 设置为零，会出现特殊 trigger。 -->
+
+## en-US
+
+Layout.Sider supports the option to setup custom breakpoints.
+
+> Note: You need to add the values of the breakpoints in px - ex '1000px'. These breakpoints will be used when you setup a `breakpoint`. The Sider will collapse to the width of `collapsedWidth` when window width is below the `breakpoint` (Using the value that you provided in the object as a breakpoint).
+
+```jsx
+import { Layout, Menu, Icon } from 'antd';
+
+const { Header, Content, Footer, Sider } = Layout;
+
+const customBreakpointMap = {
+  xs: '299.98px',
+  sm: '599.98px',
+  md: '849.98px',
+  lg: '1023.98px',
+  xl: '1319.98px',
+  xxl: '1799.98px',
+};
+
+ReactDOM.render(
+  <Layout>
+    <Sider
+      breakpoint="md"
+      collapsedWidth="0"
+      breakpointMap={customBreakpointMap}
+      onBreakpoint={broken => {
+        console.log(broken);
+      }}
+      onCollapse={(collapsed, type) => {
+        console.log(collapsed, type);
+      }}
+    >
+      <div className="logo" />
+      <Menu theme="dark" mode="inline" defaultSelectedKeys={['4']}>
+        <Menu.Item key="1">
+          <Icon type="user" />
+          <span className="nav-text">nav 1</span>
+        </Menu.Item>
+        <Menu.Item key="2">
+          <Icon type="video-camera" />
+          <span className="nav-text">nav 2</span>
+        </Menu.Item>
+        <Menu.Item key="3">
+          <Icon type="upload" />
+          <span className="nav-text">nav 3</span>
+        </Menu.Item>
+        <Menu.Item key="4">
+          <Icon type="user" />
+          <span className="nav-text">nav 4</span>
+        </Menu.Item>
+      </Menu>
+    </Sider>
+    <Layout>
+      <Header style={{ background: '#fff', padding: 0 }} />
+      <Content style={{ margin: '24px 16px 0' }}>
+        <div style={{ padding: 24, background: '#fff', minHeight: 360 }}>content</div>
+      </Content>
+      <Footer style={{ textAlign: 'center' }}>Ant Design ©2018 Created by Ant UED</Footer>
+    </Layout>
+  </Layout>,
+  mountNode,
+);
+```
+
+```css
+#components-layout-demo-responsive .logo {
+  height: 32px;
+  background: rgba(255, 255, 255, 0.2);
+  margin: 16px;
+}
+```

--- a/components/layout/index.en-US.md
+++ b/components/layout/index.en-US.md
@@ -88,6 +88,7 @@ The sidebar.
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
 | breakpoint | [breakpoints](/components/grid#Col) of the responsive layout | Enum { 'xs', 'sm', 'md', 'lg', 'xl', 'xxl' } | - |  |
+| breakpointWidth | set custom breakpoints by saying on which width does each breakpoint get activated | Object { xs: string, sm: string, md: string, lg: string, xl: string, xxl: string} | {xs: '480px', sm: '576px', md: '768px', lg: '992px', xl: '1200px', xxl: '1600px'} |  |
 | className | container className | string | - |  |
 | collapsed | to set the current status | boolean | - |  |
 | collapsedWidth | width of the collapsed sidebar, by setting to `0` a special trigger will appear | number | 80 |  |


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

**Please note:** I raised this PR against `master` branch because there was no `feature` branch open. I'm happy to adapt the PR if that is required.

### 🔗 Related issue link

[Allow Configuration of breakpoints in Layout Component](https://github.com/ant-design/ant-design/issues/19694)

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

1. Allow a new property `breakpointMap` to be passed which can define new values for the breakpoints.
2. If that property is not passed, then breakpointMap will get the default value which is hardcoded at the moment in the component.

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed


-----
[View rendered components/layout/demo/customBreakpoints.md](https://github.com/atanasgeorgiev93/ant-design/blob/feat/Sider-customBreakpointMap/components/layout/demo/customBreakpoints.md)
[View rendered components/layout/index.en-US.md](https://github.com/atanasgeorgiev93/ant-design/blob/feat/Sider-customBreakpointMap/components/layout/index.en-US.md)

-----
[View rendered components/layout/demo/customBreakpoints.md](https://github.com/atanasgeorgiev93/ant-design/blob/feat/Sider-customBreakpointMap/components/layout/demo/customBreakpoints.md)
[View rendered components/layout/index.en-US.md](https://github.com/atanasgeorgiev93/ant-design/blob/feat/Sider-customBreakpointMap/components/layout/index.en-US.md)