### PR TITLE
fix: resolve #20598 remove moment deps in Countdown

### DIFF
--- a/components/statistic/Countdown.tsx
+++ b/components/statistic/Countdown.tsx
@@ -1,6 +1,4 @@
 import * as React from 'react';
-import * as moment from 'moment';
-import interopDefault from '../_util/interopDefault';
 import Statistic, { StatisticProps } from './Statistic';
 import { formatCountdown, countdownValueType, FormatConfig } from './utils';
 
@@ -13,7 +11,7 @@ interface CountdownProps extends StatisticProps {
 }
 
 function getTime(value?: countdownValueType) {
-  return interopDefault(moment)(value).valueOf();
+  return new Date(value as any).getTime();
 }
 
 class Countdown extends React.Component<CountdownProps, {}> {

--- a/components/statistic/utils.tsx
+++ b/components/statistic/utils.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-import * as moment from 'moment';
 import padStart from 'lodash/padStart';
-import interopDefault from '../_util/interopDefault';
 
 export type valueType = number | string;
 export type countdownValueType = valueType | string;
@@ -64,8 +62,8 @@ export function formatTimeStr(duration: number, format: string) {
 
 export function formatCountdown(value: countdownValueType, config: CountdownFormatConfig) {
   const { format = '' } = config;
-  const target = interopDefault(moment)(value).valueOf();
-  const current = interopDefault(moment)().valueOf();
+  const target = new Date(value).getTime();
+  const current = Date.now();
   const diff = Math.max(target - current, 0);
 
   return formatTimeStr(diff, format);


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [x] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

close #20598

### 💡 Background and solution

Native API is OK, but Typescript doesn't allow `new Date(undefined)`, so use `new Date(value as any)` to resolve it. 

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Use native `Date` instead of `moment` to get timestamp in `Countdown` component.   |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
