### PR TITLE
fix(3.x): Input.Group 1px bug in vertical layout form

### DIFF
--- a/components/form/style/index.less
+++ b/components/form/style/index.less
@@ -262,10 +262,17 @@ form {
   // fix input with addon position. https://github.com/ant-design/ant-design/issues/8243
   :not(.@{ant-prefix}-input-group-wrapper) > .@{ant-prefix}-input-group,
   .@{ant-prefix}-input-group-wrapper {
-    position: relative;
-    top: -1px;
     display: inline-block;
     vertical-align: middle;
+  }
+
+  // https://github.com/ant-design/ant-design/issues/20616
+  &:not(.@{form-prefix-cls}-vertical) {
+    :not(.@{ant-prefix}-input-group-wrapper) > .@{ant-prefix}-input-group,
+    .@{ant-prefix}-input-group-wrapper {
+      position: relative;
+      top: -1px;
+    }
   }
 }
 


### PR DESCRIPTION


<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close #20616

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Input.Group inside `<Form layout="vertical" >` 1px bug. |
| 🇨🇳 Chinese | 修复 `<Form layout="vertical" >` 内 Input.Group 偏上一像素的问题。 |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
