### PR TITLE
fix: Move table-bg less variable into table background instead of td

### DIFF
--- a/components/table/style/index.less
+++ b/components/table/style/index.less
@@ -24,6 +24,7 @@
   position: relative;
   z-index: 0;
   clear: both;
+  background: @table-bg;
 
   // https://github.com/ant-design/ant-design/issues/17611
   table {
@@ -46,11 +47,6 @@
     position: relative;
     padding: @table-padding-vertical @table-padding-horizontal;
     overflow-wrap: break-word;
-  }
-
-  // weak priority
-  td {
-    background: @table-bg;
   }
 
   &-cell-ellipsis {
@@ -520,6 +516,7 @@
   &-cell-fix-left,
   &-cell-fix-right {
     z-index: 2;
+    background: @table-bg;
   }
 
   &-cell-fix-left-last::after {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

fix #20756

### 💡 Background and solution

Since we already provides `@table-bg` background color. Maybe not good to make it as transparent. Move into table bg instead.

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Fix Table background color css priority to high to override user customize style.     |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
