### PR TITLE
feat: Form support scrollToFirstError

### DIFF
--- a/components/form/Form.tsx
+++ b/components/form/Form.tsx
@@ -3,6 +3,7 @@ import omit from 'omit.js';
 import classNames from 'classnames';
 import FieldForm, { List } from 'rc-field-form';
 import { FormProps as RcFormProps } from 'rc-field-form/lib/Form';
+import { ValidateErrorEntity } from 'rc-field-form/lib/interface';
 import { ColProps } from '../grid/col';
 import { ConfigContext, ConfigConsumerProps } from '../config-provider';
 import { FormContext } from './context';
@@ -23,6 +24,7 @@ export interface FormProps extends Omit<RcFormProps, 'form'> {
   wrapperCol?: ColProps;
   form?: FormInstance;
   size?: SizeType;
+  scrollToFirstError?: boolean;
 }
 
 const InternalForm: React.FC<FormProps> = (props, ref) => {
@@ -40,6 +42,8 @@ const InternalForm: React.FC<FormProps> = (props, ref) => {
     className = '',
     layout = 'horizontal',
     size,
+    scrollToFirstError,
+    onFinishFailed,
   } = props;
   const prefixCls = getPrefixCls('form', customizePrefixCls);
 
@@ -62,12 +66,23 @@ const InternalForm: React.FC<FormProps> = (props, ref) => {
     'labelAlign',
     'labelCol',
     'colon',
+    'scrollToFirstError',
   ]);
 
   const [wrapForm] = useForm(form);
   wrapForm.__INTERNAL__.name = name;
 
   React.useImperativeHandle(ref, () => wrapForm);
+
+  const onInternalFinishFailed = (errorInfo: ValidateErrorEntity) => {
+    if (onFinishFailed) {
+      onFinishFailed(errorInfo);
+    }
+
+    if (scrollToFirstError && errorInfo.errorFields.length) {
+      wrapForm.scrollToField(errorInfo.errorFields[0].name);
+    }
+  };
 
   return (
     <SizeContextProvider size={size}>
@@ -81,7 +96,13 @@ const InternalForm: React.FC<FormProps> = (props, ref) => {
           colon,
         }}
       >
-        <FieldForm id={name} {...formProps} form={wrapForm} className={formClassName} />
+        <FieldForm
+          id={name}
+          {...formProps}
+          onFinishFailed={onInternalFinishFailed}
+          form={wrapForm}
+          className={formClassName}
+        />
       </FormContext.Provider>
     </SizeContextProvider>
   );

--- a/components/form/__tests__/index.test.js
+++ b/components/form/__tests__/index.test.js
@@ -291,6 +291,22 @@ describe('Form', () => {
     });
   });
 
+  it('scrollToFirstError', async () => {
+    const wrapper = mount(
+      <Form scrollToFirstError>
+        <Form.Item name="test" rules={[{ required: true }]}>
+          <input />
+        </Form.Item>
+      </Form>,
+      { attachTo: document.body },
+    );
+
+    expect(scrollIntoView).not.toHaveBeenCalled();
+    wrapper.find('form').simulate('submit');
+    await delay(50);
+    expect(scrollIntoView).toHaveBeenCalled();
+  });
+
   it('Form.Item should support data-*、aria-* and custom attribute', () => {
     const wrapper = mount(
       <Form>

--- a/components/form/__tests__/index.test.js
+++ b/components/form/__tests__/index.test.js
@@ -252,7 +252,7 @@ describe('Form', () => {
           );
         };
 
-        mount(<Demo />, { attachTo: document.body });
+        const wrapper = mount(<Demo />, { attachTo: document.body });
 
         expect(scrollIntoView).not.toHaveBeenCalled();
         const form = callGetForm();
@@ -265,6 +265,8 @@ describe('Form', () => {
           block: 'start',
           scrollMode: 'if-needed',
         });
+
+        wrapper.unmount();
       });
     }
 
