### PR TITLE
fix: Transfer header checkbox label unit calculating issue

### DIFF
--- a/components/transfer/__tests__/index.test.js
+++ b/components/transfer/__tests__/index.test.js
@@ -246,7 +246,7 @@ describe('Transfer', () => {
       .at(0)
       .find('input')
       .simulate('change', { target: { value: 'content2' } });
-    expect(headerText(wrapper)).toEqual('1 items');
+    expect(headerText(wrapper)).toEqual('1 item');
   });
 
   it('should display the correct locale', () => {

--- a/components/transfer/list.tsx
+++ b/components/transfer/list.tsx
@@ -278,7 +278,7 @@ export default class TransferList extends React.Component<TransferListProps, Tra
     const { filteredItems, filteredRenderItems } = this.getFilteredItems(dataSource, filterValue);
 
     // ================================= List Body =================================
-    const unit = dataSource.length > 1 ? itemsUnit : itemUnit;
+    const unit = filteredItems.length > 1 ? itemsUnit : itemUnit;
 
     const listBody = this.getListBody(
       prefixCls,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

The label for checkbox in the header of `Transfer` component shows the text like this: 
https://github.com/ant-design/ant-design/blob/0b4caf96d1dfb8f3c859660ac75d99f1fbf8785f/components/transfer/list.tsx#L313-L316

total items displaying use variable `filteredItems.length`, but calculate **unit** use `dataSource.length`:
https://github.com/ant-design/ant-design/blob/0b4caf96d1dfb8f3c859660ac75d99f1fbf8785f/components/transfer/list.tsx#L281

and it may cause a case like `1 items`:
https://github.com/ant-design/ant-design/blob/0b4caf96d1dfb8f3c859660ac75d99f1fbf8785f/components/transfer/__tests__/index.test.js#L249
but expect is `1 item`. 

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Transfer header checkbox label unit calculating issue. |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
