### PR TITLE
fix: 修复 carousel dotposition 问题

### DIFF
--- a/components/carousel/__tests__/__snapshots__/index.test.js.snap
+++ b/components/carousel/__tests__/__snapshots__/index.test.js.snap
@@ -55,7 +55,7 @@ exports[`Carousel should works for dotPosition bottom 1`] = `
 
 exports[`Carousel should works for dotPosition left 1`] = `
 <div
-  class="ant-carousel"
+  class="ant-carousel ant-carousel-vertical"
 >
   <div
     class="slick-slider slick-initialized"
@@ -89,7 +89,7 @@ exports[`Carousel should works for dotPosition left 1`] = `
 
 exports[`Carousel should works for dotPosition right 1`] = `
 <div
-  class="ant-carousel"
+  class="ant-carousel ant-carousel-vertical"
 >
   <div
     class="slick-slider slick-initialized"

--- a/components/carousel/index.tsx
+++ b/components/carousel/index.tsx
@@ -109,6 +109,7 @@ export default class Carousel extends React.Component<CarouselProps, {}> {
 
     const className = classNames(prefixCls, {
       [`${prefixCls}-rtl`]: direction === 'rtl',
+      [`${prefixCls}-vertical`]: dotPosition === 'left' || dotPosition === 'right',
     });
 
     return (


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->
close https://github.com/ant-design/ant-design/issues/20638
### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |Fix the display error of carousel component with dotposition of left and righ  |
| 🇨🇳 Chinese | 修复carousel 组件 dotposition 为 left 、right 的显示错误          |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
