### PR TITLE
fix: AutoComplete customize input should fully stretch

### DIFF
--- a/components/select/style/single.less
+++ b/components/select/style/single.less
@@ -104,8 +104,8 @@
 
       .@{select-prefix-cls}-selection-placeholder {
         position: absolute;
-        left: 0;
         right: 0;
+        left: 0;
         padding: 0 @input-padding-horizontal-base;
 
         &::after {

--- a/components/select/style/single.less
+++ b/components/select/style/single.less
@@ -91,6 +91,30 @@
     }
   }
 
+  &.@{select-prefix-cls}-customize-input {
+    .@{select-prefix-cls}-selector {
+      &::after {
+        display: none;
+      }
+
+      .@{select-prefix-cls}-selection-search {
+        position: static;
+        width: 100%;
+      }
+
+      .@{select-prefix-cls}-selection-placeholder {
+        position: absolute;
+        left: 0;
+        right: 0;
+        padding: 0 @input-padding-horizontal-base;
+
+        &::after {
+          display: none;
+        }
+      }
+    }
+  }
+
   // ============================================================
   // ==                          Size                          ==
   // ============================================================


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

fix #20637

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fix AutoComplete with customize component with wrong style.      |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
