### PR TITLE
fix: Minor fix on ValidationRule to match AsyncValidator

### DIFF
--- a/components/form/Form.tsx
+++ b/components/form/Form.tsx
@@ -29,7 +29,7 @@ export interface FormCreateOption<T> {
 }
 
 const FormLayouts = tuple('horizontal', 'inline', 'vertical');
-export type FormLayout = (typeof FormLayouts)[number];
+export type FormLayout = typeof FormLayouts[number];
 
 export interface FormProps extends React.FormHTMLAttributes<HTMLFormElement> {
   layout?: FormLayout;
@@ -51,11 +51,28 @@ export interface FormProps extends React.FormHTMLAttributes<HTMLFormElement> {
   labelAlign?: FormLabelAlign;
 }
 
+export type ValidationRuleType =
+  | 'string'
+  | 'number'
+  | 'boolean'
+  | 'method'
+  | 'regexp'
+  | 'integer'
+  | 'float'
+  | 'array'
+  | 'object'
+  | 'enum'
+  | 'date'
+  | 'url'
+  | 'hex'
+  | 'email'
+  | 'any';
+
 export type ValidationRule = {
   /** validation error message */
   message?: React.ReactNode;
   /** built-in validation type, available options: https://github.com/yiminghe/async-validator#type */
-  type?: string;
+  type?: ValidationRuleType;
   /** indicates whether field is required */
   required?: boolean;
   /** treat required fields that only contain whitespace as errors */
@@ -67,7 +84,7 @@ export type ValidationRule = {
   /** validate the max length of a field */
   max?: number;
   /** validate the value from a list of possible values */
-  enum?: string | string[];
+  enum?: (string | number | boolean)[];
   /** validate from a regular expression */
   pattern?: RegExp;
   /** transform a value before validation */

--- a/components/form/index.en-US.md
+++ b/components/form/index.en-US.md
@@ -210,7 +210,7 @@ Note: if Form.Item has multiple children that had been decorated by `getFieldDec
 
 | Property | Description | Type | Default Value | Version |
 | --- | --- | --- | --- | --- |
-| enum | validate a value from a list of possible values | string | - |  |
+| enum | validate a value from a list of possible values | string[] | - |  |
 | len | validate an exact length of a field | number | - |  |
 | max | validate a max length of a field | number | - |  |
 | message | validation error message | string\|ReactNode | - |  |

--- a/components/form/index.zh-CN.md
+++ b/components/form/index.zh-CN.md
@@ -212,7 +212,7 @@ validateFields(['field1', 'field2'], options, (errors, values) => {
 
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
-| enum | 枚举类型 | string | - |  |
+| enum | 枚举类型 | string[] | - |  |
 | len | 字段长度 | number | - |  |
 | max | 最大长度 | number | - |  |
 | message | 校验文案 | string\|ReactNode | - |  |


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
close https://github.com/ant-design/ant-design/issues/21143
<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution
In a scenario where one could store the `ValidationRule` and use in both in front end with Antd Form, and also could be used in the back end with `async-validator` alone. The rules could not be shared because the newest version `async-validator` v3's type definition`RuleItem`[link here](https://github.com/yiminghe/async-validator/blob/master/src/index.d.ts#L41) does not match the ValidationRule defined in Antd v3. 

After some investigation I found out  `rc-form` still depends on `async-validator`, which did not have the Typescript definitions (async validator added Typescript support later). So Antd could not directly reexport the `RuleItem`, but have to manually define `ValidationRule`. But it is not the same. 

Without introducing new features, I just corrected some fields on `ValidationRule` to be more consistent with the `RuleItem`. Even though the `RuleItem` is for `async-validator`v3, it was not changed very much after it was introduced, indicating the RuleItem still works for v1.11. 

To have `RuleItem` and `ValidationRule` to be fully assignable, the `RuleItem` may also need to be changed. 
```
import { ValidationRule } from 'antd/lib/form';
import { RuleItem, RuleType } from 'async-validator';
import { ReactNode } from 'react';


// ValidationRule.type is string, which is not assignable to RuleType
// Validation.enum is string|string[], not assignable to RuleItem
// These two are included in this PR
interface VR  extends Omit<ValidationRule,'type'|'enum'>{
  type: RuleType;
  enum?: (string|number|boolean)[];
}
// ValidationRule.message is ReactNode, RuleItem.message is string
// ValidationRule.pattern is RegExp, RuleItem.pattern is string. (actually async-validator handles pattern and string. 
// To fix these, async-validator needs a PR. 
interface RI extends Omit<RuleItem, 'pattern'|'message'>{
  pattern?: RegExp ;
  message?: ReactNode;
}

const a = {} as VR;
const b: RI = a;
```

### 📝 Changelog

Changed the ValidationRule `type` and `enum` field. 
1. The type is not a string enum. This should not affect you if you did not use types that is not handlable by async-validator.
2. BREAKING CHANGE The enum field now only support array of (string, number, boolean), it no longer support simple string. Which did not make sense anyways. 

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     ☑️      |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
