### PR TITLE
Feature. Add support for the icon prop to the Tag component

### DIFF
--- a/components/cascader/__tests__/__snapshots__/index.test.js.snap
+++ b/components/cascader/__tests__/__snapshots__/index.test.js.snap
@@ -839,6 +839,7 @@ exports[`Cascader should highlight keyword and filter when search in Cascader 1`
                       Object {
                         "__IS_FILTERED_OPTION": true,
                         "disabled": false,
+                        "isEmptyNode": true,
                         "label": Array [
                           "Jiangsu",
                           Array [
@@ -891,6 +892,7 @@ exports[`Cascader should highlight keyword and filter when search in Cascader 1`
                       Object {
                         "__IS_FILTERED_OPTION": true,
                         "disabled": false,
+                        "isEmptyNode": true,
                         "label": Array [
                           "Zhejiang",
                           Array [
@@ -1023,6 +1025,49 @@ exports[`Cascader should highlight keyword and filter when search in Cascader 1`
     </Animate>
   </div>
 </Popup>
+`;
+
+exports[`Cascader should highlight keyword and filter when search in Cascader with same field name of label and value 1`] = `
+<div>
+  <div
+    class="ant-cascader-menus ant-cascader-menus-placement-bottomLeft slide-up-appear"
+    style="left: -999px; top: -995px;"
+  >
+    <div>
+      <ul
+        class="ant-cascader-menu"
+        style="width: 0px;"
+      >
+        <li
+          class="ant-cascader-menu-item"
+          role="menuitem"
+          title=""
+        >
+          Zhejiang / Hang
+          <span
+            class="ant-cascader-menu-item-keyword"
+          >
+            z
+          </span>
+          hou / West Lake
+        </li>
+        <li
+          class="ant-cascader-menu-item ant-cascader-menu-item-disabled"
+          role="menuitem"
+          title=""
+        >
+          Zhejiang / Hang
+          <span
+            class="ant-cascader-menu-item-keyword"
+          >
+            z
+          </span>
+          hou / Xia Sha
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>
 `;
 
 exports[`Cascader should render not found content 1`] = `
@@ -1242,6 +1287,7 @@ exports[`Cascader should render not found content 1`] = `
                     Array [
                       Object {
                         "disabled": true,
+                        "isEmptyNode": true,
                         "label": <Context.Consumer>
                           [Function]
                         </Context.Consumer>,
@@ -1569,6 +1615,7 @@ exports[`Cascader should show not found content when options.length is 0 1`] = `
                     Array [
                       Object {
                         "disabled": true,
+                        "isEmptyNode": true,
                         "label": <Context.Consumer>
                           [Function]
                         </Context.Consumer>,

--- a/components/cascader/__tests__/index.test.js
+++ b/components/cascader/__tests__/index.test.js
@@ -205,6 +205,52 @@ describe('Cascader', () => {
     expect(popupWrapper).toMatchSnapshot();
   });
 
+  it('should highlight keyword and filter when search in Cascader with same field name of label and value', () => {
+    const customOptions = [
+      {
+        name: 'Zhejiang',
+        value: 'Zhejiang',
+        children: [
+          {
+            name: 'Hangzhou',
+            value: 'Hangzhou',
+            children: [
+              {
+                name: 'West Lake',
+                value: 'West Lake',
+              },
+              {
+                name: 'Xia Sha',
+                value: 'Xia Sha',
+                disabled: true,
+              },
+            ],
+          },
+        ],
+      },
+    ];
+    function customFilter(inputValue, path) {
+      return path.some(option => option.name.toLowerCase().indexOf(inputValue.toLowerCase()) > -1);
+    }
+    const wrapper = mount(
+      <Cascader
+        options={customOptions}
+        fieldNames={{ label: 'name', value: 'name' }}
+        showSearch={{ filter: customFilter }}
+      />,
+    );
+    wrapper.find('input').simulate('click');
+    wrapper.find('input').simulate('change', { target: { value: 'z' } });
+    expect(wrapper.state('inputValue')).toBe('z');
+    const popupWrapper = mount(
+      wrapper
+        .find('Trigger')
+        .instance()
+        .getComponent(),
+    );
+    expect(popupWrapper.render()).toMatchSnapshot();
+  });
+
   it('should render not found content', () => {
     const wrapper = mount(<Cascader options={options} showSearch={{ filter }} />);
     wrapper.find('input').simulate('click');

--- a/components/cascader/index.tsx
+++ b/components/cascader/index.tsx
@@ -397,17 +397,19 @@ class Cascader extends React.Component<CascaderProps, CascaderState> {
         return {
           __IS_FILTERED_OPTION: true,
           path,
-          [names.label]: render(inputValue, path, prefixCls, names),
           [names.value]: path.map((o: CascaderOptionType) => o[names.value]),
+          [names.label]: render(inputValue, path, prefixCls, names),
           disabled: path.some((o: CascaderOptionType) => !!o.disabled),
+          isEmptyNode: true,
         } as CascaderOptionType;
       });
     }
     return [
       {
-        [names.label]: notFoundContent || renderEmpty('Cascader'),
         [names.value]: 'ANT_CASCADER_NOT_FOUND',
+        [names.label]: notFoundContent || renderEmpty('Cascader'),
         disabled: true,
+        isEmptyNode: true,
       },
     ];
   }
@@ -503,9 +505,10 @@ class Cascader extends React.Component<CascaderProps, CascaderState> {
     } else {
       options = [
         {
-          [names.label]: notFoundContent || renderEmpty('Cascader'),
           [names.value]: 'ANT_CASCADER_NOT_FOUND',
+          [names.label]: notFoundContent || renderEmpty('Cascader'),
           disabled: true,
+          isEmptyNode: true,
         },
       ];
     }
@@ -517,8 +520,7 @@ class Cascader extends React.Component<CascaderProps, CascaderState> {
     }
 
     const dropdownMenuColumnStyle: { width?: number; height?: string } = {};
-    const isNotFound =
-      (options || []).length === 1 && options[0][names.value] === 'ANT_CASCADER_NOT_FOUND';
+    const isNotFound = (options || []).length === 1 && options[0].isEmptyNode;
     if (isNotFound) {
       dropdownMenuColumnStyle.height = 'auto'; // Height of one row.
     }

--- a/components/collapse/style/index.less
+++ b/components/collapse/style/index.less
@@ -102,7 +102,7 @@
   }
 
   &-borderless {
-    background-color: @component-background;
+    background-color: @collapse-header-bg;
     border: 0;
   }
 

--- a/components/form/style/index.less
+++ b/components/form/style/index.less
@@ -262,10 +262,17 @@ form {
   // fix input with addon position. https://github.com/ant-design/ant-design/issues/8243
   :not(.@{ant-prefix}-input-group-wrapper) > .@{ant-prefix}-input-group,
   .@{ant-prefix}-input-group-wrapper {
-    position: relative;
-    top: -1px;
     display: inline-block;
     vertical-align: middle;
+  }
+
+  // https://github.com/ant-design/ant-design/issues/20616
+  &:not(.@{form-prefix-cls}-vertical) {
+    :not(.@{ant-prefix}-input-group-wrapper) > .@{ant-prefix}-input-group,
+    .@{ant-prefix}-input-group-wrapper {
+      position: relative;
+      top: -1px;
+    }
   }
 }
 

--- a/components/input/demo/tooltip.md
+++ b/components/input/demo/tooltip.md
@@ -35,7 +35,7 @@ function formatNumber(value) {
 class NumericInput extends React.Component {
   onChange = e => {
     const { value } = e.target;
-    const reg = /^-?(0|[1-9][0-9]*)(\.[0-9]*)?$/;
+    const reg = /^-?[0-9]*(\.[0-9]*)?$/;
     if ((!isNaN(value) && reg.test(value)) || value === '' || value === '-') {
       this.props.onChange(value);
     }
@@ -44,9 +44,11 @@ class NumericInput extends React.Component {
   // '.' at the end or only '-' in the input box.
   onBlur = () => {
     const { value, onBlur, onChange } = this.props;
+    let valueTemp = value;
     if (value.charAt(value.length - 1) === '.' || value === '-') {
-      onChange(value.slice(0, -1));
+      valueTemp = value.slice(0, -1);
     }
+    onChange(valueTemp.replace(/0*(\d+)/, '$1'));
     if (onBlur) {
       onBlur();
     }

--- a/components/style/themes/default.less
+++ b/components/style/themes/default.less
@@ -265,10 +265,10 @@
 @layout-trigger-color-light: @text-color;
 
 // z-index list, order by `z-index`
+@zindex-badge: auto;
 @zindex-table-fixed: auto;
 @zindex-affix: 10;
 @zindex-back-top: 10;
-@zindex-badge: 10;
 @zindex-picker-panel: 10;
 @zindex-popup-close: 10;
 @zindex-modal: 1000;

--- a/components/tag/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/tag/__tests__/__snapshots__/demo.test.js.snap
@@ -442,11 +442,11 @@ exports[`renders ./components/tag/demo/controlled.md correctly 1`] = `
 
 exports[`renders ./components/tag/demo/hot-tags.md correctly 1`] = `
 <div>
-  <h6
-    style="margin-right:8px;display:inline"
+  <span
+    style="margin-right:8px"
   >
     Categories:
-  </h6>
+  </span>
   <span
     class="ant-tag ant-tag-checkable"
   >

--- a/components/tag/demo/hot-tags.md
+++ b/components/tag/demo/hot-tags.md
@@ -36,7 +36,7 @@ class HotTags extends React.Component {
     const { selectedTags } = this.state;
     return (
       <div>
-        <h6 style={{ marginRight: 8, display: 'inline' }}>Categories:</h6>
+        <span style={{ marginRight: 8 }}>Categories:</span>
         {tagsFromServer.map(tag => (
           <CheckableTag
             key={tag}

--- a/components/tag/demo/icon.md
+++ b/components/tag/demo/icon.md
@@ -1,0 +1,40 @@
+---
+order: 7
+title:
+  zh-CN: 图标按钮
+  en-US: Icon
+---
+
+## zh-CN
+
+当需要在 `Tag` 内嵌入 `Icon` 时，可以设置 `icon` 属性，或者直接在 `Tag` 内使用 `Icon` 组件。
+
+如果想控制 `Icon` 具体的位置，只能直接使用 `Icon` 组件，而非 `icon` 属性。
+
+## en-US
+
+`Tag` components can contain an `Icon`. This is done by setting the `icon` property or placing an `Icon` component within the `Tag`.
+
+If you want specific control over the positioning and placement of the `Icon`, then that should be done by placing the `Icon` component within the `Tag` rather than using the `icon` property.
+
+```jsx
+import { Tag } from 'antd';
+
+ReactDOM.render(
+  <div>
+    <Tag icon="twitter" color="#55acee">
+      Twitter
+    </Tag>
+    <Tag icon="youtube" color="#cd201f">
+      Youtube
+    </Tag>
+    <Tag icon="facebook" color="#3b5999">
+      Facebook
+    </Tag>
+    <Tag icon="linkedin" color="#55acee">
+      LinkedIn
+    </Tag>
+  </div>,
+  mountNode,
+);
+```

--- a/components/tag/index.en-US.md
+++ b/components/tag/index.en-US.md
@@ -23,6 +23,7 @@ Tag for categorizing or markup.
 | color | Color of the Tag | string | - |  |
 | onClose | Callback executed when tag is closed | (e) => void | - |  |
 | visible | Whether the Tag is closed or not | boolean | `true` | 3.7.0 |
+| icon | set the icon of tag, see: Icon component | string | - |  |
 
 ### Tag.CheckableTag
 

--- a/components/tag/index.tsx
+++ b/components/tag/index.tsx
@@ -20,6 +20,7 @@ export interface TagProps extends React.HTMLAttributes<HTMLSpanElement> {
   onClose?: Function;
   afterClose?: Function;
   style?: React.CSSProperties;
+  icon?: string;
 }
 
 interface TagState {
@@ -118,7 +119,7 @@ class Tag extends React.Component<TagProps, TagState> {
   }
 
   renderTag = (configProps: ConfigConsumerProps) => {
-    const { children, ...otherProps } = this.props;
+    const { children, icon, ...otherProps } = this.props;
     const isNeedWave =
       'onClick' in otherProps || (children && (children as React.ReactElement<any>).type === 'a');
     const tagProps = omit(otherProps, [
@@ -129,6 +130,8 @@ class Tag extends React.Component<TagProps, TagState> {
       'closable',
       'prefixCls',
     ]);
+    const iconNode = icon ? <Icon type={icon} /> : null;
+
     return isNeedWave ? (
       <Wave>
         <span
@@ -142,7 +145,14 @@ class Tag extends React.Component<TagProps, TagState> {
       </Wave>
     ) : (
       <span {...tagProps} className={this.getTagClassName(configProps)} style={this.getTagStyle()}>
-        {children}
+        {iconNode ? (
+          <>
+            {iconNode}
+            <span>{children}</span>
+          </>
+        ) : (
+          children
+        )}
         {this.renderCloseIcon()}
       </span>
     );

--- a/components/tag/index.zh-CN.md
+++ b/components/tag/index.zh-CN.md
@@ -23,6 +23,7 @@ title: Tag
 | color | 标签色 | string | - |  |
 | onClose | 关闭时的回调 | (e) => void | - |  |
 | visible | 是否显示标签 | boolean | `true` | 3.7.0 |
+| icon | 设置标签图标类型 | string | - |  |
 
 ### Tag.CheckableTag
 

--- a/components/tag/style/index.less
+++ b/components/tag/style/index.less
@@ -103,4 +103,10 @@
   }
 
   .make-color-classes();
+
+  // To ensure that a space will be placed between character and `Icon`.
+  > .@{iconfont-css-prefix} + span,
+  > span + .@{iconfont-css-prefix} {
+    margin-left: 8px;
+  }
 }

--- a/components/tree/Tree.tsx
+++ b/components/tree/Tree.tsx
@@ -194,14 +194,14 @@ export default class Tree extends React.Component<TreeProps, any> {
     if (loading) {
       return <Icon type="loading" className={`${prefixCls}-switcher-loading-icon`} />;
     }
+    if (isLeaf) {
+      return showLine ? <Icon type="file" className={`${prefixCls}-switcher-line-icon`} /> : null;
+    }
     const switcherCls = `${prefixCls}-switcher-icon`;
     if (switcherIcon) {
       return React.cloneElement(switcherIcon, {
         className: classNames(switcherIcon.props.className || '', switcherCls),
       });
-    }
-    if (isLeaf) {
-      return showLine ? <Icon type="file" className={`${prefixCls}-switcher-line-icon`} /> : null;
     }
     return showLine ? (
       <Icon

--- a/components/tree/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/tree/__tests__/__snapshots__/demo.test.js.snap
@@ -725,27 +725,7 @@ exports[`renders ./components/tree/demo/customized-icon.md correctly 1`] = `
       >
         <span
           class="ant-tree-switcher ant-tree-switcher-noop"
-        >
-          <i
-            aria-label="icon: down"
-            class="anticon anticon-down ant-tree-switcher-icon"
-          >
-            <svg
-              aria-hidden="true"
-              class=""
-              data-icon="down"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
-              />
-            </svg>
-          </i>
-        </span>
+        />
         <span
           class="ant-tree-node-content-wrapper ant-tree-node-content-wrapper-normal ant-tree-node-selected"
           title="leaf"
@@ -786,27 +766,7 @@ exports[`renders ./components/tree/demo/customized-icon.md correctly 1`] = `
       >
         <span
           class="ant-tree-switcher ant-tree-switcher-noop"
-        >
-          <i
-            aria-label="icon: down"
-            class="anticon anticon-down ant-tree-switcher-icon"
-          >
-            <svg
-              aria-hidden="true"
-              class=""
-              data-icon="down"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
-              />
-            </svg>
-          </i>
-        </span>
+        />
         <span
           class="ant-tree-node-content-wrapper ant-tree-node-content-wrapper-normal"
           title="leaf"
@@ -2249,13 +2209,13 @@ exports[`renders ./components/tree/demo/switcher-icon.md correctly 1`] = `
               class="ant-tree-switcher ant-tree-switcher-noop"
             >
               <i
-                aria-label="icon: down"
-                class="anticon anticon-down ant-tree-switcher-icon"
+                aria-label="icon: file"
+                class="anticon anticon-file ant-tree-switcher-line-icon"
               >
                 <svg
                   aria-hidden="true"
                   class=""
-                  data-icon="down"
+                  data-icon="file"
                   fill="currentColor"
                   focusable="false"
                   height="1em"
@@ -2263,7 +2223,7 @@ exports[`renders ./components/tree/demo/switcher-icon.md correctly 1`] = `
                   width="1em"
                 >
                   <path
-                    d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                    d="M854.6 288.6L639.4 73.4c-6-6-14.1-9.4-22.6-9.4H192c-17.7 0-32 14.3-32 32v832c0 17.7 14.3 32 32 32h640c17.7 0 32-14.3 32-32V311.3c0-8.5-3.4-16.7-9.4-22.7zM790.2 326H602V137.8L790.2 326zm1.8 562H232V136h302v216a42 42 0 0 0 42 42h216v494z"
                   />
                 </svg>
               </i>
@@ -2287,13 +2247,13 @@ exports[`renders ./components/tree/demo/switcher-icon.md correctly 1`] = `
               class="ant-tree-switcher ant-tree-switcher-noop"
             >
               <i
-                aria-label="icon: down"
-                class="anticon anticon-down ant-tree-switcher-icon"
+                aria-label="icon: file"
+                class="anticon anticon-file ant-tree-switcher-line-icon"
               >
                 <svg
                   aria-hidden="true"
                   class=""
-                  data-icon="down"
+                  data-icon="file"
                   fill="currentColor"
                   focusable="false"
                   height="1em"
@@ -2301,7 +2261,7 @@ exports[`renders ./components/tree/demo/switcher-icon.md correctly 1`] = `
                   width="1em"
                 >
                   <path
-                    d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                    d="M854.6 288.6L639.4 73.4c-6-6-14.1-9.4-22.6-9.4H192c-17.7 0-32 14.3-32 32v832c0 17.7 14.3 32 32 32h640c17.7 0 32-14.3 32-32V311.3c0-8.5-3.4-16.7-9.4-22.7zM790.2 326H602V137.8L790.2 326zm1.8 562H232V136h302v216a42 42 0 0 0 42 42h216v494z"
                   />
                 </svg>
               </i>
@@ -2325,13 +2285,13 @@ exports[`renders ./components/tree/demo/switcher-icon.md correctly 1`] = `
               class="ant-tree-switcher ant-tree-switcher-noop"
             >
               <i
-                aria-label="icon: down"
-                class="anticon anticon-down ant-tree-switcher-icon"
+                aria-label="icon: file"
+                class="anticon anticon-file ant-tree-switcher-line-icon"
               >
                 <svg
                   aria-hidden="true"
                   class=""
-                  data-icon="down"
+                  data-icon="file"
                   fill="currentColor"
                   focusable="false"
                   height="1em"
@@ -2339,7 +2299,7 @@ exports[`renders ./components/tree/demo/switcher-icon.md correctly 1`] = `
                   width="1em"
                 >
                   <path
-                    d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                    d="M854.6 288.6L639.4 73.4c-6-6-14.1-9.4-22.6-9.4H192c-17.7 0-32 14.3-32 32v832c0 17.7 14.3 32 32 32h640c17.7 0 32-14.3 32-32V311.3c0-8.5-3.4-16.7-9.4-22.7zM790.2 326H602V137.8L790.2 326zm1.8 562H232V136h302v216a42 42 0 0 0 42 42h216v494z"
                   />
                 </svg>
               </i>

--- a/components/tree/__tests__/index.test.js
+++ b/components/tree/__tests__/index.test.js
@@ -30,4 +30,16 @@ describe('Tree', () => {
     );
     expect(wrapper.render()).toMatchSnapshot();
   });
+
+  it('switcherIcon in Tree should not render at leaf nodes', () => {
+    const wrapper = mount(
+      <Tree switcherIcon={<i className="switcherIcon" />} defaultExpandAll>
+        <TreeNode icon="icon">
+          <TreeNode id="node1" title="node1" icon="icon" key="0-0-2" />
+          <TreeNode id="node2" title="node2" key="0-0-3" />
+        </TreeNode>
+      </Tree>,
+    );
+    expect(wrapper.find('.switcherIcon').length).toBe(1);
+  });
 });

--- a/site/theme/template/Home/Banner.jsx
+++ b/site/theme/template/Home/Banner.jsx
@@ -97,23 +97,23 @@ const Banner = ({ isMobile }) => {
               <FormattedMessage id="app.home.recommend" />
             </Divider>
             <a
-              href="https://next.ant.design/"
+              href="https://www.yuque.com/e/que?chInfo=antd"
               target="_blank"
               rel="noopener noreferrer"
               onClick={() => {
                 if (window.gtag) {
                   window.gtag('event', '点击', {
                     event_category: '首页推广',
-                    event_label: `https://next.ant.design/?from=antd`,
+                    event_label: `https://www.yuque.com/e/que?chInfo=antd`,
                   });
                 }
               }}
             >
               <img
-                src="https://gw.alipayobjects.com/zos/rmsportal/KDpgvguMpGfqaHPjicRK.svg"
-                alt="antd logo"
+                src="https://gw.alipayobjects.com/zos/rmsportal/XuVpGqBFxXplzvLjJBZB.svg"
+                alt="yuque logo"
               />
-              <FormattedMessage id="app.home.recommend.antd.next" />
+              <FormattedMessage id="app.home.recommend.yuque" />
               <Icon type="right" style={{ marginLeft: 6, fontSize: 12, opacity: 0.6 }} />
             </a>
           </div>

--- a/site/theme/zh-CN.js
+++ b/site/theme/zh-CN.js
@@ -49,7 +49,7 @@ module.exports = {
     'app.home.tool-kitchen-content': '一个为设计师提效的 Sketch 工具集',
     'app.home.getting-started': '开始使用',
     'app.home.recommend': '推荐',
-    'app.home.recommend.yuque': '语雀，我们都喜欢的文档工具',
+    'app.home.recommend.yuque': '语雀：2020 领福蛋有大奖',
     'app.home.recommend.antv.g2plot': 'G2Plot：全新企业级图表',
     'app.home.recommend.antd.next': 'Ant Design 4.0：创造快乐工作',
     'app.home.more': '查看更多',


### PR DESCRIPTION
### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

### 💡 Background and solution

Hi. Faced a need of including icons within tags for my current project, didn't find any built-in way of doing this, despite of putting icons manually withing tags. 
Updated Tag component to support 'icon' prop in alignment with what the Button component currently offers.

Final demo:
<img width="469" alt="Screenshot 2020-01-09 at 14 52 41" src="https://user-images.githubusercontent.com/25992258/72070175-8a7a4f00-32f1-11ea-82e7-eb1382610f9b.png">

Usage example:

`import { Tag } from 'antd';`
`...`
`<Tag icon="twitter" color="#55acee">Twitter</Tag>`

Let me know if that makes sense, so I can migrate that to v4 accordingly. Thanks!
### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed


-----

PS. That`s my first contribution to antd, so do not judge me badly :) Not sure if everything is fine. I did probably messed up the PR process, please correct me if I wrong. Since this is a feature for version 3 I opened a feature branch from stable3 branch and as per contribution guide says, pointed PR towards feature branch. Was I supposed to create my feature branch from the origin feature branch instead to avoid conflicts and broken commit history?