### PR TITLE
fix: Form.Item init status should also check help

### DIFF
--- a/components/form/FormItem.tsx
+++ b/components/form/FormItem.tsx
@@ -3,7 +3,7 @@ import isEqual from 'lodash/isEqual';
 import classNames from 'classnames';
 import { Field, FormInstance } from 'rc-field-form';
 import { FieldProps } from 'rc-field-form/lib/Field';
-import {Meta, NamePath} from 'rc-field-form/lib/interface';
+import { Meta, NamePath } from 'rc-field-form/lib/interface';
 import omit from 'omit.js';
 import Row from '../grid/row';
 import { ConfigContext } from '../config-provider';
@@ -42,11 +42,7 @@ export interface FormItemProps
 
 function hasValidName(name?: NamePath): Boolean {
   if (name === null) {
-    warning(
-      false,
-      'Form.Item',
-      '`null` is passed as `name` property',
-    );
+    warning(false, 'Form.Item', '`null` is passed as `name` property');
   }
   return !(name === undefined || name === null);
 }
@@ -74,7 +70,7 @@ function FormItem(props: FormItemProps): React.ReactElement {
   const { getPrefixCls } = React.useContext(ConfigContext);
   const formContext = React.useContext(FormContext);
   const { updateItemErrors } = React.useContext(FormItemContext);
-  const [domErrorVisible, setDomErrorVisible] = React.useState(false);
+  const [domErrorVisible, setDomErrorVisible] = React.useState(!!help);
   const [inlineErrors, setInlineErrors] = React.useState<Record<string, string[]>>({});
 
   const { name: formName } = formContext;
@@ -140,6 +136,8 @@ function FormItem(props: FormItemProps): React.ReactElement {
     } else if (meta && meta.touched) {
       mergedValidateStatus = 'success';
     }
+
+    console.log('===>', domErrorVisible, help);
 
     const itemClassName = {
       [`${prefixCls}-item`]: true,

--- a/components/form/FormItem.tsx
+++ b/components/form/FormItem.tsx
@@ -137,8 +137,6 @@ function FormItem(props: FormItemProps): React.ReactElement {
       mergedValidateStatus = 'success';
     }
 
-    console.log('===>', domErrorVisible, help);
-
     const itemClassName = {
       [`${prefixCls}-item`]: true,
       [`${prefixCls}-item-with-help`]: domErrorVisible || help,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

fix #21206

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Fix Form.Item with `help` first time hide will make layout jump.     |
| 🇨🇳 Chinese |     修复 Form.Item 使用 `help` 第一次去除消息会引发布局抖动的问题。      |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
