### PR TITLE
fix: Table onChange return cached data

### DIFF
--- a/components/table/__tests__/Table.filter.test.js
+++ b/components/table/__tests__/Table.filter.test.js
@@ -1104,4 +1104,71 @@ describe('Table.filter', () => {
 
     mount(<TestTable />);
   });
+
+  // https://github.com/ant-design/ant-design/issues/20854
+  it('Not cache for onChange state', () => {
+    const onChange = jest.fn();
+
+    const wrapper = mount(
+      <Table
+        columns={[
+          {
+            title: 'Name',
+            dataIndex: 'name',
+            sorter: true,
+          },
+          {
+            title: 'Gender',
+            dataIndex: 'gender',
+            filters: [
+              { text: 'Male', value: 'male' },
+              { text: 'Female', value: 'female' },
+            ],
+          },
+        ]}
+        dataSource={[]}
+        onChange={onChange}
+      />,
+    );
+
+    // Sort it
+    wrapper.find('.ant-table-column-sorters').simulate('click');
+    expect(onChange).toHaveBeenCalledWith(
+      expect.anything(),
+      {
+        gender: null,
+      },
+      expect.objectContaining({
+        column: {
+          dataIndex: 'name',
+          sorter: true,
+          title: 'Name',
+        },
+      }),
+      expect.anything(),
+    );
+
+    // Filter it
+    onChange.mockReset();
+    wrapper.find('span.ant-dropdown-trigger').simulate('click', nativeEvent);
+    wrapper
+      .find('.ant-dropdown-menu-item')
+      .first()
+      .simulate('click');
+    wrapper.find('.ant-table-filter-dropdown-link.confirm').simulate('click');
+    expect(onChange).toHaveBeenCalledWith(
+      expect.anything(),
+      {
+        gender: ['male'],
+      },
+      expect.objectContaining({
+        column: {
+          dataIndex: 'name',
+          sorter: true,
+          title: 'Name',
+        },
+      }),
+      expect.anything(),
+    );
+  });
 });

--- a/components/table/hooks/useFilter/index.tsx
+++ b/components/table/hooks/useFilter/index.tsx
@@ -208,18 +208,16 @@ function useFilter<RecordType>({
     onFilterChange(generateFilterInfo(newFilterStates), newFilterStates);
   };
 
-  const transformColumns = React.useMemo(() => {
-    return (innerColumns: ColumnsType<RecordType>) =>
-      injectFilter(
-        prefixCls,
-        dropdownPrefixCls,
-        innerColumns,
-        mergedFilterStates,
-        triggerFilter,
-        getPopupContainer,
-        tableLocale,
-      );
-  }, [mergedFilterStates]);
+  const transformColumns = (innerColumns: ColumnsType<RecordType>) =>
+    injectFilter(
+      prefixCls,
+      dropdownPrefixCls,
+      innerColumns,
+      mergedFilterStates,
+      triggerFilter,
+      getPopupContainer,
+      tableLocale,
+    );
 
   return [transformColumns, mergedFilterStates, getFilters];
 }

--- a/components/table/hooks/useSorter.tsx
+++ b/components/table/hooks/useSorter.tsx
@@ -362,11 +362,8 @@ export default function useFilterSorter<RecordType>({
     onSorterChange(generateSorterInfo(newSorterStates), newSorterStates);
   }
 
-  const transformColumns = React.useCallback(
-    (innerColumns: ColumnsType<RecordType>) =>
-      injectSorter(prefixCls, innerColumns, mergedSorterStates, triggerSorter, sortDirections),
-    [mergedSorterStates],
-  );
+  const transformColumns = (innerColumns: ColumnsType<RecordType>) =>
+    injectSorter(prefixCls, innerColumns, mergedSorterStates, triggerSorter, sortDirections);
 
   const getSorters = () => {
     return generateSorterInfo(mergedSorterStates);


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

fix #20854

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Fix Table `onChange` return cached fresh sorter & filter state.        |
| 🇨🇳 Chinese |    修复 Table `onChange` 返回缓存排序、过滤状态的问题。      |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
