### PR TITLE
fix: Tooltip hidden when title is 0

### DIFF
--- a/components/tooltip/__tests__/tooltip.test.js
+++ b/components/tooltip/__tests__/tooltip.test.js
@@ -241,4 +241,14 @@ describe('Tooltip', () => {
     expect(onVisibleChange).toHaveBeenCalledWith(false);
     expect(wrapper.instance().tooltip.props.visible).toBe(false);
   });
+
+  // https://github.com/ant-design/ant-design/issues/20891
+  it('should display zero', async () => {
+    const wrapper = mount(
+      <Tooltip title={0} visible>
+        <div />
+      </Tooltip>,
+    );
+    expect(wrapper.find('.ant-tooltip-inner').getDOMNode().innerHTML).toBe('0');
+  });
 });

--- a/components/tooltip/index.tsx
+++ b/components/tooltip/index.tsx
@@ -226,7 +226,15 @@ class Tooltip extends React.Component<TooltipProps, any> {
 
   isNoTitle() {
     const { title, overlay } = this.props;
-    return !title && !overlay; // overlay for old version compatibility
+    return !title && !overlay && title !== 0; // overlay for old version compatibility
+  }
+
+  getOverlay() {
+    const { title, overlay } = this.props;
+    if (title === 0) {
+      return title;
+    }
+    return overlay || title || '';
   }
 
   renderTooltip = ({
@@ -236,8 +244,6 @@ class Tooltip extends React.Component<TooltipProps, any> {
     const { props, state } = this;
     const {
       prefixCls: customizePrefixCls,
-      title,
-      overlay,
       openClassName,
       getPopupContainer,
       getTooltipContainer,
@@ -266,7 +272,7 @@ class Tooltip extends React.Component<TooltipProps, any> {
         getTooltipContainer={getPopupContainer || getTooltipContainer || getContextPopupContainer}
         ref={this.saveTooltip}
         builtinPlacements={this.getPlacements()}
-        overlay={overlay || title || ''}
+        overlay={this.getOverlay()}
         visible={visible}
         onVisibleChange={this.onVisibleChange}
         onPopupAlign={this.onPopupAlign}


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close #20891

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Tooltip hidden when `title` is `0`. |
| 🇨🇳 Chinese | 修复 Tooltip `title` 为 `0` 时没有显示问题。 |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
