### PR TITLE
fix: Table should not crash with empty column children

### DIFF
--- a/components/table/__tests__/Table.test.js
+++ b/components/table/__tests__/Table.test.js
@@ -142,4 +142,18 @@ describe('Table', () => {
     wrapper.find('th').simulate('click');
     expect(onClick).toHaveBeenCalled();
   });
+
+  it('should not crash when column children is empty', () => {
+    mount(
+      <Table
+        columns={[
+          {
+            dataIndex: 'name',
+            children: undefined,
+          },
+        ]}
+        dataSource={[]}
+      />,
+    );
+  });
 });

--- a/components/table/hooks/useFilter/index.tsx
+++ b/components/table/hooks/useFilter/index.tsx
@@ -27,7 +27,7 @@ function collectFilterStates<RecordType>(
 ): FilterState<RecordType>[] {
   let filterStates: FilterState<RecordType>[] = [];
 
-  columns.forEach((column, index) => {
+  (columns || []).forEach((column, index) => {
     const columnPos = getColumnPos(index, pos);
 
     if ('children' in column) {

--- a/components/table/hooks/useSorter.tsx
+++ b/components/table/hooks/useSorter.tsx
@@ -54,7 +54,7 @@ function collectSortStates<RecordType>(
 ): SortState<RecordType>[] {
   let sortStates: SortState<RecordType>[] = [];
 
-  columns.forEach((column, index) => {
+  (columns || []).forEach((column, index) => {
     const columnPos = getColumnPos(index, pos);
 
     if ('children' in column) {
@@ -91,7 +91,7 @@ function injectSorter<RecordType>(
   defaultSortDirections: SortOrder[],
   pos?: string,
 ): ColumnsType<RecordType> {
-  return columns.map((column, index) => {
+  return (columns || []).map((column, index) => {
     const columnPos = getColumnPos(index, pos);
     let newColumn: ColumnsType<RecordType>[number] = column;
 

--- a/components/table/interface.tsx
+++ b/components/table/interface.tsx
@@ -63,7 +63,6 @@ export interface ColumnType<RecordType> extends RcColumnType<RecordType> {
   title?: ColumnTitle<RecordType>;
 
   // Sorter
-  // TODO: Doc this update
   sorter?:
     | boolean
     | CompareFn<RecordType>


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

https://codesandbox.io/s/hopeful-volhard-gykps

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |       Fix Table crash when `columns` with empty children.    |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
