### PR TITLE
fix: .iconfont-size-under-12px not working

### DIFF
--- a/components/pagination/style/index.less
+++ b/components/pagination/style/index.less
@@ -110,9 +110,8 @@
       position: relative;
 
       .@{pagination-prefix-cls}-item-link-icon {
-        .iconfont-size-under-12px(12px);
-
         color: @primary-color;
+        font-size: @font-size-sm;
         letter-spacing: -1px;
         opacity: 0;
         transition: all 0.2s;

--- a/components/style/mixins/iconfont.less
+++ b/components/style/mixins/iconfont.less
@@ -29,8 +29,7 @@
 
 // for iconfont font size
 // fix chrome 12px bug
-.iconfont-size-under-12px(@size, @rotate: 0deg) {
+.iconfont-size-under-12px(@size) {
   display: inline-block;
-  @font-scale: unit(@size / 12px);
-  font-size: 12px;
+  font-size: @size;
 }

--- a/components/table/style/index.less
+++ b/components/table/style/index.less
@@ -248,7 +248,7 @@
     }
 
     &-up + &-down {
-      margin-top: -0.42em;
+      margin-top: -0.3em;
     }
   }
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close #20752

### 💡 Background and solution

Fix InputNumber and other components icon size

- [x] InputNumber
- [x] Select
- [x] Dropdown
- [x] Pagination
- [x] Table
- [x] Tabs
- [x] Tree
- [x] Upload
- [x] Cascader

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix InputNumber, Select and other components icon size |
| 🇨🇳 Chinese | 修复 InputNumber、Select、Table 等组件的图标大小问题。 |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
