### PR TITLE
fix: Input.Group align in Form.Item

### DIFF
--- a/components/form/style/components.less
+++ b/components/form/style/components.less
@@ -67,13 +67,4 @@
   .@{ant-prefix}-input-group .@{ant-prefix}-cascader-picker {
     width: auto;
   }
-
-  // fix input with addon position. https://github.com/ant-design/ant-design/issues/8243
-  :not(.@{ant-prefix}-input-group-wrapper) > .@{ant-prefix}-input-group,
-  .@{ant-prefix}-input-group-wrapper {
-    position: relative;
-    top: -1px;
-    display: inline-block;
-    vertical-align: middle;
-  }
 }


### PR DESCRIPTION


<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

### 💡 Background and solution

No more override css hacks.

<img width="693" alt="image" src="https://user-images.githubusercontent.com/507615/71795262-4cc2bf80-3080-11ea-840c-512fba16b07c.png">

to

<img width="692" alt="image" src="https://user-images.githubusercontent.com/507615/71795267-5a784500-3080-11ea-948c-9d0b27db8f01.png">


### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese | 修复 Form 下 Input.Group 偏上一像素的问题。 |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
