### PR TITLE
docs: Update font-awesome link

### DIFF
--- a/docs/react/recommendation.zh-CN.md
+++ b/docs/react/recommendation.zh-CN.md
@@ -18,7 +18,7 @@ title: 社区精选组件
 | 响应式 | [react-responsive](https://github.com/contra/react-responsive) [react-media](https://github.com/ReactTraining/react-media) |
 | 复制到剪贴板 | [react-copy-to-clipboard](https://github.com/nkbt/react-copy-to-clipboard) |
 | 页面 meta 属性 | [react-helmet](https://github.com/nfl/react-helmet) [react-helmet-async](https://github.com/staylor/react-helmet-async) |
-| 图标 | [react-fa](https://github.com/andreypopp/react-fa) [react-icons](https://github.com/gorangajic/react-icons) |
+| 图标 | [react-fa](https://github.com/FortAwesome/react-fontawesome) [react-icons](https://github.com/gorangajic/react-icons) |
 | 二维码 | [qrcode.react](https://github.com/zpao/qrcode.react) |
 | 可视化图编辑器 | [GGEditor](https://github.com/gaoli/GGEditor) |
 | 顶部进度条 | [nprogress](https://github.com/rstacruz/nprogress) |


### PR DESCRIPTION
DEPRECATED: use https://github.com/FortAwesome/react-fontawesome instead of http://andreypopp.github.io/react-fa/

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [X] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)


-----
[View rendered docs/react/recommendation.zh-CN.md](https://github.com/jhcccc/ant-design/blob/patch-2/docs/react/recommendation.zh-CN.md)