### PR TITLE
fix: Form throw error when using BraftEditor

### DIFF
--- a/components/form/FormItem.tsx
+++ b/components/form/FormItem.tsx
@@ -279,12 +279,10 @@ function FormItem(props: FormItemProps): React.ReactElement {
           });
 
           triggers.forEach(eventName => {
-            if (eventName in mergedControl && eventName in children.props) {
-              childProps[eventName] = (...args: any[]) => {
-                mergedControl[eventName](...args);
-                children.props[eventName](...args);
-              };
-            }
+            childProps[eventName] = (...args: any[]) => {
+              mergedControl[eventName]?.(...args);
+              children.props[eventName]?.(...args);
+            };
           });
 
           childNode = React.cloneElement(children, childProps);

--- a/components/form/__tests__/index.test.js
+++ b/components/form/__tests__/index.test.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Component } from 'react';
 import { mount } from 'enzyme';
 import scrollIntoView from 'scroll-into-view-if-needed';
 import Form from '..';
@@ -521,5 +521,29 @@ describe('Form', () => {
     expect(errorSpy).toHaveBeenCalledWith(
       'Warning: [antd: Form.Item] `null` is passed as `name` property',
     );
+  });
+
+  // https://github.com/ant-design/ant-design/issues/21415
+  it('Component.props.onChange is null', () => {
+    // eslint-disable-next-line
+    class CustomComponent extends Component {
+      static defaultProps = {
+        onChange: null,
+      };
+
+      render() {
+        return <input {...this.props} />;
+      }
+    }
+    expect(() => {
+      const wrapper = mount(
+        <Form>
+          <Form.Item name="custom">
+            <CustomComponent />
+          </Form.Item>
+        </Form>,
+      );
+      wrapper.find(CustomComponent).simulate('change', { value: '123' });
+    }).not.toThrow();
   });
 });


### PR DESCRIPTION


<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close #21415

### 💡 Background and solution

`component.props.onChange` should not run when it is falsy.

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Form throw error when using BraftEditor.  |
| 🇨🇳 Chinese |  修复 Form 和 BraftEditor 一起使用时抛错的问题。 |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
