### PR TITLE
feat: Pagination itemRender disabled prop

### DIFF
--- a/components/config-provider/__tests__/__snapshots__/components.test.js.snap
+++ b/components/config-provider/__tests__/__snapshots__/components.test.js.snap
@@ -8011,6 +8011,7 @@ exports[`ConfigProvider components Pagination configProvider 1`] = `
     >
       <a
         class="config-pagination-item-link"
+        disabled=""
       >
         <span
           aria-label="left"
@@ -8050,6 +8051,7 @@ exports[`ConfigProvider components Pagination configProvider 1`] = `
     >
       <a
         class="config-pagination-item-link"
+        disabled=""
       >
         <span
           aria-label="right"
@@ -8155,6 +8157,7 @@ exports[`ConfigProvider components Pagination configProvider 1`] = `
     >
       <a
         class="config-pagination-item-link"
+        disabled=""
       >
         <span
           aria-label="left"
@@ -8194,6 +8197,7 @@ exports[`ConfigProvider components Pagination configProvider 1`] = `
     >
       <a
         class="config-pagination-item-link"
+        disabled=""
       >
         <span
           aria-label="right"
@@ -8304,6 +8308,7 @@ exports[`ConfigProvider components Pagination normal 1`] = `
     >
       <a
         class="ant-pagination-item-link"
+        disabled=""
       >
         <span
           aria-label="left"
@@ -8343,6 +8348,7 @@ exports[`ConfigProvider components Pagination normal 1`] = `
     >
       <a
         class="ant-pagination-item-link"
+        disabled=""
       >
         <span
           aria-label="right"
@@ -8448,6 +8454,7 @@ exports[`ConfigProvider components Pagination normal 1`] = `
     >
       <a
         class="ant-pagination-item-link"
+        disabled=""
       >
         <span
           aria-label="left"
@@ -8487,6 +8494,7 @@ exports[`ConfigProvider components Pagination normal 1`] = `
     >
       <a
         class="ant-pagination-item-link"
+        disabled=""
       >
         <span
           aria-label="right"
@@ -8597,6 +8605,7 @@ exports[`ConfigProvider components Pagination prefixCls 1`] = `
     >
       <a
         class="prefix-Pagination-item-link"
+        disabled=""
       >
         <span
           aria-label="left"
@@ -8636,6 +8645,7 @@ exports[`ConfigProvider components Pagination prefixCls 1`] = `
     >
       <a
         class="prefix-Pagination-item-link"
+        disabled=""
       >
         <span
           aria-label="right"
@@ -8741,6 +8751,7 @@ exports[`ConfigProvider components Pagination prefixCls 1`] = `
     >
       <a
         class="prefix-Pagination-item-link"
+        disabled=""
       >
         <span
           aria-label="left"
@@ -8780,6 +8791,7 @@ exports[`ConfigProvider components Pagination prefixCls 1`] = `
     >
       <a
         class="prefix-Pagination-item-link"
+        disabled=""
       >
         <span
           aria-label="right"
@@ -11531,6 +11543,7 @@ exports[`ConfigProvider components Table configProvider 1`] = `
         >
           <a
             class="config-pagination-item-link"
+            disabled=""
           >
             <span
               aria-label="left"
@@ -11570,6 +11583,7 @@ exports[`ConfigProvider components Table configProvider 1`] = `
         >
           <a
             class="config-pagination-item-link"
+            disabled=""
           >
             <span
               aria-label="right"
@@ -11868,6 +11882,7 @@ exports[`ConfigProvider components Table normal 1`] = `
         >
           <a
             class="ant-pagination-item-link"
+            disabled=""
           >
             <span
               aria-label="left"
@@ -11907,6 +11922,7 @@ exports[`ConfigProvider components Table normal 1`] = `
         >
           <a
             class="ant-pagination-item-link"
+            disabled=""
           >
             <span
               aria-label="right"
@@ -12205,6 +12221,7 @@ exports[`ConfigProvider components Table prefixCls 1`] = `
         >
           <a
             class="ant-pagination-item-link"
+            disabled=""
           >
             <span
               aria-label="left"
@@ -12244,6 +12261,7 @@ exports[`ConfigProvider components Table prefixCls 1`] = `
         >
           <a
             class="ant-pagination-item-link"
