### PR TITLE
style: Tweak divider padding and add @divider-text-padding

### DIFF
--- a/components/divider/style/index.less
+++ b/components/divider/style/index.less
@@ -2,6 +2,7 @@
 @import '../../style/mixins/index';
 
 @divider-prefix-cls: ~'@{ant-prefix}-divider';
+@divider-text-padding: 1em;
 
 .@{divider-prefix-cls} {
   .reset-component;
@@ -55,7 +56,7 @@
   &-horizontal&-with-text-right {
     .@{divider-prefix-cls}-inner-text {
       display: inline-block;
-      padding: 0 10px;
+      padding: 0 @divider-text-padding;
     }
   }
 
@@ -83,7 +84,7 @@
 
   &-inner-text {
     display: inline-block;
-    padding: 0 24px;
+    padding: 0 @divider-text-padding;
   }
 
   &-dashed {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

Tweak divider padding and add @divider-text-padding, update it's default value to 1em

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Tweak Divider inner text padding and add `@divider-text-padding`. |
| 🇨🇳 Chinese | 调整 Divider 内嵌文字的默认 `padding`，并新增 `@divider-text-padding` 变量。 |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
