### PR TITLE
fix: Card cover image get skretched

### DIFF
--- a/components/card/style/index.less
+++ b/components/card/style/index.less
@@ -131,14 +131,15 @@
   }
 
   &-cover {
+    margin-right: -1px;
+    margin-left: -1px;
+
     > * {
       display: block;
       width: 100%;
     }
+
     img {
-      width: calc(100% + 2px);
-      margin-right: -1px;
-      margin-left: -1px;
       border-radius: @card-radius @card-radius 0 0;
     }
   }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close #20698

### 💡 Background and solution


Image `max-width` 的方案会导致 hover 卡片时边缘依然出现白色边框（这里是需要去掉的）。

cc @zombieJ 

- [x] 图片宽度不够不能拉伸。
- [x] Hover 时图片两边不能出现白色边框。

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Card cover image get skretched |
| 🇨🇳 Chinese | 修复 Card 封面图片被拉伸的问题。 |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
