### PR TITLE
style: Optimize select other sizes placeholder text centered

### DIFF
--- a/components/select/index.en-US.md
+++ b/components/select/index.en-US.md
@@ -41,7 +41,7 @@ Select component to select value from options.
 | maxTagCount | Max tag count to show | number | - |  |
 | maxTagTextLength | Max tag text length to show | number | - |  |
 | maxTagPlaceholder | Placeholder for not showing tags | ReactNode/function(omittedValues) | - |  |
-| mode | Set mode of Select | string: `multiple` `tags` | - |  |
+| mode | Set mode of Select | `multiple` \| `tags` | - |  |
 | notFoundContent | Specify content to show when no result matches.. | string | 'Not Found' |  |
 | optionFilterProp | Which prop value of option will be used for filter if filterOption is true | string | value |  |
 | optionLabelProp | Which prop value of option will render as content of select. [Example](https://codesandbox.io/s/antd-reproduction-template-tk678) | string | `value` for `combobox`, `children` for other modes |  |

--- a/components/select/index.en-US.md
+++ b/components/select/index.en-US.md
@@ -41,7 +41,7 @@ Select component to select value from options.
 | maxTagCount | Max tag count to show | number | - |  |
 | maxTagTextLength | Max tag text length to show | number | - |  |
 | maxTagPlaceholder | Placeholder for not showing tags | ReactNode/function(omittedValues) | - |  |
-| mode | Set mode of Select | 'default' \| 'multiple' \| 'tags' | 'default' |  |
+| mode | Set mode of Select | string: `multiple` `tags` | - |  |
 | notFoundContent | Specify content to show when no result matches.. | string | 'Not Found' |  |
 | optionFilterProp | Which prop value of option will be used for filter if filterOption is true | string | value |  |
 | optionLabelProp | Which prop value of option will render as content of select. [Example](https://codesandbox.io/s/antd-reproduction-template-tk678) | string | `value` for `combobox`, `children` for other modes |  |

--- a/components/select/index.zh-CN.md
+++ b/components/select/index.zh-CN.md
@@ -42,7 +42,7 @@ title: Select
 | maxTagCount | 最多显示多少个 tag | number | - |  |
 | maxTagTextLength | 最大显示的 tag 文本长度 | number | - |  |
 | maxTagPlaceholder | 隐藏 tag 时显示的内容 | ReactNode/function(omittedValues) | - |  |
-| mode | 设置 Select 的模式为多选或标签 | string: `multiple` `tags` | - |  |
+| mode | 设置 Select 的模式为多选或标签 | `multiple` \| `tags` | - |  |
 | notFoundContent | 当下拉列表为空时显示的内容 | string | 'Not Found' |  |
 | optionFilterProp | 搜索时过滤对应的 option 属性，如设置为 children 表示对内嵌内容进行搜索。[示例](https://codesandbox.io/s/antd-reproduction-template-tk678) | string | value |  |
 | optionLabelProp | 回填到选择框的 Option 的属性值，默认是 Option 的子元素。比如在子元素需要高亮效果时，此值可以设为 `value`。 | string | `children` （combobox 模式下为 `value`） |  |

--- a/components/select/index.zh-CN.md
+++ b/components/select/index.zh-CN.md
@@ -42,7 +42,7 @@ title: Select
 | maxTagCount | 最多显示多少个 tag | number | - |  |
 | maxTagTextLength | 最大显示的 tag 文本长度 | number | - |  |
 | maxTagPlaceholder | 隐藏 tag 时显示的内容 | ReactNode/function(omittedValues) | - |  |
-| mode | 设置 Select 的模式为多选或标签 | 'multiple' \| 'tags' | - |  |
+| mode | 设置 Select 的模式为多选或标签 | string: `multiple` `tags` | - |  |
 | notFoundContent | 当下拉列表为空时显示的内容 | string | 'Not Found' |  |
 | optionFilterProp | 搜索时过滤对应的 option 属性，如设置为 children 表示对内嵌内容进行搜索。[示例](https://codesandbox.io/s/antd-reproduction-template-tk678) | string | value |  |
 | optionLabelProp | 回填到选择框的 Option 的属性值，默认是 Option 的子元素。比如在子元素需要高亮效果时，此值可以设为 `value`。 | string | `children` （combobox 模式下为 `value`） |  |

--- a/components/select/style/multiple.less
+++ b/components/select/style/multiple.less
@@ -163,8 +163,10 @@
       }
 
       .@{select-prefix-cls}-selection-placeholder {
-        height: @select-height-without-border;
-        line-height: @select-height-without-border;
+        height: @select-selection-height + @select-multiple-padding + @select-multiple-padding * 2 +
+          @border-width-base;
+        line-height: @select-selection-height + @select-multiple-padding + @select-multiple-padding *
+          2 + @border-width-base;
       }
     }
   }

--- a/components/select/style/multiple.less
+++ b/components/select/style/multiple.less
@@ -125,11 +125,10 @@
   // ======================= Placeholder =======================
   .@{select-prefix-cls}-selection-placeholder {
     position: absolute;
-    top: 0;
+    top: 50%;
     right: @input-padding-horizontal;
     left: @input-padding-horizontal;
-    height: @select-height-without-border;
-    line-height: @select-height-without-border;
+    transform: translateY(-50%);
     transition: all 0.3s;
 
     .@{select-prefix-cls}-rtl& {
@@ -160,13 +159,6 @@
           height: @select-selection-height;
           line-height: @select-selection-height - @border-width-base * 2;
         }
-      }
-
-      .@{select-prefix-cls}-selection-placeholder {
-        height: @select-selection-height + @select-multiple-padding + @select-multiple-padding * 2 +
-          @border-width-base;
-        line-height: @select-selection-height + @select-multiple-padding + @select-multiple-padding *
-          2 + @border-width-base;
       }
     }
   }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / document update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
none
<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution
![](https://github.com/xrkffgg/Kimg/blob/master/ant-design/2020.01/1-min.png?raw=true)
![](https://github.com/xrkffgg/Kimg/blob/master/ant-design/2020.01/3-min.png?raw=true)


- large small 时，文字都没有居中，同时文字过长时，未处理
- 因为这个 `ant-select-selection-placeholder` 的 `position: absolute;` 这里修改为 加上了 2个 `padding`和 `border` 
- 文档中关于 `mode` 的描述，在类型中写了直接的属性值，参照 Menu 组件中 关于 `mode` 的定义，修改了一下 

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese | 修复Select 组件 `large` `small` 模式下，`placeholder`的文字居中  |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/select/index.en-US.md](https://github.com/xrkffgg/ant-design/blob/k-1/components/select/index.en-US.md)
[View rendered components/select/index.zh-CN.md](https://github.com/xrkffgg/ant-design/blob/k-1/components/select/index.zh-CN.md)