### PR TITLE
[Radio.Button] fix: replace 'outline' with 'box-shadow'

### DIFF
--- a/components/radio/style/index.less
+++ b/components/radio/style/index.less
@@ -217,8 +217,8 @@ span.@{radio-prefix-cls} + * {
       height: 100%;
       padding: @border-width-base 0;
       background-color: @border-color-base;
-      content: '';
       transition: background-color 0.3s;
+      content: '';
     }
   }
 

--- a/components/radio/style/index.less
+++ b/components/radio/style/index.less
@@ -212,8 +212,10 @@ span.@{radio-prefix-cls} + * {
       top: @border-width-base * -1;
       left: -1px;
       display: block;
+      box-sizing: content-box;
       width: 1px;
-      height: calc(100% + @border-width-base * 2);
+      height: 100%;
+      padding: @border-width-base 0;
       background-color: @border-color-base;
       content: '';
       transition: background-color 0.3s;

--- a/components/radio/style/index.less
+++ b/components/radio/style/index.less
@@ -181,7 +181,7 @@ span.@{radio-prefix-cls} + * {
   border-top-width: @border-width-base + 0.02px;
   border-left: 0;
   cursor: pointer;
-  transition: color 0.3s, background 0.3s, border-color 0.3s;
+  transition: color 0.3s, background 0.3s, border-color 0.3s, box-shadow 0.3s;
 
   a {
     color: @radio-button-color;
@@ -216,6 +216,7 @@ span.@{radio-prefix-cls} + * {
       height: calc(100% + @border-width-base * 2);
       background-color: @border-color-base;
       content: '';
+      transition: background-color 0.3s;
     }
   }
 

--- a/components/radio/style/index.less
+++ b/components/radio/style/index.less
@@ -5,7 +5,8 @@
 @radio-group-prefix-cls: ~'@{radio-prefix-cls}-group';
 @radio-inner-prefix-cls: ~'@{radio-prefix-cls}-inner';
 @radio-duration: 0.3s;
-@radio-focused-outline: 3px solid fade(@radio-dot-color, 6%);
+@radio-focus-shadow: 0 0 0 3px fade(@radio-dot-color, 8%);
+@radio-button-focus-shadow: @radio-focus-shadow;
 
 .@{radio-group-prefix-cls} {
   .reset-component;
@@ -60,7 +61,7 @@
   }
 
   &-input:focus + .@{radio-inner-prefix-cls} {
-    box-shadow: 0 0 0 3px fade(@radio-dot-color, 8%);
+    box-shadow: @radio-focus-shadow;
   }
 
   &-checked::after {
@@ -208,11 +209,11 @@ span.@{radio-prefix-cls} + * {
   &:not(:first-child) {
     &::before {
       position: absolute;
-      top: 0;
+      top: @border-width-base * -1;
       left: -1px;
       display: block;
       width: 1px;
-      height: 100%;
+      height: calc(100% + @border-width-base * 2);
       background-color: @border-color-base;
       content: '';
     }
@@ -246,7 +247,7 @@ span.@{radio-prefix-cls} + * {
   }
 
   &:focus-within {
-    outline: @radio-focused-outline;
+    box-shadow: @radio-button-focus-shadow;
   }
 
   .@{radio-prefix-cls}-inner,
@@ -263,32 +264,33 @@ span.@{radio-prefix-cls} + * {
     color: @radio-dot-color;
     background: @radio-button-checked-bg;
     border-color: @radio-dot-color;
-    box-shadow: -1px 0 0 0 @radio-dot-color;
 
     &::before {
-      background-color: @radio-dot-color !important;
-      opacity: 0.1;
+      background-color: @radio-dot-color;
     }
 
     &:first-child {
       border-color: @radio-dot-color;
-      box-shadow: none !important;
     }
 
     &:hover {
       color: @radio-button-hover-color;
       border-color: @radio-button-hover-color;
-      box-shadow: -1px 0 0 0 @radio-button-hover-color;
+      &::before {
+        background-color: @radio-button-hover-color;
+      }
     }
 
     &:active {
       color: @radio-button-active-color;
       border-color: @radio-button-active-color;
-      box-shadow: -1px 0 0 0 @radio-button-active-color;
+      &::before {
+        background-color: @radio-button-active-color;
+      }
     }
 
     &:focus-within {
-      outline: @radio-focused-outline;
+      box-shadow: @radio-button-focus-shadow;
     }
   }
 
@@ -307,7 +309,7 @@ span.@{radio-prefix-cls} + * {
       border-color: @radio-button-active-color;
     }
     &:focus-within {
-      outline: @radio-focused-outline;
+      box-shadow: @radio-button-focus-shadow;
     }
   }
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close #21389

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | replace 'outline' with 'box-shadow' as a highlighting reminder of the Radio.Button in focus |
| 🇨🇳 Chinese | 用 box-shadow 替换 outline 作为 Radio.Button 的聚焦效果 |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
