### PR TITLE
fix: Select in multiple mode has wrong padding

### DIFF
--- a/components/select/style/multiple.less
+++ b/components/select/style/multiple.less
@@ -127,13 +127,13 @@
   .@{select-prefix-cls}-selection-placeholder {
     position: absolute;
     top: 0;
-    left: @control-padding-horizontal;
+    left: @input-padding-horizontal;
     height: @select-height-without-border;
     line-height: @select-height-without-border;
     transition: all 0.3s;
 
     .@{select-prefix-cls}-rtl& {
-      right: @control-padding-horizontal;
+      right: @input-padding-horizontal;
       left: auto;
     }
   }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

fix #20850

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |       Fix Select with multiple mode has wrong `padding` of placeholder.    |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
