### PR TITLE
fix: Input suffix should work with append

### DIFF
--- a/components/input/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/input/__tests__/__snapshots__/demo.test.js.snap
@@ -881,6 +881,39 @@ exports[`renders ./components/input/demo/align.md correctly 1`] = `
       </span>
     </div>
   </div>
+  <br />
+  <span
+    class="ant-input-group-wrapper"
+  >
+    <span
+      class="ant-input-wrapper ant-input-group"
+    >
+      <span
+        class="ant-input-group-addon"
+      >
+        Http://
+      </span>
+      <span
+        class="ant-input-affix-wrapper"
+      >
+        <span
+          class="ant-input-prefix"
+        >
+          $
+        </span>
+        <input
+          class="ant-input"
+          type="text"
+          value="mysite"
+        />
+      </span>
+      <span
+        class="ant-input-group-addon"
+      >
+        .com
+      </span>
+    </span>
+  </span>
 </div>
 `;
 

--- a/components/input/demo/align.md
+++ b/components/input/demo/align.md
@@ -93,6 +93,10 @@ ReactDOM.render(
       <RadioButton value="b">Shanghai</RadioButton>
     </RadioGroup>
     <AutoComplete style={{ width: 100 }} placeholder="input here" />
+
+    <br />
+
+    <Input prefix="$" addonBefore="Http://" addonAfter=".com" defaultValue="mysite" />
   </div>,
   mountNode,
 );

--- a/components/input/style/mixin.less
+++ b/components/input/style/mixin.less
@@ -306,9 +306,7 @@
   }
 
   .@{inputClass}-affix-wrapper {
-    display: table-cell;
-    float: left;
-    width: 100%;
+    border-radius: 0;
   }
 
   &&-compact {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

fix #21099

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fix Input `suffix / prefix` style issue with `addonBefore / addonAfter`.       |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/input/demo/align.md](https://github.com/ant-design/ant-design/blob/fix-input-inline-fixed/components/input/demo/align.md)