### PR TITLE
docs: translation API description

### DIFF
--- a/components/form/index.en-US.md
+++ b/components/form/index.en-US.md
@@ -29,7 +29,7 @@ High performance Form component with data scope management. Including data colle
 | layout | Form layout | `horizontal` \| `vertical` \| `inline` | `horizontal` |
 | name | Form name. Will be the prefix of Field `id` | string | - |
 | size | Set field component size (antd components only) | `small` \| `middle` \| `large` | - |
-| validateMessages | 验证提示模板，说明[见下](#validateMessages) | [ValidateMessages](https://github.com/react-component/field-form/blob/master/src/utils/messages.ts) | - |
+| validateMessages | Validation prompt template, description [see below](#validateMessages) | [ValidateMessages](https://github.com/react-component/field-form/blob/master/src/utils/messages.ts) | - |
 | wrapperCol | The layout for input controls, same as `labelCol` | [object](https://ant.design/components/grid/#Col) | - |
 | onFinish | Trigger after submitting the form and verifying data successfully | Function(values) | - |
 | onFinishFailed | Trigger after submitting the form and verifying data failed | Function({ values, errorFields, outOfDate }) | - |

--- a/components/list/index.en-US.md
+++ b/components/list/index.en-US.md
@@ -27,6 +27,7 @@ A list can be used to display content related to a single subject. The content c
 | loadMore | Shows a load more content | string\|ReactNode | - |  |
 | locale | i18n text including empty text | object | emptyText: 'No Data' <br> |  |
 | pagination | Pagination [config](https://ant.design/components/pagination/), hide it by setting it to false | boolean \| object | false |  |
+| size | Size of list | `default` \| `large` \| `small` | `default` |  |
 | split | Toggles rendering of the split under the list item | boolean | true |  |
 | dataSource | dataSource array for list | any[] | - |  |
 | renderItem | customize list item when using `dataSource` | `item => ReactNode` | - |  |
@@ -47,7 +48,6 @@ More about pagination, please check [`Pagination`](/components/pagination/).
 | --- | --- | --- | --- | --- |
 | column | column of grid, [optional number](https://github.com/ant-design/ant-design/blob/a7f17b4cdebbca07b3b9ce5698de61e772d46237/components/list/index.tsx#L16) | number | - |  |
 | gutter | spacing between grid | number | 0 |  |
-| size | Size of list | `default` \| `middle` \| `small` | `default` |  |
 | xs | `<576px` column of grid | number | - |  |
 | sm | `≥576px` column of grid | number | - |  |
 | md | `≥768px` column of grid | number | - |  |

--- a/components/list/index.zh-CN.md
+++ b/components/list/index.zh-CN.md
@@ -27,7 +27,7 @@ cols: 1
 | loadMore | 加载更多 | string\|ReactNode | - |  |
 | locale | 默认文案设置，目前包括空数据文案 | object | emptyText: '暂无数据' |  |
 | pagination | 对应的 `pagination` 配置, 设置 `false` 不显示 | boolean\|object | false |  |
-| size | list 的尺寸 | `default` \| `middle` \| `small` | `default` |  |
+| size | list 的尺寸 | `default` \| `large` \| `small` | `default` |  |
 | split | 是否展示分割线 | boolean | true |  |
 | dataSource | 列表数据源 | any[] | - |  |
 | renderItem | 当使用 dataSource 时，可以用 `renderItem` 自定义渲染列表项 | `item => ReactNode` | - |  |

--- a/components/pagination/index.zh-CN.md
+++ b/components/pagination/index.zh-CN.md
@@ -29,7 +29,7 @@ cols: 1
 | itemRender | 用于自定义页码的结构，可用于优化 SEO | (page, type: 'page' \| 'prev' \| 'next', originalElement) => React.ReactNode | - |  |
 | pageSize | 每页条数 | number | - |  |
 | pageSizeOptions | 指定每页可以显示多少条 | string\[] | \['10', '20', '30', '40'] |  |
-| showLessItems | show less page items | boolean | false |  |
+| showLessItems | 是否显示较少页面内容 | boolean | false |  |
 | showQuickJumper | 是否可以快速跳转至某页 | boolean \| `{ goButton: ReactNode }` | false |  |
 | showSizeChanger | 是否可以改变 pageSize | boolean | false |  |
 | showTotal | 用于显示数据总量和当前数据顺序 | Function(total, range) | - |  |


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
https://github.com/ant-design/ant-design/issues/20907 
<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution
- 有 2 处地方，未进行翻译
- 查看代码，size 可选值为 `large` `small`，同时参照中文位置及其含义，将 英文版中 size 提到上面
 https://github.com/ant-design/ant-design/blob/4388a96c32b769bf0d213ef5963aad2a94ed568a/components/list/index.tsx#L195-L203
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | translation API description          |
| 🇨🇳 Chinese |  翻译API 描述         |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/form/index.en-US.md](https://github.com/xrkffgg/ant-design/blob/k-fix-doc/components/form/index.en-US.md)
[View rendered components/list/index.en-US.md](https://github.com/xrkffgg/ant-design/blob/k-fix-doc/components/list/index.en-US.md)
[View rendered components/list/index.zh-CN.md](https://github.com/xrkffgg/ant-design/blob/k-fix-doc/components/list/index.zh-CN.md)
[View rendered components/pagination/index.zh-CN.md](https://github.com/xrkffgg/ant-design/blob/k-fix-doc/components/pagination/index.zh-CN.md)