### PR TITLE
docs: add 3.26.10 changelog

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -25,6 +25,8 @@ timeline: true
 - 🐞 Fix Affix throws `Cannot read property getBoundingClientRect in mobile device`. [#21350](https://github.com/ant-design/ant-design/pull/21350)
 - 💄 Tweak Steps 1px align issue. [#21306](https://github.com/ant-design/ant-design/pull/21306)
 - 💄 Fix Row component affect next element style issue. [#21310](https://github.com/ant-design/ant-design/pull/21310)
+- Typescript
+  - 🔷 Rollback [#21250](https://github.com/ant-design/ant-design/pull/21250) Type Definition Update.[#21356](https://github.com/ant-design/ant-design/pull/21356)
 
 ## 3.26.9
 

--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -23,6 +23,8 @@ timeline: true
 - 🐞 Fix Badge color not working when contains children. [#21333](https://github.com/ant-design/ant-design/pull/21333)
 - 🐞 Fix Alert close button extra padding. [#21325](https://github.com/ant-design/ant-design/pull/21325)
 - 🐞 Fix Affix throws `Cannot read property getBoundingClientRect in mobile device`. [#21350](https://github.com/ant-design/ant-design/pull/21350)
+- 💄 Tweak Steps 1px align issue. [#21306](https://github.com/ant-design/ant-design/pull/21306)
+- 💄 Fix Row component affect next element style issue. [#21310](https://github.com/ant-design/ant-design/pull/21310)
 
 ## 3.26.9
 

--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -15,6 +15,15 @@ timeline: true
 
 ---
 
+## 3.26.10
+
+`2020-02-16`
+
+- 🐞 Fix Input.Group inside `<Form layout="vertical" >` 1px bug. [#20685](https://github.com/ant-design/ant-design/pull/20685)
+- 🐞 Fix Badge color not working when contains children. [#21333](https://github.com/ant-design/ant-design/pull/21333)
+- 🐞 Fix Alert close button extra padding. [#21325](https://github.com/ant-design/ant-design/pull/21325)
+- 🐞 Fix Affix throws `Cannot read property getBoundingClientRect in mobile device`. [#21350](https://github.com/ant-design/ant-design/pull/21350)
+
 ## 3.26.9
 
 `2020-02-08`

--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -20,8 +20,8 @@ timeline: true
 `2020-02-16`
 
 - 🐞 Fix Input.Group inside `<Form layout="vertical" >` 1px bug. [#20685](https://github.com/ant-design/ant-design/pull/20685)
-- 🐞 Fix Badge color not working when contains children. [#21333](https://github.com/ant-design/ant-design/pull/21333)
-- 🐞 Fix Alert close button extra padding. [#21325](https://github.com/ant-design/ant-design/pull/21325)
+- 🐞 Fix Badge `color` not working when contains children. [#21333](https://github.com/ant-design/ant-design/pull/21333)
+- 🐞 Fix Alert close button extra `padding`. [#21325](https://github.com/ant-design/ant-design/pull/21325)
 - 🐞 Fix Affix throws `Cannot read property getBoundingClientRect in mobile device`. [#21350](https://github.com/ant-design/ant-design/pull/21350)
 - 💄 Tweak Steps 1px align issue. [#21306](https://github.com/ant-design/ant-design/pull/21306)
 - 💄 Fix Row component affect next element style issue. [#21310](https://github.com/ant-design/ant-design/pull/21310)

--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -26,7 +26,7 @@ timeline: true
 - 💄 Tweak Steps 1px align issue. [#21306](https://github.com/ant-design/ant-design/pull/21306)
 - 💄 Fix Row component affect next element style issue. [#21310](https://github.com/ant-design/ant-design/pull/21310)
 - Typescript
-  - 🔷 Rollback [#21250](https://github.com/ant-design/ant-design/pull/21250) Type Definition Update.[#21356](https://github.com/ant-design/ant-design/pull/21356)
+  - 🔷 Revert [#21250](https://github.com/ant-design/ant-design/pull/21250) Type Definition Update.[#21356](https://github.com/ant-design/ant-design/pull/21356)
 
 ## 3.26.9
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -23,6 +23,8 @@ timeline: true
 - 🐞 修复 Badge 包裹模式下 `color` 属性失效的问题。[#21333](https://github.com/ant-design/ant-design/pull/21333)
 - 🐞 修复 Alert 关闭按钮额外的 padding。[#21325](https://github.com/ant-design/ant-design/pull/21325)
 - 🐞 修复 Affix 在移动设备下抛错 `Cannot read property getBoundingClientRect` 的问题。[#21350](https://github.com/ant-design/ant-design/pull/21350)
+- 💄 微调 Steps 文本 1px 使其居中对齐。[#21306](https://github.com/ant-design/ant-design/pull/21306)
+- 💄 修复 Row 组件影响下一个元素样式问题。[#21310](https://github.com/ant-design/ant-design/pull/21310)
 
 ## 3.26.9
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -21,7 +21,7 @@ timeline: true
 
 - 🐞 修复 `<Form layout="vertical" >` 内 Input.Group 偏上一像素的问题。[#20685](https://github.com/ant-design/ant-design/pull/20685)
 - 🐞 修复 Badge 包裹模式下 `color` 属性失效的问题。[#21333](https://github.com/ant-design/ant-design/pull/21333)
-- 🐞 修复 Alert 关闭按钮额外的 padding。[#21325](https://github.com/ant-design/ant-design/pull/21325)
+- 🐞 修复 Alert 关闭按钮额外的 `padding`。[#21325](https://github.com/ant-design/ant-design/pull/21325)
 - 🐞 修复 Affix 在移动设备下抛错 `Cannot read property getBoundingClientRect` 的问题。[#21350](https://github.com/ant-design/ant-design/pull/21350)
 - 💄 微调 Steps 文本 1px 使其居中对齐。[#21306](https://github.com/ant-design/ant-design/pull/21306)
 - 💄 修复 Row 组件影响下一个元素样式问题。[#21310](https://github.com/ant-design/ant-design/pull/21310)

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -36,7 +36,6 @@ timeline: true
 - 🐞 修复 Steps 在 `size="small"` 和 `labelPlacement="vertical"` 时图标没有对齐的问题。[#21258](https://github.com/ant-design/ant-design/pull/21258)
 - 🐞 修复 Typography 在可编辑状态时光标没有在输入框末位的问题。[#21268](https://github.com/ant-design/ant-design/pull/21268)
 - TypeScript
-
   - 💄 完善 Form 中校验规则类型的类型定义。[#21250](https://github.com/ant-design/ant-design/pull/21250) [@hansololai](https://github.com/hansololai)
   - 🐞 修复 Tree 中事件类型定义不正确的问题。[#21200](https://github.com/ant-design/ant-design/pull/21200) [@Jirka-Lhotka](https://github.com/Jirka-Lhotka)
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -26,7 +26,7 @@ timeline: true
 - 💄 微调 Steps 文本 1px 使其居中对齐。[#21306](https://github.com/ant-design/ant-design/pull/21306)
 - 💄 修复 Row 组件影响下一个元素样式问题。[#21310](https://github.com/ant-design/ant-design/pull/21310)
 - Typescript
-  - 🔷 回滚 [#21250](https://github.com/ant-design/ant-design/pull/21250)的类型定义更新。[#21356](https://github.com/ant-design/ant-design/pull/21356)
+  - 🔷 回滚 [#21250](https://github.com/ant-design/ant-design/pull/21250) 的类型定义更新。[#21356](https://github.com/ant-design/ant-design/pull/21356)
 
 ## 3.26.9
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -15,6 +15,15 @@ timeline: true
 
 ---
 
+## 3.26.10
+
+`2020-02-16`
+
+- 🐞 修复 `<Form layout="vertical" >` 内 Input.Group 偏上一像素的问题。[#20685](https://github.com/ant-design/ant-design/pull/20685)
+- 🐞 修复 Badge 包裹模式下 `color` 属性失效的问题。[#21333](https://github.com/ant-design/ant-design/pull/21333)
+- 🐞 修复 Alert 关闭按钮额外的 padding。[#21325](https://github.com/ant-design/ant-design/pull/21325)
+- 🐞 修复 Affix 在移动设备下抛错 `Cannot read property getBoundingClientRect` 的问题。[#21350](https://github.com/ant-design/ant-design/pull/21350)
+
 ## 3.26.9
 
 `2020-02-08`

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -25,6 +25,8 @@ timeline: true
 - 🐞 修复 Affix 在移动设备下抛错 `Cannot read property getBoundingClientRect` 的问题。[#21350](https://github.com/ant-design/ant-design/pull/21350)
 - 💄 微调 Steps 文本 1px 使其居中对齐。[#21306](https://github.com/ant-design/ant-design/pull/21306)
 - 💄 修复 Row 组件影响下一个元素样式问题。[#21310](https://github.com/ant-design/ant-design/pull/21310)
+- Typescript
+  - 🔷 回滚 [#21250](https://github.com/ant-design/ant-design/pull/21250)的类型定义更新。[#21356](https://github.com/ant-design/ant-design/pull/21356)
 
 ## 3.26.9
 
@@ -34,6 +36,7 @@ timeline: true
 - 🐞 修复 Steps 在 `size="small"` 和 `labelPlacement="vertical"` 时图标没有对齐的问题。[#21258](https://github.com/ant-design/ant-design/pull/21258)
 - 🐞 修复 Typography 在可编辑状态时光标没有在输入框末位的问题。[#21268](https://github.com/ant-design/ant-design/pull/21268)
 - TypeScript
+
   - 💄 完善 Form 中校验规则类型的类型定义。[#21250](https://github.com/ant-design/ant-design/pull/21250) [@hansololai](https://github.com/hansololai)
   - 🐞 修复 Tree 中事件类型定义不正确的问题。[#21200](https://github.com/ant-design/ant-design/pull/21200) [@Jirka-Lhotka](https://github.com/Jirka-Lhotka)
 


### PR DESCRIPTION
## 3.26.10

`2020-02-16`

- 🐞 Fix Input.Group inside `<Form layout="vertical" >` 1px bug. [#20685](https://github.com/ant-design/ant-design/pull/20685)
- 🐞 Fix Badge color not working when contains children. [#21333](https://github.com/ant-design/ant-design/pull/21333)
- 🐞 Fix Alert close button extra padding. [#21325](https://github.com/ant-design/ant-design/pull/21325)
- 🐞 Fix Affix throws `Cannot read property getBoundingClientRect in mobile device`. [#21350](https://github.com/ant-design/ant-design/pull/21350)

-----

## 3.26.10

`2020-02-16`

- 🐞 修复 `<Form layout="vertical" >` 内 Input.Group 偏上一像素的问题。[#20685](https://github.com/ant-design/ant-design/pull/20685)
- 🐞 修复 Badge 包裹模式下 `color` 属性失效的问题。[#21333](https://github.com/ant-design/ant-design/pull/21333)
- 🐞 修复 Alert 关闭按钮额外的 padding。[#21325](https://github.com/ant-design/ant-design/pull/21325)
- 🐞 修复 Affix 在移动设备下抛错 `Cannot read property getBoundingClientRect` 的问题。[#21350](https://github.com/ant-design/ant-design/pull/21350)


-----
[View rendered CHANGELOG.en-US.md](https://github.com/ant-design/ant-design/blob/3.26.10-changelog/CHANGELOG.en-US.md)
[View rendered CHANGELOG.zh-CN.md](https://github.com/ant-design/ant-design/blob/3.26.10-changelog/CHANGELOG.zh-CN.md)