### PR TITLE
fix: Form.Item with name `0` should be validate

### DIFF
--- a/components/form/FormItem.tsx
+++ b/components/form/FormItem.tsx
@@ -189,7 +189,7 @@ function FormItem(props: FormItemProps): React.ReactElement {
 
   const isRenderProps = typeof children === 'function';
 
-  if (!name && !isRenderProps && !dependencies) {
+  if (name === undefined && !isRenderProps && !dependencies) {
     return renderLayout(children as ChildrenNodeType);
   }
 

--- a/components/form/__tests__/index.test.js
+++ b/components/form/__tests__/index.test.js
@@ -428,4 +428,14 @@ describe('Form', () => {
 
     expect(wrapper.find('.ant-form-item-required')).toHaveLength(1);
   });
+
+  it('0 is a validate Field', () => {
+    const wrapper = mount(
+      <Form.Item name={0}>
+        <input />
+      </Form.Item>,
+    );
+
+    expect(wrapper.find('Field')).toHaveLength(1);
+  });
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close #21132

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fix Form.Item with number name `0` will fail to bind field.      |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
