### PR TITLE
fix: 较小的@form-item-margin-bottom时表单验证信息切换时表单项抖动

### DIFF
--- a/components/form/style/index.less
+++ b/components/form/style/index.less
@@ -27,6 +27,13 @@
   }
 }
 
+.explainAndExtraDistance(@num) when (@a>=0) {
+  padding-top: floor(@num);
+}
+.explainAndExtraDistance(@num) when (@a<0) {
+  margin-top: floor(@num);
+}
+
 // ================================================================
 // =                             Item                             =
 // ================================================================
@@ -123,7 +130,7 @@
   &-extra {
     clear: both;
     min-height: @form-item-margin-bottom;
-    padding-top: floor((@form-item-margin-bottom - @form-font-height) / 2);
+    .explainAndExtraDistance((@form-item-margin-bottom - @form-font-height) / 2);
     color: @text-color-secondary;
     font-size: @font-size-base;
     line-height: @line-height-base;

--- a/components/form/style/index.less
+++ b/components/form/style/index.less
@@ -27,10 +27,10 @@
   }
 }
 
-.explainAndExtraDistance(@num) when (@a>=0) {
+.explainAndExtraDistance(@num) when (@num>=0) {
   padding-top: floor(@num);
 }
-.explainAndExtraDistance(@num) when (@a<0) {
+.explainAndExtraDistance(@num) when (@num<0) {
   margin-top: floor(@num);
 }
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution
`@form-item-margin-bottom = 20px` 会造成 `padding-top = -2px`, 无效，此时应该改用`margin-top`
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |       |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
