### PR TITLE
fix: Should TimePicker defaultOpenValue work

### DIFF
--- a/components/config-provider/__tests__/__snapshots__/components.test.js.snap
+++ b/components/config-provider/__tests__/__snapshots__/components.test.js.snap
@@ -12771,7 +12771,7 @@ Array [
                 style="position:relative"
               >
                 <li
-                  class="config-picker-time-panel-cell"
+                  class="config-picker-time-panel-cell config-picker-time-panel-cell-selected"
                 >
                   <div
                     class="config-picker-time-panel-cell-inner"
@@ -12992,7 +12992,7 @@ Array [
                 style="position:relative"
               >
                 <li
-                  class="config-picker-time-panel-cell"
+                  class="config-picker-time-panel-cell config-picker-time-panel-cell-selected"
                 >
                   <div
                     class="config-picker-time-panel-cell-inner"
@@ -13537,7 +13537,7 @@ Array [
                 style="position:relative"
               >
                 <li
-                  class="config-picker-time-panel-cell"
+                  class="config-picker-time-panel-cell config-picker-time-panel-cell-selected"
                 >
                   <div
                     class="config-picker-time-panel-cell-inner"
@@ -14099,7 +14099,6 @@ Array [
               >
                 <button
                   class="config-btn config-btn-primary config-btn-sm"
-                  disabled=""
                   type="button"
                 >
                   <span>
@@ -14182,7 +14181,7 @@ Array [
                 style="position:relative"
               >
                 <li
-                  class="ant-picker-time-panel-cell"
+                  class="ant-picker-time-panel-cell ant-picker-time-panel-cell-selected"
                 >
                   <div
                     class="ant-picker-time-panel-cell-inner"
@@ -14403,7 +14402,7 @@ Array [
                 style="position:relative"
               >
                 <li
-                  class="ant-picker-time-panel-cell"
+                  class="ant-picker-time-panel-cell ant-picker-time-panel-cell-selected"
                 >
                   <div
                     class="ant-picker-time-panel-cell-inner"
@@ -14948,7 +14947,7 @@ Array [
                 style="position:relative"
               >
                 <li
-                  class="ant-picker-time-panel-cell"
+                  class="ant-picker-time-panel-cell ant-picker-time-panel-cell-selected"
                 >
                   <div
                     class="ant-picker-time-panel-cell-inner"
@@ -15510,7 +15509,6 @@ Array [
               >
                 <button
                   class="ant-btn ant-btn-primary ant-btn-sm"
-                  disabled=""
                   type="button"
                 >
                   <span>
@@ -15593,7 +15591,7 @@ Array [
                 style="position:relative"
               >
                 <li
-                  class="prefix-TimePicker-time-panel-cell"
+                  class="prefix-TimePicker-time-panel-cell prefix-TimePicker-time-panel-cell-selected"
                 >
                   <div
                     class="prefix-TimePicker-time-panel-cell-inner"
@@ -15814,7 +15812,7 @@ Array [
                 style="position:relative"
               >
                 <li
-                  class="prefix-TimePicker-time-panel-cell"
+                  class="prefix-TimePicker-time-panel-cell prefix-TimePicker-time-panel-cell-selected"
                 >
                   <div
                     class="prefix-TimePicker-time-panel-cell-inner"
@@ -16359,7 +16357,7 @@ Array [
                 style="position:relative"
               >
                 <li
-                  class="prefix-TimePicker-time-panel-cell"
+                  class="prefix-TimePicker-time-panel-cell prefix-TimePicker-time-panel-cell-selected"
                 >
                   <div
                     class="prefix-TimePicker-time-panel-cell-inner"
@@ -16921,7 +16919,6 @@ Array [
               >
                 <button
                   class="ant-btn ant-btn-primary ant-btn-sm"
-                  disabled=""
                   type="button"
                 >
                   <span>

--- a/components/time-picker/index.en-US.md
+++ b/components/time-picker/index.en-US.md
@@ -27,7 +27,6 @@ import moment from 'moment';
 | autoFocus | get focus when component mounted | boolean | false |  |
 | className | className of picker | string | '' |  |
 | clearText | clear tooltip of icon | string | clear |  |
-| defaultOpenValue | default open panel value, used to set utcOffset,locale if value/defaultValue absent | [moment](http://momentjs.com/) | moment() |  |
 | defaultValue | to set default time | [moment](http://momentjs.com/) | - |  |
 | disabled | determine whether the TimePicker is disabled | boolean | false |  |
 | disabledHours | to specify the hours that cannot be selected | function() | - |  |

--- a/components/time-picker/index.zh-CN.md
+++ b/components/time-picker/index.zh-CN.md
@@ -28,7 +28,6 @@ import moment from 'moment';
 | autoFocus | 自动获取焦点 | boolean | false |  |
 | className | 选择器类名 | string | '' |  |
 | clearText | 清除按钮的提示文案 | string | clear |  |
-| defaultOpenValue | 当 defaultValue/value 不存在时，可以设置面板打开时默认选中的值 | [moment](http://momentjs.com/) | moment() |  |
 | defaultValue | 默认时间 | [moment](http://momentjs.com/) | 无 |  |
 | disabled | 禁用全部操作 | boolean | false |  |
 | disabledHours | 禁止选择部分小时选项 | function() | 无 |  |

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
   ],
   "dependencies": {
     "@ant-design/icons": "^4.0.0-rc.0",
+    "@ant-design/react-slick": "~0.25.5",
     "array-tree-filter": "^2.1.0",
     "classnames": "~2.2.6",
     "copy-to-clipboard": "^3.2.0",
@@ -130,7 +131,6 @@
     "rc-upload": "~3.0.0-alpha.0",
     "rc-util": "^4.17.0",
     "rc-virtual-list": "^0.0.0-alpha.25",
-    "@ant-design/react-slick": "~0.25.5",
     "resize-observer-polyfill": "^1.5.1",
     "scroll-into-view-if-needed": "^2.2.20",
     "shallowequal": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "rc-menu": "~8.0.0-alpha.7",
     "rc-notification": "~3.3.1",
     "rc-pagination": "~1.20.13",
-    "rc-picker": "^0.0.1-alpha.63",
+    "rc-picker": "^0.0.1-rc.5",
     "rc-progress": "~2.5.0",
     "rc-rate": "~2.5.0",
     "rc-resize-observer": "^0.1.0",


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

fix #21153



### 💡 Background and solution

🤖 Though we add this prop back, but removed from official doc since this prop is little confused for user understand current value status.


### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fix TimePicker `defaultOpenValue` not work and remove this from doc since it may confuse user for current value status.      |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/time-picker/index.en-US.md](https://github.com/ant-design/ant-design/blob/docs/components/time-picker/index.en-US.md)
[View rendered components/time-picker/index.zh-CN.md](https://github.com/ant-design/ant-design/blob/docs/components/time-picker/index.zh-CN.md)