### PR TITLE
refactor: Button disable `autoInsertSpaceInButton` will not calculate text length

### DIFF
--- a/components/button/__tests__/index.test.js
+++ b/components/button/__tests__/index.test.js
@@ -3,6 +3,7 @@ import { render, mount } from 'enzyme';
 import renderer from 'react-test-renderer';
 import { SearchOutlined } from '@ant-design/icons';
 import Button from '..';
+import ConfigProvider from '../../config-provider';
 import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
 import { sleep } from '../../../tests/utils';
@@ -251,5 +252,24 @@ describe('Button', () => {
       `Warning: [antd: Button] \`icon\` is using ReactNode instead of string naming in v4. Please check \`search\` at https://ant.design/components/icon`,
     );
     warnSpy.mockRestore();
+  });
+
+  it('skip check 2 words when ConfigProvider disable this', () => {
+    const wrapper = mount(
+      <ConfigProvider autoInsertSpaceInButton={false}>
+        <Button>test</Button>
+      </ConfigProvider>,
+    );
+
+    const btn = wrapper.find('button').instance();
+    Object.defineProperty(btn, 'textContent', {
+      get() {
+        throw new Error('Should not called!!!');
+      },
+    });
+    wrapper
+      .find('Button')
+      .instance()
+      .forceUpdate();
   });
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [x] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

close #21160

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |       Refactor Button disable `autoInsertSpaceInButton` will not calculate text length.    |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
