### PR TITLE
docs: Added "paddingBottom" to the "Check all" checkbox in the docs

### DIFF
--- a/components/checkbox/demo/check-all.md
+++ b/components/checkbox/demo/check-all.md
@@ -47,7 +47,7 @@ class App extends React.Component {
   render() {
     return (
       <div>
-        <div style={{ borderBottom: '1px solid #E9E9E9' }}>
+        <div style={{ borderBottom: '1px solid #E9E9E9', paddingBottom: '8px' }}>
           <Checkbox
             indeterminate={this.state.indeterminate}
             onChange={this.onCheckAllChange}


### PR DESCRIPTION
I added `paddingBottom: '8px'` to the "Check all" in the docs. Because I think the `borderBottom` is very close to the checkbox.

<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution
![Check all](https://user-images.githubusercontent.com/6717356/71760308-8fdc3180-2ecc-11ea-898e-57af58b8e43d.png)

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/checkbox/demo/check-all.md](https://github.com/ozgurg/ant-design/blob/patch-1/components/checkbox/demo/check-all.md)