+            disabled=""
           >
             <span
               aria-label="right"

--- a/components/empty/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/empty/__tests__/__snapshots__/demo.test.js.snap
@@ -608,6 +608,7 @@ exports[`renders ./components/empty/demo/config-provider.md correctly 1`] = `
             >
               <a
                 class="ant-pagination-item-link"
+                disabled=""
               >
                 <span
                   aria-label="left"
@@ -647,6 +648,7 @@ exports[`renders ./components/empty/demo/config-provider.md correctly 1`] = `
             >
               <a
                 class="ant-pagination-item-link"
+                disabled=""
               >
                 <span
                   aria-label="right"

--- a/components/list/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/list/__tests__/__snapshots__/demo.test.js.snap
@@ -1319,6 +1319,7 @@ exports[`renders ./components/list/demo/vertical.md correctly 1`] = `
       >
         <a
           class="ant-pagination-item-link"
+          disabled=""
         >
           <span
             aria-label="left"

--- a/components/list/__tests__/__snapshots__/pagination.test.js.snap
+++ b/components/list/__tests__/__snapshots__/pagination.test.js.snap
@@ -40,6 +40,7 @@ exports[`List.pagination renders pagination correctly 1`] = `
       >
         <a
           class="ant-pagination-item-link"
+          disabled=""
         >
           <span
             aria-label="left"
@@ -129,6 +130,7 @@ exports[`List.pagination should change page size work 1`] = `
   >
     <a
       class="ant-pagination-item-link"
+      disabled=""
     >
       <span
         aria-label="left"
@@ -168,6 +170,7 @@ exports[`List.pagination should change page size work 1`] = `
   >
     <a
       class="ant-pagination-item-link"
+      disabled=""
     >
       <span
         aria-label="right"
@@ -268,6 +271,7 @@ exports[`List.pagination should change page size work 2`] = `
   >
     <a
       class="ant-pagination-item-link"
+      disabled=""
     >
       <span
         aria-label="left"
@@ -307,6 +311,7 @@ exports[`List.pagination should change page size work 2`] = `
   >
     <a
       class="ant-pagination-item-link"
+      disabled=""
     >
       <span
         aria-label="right"
@@ -587,6 +592,7 @@ exports[`List.pagination should default work 1`] = `
   >
     <a
       class="ant-pagination-item-link"
+      disabled=""
     >
       <span
         aria-label="right"

--- a/components/pagination/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/pagination/__tests__/__snapshots__/demo.test.js.snap
@@ -12,6 +12,7 @@ exports[`renders ./components/pagination/demo/basic.md correctly 1`] = `
   >
     <a
       class="ant-pagination-item-link"
+      disabled=""
     >
       <span
         aria-label="left"
@@ -689,7 +690,9 @@ exports[`renders ./components/pagination/demo/itemRender.md correctly 1`] = `
     class="ant-pagination-disabled ant-pagination-prev"
     title="Previous Page"
   >
-    <a>
+    <a
+      disabled=""
+    >
       Previous
     </a>
   </li>
@@ -1165,6 +1168,7 @@ exports[`renders ./components/pagination/demo/mini.md correctly 1`] = `
     >
       <a
         class="ant-pagination-item-link"
+        disabled=""
       >
         <span
           aria-label="left"
@@ -1276,6 +1280,7 @@ exports[`renders ./components/pagination/demo/mini.md correctly 1`] = `
     >
       <a
         class="ant-pagination-item-link"
+        disabled=""
       >
         <span
           aria-label="left"
@@ -1462,6 +1467,7 @@ exports[`renders ./components/pagination/demo/mini.md correctly 1`] = `
     >
       <a
         class="ant-pagination-item-link"
+        disabled=""
       >
         <span
           aria-label="left"
