### PR TITLE
Fix: get a wrong year in New Year's week

### DIFF
--- a/components/date-picker/WeekPicker.tsx
+++ b/components/date-picker/WeekPicker.tsx
@@ -10,7 +10,7 @@ import interopDefault from '../_util/interopDefault';
 import InputIcon from './InputIcon';
 
 function formatValue(value: moment.Moment | null, format: string): string {
-  return (value && value.format(format)) || '';
+  return (value && value.endOf('week').format(format)) || '';
 }
 
 interface WeekPickerState {


### PR DESCRIPTION
ISSUE:
I'm using a WeekPicker component, when it's in a New Year's first week, such as 2019-12-31, moment('2019-12-31').format('YYYYww') would output 201901 which should be 202001.

How to fix it:
We could fix it by getting the year of  the last day in the week, moment().endOf('week').format('YYYYww') 

<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
