### PR TITLE
fix: FormItem should not trigger feedback className without hasFeedback

### DIFF
--- a/components/form/FormItem.tsx
+++ b/components/form/FormItem.tsx
@@ -143,8 +143,7 @@ const FormItem: React.FC<FormItemProps> = (props: FormItemProps) => {
           [`${className}`]: !!className,
 
           // Status
-          [`${prefixCls}-item-has-feedback`]:
-            (mergedValidateStatus && hasFeedback) || mergedValidateStatus === 'validating',
+          [`${prefixCls}-item-has-feedback`]: mergedValidateStatus && hasFeedback,
           [`${prefixCls}-item-has-success`]: mergedValidateStatus === 'success',
           [`${prefixCls}-item-has-warning`]: mergedValidateStatus === 'warning',
           [`${prefixCls}-item-has-error`]: mergedValidateStatus === 'error',


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

fix #20680

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Fix Form.Item add additional feedback style when `hasFeedback` is not set.        |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
