### PR TITLE
fix: Cascader search bug when fieldNames existed

### DIFF
--- a/components/cascader/__tests__/__snapshots__/index.test.js.snap
+++ b/components/cascader/__tests__/__snapshots__/index.test.js.snap
@@ -606,7 +606,6 @@ exports[`Cascader have a notFoundContent that fit trigger input width 1`] = `
     <div>
       <ul
         class="ant-cascader-menu"
-        style="height: auto;"
       >
         <li
           class="ant-cascader-menu-item ant-cascader-menu-item-disabled"
@@ -1246,6 +1245,7 @@ exports[`Cascader should highlight keyword and filter when search in Cascader 1`
                     Object {
                       "__IS_FILTERED_OPTION": true,
                       "disabled": false,
+                      "isEmptyNode": true,
                       "label": Array [
                         "Jiangsu",
                         Array [
@@ -1298,6 +1298,7 @@ exports[`Cascader should highlight keyword and filter when search in Cascader 1`
                     Object {
                       "__IS_FILTERED_OPTION": true,
                       "disabled": false,
+                      "isEmptyNode": true,
                       "label": Array [
                         "Zhejiang",
                         Array [
@@ -1429,6 +1430,49 @@ exports[`Cascader should highlight keyword and filter when search in Cascader 1`
     </ForwardRef>
   </div>
 </Popup>
+`;
+
+exports[`Cascader should highlight keyword and filter when search in Cascader with same field name of label and value 1`] = `
+<div>
+  <div
+    class="ant-cascader-menus"
+    style="opacity: 0;"
+  >
+    <div>
+      <ul
+        class="ant-cascader-menu"
+        style="width: 0px;"
+      >
+        <li
+          class="ant-cascader-menu-item"
+          role="menuitem"
+          title=""
+        >
+          Zhejiang / Hang
+          <span
+            class="ant-cascader-menu-item-keyword"
+          >
+            z
+          </span>
+          hou / West Lake
+        </li>
+        <li
+          class="ant-cascader-menu-item ant-cascader-menu-item-disabled"
+          role="menuitem"
+          title=""
+        >
+          Zhejiang / Hang
+          <span
+            class="ant-cascader-menu-item-keyword"
+          >
+            z
+          </span>
+          hou / Xia Sha
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>
 `;
 
 exports[`Cascader should render not found content 1`] = `
@@ -1635,6 +1679,7 @@ exports[`Cascader should render not found content 1`] = `
                   Array [
                     Object {
                       "disabled": true,
+                      "isEmptyNode": true,
                       "label": <Context.Consumer>
                         [Function]
                       </Context.Consumer>,
@@ -1917,12 +1962,7 @@ exports[`Cascader should show not found content when options.length is 0 1`] = `
                   }
                 }
                 disabled={false}
-                dropdownMenuColumnStyle={
-                  Object {
-                    "height": "auto",
-                    "width": 0,
-                  }
-                }
+                dropdownMenuColumnStyle={Object {}}
                 expandIcon={<ForwardRef(RightOutlined) />}
                 expandTrigger="click"
                 fieldNames={
@@ -1968,12 +2008,7 @@ exports[`Cascader should show not found content when options.length is 0 1`] = `
                   <ul
                     className="ant-cascader-menu"
                     key="0"
-                    style={
-                      Object {
-                        "height": "auto",
-                        "width": 0,
-                      }
-                    }
+                    style={Object {}}
                   >
                     <li
                       className="ant-cascader-menu-item ant-cascader-menu-item-disabled"

--- a/components/cascader/__tests__/index.test.js
+++ b/components/cascader/__tests__/index.test.js
@@ -208,6 +208,52 @@ describe('Cascader', () => {
     expect(popupWrapper).toMatchSnapshot();
   });
 
+  it('should highlight keyword and filter when search in Cascader with same field name of label and value', () => {
+    const customOptions = [
+      {
+        name: 'Zhejiang',
+        value: 'Zhejiang',
+        children: [
+          {
+            name: 'Hangzhou',
+            value: 'Hangzhou',
+            children: [
+              {
+                name: 'West Lake',
+                value: 'West Lake',
+              },
+              {
+                name: 'Xia Sha',
+                value: 'Xia Sha',
+                disabled: true,
+              },
+            ],
+          },
+        ],
+      },
+    ];
+    function customFilter(inputValue, path) {
+      return path.some(option => option.name.toLowerCase().indexOf(inputValue.toLowerCase()) > -1);
+    }
+    const wrapper = mount(
+      <Cascader
+        options={customOptions}
+        fieldNames={{ label: 'name', value: 'name' }}
+        showSearch={{ filter: customFilter }}
+      />,
+    );
+    wrapper.find('input').simulate('click');
+    wrapper.find('input').simulate('change', { target: { value: 'z' } });
+    expect(wrapper.state('inputValue')).toBe('z');
+    const popupWrapper = mount(
+      wrapper
+        .find('Trigger')
+        .instance()
+        .getComponent(),
+    );
+    expect(popupWrapper.render()).toMatchSnapshot();
+  });
+
   it('should render not found content', () => {
     const wrapper = mount(<Cascader options={options} showSearch={{ filter }} />);
     wrapper.find('input').simulate('click');

--- a/components/cascader/index.tsx
+++ b/components/cascader/index.tsx
@@ -397,17 +397,19 @@ class Cascader extends React.Component<CascaderProps, CascaderState> {
         return {
           __IS_FILTERED_OPTION: true,
           path,
-          [names.label]: render(inputValue, path, prefixCls, names),
           [names.value]: path.map((o: CascaderOptionType) => o[names.value]),
+          [names.label]: render(inputValue, path, prefixCls, names),
           disabled: path.some((o: CascaderOptionType) => !!o.disabled),
+          isEmptyNode: true,
         } as CascaderOptionType;
       });
     }
     return [
       {
-        [names.label]: notFoundContent || renderEmpty('Cascader'),
         [names.value]: 'ANT_CASCADER_NOT_FOUND',
+        [names.label]: notFoundContent || renderEmpty('Cascader'),
         disabled: true,
+        isEmptyNode: true,
       },
     ];
   }
@@ -534,8 +536,7 @@ class Cascader extends React.Component<CascaderProps, CascaderState> {
         }
 
         const dropdownMenuColumnStyle: { width?: number; height?: string } = {};
-        const isNotFound =
-          (options || []).length === 1 && options[0][names.value] === 'ANT_CASCADER_NOT_FOUND';
+        const isNotFound = (options || []).length === 1 && options[0].isEmptyNode;
         if (isNotFound) {
           dropdownMenuColumnStyle.height = 'auto'; // Height of one row.
         }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close #20619

### 💡 Background and solution

when label/value have same field name.

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Cascader search bug when `fieldNames` is existed and label/value share same name. |
| 🇨🇳 Chinese | 修复 Cascader `fieldNames` 中 `label` 和 `value` 共用一个值时搜索功能失效的问题。|

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
