### PR TITLE
fix: Table.Column should correct handle sorter state

### DIFF
--- a/components/table/__tests__/Table.sorter.test.js
+++ b/components/table/__tests__/Table.sorter.test.js
@@ -670,4 +670,35 @@ describe('Table.sorter', () => {
 
     expect(wrapper.find('.ant-table-column-sorter-inner')).toHaveLength(0);
   });
+
+  // https://github.com/ant-design/ant-design/issues/21193
+  it('table with sugar column', () => {
+    const wrapper = mount(
+      <Table>
+        <Table.Column
+          title="Chinese Score"
+          dataIndex="chinese"
+          sorter={{
+            compare: (a, b) => a.chinese - b.chinese,
+            multiple: 3,
+          }}
+        />
+        <Table.Column
+          title="Math Score"
+          dataIndex="math"
+          sorter={{
+            compare: (a, b) => a.math - b.math,
+            multiple: 2,
+          }}
+        />
+      </Table>,
+    );
+
+    wrapper
+      .find('th')
+      .first()
+      .simulate('click');
+
+    expect(wrapper.find('th.ant-table-column-sort')).toHaveLength(1);
+  });
 });

--- a/components/table/util.ts
+++ b/components/table/util.ts
@@ -2,7 +2,7 @@
 import { ColumnType, ColumnTitle, ColumnTitleProps, Key } from './interface';
 
 export function getColumnKey<RecordType>(column: ColumnType<RecordType>, defaultKey: string): Key {
-  if ('key' in column && column.key !== undefined) {
+  if ('key' in column && column.key !== undefined && column.key !== null) {
     return column.key;
   }
   if (column.dataIndex) {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

fix #21193

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Fix syntax sugar of Table.Column can not correct handle sorter status.     |
| 🇨🇳 Chinese |     修复 Table.Column  语法糖不能正确处理排序状态的问题。      |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
