### PR TITLE
fix: Form.Item ignore help = ''

### DIFF
--- a/components/form/FormItem.tsx
+++ b/components/form/FormItem.tsx
@@ -105,7 +105,7 @@ function FormItem(props: FormItemProps): React.ReactNode {
 
     // ======================== Errors ========================
     let mergedErrors: React.ReactNode[];
-    if (help) {
+    if (help !== undefined && help !== null) {
       mergedErrors = toArray(help);
     } else {
       mergedErrors = meta ? meta.errors : [];

--- a/components/form/__tests__/index.test.js
+++ b/components/form/__tests__/index.test.js
@@ -400,4 +400,13 @@ describe('Form', () => {
     expect(shouldNotRender).toHaveBeenCalledTimes(1);
     expect(shouldRender).toHaveBeenCalledTimes(2);
   });
+
+  it('empty help should also render', () => {
+    const wrapper = mount(
+      <Form.Item help="">
+        <input />
+      </Form.Item>,
+    );
+    expect(wrapper.find('.ant-form-item-explain').length).toBeTruthy();
+  });
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

ref: https://github.com/ant-design/pro-blocks/pull/164

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fix Form.Item ignore `help=""` issue.         |
| 🇨🇳 Chinese |    修复 Form.Item 不处理 `help=""` 的问题。       |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
