### PR TITLE
fix: Table locale emptyText should work

### DIFF
--- a/components/table/Table.tsx
+++ b/components/table/Table.tsx
@@ -419,7 +419,7 @@ function Table<RecordType extends object = any>(props: TableProps<RecordType>) {
           data={pageData}
           rowKey={getRowKey}
           rowClassName={internalRowClassName}
-          emptyText={renderEmpty('Table')}
+          emptyText={(locale && locale.emptyText) || renderEmpty('Table')}
           // Internal
           internalHooks={INTERNAL_HOOKS}
           internalRefs={internalRefs as any}

--- a/components/table/__tests__/__snapshots__/empty.test.js.snap
+++ b/components/table/__tests__/__snapshots__/empty.test.js.snap
@@ -230,52 +230,7 @@ exports[`Table renders empty table with custom emptyText 1`] = `
                     class="ant-table-cell"
                     colspan="8"
                   >
-                    <div
-                      class="ant-empty ant-empty-normal"
-                    >
-                      <div
-                        class="ant-empty-image"
-                      >
-                        <svg
-                          class="ant-empty-img-simple"
-                          height="41"
-                          viewBox="0 0 64 41"
-                          width="64"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <g
-                            fill="none"
-                            fill-rule="evenodd"
-                            transform="translate(0 1)"
-                          >
-                            <ellipse
-                              class="ant-empty-img-simple-ellipse"
-                              cx="32"
-                              cy="33"
-                              rx="32"
-                              ry="7"
-                            />
-                            <g
-                              class="ant-empty-img-simple-g"
-                              fill-rule="nonzero"
-                            >
-                              <path
-                                d="M55 12.76L44.854 1.258C44.367.474 43.656 0 42.907 0H21.093c-.749 0-1.46.474-1.947 1.257L9 12.761V22h46v-9.24z"
-                              />
-                              <path
-                                class="ant-empty-img-simple-path"
-                                d="M41.613 15.931c0-1.605.994-2.93 2.227-2.931H55v18.137C55 33.26 53.68 35 52.05 35h-40.1C10.32 35 9 33.259 9 31.137V13h11.16c1.233 0 2.227 1.323 2.227 2.928v.022c0 1.605 1.005 2.901 2.237 2.901h14.752c1.232 0 2.237-1.308 2.237-2.913v-.007z"
-                              />
-                            </g>
-                          </g>
-                        </svg>
-                      </div>
-                      <p
-                        class="ant-empty-description"
-                      >
-                        No Data
-                      </p>
-                    </div>
+                    custom empty text
                   </td>
                 </tr>
               </tbody>

--- a/components/table/__tests__/empty.test.js
+++ b/components/table/__tests__/empty.test.js
@@ -61,7 +61,7 @@ describe('Table', () => {
         dataSource={[]}
         columns={columns}
         pagination={false}
-        locale={{ emptyText: 'custom empty text ' }}
+        locale={{ emptyText: 'custom empty text' }}
       />,
     );
     expect(wrapper).toMatchSnapshot();


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

fix #21023

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fix Table `locale.emptyText` not work issue.      |
| 🇨🇳 Chinese |     修复 Table `locale.emptyText` 不生效的问题。      |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
