### PR TITLE
fix: Ensure Select's Dropdown Closes When Disabled

### DIFF
--- a/components/select/index.tsx
+++ b/components/select/index.tsx
@@ -89,6 +89,8 @@ class Select<ValueType extends SelectValue = SelectValue> extends React.Componen
       listItemHeight = 32,
       getPopupContainer,
       dropdownClassName,
+      disabled,
+      open,
     } = this.props as InternalSelectProps<ValueType>;
 
     const prefixCls = getPrefixCls('select', customizePrefixCls);
@@ -119,7 +121,9 @@ class Select<ValueType extends SelectValue = SelectValue> extends React.Componen
       'removeIcon',
       'clearIcon',
       'size',
+      'open',
     ]);
+    const openValidated = disabled ? false : open;
 
     const rcSelectRtlDropDownClassName = classNames(dropdownClassName, {
       [`${prefixCls}-dropdown-${direction}`]: direction === 'rtl',
@@ -138,6 +142,7 @@ class Select<ValueType extends SelectValue = SelectValue> extends React.Componen
             <RcSelect<ValueType>
               ref={this.selectRef}
               {...selectProps}
+              open={openValidated}
               listHeight={listHeight}
               listItemHeight={listItemHeight}
               mode={mode}


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [x] Bug fix
### 🔗 Related issue link
[#20999](https://github.com/abdih/ant-design/pull/new/20999-ha-hide-select-dropdown-when-disabled)
### 💡 Background and solution

Want Select's drop-down to close once its 'disabled' property is updated to true.
### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Validate 'open' attribute's value between ant-design's Select and that of rc-select to ensure its closed if 'disabled' is true |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