@@ -305,6 +307,8 @@ describe('Form', () => {
     wrapper.find('form').simulate('submit');
     await delay(50);
     expect(scrollIntoView).toHaveBeenCalled();
+
+    wrapper.unmount();
   });
 
   it('Form.Item should support data-*、aria-* and custom attribute', () => {

--- a/components/form/__tests__/index.test.js
+++ b/components/form/__tests__/index.test.js
@@ -294,8 +294,10 @@ describe('Form', () => {
   });
 
   it('scrollToFirstError', async () => {
+    const onFinishFailed = jest.fn();
+
     const wrapper = mount(
-      <Form scrollToFirstError>
+      <Form scrollToFirstError onFinishFailed={onFinishFailed}>
         <Form.Item name="test" rules={[{ required: true }]}>
           <input />
         </Form.Item>
@@ -307,6 +309,7 @@ describe('Form', () => {
     wrapper.find('form').simulate('submit');
     await delay(50);
     expect(scrollIntoView).toHaveBeenCalled();
+    expect(onFinishFailed).toHaveBeenCalled();
 
     wrapper.unmount();
   });

--- a/components/form/demo/register.md
+++ b/components/form/demo/register.md
@@ -97,10 +97,6 @@ const RegistrationForm = () => {
     console.log('Received values of form: ', values);
   };
 
-  const onFinishFailed = ({ errorFields }) => {
-    form.scrollToField(errorFields[0].name);
-  };
-
   const prefixSelector = (
     <Form.Item name="prefix" noStyle>
       <Select style={{ width: 70 }}>
@@ -131,11 +127,11 @@ const RegistrationForm = () => {
       form={form}
       name="register"
       onFinish={onFinish}
-      onFinishFailed={onFinishFailed}
       initialValues={{
         residence: ['zhejiang', 'hangzhou', 'xihu'],
         prefix: '86',
       }}
+      scrollToFirstError
     >
       <Form.Item
         name="email"

--- a/components/form/index.en-US.md
+++ b/components/form/index.en-US.md
@@ -28,6 +28,7 @@ High performance Form component with data scope management. Including data colle
 | labelCol | label layout, like `<Col>` component. Set `span` `offset` value like `{span: 3, offset: 12}` or `sm: {span: 3, offset: 12}` | [object](https://ant.design/components/grid/#Col) | - |
 | layout | Form layout | `horizontal` \| `vertical` \| `inline` | `horizontal` |
 | name | Form name. Will be the prefix of Field `id` | string | - |
+| scrollToFirstError | Auto scroll to first failed field when submit | false | - |
 | size | Set field component size (antd components only) | `small` \| `middle` \| `large` | - |
 | validateMessages | Validation prompt template, description [see below](#validateMessages) | [ValidateMessages](https://github.com/react-component/field-form/blob/master/src/utils/messages.ts) | - |
 | wrapperCol | The layout for input controls, same as `labelCol` | [object](https://ant.design/components/grid/#Col) | - |

--- a/components/form/index.zh-CN.md
+++ b/components/form/index.zh-CN.md
@@ -29,6 +29,7 @@ title: Form
 | labelCol | label 标签布局，同 `<Col>` 组件，设置 `span` `offset` 值，如 `{span: 3, offset: 12}` 或 `sm: {span: 3, offset: 12}` | [object](https://ant.design/components/grid/#Col) | - |
 | layout | 表单布局 | `horizontal` \| `vertical` \| `inline` | `horizontal` |
 | name | 表单名称，会作为表单字段 `id` 前缀使用 | string | - |
+| scrollToFirstError | 提交失败自动滚动到第一个错误字段 | false | - |
 | size | 设置字段组件的尺寸（仅限 antd 组件） | `small` \| `middle` \| `large` | - |
 | validateMessages | 验证提示模板，说明[见下](#validateMessages) | [ValidateMessages](https://github.com/react-component/field-form/blob/master/src/utils/messages.ts) | - |
 | wrapperCol | 需要为输入控件设置布局样式时，使用该属性，用法同 labelCol | [object](https://ant.design/components/grid/#Col) | - |


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

resolve #21442

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Form support `scrollToFirstError` to simplify submit scroll logic.      |
| 🇨🇳 Chinese |   Form 支持 `scrollToFirstError` 属性以简化提交表单滚动到错误字段的编码量。       |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/form/demo/register.md](https://github.com/ant-design/ant-design/blob/form-auto-scroll/components/form/demo/register.md)