### PR TITLE
fix: Form.List resulting values

### DIFF
--- a/components/form/FormList.tsx
+++ b/components/form/FormList.tsx
@@ -3,7 +3,7 @@ import { List } from 'rc-field-form';
 import warning from '../_util/warning';
 
 interface FieldData {
-  name: number;
+  name: string;
   key: number;
   fieldKey: number;
 }
@@ -26,7 +26,10 @@ const FormList: React.FC<FormListProps> = ({ children, ...props }) => {
     <List {...props}>
       {(fields, operation) => {
         return children(
-          fields.map(field => ({ ...field, fieldKey: field.key })),
+          fields.map(field => {
+            const name = typeof field.name === 'number' ? field.name.toString() : field.name;
+            return { ...field, name, fieldKey: field.key }
+          }),
           operation,
         );
       }}

--- a/components/form/__tests__/index.test.js
+++ b/components/form/__tests__/index.test.js
@@ -112,6 +112,77 @@ describe('Form', () => {
         </Form.Item>
       </Form.Item>
     ));
+
+    it('correct onFinish values', async () => {
+      async function click(wrapper, className) {
+        wrapper
+          .find(className)
+          .last()
+          .simulate('click');
+        await delay();
+        wrapper.update();
+      }
+
+      const onFinish = jest.fn().mockImplementation(() => {});
+
+      const wrapper = mount(
+        <Form
+          onFinish={(v) => {
+            if (typeof v.list[0] === 'object') {
+              /* old version led to SyntheticEvent be passed as an value here
+                that led to weird infinite loop somewhere and OutOfMemory crash */
+              v = new Error('We expect value to be a primitive here');
+            }
+            onFinish(v);
+          }}
+        >
+          <Form.List name="list">
+            {(fields, { add, remove }) => (
+              <>
+                {fields.map(field => (
+                  // key is in a field
+                  // eslint-disable-next-line react/jsx-key
+                  <Form.Item {...field}>
+                    <Input />
+                  </Form.Item>
+                ))}
+                <Button
+                  className="add"
+                  onClick={add}
+                >
+                  Add
+                </Button>
+                <Button
+                  className="remove"
+                  onClick={() => remove(0)}
+                >
+                  Remove
+                </Button>
+              </>
+            )}
+          </Form.List>
+        </Form>,
+      );
+
+      await click(wrapper, '.add');
+      await change(wrapper, 0, 'input1');
+      wrapper.find('form').simulate('submit');
+      await delay();
+      expect(onFinish).toHaveBeenLastCalledWith({ list: ['input1'] });
+
+      await click(wrapper, '.add');
+      await change(wrapper, 1, 'input2');
+      await click(wrapper, '.add');
+      await change(wrapper, 2, 'input3');
+      wrapper.find('form').simulate('submit');
+      await delay();
+      expect(onFinish).toHaveBeenLastCalledWith({ list: ['input1', 'input2', 'input3'] });
+
+      await click(wrapper, '.remove'); // will remove first input
+      wrapper.find('form').simulate('submit');
+      await delay();
+      expect(onFinish).toHaveBeenLastCalledWith({ list: ['input2', 'input3'] });
+    })
   });
 
   it('noStyle Form.Item', async () => {


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 💡 Background and solution

`Form.List` provides an array of fields where the first element has `name` as numeric 0. If passed as it is to a `Form.Item` it leads to incorrect handling of the form values. 
You can reproduce it even with documentation example [Dynamic form item](https://next.ant.design/components/form/#components-form-demo-dynamic-form-item) (see values in the console).
After submitting anything first value will be `undefined` or with more add/remove manipulations it will end up being one of the deleted values.
 
I think that Form.List should avoid returning numbers as names and return strings instead (or if at some point for whatever reason `rc-field-form` will return array as a name pass it through).

### Alternatives
Maybe fix should be in `Form.Item` that threats 0 as being false. But I can't predict if a change from `isTrue` to `isDefined` will cause side-effects and I think name shouldn't be a number type anyway.

Another option is to change `rc-field-form`

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
