### PR TITLE
docs: Remove `optionLabelProp` in AutoComplete doc

### DIFF
--- a/components/auto-complete/index.en-US.md
+++ b/components/auto-complete/index.en-US.md
@@ -24,7 +24,6 @@ When there is a need for autocomplete functionality.
 | defaultValue | Initial selected option. | string\|string\[] | - |  |
 | disabled | Whether disabled select | boolean | false |  |
 | filterOption | If true, filter options by input, if function, filter options against it. The function will receive two arguments, `inputValue` and `option`, if the function returns `true`, the option will be included in the filtered set; Otherwise, it will be excluded. | boolean or function(inputValue, option) | true |  |
-| optionLabelProp | Which prop value of option will render as content of select. | string | `children` |  |
 | placeholder | placeholder of input | string | - |  |
 | value | selected option | string\|string\[]\|{ key: string, label: string\|ReactNode }\|Array&lt;{ key: string, label: string\|ReactNode }> | - |  |
 | onBlur | Called when leaving the component. | function() | - |  |

--- a/components/auto-complete/index.zh-CN.md
+++ b/components/auto-complete/index.zh-CN.md
@@ -26,7 +26,6 @@ title: AutoComplete
 | disabled | 是否禁用 | boolean | false |  |
 | filterOption | 是否根据输入项进行筛选。当其为一个函数时，会接收 `inputValue` `option` 两个参数，当 `option` 符合筛选条件时，应返回 `true`，反之则返回 `false`。 | boolean or function(inputValue, option) | true |  |
 | getPopupContainer | 菜单渲染父节点。默认渲染到 body 上，如果你遇到菜单滚动定位问题，试试修改为滚动的区域，并相对其定位。[示例](https://codesandbox.io/s/4j168r7jw0) | Function(triggerNode) | () => document.body |  |
-| optionLabelProp | 回填到选择框的 Option 的属性值，默认是 Option 的子元素。比如在子元素需要高亮效果时，此值可以设为 `value`。 | string | `children` |  |
 | placeholder | 输入框提示 | string | - |  |
 | value | 指定当前选中的条目 | string\|string\[]\|{ key: string, label: string\|ReactNode }\|Array&lt;{ key: string, label: string\|ReactNode }> | 无 |  |
 | onBlur | 失去焦点时的回调 | function() | - |  |

--- a/docs/react/migration-v4.en-US.md
+++ b/docs/react/migration-v4.en-US.md
@@ -119,14 +119,16 @@ const Demo = () => (
   - use virtual scrolling.
   - `onBlur` no longer trigger value change.
   - `dropdownMatchSelectWidth` no longer automatically adapts to the content width, please set the dropdown width with numbers.
+  - AutoComplete no longer support `optionLabelProp`. Please set Option `value` directly.
 - The Grid component uses flex layout.
 - Button's `danger` is now treated as a property instead of a button type.
 - Input, Select set `value` to `undefined` is uncontrolled mode now.
 - Table rewrite.
+
   - will keep at least one column even if `columns` is empty.
   - Nest `dataIndex` definition changes from `'xxx.yyy'` to `['xxx', 'yyy']`.
-  
-```diff
+
+````diff
 <Table
   columns={[
     {
@@ -155,7 +157,7 @@ yarn global add @ant-design/codemod-v4
 
 # Execute
 antd4-codemod src
-```
+````
 
 <img src="https://gw.alipayobjects.com/mdn/rms_08e378/afts/img/A*QdcbQoLC-cQAAAAAAAAAAABkARQnAQ" alt="codemod running" width="720" />
 

--- a/docs/react/migration-v4.en-US.md
+++ b/docs/react/migration-v4.en-US.md
@@ -128,7 +128,7 @@ const Demo = () => (
   - will keep at least one column even if `columns` is empty.
   - Nest `dataIndex` definition changes from `'xxx.yyy'` to `['xxx', 'yyy']`.
 
-````diff
+```diff
 <Table
   columns={[
     {
@@ -138,6 +138,7 @@ const Demo = () => (
     },
   ]}
 />
+```
 
 ## Start upgrading
 
@@ -157,7 +158,7 @@ yarn global add @ant-design/codemod-v4
 
 # Execute
 antd4-codemod src
-````
+```
 
 <img src="https://gw.alipayobjects.com/mdn/rms_08e378/afts/img/A*QdcbQoLC-cQAAAAAAAAAAABkARQnAQ" alt="codemod running" width="720" />
 

--- a/docs/react/migration-v4.zh-CN.md
+++ b/docs/react/migration-v4.zh-CN.md
@@ -119,6 +119,7 @@ const Demo = () => (
   - 使用虚拟滚动。
   - `onBlur` 时不再修改选中值。
   - `dropdownMatchSelectWidth` 不再自动适应内容宽度，请用数字设置下拉宽度。
+  - AutoComplete 不在支持 `optionLabelProp`，请直接设置 Option `value` 属性。
 - Grid 组件使用 flex 布局。
 - Button 的 `danger` 现在作为一个属性而不是按钮类型。
 - Input、Select 的 `value` 为 `undefined` 时改为非受控状态。

--- a/docs/react/migration-v4.zh-CN.md
+++ b/docs/react/migration-v4.zh-CN.md
@@ -119,7 +119,7 @@ const Demo = () => (
   - 使用虚拟滚动。
   - `onBlur` 时不再修改选中值。
   - `dropdownMatchSelectWidth` 不再自动适应内容宽度，请用数字设置下拉宽度。
-  - AutoComplete 不在支持 `optionLabelProp`，请直接设置 Option `value` 属性。
+  - AutoComplete 不再支持 `optionLabelProp`，请直接设置 Option `value` 属性。
 - Grid 组件使用 flex 布局。
 - Button 的 `danger` 现在作为一个属性而不是按钮类型。
 - Input、Select 的 `value` 为 `undefined` 时改为非受控状态。


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

 close #21458


-----
[View rendered components/auto-complete/index.en-US.md](https://github.com/ant-design/ant-design/blob/auto-docs/components/auto-complete/index.en-US.md)
[View rendered components/auto-complete/index.zh-CN.md](https://github.com/ant-design/ant-design/blob/auto-docs/components/auto-complete/index.zh-CN.md)
[View rendered docs/react/migration-v4.en-US.md](https://github.com/ant-design/ant-design/blob/auto-docs/docs/react/migration-v4.en-US.md)
[View rendered docs/react/migration-v4.zh-CN.md](https://github.com/ant-design/ant-design/blob/auto-docs/docs/react/migration-v4.zh-CN.md)