### PR TITLE
style: 优化calendar若干样式

### DIFF
--- a/components/calendar/Header.tsx
+++ b/components/calendar/Header.tsx
@@ -120,7 +120,6 @@ function MonthSelect<DateType>(props: SharedProps<DateType>) {
   return (
     <Select
       size={fullscreen ? undefined : 'small'}
-      dropdownMatchSelectWidth={100}
       className={`${prefixCls}-month-select`}
       value={month}
       options={options}

--- a/components/calendar/style/index.less
+++ b/components/calendar/style/index.less
@@ -15,11 +15,11 @@
     padding: 11px 16px 11px 0;
 
     .@{calendar-prefix-cls}-year-select {
-      width: 85px;
+      min-width: 85px;
     }
 
     .@{calendar-prefix-cls}-month-select {
-      width: 70px;
+      min-width: 70px;
       margin-left: @padding-xs;
     }
 
@@ -148,6 +148,7 @@
           position: static;
           width: auto;
           height: 86px;
+          text-align: left;
           overflow-y: auto;
           line-height: @line-height-base;
         }

--- a/components/calendar/style/index.less
+++ b/components/calendar/style/index.less
@@ -149,8 +149,8 @@
           width: auto;
           height: 86px;
           overflow-y: auto;
-          text-align: left;
           line-height: @line-height-base;
+          text-align: left;
         }
 
         &-today {

--- a/components/calendar/style/index.less
+++ b/components/calendar/style/index.less
@@ -148,8 +148,8 @@
           position: static;
           width: auto;
           height: 86px;
-          text-align: left;
           overflow-y: auto;
+          text-align: left;
           line-height: @line-height-base;
         }
 


### PR DESCRIPTION


<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution
https://next.ant.design/components/calendar-cn/
### ❄ Before
![](https://github.com/xrkffgg/Kimg/blob/master/ant-design/2020.01/1.png?raw=true)
![](https://github.com/xrkffgg/Kimg/blob/master/ant-design/2020.01/2.png?raw=true)
![](https://github.com/xrkffgg/Kimg/blob/master/ant-design/2020.01/3.png?raw=true)

### 💄 After
![](https://github.com/xrkffgg/Kimg/blob/master/ant-design/2020.01/4.png?raw=true)
![](https://github.com/xrkffgg/Kimg/blob/master/ant-design/2020.01/5.png?raw=true)

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |  1. 优化基本样式月份下拉框宽度；2. 优化通知事项的文字顺序；3. 优化卡片模式，选择框的尺寸 |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
