### PR TITLE
fix: Explicitly add children prop to Timeline.

### DIFF
--- a/components/timeline/Timeline.tsx
+++ b/components/timeline/Timeline.tsx
@@ -13,6 +13,7 @@ export interface TimelineProps {
   style?: React.CSSProperties;
   reverse?: boolean;
   mode?: 'left' | 'alternate' | 'right';
+  children?: React.ReactNode;
 }
 
 export default class Timeline extends React.Component<TimelineProps, any> {

--- a/components/timeline/TimelineItem.tsx
+++ b/components/timeline/TimelineItem.tsx
@@ -11,6 +11,7 @@ export interface TimeLineItemProps {
   pending?: boolean;
   position?: string;
   style?: React.CSSProperties;
+  children?: React.ReactNode;
 }
 
 const TimelineItem: React.SFC<TimeLineItemProps> = props => (


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 💡 Background and solution
When using a simplified type-definition for React (without propTypes and other unnecessary stuff). `Timeline.Item` errs because the `children` property is usually defined implicitly in `FunctionComponent<T>`. 
This small change just adds `children` props explicitly for `Timeline` and `TimeLineItem`. The children props seems to also be added to other components in `antd` so this will not be against any stylist rule. At the same time being more explicit about the props seems to be a good idea.

### 📝 Changelog
Added `children` props to `TimeLine` and `TimeLineItem` props.
There shouldn't be any breaking changes

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      x    |
| 🇨🇳 Chinese |           |
