### PR TITLE
fix(site): the search box is 2px taller than radio buttons

### DIFF
--- a/site/theme/static/icon-pic-searcher.less
+++ b/site/theme/static/icon-pic-searcher.less
@@ -1,6 +1,6 @@
 .icon-pic-searcher {
   display: inline-block;
-  margin: 1px 8px;
+  margin: 0 8px;
 
   .icon-pic-btn {
     color: @text-color-secondary;

--- a/site/theme/template/IconDisplay/index.tsx
+++ b/site/theme/template/IconDisplay/index.tsx
@@ -110,7 +110,7 @@ class IconDisplay extends React.Component<IconDisplayProps, IconDisplayState> {
           </Radio.Group>
           <Input.Search
             placeholder={messages['app.docs.components.icon.search.placeholder']}
-            style={{ marginLeft: 10, flex: 1, height: 40 }}
+            style={{ marginLeft: 10, flex: 1 }}
             allowClear
             onChange={e => this.handleSearchIcon(e.currentTarget.value)}
             size="large"

--- a/site/theme/template/IconDisplay/index.tsx
+++ b/site/theme/template/IconDisplay/index.tsx
@@ -110,7 +110,7 @@ class IconDisplay extends React.Component<IconDisplayProps, IconDisplayState> {
           </Radio.Group>
           <Input.Search
             placeholder={messages['app.docs.components.icon.search.placeholder']}
-            style={{ marginLeft: 10, flex: 1 }}
+            style={{ marginLeft: 10, flex: 1, height: 40 }}
             allowClear
             onChange={e => this.handleSearchIcon(e.currentTarget.value)}
             size="large"


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix the search box is 2px taller than radio buttons in the same row of icon demo page |
| 🇨🇳 Chinese | 修复 Icon 预览页面中搜索框比同在一行的单选按钮高 2px 的样式问题 |

![image](https://user-images.githubusercontent.com/32428655/74588689-a207ce80-5039-11ea-902c-54d5a231de85.png)

### ☑️ Self Check before Merge

- [ ] ~~Doc is updated/provided or not needed~~
- [ ] ~~Demo is updated/provided or not needed~~
- [ ] ~~TypeScript definition is updated/provided or not needed~~
- [x] Changelog is provided or not needed
