### PR TITLE
[WIP] fix: #21134 on 3.x checkbox can't receive context update from checkbox group

### DIFF
--- a/components/checkbox/Checkbox.tsx
+++ b/components/checkbox/Checkbox.tsx
@@ -1,10 +1,9 @@
 import * as React from 'react';
-import * as PropTypes from 'prop-types';
 import { polyfill } from 'react-lifecycles-compat';
 import classNames from 'classnames';
 import RcCheckbox from 'rc-checkbox';
 import shallowEqual from 'shallowequal';
-import CheckboxGroup, { CheckboxGroupContext } from './Group';
+import CheckboxGroup, { CheckboxGroupContext, GroupContext } from './Group';
 import { ConfigConsumer, ConfigConsumerProps } from '../config-provider';
 import warning from '../_util/warning';
 
@@ -53,9 +52,7 @@ class Checkbox extends React.Component<CheckboxProps, {}> {
     indeterminate: false,
   };
 
-  static contextTypes = {
-    checkboxGroup: PropTypes.any,
-  };
+  static contextType = GroupContext;
 
   context: any;
 

--- a/components/checkbox/Group.tsx
+++ b/components/checkbox/Group.tsx
@@ -44,6 +44,10 @@ export interface CheckboxGroupContext {
   };
 }
 
+export const GroupContext = React.createContext<{ checkboxGroup: any }>({
+  checkboxGroup: undefined,
+});
+
 class CheckboxGroup extends React.Component<CheckboxGroupProps, CheckboxGroupState> {
   static defaultProps = {
     options: [],
@@ -54,10 +58,6 @@ class CheckboxGroup extends React.Component<CheckboxGroupProps, CheckboxGroupSta
     value: PropTypes.array,
     options: PropTypes.array.isRequired,
     onChange: PropTypes.func,
-  };
-
-  static childContextTypes = {
-    checkboxGroup: PropTypes.any,
   };
 
   static getDerivedStateFromProps(nextProps: CheckboxGroupProps) {
@@ -74,21 +74,6 @@ class CheckboxGroup extends React.Component<CheckboxGroupProps, CheckboxGroupSta
     this.state = {
       value: props.value || props.defaultValue || [],
       registeredValues: [],
-    };
-  }
-
-  getChildContext() {
-    return {
-      checkboxGroup: {
-        toggleOption: this.toggleOption,
-        value: this.state.value,
-        disabled: this.props.disabled,
-        name: this.props.name,
-
-        // https://github.com/ant-design/ant-design/issues/16376
-        registerValue: this.registerValue,
-        cancelValue: this.cancelValue,
-      },
     };
   }
 
@@ -174,10 +159,23 @@ class CheckboxGroup extends React.Component<CheckboxGroupProps, CheckboxGroupSta
       ));
     }
 
+    const context = {
+      checkboxGroup: {
+        toggleOption: this.toggleOption,
+        value: this.state.value,
+        disabled: this.props.disabled,
+        name: this.props.name,
+
+        // https://github.com/ant-design/ant-design/issues/16376
+        registerValue: this.registerValue,
+        cancelValue: this.cancelValue,
+      },
+    };
+
     const classString = classNames(groupPrefixCls, className);
     return (
       <div className={classString} style={style} {...domProps}>
-        {children}
+        <GroupContext.Provider value={context}>{children}</GroupContext.Provider>
       </div>
     );
   };

--- a/components/checkbox/__tests__/group.test.js
+++ b/components/checkbox/__tests__/group.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { mount, render } from 'enzyme';
+import Collapse from '../../collapse';
 import Checkbox from '../index';
 import mountTest from '../../../tests/shared/mountTest';
 
@@ -36,7 +37,10 @@ describe('CheckboxGroup', () => {
   it('does not trigger onChange callback of both Checkbox and CheckboxGroup when CheckboxGroup is disabled', () => {
     const onChangeGroup = jest.fn();
 
-    const options = [{ label: 'Apple', value: 'Apple' }, { label: 'Pear', value: 'Pear' }];
+    const options = [
+      { label: 'Apple', value: 'Apple' },
+      { label: 'Pear', value: 'Pear' },
+    ];
 
     const groupWrapper = mount(
       <Checkbox.Group options={options} onChange={onChangeGroup} disabled />,
@@ -82,7 +86,10 @@ describe('CheckboxGroup', () => {
   });
 
   it('passes prefixCls down to checkbox', () => {
-    const options = [{ label: 'Apple', value: 'Apple' }, { label: 'Orange', value: 'Orange' }];
+    const options = [
+      { label: 'Apple', value: 'Apple' },
+      { label: 'Orange', value: 'Orange' },
+    ];
 
     const wrapper = render(<Checkbox.Group prefixCls="my-checkbox" options={options} />);
 
@@ -90,7 +97,10 @@ describe('CheckboxGroup', () => {
   });
 
   it('should be controlled by value', () => {
-    const options = [{ label: 'Apple', value: 'Apple' }, { label: 'Orange', value: 'Orange' }];
+    const options = [
+      { label: 'Apple', value: 'Apple' },
+      { label: 'Orange', value: 'Orange' },
+    ];
 
     const wrapper = mount(<Checkbox.Group options={options} />);
 
@@ -169,5 +179,45 @@ describe('CheckboxGroup', () => {
       .at(0)
       .simulate('change');
     expect(onChange).toHaveBeenCalledWith([1, 2]);
+  });
+
+  // https://github.com/ant-design/ant-design/issues/21134
+  it('should work when checkbox is wrapped by other components', () => {
+    const wrapper = mount(
+      <Checkbox.Group>
+        <Collapse bordered={false}>
+          <Collapse.Panel header="test panel">
+            <div>
+              <Checkbox value="1">item</Checkbox>
+            </div>
+          </Collapse.Panel>
+        </Collapse>
+      </Checkbox.Group>,
+    );
+    wrapper
+      .find('.ant-collapse-item')
+      .at(0)
+      .find('.ant-collapse-header')
+      .simulate('click');
+    wrapper
+      .find('.ant-checkbox-input')
+      .at(0)
+      .simulate('change');
+    expect(
+      wrapper
+        .find(Checkbox.Group)
+        .at(0)
+        .state('value'),
+    ).toEqual(['1']);
+    wrapper
+      .find('.ant-checkbox-input')
+      .at(0)
+      .simulate('change');
+    expect(
+      wrapper
+        .find(Checkbox.Group)
+        .at(0)
+        .state('value'),
+    ).toEqual([]);
   });
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

https://github.com/ant-design/ant-design/issues/21134
https://github.com/ant-design/ant-design/pull/21146

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

Replace legency context api with `React.createContext` API and `Context.Provider`. 

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix checkbox can't receive context update from checkbox group. |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
