### PR TITLE
fix(Form.Item): label text align not correct when media less than xs and span not 24

### DIFF
--- a/components/form/style/vertical.less
+++ b/components/form/style/vertical.less
@@ -20,6 +20,12 @@
   }
 }
 
+.make-vertical-layout() {
+  .@{form-prefix-cls}-item .@{form-prefix-cls}-item-label {
+    .make-vertical-layout-label();
+  }
+}
+
 .@{form-prefix-cls}-vertical {
   .@{form-item-prefix-cls} {
     flex-direction: column;
@@ -34,6 +40,7 @@
 }
 
 @media (max-width: @screen-xs-max) {
+  .make-vertical-layout();
   .@{ant-prefix}-col-xs-24.@{form-item-prefix-cls}-label {
     .make-vertical-layout-label();
   }


### PR DESCRIPTION
…and span not 24

<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
Fixes #20834

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |修复 Form.Item label 在屏幕小于 `xs` 并且 `span` 不是 24 的时候对齐不正确|

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
