### PR TITLE
Add support for the icon prop to the Tag component

### DIFF
--- a/components/tag/demo/icon.md
+++ b/components/tag/demo/icon.md
@@ -1,0 +1,40 @@
+---
+order: 7
+title:
+  zh-CN: 图标按钮
+  en-US: Icon
+---
+
+## zh-CN
+
+当需要在 `Tag` 内嵌入 `Icon` 时，可以设置 `icon` 属性，或者直接在 `Tag` 内使用 `Icon` 组件。
+
+如果想控制 `Icon` 具体的位置，只能直接使用 `Icon` 组件，而非 `icon` 属性。
+
+## en-US
+
+`Tag` components can contain an `Icon`. This is done by setting the `icon` property or placing an `Icon` component within the `Tag`.
+
+If you want specific control over the positioning and placement of the `Icon`, then that should be done by placing the `Icon` component within the `Tag` rather than using the `icon` property.
+
+```jsx
+import { Tag } from 'antd';
+
+ReactDOM.render(
+  <div>
+    <Tag icon="twitter" color="#55acee">
+      Twitter
+    </Tag>
+    <Tag icon="youtube" color="#cd201f">
+      Youtube
+    </Tag>
+    <Tag icon="facebook" color="#3b5999">
+      Facebook
+    </Tag>
+    <Tag icon="linkedin" color="#55acee">
+      LinkedIn
+    </Tag>
+  </div>,
+  mountNode,
+);
+```

--- a/components/tag/index.en-US.md
+++ b/components/tag/index.en-US.md
@@ -23,6 +23,7 @@ Tag for categorizing or markup.
 | color | Color of the Tag | string | - |  |
 | onClose | Callback executed when tag is closed | (e) => void | - |  |
 | visible | Whether the Tag is closed or not | boolean | `true` | 3.7.0 |
+| icon | set the icon of tag, see: Icon component | string | - |  |
 
 ### Tag.CheckableTag
 

--- a/components/tag/index.tsx
+++ b/components/tag/index.tsx
@@ -20,6 +20,7 @@ export interface TagProps extends React.HTMLAttributes<HTMLSpanElement> {
   onClose?: Function;
   afterClose?: Function;
   style?: React.CSSProperties;
+  icon?: string;
 }
 
 interface TagState {
@@ -118,7 +119,7 @@ class Tag extends React.Component<TagProps, TagState> {
   }
 
   renderTag = (configProps: ConfigConsumerProps) => {
-    const { children, ...otherProps } = this.props;
+    const { children, icon, ...otherProps } = this.props;
     const isNeedWave =
       'onClick' in otherProps || (children && (children as React.ReactElement<any>).type === 'a');
     const tagProps = omit(otherProps, [
@@ -129,6 +130,8 @@ class Tag extends React.Component<TagProps, TagState> {
       'closable',
       'prefixCls',
     ]);
+    const iconNode = icon ? <Icon type={icon} /> : null;
+
     return isNeedWave ? (
       <Wave>
         <span
@@ -142,7 +145,14 @@ class Tag extends React.Component<TagProps, TagState> {
       </Wave>
     ) : (
       <span {...tagProps} className={this.getTagClassName(configProps)} style={this.getTagStyle()}>
-        {children}
+        {iconNode ? (
+          <>
+            {iconNode}
+            <span>{children}</span>
+          </>
+        ) : (
+          children
+        )}
         {this.renderCloseIcon()}
       </span>
     );

--- a/components/tag/index.zh-CN.md
+++ b/components/tag/index.zh-CN.md
@@ -23,6 +23,7 @@ title: Tag
 | color | 标签色 | string | - |  |
 | onClose | 关闭时的回调 | (e) => void | - |  |
 | visible | 是否显示标签 | boolean | `true` | 3.7.0 |
+| icon | 设置标签图标类型 | string | - |  |
 
 ### Tag.CheckableTag
 

--- a/components/tag/style/index.less
+++ b/components/tag/style/index.less
@@ -103,4 +103,10 @@
   }
 
   .make-color-classes();
+
+  // To ensure that a space will be placed between character and `Icon`.
+  > .@{iconfont-css-prefix} + span,
+  > span + .@{iconfont-css-prefix} {
+    margin-left: 8px;
+  }
 }


### PR DESCRIPTION
### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] TypeScript definition update
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

### 💡 Background and solution

Hi. Faced a need of including icons within tags for my current project, didn't find any built-in way of doing this, despite of putting icons manually withing tags. 
Updated Tag component to support 'icon' prop in alignment with what the Button component currently offers.

Final demo:
<img width="469" alt="Screenshot 2020-01-09 at 14 52 41" src="https://user-images.githubusercontent.com/25992258/72070175-8a7a4f00-32f1-11ea-82e7-eb1382610f9b.png">

Usage example:

`import { Tag } from 'antd';`
`...`
`<Tag icon="twitter" color="#55acee">Twitter</Tag>`

Let me know if that makes sense, so I can migrate that to v4 accordingly. Thanks!
### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

PS. This is my first attempt contributing to the antd, so please don't judge me badly. I didn't find a mention of the desired branch to address PR to if I wanna update antd of version 3 as the feature branch already contains codebase for v4, so I addressed current PR to the 3.x-stable. Any guidance and support for the correct way of doing things will be much appreciated!


-----
[View rendered components/tag/demo/icon.md](https://github.com/vtsybulin/ant-design/blob/feature-support-tag-icon-prop/components/tag/demo/icon.md)
[View rendered components/tag/index.en-US.md](https://github.com/vtsybulin/ant-design/blob/feature-support-tag-icon-prop/components/tag/index.en-US.md)
[View rendered components/tag/index.zh-CN.md](https://github.com/vtsybulin/ant-design/blob/feature-support-tag-icon-prop/components/tag/index.zh-CN.md)