### PR TITLE
docs: fix typo

### DIFF
--- a/components/slider/demo/tip-formatter.md
+++ b/components/slider/demo/tip-formatter.md
@@ -11,7 +11,7 @@ title:
 
 ## en-US
 
-Use `tipFormatter` to format content of `Toolip`. If `tipFormatter` is null, hide it.
+Use `tipFormatter` to format content of `Tooltip`. If `tipFormatter` is null, hide it.
 
 ```jsx
 import { Slider } from 'antd';


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

Typo in Slider examples.

### 💡 Background and solution

Typo in Slider examples.

### 📝 Changelog

`Toolip` is changed to `Tooltip`

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |`Toolip` is changed to `Tooltip`|
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/slider/demo/tip-formatter.md](https://github.com/marcusstenbeck/ant-design/blob/patch-1/components/slider/demo/tip-formatter.md)