### PR TITLE
fix: Button.Group size style issue

### DIFF
--- a/components/button/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/button/__tests__/__snapshots__/demo.test.js.snap
@@ -509,6 +509,77 @@ exports[`renders ./components/button/demo/icon.md correctly 1`] = `
 </div>
 `;
 
+exports[`renders ./components/button/demo/legacy-group.md correctly 1`] = `
+<div>
+  <div>
+    <div
+      class="ant-btn-group ant-btn-group-sm"
+    >
+      <button
+        class="ant-btn ant-btn-primary"
+        type="button"
+      >
+        <span>
+          Button 1
+        </span>
+      </button>
+      <button
+        class="ant-btn ant-btn-primary"
+        type="button"
+      >
+        <span>
+          Button 2
+        </span>
+      </button>
+    </div>
+  </div>
+  <div>
+    <div
+      class="ant-btn-group"
+    >
+      <button
+        class="ant-btn ant-btn-primary"
+        type="button"
+      >
+        <span>
+          Button 1
+        </span>
+      </button>
+      <button
+        class="ant-btn ant-btn-primary"
+        type="button"
+      >
+        <span>
+          Button 2
+        </span>
+      </button>
+    </div>
+  </div>
+  <div>
+    <div
+      class="ant-btn-group ant-btn-group-lg"
+    >
+      <button
+        class="ant-btn ant-btn-primary"
+        type="button"
+      >
+        <span>
+          Button 1
+        </span>
+      </button>
+      <button
+        class="ant-btn ant-btn-primary"
+        type="button"
+      >
+        <span>
+          Button 2
+        </span>
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`renders ./components/button/demo/loading.md correctly 1`] = `
 <div>
   <button

--- a/components/button/demo/legacy-group.md
+++ b/components/button/demo/legacy-group.md
@@ -1,0 +1,39 @@
+---
+order: 99
+title:
+  zh-CN: 废弃的 Block 组
+  en-US: Deprecated Button Group
+debug: true
+---
+
+## zh-CN
+
+Debug usage
+
+## en-US
+
+Debug usage
+
+```jsx
+import { Button } from 'antd';
+
+function getGroup(props) {
+  return (
+    <div>
+      <Button.Group {...props}>
+        <Button type="primary">Button 1</Button>
+        <Button type="primary">Button 2</Button>
+      </Button.Group>
+    </div>
+  );
+}
+
+ReactDOM.render(
+  <div>
+    {getGroup({ size: 'small' })}
+    {getGroup()}
+    {getGroup({ size: 'large' })}
+  </div>,
+  mountNode,
+);
+```

--- a/components/button/style/mixin.less
+++ b/components/button/style/mixin.less
@@ -185,7 +185,6 @@
   &-lg > .@{btnClassName},
   &-lg > span > .@{btnClassName} {
     .button-size(@btn-height-lg; @btn-padding-horizontal-lg; @btn-font-size-lg; 0);
-    line-height: @btn-height-lg - 2px;
   }
   &-lg > .@{btnClassName}.@{btnClassName}-icon-only {
     .square(@btn-height-lg);
@@ -195,7 +194,6 @@
   &-sm > .@{btnClassName},
   &-sm > span > .@{btnClassName} {
     .button-size(@btn-height-sm; @btn-padding-horizontal-sm; @font-size-base; 0);
-    line-height: @btn-height-sm - 2px;
     > .@{iconfont-css-prefix} {
       font-size: @font-size-base;
     }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

fix #21295

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fix legacy Button.Group `large` size style issue.      |
| 🇨🇳 Chinese |    修复遗留的 Button.Group `large` 尺寸的样式问题。       |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/button/demo/legacy-group.md](https://github.com/ant-design/ant-design/blob/fix-group-style/components/button/demo/legacy-group.md)