### PR TITLE
docs: In Chinese and doesn't prompt an auto translate

### DIFF
--- a/docs/spec/work-with-us.en-US.md
+++ b/docs/spec/work-with-us.en-US.md
@@ -33,6 +33,24 @@ ReactDOM.render(
 - 岗位职责：
   - 参与金融云、数据服务、人工智能以及金融核心等业务领域的设计工作；
   - 参与 Ant Design 的打磨，将其建设成全球卓越的设计体系。
+  
+## UI/UX Designer
+
+Please submit your work and resume: momo.zxy # alipay.com
+
+- Post level: P6 / P7
+- Position/Location: Hangzhou
+- Job requirements:
+  - At least 2-3 years working experience, solid design skills;
+  - Strong abstract ability, good at finding essence through appearance;
+  - Good communication skills and good at self-management;
+  - Have practical experience in enterprise-level design, extra points;
+  - Have good English skills and international vision, extra points;
+  - In-depth understanding of design systems such as SAP, Salesforce, Google, and more points.
+- Job Responsibilities:
+  - Participate in the design of financial cloud, data services, artificial intelligence and financial core business areas;
+  - Participate in the polishing of Ant Design and build it into a global outstanding design system.
+  
 
 ## 前端工程师
 
@@ -51,3 +69,18 @@ ReactDOM.render(
 - 岗位职责：
   - 负责 Ant Design 前端基础设施研发。
   - 负责中后台设计/前端工具体系建设。
+  
+##Front-end Engineer
+
+Please submit your resume: afc163+antd@gmail.com
+
+- Post level: P6 / P7 / P8
+- Position: Hangzhou
+- Job requirements:
+  - Continue to work on the React technology stack and love it.
+  - Love open source.
+  - Persist and be good at using technology and tools to solve other problems.
+  - Rich experience in mid- and back-end front-end R & D.
+- Job Responsibilities:
+  - Responsible for Ant Design front-end infrastructure research and development.
+  - Responsible for mid-back design / front-end tool system construction.

--- a/docs/spec/work-with-us.en-US.md
+++ b/docs/spec/work-with-us.en-US.md
@@ -36,7 +36,7 @@ ReactDOM.render(
   
 ## UI/UX Designer
 
-Please submit your work and resume: momo.zxy # alipay.com
+Please submit your work and resume: lindong.lld@alipay.com
 
 - Post level: P6 / P7
 - Position/Location: Hangzhou


### PR DESCRIPTION
All the pages on the website are in English, whereas this page is in Chinese. Creating an abrupt experience. 
The work with us page is not prompting the auto-translate feature on chrome or Edge Beta, or a person unfamiliar with the language it might be annoying to figure out which one it is

<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

####1. Describe the source of requirement, like related issue link.
https://ant.design/docs/spec/work-with-us


### 💡 Background and solution

#### 1. Describe the problem and the scenario.
The webpage of work with us is in Chinese there might be people who are not from China but are very much willing to work with your organisation with the job role at hand but everything in Chinese with no auto-translate is a bad experience 

#### 2. GIF or snapshot should be provided if includes UI/interactive modification.
![image](https://user-images.githubusercontent.com/26500944/74710817-8c1c2880-5248-11ea-9382-9ea73d0711b7.png)


#### 3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
There are multiple solutions to this, most intuitive and appropriate solution is to have the auto-translate prompt from the browser.
Other solution might be one that I have added temporarily which is to add English text along with Chinese
Finally one weird but a possible solution is to provide specific language based on the location, but there are privacy issues with that option.


### 📝 Changelog

<!--
Describe changes from user-side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     x      |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed


-----
[View rendered docs/spec/work-with-us.en-US.md](https://github.com/tannmaysgupta/ant-design/blob/patch-1/docs/spec/work-with-us.en-US.md)