### PR TITLE
4.0 Form scrollToField: Pass options to form scrollToField

### DIFF
--- a/components/form/__tests__/index.test.js
+++ b/components/form/__tests__/index.test.js
@@ -188,8 +188,16 @@ describe('Form', () => {
         mount(<Demo />, { attachTo: document.body });
 
         expect(scrollIntoView).not.toHaveBeenCalled();
-        callGetForm().scrollToField('test');
-        expect(scrollIntoView).toHaveBeenCalled();
+        const form = callGetForm();
+        form.scrollToField('test', {
+          block: 'start',
+        });
+
+        const inputNode = document.getElementById('scroll_test');
+        expect(scrollIntoView).toHaveBeenCalledWith(inputNode, {
+          block: 'start',
+          scrollMode: 'if-needed',
+        });
       });
     }
 

--- a/components/form/index.en-US.md
+++ b/components/form/index.en-US.md
@@ -183,7 +183,7 @@ Provide linkage between forms. If a sub form with `name` prop update, it will au
 | isFieldsTouched | Check if fields have been operated. Check if all fields is touched when `allTouched` is `true` | (nameList?: [NamePath](#NamePath)[], allTouched?: boolean) => boolean |
 | isFieldValidating | Check fields if is in validating | (name: [NamePath](#NamePath)) => boolean |
 | resetFields | Reset fields to `initialValues` | (fields?: [NamePath](#NamePath)[]) => void |
-| scrollToField | Scroll to field position | (name: [NamePath](#NamePath), options: [[ScrollOptions](https://github.com/stipsan/scroll-into-view-if-needed/blob/master/src/types.ts#L10)]) => void |
+| scrollToField | Scroll to field position | (name: [NamePath](#NamePath), options: [[ScrollOptions](https://github.com/stipsan/scroll-into-view-if-needed/blob/ece40bd9143f48caf4b99503425ecb16b0ad8249/src/types.ts#L10)]) => void |
 | setFields | Set fields status | (fields: FieldData[]) => void |
 | setFieldsValue | Set fields value | (values) => void |
 | submit | Submit the form. It's same as click `submit` button | () => void |

--- a/components/form/index.en-US.md
+++ b/components/form/index.en-US.md
@@ -183,7 +183,7 @@ Provide linkage between forms. If a sub form with `name` prop update, it will au
 | isFieldsTouched | Check if fields have been operated. Check if all fields is touched when `allTouched` is `true` | (nameList?: [NamePath](#NamePath)[], allTouched?: boolean) => boolean |
 | isFieldValidating | Check fields if is in validating | (name: [NamePath](#NamePath)) => boolean |
 | resetFields | Reset fields to `initialValues` | (fields?: [NamePath](#NamePath)[]) => void |
-| scrollToField | Scroll to field position | (name: [NamePath](#NamePath)) => void |
+| scrollToField | Scroll to field position | (name: [NamePath](#NamePath), options: [[ScrollOptions](https://github.com/stipsan/scroll-into-view-if-needed/blob/master/src/types.ts#L10)]) => void |
 | setFields | Set fields status | (fields: FieldData[]) => void |
 | setFieldsValue | Set fields value | (values) => void |
 | submit | Submit the form. It's same as click `submit` button | () => void |

--- a/components/form/index.zh-CN.md
+++ b/components/form/index.zh-CN.md
@@ -184,7 +184,7 @@ Form 通过增量更新方式，只更新被修改的字段相关组件以达到
 | isFieldsTouched | 检查一组字段是否被用户操作过，`allTouched` 为 `true` 时检查是否所有字段都被操作过 | (nameList?: [NamePath](#NamePath)[], allTouched?: boolean) => boolean |
 | isFieldValidating | 检查一组字段是否正在校验 | (name: [NamePath](#NamePath)) => boolean |
 | resetFields | 重置一组字段到 `initialValues` | (fields?: [NamePath](#NamePath)[]) => void |
-| scrollToField | 滚动到对应字段位置 | (name: [NamePath](#NamePath), options: [[ScrollOptions](https://github.com/stipsan/scroll-into-view-if-needed/blob/master/src/types.ts#L10)]) => void |
+| scrollToField | 滚动到对应字段位置 | (name: [NamePath](#NamePath), options: [[ScrollOptions](https://github.com/stipsan/scroll-into-view-if-needed/blob/ece40bd9143f48caf4b99503425ecb16b0ad8249/src/types.ts#L10)]) => void |
 | setFields | 设置一组字段状态 | (fields: FieldData[]) => void |
 | setFieldsValue | 设置表单的值 | (values) => void |
 | submit | 提交表单，与点击 `submit` 按钮效果相同 | () => void |

--- a/components/form/index.zh-CN.md
+++ b/components/form/index.zh-CN.md
@@ -183,8 +183,8 @@ Form 通过增量更新方式，只更新被修改的字段相关组件以达到
 | isFieldTouched | 检查对应字段是否被用户操作过 | (name: [NamePath](#NamePath)) => boolean |
 | isFieldsTouched | 检查一组字段是否被用户操作过，`allTouched` 为 `true` 时检查是否所有字段都被操作过 | (nameList?: [NamePath](#NamePath)[], allTouched?: boolean) => boolean |
 | isFieldValidating | 检查一组字段是否正在校验 | (name: [NamePath](#NamePath)) => boolean |
-| resetFields | 重置一组字段到 `initialValues` | (name: [NamePath](#NamePath), options: [[ScrollOptions](https://github.com/stipsan/scroll-into-view-if-needed/blob/master/src/types.ts#L10)]) => void |
-| scrollToField | 滚动到对应字段位置 | (name: [NamePath](#NamePath)) => void |
+| resetFields | 重置一组字段到 `initialValues` | (fields?: [NamePath](#NamePath)[]) => void |
+| scrollToField | 滚动到对应字段位置 | (name: [NamePath](#NamePath), options: [[ScrollOptions](https://github.com/stipsan/scroll-into-view-if-needed/blob/master/src/types.ts#L10)]) => void |
 | setFields | 设置一组字段状态 | (fields: FieldData[]) => void |
 | setFieldsValue | 设置表单的值 | (values) => void |
 | submit | 提交表单，与点击 `submit` 按钮效果相同 | () => void |

--- a/components/form/index.zh-CN.md
+++ b/components/form/index.zh-CN.md
@@ -183,7 +183,7 @@ Form 通过增量更新方式，只更新被修改的字段相关组件以达到
 | isFieldTouched | 检查对应字段是否被用户操作过 | (name: [NamePath](#NamePath)) => boolean |
 | isFieldsTouched | 检查一组字段是否被用户操作过，`allTouched` 为 `true` 时检查是否所有字段都被操作过 | (nameList?: [NamePath](#NamePath)[], allTouched?: boolean) => boolean |
 | isFieldValidating | 检查一组字段是否正在校验 | (name: [NamePath](#NamePath)) => boolean |
-| resetFields | 重置一组字段到 `initialValues` | (fields?: [NamePath](#NamePath)[]) => void |
+| resetFields | 重置一组字段到 `initialValues` | (name: [NamePath](#NamePath), options: [[ScrollOptions](https://github.com/stipsan/scroll-into-view-if-needed/blob/master/src/types.ts#L10)]) => void |
 | scrollToField | 滚动到对应字段位置 | (name: [NamePath](#NamePath)) => void |
 | setFields | 设置一组字段状态 | (fields: FieldData[]) => void |
 | setFieldsValue | 设置表单的值 | (values) => void |

--- a/components/form/interface.ts
+++ b/components/form/interface.ts
@@ -1,1 +1,2 @@
+export { Options as ScrollOptions } from 'scroll-into-view-if-needed';
 export type FormLabelAlign = 'left' | 'right';

--- a/components/form/util.ts
+++ b/components/form/util.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { useForm as useRcForm, FormInstance as RcFormInstance } from 'rc-field-form';
 import scrollIntoView from 'scroll-into-view-if-needed';
+import { ScrollOptions } from './interface';
 
 type InternalNamePath = (string | number)[];
 
@@ -65,7 +66,7 @@ export function getFieldId(namePath: InternalNamePath, formName?: string): strin
 }
 
 export interface FormInstance extends RcFormInstance {
-  scrollToField: (name: string | number | InternalNamePath) => void;
+  scrollToField: (name: string | number | InternalNamePath, options?: ScrollOptions) => void;
   __INTERNAL__: {
     name?: string;
   };
@@ -75,7 +76,7 @@ export function useForm(form?: FormInstance): [FormInstance] {
   const wrapForm: FormInstance = form || {
     ...useRcForm()[0],
     __INTERNAL__: {},
-    scrollToField: name => {
+    scrollToField: (name: string, options: ScrollOptions = {}) => {
       const namePath = toArray(name);
       const fieldId = getFieldId(namePath, wrapForm.__INTERNAL__.name);
       const node: HTMLElement | null = fieldId ? document.getElementById(fieldId) : null;
@@ -84,6 +85,7 @@ export function useForm(form?: FormInstance): [FormInstance] {
         scrollIntoView(node, {
           scrollMode: 'if-needed',
           block: 'nearest',
+          ...options,
         });
       }
     },


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [x] Site / document update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

if there were fixed header, `scrollToField` is scrolling to the wrong position.

according to the thread here https://github.com/stipsan/scroll-into-view-if-needed/issues/126#issuecomment-533089870, passing in options to `scroll-into-view-if-needded` package could potentially solve the problem.

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   pass `form.scrollToField`'s second parameter to `scroll-to-field-if-needed` package        |
| 🇨🇳 Chinese |   允许`form.scrollToField`的第二个参数传入`scroll-to-field-if-needed`包         |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/form/index.en-US.md](https://github.com/hans-lizihan/ant-design/blob/master/components/form/index.en-US.md)
[View rendered components/form/index.zh-CN.md](https://github.com/hans-lizihan/ant-design/blob/master/components/form/index.zh-CN.md)