### PR TITLE
fix: Table expand icon not clickable when expandRowByClick is set

### DIFF
--- a/components/table/ExpandIcon.tsx
+++ b/components/table/ExpandIcon.tsx
@@ -23,7 +23,10 @@ function renderExpandIcon(locale: TableLocale) {
     return (
       <button
         type="button"
-        onClick={e => onExpand(record, e!)}
+        onClick={e => {
+          onExpand(record, e!);
+          e.stopPropagation();
+        }}
         className={classNames(iconPrefix, {
           [`${iconPrefix}-spaced`]: !expandable,
           [`${iconPrefix}-expanded`]: expandable && expanded,

--- a/components/table/__tests__/Table.expand.test.js
+++ b/components/table/__tests__/Table.expand.test.js
@@ -11,19 +11,27 @@ const columns = [
   },
 ];
 
+const John = {
+  key: '1',
+  firstName: 'John',
+  lastName: 'Brown',
+  age: 32,
+};
+
+const Jim = {
+  key: '2',
+  firstName: 'Jim',
+  lastName: 'Green',
+  age: 42,
+};
+
 const data = [
   {
-    key: '1',
-    firstName: 'John',
-    lastName: 'Brown',
-    age: 32,
+    ...John,
 
     children: [
       {
-        key: '2',
-        firstName: 'Jim',
-        lastName: 'Green',
-        age: 42,
+        ...Jim,
       },
     ],
   },
@@ -42,5 +50,40 @@ describe('Table.expand', () => {
   it('should support expandIconColumnIndex', () => {
     const wrapper = mount(<Table columns={[]} dataSource={data} expandIconColumnIndex={1} />);
     expect(wrapper.render()).toMatchSnapshot();
+  });
+
+  it('expandRowByClick should not block click icon', () => {
+    const wrapper = mount(
+      <Table
+        columns={columns}
+        dataSource={[John, Jim]}
+        expandable={{
+          expandRowByClick: true,
+          expandedRowRender: () => '',
+        }}
+      />,
+    );
+
+    wrapper
+      .find('.ant-table-row-expand-icon')
+      .first()
+      .simulate('click');
+    expect(
+      wrapper
+        .find('.ant-table-row-expand-icon')
+        .first()
+        .hasClass('ant-table-row-expand-icon-expanded'),
+    ).toBeTruthy();
+
+    wrapper
+      .find('.ant-table-row-expand-icon')
+      .first()
+      .simulate('click');
+    expect(
+      wrapper
+        .find('.ant-table-row-expand-icon')
+        .first()
+        .hasClass('ant-table-row-expand-icon-collapsed'),
+    ).toBeTruthy();
   });
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

fix #20802

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Fix Table expanded icon not work when `expandRowByClick` is set.       |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
