### PR TITLE
fix: Tooltip doesn't disappear on disabled Dropdown.Button

### DIFF
--- a/components/dropdown/__tests__/dropdown-button.test.js
+++ b/components/dropdown/__tests__/dropdown-button.test.js
@@ -65,4 +65,14 @@ describe('DropdownButton', () => {
     const wrapper = mount(<Dropdown.Button overlay={menu} href="https://ant.design" />);
     expect(wrapper.render()).toMatchSnapshot();
   });
+
+  it('have static property for type detecting', () => {
+    const menu = (
+      <Menu>
+        <Menu.Item>foo</Menu.Item>
+      </Menu>
+    );
+    const wrapper = mount(<Dropdown.Button overlay={menu} />);
+    expect(wrapper.type().__ANT_BUTTON).toBe(true);
+  });
 });

--- a/components/dropdown/dropdown-button.tsx
+++ b/components/dropdown/dropdown-button.tsx
@@ -25,6 +25,8 @@ export interface DropdownButtonProps extends ButtonGroupProps, DropDownProps {
 }
 
 export default class DropdownButton extends React.Component<DropdownButtonProps, any> {
+  static __ANT_BUTTON = true;
+
   static defaultProps = {
     placement: 'bottomRight' as DropDownProps['placement'],
     type: 'default' as DropdownButtonType,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Tooltip doesn't disappear on disabled Dropdown.Button  |
| 🇨🇳 Chinese | Tooltip 没有消失在disabled 的 Dropdown.Button          |

