### PR TITLE
fix: Table `expandIcon` should work

### DIFF
--- a/components/table/Table.tsx
+++ b/components/table/Table.tsx
@@ -329,6 +329,9 @@ function Table<RecordType extends object = any>(props: TableProps<RecordType>) {
     ...expandable,
   };
 
+  // Pass origin render status into `rc-table`, this can be removed when refactor with `rc-table`
+  (mergedExpandable as any).__PARENT_RENDER_ICON__ = mergedExpandable.expandIcon;
+
   // Customize expandable icon
   mergedExpandable.expandIcon =
     mergedExpandable.expandIcon || expandIcon || renderExpandIcon(tableLocale!);

--- a/components/table/__tests__/Table.expand.test.js
+++ b/components/table/__tests__/Table.expand.test.js
@@ -86,4 +86,18 @@ describe('Table.expand', () => {
         .hasClass('ant-table-row-expand-icon-collapsed'),
     ).toBeTruthy();
   });
+
+  it('show expandIcon', () => {
+    const wrapper = mount(
+      <Table
+        columns={[{ dataIndex: 'key' }]}
+        data={[{ key: 233 }]}
+        expandable={{
+          expandIcon: () => <div className="expand-icon" />,
+        }}
+      />,
+    );
+
+    expect(wrapper.find('.expand-icon')).toHaveLength(1);
+  });
 });

--- a/components/table/__tests__/Table.expand.test.js
+++ b/components/table/__tests__/Table.expand.test.js
@@ -91,7 +91,7 @@ describe('Table.expand', () => {
     const wrapper = mount(
       <Table
         columns={[{ dataIndex: 'key' }]}
-        data={[{ key: 233 }]}
+        dataSource={[{ key: 233 }]}
         expandable={{
           expandIcon: () => <div className="expand-icon" />,
         }}

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "rc-slider": "~9.1.0",
     "rc-steps": "~3.5.0",
     "rc-switch": "~1.9.0",
-    "rc-table": "~7.0.0-rc.8",
+    "rc-table": "~7.0.0-rc.9",
     "rc-tabs": "~10.0.0-alpha.1",
     "rc-tooltip": "~4.0.0-alpha.3",
     "rc-tree": "~3.0.0-alpha.37",


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

fix #21154

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fix Table `expandIcon` not work when data do not have children.      |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