@@ -1879,6 +1885,7 @@ exports[`renders ./components/pagination/demo/total.md correctly 1`] = `
     >
       <a
         class="ant-pagination-item-link"
+        disabled=""
       >
         <span
           aria-label="left"
@@ -1996,6 +2003,7 @@ exports[`renders ./components/pagination/demo/total.md correctly 1`] = `
     >
       <a
         class="ant-pagination-item-link"
+        disabled=""
       >
         <span
           aria-label="left"

--- a/components/pagination/__tests__/__snapshots__/index.test.js.snap
+++ b/components/pagination/__tests__/__snapshots__/index.test.js.snap
@@ -12,6 +12,7 @@ exports[`Pagination rtl render component should be rendered correctly in RTL dir
   >
     <a
       class="ant-pagination-item-link"
+      disabled=""
     >
       <span
         aria-label="right"
@@ -51,6 +52,7 @@ exports[`Pagination rtl render component should be rendered correctly in RTL dir
   >
     <a
       class="ant-pagination-item-link"
+      disabled=""
     >
       <span
         aria-label="left"
@@ -89,6 +91,7 @@ exports[`Pagination should be rendered correctly in RTL 1`] = `
   >
     <a
       class="ant-pagination-item-link"
+      disabled=""
     >
       <span
         aria-label="right"

--- a/components/pagination/__tests__/index.test.js
+++ b/components/pagination/__tests__/index.test.js
@@ -17,4 +17,23 @@ describe('Pagination', () => {
     );
     expect(render(wrapper)).toMatchSnapshot();
   });
+
+  it('should pass disabled to prev and next buttons', () => {
+    function itemRender(current, type, originalElement) {
+      if (type === 'prev') {
+        return <button type="button">prev</button>;
+      }
+      if (type === 'next') {
+        return <button type="button">next</button>;
+      }
+      return originalElement;
+    }
+    const wrapper = mount(<Pagination defaultCurrent={1} total={50} itemRender={itemRender} />);
+    expect(
+      wrapper
+        .find('button')
+        .at(0)
+        .props().disabled,
+    ).toBe(true);
+  });
 });

--- a/components/table/__tests__/__snapshots__/Table.expand.test.js.snap
+++ b/components/table/__tests__/__snapshots__/Table.expand.test.js.snap
@@ -89,6 +89,7 @@ exports[`Table.expand click to expand 1`] = `
         >
           <a
             class="ant-pagination-item-link"
+            disabled=""
           >
             <span
               aria-label="left"
@@ -128,6 +129,7 @@ exports[`Table.expand click to expand 1`] = `
         >
           <a
             class="ant-pagination-item-link"
+            disabled=""
           >
             <span
               aria-label="right"
@@ -226,6 +228,7 @@ exports[`Table.expand should support expandIconColumnIndex 1`] = `
         >
           <a
             class="ant-pagination-item-link"
+            disabled=""
           >
             <span
               aria-label="left"
@@ -265,6 +268,7 @@ exports[`Table.expand should support expandIconColumnIndex 1`] = `
         >
           <a
             class="ant-pagination-item-link"
+            disabled=""
           >
             <span
               aria-label="right"

--- a/components/table/__tests__/__snapshots__/Table.pagination.test.js.snap
+++ b/components/table/__tests__/__snapshots__/Table.pagination.test.js.snap
@@ -93,6 +93,7 @@ exports[`Table.pagination Accepts pagination as true 1`] = `
         >
           <a
             class="ant-pagination-item-link"
+            disabled=""
           >
             <span
               aria-label="left"
@@ -132,6 +133,7 @@ exports[`Table.pagination Accepts pagination as true 1`] = `
         >
           <a
             class="ant-pagination-item-link"
+            disabled=""
           >
             <span
               aria-label="right"
@@ -234,6 +236,7 @@ exports[`Table.pagination renders pagination correctly 1`] = `
         >
           <a
             class="ant-pagination-item-link"
+            disabled=""
           >
             <span
               aria-label="left"

--- a/components/table/__tests__/__snapshots__/Table.rowSelection.test.js.snap
+++ b/components/table/__tests__/__snapshots__/Table.rowSelection.test.js.snap
@@ -200,6 +200,7 @@ exports[`Table.rowSelection fix selection column on the left 1`] = `
         >
           <a
             class="ant-pagination-item-link"
+            disabled=""
           >
             <span
               aria-label="left"
@@ -239,6 +240,7 @@ exports[`Table.rowSelection fix selection column on the left 1`] = `
         >
           <a
             class="ant-pagination-item-link"
+            disabled=""
           >
             <span
               aria-label="right"
@@ -473,6 +475,7 @@ exports[`Table.rowSelection fix selection column on the left when any other colu
         >
           <a
             class="ant-pagination-item-link"
+            disabled=""
           >
             <span
               aria-label="left"
@@ -512,6 +515,7 @@ exports[`Table.rowSelection fix selection column on the left when any other colu
         >
           <a
             class="ant-pagination-item-link"
+            disabled=""
           >
             <span
               aria-label="right"
@@ -763,6 +767,7 @@ exports[`Table.rowSelection use column as selection column when key is \`selecti
         >
           <a
             class="ant-pagination-item-link"
+            disabled=""
           >
             <span
               aria-label="left"
@@ -802,6 +807,7 @@ exports[`Table.rowSelection use column as selection column when key is \`selecti
         >
           <a
             class="ant-pagination-item-link"
+            disabled=""
           >
             <span
               aria-label="right"

--- a/components/table/__tests__/__snapshots__/Table.sorter.test.js.snap
+++ b/components/table/__tests__/__snapshots__/Table.sorter.test.js.snap
@@ -183,6 +183,7 @@ exports[`Table.sorter should support defaultOrder in Column 1`] = `
         >
           <a
             class="ant-pagination-item-link"
+            disabled=""
           >
             <span
               aria-label="left"
@@ -222,6 +223,7 @@ exports[`Table.sorter should support defaultOrder in Column 1`] = `
         >
           <a
             class="ant-pagination-item-link"
+            disabled=""
           >
             <span
               aria-label="right"

--- a/components/table/__tests__/__snapshots__/Table.test.js.snap
+++ b/components/table/__tests__/__snapshots__/Table.test.js.snap
@@ -213,6 +213,7 @@ exports[`Table rtl render component should be rendered correctly in RTL directio
         >
           <a
             class="ant-pagination-item-link"
+            disabled=""
           >
             <span
               aria-label="right"
@@ -252,6 +253,7 @@ exports[`Table rtl render component should be rendered correctly in RTL directio
         >
           <a
             class="ant-pagination-item-link"
+            disabled=""
           >
             <span
               aria-label="left"

--- a/components/table/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/table/__tests__/__snapshots__/demo.test.js.snap
@@ -216,6 +216,7 @@ exports[`renders ./components/table/demo/ajax.md correctly 1`] = `
         >
           <a
             class="ant-pagination-item-link"
+            disabled=""
           >
             <span
               aria-label="left"
@@ -255,6 +256,7 @@ exports[`renders ./components/table/demo/ajax.md correctly 1`] = `
         >
           <a
             class="ant-pagination-item-link"
+            disabled=""
           >
             <span
               aria-label="right"
@@ -512,6 +514,7 @@ exports[`renders ./components/table/demo/basic.md correctly 1`] = `
         >
           <a
             class="ant-pagination-item-link"
+            disabled=""
           >
             <span
               aria-label="left"
@@ -551,6 +554,7 @@ exports[`renders ./components/table/demo/basic.md correctly 1`] = `
         >
           <a
             class="ant-pagination-item-link"
+            disabled=""
           >
             <span
               aria-label="right"
@@ -721,6 +725,7 @@ exports[`renders ./components/table/demo/bordered.md correctly 1`] = `
         >
           <a
             class="ant-pagination-item-link"
+            disabled=""
           >
             <span
               aria-label="left"
@@ -760,6 +765,7 @@ exports[`renders ./components/table/demo/bordered.md correctly 1`] = `
         >
           <a
             class="ant-pagination-item-link"
+            disabled=""
           >
             <span
               aria-label="right"
@@ -999,6 +1005,7 @@ exports[`renders ./components/table/demo/colspan-rowspan.md correctly 1`] = `
         >
           <a
             class="ant-pagination-item-link"
+            disabled=""
           >
             <span
               aria-label="left"
@@ -1038,6 +1045,7 @@ exports[`renders ./components/table/demo/colspan-rowspan.md correctly 1`] = `
         >
           <a
             class="ant-pagination-item-link"
+            disabled=""
           >
             <span
               aria-label="right"
@@ -1330,6 +1338,7 @@ exports[`renders ./components/table/demo/custom-filter-panel.md correctly 1`] = 
         >
           <a
             class="ant-pagination-item-link"
+            disabled=""
           >
             <span
               aria-label="left"
@@ -1369,6 +1378,7 @@ exports[`renders ./components/table/demo/custom-filter-panel.md correctly 1`] = 
         >
           <a
             class="ant-pagination-item-link"
+            disabled=""
           >
             <span
               aria-label="right"
@@ -1529,6 +1539,7 @@ exports[`renders ./components/table/demo/drag-sorting.md correctly 1`] = `
         >
           <a
             class="ant-pagination-item-link"
+            disabled=""
           >
             <span
               aria-label="left"
@@ -1568,6 +1579,7 @@ exports[`renders ./components/table/demo/drag-sorting.md correctly 1`] = `
         >
           <a
             class="ant-pagination-item-link"
+            disabled=""
           >
             <span
               aria-label="right"
@@ -3230,6 +3242,7 @@ exports[`renders ./components/table/demo/dynamic-settings.md correctly 1`] = `
           >
             <a
               class="ant-pagination-item-link"
+              disabled=""
             >
               <span
                 aria-label="left"
@@ -3269,6 +3282,7 @@ exports[`renders ./components/table/demo/dynamic-settings.md correctly 1`] = `
           >
             <a
               class="ant-pagination-item-link"
+              disabled=""
             >
               <span
                 aria-label="right"
@@ -3446,6 +3460,7 @@ exports[`renders ./components/table/demo/edit-cell.md correctly 1`] = `
           >
             <a
               class="ant-pagination-item-link"
+              disabled=""
             >
               <span
                 aria-label="left"
@@ -3485,6 +3500,7 @@ exports[`renders ./components/table/demo/edit-cell.md correctly 1`] = `
           >
             <a
               class="ant-pagination-item-link"
+              disabled=""
             >
               <span
                 aria-label="right"
@@ -3862,6 +3878,7 @@ exports[`renders ./components/table/demo/edit-row.md correctly 1`] = `
         >
           <a
             class="ant-pagination-item-link"
+            disabled=""
           >
             <span
               aria-label="left"
@@ -4229,6 +4246,7 @@ exports[`renders ./components/table/demo/ellipsis.md correctly 1`] = `
         >
           <a
             class="ant-pagination-item-link"
+            disabled=""
           >
             <span
               aria-label="left"
@@ -4268,6 +4286,7 @@ exports[`renders ./components/table/demo/ellipsis.md correctly 1`] = `
         >
           <a
             class="ant-pagination-item-link"
+            disabled=""
           >
             <span
               aria-label="right"
@@ -4518,6 +4537,7 @@ exports[`renders ./components/table/demo/expand.md correctly 1`] = `
         >
           <a
             class="ant-pagination-item-link"
+            disabled=""
           >
             <span
               aria-label="left"
@@ -4557,6 +4577,7 @@ exports[`renders ./components/table/demo/expand.md correctly 1`] = `
         >
           <a
             class="ant-pagination-item-link"
+            disabled=""
           >
             <span
               aria-label="right"
@@ -4777,6 +4798,7 @@ exports[`renders ./components/table/demo/expand-children.md correctly 1`] = `
         >
           <a
             class="ant-pagination-item-link"
+            disabled=""
           >
             <span
               aria-label="left"
@@ -4816,6 +4838,7 @@ exports[`renders ./components/table/demo/expand-children.md correctly 1`] = `
         >
           <a
             class="ant-pagination-item-link"
+            disabled=""
           >
             <span
               aria-label="right"
@@ -5136,6 +5159,7 @@ exports[`renders ./components/table/demo/fixed-columns.md correctly 1`] = `
         >
           <a
             class="ant-pagination-item-link"
+            disabled=""
           >
             <span
               aria-label="left"
@@ -5175,6 +5199,7 @@ exports[`renders ./components/table/demo/fixed-columns.md correctly 1`] = `
         >
           <a
             class="ant-pagination-item-link"
+            disabled=""
           >
             <span
               aria-label="right"
@@ -6054,6 +6079,7 @@ exports[`renders ./components/table/demo/fixed-columns-header.md correctly 1`] =
         >
           <a
             class="ant-pagination-item-link"
+            disabled=""
           >
             <span
               aria-label="left"
@@ -7308,6 +7334,7 @@ exports[`renders ./components/table/demo/fixed-header.md correctly 1`] = `
         >
           <a
             class="ant-pagination-item-link"
+            disabled=""
           >
             <span
               aria-label="left"
@@ -8147,6 +8174,7 @@ exports[`renders ./components/table/demo/grouping-columns.md correctly 1`] = `
         >
           <a
             class="ant-pagination-item-link"
+            disabled=""
           >
             <span
               aria-label="left"
@@ -8663,6 +8691,7 @@ exports[`renders ./components/table/demo/head.md correctly 1`] = `
         >
           <a
             class="ant-pagination-item-link"
+            disabled=""
           >
             <span
               aria-label="left"
@@ -8702,6 +8731,7 @@ exports[`renders ./components/table/demo/head.md correctly 1`] = `
         >
           <a
             class="ant-pagination-item-link"
+            disabled=""
           >
             <span
               aria-label="right"
@@ -8986,6 +9016,7 @@ exports[`renders ./components/table/demo/jsx.md correctly 1`] = `
         >
           <a
             class="ant-pagination-item-link"
+            disabled=""
           >
             <span
               aria-label="left"
@@ -9025,6 +9056,7 @@ exports[`renders ./components/table/demo/jsx.md correctly 1`] = `
         >
           <a
             class="ant-pagination-item-link"
+            disabled=""
           >
             <span
               aria-label="right"
@@ -9387,6 +9419,7 @@ exports[`renders ./components/table/demo/multiple-sorter.md correctly 1`] = `
         >
           <a
             class="ant-pagination-item-link"
+            disabled=""
           >
             <span
               aria-label="left"
@@ -9426,6 +9459,7 @@ exports[`renders ./components/table/demo/multiple-sorter.md correctly 1`] = `
         >
           <a
             class="ant-pagination-item-link"
+            disabled=""
           >
             <span
               aria-label="right"
@@ -9703,6 +9737,7 @@ exports[`renders ./components/table/demo/nested-table.md correctly 1`] = `
         >
           <a
             class="ant-pagination-item-link"
+            disabled=""
           >
             <span
               aria-label="left"
@@ -9742,6 +9777,7 @@ exports[`renders ./components/table/demo/nested-table.md correctly 1`] = `
         >
           <a
             class="ant-pagination-item-link"
+            disabled=""
           >
             <span
               aria-label="right"
@@ -10191,6 +10227,7 @@ exports[`renders ./components/table/demo/reset-filter.md correctly 1`] = `
           >
             <a
               class="ant-pagination-item-link"
+              disabled=""
             >
               <span
                 aria-label="left"
@@ -10230,6 +10267,7 @@ exports[`renders ./components/table/demo/reset-filter.md correctly 1`] = `
           >
             <a
               class="ant-pagination-item-link"
+              disabled=""
             >
               <span
                 aria-label="right"
@@ -10457,6 +10495,7 @@ exports[`renders ./components/table/demo/resizable-column.md correctly 1`] = `
         >
           <a
             class="ant-pagination-item-link"
+            disabled=""
           >
             <span
               aria-label="left"
@@ -10496,6 +10535,7 @@ exports[`renders ./components/table/demo/resizable-column.md correctly 1`] = `
         >
           <a
             class="ant-pagination-item-link"
+            disabled=""
           >
             <span
               aria-label="right"
@@ -10833,6 +10873,7 @@ exports[`renders ./components/table/demo/row-selection.md correctly 1`] = `
           >
             <a
               class="ant-pagination-item-link"
+              disabled=""
             >
               <span
                 aria-label="left"
@@ -10872,6 +10913,7 @@ exports[`renders ./components/table/demo/row-selection.md correctly 1`] = `
           >
             <a
               class="ant-pagination-item-link"
+              disabled=""
             >
               <span
                 aria-label="right"
@@ -11400,6 +11442,7 @@ exports[`renders ./components/table/demo/row-selection-and-operation.md correctl
           >
             <a
               class="ant-pagination-item-link"
+              disabled=""
             >
               <span
                 aria-label="left"
@@ -12015,6 +12058,7 @@ exports[`renders ./components/table/demo/row-selection-custom.md correctly 1`] =
         >
           <a
             class="ant-pagination-item-link"
+            disabled=""
           >
             <span
               aria-label="left"
@@ -12249,6 +12293,7 @@ exports[`renders ./components/table/demo/size.md correctly 1`] = `
           >
             <a
               class="ant-pagination-item-link"
+              disabled=""
             >
               <span
                 aria-label="left"
@@ -12288,6 +12333,7 @@ exports[`renders ./components/table/demo/size.md correctly 1`] = `
           >
             <a
               class="ant-pagination-item-link"
+              disabled=""
             >
               <span
                 aria-label="right"
@@ -12442,6 +12488,7 @@ exports[`renders ./components/table/demo/size.md correctly 1`] = `
           >
             <a
               class="ant-pagination-item-link"
+              disabled=""
             >
               <span
                 aria-label="left"
@@ -12481,6 +12528,7 @@ exports[`renders ./components/table/demo/size.md correctly 1`] = `
           >
             <a
               class="ant-pagination-item-link"
+              disabled=""
             >
               <span
                 aria-label="right"

--- a/components/table/__tests__/__snapshots__/empty.test.js.snap
+++ b/components/table/__tests__/__snapshots__/empty.test.js.snap
@@ -586,6 +586,7 @@ exports[`Table renders empty table without emptyText when loading 1`] = `
         >
           <a
             class="ant-pagination-item-link"
+            disabled=""
           >
             <span
               aria-label="left"
@@ -625,6 +626,7 @@ exports[`Table renders empty table without emptyText when loading 1`] = `
         >
           <a
             class="ant-pagination-item-link"
+            disabled=""
           >
             <span
               aria-label="right"

--- a/components/transfer/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/transfer/__tests__/__snapshots__/demo.test.js.snap
@@ -2745,6 +2745,7 @@ exports[`renders ./components/transfer/demo/table-transfer.md correctly 1`] = `
                   >
                     <a
                       class="ant-pagination-item-link"
+                      disabled=""
                     >
                       <span
                         aria-label="left"
@@ -3156,6 +3157,7 @@ exports[`renders ./components/transfer/demo/table-transfer.md correctly 1`] = `
                   >
                     <a
                       class="ant-pagination-item-link"
+                      disabled=""
                     >
                       <span
                         aria-label="left"
@@ -3195,6 +3197,7 @@ exports[`renders ./components/transfer/demo/table-transfer.md correctly 1`] = `
                   >
                     <a
                       class="ant-pagination-item-link"
+                      disabled=""
                     >
                       <span
                         aria-label="right"

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "rc-mentions": "~1.0.0-alpha.3",
     "rc-menu": "~8.0.0-alpha.7",
     "rc-notification": "~4.0.0-rc.1",
-    "rc-pagination": "~1.20.13",
+    "rc-pagination": "~1.21.0",
     "rc-picker": "^0.0.1-rc.5",
     "rc-progress": "~2.5.0",
     "rc-rate": "~2.5.1",


### PR DESCRIPTION

<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close #21351

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Pagination will pass `disabled` prop to prev/next buttons return by `itemRender`. |
| 🇨🇳 Chinese | Pagination 自定义 `itemRender` 返回的上一页下一页现在会补充 `disabled` 属性。 |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
