### PR TITLE
fix: upload 识别图片类型逻辑错误

### DIFF
--- a/components/upload/__tests__/upload.test.js
+++ b/components/upload/__tests__/upload.test.js
@@ -498,4 +498,12 @@ describe('Upload', () => {
     );
     errorSpy.mockRestore();
   });
+
+  it('it should be treated as file but not an image', () => {
+    const file = { status: 'done', uid: '-1', type: 'video/mp4', url: 'https://zos.alipayobjects.com/rmsportal/IQKRngzUuFzJzGzRJXUs.png' };
+    const wrapper = mount(
+      <Upload listType="picture-card" fileList={[file]} />,
+    );
+    expect(wrapper.find('img').length).toBe(0);
+  });
 });

--- a/components/upload/utils.tsx
+++ b/components/upload/utils.tsx
@@ -42,11 +42,11 @@ const extname = (url: string = '') => {
   return (/\.[^./\\]*$/.exec(filenameWithoutSuffix) || [''])[0];
 };
 
-const isImageFileType = (type: string): boolean => !!type && type.indexOf('image/') === 0;
+const isImageFileType = (type: string): boolean => type.indexOf('image/') === 0;
 
 export const isImageUrl = (file: UploadFile): boolean => {
-  if (isImageFileType(file.type)) {
-    return true;
+  if (file.type) {
+    return isImageFileType(file.type);
   }
   const url: string = (file.thumbUrl || file.url) as string;
   const extension = extname(url);
@@ -70,7 +70,7 @@ export const isImageUrl = (file: UploadFile): boolean => {
 const MEASURE_SIZE = 200;
 export function previewImage(file: File | Blob): Promise<string> {
   return new Promise(resolve => {
-    if (!isImageFileType(file.type)) {
+    if (!file.type || !isImageFileType(file.type)) {
       resolve('');
       return;
     }


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

新特性请提交至 feature 分支，其余可提交至 master 分支。
在一个维护者审核通过后合并。
请确保填写以下 pull request 的信息，谢谢！~

[[English Template / 英文模板](?expand=1)]
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 组件样式改进
- [ ] TypeScript 定义更新
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
需求背景：当上传的文件为非图片，且服务端返回的资源链接不具有扩展名时，UploadList 依然会将该文件识别为图片，并导致渲染的预览图出错。
解决方案：在判断文件是否为图片时，如果有文件类型 (type)，则直接依据类型作出判断。
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志怎么写？

<!--
> 从用户角度描述具体变化，以及可能的 breaking change 和其他风险？
-->

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |  fix uploaded file type  detection |
| 🇨🇳 中文 |    修复上传文件类型判断错误      |

- 中文（可选）:

### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供