### PR TITLE
fix: avoid reading innerText in Button

### DIFF
--- a/components/button/button.tsx
+++ b/components/button/button.tsx
@@ -185,7 +185,7 @@ class Button extends React.Component<ButtonProps, ButtonState> {
     if (!this.buttonNode || autoInsertSpaceInButton === false) {
       return;
     }
-    const buttonText = this.buttonNode.textContent || this.buttonNode.innerText;
+    const buttonText = this.buttonNode.textContent;
     if (this.isNeedInserted() && isTwoCNChar(buttonText)) {
       if (!this.state.hasTwoCNChar) {
         this.setState({


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
this resolves https://github.com/ant-design/ant-design/issues/21160
<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution
`this.buttonNode.textContent || this.buttonNode.innerText` is same as `this.buttonNode.textContent` for any browser >= IE9
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  improve Button performance  |
| 🇨🇳 Chinese | 优化Button渲染速度 |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
