### PR TITLE
fix: expandable.expandIconColumnIndex setting failure in version 4.0

### DIFF
--- a/components/table/Table.tsx
+++ b/components/table/Table.tsx
@@ -336,8 +336,8 @@ function Table<RecordType extends object = any>(props: TableProps<RecordType>) {
   mergedExpandable.expandIcon =
     mergedExpandable.expandIcon || expandIcon || renderExpandIcon(tableLocale!);
 
-  // Adjust expand icon index
-  if (expandType === 'nest') {
+  // Adjust expand icon index, no overwrite expandIconColumnIndex if set.
+  if (expandType === 'nest' && !('expandIconColumnIndex' in mergedExpandable)) {
     mergedExpandable.expandIconColumnIndex = rowSelection ? 1 : 0;
   }
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->
https://github.com/ant-design/ant-design/issues/17942
### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

4.0版本下的  expandable.expandIconColumnIndex 设置会被覆盖掉。3.x版本没有这个问题。对比源码发现3.x版本判断了用户设置里是否自定义里expandIconColumnIndex，而4.0版本expandIconColumnIndex设置方式有误，没有做判断。会覆盖掉用户设置的expandIconColumnIndex。

3.x 代码片段：
```
    let expandIconColumnIndex = columns[0] && columns[0].key === 'selection-column' ? 1 : 0;
    if ('expandIconColumnIndex' in restProps) {
      expandIconColumnIndex = restProps.expandIconColumnIndex as number;
    }
```

4.0 代码片段：

```
  // ========================== Expandable ==========================
  const mergedExpandable: ExpandableConfig<RecordType> = {
    ...expandable,
  };
...
  // Adjust expand icon index
  if (expandType === 'nest') {
    mergedExpandable.expandIconColumnIndex = rowSelection ? 1 : 0;
  }
```

修改后：

```
  // ========================== Expandable ==========================
  const mergedExpandable: ExpandableConfig<RecordType> = {
    ...expandable,
  };
...
  // Adjust expand icon index, no overwrite expandIconColumnIndex if set.
  if (expandType === 'nest' && !('expandIconColumnIndex' in mergedExpandable)) {
    mergedExpandable.expandIconColumnIndex = rowSelection ? 1 : 0;
  }
```

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
