### PR TITLE
fix: Steps style when size="small" and labelPlacement="vertical"

### DIFF
--- a/components/steps/style/label-placement.less
+++ b/components/steps/style/label-placement.less
@@ -31,7 +31,7 @@
   &.@{steps-prefix-cls}-small:not(.@{steps-prefix-cls}-dot) {
     .@{steps-prefix-cls}-item {
       &-icon {
-        margin-left: 40px;
+        margin-left: 47px;
       }
     }
   }


### PR DESCRIPTION
close #21257

<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close #21257

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Steps text align when `size="small"` and `labelPlacement="vertical"`. |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
