### PR TITLE
docs: ✨ release 3.26.8

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -15,6 +15,16 @@ timeline: true
 
 ---
 
+## 3.26.8
+
+`2020-02-03`
+
+- 🐞 Fix Tooltip hidden when `title` is `0`. [#20894](https://github.com/ant-design/ant-design/pull/20894)
+- 🐞 Fix List `actions` inconsistent position. [#20897](https://github.com/ant-design/ant-design/pull/20897)
+- 🐞 Fix Card `font-size` of `actions` not in less theme variables. [#21106](https://github.com/ant-design/ant-design/pull/21106)
+- 🐞 Fix Layout components `displayName`. [#21124](https://github.com/ant-design/ant-design/pull/21124)
+- 🐞 Fix Modal.confirm `okButtonProps` and `cancelButtonProps` interface. [#21165](https://github.com/ant-design/ant-design/pull/21165)
+
 ## 3.26.7
 
 `2020-01-13`

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -15,6 +15,16 @@ timeline: true
 
 ---
 
+## 3.26.8
+
+`2020-02-03`
+
+- 🐞 修复 Tooltip `title` 为 `0` 时没有显示的问题。[#20894](https://github.com/ant-design/ant-design/pull/20894)
+- 🐞 修复 List `actions` 位置不在右边的问题。[#20897](https://github.com/ant-design/ant-design/pull/20897)
+- 🐞 修复 Card `actions` 字体大小不受 less 变量影响的问题。[#21106](https://github.com/ant-design/ant-design/pull/21106)
+- 🐞 修正 Layout 各组件的 `displayName`。[#21124](https://github.com/ant-design/ant-design/pull/21124)
+- 🐞 优化 Modal.confirm 的 `okButtonProps` 和 `cancelButtonProps` 的 TypeScript 类型。[#21165](https://github.com/ant-design/ant-design/pull/21165)
+
 ## 3.26.7
 
 `2020-01-13`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "antd",
-  "version": "3.26.7",
+  "version": "3.26.8",
   "description": "An enterprise-class UI design language and React components implementation",
   "keywords": [
     "ant",


### PR DESCRIPTION
- 🐞 Fix Tooltip hidden when `title` is `0`. [#20894](https://github.com/ant-design/ant-design/pull/20894)
- 🐞 Fix List `actions` inconsistent position. [#20897](https://github.com/ant-design/ant-design/pull/20897)
- 🐞 Fix Card `font-size` of `actions` not in less theme variables. [#21106](https://github.com/ant-design/ant-design/pull/21106)
- 🐞 Fix Layout components `displayName`. [#21124](https://github.com/ant-design/ant-design/pull/21124)
- 🐞 Fix Modal.confirm `okButtonProps` and `cancelButtonProps` interface. [#21165](https://github.com/ant-design/ant-design/pull/21165)

---

- 🐞 修复 Tooltip `title` 为 `0` 时没有显示的问题。[#20894](https://github.com/ant-design/ant-design/pull/20894)
- 🐞 修复 List `actions` 位置不在右边的问题。[#20897](https://github.com/ant-design/ant-design/pull/20897)
- 🐞 修复 Card `actions` 字体大小不受 less 变量影响的问题。[#21106](https://github.com/ant-design/ant-design/pull/21106)
- 🐞 修正 Layout 各组件的 `displayName`。[#21124](https://github.com/ant-design/ant-design/pull/21124)
- 🐞 优化 Modal.confirm 的 `okButtonProps` 和 `cancelButtonProps` 的 TypeScript 类型。[#21165](https://github.com/ant-design/ant-design/pull/21165)

-----
[View rendered CHANGELOG.en-US.md](https://github.com/ant-design/ant-design/blob/changelog-3.26.8/CHANGELOG.en-US.md)
[View rendered CHANGELOG.zh-CN.md](https://github.com/ant-design/ant-design/blob/changelog-3.26.8/CHANGELOG.zh-CN.md)