### PR TITLE
fix: Form validate should keep refresh

### DIFF
--- a/components/form/__tests__/index.test.js
+++ b/components/form/__tests__/index.test.js
@@ -268,4 +268,48 @@ describe('Form', () => {
       'Warning: [antd: Form] antd v4 removed `Form.create`. Please remove or use `@ant-design/compatible` instead.',
     );
   });
+
+  // https://github.com/ant-design/ant-design/issues/20706
+  it('Error change should work', async () => {
+    const wrapper = mount(
+      <Form>
+        <Form.Item
+          name="name"
+          rules={[
+            { required: true },
+            {
+              validator: (_, value) => {
+                if (value === 'p') {
+                  return Promise.reject(new Error('not a p'));
+                }
+                return Promise.resolve();
+              },
+            },
+          ]}
+        >
+          <Input />
+        </Form.Item>
+      </Form>,
+    );
+
+    /* eslint-disable no-await-in-loop */
+    for (let i = 0; i < 3; i += 1) {
+      await change(wrapper, 0, '');
+      expect(
+        wrapper
+          .find('.ant-form-item-explain')
+          .first()
+          .text(),
+      ).toEqual("'name' is required");
+
+      await change(wrapper, 0, 'p');
+      expect(
+        wrapper
+          .find('.ant-form-item-explain')
+          .first()
+          .text(),
+      ).toEqual('not a p');
+    }
+    /* eslint-enable */
+  });
 });

--- a/components/form/util.ts
+++ b/components/form/util.ts
@@ -16,16 +16,24 @@ export function useCacheErrors(
     visible: !!errors.length,
   });
 
+  const [, forceUpdate] = React.useState({});
+
   React.useEffect(() => {
     const timeout = setTimeout(() => {
       const prevVisible = cacheRef.current.visible;
       const newVisible = !!errors.length;
 
+      const prevErrors = cacheRef.current.errors;
       cacheRef.current.errors = errors;
       cacheRef.current.visible = newVisible;
 
       if (prevVisible !== newVisible) {
         changeTrigger(newVisible);
+      } else if (
+        prevErrors.length !== errors.length ||
+        prevErrors.some((prevErr, index) => prevErr !== errors[index])
+      ) {
+        forceUpdate({});
       }
     }, 10);
     return () => clearTimeout(timeout);


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

fix #20706

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fix Form.Item not keep error message sync when hit rule changed.         |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
