### PR TITLE
fix: Form item has default height align with form size

### DIFF
--- a/components/auto-complete/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/auto-complete/__tests__/__snapshots__/demo.test.js.snap
@@ -182,189 +182,8 @@ exports[`renders ./components/auto-complete/demo/form-debug.md correctly 1`] = `
         class="ant-form-item-control-input"
       >
         <div
-          class="ant-select ant-select-auto-complete ant-select-single ant-select-show-search"
+          class="ant-form-item-control-input-content"
         >
-          <div
-            class="ant-select-selector"
-          >
-            <span
-              class="ant-select-selection-search"
-            >
-              <input
-                aria-activedescendant="undefined_list_0"
-                aria-autocomplete="list"
-                aria-controls="undefined_list"
-                aria-haspopup="listbox"
-                aria-owns="undefined_list"
-                autocomplete="off"
-                class="ant-select-selection-search-input"
-                role="combobox"
-                value=""
-              />
-            </span>
-            <span
-              class="ant-select-selection-placeholder"
-            />
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    class="ant-row ant-form-item"
-  >
-    <div
-      class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
-    >
-      <label
-        class=""
-        title="单独 TreeSelect"
-      >
-        单独 TreeSelect
-      </label>
-    </div>
-    <div
-      class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
-    >
-      <div
-        class="ant-form-item-control-input"
-      >
-        <div
-          class="ant-select ant-tree-select ant-select-single ant-select-show-arrow"
-        >
-          <div
-            class="ant-select-selector"
-          >
-            <span
-              class="ant-select-selection-search"
-            >
-              <input
-                aria-activedescendant="undefined_list_0"
-                aria-autocomplete="list"
-                aria-controls="undefined_list"
-                aria-haspopup="listbox"
-                aria-owns="undefined_list"
-                autocomplete="off"
-                class="ant-select-selection-search-input"
-                readonly=""
-                role="combobox"
-                style="opacity:0"
-                value=""
-              />
-            </span>
-            <span
-              class="ant-select-selection-placeholder"
-            />
-          </div>
-          <span
-            aria-hidden="true"
-            class="ant-select-arrow"
-            style="user-select:none;-webkit-user-select:none"
-            unselectable="on"
-          >
-            <span
-              aria-label="down"
-              class="anticon anticon-down"
-              role="img"
-            >
-              <svg
-                aria-hidden="true"
-                class=""
-                data-icon="down"
-                fill="currentColor"
-                focusable="false"
-                height="1em"
-                viewBox="64 64 896 896"
-                width="1em"
-              >
-                <path
-                  d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
-                />
-              </svg>
-            </span>
-          </span>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    class="ant-row ant-form-item"
-  >
-    <div
-      class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
-    >
-      <label
-        class=""
-        title="添加 Input.Group 正常"
-      >
-        添加 Input.Group 正常
-      </label>
-    </div>
-    <div
-      class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
-    >
-      <div
-        class="ant-form-item-control-input"
-      >
-        <span
-          class="ant-input-group ant-input-group-compact"
-        >
-          <div
-            class="ant-select ant-tree-select ant-select-single ant-select-show-arrow"
-            style="width:30%"
-          >
-            <div
-              class="ant-select-selector"
-            >
-              <span
-                class="ant-select-selection-search"
-              >
-                <input
-                  aria-activedescendant="undefined_list_0"
-                  aria-autocomplete="list"
-                  aria-controls="undefined_list"
-                  aria-haspopup="listbox"
-                  aria-owns="undefined_list"
-                  autocomplete="off"
-                  class="ant-select-selection-search-input"
-                  readonly=""
-                  role="combobox"
-                  style="opacity:0"
-                  value=""
-                />
-              </span>
-              <span
-                class="ant-select-selection-placeholder"
-              />
-            </div>
-            <span
-              aria-hidden="true"
-              class="ant-select-arrow"
-              style="user-select:none;-webkit-user-select:none"
-              unselectable="on"
-            >
-              <span
-                aria-label="down"
-                class="anticon anticon-down"
-                role="img"
-              >
-                <svg
-                  aria-hidden="true"
-                  class=""
-                  data-icon="down"
-                  fill="currentColor"
-                  focusable="false"
-                  height="1em"
-                  viewBox="64 64 896 896"
-                  width="1em"
-                >
-                  <path
-                    d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
-                  />
-                </svg>
-              </span>
-            </span>
-          </div>
           <div
             class="ant-select ant-select-auto-complete ant-select-single ant-select-show-search"
           >
@@ -391,83 +210,6 @@ exports[`renders ./components/auto-complete/demo/form-debug.md correctly 1`] = `
               />
             </div>
           </div>
-        </span>
-      </div>
-    </div>
-  </div>
-  <div
-    class="ant-row ant-form-item"
-  >
-    <div
-      class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
-    >
-      <label
-        class=""
-        title="包含 search 图标正常"
-      >
-        包含 search 图标正常
-      </label>
-    </div>
-    <div
-      class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
-    >
-      <div
-        class="ant-form-item-control-input"
-      >
-        <div
-          class="ant-select ant-select-auto-complete ant-select-single ant-select-customize-input ant-select-show-search"
-        >
-          <div
-            class="ant-select-selector"
-          >
-            <span
-              class="ant-select-selection-search"
-            >
-              <span
-                class="ant-select-selection-search-input ant-input-affix-wrapper"
-              >
-                <input
-                  aria-activedescendant="undefined_list_0"
-                  aria-autocomplete="list"
-                  aria-controls="undefined_list"
-                  aria-haspopup="listbox"
-                  aria-owns="undefined_list"
-                  autocomplete="off"
-                  class="ant-input"
-                  role="combobox"
-                  type="text"
-                  value=""
-                />
-                <span
-                  class="ant-input-suffix"
-                >
-                  <span
-                    aria-label="search"
-                    class="anticon anticon-search"
-                    role="img"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      class=""
-                      data-icon="search"
-                      fill="currentColor"
-                      focusable="false"
-                      height="1em"
-                      viewBox="64 64 896 896"
-                      width="1em"
-                    >
-                      <path
-                        d="M909.6 854.5L649.9 594.8C690.2 542.7 712 479 712 412c0-80.2-31.3-155.4-87.9-212.1-56.6-56.7-132-87.9-212.1-87.9s-155.5 31.3-212.1 87.9C143.2 256.5 112 331.8 112 412c0 80.1 31.3 155.5 87.9 212.1C256.5 680.8 331.8 712 412 712c67 0 130.6-21.8 182.7-62l259.7 259.6a8.2 8.2 0 0011.6 0l43.6-43.5a8.2 8.2 0 000-11.6zM570.4 570.4C528 612.7 471.8 636 412 636s-116-23.3-158.4-65.6C211.3 528 188 471.8 188 412s23.3-116.1 65.6-158.4C296 211.3 352.2 188 412 188s116.1 23.2 158.4 65.6S636 352.2 636 412s-23.3 116.1-65.6 158.4z"
-                      />
-                    </svg>
-                  </span>
-                </span>
-              </span>
-            </span>
-            <span
-              class="ant-select-selection-placeholder"
-            />
-          </div>
         </div>
       </div>
     </div>
@@ -480,9 +222,9 @@ exports[`renders ./components/auto-complete/demo/form-debug.md correctly 1`] = `
     >
       <label
         class=""
-        title="同时有 Input.Group 和图标发生移位"
+        title="单独 TreeSelect"
       >
-        同时有 Input.Group 和图标发生移位
+        单独 TreeSelect
       </label>
     </div>
     <div
@@ -491,12 +233,11 @@ exports[`renders ./components/auto-complete/demo/form-debug.md correctly 1`] = `
       <div
         class="ant-form-item-control-input"
       >
-        <span
-          class="ant-input-group ant-input-group-compact"
+        <div
+          class="ant-form-item-control-input-content"
         >
           <div
             class="ant-select ant-tree-select ant-select-single ant-select-show-arrow"
-            style="width:30%"
           >
             <div
               class="ant-select-selector"
@@ -550,6 +291,144 @@ exports[`renders ./components/auto-complete/demo/form-debug.md correctly 1`] = `
               </span>
             </span>
           </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-row ant-form-item"
+  >
+    <div
+      class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
+    >
+      <label
+        class=""
+        title="添加 Input.Group 正常"
+      >
+        添加 Input.Group 正常
+      </label>
+    </div>
+    <div
+      class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
+    >
+      <div
+        class="ant-form-item-control-input"
+      >
+        <div
+          class="ant-form-item-control-input-content"
+        >
+          <span
+            class="ant-input-group ant-input-group-compact"
+          >
+            <div
+              class="ant-select ant-tree-select ant-select-single ant-select-show-arrow"
+              style="width:30%"
+            >
+              <div
+                class="ant-select-selector"
+              >
+                <span
+                  class="ant-select-selection-search"
+                >
+                  <input
+                    aria-activedescendant="undefined_list_0"
+                    aria-autocomplete="list"
+                    aria-controls="undefined_list"
+                    aria-haspopup="listbox"
+                    aria-owns="undefined_list"
+                    autocomplete="off"
+                    class="ant-select-selection-search-input"
+                    readonly=""
+                    role="combobox"
+                    style="opacity:0"
+                    value=""
+                  />
+                </span>
+                <span
+                  class="ant-select-selection-placeholder"
+                />
+              </div>
+              <span
+                aria-hidden="true"
+                class="ant-select-arrow"
+                style="user-select:none;-webkit-user-select:none"
+                unselectable="on"
+              >
+                <span
+                  aria-label="down"
+                  class="anticon anticon-down"
+                  role="img"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class=""
+                    data-icon="down"
+                    fill="currentColor"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                    />
+                  </svg>
+                </span>
+              </span>
+            </div>
+            <div
+              class="ant-select ant-select-auto-complete ant-select-single ant-select-show-search"
+            >
+              <div
+                class="ant-select-selector"
+              >
+                <span
+                  class="ant-select-selection-search"
+                >
+                  <input
+                    aria-activedescendant="undefined_list_0"
+                    aria-autocomplete="list"
+                    aria-controls="undefined_list"
+                    aria-haspopup="listbox"
+                    aria-owns="undefined_list"
+                    autocomplete="off"
+                    class="ant-select-selection-search-input"
+                    role="combobox"
+                    value=""
+                  />
+                </span>
+                <span
+                  class="ant-select-selection-placeholder"
+                />
+              </div>
+            </div>
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-row ant-form-item"
+  >
+    <div
+      class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
+    >
+      <label
+        class=""
+        title="包含 search 图标正常"
+      >
+        包含 search 图标正常
+      </label>
+    </div>
+    <div
+      class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
+    >
+      <div
+        class="ant-form-item-control-input"
+      >
+        <div
+          class="ant-form-item-control-input-content"
+        >
           <div
             class="ant-select ant-select-auto-complete ant-select-single ant-select-customize-input ant-select-show-search"
           >
@@ -605,7 +484,148 @@ exports[`renders ./components/auto-complete/demo/form-debug.md correctly 1`] = `
               />
             </div>
           </div>
-        </span>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-row ant-form-item"
+  >
+    <div
+      class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
+    >
+      <label
+        class=""
+        title="同时有 Input.Group 和图标发生移位"
+      >
+        同时有 Input.Group 和图标发生移位
+      </label>
+    </div>
+    <div
+      class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
+    >
+      <div
+        class="ant-form-item-control-input"
+      >
+        <div
+          class="ant-form-item-control-input-content"
+        >
+          <span
+            class="ant-input-group ant-input-group-compact"
+          >
+            <div
+              class="ant-select ant-tree-select ant-select-single ant-select-show-arrow"
+              style="width:30%"
+            >
+              <div
+                class="ant-select-selector"
+              >
+                <span
+                  class="ant-select-selection-search"
+                >
+                  <input
+                    aria-activedescendant="undefined_list_0"
+                    aria-autocomplete="list"
+                    aria-controls="undefined_list"
+                    aria-haspopup="listbox"
+                    aria-owns="undefined_list"
+                    autocomplete="off"
+                    class="ant-select-selection-search-input"
+                    readonly=""
+                    role="combobox"
+                    style="opacity:0"
+                    value=""
+                  />
+                </span>
+                <span
+                  class="ant-select-selection-placeholder"
+                />
+              </div>
+              <span
+                aria-hidden="true"
+                class="ant-select-arrow"
+                style="user-select:none;-webkit-user-select:none"
+                unselectable="on"
+              >
+                <span
+                  aria-label="down"
+                  class="anticon anticon-down"
+                  role="img"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class=""
+                    data-icon="down"
+                    fill="currentColor"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                    />
+                  </svg>
+                </span>
+              </span>
+            </div>
+            <div
+              class="ant-select ant-select-auto-complete ant-select-single ant-select-customize-input ant-select-show-search"
+            >
+              <div
+                class="ant-select-selector"
+              >
+                <span
+                  class="ant-select-selection-search"
+                >
+                  <span
+                    class="ant-select-selection-search-input ant-input-affix-wrapper"
+                  >
+                    <input
+                      aria-activedescendant="undefined_list_0"
+                      aria-autocomplete="list"
+                      aria-controls="undefined_list"
+                      aria-haspopup="listbox"
+                      aria-owns="undefined_list"
+                      autocomplete="off"
+                      class="ant-input"
+                      role="combobox"
+                      type="text"
+                      value=""
+                    />
+                    <span
+                      class="ant-input-suffix"
+                    >
+                      <span
+                        aria-label="search"
+                        class="anticon anticon-search"
+                        role="img"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class=""
+                          data-icon="search"
+                          fill="currentColor"
+                          focusable="false"
+                          height="1em"
+                          viewBox="64 64 896 896"
+                          width="1em"
+                        >
+                          <path
+                            d="M909.6 854.5L649.9 594.8C690.2 542.7 712 479 712 412c0-80.2-31.3-155.4-87.9-212.1-56.6-56.7-132-87.9-212.1-87.9s-155.5 31.3-212.1 87.9C143.2 256.5 112 331.8 112 412c0 80.1 31.3 155.5 87.9 212.1C256.5 680.8 331.8 712 412 712c67 0 130.6-21.8 182.7-62l259.7 259.6a8.2 8.2 0 0011.6 0l43.6-43.5a8.2 8.2 0 000-11.6zM570.4 570.4C528 612.7 471.8 636 412 636s-116-23.3-158.4-65.6C211.3 528 188 471.8 188 412s23.3-116.1 65.6-158.4C296 211.3 352.2 188 412 188s116.1 23.2 158.4 65.6S636 352.2 636 412s-23.3 116.1-65.6 158.4z"
+                          />
+                        </svg>
+                      </span>
+                    </span>
+                  </span>
+                </span>
+                <span
+                  class="ant-select-selection-placeholder"
+                />
+              </div>
+            </div>
+          </span>
+        </div>
       </div>
     </div>
   </div>
@@ -628,76 +648,21 @@ exports[`renders ./components/auto-complete/demo/form-debug.md correctly 1`] = `
       <div
         class="ant-form-item-control-input"
       >
-        <span
-          class="ant-input-group ant-input-group-compact"
+        <div
+          class="ant-form-item-control-input-content"
         >
-          <div
-            class="ant-select ant-tree-select ant-select-single ant-select-show-arrow"
-            style="width:30%"
+          <span
+            class="ant-input-group ant-input-group-compact"
           >
             <div
-              class="ant-select-selector"
+              class="ant-select ant-tree-select ant-select-single ant-select-show-arrow"
+              style="width:30%"
             >
-              <span
-                class="ant-select-selection-search"
-              >
-                <input
-                  aria-activedescendant="undefined_list_0"
-                  aria-autocomplete="list"
-                  aria-controls="undefined_list"
-                  aria-haspopup="listbox"
-                  aria-owns="undefined_list"
-                  autocomplete="off"
-                  class="ant-select-selection-search-input"
-                  readonly=""
-                  role="combobox"
-                  style="opacity:0"
-                  value=""
-                />
-              </span>
-              <span
-                class="ant-select-selection-placeholder"
-              />
-            </div>
-            <span
-              aria-hidden="true"
-              class="ant-select-arrow"
-              style="user-select:none;-webkit-user-select:none"
-              unselectable="on"
-            >
-              <span
-                aria-label="down"
-                class="anticon anticon-down"
-                role="img"
-              >
-                <svg
-                  aria-hidden="true"
-                  class=""
-                  data-icon="down"
-                  fill="currentColor"
-                  focusable="false"
-                  height="1em"
-                  viewBox="64 64 896 896"
-                  width="1em"
-                >
-                  <path
-                    d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
-                  />
-                </svg>
-              </span>
-            </span>
-          </div>
-          <div
-            class="ant-select ant-select-auto-complete ant-select-single ant-select-customize-input ant-select-show-search"
-          >
-            <div
-              class="ant-select-selector"
-            >
-              <span
-                class="ant-select-selection-search"
+              <div
+                class="ant-select-selector"
               >
                 <span
-                  class="ant-input-search ant-select-selection-search-input ant-input-affix-wrapper"
+                  class="ant-select-selection-search"
                 >
                   <input
                     aria-activedescendant="undefined_list_0"
@@ -706,44 +671,103 @@ exports[`renders ./components/auto-complete/demo/form-debug.md correctly 1`] = `
                     aria-haspopup="listbox"
                     aria-owns="undefined_list"
                     autocomplete="off"
-                    class="ant-input"
+                    class="ant-select-selection-search-input"
+                    readonly=""
                     role="combobox"
-                    type="text"
+                    style="opacity:0"
                     value=""
                   />
-                  <span
-                    class="ant-input-suffix"
+                </span>
+                <span
+                  class="ant-select-selection-placeholder"
+                />
+              </div>
+              <span
+                aria-hidden="true"
+                class="ant-select-arrow"
+                style="user-select:none;-webkit-user-select:none"
+                unselectable="on"
+              >
+                <span
+                  aria-label="down"
+                  class="anticon anticon-down"
+                  role="img"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class=""
+                    data-icon="down"
+                    fill="currentColor"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
                   >
+                    <path
+                      d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                    />
+                  </svg>
+                </span>
+              </span>
+            </div>
+            <div
+              class="ant-select ant-select-auto-complete ant-select-single ant-select-customize-input ant-select-show-search"
+            >
+              <div
+                class="ant-select-selector"
+              >
+                <span
+                  class="ant-select-selection-search"
+                >
+                  <span
+                    class="ant-input-search ant-select-selection-search-input ant-input-affix-wrapper"
+                  >
+                    <input
+                      aria-activedescendant="undefined_list_0"
+                      aria-autocomplete="list"
+                      aria-controls="undefined_list"
+                      aria-haspopup="listbox"
+                      aria-owns="undefined_list"
+                      autocomplete="off"
+                      class="ant-input"
+                      role="combobox"
+                      type="text"
+                      value=""
+                    />
                     <span
-                      aria-label="search"
-                      class="anticon anticon-search ant-input-search-icon"
-                      role="img"
-                      tabindex="-1"
+                      class="ant-input-suffix"
                     >
-                      <svg
-                        aria-hidden="true"
-                        class=""
-                        data-icon="search"
-                        fill="currentColor"
-                        focusable="false"
-                        height="1em"
-                        viewBox="64 64 896 896"
-                        width="1em"
+                      <span
+                        aria-label="search"
+                        class="anticon anticon-search ant-input-search-icon"
+                        role="img"
+                        tabindex="-1"
                       >
-                        <path
-                          d="M909.6 854.5L649.9 594.8C690.2 542.7 712 479 712 412c0-80.2-31.3-155.4-87.9-212.1-56.6-56.7-132-87.9-212.1-87.9s-155.5 31.3-212.1 87.9C143.2 256.5 112 331.8 112 412c0 80.1 31.3 155.5 87.9 212.1C256.5 680.8 331.8 712 412 712c67 0 130.6-21.8 182.7-62l259.7 259.6a8.2 8.2 0 0011.6 0l43.6-43.5a8.2 8.2 0 000-11.6zM570.4 570.4C528 612.7 471.8 636 412 636s-116-23.3-158.4-65.6C211.3 528 188 471.8 188 412s23.3-116.1 65.6-158.4C296 211.3 352.2 188 412 188s116.1 23.2 158.4 65.6S636 352.2 636 412s-23.3 116.1-65.6 158.4z"
-                        />
-                      </svg>
+                        <svg
+                          aria-hidden="true"
+                          class=""
+                          data-icon="search"
+                          fill="currentColor"
+                          focusable="false"
+                          height="1em"
+                          viewBox="64 64 896 896"
+                          width="1em"
+                        >
+                          <path
+                            d="M909.6 854.5L649.9 594.8C690.2 542.7 712 479 712 412c0-80.2-31.3-155.4-87.9-212.1-56.6-56.7-132-87.9-212.1-87.9s-155.5 31.3-212.1 87.9C143.2 256.5 112 331.8 112 412c0 80.1 31.3 155.5 87.9 212.1C256.5 680.8 331.8 712 412 712c67 0 130.6-21.8 182.7-62l259.7 259.6a8.2 8.2 0 0011.6 0l43.6-43.5a8.2 8.2 0 000-11.6zM570.4 570.4C528 612.7 471.8 636 412 636s-116-23.3-158.4-65.6C211.3 528 188 471.8 188 412s23.3-116.1 65.6-158.4C296 211.3 352.2 188 412 188s116.1 23.2 158.4 65.6S636 352.2 636 412s-23.3 116.1-65.6 158.4z"
+                          />
+                        </svg>
+                      </span>
                     </span>
                   </span>
                 </span>
-              </span>
-              <span
-                class="ant-select-selection-placeholder"
-              />
+                <span
+                  class="ant-select-selection-placeholder"
+                />
+              </div>
             </div>
-          </div>
-        </span>
+          </span>
+        </div>
       </div>
     </div>
   </div>
@@ -766,76 +790,21 @@ exports[`renders ./components/auto-complete/demo/form-debug.md correctly 1`] = `
       <div
         class="ant-form-item-control-input"
       >
-        <span
-          class="ant-input-group ant-input-group-compact"
+        <div
+          class="ant-form-item-control-input-content"
         >
-          <div
-            class="ant-select ant-tree-select ant-select-single ant-select-show-arrow"
-            style="width:20%"
+          <span
+            class="ant-input-group ant-input-group-compact"
           >
             <div
-              class="ant-select-selector"
+              class="ant-select ant-tree-select ant-select-single ant-select-show-arrow"
+              style="width:20%"
             >
-              <span
-                class="ant-select-selection-search"
-              >
-                <input
-                  aria-activedescendant="undefined_list_0"
-                  aria-autocomplete="list"
-                  aria-controls="undefined_list"
-                  aria-haspopup="listbox"
-                  aria-owns="undefined_list"
-                  autocomplete="off"
-                  class="ant-select-selection-search-input"
-                  readonly=""
-                  role="combobox"
-                  style="opacity:0"
-                  value=""
-                />
-              </span>
-              <span
-                class="ant-select-selection-placeholder"
-              />
-            </div>
-            <span
-              aria-hidden="true"
-              class="ant-select-arrow"
-              style="user-select:none;-webkit-user-select:none"
-              unselectable="on"
-            >
-              <span
-                aria-label="down"
-                class="anticon anticon-down"
-                role="img"
-              >
-                <svg
-                  aria-hidden="true"
-                  class=""
-                  data-icon="down"
-                  fill="currentColor"
-                  focusable="false"
-                  height="1em"
-                  viewBox="64 64 896 896"
-                  width="1em"
-                >
-                  <path
-                    d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
-                  />
-                </svg>
-              </span>
-            </span>
-          </div>
-          <div
-            class="ant-select ant-select-auto-complete ant-select-single ant-select-customize-input ant-select-show-search"
-          >
-            <div
-              class="ant-select-selector"
-            >
-              <span
-                class="ant-select-selection-search"
+              <div
+                class="ant-select-selector"
               >
                 <span
-                  class="ant-input-search ant-select-selection-search-input ant-input-affix-wrapper"
+                  class="ant-select-selection-search"
                 >
                   <input
                     aria-activedescendant="undefined_list_0"
@@ -844,72 +813,131 @@ exports[`renders ./components/auto-complete/demo/form-debug.md correctly 1`] = `
                     aria-haspopup="listbox"
                     aria-owns="undefined_list"
                     autocomplete="off"
-                    class="ant-input"
+                    class="ant-select-selection-search-input"
+                    readonly=""
                     role="combobox"
-                    type="text"
+                    style="opacity:0"
                     value=""
                   />
-                  <span
-                    class="ant-input-suffix"
+                </span>
+                <span
+                  class="ant-select-selection-placeholder"
+                />
+              </div>
+              <span
+                aria-hidden="true"
+                class="ant-select-arrow"
+                style="user-select:none;-webkit-user-select:none"
+                unselectable="on"
+              >
+                <span
+                  aria-label="down"
+                  class="anticon anticon-down"
+                  role="img"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class=""
+                    data-icon="down"
+                    fill="currentColor"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
                   >
+                    <path
+                      d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                    />
+                  </svg>
+                </span>
+              </span>
+            </div>
+            <div
+              class="ant-select ant-select-auto-complete ant-select-single ant-select-customize-input ant-select-show-search"
+            >
+              <div
+                class="ant-select-selector"
+              >
+                <span
+                  class="ant-select-selection-search"
+                >
+                  <span
+                    class="ant-input-search ant-select-selection-search-input ant-input-affix-wrapper"
+                  >
+                    <input
+                      aria-activedescendant="undefined_list_0"
+                      aria-autocomplete="list"
+                      aria-controls="undefined_list"
+                      aria-haspopup="listbox"
+                      aria-owns="undefined_list"
+                      autocomplete="off"
+                      class="ant-input"
+                      role="combobox"
+                      type="text"
+                      value=""
+                    />
                     <span
-                      aria-label="search"
-                      class="anticon anticon-search ant-input-search-icon"
-                      role="img"
-                      tabindex="-1"
+                      class="ant-input-suffix"
                     >
-                      <svg
-                        aria-hidden="true"
-                        class=""
-                        data-icon="search"
-                        fill="currentColor"
-                        focusable="false"
-                        height="1em"
-                        viewBox="64 64 896 896"
-                        width="1em"
+                      <span
+                        aria-label="search"
+                        class="anticon anticon-search ant-input-search-icon"
+                        role="img"
+                        tabindex="-1"
                       >
-                        <path
-                          d="M909.6 854.5L649.9 594.8C690.2 542.7 712 479 712 412c0-80.2-31.3-155.4-87.9-212.1-56.6-56.7-132-87.9-212.1-87.9s-155.5 31.3-212.1 87.9C143.2 256.5 112 331.8 112 412c0 80.1 31.3 155.5 87.9 212.1C256.5 680.8 331.8 712 412 712c67 0 130.6-21.8 182.7-62l259.7 259.6a8.2 8.2 0 0011.6 0l43.6-43.5a8.2 8.2 0 000-11.6zM570.4 570.4C528 612.7 471.8 636 412 636s-116-23.3-158.4-65.6C211.3 528 188 471.8 188 412s23.3-116.1 65.6-158.4C296 211.3 352.2 188 412 188s116.1 23.2 158.4 65.6S636 352.2 636 412s-23.3 116.1-65.6 158.4z"
-                        />
-                      </svg>
+                        <svg
+                          aria-hidden="true"
+                          class=""
+                          data-icon="search"
+                          fill="currentColor"
+                          focusable="false"
+                          height="1em"
+                          viewBox="64 64 896 896"
+                          width="1em"
+                        >
+                          <path
+                            d="M909.6 854.5L649.9 594.8C690.2 542.7 712 479 712 412c0-80.2-31.3-155.4-87.9-212.1-56.6-56.7-132-87.9-212.1-87.9s-155.5 31.3-212.1 87.9C143.2 256.5 112 331.8 112 412c0 80.1 31.3 155.5 87.9 212.1C256.5 680.8 331.8 712 412 712c67 0 130.6-21.8 182.7-62l259.7 259.6a8.2 8.2 0 0011.6 0l43.6-43.5a8.2 8.2 0 000-11.6zM570.4 570.4C528 612.7 471.8 636 412 636s-116-23.3-158.4-65.6C211.3 528 188 471.8 188 412s23.3-116.1 65.6-158.4C296 211.3 352.2 188 412 188s116.1 23.2 158.4 65.6S636 352.2 636 412s-23.3 116.1-65.6 158.4z"
+                          />
+                        </svg>
+                      </span>
                     </span>
                   </span>
                 </span>
-              </span>
-              <span
-                class="ant-select-selection-placeholder"
-              />
-            </div>
-          </div>
-          <button
-            class="ant-btn ant-btn-primary"
-            type="button"
-          >
-            <span
-              aria-label="search"
-              class="anticon anticon-search"
-              role="img"
-            >
-              <svg
-                aria-hidden="true"
-                class=""
-                data-icon="search"
-                fill="currentColor"
-                focusable="false"
-                height="1em"
-                viewBox="64 64 896 896"
-                width="1em"
-              >
-                <path
-                  d="M909.6 854.5L649.9 594.8C690.2 542.7 712 479 712 412c0-80.2-31.3-155.4-87.9-212.1-56.6-56.7-132-87.9-212.1-87.9s-155.5 31.3-212.1 87.9C143.2 256.5 112 331.8 112 412c0 80.1 31.3 155.5 87.9 212.1C256.5 680.8 331.8 712 412 712c67 0 130.6-21.8 182.7-62l259.7 259.6a8.2 8.2 0 0011.6 0l43.6-43.5a8.2 8.2 0 000-11.6zM570.4 570.4C528 612.7 471.8 636 412 636s-116-23.3-158.4-65.6C211.3 528 188 471.8 188 412s23.3-116.1 65.6-158.4C296 211.3 352.2 188 412 188s116.1 23.2 158.4 65.6S636 352.2 636 412s-23.3 116.1-65.6 158.4z"
+                <span
+                  class="ant-select-selection-placeholder"
                 />
-              </svg>
-            </span>
-            <span>
-              Search
-            </span>
-          </button>
-        </span>
+              </div>
+            </div>
+            <button
+              class="ant-btn ant-btn-primary"
+              type="button"
+            >
+              <span
+                aria-label="search"
+                class="anticon anticon-search"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  class=""
+                  data-icon="search"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M909.6 854.5L649.9 594.8C690.2 542.7 712 479 712 412c0-80.2-31.3-155.4-87.9-212.1-56.6-56.7-132-87.9-212.1-87.9s-155.5 31.3-212.1 87.9C143.2 256.5 112 331.8 112 412c0 80.1 31.3 155.5 87.9 212.1C256.5 680.8 331.8 712 412 712c67 0 130.6-21.8 182.7-62l259.7 259.6a8.2 8.2 0 0011.6 0l43.6-43.5a8.2 8.2 0 000-11.6zM570.4 570.4C528 612.7 471.8 636 412 636s-116-23.3-158.4-65.6C211.3 528 188 471.8 188 412s23.3-116.1 65.6-158.4C296 211.3 352.2 188 412 188s116.1 23.2 158.4 65.6S636 352.2 636 412s-23.3 116.1-65.6 158.4z"
+                  />
+                </svg>
+              </span>
+              <span>
+                Search
+              </span>
+            </button>
+          </span>
+        </div>
       </div>
     </div>
   </div>

--- a/components/comment/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/comment/__tests__/__snapshots__/demo.test.js.snap
@@ -160,10 +160,14 @@ exports[`renders ./components/comment/demo/editor.md correctly 1`] = `
                 <div
                   class="ant-form-item-control-input"
                 >
-                  <textarea
-                    class="ant-input"
-                    rows="4"
-                  />
+                  <div
+                    class="ant-form-item-control-input-content"
+                  >
+                    <textarea
+                      class="ant-input"
+                      rows="4"
+                    />
+                  </div>
                 </div>
               </div>
             </div>
@@ -176,14 +180,18 @@ exports[`renders ./components/comment/demo/editor.md correctly 1`] = `
                 <div
                   class="ant-form-item-control-input"
                 >
-                  <button
-                    class="ant-btn ant-btn-primary"
-                    type="submit"
+                  <div
+                    class="ant-form-item-control-input-content"
                   >
-                    <span>
-                      Add Comment
-                    </span>
-                  </button>
+                    <button
+                      class="ant-btn ant-btn-primary"
+                      type="submit"
+                    >
+                      <span>
+                        Add Comment
+                      </span>
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>

--- a/components/config-provider/__tests__/__snapshots__/components.test.js.snap
+++ b/components/config-provider/__tests__/__snapshots__/components.test.js.snap
@@ -6979,11 +6979,15 @@ exports[`ConfigProvider components Form configProvider 1`] = `
       <div
         class="config-form-item-control-input"
       >
-        <input
-          class="config-input"
-          type="text"
-          value=""
-        />
+        <div
+          class="config-form-item-control-input-content"
+        >
+          <input
+            class="config-input"
+            type="text"
+            value=""
+          />
+        </div>
       </div>
       <div
         class="config-form-item-explain"
@@ -7010,11 +7014,15 @@ exports[`ConfigProvider components Form normal 1`] = `
       <div
         class="ant-form-item-control-input"
       >
-        <input
-          class="ant-input"
-          type="text"
-          value=""
-        />
+        <div
+          class="ant-form-item-control-input-content"
+        >
+          <input
+            class="ant-input"
+            type="text"
+            value=""
+          />
+        </div>
       </div>
       <div
         class="ant-form-item-explain"
@@ -7041,11 +7049,15 @@ exports[`ConfigProvider components Form prefixCls 1`] = `
       <div
         class="prefix-Form-item-control-input"
       >
-        <input
-          class="prefix-Form"
-          type="text"
-          value=""
-        />
+        <div
+          class="prefix-Form-item-control-input-content"
+        >
+          <input
+            class="prefix-Form"
+            type="text"
+            value=""
+          />
+        </div>
       </div>
       <div
         class="prefix-Form-item-explain"

--- a/components/form/Form.tsx
+++ b/components/form/Form.tsx
@@ -8,7 +8,7 @@ import { ConfigContext, ConfigConsumerProps } from '../config-provider';
 import { FormContext } from './context';
 import { FormLabelAlign } from './interface';
 import { useForm, FormInstance } from './util';
-import { SizeType, SizeContextProvider } from '../config-provider/SizeContext';
+import SizeContext, { SizeType, SizeContextProvider } from '../config-provider/SizeContext';
 
 export type FormLayout = 'horizontal' | 'inline' | 'vertical';
 
@@ -26,6 +26,7 @@ export interface FormProps extends Omit<RcFormProps, 'form'> {
 }
 
 const InternalForm: React.FC<FormProps> = (props, ref) => {
+  const contextSize = React.useContext(SizeContext);
   const { getPrefixCls, direction }: ConfigConsumerProps = React.useContext(ConfigContext);
 
   const {
@@ -39,7 +40,7 @@ const InternalForm: React.FC<FormProps> = (props, ref) => {
     hideRequiredMark,
     className = '',
     layout = 'horizontal',
-    size,
+    size = contextSize,
   } = props;
   const prefixCls = getPrefixCls('form', customizePrefixCls);
 
@@ -49,6 +50,7 @@ const InternalForm: React.FC<FormProps> = (props, ref) => {
       [`${prefixCls}-${layout}`]: true,
       [`${prefixCls}-hide-required-mark`]: hideRequiredMark,
       [`${prefixCls}-rtl`]: direction === 'rtl',
+      [`${prefixCls}-${size}`]: size,
     },
     className,
   );

--- a/components/form/FormItemInput.tsx
+++ b/components/form/FormItemInput.tsx
@@ -92,7 +92,7 @@ const FormItemInput: React.FC<FormItemInputProps & FormItemInputMiscProps> = ({
     <FormContext.Provider value={subFormContext}>
       <Col {...mergedWrapperCol} className={className}>
         <div className={`${baseClassName}-control-input`}>
-          {children}
+          <div className={`${baseClassName}-control-input-content`}>{children}</div>
           {icon}
         </div>
         <CSSMotion

--- a/components/form/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/form/__tests__/__snapshots__/demo.test.js.snap
@@ -34,13 +34,17 @@ exports[`renders ./components/form/demo/advanced-search.md correctly 1`] = `
             <div
               class="ant-form-item-control-input"
             >
-              <input
-                class="ant-input"
-                id="advanced_search_field-0"
-                placeholder="placeholder"
-                type="text"
-                value=""
-              />
+              <div
+                class="ant-form-item-control-input-content"
+              >
+                <input
+                  class="ant-input"
+                  id="advanced_search_field-0"
+                  placeholder="placeholder"
+                  type="text"
+                  value=""
+                />
+              </div>
             </div>
           </div>
         </div>
@@ -69,13 +73,17 @@ exports[`renders ./components/form/demo/advanced-search.md correctly 1`] = `
             <div
               class="ant-form-item-control-input"
             >
-              <input
-                class="ant-input"
-                id="advanced_search_field-1"
-                placeholder="placeholder"
-                type="text"
-                value=""
-              />
+              <div
+                class="ant-form-item-control-input-content"
+              >
+                <input
+                  class="ant-input"
+                  id="advanced_search_field-1"
+                  placeholder="placeholder"
+                  type="text"
+                  value=""
+                />
+              </div>
             </div>
           </div>
         </div>
@@ -104,13 +112,17 @@ exports[`renders ./components/form/demo/advanced-search.md correctly 1`] = `
             <div
               class="ant-form-item-control-input"
             >
-              <input
-                class="ant-input"
-                id="advanced_search_field-2"
-                placeholder="placeholder"
-                type="text"
-                value=""
-              />
+              <div
+                class="ant-form-item-control-input-content"
+              >
+                <input
+                  class="ant-input"
+                  id="advanced_search_field-2"
+                  placeholder="placeholder"
+                  type="text"
+                  value=""
+                />
+              </div>
             </div>
           </div>
         </div>
@@ -139,13 +151,17 @@ exports[`renders ./components/form/demo/advanced-search.md correctly 1`] = `
             <div
               class="ant-form-item-control-input"
             >
-              <input
-                class="ant-input"
-                id="advanced_search_field-3"
-                placeholder="placeholder"
-                type="text"
-                value=""
-              />
+              <div
+                class="ant-form-item-control-input-content"
+              >
+                <input
+                  class="ant-input"
+                  id="advanced_search_field-3"
+                  placeholder="placeholder"
+                  type="text"
+                  value=""
+                />
+              </div>
             </div>
           </div>
         </div>
@@ -174,13 +190,17 @@ exports[`renders ./components/form/demo/advanced-search.md correctly 1`] = `
             <div
               class="ant-form-item-control-input"
             >
-              <input
-                class="ant-input"
-                id="advanced_search_field-4"
-                placeholder="placeholder"
-                type="text"
-                value=""
-              />
+              <div
+                class="ant-form-item-control-input-content"
+              >
+                <input
+                  class="ant-input"
+                  id="advanced_search_field-4"
+                  placeholder="placeholder"
+                  type="text"
+                  value=""
+                />
+              </div>
             </div>
           </div>
         </div>
@@ -209,13 +229,17 @@ exports[`renders ./components/form/demo/advanced-search.md correctly 1`] = `
             <div
               class="ant-form-item-control-input"
             >
-              <input
-                class="ant-input"
-                id="advanced_search_field-5"
-                placeholder="placeholder"
-                type="text"
-                value=""
-              />
+              <div
+                class="ant-form-item-control-input-content"
+              >
+                <input
+                  class="ant-input"
+                  id="advanced_search_field-5"
+                  placeholder="placeholder"
+                  type="text"
+                  value=""
+                />
+              </div>
             </div>
           </div>
         </div>
@@ -306,12 +330,16 @@ exports[`renders ./components/form/demo/basic.md correctly 1`] = `
       <div
         class="ant-form-item-control-input"
       >
-        <input
-          class="ant-input"
-          id="basic_username"
-          type="text"
-          value=""
-        />
+        <div
+          class="ant-form-item-control-input-content"
+        >
+          <input
+            class="ant-input"
+            id="basic_username"
+            type="text"
+            value=""
+          />
+        </div>
       </div>
     </div>
   </div>
@@ -335,77 +363,49 @@ exports[`renders ./components/form/demo/basic.md correctly 1`] = `
       <div
         class="ant-form-item-control-input"
       >
-        <span
-          class="ant-input-password ant-input-affix-wrapper"
-        >
-          <input
-            action="click"
-            class="ant-input"
-            id="basic_password"
-            type="password"
-            value=""
-          />
-          <span
-            class="ant-input-suffix"
-          >
-            <span
-              aria-label="eye-invisible"
-              class="anticon anticon-eye-invisible ant-input-password-icon"
-              role="img"
-              tabindex="-1"
-            >
-              <svg
-                aria-hidden="true"
-                class=""
-                data-icon="eye-invisible"
-                fill="currentColor"
-                focusable="false"
-                height="1em"
-                viewBox="64 64 896 896"
-                width="1em"
-              >
-                <path
-                  d="M942.2 486.2Q889.47 375.11 816.7 305l-50.88 50.88C807.31 395.53 843.45 447.4 874.7 512 791.5 684.2 673.4 766 512 766q-72.67 0-133.87-22.38L323 798.75Q408 838 512 838q288.3 0 430.2-300.3a60.29 60.29 0 000-51.5zm-63.57-320.64L836 122.88a8 8 0 00-11.32 0L715.31 232.2Q624.86 186 512 186q-288.3 0-430.2 300.3a60.3 60.3 0 000 51.5q56.69 119.4 136.5 191.41L112.48 835a8 8 0 000 11.31L155.17 889a8 8 0 0011.31 0l712.15-712.12a8 8 0 000-11.32zM149.3 512C232.6 339.8 350.7 258 512 258c54.54 0 104.13 9.36 149.12 28.39l-70.3 70.3a176 176 0 00-238.13 238.13l-83.42 83.42C223.1 637.49 183.3 582.28 149.3 512zm246.7 0a112.11 112.11 0 01146.2-106.69L401.31 546.2A112 112 0 01396 512z"
-                />
-                <path
-                  d="M508 624c-3.46 0-6.87-.16-10.25-.47l-52.82 52.82a176.09 176.09 0 00227.42-227.42l-52.82 52.82c.31 3.38.47 6.79.47 10.25a111.94 111.94 0 01-112 112z"
-                />
-              </svg>
-            </span>
-          </span>
-        </span>
-      </div>
-    </div>
-  </div>
-  <div
-    class="ant-row ant-form-item"
-  >
-    <div
-      class="ant-col ant-col-16 ant-col-offset-8 ant-form-item-control"
-    >
-      <div
-        class="ant-form-item-control-input"
-      >
-        <label
-          class="ant-checkbox-wrapper ant-checkbox-wrapper-checked"
+        <div
+          class="ant-form-item-control-input-content"
         >
           <span
-            class="ant-checkbox ant-checkbox-checked"
+            class="ant-input-password ant-input-affix-wrapper"
           >
             <input
-              checked=""
-              class="ant-checkbox-input"
-              id="basic_remember"
-              type="checkbox"
+              action="click"
+              class="ant-input"
+              id="basic_password"
+              type="password"
+              value=""
             />
             <span
-              class="ant-checkbox-inner"
-            />
+              class="ant-input-suffix"
+            >
+              <span
+                aria-label="eye-invisible"
+                class="anticon anticon-eye-invisible ant-input-password-icon"
+                role="img"
+                tabindex="-1"
+              >
+                <svg
+                  aria-hidden="true"
+                  class=""
+                  data-icon="eye-invisible"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M942.2 486.2Q889.47 375.11 816.7 305l-50.88 50.88C807.31 395.53 843.45 447.4 874.7 512 791.5 684.2 673.4 766 512 766q-72.67 0-133.87-22.38L323 798.75Q408 838 512 838q288.3 0 430.2-300.3a60.29 60.29 0 000-51.5zm-63.57-320.64L836 122.88a8 8 0 00-11.32 0L715.31 232.2Q624.86 186 512 186q-288.3 0-430.2 300.3a60.3 60.3 0 000 51.5q56.69 119.4 136.5 191.41L112.48 835a8 8 0 000 11.31L155.17 889a8 8 0 0011.31 0l712.15-712.12a8 8 0 000-11.32zM149.3 512C232.6 339.8 350.7 258 512 258c54.54 0 104.13 9.36 149.12 28.39l-70.3 70.3a176 176 0 00-238.13 238.13l-83.42 83.42C223.1 637.49 183.3 582.28 149.3 512zm246.7 0a112.11 112.11 0 01146.2-106.69L401.31 546.2A112 112 0 01396 512z"
+                  />
+                  <path
+                    d="M508 624c-3.46 0-6.87-.16-10.25-.47l-52.82 52.82a176.09 176.09 0 00227.42-227.42l-52.82 52.82c.31 3.38.47 6.79.47 10.25a111.94 111.94 0 01-112 112z"
+                  />
+                </svg>
+              </span>
+            </span>
           </span>
-          <span>
-            Remember me
-          </span>
-        </label>
+        </div>
       </div>
     </div>
   </div>
@@ -418,14 +418,54 @@ exports[`renders ./components/form/demo/basic.md correctly 1`] = `
       <div
         class="ant-form-item-control-input"
       >
-        <button
-          class="ant-btn ant-btn-primary"
-          type="submit"
+        <div
+          class="ant-form-item-control-input-content"
         >
-          <span>
-            Submit
-          </span>
-        </button>
+          <label
+            class="ant-checkbox-wrapper ant-checkbox-wrapper-checked"
+          >
+            <span
+              class="ant-checkbox ant-checkbox-checked"
+            >
+              <input
+                checked=""
+                class="ant-checkbox-input"
+                id="basic_remember"
+                type="checkbox"
+              />
+              <span
+                class="ant-checkbox-inner"
+              />
+            </span>
+            <span>
+              Remember me
+            </span>
+          </label>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-row ant-form-item"
+  >
+    <div
+      class="ant-col ant-col-16 ant-col-offset-8 ant-form-item-control"
+    >
+      <div
+        class="ant-form-item-control-input"
+      >
+        <div
+          class="ant-form-item-control-input-content"
+        >
+          <button
+            class="ant-btn ant-btn-primary"
+            type="submit"
+          >
+            <span>
+              Submit
+            </span>
+          </button>
+        </div>
       </div>
     </div>
   </div>
@@ -457,12 +497,16 @@ exports[`renders ./components/form/demo/control-hooks.md correctly 1`] = `
       <div
         class="ant-form-item-control-input"
       >
-        <input
-          class="ant-input"
-          id="control-hooks_note"
-          type="text"
-          value=""
-        />
+        <div
+          class="ant-form-item-control-input-content"
+        >
+          <input
+            class="ant-input"
+            id="control-hooks_note"
+            type="text"
+            value=""
+          />
+        </div>
       </div>
     </div>
   </div>
@@ -487,62 +531,66 @@ exports[`renders ./components/form/demo/control-hooks.md correctly 1`] = `
         class="ant-form-item-control-input"
       >
         <div
-          class="ant-select ant-select-single ant-select-allow-clear ant-select-show-arrow"
+          class="ant-form-item-control-input-content"
         >
           <div
-            class="ant-select-selector"
+            class="ant-select ant-select-single ant-select-allow-clear ant-select-show-arrow"
           >
-            <span
-              class="ant-select-selection-search"
+            <div
+              class="ant-select-selector"
             >
-              <input
-                aria-activedescendant="control-hooks_gender_list_0"
-                aria-autocomplete="list"
-                aria-controls="control-hooks_gender_list"
-                aria-haspopup="listbox"
-                aria-owns="control-hooks_gender_list"
-                autocomplete="off"
-                class="ant-select-selection-search-input"
-                id="control-hooks_gender"
-                readonly=""
-                role="combobox"
-                style="opacity:0"
-                value=""
-              />
-            </span>
+              <span
+                class="ant-select-selection-search"
+              >
+                <input
+                  aria-activedescendant="control-hooks_gender_list_0"
+                  aria-autocomplete="list"
+                  aria-controls="control-hooks_gender_list"
+                  aria-haspopup="listbox"
+                  aria-owns="control-hooks_gender_list"
+                  autocomplete="off"
+                  class="ant-select-selection-search-input"
+                  id="control-hooks_gender"
+                  readonly=""
+                  role="combobox"
+                  style="opacity:0"
+                  value=""
+                />
+              </span>
+              <span
+                class="ant-select-selection-placeholder"
+              >
+                Select a option and change input text above
+              </span>
+            </div>
             <span
-              class="ant-select-selection-placeholder"
+              aria-hidden="true"
+              class="ant-select-arrow"
+              style="user-select:none;-webkit-user-select:none"
+              unselectable="on"
             >
-              Select a option and change input text above
+              <span
+                aria-label="down"
+                class="anticon anticon-down"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  class=""
+                  data-icon="down"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                  />
+                </svg>
+              </span>
             </span>
           </div>
-          <span
-            aria-hidden="true"
-            class="ant-select-arrow"
-            style="user-select:none;-webkit-user-select:none"
-            unselectable="on"
-          >
-            <span
-              aria-label="down"
-              class="anticon anticon-down"
-              role="img"
-            >
-              <svg
-                aria-hidden="true"
-                class=""
-                data-icon="down"
-                fill="currentColor"
-                focusable="false"
-                height="1em"
-                viewBox="64 64 896 896"
-                width="1em"
-              >
-                <path
-                  d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
-                />
-              </svg>
-            </span>
-          </span>
         </div>
       </div>
     </div>
@@ -556,30 +604,34 @@ exports[`renders ./components/form/demo/control-hooks.md correctly 1`] = `
       <div
         class="ant-form-item-control-input"
       >
-        <button
-          class="ant-btn ant-btn-primary"
-          type="submit"
+        <div
+          class="ant-form-item-control-input-content"
         >
-          <span>
-            Submit
-          </span>
-        </button>
-        <button
-          class="ant-btn"
-          type="button"
-        >
-          <span>
-            Reset
-          </span>
-        </button>
-        <button
-          class="ant-btn ant-btn-link"
-          type="button"
-        >
-          <span>
-            Fill form
-          </span>
-        </button>
+          <button
+            class="ant-btn ant-btn-primary"
+            type="submit"
+          >
+            <span>
+              Submit
+            </span>
+          </button>
+          <button
+            class="ant-btn"
+            type="button"
+          >
+            <span>
+              Reset
+            </span>
+          </button>
+          <button
+            class="ant-btn ant-btn-link"
+            type="button"
+          >
+            <span>
+              Fill form
+            </span>
+          </button>
+        </div>
       </div>
     </div>
   </div>
@@ -611,12 +663,16 @@ exports[`renders ./components/form/demo/control-ref.md correctly 1`] = `
       <div
         class="ant-form-item-control-input"
       >
-        <input
-          class="ant-input"
-          id="control-ref_note"
-          type="text"
-          value=""
-        />
+        <div
+          class="ant-form-item-control-input-content"
+        >
+          <input
+            class="ant-input"
+            id="control-ref_note"
+            type="text"
+            value=""
+          />
+        </div>
       </div>
     </div>
   </div>
@@ -641,62 +697,66 @@ exports[`renders ./components/form/demo/control-ref.md correctly 1`] = `
         class="ant-form-item-control-input"
       >
         <div
-          class="ant-select ant-select-single ant-select-allow-clear ant-select-show-arrow"
+          class="ant-form-item-control-input-content"
         >
           <div
-            class="ant-select-selector"
+            class="ant-select ant-select-single ant-select-allow-clear ant-select-show-arrow"
           >
-            <span
-              class="ant-select-selection-search"
+            <div
+              class="ant-select-selector"
             >
-              <input
-                aria-activedescendant="control-ref_gender_list_0"
-                aria-autocomplete="list"
-                aria-controls="control-ref_gender_list"
-                aria-haspopup="listbox"
-                aria-owns="control-ref_gender_list"
-                autocomplete="off"
-                class="ant-select-selection-search-input"
-                id="control-ref_gender"
-                readonly=""
-                role="combobox"
-                style="opacity:0"
-                value=""
-              />
-            </span>
+              <span
+                class="ant-select-selection-search"
+              >
+                <input
+                  aria-activedescendant="control-ref_gender_list_0"
+                  aria-autocomplete="list"
+                  aria-controls="control-ref_gender_list"
+                  aria-haspopup="listbox"
+                  aria-owns="control-ref_gender_list"
+                  autocomplete="off"
+                  class="ant-select-selection-search-input"
+                  id="control-ref_gender"
+                  readonly=""
+                  role="combobox"
+                  style="opacity:0"
+                  value=""
+                />
+              </span>
+              <span
+                class="ant-select-selection-placeholder"
+              >
+                Select a option and change input text above
+              </span>
+            </div>
             <span
-              class="ant-select-selection-placeholder"
+              aria-hidden="true"
+              class="ant-select-arrow"
+              style="user-select:none;-webkit-user-select:none"
+              unselectable="on"
             >
-              Select a option and change input text above
+              <span
+                aria-label="down"
+                class="anticon anticon-down"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  class=""
+                  data-icon="down"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                  />
+                </svg>
+              </span>
             </span>
           </div>
-          <span
-            aria-hidden="true"
-            class="ant-select-arrow"
-            style="user-select:none;-webkit-user-select:none"
-            unselectable="on"
-          >
-            <span
-              aria-label="down"
-              class="anticon anticon-down"
-              role="img"
-            >
-              <svg
-                aria-hidden="true"
-                class=""
-                data-icon="down"
-                fill="currentColor"
-                focusable="false"
-                height="1em"
-                viewBox="64 64 896 896"
-                width="1em"
-              >
-                <path
-                  d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
-                />
-              </svg>
-            </span>
-          </span>
         </div>
       </div>
     </div>
@@ -710,30 +770,34 @@ exports[`renders ./components/form/demo/control-ref.md correctly 1`] = `
       <div
         class="ant-form-item-control-input"
       >
-        <button
-          class="ant-btn ant-btn-primary"
-          type="submit"
+        <div
+          class="ant-form-item-control-input-content"
         >
-          <span>
-            Submit
-          </span>
-        </button>
-        <button
-          class="ant-btn"
-          type="button"
-        >
-          <span>
-            Reset
-          </span>
-        </button>
-        <button
-          class="ant-btn ant-btn-link"
-          type="button"
-        >
-          <span>
-            Fill form
-          </span>
-        </button>
+          <button
+            class="ant-btn ant-btn-primary"
+            type="submit"
+          >
+            <span>
+              Submit
+            </span>
+          </button>
+          <button
+            class="ant-btn"
+            type="button"
+          >
+            <span>
+              Reset
+            </span>
+          </button>
+          <button
+            class="ant-btn ant-btn-link"
+            type="button"
+          >
+            <span>
+              Fill form
+            </span>
+          </button>
+        </div>
       </div>
     </div>
   </div>
@@ -765,72 +829,76 @@ exports[`renders ./components/form/demo/customized-form-controls.md correctly 1`
       <div
         class="ant-form-item-control-input"
       >
-        <span>
-          <input
-            class="ant-input"
-            style="width:100px;margin-right:8px"
-            type="text"
-            value="0"
-          />
-          <div
-            class="ant-select ant-select-single ant-select-show-arrow"
-            style="width:80px"
-          >
+        <div
+          class="ant-form-item-control-input-content"
+        >
+          <span>
+            <input
+              class="ant-input"
+              style="width:100px;margin-right:8px"
+              type="text"
+              value="0"
+            />
             <div
-              class="ant-select-selector"
+              class="ant-select ant-select-single ant-select-show-arrow"
+              style="width:80px"
             >
-              <span
-                class="ant-select-selection-search"
+              <div
+                class="ant-select-selector"
               >
-                <input
-                  aria-activedescendant="undefined_list_0"
-                  aria-autocomplete="list"
-                  aria-controls="undefined_list"
-                  aria-haspopup="listbox"
-                  aria-owns="undefined_list"
-                  autocomplete="off"
-                  class="ant-select-selection-search-input"
-                  readonly=""
-                  role="combobox"
-                  style="opacity:0"
-                  value=""
-                />
-              </span>
+                <span
+                  class="ant-select-selection-search"
+                >
+                  <input
+                    aria-activedescendant="undefined_list_0"
+                    aria-autocomplete="list"
+                    aria-controls="undefined_list"
+                    aria-haspopup="listbox"
+                    aria-owns="undefined_list"
+                    autocomplete="off"
+                    class="ant-select-selection-search-input"
+                    readonly=""
+                    role="combobox"
+                    style="opacity:0"
+                    value=""
+                  />
+                </span>
+                <span
+                  class="ant-select-selection-item"
+                >
+                  RMB
+                </span>
+              </div>
               <span
-                class="ant-select-selection-item"
+                aria-hidden="true"
+                class="ant-select-arrow"
+                style="user-select:none;-webkit-user-select:none"
+                unselectable="on"
               >
-                RMB
+                <span
+                  aria-label="down"
+                  class="anticon anticon-down"
+                  role="img"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class=""
+                    data-icon="down"
+                    fill="currentColor"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                    />
+                  </svg>
+                </span>
               </span>
             </div>
-            <span
-              aria-hidden="true"
-              class="ant-select-arrow"
-              style="user-select:none;-webkit-user-select:none"
-              unselectable="on"
-            >
-              <span
-                aria-label="down"
-                class="anticon anticon-down"
-                role="img"
-              >
-                <svg
-                  aria-hidden="true"
-                  class=""
-                  data-icon="down"
-                  fill="currentColor"
-                  focusable="false"
-                  height="1em"
-                  viewBox="64 64 896 896"
-                  width="1em"
-                >
-                  <path
-                    d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
-                  />
-                </svg>
-              </span>
-            </span>
-          </div>
-        </span>
+          </span>
+        </div>
       </div>
     </div>
   </div>
@@ -843,14 +911,18 @@ exports[`renders ./components/form/demo/customized-form-controls.md correctly 1`
       <div
         class="ant-form-item-control-input"
       >
-        <button
-          class="ant-btn ant-btn-primary"
-          type="submit"
+        <div
+          class="ant-form-item-control-input-content"
         >
-          <span>
-            Submit
-          </span>
-        </button>
+          <button
+            class="ant-btn ant-btn-primary"
+            type="submit"
+          >
+            <span>
+              Submit
+            </span>
+          </button>
+        </div>
       </div>
     </div>
   </div>
@@ -872,39 +944,43 @@ exports[`renders ./components/form/demo/dynamic-form-item.md correctly 1`] = `
         <div
           class="ant-form-item-control-input"
         >
-          <button
-            class="ant-btn ant-btn-dashed"
-            style="width:60%"
-            type="button"
+          <div
+            class="ant-form-item-control-input-content"
           >
-            <span
-              aria-label="plus"
-              class="anticon anticon-plus"
-              role="img"
+            <button
+              class="ant-btn ant-btn-dashed"
+              style="width:60%"
+              type="button"
             >
-              <svg
-                aria-hidden="true"
-                class=""
-                data-icon="plus"
-                fill="currentColor"
-                focusable="false"
-                height="1em"
-                viewBox="64 64 896 896"
-                width="1em"
+              <span
+                aria-label="plus"
+                class="anticon anticon-plus"
+                role="img"
               >
-                <defs />
-                <path
-                  d="M482 152h60q8 0 8 8v704q0 8-8 8h-60q-8 0-8-8V160q0-8 8-8z"
-                />
-                <path
-                  d="M176 474h672q8 0 8 8v60q0 8-8 8H176q-8 0-8-8v-60q0-8 8-8z"
-                />
-              </svg>
-            </span>
-            <span>
-               Add field
-            </span>
-          </button>
+                <svg
+                  aria-hidden="true"
+                  class=""
+                  data-icon="plus"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <defs />
+                  <path
+                    d="M482 152h60q8 0 8 8v704q0 8-8 8h-60q-8 0-8-8V160q0-8 8-8z"
+                  />
+                  <path
+                    d="M176 474h672q8 0 8 8v60q0 8-8 8H176q-8 0-8-8v-60q0-8 8-8z"
+                  />
+                </svg>
+              </span>
+              <span>
+                 Add field
+              </span>
+            </button>
+          </div>
         </div>
       </div>
     </div>
@@ -918,14 +994,18 @@ exports[`renders ./components/form/demo/dynamic-form-item.md correctly 1`] = `
       <div
         class="ant-form-item-control-input"
       >
-        <button
-          class="ant-btn ant-btn-primary"
-          type="submit"
+        <div
+          class="ant-form-item-control-input-content"
         >
-          <span>
-            Submit
-          </span>
-        </button>
+          <button
+            class="ant-btn ant-btn-primary"
+            type="submit"
+          >
+            <span>
+              Submit
+            </span>
+          </button>
+        </div>
       </div>
     </div>
   </div>
@@ -957,13 +1037,17 @@ exports[`renders ./components/form/demo/dynamic-rule.md correctly 1`] = `
       <div
         class="ant-form-item-control-input"
       >
-        <input
-          class="ant-input"
-          id="dynamic_rule_username"
-          placeholder="Please input your name"
-          type="text"
-          value=""
-        />
+        <div
+          class="ant-form-item-control-input-content"
+        >
+          <input
+            class="ant-input"
+            id="dynamic_rule_username"
+            placeholder="Please input your name"
+            type="text"
+            value=""
+          />
+        </div>
       </div>
     </div>
   </div>
@@ -987,13 +1071,17 @@ exports[`renders ./components/form/demo/dynamic-rule.md correctly 1`] = `
       <div
         class="ant-form-item-control-input"
       >
-        <input
-          class="ant-input"
-          id="dynamic_rule_nickname"
-          placeholder="Please input your nickname"
-          type="text"
-          value=""
-        />
+        <div
+          class="ant-form-item-control-input-content"
+        >
+          <input
+            class="ant-input"
+            id="dynamic_rule_nickname"
+            placeholder="Please input your nickname"
+            type="text"
+            value=""
+          />
+        </div>
       </div>
     </div>
   </div>
@@ -1006,24 +1094,28 @@ exports[`renders ./components/form/demo/dynamic-rule.md correctly 1`] = `
       <div
         class="ant-form-item-control-input"
       >
-        <label
-          class="ant-checkbox-wrapper"
+        <div
+          class="ant-form-item-control-input-content"
         >
-          <span
-            class="ant-checkbox"
+          <label
+            class="ant-checkbox-wrapper"
           >
-            <input
-              class="ant-checkbox-input"
-              type="checkbox"
-            />
             <span
-              class="ant-checkbox-inner"
-            />
-          </span>
-          <span>
-            Nickname is required
-          </span>
-        </label>
+              class="ant-checkbox"
+            >
+              <input
+                class="ant-checkbox-input"
+                type="checkbox"
+              />
+              <span
+                class="ant-checkbox-inner"
+              />
+            </span>
+            <span>
+              Nickname is required
+            </span>
+          </label>
+        </div>
       </div>
     </div>
   </div>
@@ -1036,14 +1128,18 @@ exports[`renders ./components/form/demo/dynamic-rule.md correctly 1`] = `
       <div
         class="ant-form-item-control-input"
       >
-        <button
-          class="ant-btn ant-btn-primary"
-          type="button"
+        <div
+          class="ant-form-item-control-input-content"
         >
-          <span>
-            Check
-          </span>
-        </button>
+          <button
+            class="ant-btn ant-btn-primary"
+            type="button"
+          >
+            <span>
+              Check
+            </span>
+          </button>
+        </div>
       </div>
     </div>
   </div>
@@ -1076,12 +1172,16 @@ exports[`renders ./components/form/demo/form-context.md correctly 1`] = `
         <div
           class="ant-form-item-control-input"
         >
-          <input
-            class="ant-input"
-            id="basicForm_group"
-            type="text"
-            value=""
-          />
+          <div
+            class="ant-form-item-control-input-content"
+          >
+            <input
+              class="ant-input"
+              id="basicForm_group"
+              type="text"
+              value=""
+            />
+          </div>
         </div>
       </div>
     </div>
@@ -1104,32 +1204,36 @@ exports[`renders ./components/form/demo/form-context.md correctly 1`] = `
         <div
           class="ant-form-item-control-input"
         >
-          <span
-            class="ant-typography ant-form-text ant-typography-secondary"
+          <div
+            class="ant-form-item-control-input-content"
           >
-            ( 
             <span
-              aria-label="smile"
-              class="anticon anticon-smile"
-              role="img"
+              class="ant-typography ant-form-text ant-typography-secondary"
             >
-              <svg
-                aria-hidden="true"
-                class=""
-                data-icon="smile"
-                fill="currentColor"
-                focusable="false"
-                height="1em"
-                viewBox="64 64 896 896"
-                width="1em"
+              ( 
+              <span
+                aria-label="smile"
+                class="anticon anticon-smile"
+                role="img"
               >
-                <path
-                  d="M288 421a48 48 0 1096 0 48 48 0 10-96 0zm352 0a48 48 0 1096 0 48 48 0 10-96 0zM512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm263 711c-34.2 34.2-74 61-118.3 79.8C611 874.2 562.3 884 512 884c-50.3 0-99-9.8-144.8-29.2A370.4 370.4 0 01248.9 775c-34.2-34.2-61-74-79.8-118.3C149.8 611 140 562.3 140 512s9.8-99 29.2-144.8A370.4 370.4 0 01249 248.9c34.2-34.2 74-61 118.3-79.8C413 149.8 461.7 140 512 140c50.3 0 99 9.8 144.8 29.2A370.4 370.4 0 01775.1 249c34.2 34.2 61 74 79.8 118.3C874.2 413 884 461.7 884 512s-9.8 99-29.2 144.8A368.89 368.89 0 01775 775zM664 533h-48.1c-4.2 0-7.8 3.2-8.1 7.4C604 589.9 562.5 629 512 629s-92.1-39.1-95.8-88.6c-.3-4.2-3.9-7.4-8.1-7.4H360a8 8 0 00-8 8.4c4.4 84.3 74.5 151.6 160 151.6s155.6-67.3 160-151.6a8 8 0 00-8-8.4z"
-                />
-              </svg>
+                <svg
+                  aria-hidden="true"
+                  class=""
+                  data-icon="smile"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M288 421a48 48 0 1096 0 48 48 0 10-96 0zm352 0a48 48 0 1096 0 48 48 0 10-96 0zM512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm263 711c-34.2 34.2-74 61-118.3 79.8C611 874.2 562.3 884 512 884c-50.3 0-99-9.8-144.8-29.2A370.4 370.4 0 01248.9 775c-34.2-34.2-61-74-79.8-118.3C149.8 611 140 562.3 140 512s9.8-99 29.2-144.8A370.4 370.4 0 01249 248.9c34.2-34.2 74-61 118.3-79.8C413 149.8 461.7 140 512 140c50.3 0 99 9.8 144.8 29.2A370.4 370.4 0 01775.1 249c34.2 34.2 61 74 79.8 118.3C874.2 413 884 461.7 884 512s-9.8 99-29.2 144.8A368.89 368.89 0 01775 775zM664 533h-48.1c-4.2 0-7.8 3.2-8.1 7.4C604 589.9 562.5 629 512 629s-92.1-39.1-95.8-88.6c-.3-4.2-3.9-7.4-8.1-7.4H360a8 8 0 00-8 8.4c4.4 84.3 74.5 151.6 160 151.6s155.6-67.3 160-151.6a8 8 0 00-8-8.4z"
+                  />
+                </svg>
+              </span>
+               No user yet. )
             </span>
-             No user yet. )
-          </span>
+          </div>
         </div>
       </div>
     </div>
@@ -1142,23 +1246,27 @@ exports[`renders ./components/form/demo/form-context.md correctly 1`] = `
         <div
           class="ant-form-item-control-input"
         >
-          <button
-            class="ant-btn ant-btn-primary"
-            type="submit"
+          <div
+            class="ant-form-item-control-input-content"
           >
-            <span>
-              Submit
-            </span>
-          </button>
-          <button
-            class="ant-btn"
-            style="margin-left:8px"
-            type="button"
-          >
-            <span>
-              Add User
-            </span>
-          </button>
+            <button
+              class="ant-btn ant-btn-primary"
+              type="submit"
+            >
+              <span>
+                Submit
+              </span>
+            </button>
+            <button
+              class="ant-btn"
+              style="margin-left:8px"
+              type="button"
+            >
+              <span>
+                Add User
+              </span>
+            </button>
+          </div>
         </div>
       </div>
     </div>
@@ -1205,12 +1313,16 @@ exports[`renders ./components/form/demo/global-state.md correctly 1`] = `
         <div
           class="ant-form-item-control-input"
         >
-          <input
-            class="ant-input"
-            id="global_state_username"
-            type="text"
-            value=""
-          />
+          <div
+            class="ant-form-item-control-input-content"
+          >
+            <input
+              class="ant-input"
+              id="global_state_username"
+              type="text"
+              value=""
+            />
+          </div>
         </div>
       </div>
     </div>
@@ -1244,41 +1356,45 @@ exports[`renders ./components/form/demo/inline-login.md correctly 1`] = `
       <div
         class="ant-form-item-control-input"
       >
-        <span
-          class="ant-input-affix-wrapper"
+        <div
+          class="ant-form-item-control-input-content"
         >
           <span
-            class="ant-input-prefix"
+            class="ant-input-affix-wrapper"
           >
             <span
-              aria-label="user"
-              class="anticon anticon-user site-form-item-icon"
-              role="img"
+              class="ant-input-prefix"
             >
-              <svg
-                aria-hidden="true"
-                class=""
-                data-icon="user"
-                fill="currentColor"
-                focusable="false"
-                height="1em"
-                viewBox="64 64 896 896"
-                width="1em"
+              <span
+                aria-label="user"
+                class="anticon anticon-user site-form-item-icon"
+                role="img"
               >
-                <path
-                  d="M858.5 763.6a374 374 0 00-80.6-119.5 375.63 375.63 0 00-119.5-80.6c-.4-.2-.8-.3-1.2-.5C719.5 518 760 444.7 760 362c0-137-111-248-248-248S264 225 264 362c0 82.7 40.5 156 102.8 201.1-.4.2-.8.3-1.2.5-44.8 18.9-85 46-119.5 80.6a375.63 375.63 0 00-80.6 119.5A371.7 371.7 0 00136 901.8a8 8 0 008 8.2h60c4.4 0 7.9-3.5 8-7.8 2-77.2 33-149.5 87.8-204.3 56.7-56.7 132-87.9 212.2-87.9s155.5 31.2 212.2 87.9C779 752.7 810 825 812 902.2c.1 4.4 3.6 7.8 8 7.8h60a8 8 0 008-8.2c-1-47.8-10.9-94.3-29.5-138.2zM512 534c-45.9 0-89.1-17.9-121.6-50.4S340 407.9 340 362c0-45.9 17.9-89.1 50.4-121.6S466.1 190 512 190s89.1 17.9 121.6 50.4S684 316.1 684 362c0 45.9-17.9 89.1-50.4 121.6S557.9 534 512 534z"
-                />
-              </svg>
+                <svg
+                  aria-hidden="true"
+                  class=""
+                  data-icon="user"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M858.5 763.6a374 374 0 00-80.6-119.5 375.63 375.63 0 00-119.5-80.6c-.4-.2-.8-.3-1.2-.5C719.5 518 760 444.7 760 362c0-137-111-248-248-248S264 225 264 362c0 82.7 40.5 156 102.8 201.1-.4.2-.8.3-1.2.5-44.8 18.9-85 46-119.5 80.6a375.63 375.63 0 00-80.6 119.5A371.7 371.7 0 00136 901.8a8 8 0 008 8.2h60c4.4 0 7.9-3.5 8-7.8 2-77.2 33-149.5 87.8-204.3 56.7-56.7 132-87.9 212.2-87.9s155.5 31.2 212.2 87.9C779 752.7 810 825 812 902.2c.1 4.4 3.6 7.8 8 7.8h60a8 8 0 008-8.2c-1-47.8-10.9-94.3-29.5-138.2zM512 534c-45.9 0-89.1-17.9-121.6-50.4S340 407.9 340 362c0-45.9 17.9-89.1 50.4-121.6S466.1 190 512 190s89.1 17.9 121.6 50.4S684 316.1 684 362c0 45.9-17.9 89.1-50.4 121.6S557.9 534 512 534z"
+                  />
+                </svg>
+              </span>
             </span>
+            <input
+              class="ant-input"
+              id="horizontal_login_username"
+              placeholder="Username"
+              type="text"
+              value=""
+            />
           </span>
-          <input
-            class="ant-input"
-            id="horizontal_login_username"
-            placeholder="Username"
-            type="text"
-            value=""
-          />
-        </span>
+        </div>
       </div>
     </div>
   </div>
@@ -1291,41 +1407,45 @@ exports[`renders ./components/form/demo/inline-login.md correctly 1`] = `
       <div
         class="ant-form-item-control-input"
       >
-        <span
-          class="ant-input-affix-wrapper"
+        <div
+          class="ant-form-item-control-input-content"
         >
           <span
-            class="ant-input-prefix"
+            class="ant-input-affix-wrapper"
           >
             <span
-              aria-label="lock"
-              class="anticon anticon-lock site-form-item-icon"
-              role="img"
+              class="ant-input-prefix"
             >
-              <svg
-                aria-hidden="true"
-                class=""
-                data-icon="lock"
-                fill="currentColor"
-                focusable="false"
-                height="1em"
-                viewBox="64 64 896 896"
-                width="1em"
+              <span
+                aria-label="lock"
+                class="anticon anticon-lock site-form-item-icon"
+                role="img"
               >
-                <path
-                  d="M832 464h-68V240c0-70.7-57.3-128-128-128H388c-70.7 0-128 57.3-128 128v224h-68c-17.7 0-32 14.3-32 32v384c0 17.7 14.3 32 32 32h640c17.7 0 32-14.3 32-32V496c0-17.7-14.3-32-32-32zM332 240c0-30.9 25.1-56 56-56h248c30.9 0 56 25.1 56 56v224H332V240zm460 600H232V536h560v304zM484 701v53c0 4.4 3.6 8 8 8h40c4.4 0 8-3.6 8-8v-53a48.01 48.01 0 10-56 0z"
-                />
-              </svg>
+                <svg
+                  aria-hidden="true"
+                  class=""
+                  data-icon="lock"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M832 464h-68V240c0-70.7-57.3-128-128-128H388c-70.7 0-128 57.3-128 128v224h-68c-17.7 0-32 14.3-32 32v384c0 17.7 14.3 32 32 32h640c17.7 0 32-14.3 32-32V496c0-17.7-14.3-32-32-32zM332 240c0-30.9 25.1-56 56-56h248c30.9 0 56 25.1 56 56v224H332V240zm460 600H232V536h560v304zM484 701v53c0 4.4 3.6 8 8 8h40c4.4 0 8-3.6 8-8v-53a48.01 48.01 0 10-56 0z"
+                  />
+                </svg>
+              </span>
             </span>
+            <input
+              class="ant-input"
+              id="horizontal_login_password"
+              placeholder="Password"
+              type="password"
+              value=""
+            />
           </span>
-          <input
-            class="ant-input"
-            id="horizontal_login_password"
-            placeholder="Password"
-            type="password"
-            value=""
-          />
-        </span>
+        </div>
       </div>
     </div>
   </div>
@@ -1338,14 +1458,18 @@ exports[`renders ./components/form/demo/inline-login.md correctly 1`] = `
       <div
         class="ant-form-item-control-input"
       >
-        <button
-          class="ant-btn ant-btn-primary"
-          type="submit"
+        <div
+          class="ant-form-item-control-input-content"
         >
-          <span>
-            Log in
-          </span>
-        </button>
+          <button
+            class="ant-btn ant-btn-primary"
+            type="submit"
+          >
+            <span>
+              Log in
+            </span>
+          </button>
+        </div>
       </div>
     </div>
   </div>
@@ -1378,67 +1502,71 @@ exports[`renders ./components/form/demo/layout.md correctly 1`] = `
           class="ant-form-item-control-input"
         >
           <div
-            class="ant-radio-group ant-radio-group-outline"
-            id="layout"
+            class="ant-form-item-control-input-content"
           >
-            <label
-              class="ant-radio-button-wrapper ant-radio-button-wrapper-checked"
+            <div
+              class="ant-radio-group ant-radio-group-outline"
+              id="layout"
             >
-              <span
-                class="ant-radio-button ant-radio-button-checked"
+              <label
+                class="ant-radio-button-wrapper ant-radio-button-wrapper-checked"
               >
-                <input
-                  checked=""
-                  class="ant-radio-button-input"
-                  type="radio"
-                  value="horizontal"
-                />
                 <span
-                  class="ant-radio-button-inner"
-                />
-              </span>
-              <span>
-                Horizontal
-              </span>
-            </label>
-            <label
-              class="ant-radio-button-wrapper"
-            >
-              <span
-                class="ant-radio-button"
+                  class="ant-radio-button ant-radio-button-checked"
+                >
+                  <input
+                    checked=""
+                    class="ant-radio-button-input"
+                    type="radio"
+                    value="horizontal"
+                  />
+                  <span
+                    class="ant-radio-button-inner"
+                  />
+                </span>
+                <span>
+                  Horizontal
+                </span>
+              </label>
+              <label
+                class="ant-radio-button-wrapper"
               >
-                <input
-                  class="ant-radio-button-input"
-                  type="radio"
-                  value="vertical"
-                />
                 <span
-                  class="ant-radio-button-inner"
-                />
-              </span>
-              <span>
-                Vertical
-              </span>
-            </label>
-            <label
-              class="ant-radio-button-wrapper"
-            >
-              <span
-                class="ant-radio-button"
+                  class="ant-radio-button"
+                >
+                  <input
+                    class="ant-radio-button-input"
+                    type="radio"
+                    value="vertical"
+                  />
+                  <span
+                    class="ant-radio-button-inner"
+                  />
+                </span>
+                <span>
+                  Vertical
+                </span>
+              </label>
+              <label
+                class="ant-radio-button-wrapper"
               >
-                <input
-                  class="ant-radio-button-input"
-                  type="radio"
-                  value="inline"
-                />
                 <span
-                  class="ant-radio-button-inner"
-                />
-              </span>
-              <span>
-                Inline
-              </span>
-            </label>
+                  class="ant-radio-button"
+                >
+                  <input
+                    class="ant-radio-button-input"
+                    type="radio"
+                    value="inline"
+                  />
+                  <span
+                    class="ant-radio-button-inner"
+                  />
+                </span>
+                <span>
+                  Inline
+                </span>
+              </label>
+            </div>
           </div>
         </div>
       </div>
@@ -1462,12 +1590,16 @@ exports[`renders ./components/form/demo/layout.md correctly 1`] = `
         <div
           class="ant-form-item-control-input"
         >
-          <input
-            class="ant-input"
-            placeholder="input placeholder"
-            type="text"
-            value=""
-          />
+          <div
+            class="ant-form-item-control-input-content"
+          >
+            <input
+              class="ant-input"
+              placeholder="input placeholder"
+              type="text"
+              value=""
+            />
+          </div>
         </div>
       </div>
     </div>
@@ -1490,12 +1622,16 @@ exports[`renders ./components/form/demo/layout.md correctly 1`] = `
         <div
           class="ant-form-item-control-input"
         >
-          <input
-            class="ant-input"
-            placeholder="input placeholder"
-            type="text"
-            value=""
-          />
+          <div
+            class="ant-form-item-control-input-content"
+          >
+            <input
+              class="ant-input"
+              placeholder="input placeholder"
+              type="text"
+              value=""
+            />
+          </div>
         </div>
       </div>
     </div>
@@ -1508,14 +1644,18 @@ exports[`renders ./components/form/demo/layout.md correctly 1`] = `
         <div
           class="ant-form-item-control-input"
         >
-          <button
-            class="ant-btn ant-btn-primary"
-            type="button"
+          <div
+            class="ant-form-item-control-input-content"
           >
-            <span>
-              Submit
-            </span>
-          </button>
+            <button
+              class="ant-btn ant-btn-primary"
+              type="button"
+            >
+              <span>
+                Submit
+              </span>
+            </button>
+          </div>
         </div>
       </div>
     </div>
@@ -1548,12 +1688,16 @@ exports[`renders ./components/form/demo/nest-messages.md correctly 1`] = `
       <div
         class="ant-form-item-control-input"
       >
-        <input
-          class="ant-input"
-          id="nest-messages_user_name"
-          type="text"
-          value=""
-        />
+        <div
+          class="ant-form-item-control-input-content"
+        >
+          <input
+            class="ant-input"
+            id="nest-messages_user_name"
+            type="text"
+            value=""
+          />
+        </div>
       </div>
     </div>
   </div>
@@ -1577,12 +1721,16 @@ exports[`renders ./components/form/demo/nest-messages.md correctly 1`] = `
       <div
         class="ant-form-item-control-input"
       >
-        <input
-          class="ant-input"
-          id="nest-messages_user_email"
-          type="text"
-          value=""
-        />
+        <div
+          class="ant-form-item-control-input-content"
+        >
+          <input
+            class="ant-input"
+            id="nest-messages_user_email"
+            type="text"
+            value=""
+          />
+        </div>
       </div>
     </div>
   </div>
@@ -1607,81 +1755,85 @@ exports[`renders ./components/form/demo/nest-messages.md correctly 1`] = `
         class="ant-form-item-control-input"
       >
         <div
-          class="ant-input-number"
+          class="ant-form-item-control-input-content"
         >
           <div
-            class="ant-input-number-handler-wrap"
+            class="ant-input-number"
           >
-            <span
-              aria-disabled="false"
-              aria-label="Increase Value"
-              class="ant-input-number-handler ant-input-number-handler-up "
-              role="button"
-              unselectable="unselectable"
+            <div
+              class="ant-input-number-handler-wrap"
             >
               <span
-                aria-label="up"
-                class="anticon anticon-up ant-input-number-handler-up-inner"
-                role="img"
+                aria-disabled="false"
+                aria-label="Increase Value"
+                class="ant-input-number-handler ant-input-number-handler-up "
+                role="button"
+                unselectable="unselectable"
               >
-                <svg
-                  aria-hidden="true"
-                  class=""
-                  data-icon="up"
-                  fill="currentColor"
-                  focusable="false"
-                  height="1em"
-                  viewBox="64 64 896 896"
-                  width="1em"
+                <span
+                  aria-label="up"
+                  class="anticon anticon-up ant-input-number-handler-up-inner"
+                  role="img"
                 >
-                  <path
-                    d="M890.5 755.3L537.9 269.2c-12.8-17.6-39-17.6-51.7 0L133.5 755.3A8 8 0 00140 768h75c5.1 0 9.9-2.5 12.9-6.6L512 369.8l284.1 391.6c3 4.1 7.8 6.6 12.9 6.6h75c6.5 0 10.3-7.4 6.5-12.7z"
-                  />
-                </svg>
+                  <svg
+                    aria-hidden="true"
+                    class=""
+                    data-icon="up"
+                    fill="currentColor"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M890.5 755.3L537.9 269.2c-12.8-17.6-39-17.6-51.7 0L133.5 755.3A8 8 0 00140 768h75c5.1 0 9.9-2.5 12.9-6.6L512 369.8l284.1 391.6c3 4.1 7.8 6.6 12.9 6.6h75c6.5 0 10.3-7.4 6.5-12.7z"
+                    />
+                  </svg>
+                </span>
               </span>
-            </span>
-            <span
-              aria-disabled="false"
-              aria-label="Decrease Value"
-              class="ant-input-number-handler ant-input-number-handler-down "
-              role="button"
-              unselectable="unselectable"
-            >
               <span
-                aria-label="down"
-                class="anticon anticon-down ant-input-number-handler-down-inner"
-                role="img"
+                aria-disabled="false"
+                aria-label="Decrease Value"
+                class="ant-input-number-handler ant-input-number-handler-down "
+                role="button"
+                unselectable="unselectable"
               >
-                <svg
-                  aria-hidden="true"
-                  class=""
-                  data-icon="down"
-                  fill="currentColor"
-                  focusable="false"
-                  height="1em"
-                  viewBox="64 64 896 896"
-                  width="1em"
+                <span
+                  aria-label="down"
+                  class="anticon anticon-down ant-input-number-handler-down-inner"
+                  role="img"
                 >
-                  <path
-                    d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
-                  />
-                </svg>
+                  <svg
+                    aria-hidden="true"
+                    class=""
+                    data-icon="down"
+                    fill="currentColor"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                    />
+                  </svg>
+                </span>
               </span>
-            </span>
-          </div>
-          <div
-            class="ant-input-number-input-wrap"
-          >
-            <input
-              aria-valuemin="-9007199254740991"
-              autocomplete="off"
-              class="ant-input-number-input"
-              id="nest-messages_user_age"
-              min="-9007199254740991"
-              role="spinbutton"
-              step="1"
-              value=""
-            />
+            </div>
+            <div
+              class="ant-input-number-input-wrap"
+            >
+              <input
+                aria-valuemin="-9007199254740991"
+                autocomplete="off"
+                class="ant-input-number-input"
+                id="nest-messages_user_age"
+                min="-9007199254740991"
+                role="spinbutton"
+                step="1"
+                value=""
+              />
+            </div>
           </div>
         </div>
       </div>
@@ -1707,12 +1859,16 @@ exports[`renders ./components/form/demo/nest-messages.md correctly 1`] = `
       <div
         class="ant-form-item-control-input"
       >
-        <input
-          class="ant-input"
-          id="nest-messages_user_website"
-          type="text"
-          value=""
-        />
+        <div
+          class="ant-form-item-control-input-content"
+        >
+          <input
+            class="ant-input"
+            id="nest-messages_user_website"
+            type="text"
+            value=""
+          />
+        </div>
       </div>
     </div>
   </div>
@@ -1736,10 +1892,14 @@ exports[`renders ./components/form/demo/nest-messages.md correctly 1`] = `
       <div
         class="ant-form-item-control-input"
       >
-        <textarea
-          class="ant-input"
-          id="nest-messages_user_introduction"
-        />
+        <div
+          class="ant-form-item-control-input-content"
+        >
+          <textarea
+            class="ant-input"
+            id="nest-messages_user_introduction"
+          />
+        </div>
       </div>
     </div>
   </div>
@@ -1752,14 +1912,18 @@ exports[`renders ./components/form/demo/nest-messages.md correctly 1`] = `
       <div
         class="ant-form-item-control-input"
       >
-        <button
-          class="ant-btn ant-btn-primary"
-          type="submit"
+        <div
+          class="ant-form-item-control-input-content"
         >
-          <span>
-            Submit
-          </span>
-        </button>
+          <button
+            class="ant-btn ant-btn-primary"
+            type="submit"
+          >
+            <span>
+              Submit
+            </span>
+          </button>
+        </div>
       </div>
     </div>
   </div>
@@ -1780,126 +1944,45 @@ exports[`renders ./components/form/demo/normal-login.md correctly 1`] = `
       <div
         class="ant-form-item-control-input"
       >
-        <span
-          class="ant-input-affix-wrapper"
+        <div
+          class="ant-form-item-control-input-content"
         >
           <span
-            class="ant-input-prefix"
+            class="ant-input-affix-wrapper"
           >
             <span
-              aria-label="user"
-              class="anticon anticon-user site-form-item-icon"
-              role="img"
+              class="ant-input-prefix"
             >
-              <svg
-                aria-hidden="true"
-                class=""
-                data-icon="user"
-                fill="currentColor"
-                focusable="false"
-                height="1em"
-                viewBox="64 64 896 896"
-                width="1em"
+              <span
+                aria-label="user"
+                class="anticon anticon-user site-form-item-icon"
+                role="img"
               >
-                <path
-                  d="M858.5 763.6a374 374 0 00-80.6-119.5 375.63 375.63 0 00-119.5-80.6c-.4-.2-.8-.3-1.2-.5C719.5 518 760 444.7 760 362c0-137-111-248-248-248S264 225 264 362c0 82.7 40.5 156 102.8 201.1-.4.2-.8.3-1.2.5-44.8 18.9-85 46-119.5 80.6a375.63 375.63 0 00-80.6 119.5A371.7 371.7 0 00136 901.8a8 8 0 008 8.2h60c4.4 0 7.9-3.5 8-7.8 2-77.2 33-149.5 87.8-204.3 56.7-56.7 132-87.9 212.2-87.9s155.5 31.2 212.2 87.9C779 752.7 810 825 812 902.2c.1 4.4 3.6 7.8 8 7.8h60a8 8 0 008-8.2c-1-47.8-10.9-94.3-29.5-138.2zM512 534c-45.9 0-89.1-17.9-121.6-50.4S340 407.9 340 362c0-45.9 17.9-89.1 50.4-121.6S466.1 190 512 190s89.1 17.9 121.6 50.4S684 316.1 684 362c0 45.9-17.9 89.1-50.4 121.6S557.9 534 512 534z"
-                />
-              </svg>
+                <svg
+                  aria-hidden="true"
+                  class=""
+                  data-icon="user"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M858.5 763.6a374 374 0 00-80.6-119.5 375.63 375.63 0 00-119.5-80.6c-.4-.2-.8-.3-1.2-.5C719.5 518 760 444.7 760 362c0-137-111-248-248-248S264 225 264 362c0 82.7 40.5 156 102.8 201.1-.4.2-.8.3-1.2.5-44.8 18.9-85 46-119.5 80.6a375.63 375.63 0 00-80.6 119.5A371.7 371.7 0 00136 901.8a8 8 0 008 8.2h60c4.4 0 7.9-3.5 8-7.8 2-77.2 33-149.5 87.8-204.3 56.7-56.7 132-87.9 212.2-87.9s155.5 31.2 212.2 87.9C779 752.7 810 825 812 902.2c.1 4.4 3.6 7.8 8 7.8h60a8 8 0 008-8.2c-1-47.8-10.9-94.3-29.5-138.2zM512 534c-45.9 0-89.1-17.9-121.6-50.4S340 407.9 340 362c0-45.9 17.9-89.1 50.4-121.6S466.1 190 512 190s89.1 17.9 121.6 50.4S684 316.1 684 362c0 45.9-17.9 89.1-50.4 121.6S557.9 534 512 534z"
+                  />
+                </svg>
+              </span>
             </span>
-          </span>
-          <input
-            class="ant-input"
-            id="normal_login_username"
-            placeholder="Username"
-            type="text"
-            value=""
-          />
-        </span>
-      </div>
-    </div>
-  </div>
-  <div
-    class="ant-row ant-form-item"
-  >
-    <div
-      class="ant-col ant-form-item-control"
-    >
-      <div
-        class="ant-form-item-control-input"
-      >
-        <span
-          class="ant-input-affix-wrapper"
-        >
-          <span
-            class="ant-input-prefix"
-          >
-            <span
-              aria-label="lock"
-              class="anticon anticon-lock site-form-item-icon"
-              role="img"
-            >
-              <svg
-                aria-hidden="true"
-                class=""
-                data-icon="lock"
-                fill="currentColor"
-                focusable="false"
-                height="1em"
-                viewBox="64 64 896 896"
-                width="1em"
-              >
-                <path
-                  d="M832 464h-68V240c0-70.7-57.3-128-128-128H388c-70.7 0-128 57.3-128 128v224h-68c-17.7 0-32 14.3-32 32v384c0 17.7 14.3 32 32 32h640c17.7 0 32-14.3 32-32V496c0-17.7-14.3-32-32-32zM332 240c0-30.9 25.1-56 56-56h248c30.9 0 56 25.1 56 56v224H332V240zm460 600H232V536h560v304zM484 701v53c0 4.4 3.6 8 8 8h40c4.4 0 8-3.6 8-8v-53a48.01 48.01 0 10-56 0z"
-                />
-              </svg>
-            </span>
-          </span>
-          <input
-            class="ant-input"
-            id="normal_login_password"
-            placeholder="Password"
-            type="password"
-            value=""
-          />
-        </span>
-      </div>
-    </div>
-  </div>
-  <div
-    class="ant-row ant-form-item"
-  >
-    <div
-      class="ant-col ant-form-item-control"
-    >
-      <div
-        class="ant-form-item-control-input"
-      >
-        <label
-          class="ant-checkbox-wrapper ant-checkbox-wrapper-checked"
-        >
-          <span
-            class="ant-checkbox ant-checkbox-checked"
-          >
             <input
-              checked=""
-              class="ant-checkbox-input"
-              id="normal_login_remember"
-              type="checkbox"
-            />
-            <span
-              class="ant-checkbox-inner"
+              class="ant-input"
+              id="normal_login_username"
+              placeholder="Username"
+              type="text"
+              value=""
             />
           </span>
-          <span>
-            Remember me
-          </span>
-        </label>
-        <a
-          class="login-form-forgot"
-          href=""
-        >
-          Forgot password
-        </a>
+        </div>
       </div>
     </div>
   </div>
@@ -1912,20 +1995,117 @@ exports[`renders ./components/form/demo/normal-login.md correctly 1`] = `
       <div
         class="ant-form-item-control-input"
       >
-        <button
-          class="ant-btn login-form-button ant-btn-primary"
-          type="submit"
+        <div
+          class="ant-form-item-control-input-content"
         >
-          <span>
-            Log in
+          <span
+            class="ant-input-affix-wrapper"
+          >
+            <span
+              class="ant-input-prefix"
+            >
+              <span
+                aria-label="lock"
+                class="anticon anticon-lock site-form-item-icon"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  class=""
+                  data-icon="lock"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M832 464h-68V240c0-70.7-57.3-128-128-128H388c-70.7 0-128 57.3-128 128v224h-68c-17.7 0-32 14.3-32 32v384c0 17.7 14.3 32 32 32h640c17.7 0 32-14.3 32-32V496c0-17.7-14.3-32-32-32zM332 240c0-30.9 25.1-56 56-56h248c30.9 0 56 25.1 56 56v224H332V240zm460 600H232V536h560v304zM484 701v53c0 4.4 3.6 8 8 8h40c4.4 0 8-3.6 8-8v-53a48.01 48.01 0 10-56 0z"
+                  />
+                </svg>
+              </span>
+            </span>
+            <input
+              class="ant-input"
+              id="normal_login_password"
+              placeholder="Password"
+              type="password"
+              value=""
+            />
           </span>
-        </button>
-        Or 
-        <a
-          href=""
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-row ant-form-item"
+  >
+    <div
+      class="ant-col ant-form-item-control"
+    >
+      <div
+        class="ant-form-item-control-input"
+      >
+        <div
+          class="ant-form-item-control-input-content"
         >
-          register now!
-        </a>
+          <label
+            class="ant-checkbox-wrapper ant-checkbox-wrapper-checked"
+          >
+            <span
+              class="ant-checkbox ant-checkbox-checked"
+            >
+              <input
+                checked=""
+                class="ant-checkbox-input"
+                id="normal_login_remember"
+                type="checkbox"
+              />
+              <span
+                class="ant-checkbox-inner"
+              />
+            </span>
+            <span>
+              Remember me
+            </span>
+          </label>
+          <a
+            class="login-form-forgot"
+            href=""
+          >
+            Forgot password
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-row ant-form-item"
+  >
+    <div
+      class="ant-col ant-form-item-control"
+    >
+      <div
+        class="ant-form-item-control-input"
+      >
+        <div
+          class="ant-form-item-control-input-content"
+        >
+          <button
+            class="ant-btn login-form-button ant-btn-primary"
+            type="submit"
+          >
+            <span>
+              Log in
+            </span>
+          </button>
+          Or 
+          <a
+            href=""
+          >
+            register now!
+          </a>
+        </div>
       </div>
     </div>
   </div>
@@ -1957,12 +2137,16 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
       <div
         class="ant-form-item-control-input"
       >
-        <input
-          class="ant-input"
-          id="register_email"
-          type="text"
-          value=""
-        />
+        <div
+          class="ant-form-item-control-input-content"
+        >
+          <input
+            class="ant-input"
+            id="register_email"
+            type="text"
+            value=""
+          />
+        </div>
       </div>
     </div>
   </div>
@@ -1986,45 +2170,49 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
       <div
         class="ant-form-item-control-input"
       >
-        <span
-          class="ant-input-password ant-input-affix-wrapper"
+        <div
+          class="ant-form-item-control-input-content"
         >
-          <input
-            action="click"
-            class="ant-input"
-            id="register_password"
-            type="password"
-            value=""
-          />
           <span
-            class="ant-input-suffix"
+            class="ant-input-password ant-input-affix-wrapper"
           >
+            <input
+              action="click"
+              class="ant-input"
+              id="register_password"
+              type="password"
+              value=""
+            />
             <span
-              aria-label="eye-invisible"
-              class="anticon anticon-eye-invisible ant-input-password-icon"
-              role="img"
-              tabindex="-1"
+              class="ant-input-suffix"
             >
-              <svg
-                aria-hidden="true"
-                class=""
-                data-icon="eye-invisible"
-                fill="currentColor"
-                focusable="false"
-                height="1em"
-                viewBox="64 64 896 896"
-                width="1em"
+              <span
+                aria-label="eye-invisible"
+                class="anticon anticon-eye-invisible ant-input-password-icon"
+                role="img"
+                tabindex="-1"
               >
-                <path
-                  d="M942.2 486.2Q889.47 375.11 816.7 305l-50.88 50.88C807.31 395.53 843.45 447.4 874.7 512 791.5 684.2 673.4 766 512 766q-72.67 0-133.87-22.38L323 798.75Q408 838 512 838q288.3 0 430.2-300.3a60.29 60.29 0 000-51.5zm-63.57-320.64L836 122.88a8 8 0 00-11.32 0L715.31 232.2Q624.86 186 512 186q-288.3 0-430.2 300.3a60.3 60.3 0 000 51.5q56.69 119.4 136.5 191.41L112.48 835a8 8 0 000 11.31L155.17 889a8 8 0 0011.31 0l712.15-712.12a8 8 0 000-11.32zM149.3 512C232.6 339.8 350.7 258 512 258c54.54 0 104.13 9.36 149.12 28.39l-70.3 70.3a176 176 0 00-238.13 238.13l-83.42 83.42C223.1 637.49 183.3 582.28 149.3 512zm246.7 0a112.11 112.11 0 01146.2-106.69L401.31 546.2A112 112 0 01396 512z"
-                />
-                <path
-                  d="M508 624c-3.46 0-6.87-.16-10.25-.47l-52.82 52.82a176.09 176.09 0 00227.42-227.42l-52.82 52.82c.31 3.38.47 6.79.47 10.25a111.94 111.94 0 01-112 112z"
-                />
-              </svg>
+                <svg
+                  aria-hidden="true"
+                  class=""
+                  data-icon="eye-invisible"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M942.2 486.2Q889.47 375.11 816.7 305l-50.88 50.88C807.31 395.53 843.45 447.4 874.7 512 791.5 684.2 673.4 766 512 766q-72.67 0-133.87-22.38L323 798.75Q408 838 512 838q288.3 0 430.2-300.3a60.29 60.29 0 000-51.5zm-63.57-320.64L836 122.88a8 8 0 00-11.32 0L715.31 232.2Q624.86 186 512 186q-288.3 0-430.2 300.3a60.3 60.3 0 000 51.5q56.69 119.4 136.5 191.41L112.48 835a8 8 0 000 11.31L155.17 889a8 8 0 0011.31 0l712.15-712.12a8 8 0 000-11.32zM149.3 512C232.6 339.8 350.7 258 512 258c54.54 0 104.13 9.36 149.12 28.39l-70.3 70.3a176 176 0 00-238.13 238.13l-83.42 83.42C223.1 637.49 183.3 582.28 149.3 512zm246.7 0a112.11 112.11 0 01146.2-106.69L401.31 546.2A112 112 0 01396 512z"
+                  />
+                  <path
+                    d="M508 624c-3.46 0-6.87-.16-10.25-.47l-52.82 52.82a176.09 176.09 0 00227.42-227.42l-52.82 52.82c.31 3.38.47 6.79.47 10.25a111.94 111.94 0 01-112 112z"
+                  />
+                </svg>
+              </span>
             </span>
           </span>
-        </span>
+        </div>
       </div>
     </div>
   </div>
@@ -2048,45 +2236,49 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
       <div
         class="ant-form-item-control-input"
       >
-        <span
-          class="ant-input-password ant-input-affix-wrapper"
+        <div
+          class="ant-form-item-control-input-content"
         >
-          <input
-            action="click"
-            class="ant-input"
-            id="register_confirm"
-            type="password"
-            value=""
-          />
           <span
-            class="ant-input-suffix"
+            class="ant-input-password ant-input-affix-wrapper"
           >
+            <input
+              action="click"
+              class="ant-input"
+              id="register_confirm"
+              type="password"
+              value=""
+            />
             <span
-              aria-label="eye-invisible"
-              class="anticon anticon-eye-invisible ant-input-password-icon"
-              role="img"
-              tabindex="-1"
+              class="ant-input-suffix"
             >
-              <svg
-                aria-hidden="true"
-                class=""
-                data-icon="eye-invisible"
-                fill="currentColor"
-                focusable="false"
-                height="1em"
-                viewBox="64 64 896 896"
-                width="1em"
+              <span
+                aria-label="eye-invisible"
+                class="anticon anticon-eye-invisible ant-input-password-icon"
+                role="img"
+                tabindex="-1"
               >
-                <path
-                  d="M942.2 486.2Q889.47 375.11 816.7 305l-50.88 50.88C807.31 395.53 843.45 447.4 874.7 512 791.5 684.2 673.4 766 512 766q-72.67 0-133.87-22.38L323 798.75Q408 838 512 838q288.3 0 430.2-300.3a60.29 60.29 0 000-51.5zm-63.57-320.64L836 122.88a8 8 0 00-11.32 0L715.31 232.2Q624.86 186 512 186q-288.3 0-430.2 300.3a60.3 60.3 0 000 51.5q56.69 119.4 136.5 191.41L112.48 835a8 8 0 000 11.31L155.17 889a8 8 0 0011.31 0l712.15-712.12a8 8 0 000-11.32zM149.3 512C232.6 339.8 350.7 258 512 258c54.54 0 104.13 9.36 149.12 28.39l-70.3 70.3a176 176 0 00-238.13 238.13l-83.42 83.42C223.1 637.49 183.3 582.28 149.3 512zm246.7 0a112.11 112.11 0 01146.2-106.69L401.31 546.2A112 112 0 01396 512z"
-                />
-                <path
-                  d="M508 624c-3.46 0-6.87-.16-10.25-.47l-52.82 52.82a176.09 176.09 0 00227.42-227.42l-52.82 52.82c.31 3.38.47 6.79.47 10.25a111.94 111.94 0 01-112 112z"
-                />
-              </svg>
+                <svg
+                  aria-hidden="true"
+                  class=""
+                  data-icon="eye-invisible"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M942.2 486.2Q889.47 375.11 816.7 305l-50.88 50.88C807.31 395.53 843.45 447.4 874.7 512 791.5 684.2 673.4 766 512 766q-72.67 0-133.87-22.38L323 798.75Q408 838 512 838q288.3 0 430.2-300.3a60.29 60.29 0 000-51.5zm-63.57-320.64L836 122.88a8 8 0 00-11.32 0L715.31 232.2Q624.86 186 512 186q-288.3 0-430.2 300.3a60.3 60.3 0 000 51.5q56.69 119.4 136.5 191.41L112.48 835a8 8 0 000 11.31L155.17 889a8 8 0 0011.31 0l712.15-712.12a8 8 0 000-11.32zM149.3 512C232.6 339.8 350.7 258 512 258c54.54 0 104.13 9.36 149.12 28.39l-70.3 70.3a176 176 0 00-238.13 238.13l-83.42 83.42C223.1 637.49 183.3 582.28 149.3 512zm246.7 0a112.11 112.11 0 01146.2-106.69L401.31 546.2A112 112 0 01396 512z"
+                  />
+                  <path
+                    d="M508 624c-3.46 0-6.87-.16-10.25-.47l-52.82 52.82a176.09 176.09 0 00227.42-227.42l-52.82 52.82c.31 3.38.47 6.79.47 10.25a111.94 111.94 0 01-112 112z"
+                  />
+                </svg>
+              </span>
             </span>
           </span>
-        </span>
+        </div>
       </div>
     </div>
   </div>
@@ -2135,12 +2327,16 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
       <div
         class="ant-form-item-control-input"
       >
-        <input
-          class="ant-input"
-          id="register_nickname"
-          type="text"
-          value=""
-        />
+        <div
+          class="ant-form-item-control-input-content"
+        >
+          <input
+            class="ant-input"
+            id="register_nickname"
+            type="text"
+            value=""
+          />
+        </div>
       </div>
     </div>
   </div>
@@ -2164,66 +2360,70 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
       <div
         class="ant-form-item-control-input"
       >
-        <span
-          class="ant-cascader-picker"
-          tabindex="0"
+        <div
+          class="ant-form-item-control-input-content"
         >
           <span
-            class="ant-cascader-picker-label"
+            class="ant-cascader-picker"
+            tabindex="0"
           >
-            Zhejiang / Hangzhou / West Lake
-          </span>
-          <input
-            autocomplete="off"
-            class="ant-input ant-cascader-input "
-            id="register_residence"
-            readonly=""
-            tabindex="-1"
-            type="text"
-            value=""
-          />
-          <span
-            aria-label="close-circle"
-            class="anticon anticon-close-circle ant-cascader-picker-clear"
-            role="img"
-            tabindex="-1"
-          >
-            <svg
-              aria-hidden="true"
-              class=""
-              data-icon="close-circle"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
+            <span
+              class="ant-cascader-picker-label"
             >
-              <path
-                d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm165.4 618.2l-66-.3L512 563.4l-99.3 118.4-66.1.3c-4.4 0-8-3.5-8-8 0-1.9.7-3.7 1.9-5.2l130.1-155L340.5 359a8.32 8.32 0 01-1.9-5.2c0-4.4 3.6-8 8-8l66.1.3L512 464.6l99.3-118.4 66-.3c4.4 0 8 3.5 8 8 0 1.9-.7 3.7-1.9 5.2L553.5 514l130 155c1.2 1.5 1.9 3.3 1.9 5.2 0 4.4-3.6 8-8 8z"
-              />
-            </svg>
-          </span>
-          <span
-            aria-label="down"
-            class="anticon anticon-down ant-cascader-picker-arrow"
-            role="img"
-          >
-            <svg
-              aria-hidden="true"
-              class=""
-              data-icon="down"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
+              Zhejiang / Hangzhou / West Lake
+            </span>
+            <input
+              autocomplete="off"
+              class="ant-input ant-cascader-input "
+              id="register_residence"
+              readonly=""
+              tabindex="-1"
+              type="text"
+              value=""
+            />
+            <span
+              aria-label="close-circle"
+              class="anticon anticon-close-circle ant-cascader-picker-clear"
+              role="img"
+              tabindex="-1"
             >
-              <path
-                d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
-              />
-            </svg>
+              <svg
+                aria-hidden="true"
+                class=""
+                data-icon="close-circle"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm165.4 618.2l-66-.3L512 563.4l-99.3 118.4-66.1.3c-4.4 0-8-3.5-8-8 0-1.9.7-3.7 1.9-5.2l130.1-155L340.5 359a8.32 8.32 0 01-1.9-5.2c0-4.4 3.6-8 8-8l66.1.3L512 464.6l99.3-118.4 66-.3c4.4 0 8 3.5 8 8 0 1.9-.7 3.7-1.9 5.2L553.5 514l130 155c1.2 1.5 1.9 3.3 1.9 5.2 0 4.4-3.6 8-8 8z"
+                />
+              </svg>
+            </span>
+            <span
+              aria-label="down"
+              class="anticon anticon-down ant-cascader-picker-arrow"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                class=""
+                data-icon="down"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                />
+              </svg>
+            </span>
           </span>
-        </span>
+        </div>
       </div>
     </div>
   </div>
@@ -2247,84 +2447,88 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
       <div
         class="ant-form-item-control-input"
       >
-        <span
-          class="ant-input-group-wrapper"
-          style="width:100%"
+        <div
+          class="ant-form-item-control-input-content"
         >
           <span
-            class="ant-input-wrapper ant-input-group"
+            class="ant-input-group-wrapper"
+            style="width:100%"
           >
             <span
-              class="ant-input-group-addon"
+              class="ant-input-wrapper ant-input-group"
             >
-              <div
-                class="ant-select ant-select-single ant-select-show-arrow"
-                style="width:70px"
+              <span
+                class="ant-input-group-addon"
               >
                 <div
-                  class="ant-select-selector"
+                  class="ant-select ant-select-single ant-select-show-arrow"
+                  style="width:70px"
                 >
-                  <span
-                    class="ant-select-selection-search"
+                  <div
+                    class="ant-select-selector"
                   >
-                    <input
-                      aria-activedescendant="register_prefix_list_0"
-                      aria-autocomplete="list"
-                      aria-controls="register_prefix_list"
-                      aria-haspopup="listbox"
-                      aria-owns="register_prefix_list"
-                      autocomplete="off"
-                      class="ant-select-selection-search-input"
-                      id="register_prefix"
-                      readonly=""
-                      role="combobox"
-                      style="opacity:0"
-                      value=""
-                    />
-                  </span>
+                    <span
+                      class="ant-select-selection-search"
+                    >
+                      <input
+                        aria-activedescendant="register_prefix_list_0"
+                        aria-autocomplete="list"
+                        aria-controls="register_prefix_list"
+                        aria-haspopup="listbox"
+                        aria-owns="register_prefix_list"
+                        autocomplete="off"
+                        class="ant-select-selection-search-input"
+                        id="register_prefix"
+                        readonly=""
+                        role="combobox"
+                        style="opacity:0"
+                        value=""
+                      />
+                    </span>
+                    <span
+                      class="ant-select-selection-item"
+                    >
+                      +86
+                    </span>
+                  </div>
                   <span
-                    class="ant-select-selection-item"
+                    aria-hidden="true"
+                    class="ant-select-arrow"
+                    style="user-select:none;-webkit-user-select:none"
+                    unselectable="on"
                   >
-                    +86
+                    <span
+                      aria-label="down"
+                      class="anticon anticon-down"
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class=""
+                        data-icon="down"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                        />
+                      </svg>
+                    </span>
                   </span>
                 </div>
-                <span
-                  aria-hidden="true"
-                  class="ant-select-arrow"
-                  style="user-select:none;-webkit-user-select:none"
-                  unselectable="on"
-                >
-                  <span
-                    aria-label="down"
-                    class="anticon anticon-down"
-                    role="img"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      class=""
-                      data-icon="down"
-                      fill="currentColor"
-                      focusable="false"
-                      height="1em"
-                      viewBox="64 64 896 896"
-                      width="1em"
-                    >
-                      <path
-                        d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
-                      />
-                    </svg>
-                  </span>
-                </span>
-              </div>
+              </span>
+              <input
+                class="ant-input"
+                id="register_phone"
+                type="text"
+                value=""
+              />
             </span>
-            <input
-              class="ant-input"
-              id="register_phone"
-              type="text"
-              value=""
-            />
           </span>
-        </span>
+        </div>
       </div>
     </div>
   </div>
@@ -2349,33 +2553,37 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
         class="ant-form-item-control-input"
       >
         <div
-          class="ant-select ant-select-auto-complete ant-select-single ant-select-customize-input ant-select-show-search"
+          class="ant-form-item-control-input-content"
         >
           <div
-            class="ant-select-selector"
+            class="ant-select ant-select-auto-complete ant-select-single ant-select-customize-input ant-select-show-search"
           >
-            <span
-              class="ant-select-selection-search"
+            <div
+              class="ant-select-selector"
             >
-              <input
-                aria-activedescendant="register_website_list_0"
-                aria-autocomplete="list"
-                aria-controls="register_website_list"
-                aria-haspopup="listbox"
-                aria-owns="register_website_list"
-                autocomplete="off"
-                class="ant-input ant-select-selection-search-input"
-                id="register_website"
-                role="combobox"
-                type="text"
-                value=""
-              />
-            </span>
-            <span
-              class="ant-select-selection-placeholder"
-            >
-              website
-            </span>
+              <span
+                class="ant-select-selection-search"
+              >
+                <input
+                  aria-activedescendant="register_website_list_0"
+                  aria-autocomplete="list"
+                  aria-controls="register_website_list"
+                  aria-haspopup="listbox"
+                  aria-owns="register_website_list"
+                  autocomplete="off"
+                  class="ant-input ant-select-selection-search-input"
+                  id="register_website"
+                  role="combobox"
+                  type="text"
+                  value=""
+                />
+              </span>
+              <span
+                class="ant-select-selection-placeholder"
+              >
+                website
+              </span>
+            </div>
           </div>
         </div>
       </div>
@@ -2401,32 +2609,36 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
         class="ant-form-item-control-input"
       >
         <div
-          class="ant-row"
-          style="margin-left:-4px;margin-right:-4px"
+          class="ant-form-item-control-input-content"
         >
           <div
-            class="ant-col ant-col-12"
-            style="padding-left:4px;padding-right:4px"
+            class="ant-row"
+            style="margin-left:-4px;margin-right:-4px"
           >
-            <input
-              class="ant-input"
-              id="register_captcha"
-              type="text"
-              value=""
-            />
-          </div>
-          <div
-            class="ant-col ant-col-12"
-            style="padding-left:4px;padding-right:4px"
-          >
-            <button
-              class="ant-btn"
-              type="button"
+            <div
+              class="ant-col ant-col-12"
+              style="padding-left:4px;padding-right:4px"
             >
-              <span>
-                Get captcha
-              </span>
-            </button>
+              <input
+                class="ant-input"
+                id="register_captcha"
+                type="text"
+                value=""
+              />
+            </div>
+            <div
+              class="ant-col ant-col-12"
+              style="padding-left:4px;padding-right:4px"
+            >
+              <button
+                class="ant-btn"
+                type="button"
+              >
+                <span>
+                  Get captcha
+                </span>
+              </button>
+            </div>
           </div>
         </div>
       </div>
@@ -2446,30 +2658,34 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
       <div
         class="ant-form-item-control-input"
       >
-        <label
-          class="ant-checkbox-wrapper"
+        <div
+          class="ant-form-item-control-input-content"
         >
-          <span
-            class="ant-checkbox"
+          <label
+            class="ant-checkbox-wrapper"
           >
-            <input
-              class="ant-checkbox-input"
-              id="register_agreement"
-              type="checkbox"
-            />
             <span
-              class="ant-checkbox-inner"
-            />
-          </span>
-          <span>
-            I have read the 
-            <a
-              href=""
+              class="ant-checkbox"
             >
-              agreement
-            </a>
-          </span>
-        </label>
+              <input
+                class="ant-checkbox-input"
+                id="register_agreement"
+                type="checkbox"
+              />
+              <span
+                class="ant-checkbox-inner"
+              />
+            </span>
+            <span>
+              I have read the 
+              <a
+                href=""
+              >
+                agreement
+              </a>
+            </span>
+          </label>
+        </div>
       </div>
     </div>
   </div>
@@ -2482,14 +2698,18 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
       <div
         class="ant-form-item-control-input"
       >
-        <button
-          class="ant-btn ant-btn-primary"
-          type="submit"
+        <div
+          class="ant-form-item-control-input-content"
         >
-          <span>
-            Register
-          </span>
-        </button>
+          <button
+            class="ant-btn ant-btn-primary"
+            type="submit"
+          >
+            <span>
+              Register
+            </span>
+          </button>
+        </div>
       </div>
     </div>
   </div>
@@ -2499,7 +2719,7 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
 exports[`renders ./components/form/demo/size.md correctly 1`] = `
 <div>
   <form
-    class="ant-form ant-form-horizontal"
+    class="ant-form ant-form-horizontal ant-form-small"
   >
     <div
       class="ant-row ant-form-item"
@@ -2522,67 +2742,71 @@ exports[`renders ./components/form/demo/size.md correctly 1`] = `
           class="ant-form-item-control-input"
         >
           <div
-            class="ant-radio-group ant-radio-group-outline ant-radio-group-small"
-            id="size"
+            class="ant-form-item-control-input-content"
           >
-            <label
-              class="ant-radio-button-wrapper ant-radio-button-wrapper-checked"
+            <div
+              class="ant-radio-group ant-radio-group-outline ant-radio-group-small"
+              id="size"
             >
-              <span
-                class="ant-radio-button ant-radio-button-checked"
+              <label
+                class="ant-radio-button-wrapper ant-radio-button-wrapper-checked"
               >
-                <input
-                  checked=""
-                  class="ant-radio-button-input"
-                  type="radio"
-                  value="small"
-                />
                 <span
-                  class="ant-radio-button-inner"
-                />
-              </span>
-              <span>
-                Small
-              </span>
-            </label>
-            <label
-              class="ant-radio-button-wrapper"
-            >
-              <span
-                class="ant-radio-button"
+                  class="ant-radio-button ant-radio-button-checked"
+                >
+                  <input
+                    checked=""
+                    class="ant-radio-button-input"
+                    type="radio"
+                    value="small"
+                  />
+                  <span
+                    class="ant-radio-button-inner"
+                  />
+                </span>
+                <span>
+                  Small
+                </span>
+              </label>
+              <label
+                class="ant-radio-button-wrapper"
               >
-                <input
-                  class="ant-radio-button-input"
-                  type="radio"
-                  value="middle"
-                />
                 <span
-                  class="ant-radio-button-inner"
-                />
-              </span>
-              <span>
-                Middle
-              </span>
-            </label>
-            <label
-              class="ant-radio-button-wrapper"
-            >
-              <span
-                class="ant-radio-button"
+                  class="ant-radio-button"
+                >
+                  <input
+                    class="ant-radio-button-input"
+                    type="radio"
+                    value="middle"
+                  />
+                  <span
+                    class="ant-radio-button-inner"
+                  />
+                </span>
+                <span>
+                  Middle
+                </span>
+              </label>
+              <label
+                class="ant-radio-button-wrapper"
               >
-                <input
-                  class="ant-radio-button-input"
-                  type="radio"
-                  value="large"
-                />
                 <span
-                  class="ant-radio-button-inner"
-                />
-              </span>
-              <span>
-                Large
-              </span>
-            </label>
+                  class="ant-radio-button"
+                >
+                  <input
+                    class="ant-radio-button-input"
+                    type="radio"
+                    value="large"
+                  />
+                  <span
+                    class="ant-radio-button-inner"
+                  />
+                </span>
+                <span>
+                  Large
+                </span>
+              </label>
+            </div>
           </div>
         </div>
       </div>
@@ -2606,11 +2830,15 @@ exports[`renders ./components/form/demo/size.md correctly 1`] = `
         <div
           class="ant-form-item-control-input"
         >
-          <input
-            class="ant-input ant-input-sm"
-            type="text"
-            value=""
-          />
+          <div
+            class="ant-form-item-control-input-content"
+          >
+            <input
+              class="ant-input ant-input-sm"
+              type="text"
+              value=""
+            />
+          </div>
         </div>
       </div>
     </div>
@@ -2634,59 +2862,63 @@ exports[`renders ./components/form/demo/size.md correctly 1`] = `
           class="ant-form-item-control-input"
         >
           <div
-            class="ant-select ant-select-sm ant-select-single ant-select-show-arrow"
+            class="ant-form-item-control-input-content"
           >
             <div
-              class="ant-select-selector"
+              class="ant-select ant-select-sm ant-select-single ant-select-show-arrow"
             >
-              <span
-                class="ant-select-selection-search"
+              <div
+                class="ant-select-selector"
               >
-                <input
-                  aria-activedescendant="undefined_list_0"
-                  aria-autocomplete="list"
-                  aria-controls="undefined_list"
-                  aria-haspopup="listbox"
-                  aria-owns="undefined_list"
-                  autocomplete="off"
-                  class="ant-select-selection-search-input"
-                  readonly=""
-                  role="combobox"
-                  style="opacity:0"
-                  value=""
-                />
-              </span>
-              <span
-                class="ant-select-selection-placeholder"
-              />
-            </div>
-            <span
-              aria-hidden="true"
-              class="ant-select-arrow"
-              style="user-select:none;-webkit-user-select:none"
-              unselectable="on"
-            >
-              <span
-                aria-label="down"
-                class="anticon anticon-down"
-                role="img"
-              >
-                <svg
-                  aria-hidden="true"
-                  class=""
-                  data-icon="down"
-                  fill="currentColor"
-                  focusable="false"
-                  height="1em"
-                  viewBox="64 64 896 896"
-                  width="1em"
+                <span
+                  class="ant-select-selection-search"
                 >
-                  <path
-                    d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                  <input
+                    aria-activedescendant="undefined_list_0"
+                    aria-autocomplete="list"
+                    aria-controls="undefined_list"
+                    aria-haspopup="listbox"
+                    aria-owns="undefined_list"
+                    autocomplete="off"
+                    class="ant-select-selection-search-input"
+                    readonly=""
+                    role="combobox"
+                    style="opacity:0"
+                    value=""
                   />
-                </svg>
+                </span>
+                <span
+                  class="ant-select-selection-placeholder"
+                />
+              </div>
+              <span
+                aria-hidden="true"
+                class="ant-select-arrow"
+                style="user-select:none;-webkit-user-select:none"
+                unselectable="on"
+              >
+                <span
+                  aria-label="down"
+                  class="anticon anticon-down"
+                  role="img"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class=""
+                    data-icon="down"
+                    fill="currentColor"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                    />
+                  </svg>
+                </span>
               </span>
-            </span>
+            </div>
           </div>
         </div>
       </div>
@@ -2711,41 +2943,108 @@ exports[`renders ./components/form/demo/size.md correctly 1`] = `
           class="ant-form-item-control-input"
         >
           <div
-            class="ant-select ant-tree-select ant-select-sm ant-select-single ant-select-show-arrow"
+            class="ant-form-item-control-input-content"
           >
             <div
-              class="ant-select-selector"
+              class="ant-select ant-tree-select ant-select-sm ant-select-single ant-select-show-arrow"
             >
-              <span
-                class="ant-select-selection-search"
+              <div
+                class="ant-select-selector"
               >
-                <input
-                  aria-activedescendant="undefined_list_0"
-                  aria-autocomplete="list"
-                  aria-controls="undefined_list"
-                  aria-haspopup="listbox"
-                  aria-owns="undefined_list"
-                  autocomplete="off"
-                  class="ant-select-selection-search-input"
-                  readonly=""
-                  role="combobox"
-                  style="opacity:0"
-                  value=""
+                <span
+                  class="ant-select-selection-search"
+                >
+                  <input
+                    aria-activedescendant="undefined_list_0"
+                    aria-autocomplete="list"
+                    aria-controls="undefined_list"
+                    aria-haspopup="listbox"
+                    aria-owns="undefined_list"
+                    autocomplete="off"
+                    class="ant-select-selection-search-input"
+                    readonly=""
+                    role="combobox"
+                    style="opacity:0"
+                    value=""
+                  />
+                </span>
+                <span
+                  class="ant-select-selection-placeholder"
                 />
-              </span>
+              </div>
               <span
-                class="ant-select-selection-placeholder"
-              />
+                aria-hidden="true"
+                class="ant-select-arrow"
+                style="user-select:none;-webkit-user-select:none"
+                unselectable="on"
+              >
+                <span
+                  aria-label="down"
+                  class="anticon anticon-down"
+                  role="img"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class=""
+                    data-icon="down"
+                    fill="currentColor"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                    />
+                  </svg>
+                </span>
+              </span>
             </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="ant-row ant-form-item"
+    >
+      <div
+        class="ant-col ant-col-4 ant-form-item-label"
+      >
+        <label
+          class=""
+          title="Cascader"
+        >
+          Cascader
+        </label>
+      </div>
+      <div
+        class="ant-col ant-col-14 ant-form-item-control"
+      >
+        <div
+          class="ant-form-item-control-input"
+        >
+          <div
+            class="ant-form-item-control-input-content"
+          >
             <span
-              aria-hidden="true"
-              class="ant-select-arrow"
-              style="user-select:none;-webkit-user-select:none"
-              unselectable="on"
+              class="ant-cascader-picker ant-cascader-picker-small"
+              tabindex="0"
             >
+              <span
+                class="ant-cascader-picker-label"
+              />
+              <input
+                autocomplete="off"
+                class="ant-input ant-input-sm ant-cascader-input ant-input-sm"
+                placeholder="Please select"
+                readonly=""
+                tabindex="-1"
+                type="text"
+                value=""
+              />
               <span
                 aria-label="down"
-                class="anticon anticon-down"
+                class="anticon anticon-down ant-cascader-picker-arrow"
                 role="img"
               >
                 <svg
@@ -2776,65 +3075,6 @@ exports[`renders ./components/form/demo/size.md correctly 1`] = `
       >
         <label
           class=""
-          title="Cascader"
-        >
-          Cascader
-        </label>
-      </div>
-      <div
-        class="ant-col ant-col-14 ant-form-item-control"
-      >
-        <div
-          class="ant-form-item-control-input"
-        >
-          <span
-            class="ant-cascader-picker ant-cascader-picker-small"
-            tabindex="0"
-          >
-            <span
-              class="ant-cascader-picker-label"
-            />
-            <input
-              autocomplete="off"
-              class="ant-input ant-input-sm ant-cascader-input ant-input-sm"
-              placeholder="Please select"
-              readonly=""
-              tabindex="-1"
-              type="text"
-              value=""
-            />
-            <span
-              aria-label="down"
-              class="anticon anticon-down ant-cascader-picker-arrow"
-              role="img"
-            >
-              <svg
-                aria-hidden="true"
-                class=""
-                data-icon="down"
-                fill="currentColor"
-                focusable="false"
-                height="1em"
-                viewBox="64 64 896 896"
-                width="1em"
-              >
-                <path
-                  d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
-                />
-              </svg>
-            </span>
-          </span>
-        </div>
-      </div>
-    </div>
-    <div
-      class="ant-row ant-form-item"
-    >
-      <div
-        class="ant-col ant-col-4 ant-form-item-label"
-      >
-        <label
-          class=""
           title="DatePicker"
         >
           DatePicker
@@ -2847,7 +3087,257 @@ exports[`renders ./components/form/demo/size.md correctly 1`] = `
           class="ant-form-item-control-input"
         >
           <div
-            class="ant-picker ant-picker-small"
+            class="ant-form-item-control-input-content"
+          >
+            <div
+              class="ant-picker ant-picker-small"
+            >
+              <div
+                class="ant-picker-input"
+              >
+                <input
+                  placeholder="Select date"
+                  readonly=""
+                  size="12"
+                  value=""
+                />
+                <span
+                  class="ant-picker-suffix"
+                >
+                  <span
+                    aria-label="calendar"
+                    class="anticon anticon-calendar"
+                    role="img"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class=""
+                      data-icon="calendar"
+                      fill="currentColor"
+                      focusable="false"
+                      height="1em"
+                      viewBox="64 64 896 896"
+                      width="1em"
+                    >
+                      <path
+                        d="M880 184H712v-64c0-4.4-3.6-8-8-8h-56c-4.4 0-8 3.6-8 8v64H384v-64c0-4.4-3.6-8-8-8h-56c-4.4 0-8 3.6-8 8v64H144c-17.7 0-32 14.3-32 32v664c0 17.7 14.3 32 32 32h736c17.7 0 32-14.3 32-32V216c0-17.7-14.3-32-32-32zm-40 656H184V460h656v380zM184 392V256h128v48c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8v-48h256v48c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8v-48h128v136H184z"
+                      />
+                    </svg>
+                  </span>
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="ant-row ant-form-item"
+    >
+      <div
+        class="ant-col ant-col-4 ant-form-item-label"
+      >
+        <label
+          class=""
+          title="InputNumber"
+        >
+          InputNumber
+        </label>
+      </div>
+      <div
+        class="ant-col ant-col-14 ant-form-item-control"
+      >
+        <div
+          class="ant-form-item-control-input"
+        >
+          <div
+            class="ant-form-item-control-input-content"
+          >
+            <div
+              class="ant-input-number ant-input-number-sm"
+            >
+              <div
+                class="ant-input-number-handler-wrap"
+              >
+                <span
+                  aria-disabled="false"
+                  aria-label="Increase Value"
+                  class="ant-input-number-handler ant-input-number-handler-up "
+                  role="button"
+                  unselectable="unselectable"
+                >
+                  <span
+                    aria-label="up"
+                    class="anticon anticon-up ant-input-number-handler-up-inner"
+                    role="img"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class=""
+                      data-icon="up"
+                      fill="currentColor"
+                      focusable="false"
+                      height="1em"
+                      viewBox="64 64 896 896"
+                      width="1em"
+                    >
+                      <path
+                        d="M890.5 755.3L537.9 269.2c-12.8-17.6-39-17.6-51.7 0L133.5 755.3A8 8 0 00140 768h75c5.1 0 9.9-2.5 12.9-6.6L512 369.8l284.1 391.6c3 4.1 7.8 6.6 12.9 6.6h75c6.5 0 10.3-7.4 6.5-12.7z"
+                      />
+                    </svg>
+                  </span>
+                </span>
+                <span
+                  aria-disabled="false"
+                  aria-label="Decrease Value"
+                  class="ant-input-number-handler ant-input-number-handler-down "
+                  role="button"
+                  unselectable="unselectable"
+                >
+                  <span
+                    aria-label="down"
+                    class="anticon anticon-down ant-input-number-handler-down-inner"
+                    role="img"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class=""
+                      data-icon="down"
+                      fill="currentColor"
+                      focusable="false"
+                      height="1em"
+                      viewBox="64 64 896 896"
+                      width="1em"
+                    >
+                      <path
+                        d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                      />
+                    </svg>
+                  </span>
+                </span>
+              </div>
+              <div
+                class="ant-input-number-input-wrap"
+              >
+                <input
+                  aria-valuemin="-9007199254740991"
+                  autocomplete="off"
+                  class="ant-input-number-input"
+                  min="-9007199254740991"
+                  role="spinbutton"
+                  step="1"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="ant-row ant-form-item"
+    >
+      <div
+        class="ant-col ant-col-4 ant-form-item-label"
+      >
+        <label
+          class=""
+          title="Switch"
+        >
+          Switch
+        </label>
+      </div>
+      <div
+        class="ant-col ant-col-14 ant-form-item-control"
+      >
+        <div
+          class="ant-form-item-control-input"
+        >
+          <div
+            class="ant-form-item-control-input-content"
+          >
+            <button
+              aria-checked="false"
+              class="ant-switch-small ant-switch"
+              role="switch"
+              type="button"
+            >
+              <span
+                class="ant-switch-inner"
+              />
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="ant-row ant-form-item"
+    >
+      <div
+        class="ant-col ant-col-4 ant-form-item-label"
+      >
+        <label
+          class=""
+          title="Button"
+        >
+          Button
+        </label>
+      </div>
+      <div
+        class="ant-col ant-col-14 ant-form-item-control"
+      >
+        <div
+          class="ant-form-item-control-input"
+        >
+          <div
+            class="ant-form-item-control-input-content"
+          >
+            <button
+              class="ant-btn ant-btn-sm"
+              type="button"
+            >
+              <span>
+                Button
+              </span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </form>
+</div>
+`;
+
+exports[`renders ./components/form/demo/time-related-controls.md correctly 1`] = `
+<form
+  class="ant-form ant-form-horizontal"
+  id="time_related_controls"
+>
+  <div
+    class="ant-row ant-form-item"
+  >
+    <div
+      class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
+    >
+      <label
+        class="ant-form-item-required"
+        for="time_related_controls_date-picker"
+        title="DatePicker"
+      >
+        DatePicker
+      </label>
+    </div>
+    <div
+      class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
+    >
+      <div
+        class="ant-form-item-control-input"
+      >
+        <div
+          class="ant-form-item-control-input-content"
+        >
+          <div
+            class="ant-picker"
           >
             <div
               class="ant-picker-input"
@@ -2887,27 +3377,2622 @@ exports[`renders ./components/form/demo/size.md correctly 1`] = `
         </div>
       </div>
     </div>
+  </div>
+  <div
+    class="ant-row ant-form-item"
+  >
     <div
-      class="ant-row ant-form-item"
+      class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
+    >
+      <label
+        class="ant-form-item-required"
+        for="time_related_controls_date-time-picker"
+        title="DatePicker[showTime]"
+      >
+        DatePicker[showTime]
+      </label>
+    </div>
+    <div
+      class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
     >
       <div
-        class="ant-col ant-col-4 ant-form-item-label"
-      >
-        <label
-          class=""
-          title="InputNumber"
-        >
-          InputNumber
-        </label>
-      </div>
-      <div
-        class="ant-col ant-col-14 ant-form-item-control"
+        class="ant-form-item-control-input"
       >
         <div
-          class="ant-form-item-control-input"
+          class="ant-form-item-control-input-content"
         >
           <div
-            class="ant-input-number ant-input-number-sm"
+            class="ant-picker"
+          >
+            <div
+              class="ant-picker-input"
+            >
+              <input
+                placeholder="Select date"
+                readonly=""
+                size="21"
+                value=""
+              />
+              <span
+                class="ant-picker-suffix"
+              >
+                <span
+                  aria-label="calendar"
+                  class="anticon anticon-calendar"
+                  role="img"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class=""
+                    data-icon="calendar"
+                    fill="currentColor"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M880 184H712v-64c0-4.4-3.6-8-8-8h-56c-4.4 0-8 3.6-8 8v64H384v-64c0-4.4-3.6-8-8-8h-56c-4.4 0-8 3.6-8 8v64H144c-17.7 0-32 14.3-32 32v664c0 17.7 14.3 32 32 32h736c17.7 0 32-14.3 32-32V216c0-17.7-14.3-32-32-32zm-40 656H184V460h656v380zM184 392V256h128v48c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8v-48h256v48c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8v-48h128v136H184z"
+                    />
+                  </svg>
+                </span>
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-row ant-form-item"
+  >
+    <div
+      class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
+    >
+      <label
+        class="ant-form-item-required"
+        for="time_related_controls_month-picker"
+        title="MonthPicker"
+      >
+        MonthPicker
+      </label>
+    </div>
+    <div
+      class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
+    >
+      <div
+        class="ant-form-item-control-input"
+      >
+        <div
+          class="ant-form-item-control-input-content"
+        >
+          <div
+            class="ant-picker"
+          >
+            <div
+              class="ant-picker-input"
+            >
+              <input
+                placeholder="Select month"
+                readonly=""
+                size="12"
+                value=""
+              />
+              <span
+                class="ant-picker-suffix"
+              >
+                <span
+                  aria-label="calendar"
+                  class="anticon anticon-calendar"
+                  role="img"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class=""
+                    data-icon="calendar"
+                    fill="currentColor"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M880 184H712v-64c0-4.4-3.6-8-8-8h-56c-4.4 0-8 3.6-8 8v64H384v-64c0-4.4-3.6-8-8-8h-56c-4.4 0-8 3.6-8 8v64H144c-17.7 0-32 14.3-32 32v664c0 17.7 14.3 32 32 32h736c17.7 0 32-14.3 32-32V216c0-17.7-14.3-32-32-32zm-40 656H184V460h656v380zM184 392V256h128v48c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8v-48h256v48c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8v-48h128v136H184z"
+                    />
+                  </svg>
+                </span>
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-row ant-form-item"
+  >
+    <div
+      class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
+    >
+      <label
+        class="ant-form-item-required"
+        for="time_related_controls_range-picker"
+        title="RangePicker"
+      >
+        RangePicker
+      </label>
+    </div>
+    <div
+      class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
+    >
+      <div
+        class="ant-form-item-control-input"
+      >
+        <div
+          class="ant-form-item-control-input-content"
+        >
+          <div
+            class="ant-picker ant-picker-range"
+          >
+            <div
+              class="ant-picker-input ant-picker-input-active"
+            >
+              <input
+                placeholder="Start date"
+                readonly=""
+                size="12"
+                value=""
+              />
+            </div>
+            <div
+              class="ant-picker-range-separator"
+            >
+              <span
+                class="ant-picker-separator"
+              >
+                →
+              </span>
+            </div>
+            <div
+              class="ant-picker-input"
+            >
+              <input
+                placeholder="End date"
+                readonly=""
+                size="12"
+                value=""
+              />
+            </div>
+            <div
+              class="ant-picker-active-bar"
+              style="left:0;width:0;position:absolute"
+            />
+            <span
+              class="ant-picker-suffix"
+            >
+              <span
+                aria-label="calendar"
+                class="anticon anticon-calendar"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  class=""
+                  data-icon="calendar"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M880 184H712v-64c0-4.4-3.6-8-8-8h-56c-4.4 0-8 3.6-8 8v64H384v-64c0-4.4-3.6-8-8-8h-56c-4.4 0-8 3.6-8 8v64H144c-17.7 0-32 14.3-32 32v664c0 17.7 14.3 32 32 32h736c17.7 0 32-14.3 32-32V216c0-17.7-14.3-32-32-32zm-40 656H184V460h656v380zM184 392V256h128v48c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8v-48h256v48c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8v-48h128v136H184z"
+                  />
+                </svg>
+              </span>
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-row ant-form-item"
+  >
+    <div
+      class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
+    >
+      <label
+        class="ant-form-item-required"
+        for="time_related_controls_range-time-picker"
+        title="RangePicker[showTime]"
+      >
+        RangePicker[showTime]
+      </label>
+    </div>
+    <div
+      class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
+    >
+      <div
+        class="ant-form-item-control-input"
+      >
+        <div
+          class="ant-form-item-control-input-content"
+        >
+          <div
+            class="ant-picker ant-picker-range"
+          >
+            <div
+              class="ant-picker-input ant-picker-input-active"
+            >
+              <input
+                placeholder="Start date"
+                readonly=""
+                size="21"
+                value=""
+              />
+            </div>
+            <div
+              class="ant-picker-range-separator"
+            >
+              <span
+                class="ant-picker-separator"
+              >
+                →
+              </span>
+            </div>
+            <div
+              class="ant-picker-input"
+            >
+              <input
+                placeholder="End date"
+                readonly=""
+                size="21"
+                value=""
+              />
+            </div>
+            <div
+              class="ant-picker-active-bar"
+              style="left:0;width:0;position:absolute"
+            />
+            <span
+              class="ant-picker-suffix"
+            >
+              <span
+                aria-label="calendar"
+                class="anticon anticon-calendar"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  class=""
+                  data-icon="calendar"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M880 184H712v-64c0-4.4-3.6-8-8-8h-56c-4.4 0-8 3.6-8 8v64H384v-64c0-4.4-3.6-8-8-8h-56c-4.4 0-8 3.6-8 8v64H144c-17.7 0-32 14.3-32 32v664c0 17.7 14.3 32 32 32h736c17.7 0 32-14.3 32-32V216c0-17.7-14.3-32-32-32zm-40 656H184V460h656v380zM184 392V256h128v48c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8v-48h256v48c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8v-48h128v136H184z"
+                  />
+                </svg>
+              </span>
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-row ant-form-item"
+  >
+    <div
+      class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
+    >
+      <label
+        class="ant-form-item-required"
+        for="time_related_controls_time-picker"
+        title="TimePicker"
+      >
+        TimePicker
+      </label>
+    </div>
+    <div
+      class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
+    >
+      <div
+        class="ant-form-item-control-input"
+      >
+        <div
+          class="ant-form-item-control-input-content"
+        >
+          <div
+            class="ant-picker"
+          >
+            <div
+              class="ant-picker-input"
+            >
+              <input
+                placeholder="Select time"
+                readonly=""
+                size="10"
+                value=""
+              />
+              <span
+                class="ant-picker-suffix"
+              >
+                <span
+                  aria-label="clock-circle"
+                  class="anticon anticon-clock-circle"
+                  role="img"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class=""
+                    data-icon="clock-circle"
+                    fill="currentColor"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+                    />
+                    <path
+                      d="M686.7 638.6L544.1 535.5V288c0-4.4-3.6-8-8-8H488c-4.4 0-8 3.6-8 8v275.4c0 2.6 1.2 5 3.3 6.5l165.4 120.6c3.6 2.6 8.6 1.8 11.2-1.7l28.6-39c2.6-3.7 1.8-8.7-1.8-11.2z"
+                    />
+                  </svg>
+                </span>
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-row ant-form-item"
+  >
+    <div
+      class="ant-col ant-form-item-control ant-col-xs-24 ant-col-xs-offset-0 ant-col-sm-16 ant-col-sm-offset-8"
+    >
+      <div
+        class="ant-form-item-control-input"
+      >
+        <div
+          class="ant-form-item-control-input-content"
+        >
+          <button
+            class="ant-btn ant-btn-primary"
+            type="submit"
+          >
+            <span>
+              Submit
+            </span>
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</form>
+`;
+
+exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
+<form
+  class="ant-form ant-form-horizontal"
+  id="validate_other"
+>
+  <div
+    class="ant-row ant-form-item"
+  >
+    <div
+      class="ant-col ant-col-6 ant-form-item-label"
+    >
+      <label
+        class=""
+        title="Plain Text"
+      >
+        Plain Text
+      </label>
+    </div>
+    <div
+      class="ant-col ant-col-14 ant-form-item-control"
+    >
+      <div
+        class="ant-form-item-control-input"
+      >
+        <div
+          class="ant-form-item-control-input-content"
+        >
+          <span
+            class="ant-form-text"
+          >
+            China
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-row ant-form-item"
+  >
+    <div
+      class="ant-col ant-col-6 ant-form-item-label"
+    >
+      <label
+        class="ant-form-item-required"
+        for="validate_other_select"
+        title="Select"
+      >
+        Select
+      </label>
+    </div>
+    <div
+      class="ant-col ant-col-14 ant-form-item-control"
+    >
+      <div
+        class="ant-form-item-control-input"
+      >
+        <div
+          class="ant-form-item-control-input-content"
+        >
+          <div
+            class="ant-select ant-select-single ant-select-show-arrow"
+          >
+            <div
+              class="ant-select-selector"
+            >
+              <span
+                class="ant-select-selection-search"
+              >
+                <input
+                  aria-activedescendant="validate_other_select_list_0"
+                  aria-autocomplete="list"
+                  aria-controls="validate_other_select_list"
+                  aria-haspopup="listbox"
+                  aria-owns="validate_other_select_list"
+                  autocomplete="off"
+                  class="ant-select-selection-search-input"
+                  id="validate_other_select"
+                  readonly=""
+                  role="combobox"
+                  style="opacity:0"
+                  value=""
+                />
+              </span>
+              <span
+                class="ant-select-selection-placeholder"
+              >
+                Please select a country
+              </span>
+            </div>
+            <span
+              aria-hidden="true"
+              class="ant-select-arrow"
+              style="user-select:none;-webkit-user-select:none"
+              unselectable="on"
+            >
+              <span
+                aria-label="down"
+                class="anticon anticon-down"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  class=""
+                  data-icon="down"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                  />
+                </svg>
+              </span>
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-row ant-form-item"
+  >
+    <div
+      class="ant-col ant-col-6 ant-form-item-label"
+    >
+      <label
+        class="ant-form-item-required"
+        for="validate_other_select-multiple"
+        title="Select[multiple]"
+      >
+        Select[multiple]
+      </label>
+    </div>
+    <div
+      class="ant-col ant-col-14 ant-form-item-control"
+    >
+      <div
+        class="ant-form-item-control-input"
+      >
+        <div
+          class="ant-form-item-control-input-content"
+        >
+          <div
+            class="ant-select ant-select-multiple ant-select-show-search"
+          >
+            <div
+              class="ant-select-selector"
+            >
+              <span
+                class="ant-select-selection-search"
+                style="width:0"
+              >
+                <input
+                  aria-activedescendant="validate_other_select-multiple_list_0"
+                  aria-autocomplete="list"
+                  aria-controls="validate_other_select-multiple_list"
+                  aria-haspopup="listbox"
+                  aria-owns="validate_other_select-multiple_list"
+                  autocomplete="off"
+                  class="ant-select-selection-search-input"
+                  id="validate_other_select-multiple"
+                  readonly=""
+                  role="combobox"
+                  style="opacity:0"
+                  value=""
+                />
+                <span
+                  aria-hidden="true"
+                  class="ant-select-selection-search-mirror"
+                >
+                   
+                </span>
+              </span>
+              <span
+                class="ant-select-selection-placeholder"
+              >
+                Please select favourite colors
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-row ant-form-item"
+  >
+    <div
+      class="ant-col ant-col-6 ant-form-item-label"
+    >
+      <label
+        class=""
+        title="InputNumber"
+      >
+        InputNumber
+      </label>
+    </div>
+    <div
+      class="ant-col ant-col-14 ant-form-item-control"
+    >
+      <div
+        class="ant-form-item-control-input"
+      >
+        <div
+          class="ant-form-item-control-input-content"
+        >
+          <div
+            class="ant-input-number"
+          >
+            <div
+              class="ant-input-number-handler-wrap"
+            >
+              <span
+                aria-disabled="false"
+                aria-label="Increase Value"
+                class="ant-input-number-handler ant-input-number-handler-up "
+                role="button"
+                unselectable="unselectable"
+              >
+                <span
+                  aria-label="up"
+                  class="anticon anticon-up ant-input-number-handler-up-inner"
+                  role="img"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class=""
+                    data-icon="up"
+                    fill="currentColor"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M890.5 755.3L537.9 269.2c-12.8-17.6-39-17.6-51.7 0L133.5 755.3A8 8 0 00140 768h75c5.1 0 9.9-2.5 12.9-6.6L512 369.8l284.1 391.6c3 4.1 7.8 6.6 12.9 6.6h75c6.5 0 10.3-7.4 6.5-12.7z"
+                    />
+                  </svg>
+                </span>
+              </span>
+              <span
+                aria-disabled="false"
+                aria-label="Decrease Value"
+                class="ant-input-number-handler ant-input-number-handler-down "
+                role="button"
+                unselectable="unselectable"
+              >
+                <span
+                  aria-label="down"
+                  class="anticon anticon-down ant-input-number-handler-down-inner"
+                  role="img"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class=""
+                    data-icon="down"
+                    fill="currentColor"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                    />
+                  </svg>
+                </span>
+              </span>
+            </div>
+            <div
+              class="ant-input-number-input-wrap"
+            >
+              <input
+                aria-valuemax="10"
+                aria-valuemin="1"
+                aria-valuenow="3"
+                autocomplete="off"
+                class="ant-input-number-input"
+                id="validate_other_input-number"
+                max="10"
+                min="1"
+                role="spinbutton"
+                step="1"
+                value="3"
+              />
+            </div>
+          </div>
+          <span
+            class="ant-form-text"
+          >
+             machines
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-row ant-form-item"
+  >
+    <div
+      class="ant-col ant-col-6 ant-form-item-label"
+    >
+      <label
+        class=""
+        for="validate_other_switch"
+        title="Switch"
+      >
+        Switch
+      </label>
+    </div>
+    <div
+      class="ant-col ant-col-14 ant-form-item-control"
+    >
+      <div
+        class="ant-form-item-control-input"
+      >
+        <div
+          class="ant-form-item-control-input-content"
+        >
+          <button
+            aria-checked="false"
+            class="ant-switch"
+            id="validate_other_switch"
+            role="switch"
+            type="button"
+          >
+            <span
+              class="ant-switch-inner"
+            />
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-row ant-form-item"
+  >
+    <div
+      class="ant-col ant-col-6 ant-form-item-label"
+    >
+      <label
+        class=""
+        for="validate_other_slider"
+        title="Slider"
+      >
+        Slider
+      </label>
+    </div>
+    <div
+      class="ant-col ant-col-14 ant-form-item-control"
+    >
+      <div
+        class="ant-form-item-control-input"
+      >
+        <div
+          class="ant-form-item-control-input-content"
+        >
+          <div
+            class="ant-slider ant-slider-with-marks"
+          >
+            <div
+              class="ant-slider-rail"
+            />
+            <div
+              class="ant-slider-track"
+              style="left:0%;right:auto;width:0%"
+            />
+            <div
+              class="ant-slider-step"
+            >
+              <span
+                class="ant-slider-dot ant-slider-dot-active"
+                style="left:0%"
+              />
+              <span
+                class="ant-slider-dot"
+                style="left:20%"
+              />
+              <span
+                class="ant-slider-dot"
+                style="left:40%"
+              />
+              <span
+                class="ant-slider-dot"
+                style="left:60%"
+              />
+              <span
+                class="ant-slider-dot"
+                style="left:80%"
+              />
+              <span
+                class="ant-slider-dot"
+                style="left:100%"
+              />
+            </div>
+            <div
+              aria-disabled="false"
+              aria-valuemax="100"
+              aria-valuemin="0"
+              aria-valuenow="0"
+              class="ant-slider-handle"
+              role="slider"
+              style="left:0%;right:auto;transform:translateX(-50%)"
+              tabindex="0"
+            />
+            <div
+              class="ant-slider-mark"
+            >
+              <span
+                class="ant-slider-mark-text ant-slider-mark-text-active"
+                style="transform:translateX(-50%);-ms-transform:translateX(-50%);left:0%"
+              >
+                A
+              </span>
+              <span
+                class="ant-slider-mark-text"
+                style="transform:translateX(-50%);-ms-transform:translateX(-50%);left:20%"
+              >
+                B
+              </span>
+              <span
+                class="ant-slider-mark-text"
+                style="transform:translateX(-50%);-ms-transform:translateX(-50%);left:40%"
+              >
+                C
+              </span>
+              <span
+                class="ant-slider-mark-text"
+                style="transform:translateX(-50%);-ms-transform:translateX(-50%);left:60%"
+              >
+                D
+              </span>
+              <span
+                class="ant-slider-mark-text"
+                style="transform:translateX(-50%);-ms-transform:translateX(-50%);left:80%"
+              >
+                E
+              </span>
+              <span
+                class="ant-slider-mark-text"
+                style="transform:translateX(-50%);-ms-transform:translateX(-50%);left:100%"
+              >
+                F
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-row ant-form-item"
+  >
+    <div
+      class="ant-col ant-col-6 ant-form-item-label"
+    >
+      <label
+        class=""
+        for="validate_other_radio-group"
+        title="Radio.Group"
+      >
+        Radio.Group
+      </label>
+    </div>
+    <div
+      class="ant-col ant-col-14 ant-form-item-control"
+    >
+      <div
+        class="ant-form-item-control-input"
+      >
+        <div
+          class="ant-form-item-control-input-content"
+        >
+          <div
+            class="ant-radio-group ant-radio-group-outline"
+            id="validate_other_radio-group"
+          >
+            <label
+              class="ant-radio-wrapper"
+            >
+              <span
+                class="ant-radio"
+              >
+                <input
+                  class="ant-radio-input"
+                  type="radio"
+                  value="a"
+                />
+                <span
+                  class="ant-radio-inner"
+                />
+              </span>
+              <span>
+                item 1
+              </span>
+            </label>
+            <label
+              class="ant-radio-wrapper"
+            >
+              <span
+                class="ant-radio"
+              >
+                <input
+                  class="ant-radio-input"
+                  type="radio"
+                  value="b"
+                />
+                <span
+                  class="ant-radio-inner"
+                />
+              </span>
+              <span>
+                item 2
+              </span>
+            </label>
+            <label
+              class="ant-radio-wrapper"
+            >
+              <span
+                class="ant-radio"
+              >
+                <input
+                  class="ant-radio-input"
+                  type="radio"
+                  value="c"
+                />
+                <span
+                  class="ant-radio-inner"
+                />
+              </span>
+              <span>
+                item 3
+              </span>
+            </label>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-row ant-form-item"
+  >
+    <div
+      class="ant-col ant-col-6 ant-form-item-label"
+    >
+      <label
+        class=""
+        for="validate_other_radio-button"
+        title="Radio.Button"
+      >
+        Radio.Button
+      </label>
+    </div>
+    <div
+      class="ant-col ant-col-14 ant-form-item-control"
+    >
+      <div
+        class="ant-form-item-control-input"
+      >
+        <div
+          class="ant-form-item-control-input-content"
+        >
+          <div
+            class="ant-radio-group ant-radio-group-outline"
+            id="validate_other_radio-button"
+          >
+            <label
+              class="ant-radio-button-wrapper"
+            >
+              <span
+                class="ant-radio-button"
+              >
+                <input
+                  class="ant-radio-button-input"
+                  type="radio"
+                  value="a"
+                />
+                <span
+                  class="ant-radio-button-inner"
+                />
+              </span>
+              <span>
+                item 1
+              </span>
+            </label>
+            <label
+              class="ant-radio-button-wrapper"
+            >
+              <span
+                class="ant-radio-button"
+              >
+                <input
+                  class="ant-radio-button-input"
+                  type="radio"
+                  value="b"
+                />
+                <span
+                  class="ant-radio-button-inner"
+                />
+              </span>
+              <span>
+                item 2
+              </span>
+            </label>
+            <label
+              class="ant-radio-button-wrapper"
+            >
+              <span
+                class="ant-radio-button"
+              >
+                <input
+                  class="ant-radio-button-input"
+                  type="radio"
+                  value="c"
+                />
+                <span
+                  class="ant-radio-button-inner"
+                />
+              </span>
+              <span>
+                item 3
+              </span>
+            </label>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-row ant-form-item"
+  >
+    <div
+      class="ant-col ant-col-6 ant-form-item-label"
+    >
+      <label
+        class=""
+        for="validate_other_checkbox-group"
+        title="Checkbox.Group"
+      >
+        Checkbox.Group
+      </label>
+    </div>
+    <div
+      class="ant-col ant-col-14 ant-form-item-control"
+    >
+      <div
+        class="ant-form-item-control-input"
+      >
+        <div
+          class="ant-form-item-control-input-content"
+        >
+          <div
+            class="ant-checkbox-group"
+            id="validate_other_checkbox-group"
+            style="width:100%"
+          >
+            <div
+              class="ant-row"
+            >
+              <div
+                class="ant-col ant-col-8"
+              >
+                <label
+                  class="ant-checkbox-wrapper ant-checkbox-wrapper-checked"
+                >
+                  <span
+                    class="ant-checkbox ant-checkbox-checked"
+                  >
+                    <input
+                      checked=""
+                      class="ant-checkbox-input"
+                      type="checkbox"
+                      value="A"
+                    />
+                    <span
+                      class="ant-checkbox-inner"
+                    />
+                  </span>
+                  <span>
+                    A
+                  </span>
+                </label>
+              </div>
+              <div
+                class="ant-col ant-col-8"
+              >
+                <label
+                  class="ant-checkbox-wrapper ant-checkbox-wrapper-checked ant-checkbox-wrapper-disabled"
+                >
+                  <span
+                    class="ant-checkbox ant-checkbox-checked ant-checkbox-disabled"
+                  >
+                    <input
+                      checked=""
+                      class="ant-checkbox-input"
+                      disabled=""
+                      type="checkbox"
+                      value="B"
+                    />
+                    <span
+                      class="ant-checkbox-inner"
+                    />
+                  </span>
+                  <span>
+                    B
+                  </span>
+                </label>
+              </div>
+              <div
+                class="ant-col ant-col-8"
+              >
+                <label
+                  class="ant-checkbox-wrapper"
+                >
+                  <span
+                    class="ant-checkbox"
+                  >
+                    <input
+                      class="ant-checkbox-input"
+                      type="checkbox"
+                      value="C"
+                    />
+                    <span
+                      class="ant-checkbox-inner"
+                    />
+                  </span>
+                  <span>
+                    C
+                  </span>
+                </label>
+              </div>
+              <div
+                class="ant-col ant-col-8"
+              >
+                <label
+                  class="ant-checkbox-wrapper"
+                >
+                  <span
+                    class="ant-checkbox"
+                  >
+                    <input
+                      class="ant-checkbox-input"
+                      type="checkbox"
+                      value="D"
+                    />
+                    <span
+                      class="ant-checkbox-inner"
+                    />
+                  </span>
+                  <span>
+                    D
+                  </span>
+                </label>
+              </div>
+              <div
+                class="ant-col ant-col-8"
+              >
+                <label
+                  class="ant-checkbox-wrapper"
+                >
+                  <span
+                    class="ant-checkbox"
+                  >
+                    <input
+                      class="ant-checkbox-input"
+                      type="checkbox"
+                      value="E"
+                    />
+                    <span
+                      class="ant-checkbox-inner"
+                    />
+                  </span>
+                  <span>
+                    E
+                  </span>
+                </label>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-row ant-form-item"
+  >
+    <div
+      class="ant-col ant-col-6 ant-form-item-label"
+    >
+      <label
+        class=""
+        for="validate_other_rate"
+        title="Rate"
+      >
+        Rate
+      </label>
+    </div>
+    <div
+      class="ant-col ant-col-14 ant-form-item-control"
+    >
+      <div
+        class="ant-form-item-control-input"
+      >
+        <div
+          class="ant-form-item-control-input-content"
+        >
+          <ul
+            class="ant-rate"
+            role="radiogroup"
+            tabindex="0"
+          >
+            <li
+              class="ant-rate-star ant-rate-star-full"
+            >
+              <div
+                aria-checked="true"
+                aria-posinset="1"
+                aria-setsize="5"
+                role="radio"
+                tabindex="0"
+              >
+                <div
+                  class="ant-rate-star-first"
+                >
+                  <span
+                    aria-label="star"
+                    class="anticon anticon-star"
+                    role="img"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class=""
+                      data-icon="star"
+                      fill="currentColor"
+                      focusable="false"
+                      height="1em"
+                      viewBox="64 64 896 896"
+                      width="1em"
+                    >
+                      <path
+                        d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
+                      />
+                    </svg>
+                  </span>
+                </div>
+                <div
+                  class="ant-rate-star-second"
+                >
+                  <span
+                    aria-label="star"
+                    class="anticon anticon-star"
+                    role="img"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class=""
+                      data-icon="star"
+                      fill="currentColor"
+                      focusable="false"
+                      height="1em"
+                      viewBox="64 64 896 896"
+                      width="1em"
+                    >
+                      <path
+                        d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
+                      />
+                    </svg>
+                  </span>
+                </div>
+              </div>
+            </li>
+            <li
+              class="ant-rate-star ant-rate-star-full"
+            >
+              <div
+                aria-checked="true"
+                aria-posinset="2"
+                aria-setsize="5"
+                role="radio"
+                tabindex="0"
+              >
+                <div
+                  class="ant-rate-star-first"
+                >
+                  <span
+                    aria-label="star"
+                    class="anticon anticon-star"
+                    role="img"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class=""
+                      data-icon="star"
+                      fill="currentColor"
+                      focusable="false"
+                      height="1em"
+                      viewBox="64 64 896 896"
+                      width="1em"
+                    >
+                      <path
+                        d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
+                      />
+                    </svg>
+                  </span>
+                </div>
+                <div
+                  class="ant-rate-star-second"
+                >
+                  <span
+                    aria-label="star"
+                    class="anticon anticon-star"
+                    role="img"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class=""
+                      data-icon="star"
+                      fill="currentColor"
+                      focusable="false"
+                      height="1em"
+                      viewBox="64 64 896 896"
+                      width="1em"
+                    >
+                      <path
+                        d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
+                      />
+                    </svg>
+                  </span>
+                </div>
+              </div>
+            </li>
+            <li
+              class="ant-rate-star ant-rate-star-full"
+            >
+              <div
+                aria-checked="true"
+                aria-posinset="3"
+                aria-setsize="5"
+                role="radio"
+                tabindex="0"
+              >
+                <div
+                  class="ant-rate-star-first"
+                >
+                  <span
+                    aria-label="star"
+                    class="anticon anticon-star"
+                    role="img"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class=""
+                      data-icon="star"
+                      fill="currentColor"
+                      focusable="false"
+                      height="1em"
+                      viewBox="64 64 896 896"
+                      width="1em"
+                    >
+                      <path
+                        d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
+                      />
+                    </svg>
+                  </span>
+                </div>
+                <div
+                  class="ant-rate-star-second"
+                >
+                  <span
+                    aria-label="star"
+                    class="anticon anticon-star"
+                    role="img"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class=""
+                      data-icon="star"
+                      fill="currentColor"
+                      focusable="false"
+                      height="1em"
+                      viewBox="64 64 896 896"
+                      width="1em"
+                    >
+                      <path
+                        d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
+                      />
+                    </svg>
+                  </span>
+                </div>
+              </div>
+            </li>
+            <li
+              class="ant-rate-star ant-rate-star-zero"
+            >
+              <div
+                aria-checked="true"
+                aria-posinset="4"
+                aria-setsize="5"
+                role="radio"
+                tabindex="0"
+              >
+                <div
+                  class="ant-rate-star-first"
+                >
+                  <span
+                    aria-label="star"
+                    class="anticon anticon-star"
+                    role="img"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class=""
+                      data-icon="star"
+                      fill="currentColor"
+                      focusable="false"
+                      height="1em"
+                      viewBox="64 64 896 896"
+                      width="1em"
+                    >
+                      <path
+                        d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
+                      />
+                    </svg>
+                  </span>
+                </div>
+                <div
+                  class="ant-rate-star-second"
+                >
+                  <span
+                    aria-label="star"
+                    class="anticon anticon-star"
+                    role="img"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class=""
+                      data-icon="star"
+                      fill="currentColor"
+                      focusable="false"
+                      height="1em"
+                      viewBox="64 64 896 896"
+                      width="1em"
+                    >
+                      <path
+                        d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
+                      />
+                    </svg>
+                  </span>
+                </div>
+              </div>
+            </li>
+            <li
+              class="ant-rate-star ant-rate-star-zero"
+            >
+              <div
+                aria-checked="false"
+                aria-posinset="5"
+                aria-setsize="5"
+                role="radio"
+                tabindex="0"
+              >
+                <div
+                  class="ant-rate-star-first"
+                >
+                  <span
+                    aria-label="star"
+                    class="anticon anticon-star"
+                    role="img"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class=""
+                      data-icon="star"
+                      fill="currentColor"
+                      focusable="false"
+                      height="1em"
+                      viewBox="64 64 896 896"
+                      width="1em"
+                    >
+                      <path
+                        d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
+                      />
+                    </svg>
+                  </span>
+                </div>
+                <div
+                  class="ant-rate-star-second"
+                >
+                  <span
+                    aria-label="star"
+                    class="anticon anticon-star"
+                    role="img"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class=""
+                      data-icon="star"
+                      fill="currentColor"
+                      focusable="false"
+                      height="1em"
+                      viewBox="64 64 896 896"
+                      width="1em"
+                    >
+                      <path
+                        d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
+                      />
+                    </svg>
+                  </span>
+                </div>
+              </div>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-row ant-form-item"
+  >
+    <div
+      class="ant-col ant-col-6 ant-form-item-label"
+    >
+      <label
+        class=""
+        for="validate_other_upload"
+        title="Upload"
+      >
+        Upload
+      </label>
+    </div>
+    <div
+      class="ant-col ant-col-14 ant-form-item-control"
+    >
+      <div
+        class="ant-form-item-control-input"
+      >
+        <div
+          class="ant-form-item-control-input-content"
+        >
+          <span
+            class=""
+          >
+            <div
+              class="ant-upload ant-upload-select ant-upload-select-picture"
+            >
+              <span
+                class="ant-upload"
+                role="button"
+                tabindex="0"
+              >
+                <input
+                  accept=""
+                  id="validate_other_upload"
+                  style="display:none"
+                  type="file"
+                />
+                <button
+                  class="ant-btn"
+                  type="button"
+                >
+                  <span
+                    aria-label="upload"
+                    class="anticon anticon-upload"
+                    role="img"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class=""
+                      data-icon="upload"
+                      fill="currentColor"
+                      focusable="false"
+                      height="1em"
+                      viewBox="64 64 896 896"
+                      width="1em"
+                    >
+                      <path
+                        d="M400 317.7h73.9V656c0 4.4 3.6 8 8 8h60c4.4 0 8-3.6 8-8V317.7H624c6.7 0 10.4-7.7 6.3-12.9L518.3 163a8 8 0 00-12.6 0l-112 141.7c-4.1 5.3-.4 13 6.3 13zM878 626h-60c-4.4 0-8 3.6-8 8v154H214V634c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v198c0 17.7 14.3 32 32 32h684c17.7 0 32-14.3 32-32V634c0-4.4-3.6-8-8-8z"
+                      />
+                    </svg>
+                  </span>
+                  <span>
+                     Click to upload
+                  </span>
+                </button>
+              </span>
+            </div>
+            <div
+              class="ant-upload-list ant-upload-list-picture"
+            />
+          </span>
+        </div>
+      </div>
+      <div
+        class="ant-form-item-extra"
+      >
+        longgggggggggggggggggggggggggggggggggg
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-row ant-form-item"
+  >
+    <div
+      class="ant-col ant-col-6 ant-form-item-label"
+    >
+      <label
+        class=""
+        title="Dragger"
+      >
+        Dragger
+      </label>
+    </div>
+    <div
+      class="ant-col ant-col-14 ant-form-item-control"
+    >
+      <div
+        class="ant-form-item-control-input"
+      >
+        <div
+          class="ant-form-item-control-input-content"
+        >
+          <span>
+            <div
+              class="ant-upload ant-upload-drag"
+            >
+              <span
+                class="ant-upload ant-upload-btn"
+                role="button"
+                tabindex="0"
+              >
+                <input
+                  accept=""
+                  id="validate_other_dragger"
+                  style="display:none"
+                  type="file"
+                />
+                <div
+                  class="ant-upload-drag-container"
+                >
+                  <p
+                    class="ant-upload-drag-icon"
+                  >
+                    <span
+                      aria-label="inbox"
+                      class="anticon anticon-inbox"
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class=""
+                        data-icon="inbox"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="0 0 1024 1024"
+                        width="1em"
+                      >
+                        <path
+                          d="M885.2 446.3l-.2-.8-112.2-285.1c-5-16.1-19.9-27.2-36.8-27.2H281.2c-17 0-32.1 11.3-36.9 27.6L139.4 443l-.3.7-.2.8c-1.3 4.9-1.7 9.9-1 14.8-.1 1.6-.2 3.2-.2 4.8V830a60.9 60.9 0 0060.8 60.8h627.2c33.5 0 60.8-27.3 60.9-60.8V464.1c0-1.3 0-2.6-.1-3.7.4-4.9 0-9.6-1.3-14.1zm-295.8-43l-.3 15.7c-.8 44.9-31.8 75.1-77.1 75.1-22.1 0-41.1-7.1-54.8-20.6S436 441.2 435.6 419l-.3-15.7H229.5L309 210h399.2l81.7 193.3H589.4zm-375 76.8h157.3c24.3 57.1 76 90.8 140.4 90.8 33.7 0 65-9.4 90.3-27.2 22.2-15.6 39.5-37.4 50.7-63.6h156.5V814H214.4V480.1z"
+                        />
+                      </svg>
+                    </span>
+                  </p>
+                  <p
+                    class="ant-upload-text"
+                  >
+                    Click or drag file to this area to upload
+                  </p>
+                  <p
+                    class="ant-upload-hint"
+                  >
+                    Support for a single or bulk upload.
+                  </p>
+                </div>
+              </span>
+            </div>
+            <div
+              class="ant-upload-list ant-upload-list-text"
+            />
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-row ant-form-item"
+  >
+    <div
+      class="ant-col ant-col-12 ant-col-offset-6 ant-form-item-control"
+    >
+      <div
+        class="ant-form-item-control-input"
+      >
+        <div
+          class="ant-form-item-control-input-content"
+        >
+          <button
+            class="ant-btn ant-btn-primary"
+            type="submit"
+          >
+            <span>
+              Submit
+            </span>
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</form>
+`;
+
+exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
+<form
+  class="ant-form ant-form-horizontal"
+>
+  <div
+    class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-error"
+  >
+    <div
+      class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-5"
+    >
+      <label
+        class=""
+        title="Fail"
+      >
+        Fail
+      </label>
+    </div>
+    <div
+      class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-12"
+    >
+      <div
+        class="ant-form-item-control-input"
+      >
+        <div
+          class="ant-form-item-control-input-content"
+        >
+          <input
+            class="ant-input"
+            id="error"
+            placeholder="unavailable choice"
+            type="text"
+            value=""
+          />
+        </div>
+      </div>
+      <div
+        class="ant-form-item-explain"
+      >
+        <div>
+          Should be combination of numbers & alphabets
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-row ant-form-item ant-form-item-has-warning"
+  >
+    <div
+      class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-5"
+    >
+      <label
+        class=""
+        title="Warning"
+      >
+        Warning
+      </label>
+    </div>
+    <div
+      class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-12"
+    >
+      <div
+        class="ant-form-item-control-input"
+      >
+        <div
+          class="ant-form-item-control-input-content"
+        >
+          <span
+            class="ant-input-affix-wrapper"
+          >
+            <span
+              class="ant-input-prefix"
+            >
+              <span
+                aria-label="smile"
+                class="anticon anticon-smile"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  class=""
+                  data-icon="smile"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M288 421a48 48 0 1096 0 48 48 0 10-96 0zm352 0a48 48 0 1096 0 48 48 0 10-96 0zM512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm263 711c-34.2 34.2-74 61-118.3 79.8C611 874.2 562.3 884 512 884c-50.3 0-99-9.8-144.8-29.2A370.4 370.4 0 01248.9 775c-34.2-34.2-61-74-79.8-118.3C149.8 611 140 562.3 140 512s9.8-99 29.2-144.8A370.4 370.4 0 01249 248.9c34.2-34.2 74-61 118.3-79.8C413 149.8 461.7 140 512 140c50.3 0 99 9.8 144.8 29.2A370.4 370.4 0 01775.1 249c34.2 34.2 61 74 79.8 118.3C874.2 413 884 461.7 884 512s-9.8 99-29.2 144.8A368.89 368.89 0 01775 775zM664 533h-48.1c-4.2 0-7.8 3.2-8.1 7.4C604 589.9 562.5 629 512 629s-92.1-39.1-95.8-88.6c-.3-4.2-3.9-7.4-8.1-7.4H360a8 8 0 00-8 8.4c4.4 84.3 74.5 151.6 160 151.6s155.6-67.3 160-151.6a8 8 0 00-8-8.4z"
+                  />
+                </svg>
+              </span>
+            </span>
+            <input
+              class="ant-input"
+              id="warning"
+              placeholder="Warning"
+              type="text"
+              value=""
+            />
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-feedback ant-form-item-is-validating"
+  >
+    <div
+      class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-5"
+    >
+      <label
+        class=""
+        title="Validating"
+      >
+        Validating
+      </label>
+    </div>
+    <div
+      class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-12"
+    >
+      <div
+        class="ant-form-item-control-input"
+      >
+        <div
+          class="ant-form-item-control-input-content"
+        >
+          <input
+            class="ant-input"
+            id="validating"
+            placeholder="I'm the content is being validated"
+            type="text"
+            value=""
+          />
+        </div>
+        <span
+          class="ant-form-item-children-icon"
+        >
+          <span
+            aria-label="loading"
+            class="anticon anticon-loading"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              class="anticon-spin"
+              data-icon="loading"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="0 0 1024 1024"
+              width="1em"
+            >
+              <path
+                d="M988 548c-19.9 0-36-16.1-36-36 0-59.4-11.6-117-34.6-171.3a440.45 440.45 0 00-94.3-139.9 437.71 437.71 0 00-139.9-94.3C629 83.6 571.4 72 512 72c-19.9 0-36-16.1-36-36s16.1-36 36-36c69.1 0 136.2 13.5 199.3 40.3C772.3 66 827 103 874 150c47 47 83.9 101.8 109.7 162.7 26.7 63.1 40.2 130.2 40.2 199.3.1 19.9-16 36-35.9 36z"
+              />
+            </svg>
+          </span>
+        </span>
+      </div>
+      <div
+        class="ant-form-item-explain"
+      >
+        <div>
+          The information is being validated...
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-row ant-form-item ant-form-item-has-feedback ant-form-item-has-success"
+  >
+    <div
+      class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-5"
+    >
+      <label
+        class=""
+        title="Success"
+      >
+        Success
+      </label>
+    </div>
+    <div
+      class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-12"
+    >
+      <div
+        class="ant-form-item-control-input"
+      >
+        <div
+          class="ant-form-item-control-input-content"
+        >
+          <input
+            class="ant-input"
+            id="success"
+            placeholder="I'm the content"
+            type="text"
+            value=""
+          />
+        </div>
+        <span
+          class="ant-form-item-children-icon"
+        >
+          <span
+            aria-label="check-circle"
+            class="anticon anticon-check-circle"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              class=""
+              data-icon="check-circle"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm193.5 301.7l-210.6 292a31.8 31.8 0 01-51.7 0L318.5 484.9c-3.8-5.3 0-12.7 6.5-12.7h46.9c10.2 0 19.9 4.9 25.9 13.3l71.2 98.8 157.2-218c6-8.3 15.6-13.3 25.9-13.3H699c6.5 0 10.3 7.4 6.5 12.7z"
+              />
+            </svg>
+          </span>
+        </span>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-row ant-form-item ant-form-item-has-feedback ant-form-item-has-warning"
+  >
+    <div
+      class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-5"
+    >
+      <label
+        class=""
+        title="Warning"
+      >
+        Warning
+      </label>
+    </div>
+    <div
+      class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-12"
+    >
+      <div
+        class="ant-form-item-control-input"
+      >
+        <div
+          class="ant-form-item-control-input-content"
+        >
+          <input
+            class="ant-input"
+            id="warning2"
+            placeholder="Warning"
+            type="text"
+            value=""
+          />
+        </div>
+        <span
+          class="ant-form-item-children-icon"
+        >
+          <span
+            aria-label="exclamation-circle"
+            class="anticon anticon-exclamation-circle"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              class=""
+              data-icon="exclamation-circle"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm-32 232c0-4.4 3.6-8 8-8h48c4.4 0 8 3.6 8 8v272c0 4.4-3.6 8-8 8h-48c-4.4 0-8-3.6-8-8V296zm32 440a48.01 48.01 0 010-96 48.01 48.01 0 010 96z"
+              />
+            </svg>
+          </span>
+        </span>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-feedback ant-form-item-has-error"
+  >
+    <div
+      class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-5"
+    >
+      <label
+        class=""
+        title="Fail"
+      >
+        Fail
+      </label>
+    </div>
+    <div
+      class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-12"
+    >
+      <div
+        class="ant-form-item-control-input"
+      >
+        <div
+          class="ant-form-item-control-input-content"
+        >
+          <input
+            class="ant-input"
+            id="error2"
+            placeholder="unavailable choice"
+            type="text"
+            value=""
+          />
+        </div>
+        <span
+          class="ant-form-item-children-icon"
+        >
+          <span
+            aria-label="close-circle"
+            class="anticon anticon-close-circle"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              class=""
+              data-icon="close-circle"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm165.4 618.2l-66-.3L512 563.4l-99.3 118.4-66.1.3c-4.4 0-8-3.5-8-8 0-1.9.7-3.7 1.9-5.2l130.1-155L340.5 359a8.32 8.32 0 01-1.9-5.2c0-4.4 3.6-8 8-8l66.1.3L512 464.6l99.3-118.4 66-.3c4.4 0 8 3.5 8 8 0 1.9-.7 3.7-1.9 5.2L553.5 514l130 155c1.2 1.5 1.9 3.3 1.9 5.2 0 4.4-3.6 8-8 8z"
+              />
+            </svg>
+          </span>
+        </span>
+      </div>
+      <div
+        class="ant-form-item-explain"
+      >
+        <div>
+          Should be combination of numbers & alphabets
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-row ant-form-item ant-form-item-has-feedback ant-form-item-has-success"
+  >
+    <div
+      class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-5"
+    >
+      <label
+        class=""
+        title="Success"
+      >
+        Success
+      </label>
+    </div>
+    <div
+      class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-12"
+    >
+      <div
+        class="ant-form-item-control-input"
+      >
+        <div
+          class="ant-form-item-control-input-content"
+        >
+          <div
+            class="ant-picker"
+            style="width:100%"
+          >
+            <div
+              class="ant-picker-input"
+            >
+              <input
+                placeholder="Select date"
+                readonly=""
+                size="12"
+                value=""
+              />
+              <span
+                class="ant-picker-suffix"
+              >
+                <span
+                  aria-label="calendar"
+                  class="anticon anticon-calendar"
+                  role="img"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class=""
+                    data-icon="calendar"
+                    fill="currentColor"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M880 184H712v-64c0-4.4-3.6-8-8-8h-56c-4.4 0-8 3.6-8 8v64H384v-64c0-4.4-3.6-8-8-8h-56c-4.4 0-8 3.6-8 8v64H144c-17.7 0-32 14.3-32 32v664c0 17.7 14.3 32 32 32h736c17.7 0 32-14.3 32-32V216c0-17.7-14.3-32-32-32zm-40 656H184V460h656v380zM184 392V256h128v48c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8v-48h256v48c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8v-48h128v136H184z"
+                    />
+                  </svg>
+                </span>
+              </span>
+            </div>
+          </div>
+        </div>
+        <span
+          class="ant-form-item-children-icon"
+        >
+          <span
+            aria-label="check-circle"
+            class="anticon anticon-check-circle"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              class=""
+              data-icon="check-circle"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm193.5 301.7l-210.6 292a31.8 31.8 0 01-51.7 0L318.5 484.9c-3.8-5.3 0-12.7 6.5-12.7h46.9c10.2 0 19.9 4.9 25.9 13.3l71.2 98.8 157.2-218c6-8.3 15.6-13.3 25.9-13.3H699c6.5 0 10.3 7.4 6.5 12.7z"
+              />
+            </svg>
+          </span>
+        </span>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-row ant-form-item ant-form-item-has-feedback ant-form-item-has-warning"
+  >
+    <div
+      class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-5"
+    >
+      <label
+        class=""
+        title="Warning"
+      >
+        Warning
+      </label>
+    </div>
+    <div
+      class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-12"
+    >
+      <div
+        class="ant-form-item-control-input"
+      >
+        <div
+          class="ant-form-item-control-input-content"
+        >
+          <div
+            class="ant-picker"
+            style="width:100%"
+          >
+            <div
+              class="ant-picker-input"
+            >
+              <input
+                placeholder="Select time"
+                readonly=""
+                size="10"
+                value=""
+              />
+              <span
+                class="ant-picker-suffix"
+              >
+                <span
+                  aria-label="clock-circle"
+                  class="anticon anticon-clock-circle"
+                  role="img"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class=""
+                    data-icon="clock-circle"
+                    fill="currentColor"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+                    />
+                    <path
+                      d="M686.7 638.6L544.1 535.5V288c0-4.4-3.6-8-8-8H488c-4.4 0-8 3.6-8 8v275.4c0 2.6 1.2 5 3.3 6.5l165.4 120.6c3.6 2.6 8.6 1.8 11.2-1.7l28.6-39c2.6-3.7 1.8-8.7-1.8-11.2z"
+                    />
+                  </svg>
+                </span>
+              </span>
+            </div>
+          </div>
+        </div>
+        <span
+          class="ant-form-item-children-icon"
+        >
+          <span
+            aria-label="exclamation-circle"
+            class="anticon anticon-exclamation-circle"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              class=""
+              data-icon="exclamation-circle"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm-32 232c0-4.4 3.6-8 8-8h48c4.4 0 8 3.6 8 8v272c0 4.4-3.6 8-8 8h-48c-4.4 0-8-3.6-8-8V296zm32 440a48.01 48.01 0 010-96 48.01 48.01 0 010 96z"
+              />
+            </svg>
+          </span>
+        </span>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-row ant-form-item ant-form-item-has-feedback ant-form-item-has-error"
+  >
+    <div
+      class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-5"
+    >
+      <label
+        class=""
+        title="Error"
+      >
+        Error
+      </label>
+    </div>
+    <div
+      class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-12"
+    >
+      <div
+        class="ant-form-item-control-input"
+      >
+        <div
+          class="ant-form-item-control-input-content"
+        >
+          <div
+            class="ant-select ant-select-single ant-select-show-arrow"
+          >
+            <div
+              class="ant-select-selector"
+            >
+              <span
+                class="ant-select-selection-search"
+              >
+                <input
+                  aria-activedescendant="undefined_list_0"
+                  aria-autocomplete="list"
+                  aria-controls="undefined_list"
+                  aria-haspopup="listbox"
+                  aria-owns="undefined_list"
+                  autocomplete="off"
+                  class="ant-select-selection-search-input"
+                  readonly=""
+                  role="combobox"
+                  style="opacity:0"
+                  value=""
+                />
+              </span>
+              <span
+                class="ant-select-selection-placeholder"
+              />
+            </div>
+            <span
+              aria-hidden="true"
+              class="ant-select-arrow"
+              style="user-select:none;-webkit-user-select:none"
+              unselectable="on"
+            >
+              <span
+                aria-label="down"
+                class="anticon anticon-down"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  class=""
+                  data-icon="down"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                  />
+                </svg>
+              </span>
+            </span>
+          </div>
+        </div>
+        <span
+          class="ant-form-item-children-icon"
+        >
+          <span
+            aria-label="close-circle"
+            class="anticon anticon-close-circle"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              class=""
+              data-icon="close-circle"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm165.4 618.2l-66-.3L512 563.4l-99.3 118.4-66.1.3c-4.4 0-8-3.5-8-8 0-1.9.7-3.7 1.9-5.2l130.1-155L340.5 359a8.32 8.32 0 01-1.9-5.2c0-4.4 3.6-8 8-8l66.1.3L512 464.6l99.3-118.4 66-.3c4.4 0 8 3.5 8 8 0 1.9-.7 3.7-1.9 5.2L553.5 514l130 155c1.2 1.5 1.9 3.3 1.9 5.2 0 4.4-3.6 8-8 8z"
+              />
+            </svg>
+          </span>
+        </span>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-feedback ant-form-item-is-validating"
+  >
+    <div
+      class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-5"
+    >
+      <label
+        class=""
+        title="Validating"
+      >
+        Validating
+      </label>
+    </div>
+    <div
+      class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-12"
+    >
+      <div
+        class="ant-form-item-control-input"
+      >
+        <div
+          class="ant-form-item-control-input-content"
+        >
+          <span
+            class="ant-cascader-picker"
+            tabindex="0"
+          >
+            <span
+              class="ant-cascader-picker-label"
+            />
+            <input
+              autocomplete="off"
+              class="ant-input ant-cascader-input "
+              placeholder="Please select"
+              readonly=""
+              tabindex="-1"
+              type="text"
+              value=""
+            />
+            <span
+              aria-label="down"
+              class="anticon anticon-down ant-cascader-picker-arrow"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                class=""
+                data-icon="down"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                />
+              </svg>
+            </span>
+          </span>
+        </div>
+        <span
+          class="ant-form-item-children-icon"
+        >
+          <span
+            aria-label="loading"
+            class="anticon anticon-loading"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              class="anticon-spin"
+              data-icon="loading"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="0 0 1024 1024"
+              width="1em"
+            >
+              <path
+                d="M988 548c-19.9 0-36-16.1-36-36 0-59.4-11.6-117-34.6-171.3a440.45 440.45 0 00-94.3-139.9 437.71 437.71 0 00-139.9-94.3C629 83.6 571.4 72 512 72c-19.9 0-36-16.1-36-36s16.1-36 36-36c69.1 0 136.2 13.5 199.3 40.3C772.3 66 827 103 874 150c47 47 83.9 101.8 109.7 162.7 26.7 63.1 40.2 130.2 40.2 199.3.1 19.9-16 36-35.9 36z"
+              />
+            </svg>
+          </span>
+        </span>
+      </div>
+      <div
+        class="ant-form-item-explain"
+      >
+        <div>
+          The information is being validated...
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-row ant-form-item"
+    style="margin-bottom:0"
+  >
+    <div
+      class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-5"
+    >
+      <label
+        class=""
+        title="inline"
+      >
+        inline
+      </label>
+    </div>
+    <div
+      class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-12"
+    >
+      <div
+        class="ant-form-item-control-input"
+      >
+        <div
+          class="ant-form-item-control-input-content"
+        >
+          <div
+            class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-error"
+            style="display:inline-block;width:calc(50% - 12px)"
+          >
+            <div
+              class="ant-col ant-form-item-control"
+            >
+              <div
+                class="ant-form-item-control-input"
+              >
+                <div
+                  class="ant-form-item-control-input-content"
+                >
+                  <div
+                    class="ant-picker"
+                  >
+                    <div
+                      class="ant-picker-input"
+                    >
+                      <input
+                        placeholder="Select date"
+                        readonly=""
+                        size="12"
+                        value=""
+                      />
+                      <span
+                        class="ant-picker-suffix"
+                      >
+                        <span
+                          aria-label="calendar"
+                          class="anticon anticon-calendar"
+                          role="img"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class=""
+                            data-icon="calendar"
+                            fill="currentColor"
+                            focusable="false"
+                            height="1em"
+                            viewBox="64 64 896 896"
+                            width="1em"
+                          >
+                            <path
+                              d="M880 184H712v-64c0-4.4-3.6-8-8-8h-56c-4.4 0-8 3.6-8 8v64H384v-64c0-4.4-3.6-8-8-8h-56c-4.4 0-8 3.6-8 8v64H144c-17.7 0-32 14.3-32 32v664c0 17.7 14.3 32 32 32h736c17.7 0 32-14.3 32-32V216c0-17.7-14.3-32-32-32zm-40 656H184V460h656v380zM184 392V256h128v48c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8v-48h256v48c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8v-48h128v136H184z"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="ant-form-item-explain"
+              >
+                <div>
+                  Please select the correct date
+                </div>
+              </div>
+            </div>
+          </div>
+          <span
+            style="display:inline-block;width:24px;text-align:center"
+          >
+            -
+          </span>
+          <div
+            class="ant-row ant-form-item"
+            style="display:inline-block;width:calc(50% - 12px)"
+          >
+            <div
+              class="ant-col ant-form-item-control"
+            >
+              <div
+                class="ant-form-item-control-input"
+              >
+                <div
+                  class="ant-form-item-control-input-content"
+                >
+                  <div
+                    class="ant-picker"
+                  >
+                    <div
+                      class="ant-picker-input"
+                    >
+                      <input
+                        placeholder="Select date"
+                        readonly=""
+                        size="12"
+                        value=""
+                      />
+                      <span
+                        class="ant-picker-suffix"
+                      >
+                        <span
+                          aria-label="calendar"
+                          class="anticon anticon-calendar"
+                          role="img"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class=""
+                            data-icon="calendar"
+                            fill="currentColor"
+                            focusable="false"
+                            height="1em"
+                            viewBox="64 64 896 896"
+                            width="1em"
+                          >
+                            <path
+                              d="M880 184H712v-64c0-4.4-3.6-8-8-8h-56c-4.4 0-8 3.6-8 8v64H384v-64c0-4.4-3.6-8-8-8h-56c-4.4 0-8 3.6-8 8v64H144c-17.7 0-32 14.3-32 32v664c0 17.7 14.3 32 32 32h736c17.7 0 32-14.3 32-32V216c0-17.7-14.3-32-32-32zm-40 656H184V460h656v380zM184 392V256h128v48c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8v-48h256v48c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8v-48h128v136H184z"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-row ant-form-item ant-form-item-has-feedback ant-form-item-has-success"
+  >
+    <div
+      class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-5"
+    >
+      <label
+        class=""
+        title="Success"
+      >
+        Success
+      </label>
+    </div>
+    <div
+      class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-12"
+    >
+      <div
+        class="ant-form-item-control-input"
+      >
+        <div
+          class="ant-form-item-control-input-content"
+        >
+          <div
+            class="ant-input-number"
+            style="width:100%"
           >
             <div
               class="ant-input-number-handler-wrap"
@@ -2984,1961 +6069,6 @@ exports[`renders ./components/form/demo/size.md correctly 1`] = `
             </div>
           </div>
         </div>
-      </div>
-    </div>
-    <div
-      class="ant-row ant-form-item"
-    >
-      <div
-        class="ant-col ant-col-4 ant-form-item-label"
-      >
-        <label
-          class=""
-          title="Switch"
-        >
-          Switch
-        </label>
-      </div>
-      <div
-        class="ant-col ant-col-14 ant-form-item-control"
-      >
-        <div
-          class="ant-form-item-control-input"
-        >
-          <button
-            aria-checked="false"
-            class="ant-switch-small ant-switch"
-            role="switch"
-            type="button"
-          >
-            <span
-              class="ant-switch-inner"
-            />
-          </button>
-        </div>
-      </div>
-    </div>
-    <div
-      class="ant-row ant-form-item"
-    >
-      <div
-        class="ant-col ant-col-4 ant-form-item-label"
-      >
-        <label
-          class=""
-          title="Button"
-        >
-          Button
-        </label>
-      </div>
-      <div
-        class="ant-col ant-col-14 ant-form-item-control"
-      >
-        <div
-          class="ant-form-item-control-input"
-        >
-          <button
-            class="ant-btn ant-btn-sm"
-            type="button"
-          >
-            <span>
-              Button
-            </span>
-          </button>
-        </div>
-      </div>
-    </div>
-  </form>
-</div>
-`;
-
-exports[`renders ./components/form/demo/time-related-controls.md correctly 1`] = `
-<form
-  class="ant-form ant-form-horizontal"
-  id="time_related_controls"
->
-  <div
-    class="ant-row ant-form-item"
-  >
-    <div
-      class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
-    >
-      <label
-        class="ant-form-item-required"
-        for="time_related_controls_date-picker"
-        title="DatePicker"
-      >
-        DatePicker
-      </label>
-    </div>
-    <div
-      class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
-    >
-      <div
-        class="ant-form-item-control-input"
-      >
-        <div
-          class="ant-picker"
-        >
-          <div
-            class="ant-picker-input"
-          >
-            <input
-              placeholder="Select date"
-              readonly=""
-              size="12"
-              value=""
-            />
-            <span
-              class="ant-picker-suffix"
-            >
-              <span
-                aria-label="calendar"
-                class="anticon anticon-calendar"
-                role="img"
-              >
-                <svg
-                  aria-hidden="true"
-                  class=""
-                  data-icon="calendar"
-                  fill="currentColor"
-                  focusable="false"
-                  height="1em"
-                  viewBox="64 64 896 896"
-                  width="1em"
-                >
-                  <path
-                    d="M880 184H712v-64c0-4.4-3.6-8-8-8h-56c-4.4 0-8 3.6-8 8v64H384v-64c0-4.4-3.6-8-8-8h-56c-4.4 0-8 3.6-8 8v64H144c-17.7 0-32 14.3-32 32v664c0 17.7 14.3 32 32 32h736c17.7 0 32-14.3 32-32V216c0-17.7-14.3-32-32-32zm-40 656H184V460h656v380zM184 392V256h128v48c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8v-48h256v48c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8v-48h128v136H184z"
-                  />
-                </svg>
-              </span>
-            </span>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    class="ant-row ant-form-item"
-  >
-    <div
-      class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
-    >
-      <label
-        class="ant-form-item-required"
-        for="time_related_controls_date-time-picker"
-        title="DatePicker[showTime]"
-      >
-        DatePicker[showTime]
-      </label>
-    </div>
-    <div
-      class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
-    >
-      <div
-        class="ant-form-item-control-input"
-      >
-        <div
-          class="ant-picker"
-        >
-          <div
-            class="ant-picker-input"
-          >
-            <input
-              placeholder="Select date"
-              readonly=""
-              size="21"
-              value=""
-            />
-            <span
-              class="ant-picker-suffix"
-            >
-              <span
-                aria-label="calendar"
-                class="anticon anticon-calendar"
-                role="img"
-              >
-                <svg
-                  aria-hidden="true"
-                  class=""
-                  data-icon="calendar"
-                  fill="currentColor"
-                  focusable="false"
-                  height="1em"
-                  viewBox="64 64 896 896"
-                  width="1em"
-                >
-                  <path
-                    d="M880 184H712v-64c0-4.4-3.6-8-8-8h-56c-4.4 0-8 3.6-8 8v64H384v-64c0-4.4-3.6-8-8-8h-56c-4.4 0-8 3.6-8 8v64H144c-17.7 0-32 14.3-32 32v664c0 17.7 14.3 32 32 32h736c17.7 0 32-14.3 32-32V216c0-17.7-14.3-32-32-32zm-40 656H184V460h656v380zM184 392V256h128v48c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8v-48h256v48c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8v-48h128v136H184z"
-                  />
-                </svg>
-              </span>
-            </span>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    class="ant-row ant-form-item"
-  >
-    <div
-      class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
-    >
-      <label
-        class="ant-form-item-required"
-        for="time_related_controls_month-picker"
-        title="MonthPicker"
-      >
-        MonthPicker
-      </label>
-    </div>
-    <div
-      class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
-    >
-      <div
-        class="ant-form-item-control-input"
-      >
-        <div
-          class="ant-picker"
-        >
-          <div
-            class="ant-picker-input"
-          >
-            <input
-              placeholder="Select month"
-              readonly=""
-              size="12"
-              value=""
-            />
-            <span
-              class="ant-picker-suffix"
-            >
-              <span
-                aria-label="calendar"
-                class="anticon anticon-calendar"
-                role="img"
-              >
-                <svg
-                  aria-hidden="true"
-                  class=""
-                  data-icon="calendar"
-                  fill="currentColor"
-                  focusable="false"
-                  height="1em"
-                  viewBox="64 64 896 896"
-                  width="1em"
-                >
-                  <path
-                    d="M880 184H712v-64c0-4.4-3.6-8-8-8h-56c-4.4 0-8 3.6-8 8v64H384v-64c0-4.4-3.6-8-8-8h-56c-4.4 0-8 3.6-8 8v64H144c-17.7 0-32 14.3-32 32v664c0 17.7 14.3 32 32 32h736c17.7 0 32-14.3 32-32V216c0-17.7-14.3-32-32-32zm-40 656H184V460h656v380zM184 392V256h128v48c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8v-48h256v48c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8v-48h128v136H184z"
-                  />
-                </svg>
-              </span>
-            </span>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    class="ant-row ant-form-item"
-  >
-    <div
-      class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
-    >
-      <label
-        class="ant-form-item-required"
-        for="time_related_controls_range-picker"
-        title="RangePicker"
-      >
-        RangePicker
-      </label>
-    </div>
-    <div
-      class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
-    >
-      <div
-        class="ant-form-item-control-input"
-      >
-        <div
-          class="ant-picker ant-picker-range"
-        >
-          <div
-            class="ant-picker-input ant-picker-input-active"
-          >
-            <input
-              placeholder="Start date"
-              readonly=""
-              size="12"
-              value=""
-            />
-          </div>
-          <div
-            class="ant-picker-range-separator"
-          >
-            <span
-              class="ant-picker-separator"
-            >
-              →
-            </span>
-          </div>
-          <div
-            class="ant-picker-input"
-          >
-            <input
-              placeholder="End date"
-              readonly=""
-              size="12"
-              value=""
-            />
-          </div>
-          <div
-            class="ant-picker-active-bar"
-            style="left:0;width:0;position:absolute"
-          />
-          <span
-            class="ant-picker-suffix"
-          >
-            <span
-              aria-label="calendar"
-              class="anticon anticon-calendar"
-              role="img"
-            >
-              <svg
-                aria-hidden="true"
-                class=""
-                data-icon="calendar"
-                fill="currentColor"
-                focusable="false"
-                height="1em"
-                viewBox="64 64 896 896"
-                width="1em"
-              >
-                <path
-                  d="M880 184H712v-64c0-4.4-3.6-8-8-8h-56c-4.4 0-8 3.6-8 8v64H384v-64c0-4.4-3.6-8-8-8h-56c-4.4 0-8 3.6-8 8v64H144c-17.7 0-32 14.3-32 32v664c0 17.7 14.3 32 32 32h736c17.7 0 32-14.3 32-32V216c0-17.7-14.3-32-32-32zm-40 656H184V460h656v380zM184 392V256h128v48c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8v-48h256v48c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8v-48h128v136H184z"
-                />
-              </svg>
-            </span>
-          </span>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    class="ant-row ant-form-item"
-  >
-    <div
-      class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
-    >
-      <label
-        class="ant-form-item-required"
-        for="time_related_controls_range-time-picker"
-        title="RangePicker[showTime]"
-      >
-        RangePicker[showTime]
-      </label>
-    </div>
-    <div
-      class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
-    >
-      <div
-        class="ant-form-item-control-input"
-      >
-        <div
-          class="ant-picker ant-picker-range"
-        >
-          <div
-            class="ant-picker-input ant-picker-input-active"
-          >
-            <input
-              placeholder="Start date"
-              readonly=""
-              size="21"
-              value=""
-            />
-          </div>
-          <div
-            class="ant-picker-range-separator"
-          >
-            <span
-              class="ant-picker-separator"
-            >
-              →
-            </span>
-          </div>
-          <div
-            class="ant-picker-input"
-          >
-            <input
-              placeholder="End date"
-              readonly=""
-              size="21"
-              value=""
-            />
-          </div>
-          <div
-            class="ant-picker-active-bar"
-            style="left:0;width:0;position:absolute"
-          />
-          <span
-            class="ant-picker-suffix"
-          >
-            <span
-              aria-label="calendar"
-              class="anticon anticon-calendar"
-              role="img"
-            >
-              <svg
-                aria-hidden="true"
-                class=""
-                data-icon="calendar"
-                fill="currentColor"
-                focusable="false"
-                height="1em"
-                viewBox="64 64 896 896"
-                width="1em"
-              >
-                <path
-                  d="M880 184H712v-64c0-4.4-3.6-8-8-8h-56c-4.4 0-8 3.6-8 8v64H384v-64c0-4.4-3.6-8-8-8h-56c-4.4 0-8 3.6-8 8v64H144c-17.7 0-32 14.3-32 32v664c0 17.7 14.3 32 32 32h736c17.7 0 32-14.3 32-32V216c0-17.7-14.3-32-32-32zm-40 656H184V460h656v380zM184 392V256h128v48c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8v-48h256v48c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8v-48h128v136H184z"
-                />
-              </svg>
-            </span>
-          </span>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    class="ant-row ant-form-item"
-  >
-    <div
-      class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
-    >
-      <label
-        class="ant-form-item-required"
-        for="time_related_controls_time-picker"
-        title="TimePicker"
-      >
-        TimePicker
-      </label>
-    </div>
-    <div
-      class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
-    >
-      <div
-        class="ant-form-item-control-input"
-      >
-        <div
-          class="ant-picker"
-        >
-          <div
-            class="ant-picker-input"
-          >
-            <input
-              placeholder="Select time"
-              readonly=""
-              size="10"
-              value=""
-            />
-            <span
-              class="ant-picker-suffix"
-            >
-              <span
-                aria-label="clock-circle"
-                class="anticon anticon-clock-circle"
-                role="img"
-              >
-                <svg
-                  aria-hidden="true"
-                  class=""
-                  data-icon="clock-circle"
-                  fill="currentColor"
-                  focusable="false"
-                  height="1em"
-                  viewBox="64 64 896 896"
-                  width="1em"
-                >
-                  <path
-                    d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
-                  />
-                  <path
-                    d="M686.7 638.6L544.1 535.5V288c0-4.4-3.6-8-8-8H488c-4.4 0-8 3.6-8 8v275.4c0 2.6 1.2 5 3.3 6.5l165.4 120.6c3.6 2.6 8.6 1.8 11.2-1.7l28.6-39c2.6-3.7 1.8-8.7-1.8-11.2z"
-                  />
-                </svg>
-              </span>
-            </span>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    class="ant-row ant-form-item"
-  >
-    <div
-      class="ant-col ant-form-item-control ant-col-xs-24 ant-col-xs-offset-0 ant-col-sm-16 ant-col-sm-offset-8"
-    >
-      <div
-        class="ant-form-item-control-input"
-      >
-        <button
-          class="ant-btn ant-btn-primary"
-          type="submit"
-        >
-          <span>
-            Submit
-          </span>
-        </button>
-      </div>
-    </div>
-  </div>
-</form>
-`;
-
-exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
-<form
-  class="ant-form ant-form-horizontal"
-  id="validate_other"
->
-  <div
-    class="ant-row ant-form-item"
-  >
-    <div
-      class="ant-col ant-col-6 ant-form-item-label"
-    >
-      <label
-        class=""
-        title="Plain Text"
-      >
-        Plain Text
-      </label>
-    </div>
-    <div
-      class="ant-col ant-col-14 ant-form-item-control"
-    >
-      <div
-        class="ant-form-item-control-input"
-      >
-        <span
-          class="ant-form-text"
-        >
-          China
-        </span>
-      </div>
-    </div>
-  </div>
-  <div
-    class="ant-row ant-form-item"
-  >
-    <div
-      class="ant-col ant-col-6 ant-form-item-label"
-    >
-      <label
-        class="ant-form-item-required"
-        for="validate_other_select"
-        title="Select"
-      >
-        Select
-      </label>
-    </div>
-    <div
-      class="ant-col ant-col-14 ant-form-item-control"
-    >
-      <div
-        class="ant-form-item-control-input"
-      >
-        <div
-          class="ant-select ant-select-single ant-select-show-arrow"
-        >
-          <div
-            class="ant-select-selector"
-          >
-            <span
-              class="ant-select-selection-search"
-            >
-              <input
-                aria-activedescendant="validate_other_select_list_0"
-                aria-autocomplete="list"
-                aria-controls="validate_other_select_list"
-                aria-haspopup="listbox"
-                aria-owns="validate_other_select_list"
-                autocomplete="off"
-                class="ant-select-selection-search-input"
-                id="validate_other_select"
-                readonly=""
-                role="combobox"
-                style="opacity:0"
-                value=""
-              />
-            </span>
-            <span
-              class="ant-select-selection-placeholder"
-            >
-              Please select a country
-            </span>
-          </div>
-          <span
-            aria-hidden="true"
-            class="ant-select-arrow"
-            style="user-select:none;-webkit-user-select:none"
-            unselectable="on"
-          >
-            <span
-              aria-label="down"
-              class="anticon anticon-down"
-              role="img"
-            >
-              <svg
-                aria-hidden="true"
-                class=""
-                data-icon="down"
-                fill="currentColor"
-                focusable="false"
-                height="1em"
-                viewBox="64 64 896 896"
-                width="1em"
-              >
-                <path
-                  d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
-                />
-              </svg>
-            </span>
-          </span>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    class="ant-row ant-form-item"
-  >
-    <div
-      class="ant-col ant-col-6 ant-form-item-label"
-    >
-      <label
-        class="ant-form-item-required"
-        for="validate_other_select-multiple"
-        title="Select[multiple]"
-      >
-        Select[multiple]
-      </label>
-    </div>
-    <div
-      class="ant-col ant-col-14 ant-form-item-control"
-    >
-      <div
-        class="ant-form-item-control-input"
-      >
-        <div
-          class="ant-select ant-select-multiple ant-select-show-search"
-        >
-          <div
-            class="ant-select-selector"
-          >
-            <span
-              class="ant-select-selection-search"
-              style="width:0"
-            >
-              <input
-                aria-activedescendant="validate_other_select-multiple_list_0"
-                aria-autocomplete="list"
-                aria-controls="validate_other_select-multiple_list"
-                aria-haspopup="listbox"
-                aria-owns="validate_other_select-multiple_list"
-                autocomplete="off"
-                class="ant-select-selection-search-input"
-                id="validate_other_select-multiple"
-                readonly=""
-                role="combobox"
-                style="opacity:0"
-                value=""
-              />
-              <span
-                aria-hidden="true"
-                class="ant-select-selection-search-mirror"
-              >
-                 
-              </span>
-            </span>
-            <span
-              class="ant-select-selection-placeholder"
-            >
-              Please select favourite colors
-            </span>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    class="ant-row ant-form-item"
-  >
-    <div
-      class="ant-col ant-col-6 ant-form-item-label"
-    >
-      <label
-        class=""
-        title="InputNumber"
-      >
-        InputNumber
-      </label>
-    </div>
-    <div
-      class="ant-col ant-col-14 ant-form-item-control"
-    >
-      <div
-        class="ant-form-item-control-input"
-      >
-        <div
-          class="ant-input-number"
-        >
-          <div
-            class="ant-input-number-handler-wrap"
-          >
-            <span
-              aria-disabled="false"
-              aria-label="Increase Value"
-              class="ant-input-number-handler ant-input-number-handler-up "
-              role="button"
-              unselectable="unselectable"
-            >
-              <span
-                aria-label="up"
-                class="anticon anticon-up ant-input-number-handler-up-inner"
-                role="img"
-              >
-                <svg
-                  aria-hidden="true"
-                  class=""
-                  data-icon="up"
-                  fill="currentColor"
-                  focusable="false"
-                  height="1em"
-                  viewBox="64 64 896 896"
-                  width="1em"
-                >
-                  <path
-                    d="M890.5 755.3L537.9 269.2c-12.8-17.6-39-17.6-51.7 0L133.5 755.3A8 8 0 00140 768h75c5.1 0 9.9-2.5 12.9-6.6L512 369.8l284.1 391.6c3 4.1 7.8 6.6 12.9 6.6h75c6.5 0 10.3-7.4 6.5-12.7z"
-                  />
-                </svg>
-              </span>
-            </span>
-            <span
-              aria-disabled="false"
-              aria-label="Decrease Value"
-              class="ant-input-number-handler ant-input-number-handler-down "
-              role="button"
-              unselectable="unselectable"
-            >
-              <span
-                aria-label="down"
-                class="anticon anticon-down ant-input-number-handler-down-inner"
-                role="img"
-              >
-                <svg
-                  aria-hidden="true"
-                  class=""
-                  data-icon="down"
-                  fill="currentColor"
-                  focusable="false"
-                  height="1em"
-                  viewBox="64 64 896 896"
-                  width="1em"
-                >
-                  <path
-                    d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
-                  />
-                </svg>
-              </span>
-            </span>
-          </div>
-          <div
-            class="ant-input-number-input-wrap"
-          >
-            <input
-              aria-valuemax="10"
-              aria-valuemin="1"
-              aria-valuenow="3"
-              autocomplete="off"
-              class="ant-input-number-input"
-              id="validate_other_input-number"
-              max="10"
-              min="1"
-              role="spinbutton"
-              step="1"
-              value="3"
-            />
-          </div>
-        </div>
-        <span
-          class="ant-form-text"
-        >
-           machines
-        </span>
-      </div>
-    </div>
-  </div>
-  <div
-    class="ant-row ant-form-item"
-  >
-    <div
-      class="ant-col ant-col-6 ant-form-item-label"
-    >
-      <label
-        class=""
-        for="validate_other_switch"
-        title="Switch"
-      >
-        Switch
-      </label>
-    </div>
-    <div
-      class="ant-col ant-col-14 ant-form-item-control"
-    >
-      <div
-        class="ant-form-item-control-input"
-      >
-        <button
-          aria-checked="false"
-          class="ant-switch"
-          id="validate_other_switch"
-          role="switch"
-          type="button"
-        >
-          <span
-            class="ant-switch-inner"
-          />
-        </button>
-      </div>
-    </div>
-  </div>
-  <div
-    class="ant-row ant-form-item"
-  >
-    <div
-      class="ant-col ant-col-6 ant-form-item-label"
-    >
-      <label
-        class=""
-        for="validate_other_slider"
-        title="Slider"
-      >
-        Slider
-      </label>
-    </div>
-    <div
-      class="ant-col ant-col-14 ant-form-item-control"
-    >
-      <div
-        class="ant-form-item-control-input"
-      >
-        <div
-          class="ant-slider ant-slider-with-marks"
-        >
-          <div
-            class="ant-slider-rail"
-          />
-          <div
-            class="ant-slider-track"
-            style="left:0%;right:auto;width:0%"
-          />
-          <div
-            class="ant-slider-step"
-          >
-            <span
-              class="ant-slider-dot ant-slider-dot-active"
-              style="left:0%"
-            />
-            <span
-              class="ant-slider-dot"
-              style="left:20%"
-            />
-            <span
-              class="ant-slider-dot"
-              style="left:40%"
-            />
-            <span
-              class="ant-slider-dot"
-              style="left:60%"
-            />
-            <span
-              class="ant-slider-dot"
-              style="left:80%"
-            />
-            <span
-              class="ant-slider-dot"
-              style="left:100%"
-            />
-          </div>
-          <div
-            aria-disabled="false"
-            aria-valuemax="100"
-            aria-valuemin="0"
-            aria-valuenow="0"
-            class="ant-slider-handle"
-            role="slider"
-            style="left:0%;right:auto;transform:translateX(-50%)"
-            tabindex="0"
-          />
-          <div
-            class="ant-slider-mark"
-          >
-            <span
-              class="ant-slider-mark-text ant-slider-mark-text-active"
-              style="transform:translateX(-50%);-ms-transform:translateX(-50%);left:0%"
-            >
-              A
-            </span>
-            <span
-              class="ant-slider-mark-text"
-              style="transform:translateX(-50%);-ms-transform:translateX(-50%);left:20%"
-            >
-              B
-            </span>
-            <span
-              class="ant-slider-mark-text"
-              style="transform:translateX(-50%);-ms-transform:translateX(-50%);left:40%"
-            >
-              C
-            </span>
-            <span
-              class="ant-slider-mark-text"
-              style="transform:translateX(-50%);-ms-transform:translateX(-50%);left:60%"
-            >
-              D
-            </span>
-            <span
-              class="ant-slider-mark-text"
-              style="transform:translateX(-50%);-ms-transform:translateX(-50%);left:80%"
-            >
-              E
-            </span>
-            <span
-              class="ant-slider-mark-text"
-              style="transform:translateX(-50%);-ms-transform:translateX(-50%);left:100%"
-            >
-              F
-            </span>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    class="ant-row ant-form-item"
-  >
-    <div
-      class="ant-col ant-col-6 ant-form-item-label"
-    >
-      <label
-        class=""
-        for="validate_other_radio-group"
-        title="Radio.Group"
-      >
-        Radio.Group
-      </label>
-    </div>
-    <div
-      class="ant-col ant-col-14 ant-form-item-control"
-    >
-      <div
-        class="ant-form-item-control-input"
-      >
-        <div
-          class="ant-radio-group ant-radio-group-outline"
-          id="validate_other_radio-group"
-        >
-          <label
-            class="ant-radio-wrapper"
-          >
-            <span
-              class="ant-radio"
-            >
-              <input
-                class="ant-radio-input"
-                type="radio"
-                value="a"
-              />
-              <span
-                class="ant-radio-inner"
-              />
-            </span>
-            <span>
-              item 1
-            </span>
-          </label>
-          <label
-            class="ant-radio-wrapper"
-          >
-            <span
-              class="ant-radio"
-            >
-              <input
-                class="ant-radio-input"
-                type="radio"
-                value="b"
-              />
-              <span
-                class="ant-radio-inner"
-              />
-            </span>
-            <span>
-              item 2
-            </span>
-          </label>
-          <label
-            class="ant-radio-wrapper"
-          >
-            <span
-              class="ant-radio"
-            >
-              <input
-                class="ant-radio-input"
-                type="radio"
-                value="c"
-              />
-              <span
-                class="ant-radio-inner"
-              />
-            </span>
-            <span>
-              item 3
-            </span>
-          </label>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    class="ant-row ant-form-item"
-  >
-    <div
-      class="ant-col ant-col-6 ant-form-item-label"
-    >
-      <label
-        class=""
-        for="validate_other_radio-button"
-        title="Radio.Button"
-      >
-        Radio.Button
-      </label>
-    </div>
-    <div
-      class="ant-col ant-col-14 ant-form-item-control"
-    >
-      <div
-        class="ant-form-item-control-input"
-      >
-        <div
-          class="ant-radio-group ant-radio-group-outline"
-          id="validate_other_radio-button"
-        >
-          <label
-            class="ant-radio-button-wrapper"
-          >
-            <span
-              class="ant-radio-button"
-            >
-              <input
-                class="ant-radio-button-input"
-                type="radio"
-                value="a"
-              />
-              <span
-                class="ant-radio-button-inner"
-              />
-            </span>
-            <span>
-              item 1
-            </span>
-          </label>
-          <label
-            class="ant-radio-button-wrapper"
-          >
-            <span
-              class="ant-radio-button"
-            >
-              <input
-                class="ant-radio-button-input"
-                type="radio"
-                value="b"
-              />
-              <span
-                class="ant-radio-button-inner"
-              />
-            </span>
-            <span>
-              item 2
-            </span>
-          </label>
-          <label
-            class="ant-radio-button-wrapper"
-          >
-            <span
-              class="ant-radio-button"
-            >
-              <input
-                class="ant-radio-button-input"
-                type="radio"
-                value="c"
-              />
-              <span
-                class="ant-radio-button-inner"
-              />
-            </span>
-            <span>
-              item 3
-            </span>
-          </label>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    class="ant-row ant-form-item"
-  >
-    <div
-      class="ant-col ant-col-6 ant-form-item-label"
-    >
-      <label
-        class=""
-        for="validate_other_checkbox-group"
-        title="Checkbox.Group"
-      >
-        Checkbox.Group
-      </label>
-    </div>
-    <div
-      class="ant-col ant-col-14 ant-form-item-control"
-    >
-      <div
-        class="ant-form-item-control-input"
-      >
-        <div
-          class="ant-checkbox-group"
-          id="validate_other_checkbox-group"
-          style="width:100%"
-        >
-          <div
-            class="ant-row"
-          >
-            <div
-              class="ant-col ant-col-8"
-            >
-              <label
-                class="ant-checkbox-wrapper ant-checkbox-wrapper-checked"
-              >
-                <span
-                  class="ant-checkbox ant-checkbox-checked"
-                >
-                  <input
-                    checked=""
-                    class="ant-checkbox-input"
-                    type="checkbox"
-                    value="A"
-                  />
-                  <span
-                    class="ant-checkbox-inner"
-                  />
-                </span>
-                <span>
-                  A
-                </span>
-              </label>
-            </div>
-            <div
-              class="ant-col ant-col-8"
-            >
-              <label
-                class="ant-checkbox-wrapper ant-checkbox-wrapper-checked ant-checkbox-wrapper-disabled"
-              >
-                <span
-                  class="ant-checkbox ant-checkbox-checked ant-checkbox-disabled"
-                >
-                  <input
-                    checked=""
-                    class="ant-checkbox-input"
-                    disabled=""
-                    type="checkbox"
-                    value="B"
-                  />
-                  <span
-                    class="ant-checkbox-inner"
-                  />
-                </span>
-                <span>
-                  B
-                </span>
-              </label>
-            </div>
-            <div
-              class="ant-col ant-col-8"
-            >
-              <label
-                class="ant-checkbox-wrapper"
-              >
-                <span
-                  class="ant-checkbox"
-                >
-                  <input
-                    class="ant-checkbox-input"
-                    type="checkbox"
-                    value="C"
-                  />
-                  <span
-                    class="ant-checkbox-inner"
-                  />
-                </span>
-                <span>
-                  C
-                </span>
-              </label>
-            </div>
-            <div
-              class="ant-col ant-col-8"
-            >
-              <label
-                class="ant-checkbox-wrapper"
-              >
-                <span
-                  class="ant-checkbox"
-                >
-                  <input
-                    class="ant-checkbox-input"
-                    type="checkbox"
-                    value="D"
-                  />
-                  <span
-                    class="ant-checkbox-inner"
-                  />
-                </span>
-                <span>
-                  D
-                </span>
-              </label>
-            </div>
-            <div
-              class="ant-col ant-col-8"
-            >
-              <label
-                class="ant-checkbox-wrapper"
-              >
-                <span
-                  class="ant-checkbox"
-                >
-                  <input
-                    class="ant-checkbox-input"
-                    type="checkbox"
-                    value="E"
-                  />
-                  <span
-                    class="ant-checkbox-inner"
-                  />
-                </span>
-                <span>
-                  E
-                </span>
-              </label>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    class="ant-row ant-form-item"
-  >
-    <div
-      class="ant-col ant-col-6 ant-form-item-label"
-    >
-      <label
-        class=""
-        for="validate_other_rate"
-        title="Rate"
-      >
-        Rate
-      </label>
-    </div>
-    <div
-      class="ant-col ant-col-14 ant-form-item-control"
-    >
-      <div
-        class="ant-form-item-control-input"
-      >
-        <ul
-          class="ant-rate"
-          role="radiogroup"
-          tabindex="0"
-        >
-          <li
-            class="ant-rate-star ant-rate-star-full"
-          >
-            <div
-              aria-checked="true"
-              aria-posinset="1"
-              aria-setsize="5"
-              role="radio"
-              tabindex="0"
-            >
-              <div
-                class="ant-rate-star-first"
-              >
-                <span
-                  aria-label="star"
-                  class="anticon anticon-star"
-                  role="img"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class=""
-                    data-icon="star"
-                    fill="currentColor"
-                    focusable="false"
-                    height="1em"
-                    viewBox="64 64 896 896"
-                    width="1em"
-                  >
-                    <path
-                      d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
-                    />
-                  </svg>
-                </span>
-              </div>
-              <div
-                class="ant-rate-star-second"
-              >
-                <span
-                  aria-label="star"
-                  class="anticon anticon-star"
-                  role="img"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class=""
-                    data-icon="star"
-                    fill="currentColor"
-                    focusable="false"
-                    height="1em"
-                    viewBox="64 64 896 896"
-                    width="1em"
-                  >
-                    <path
-                      d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
-                    />
-                  </svg>
-                </span>
-              </div>
-            </div>
-          </li>
-          <li
-            class="ant-rate-star ant-rate-star-full"
-          >
-            <div
-              aria-checked="true"
-              aria-posinset="2"
-              aria-setsize="5"
-              role="radio"
-              tabindex="0"
-            >
-              <div
-                class="ant-rate-star-first"
-              >
-                <span
-                  aria-label="star"
-                  class="anticon anticon-star"
-                  role="img"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class=""
-                    data-icon="star"
-                    fill="currentColor"
-                    focusable="false"
-                    height="1em"
-                    viewBox="64 64 896 896"
-                    width="1em"
-                  >
-                    <path
-                      d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
-                    />
-                  </svg>
-                </span>
-              </div>
-              <div
-                class="ant-rate-star-second"
-              >
-                <span
-                  aria-label="star"
-                  class="anticon anticon-star"
-                  role="img"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class=""
-                    data-icon="star"
-                    fill="currentColor"
-                    focusable="false"
-                    height="1em"
-                    viewBox="64 64 896 896"
-                    width="1em"
-                  >
-                    <path
-                      d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
-                    />
-                  </svg>
-                </span>
-              </div>
-            </div>
-          </li>
-          <li
-            class="ant-rate-star ant-rate-star-full"
-          >
-            <div
-              aria-checked="true"
-              aria-posinset="3"
-              aria-setsize="5"
-              role="radio"
-              tabindex="0"
-            >
-              <div
-                class="ant-rate-star-first"
-              >
-                <span
-                  aria-label="star"
-                  class="anticon anticon-star"
-                  role="img"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class=""
-                    data-icon="star"
-                    fill="currentColor"
-                    focusable="false"
-                    height="1em"
-                    viewBox="64 64 896 896"
-                    width="1em"
-                  >
-                    <path
-                      d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
-                    />
-                  </svg>
-                </span>
-              </div>
-              <div
-                class="ant-rate-star-second"
-              >
-                <span
-                  aria-label="star"
-                  class="anticon anticon-star"
-                  role="img"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class=""
-                    data-icon="star"
-                    fill="currentColor"
-                    focusable="false"
-                    height="1em"
-                    viewBox="64 64 896 896"
-                    width="1em"
-                  >
-                    <path
-                      d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
-                    />
-                  </svg>
-                </span>
-              </div>
-            </div>
-          </li>
-          <li
-            class="ant-rate-star ant-rate-star-zero"
-          >
-            <div
-              aria-checked="true"
-              aria-posinset="4"
-              aria-setsize="5"
-              role="radio"
-              tabindex="0"
-            >
-              <div
-                class="ant-rate-star-first"
-              >
-                <span
-                  aria-label="star"
-                  class="anticon anticon-star"
-                  role="img"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class=""
-                    data-icon="star"
-                    fill="currentColor"
-                    focusable="false"
-                    height="1em"
-                    viewBox="64 64 896 896"
-                    width="1em"
-                  >
-                    <path
-                      d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
-                    />
-                  </svg>
-                </span>
-              </div>
-              <div
-                class="ant-rate-star-second"
-              >
-                <span
-                  aria-label="star"
-                  class="anticon anticon-star"
-                  role="img"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class=""
-                    data-icon="star"
-                    fill="currentColor"
-                    focusable="false"
-                    height="1em"
-                    viewBox="64 64 896 896"
-                    width="1em"
-                  >
-                    <path
-                      d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
-                    />
-                  </svg>
-                </span>
-              </div>
-            </div>
-          </li>
-          <li
-            class="ant-rate-star ant-rate-star-zero"
-          >
-            <div
-              aria-checked="false"
-              aria-posinset="5"
-              aria-setsize="5"
-              role="radio"
-              tabindex="0"
-            >
-              <div
-                class="ant-rate-star-first"
-              >
-                <span
-                  aria-label="star"
-                  class="anticon anticon-star"
-                  role="img"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class=""
-                    data-icon="star"
-                    fill="currentColor"
-                    focusable="false"
-                    height="1em"
-                    viewBox="64 64 896 896"
-                    width="1em"
-                  >
-                    <path
-                      d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
-                    />
-                  </svg>
-                </span>
-              </div>
-              <div
-                class="ant-rate-star-second"
-              >
-                <span
-                  aria-label="star"
-                  class="anticon anticon-star"
-                  role="img"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class=""
-                    data-icon="star"
-                    fill="currentColor"
-                    focusable="false"
-                    height="1em"
-                    viewBox="64 64 896 896"
-                    width="1em"
-                  >
-                    <path
-                      d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
-                    />
-                  </svg>
-                </span>
-              </div>
-            </div>
-          </li>
-        </ul>
-      </div>
-    </div>
-  </div>
-  <div
-    class="ant-row ant-form-item"
-  >
-    <div
-      class="ant-col ant-col-6 ant-form-item-label"
-    >
-      <label
-        class=""
-        for="validate_other_upload"
-        title="Upload"
-      >
-        Upload
-      </label>
-    </div>
-    <div
-      class="ant-col ant-col-14 ant-form-item-control"
-    >
-      <div
-        class="ant-form-item-control-input"
-      >
-        <span
-          class=""
-        >
-          <div
-            class="ant-upload ant-upload-select ant-upload-select-picture"
-          >
-            <span
-              class="ant-upload"
-              role="button"
-              tabindex="0"
-            >
-              <input
-                accept=""
-                id="validate_other_upload"
-                style="display:none"
-                type="file"
-              />
-              <button
-                class="ant-btn"
-                type="button"
-              >
-                <span
-                  aria-label="upload"
-                  class="anticon anticon-upload"
-                  role="img"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class=""
-                    data-icon="upload"
-                    fill="currentColor"
-                    focusable="false"
-                    height="1em"
-                    viewBox="64 64 896 896"
-                    width="1em"
-                  >
-                    <path
-                      d="M400 317.7h73.9V656c0 4.4 3.6 8 8 8h60c4.4 0 8-3.6 8-8V317.7H624c6.7 0 10.4-7.7 6.3-12.9L518.3 163a8 8 0 00-12.6 0l-112 141.7c-4.1 5.3-.4 13 6.3 13zM878 626h-60c-4.4 0-8 3.6-8 8v154H214V634c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v198c0 17.7 14.3 32 32 32h684c17.7 0 32-14.3 32-32V634c0-4.4-3.6-8-8-8z"
-                    />
-                  </svg>
-                </span>
-                <span>
-                   Click to upload
-                </span>
-              </button>
-            </span>
-          </div>
-          <div
-            class="ant-upload-list ant-upload-list-picture"
-          />
-        </span>
-      </div>
-      <div
-        class="ant-form-item-extra"
-      >
-        longgggggggggggggggggggggggggggggggggg
-      </div>
-    </div>
-  </div>
-  <div
-    class="ant-row ant-form-item"
-  >
-    <div
-      class="ant-col ant-col-6 ant-form-item-label"
-    >
-      <label
-        class=""
-        title="Dragger"
-      >
-        Dragger
-      </label>
-    </div>
-    <div
-      class="ant-col ant-col-14 ant-form-item-control"
-    >
-      <div
-        class="ant-form-item-control-input"
-      >
-        <span>
-          <div
-            class="ant-upload ant-upload-drag"
-          >
-            <span
-              class="ant-upload ant-upload-btn"
-              role="button"
-              tabindex="0"
-            >
-              <input
-                accept=""
-                id="validate_other_dragger"
-                style="display:none"
-                type="file"
-              />
-              <div
-                class="ant-upload-drag-container"
-              >
-                <p
-                  class="ant-upload-drag-icon"
-                >
-                  <span
-                    aria-label="inbox"
-                    class="anticon anticon-inbox"
-                    role="img"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      class=""
-                      data-icon="inbox"
-                      fill="currentColor"
-                      focusable="false"
-                      height="1em"
-                      viewBox="0 0 1024 1024"
-                      width="1em"
-                    >
-                      <path
-                        d="M885.2 446.3l-.2-.8-112.2-285.1c-5-16.1-19.9-27.2-36.8-27.2H281.2c-17 0-32.1 11.3-36.9 27.6L139.4 443l-.3.7-.2.8c-1.3 4.9-1.7 9.9-1 14.8-.1 1.6-.2 3.2-.2 4.8V830a60.9 60.9 0 0060.8 60.8h627.2c33.5 0 60.8-27.3 60.9-60.8V464.1c0-1.3 0-2.6-.1-3.7.4-4.9 0-9.6-1.3-14.1zm-295.8-43l-.3 15.7c-.8 44.9-31.8 75.1-77.1 75.1-22.1 0-41.1-7.1-54.8-20.6S436 441.2 435.6 419l-.3-15.7H229.5L309 210h399.2l81.7 193.3H589.4zm-375 76.8h157.3c24.3 57.1 76 90.8 140.4 90.8 33.7 0 65-9.4 90.3-27.2 22.2-15.6 39.5-37.4 50.7-63.6h156.5V814H214.4V480.1z"
-                      />
-                    </svg>
-                  </span>
-                </p>
-                <p
-                  class="ant-upload-text"
-                >
-                  Click or drag file to this area to upload
-                </p>
-                <p
-                  class="ant-upload-hint"
-                >
-                  Support for a single or bulk upload.
-                </p>
-              </div>
-            </span>
-          </div>
-          <div
-            class="ant-upload-list ant-upload-list-text"
-          />
-        </span>
-      </div>
-    </div>
-  </div>
-  <div
-    class="ant-row ant-form-item"
-  >
-    <div
-      class="ant-col ant-col-12 ant-col-offset-6 ant-form-item-control"
-    >
-      <div
-        class="ant-form-item-control-input"
-      >
-        <button
-          class="ant-btn ant-btn-primary"
-          type="submit"
-        >
-          <span>
-            Submit
-          </span>
-        </button>
-      </div>
-    </div>
-  </div>
-</form>
-`;
-
-exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
-<form
-  class="ant-form ant-form-horizontal"
->
-  <div
-    class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-error"
-  >
-    <div
-      class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-5"
-    >
-      <label
-        class=""
-        title="Fail"
-      >
-        Fail
-      </label>
-    </div>
-    <div
-      class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-12"
-    >
-      <div
-        class="ant-form-item-control-input"
-      >
-        <input
-          class="ant-input"
-          id="error"
-          placeholder="unavailable choice"
-          type="text"
-          value=""
-        />
-      </div>
-      <div
-        class="ant-form-item-explain"
-      >
-        <div>
-          Should be combination of numbers & alphabets
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    class="ant-row ant-form-item ant-form-item-has-warning"
-  >
-    <div
-      class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-5"
-    >
-      <label
-        class=""
-        title="Warning"
-      >
-        Warning
-      </label>
-    </div>
-    <div
-      class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-12"
-    >
-      <div
-        class="ant-form-item-control-input"
-      >
-        <span
-          class="ant-input-affix-wrapper"
-        >
-          <span
-            class="ant-input-prefix"
-          >
-            <span
-              aria-label="smile"
-              class="anticon anticon-smile"
-              role="img"
-            >
-              <svg
-                aria-hidden="true"
-                class=""
-                data-icon="smile"
-                fill="currentColor"
-                focusable="false"
-                height="1em"
-                viewBox="64 64 896 896"
-                width="1em"
-              >
-                <path
-                  d="M288 421a48 48 0 1096 0 48 48 0 10-96 0zm352 0a48 48 0 1096 0 48 48 0 10-96 0zM512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm263 711c-34.2 34.2-74 61-118.3 79.8C611 874.2 562.3 884 512 884c-50.3 0-99-9.8-144.8-29.2A370.4 370.4 0 01248.9 775c-34.2-34.2-61-74-79.8-118.3C149.8 611 140 562.3 140 512s9.8-99 29.2-144.8A370.4 370.4 0 01249 248.9c34.2-34.2 74-61 118.3-79.8C413 149.8 461.7 140 512 140c50.3 0 99 9.8 144.8 29.2A370.4 370.4 0 01775.1 249c34.2 34.2 61 74 79.8 118.3C874.2 413 884 461.7 884 512s-9.8 99-29.2 144.8A368.89 368.89 0 01775 775zM664 533h-48.1c-4.2 0-7.8 3.2-8.1 7.4C604 589.9 562.5 629 512 629s-92.1-39.1-95.8-88.6c-.3-4.2-3.9-7.4-8.1-7.4H360a8 8 0 00-8 8.4c4.4 84.3 74.5 151.6 160 151.6s155.6-67.3 160-151.6a8 8 0 00-8-8.4z"
-                />
-              </svg>
-            </span>
-          </span>
-          <input
-            class="ant-input"
-            id="warning"
-            placeholder="Warning"
-            type="text"
-            value=""
-          />
-        </span>
-      </div>
-    </div>
-  </div>
-  <div
-    class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-feedback ant-form-item-is-validating"
-  >
-    <div
-      class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-5"
-    >
-      <label
-        class=""
-        title="Validating"
-      >
-        Validating
-      </label>
-    </div>
-    <div
-      class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-12"
-    >
-      <div
-        class="ant-form-item-control-input"
-      >
-        <input
-          class="ant-input"
-          id="validating"
-          placeholder="I'm the content is being validated"
-          type="text"
-          value=""
-        />
-        <span
-          class="ant-form-item-children-icon"
-        >
-          <span
-            aria-label="loading"
-            class="anticon anticon-loading"
-            role="img"
-          >
-            <svg
-              aria-hidden="true"
-              class="anticon-spin"
-              data-icon="loading"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="0 0 1024 1024"
-              width="1em"
-            >
-              <path
-                d="M988 548c-19.9 0-36-16.1-36-36 0-59.4-11.6-117-34.6-171.3a440.45 440.45 0 00-94.3-139.9 437.71 437.71 0 00-139.9-94.3C629 83.6 571.4 72 512 72c-19.9 0-36-16.1-36-36s16.1-36 36-36c69.1 0 136.2 13.5 199.3 40.3C772.3 66 827 103 874 150c47 47 83.9 101.8 109.7 162.7 26.7 63.1 40.2 130.2 40.2 199.3.1 19.9-16 36-35.9 36z"
-              />
-            </svg>
-          </span>
-        </span>
-      </div>
-      <div
-        class="ant-form-item-explain"
-      >
-        <div>
-          The information is being validated...
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    class="ant-row ant-form-item ant-form-item-has-feedback ant-form-item-has-success"
-  >
-    <div
-      class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-5"
-    >
-      <label
-        class=""
-        title="Success"
-      >
-        Success
-      </label>
-    </div>
-    <div
-      class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-12"
-    >
-      <div
-        class="ant-form-item-control-input"
-      >
-        <input
-          class="ant-input"
-          id="success"
-          placeholder="I'm the content"
-          type="text"
-          value=""
-        />
         <span
           class="ant-form-item-children-icon"
         >
@@ -4967,119 +6097,6 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
     </div>
   </div>
   <div
-    class="ant-row ant-form-item ant-form-item-has-feedback ant-form-item-has-warning"
-  >
-    <div
-      class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-5"
-    >
-      <label
-        class=""
-        title="Warning"
-      >
-        Warning
-      </label>
-    </div>
-    <div
-      class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-12"
-    >
-      <div
-        class="ant-form-item-control-input"
-      >
-        <input
-          class="ant-input"
-          id="warning2"
-          placeholder="Warning"
-          type="text"
-          value=""
-        />
-        <span
-          class="ant-form-item-children-icon"
-        >
-          <span
-            aria-label="exclamation-circle"
-            class="anticon anticon-exclamation-circle"
-            role="img"
-          >
-            <svg
-              aria-hidden="true"
-              class=""
-              data-icon="exclamation-circle"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm-32 232c0-4.4 3.6-8 8-8h48c4.4 0 8 3.6 8 8v272c0 4.4-3.6 8-8 8h-48c-4.4 0-8-3.6-8-8V296zm32 440a48.01 48.01 0 010-96 48.01 48.01 0 010 96z"
-              />
-            </svg>
-          </span>
-        </span>
-      </div>
-    </div>
-  </div>
-  <div
-    class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-feedback ant-form-item-has-error"
-  >
-    <div
-      class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-5"
-    >
-      <label
-        class=""
-        title="Fail"
-      >
-        Fail
-      </label>
-    </div>
-    <div
-      class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-12"
-    >
-      <div
-        class="ant-form-item-control-input"
-      >
-        <input
-          class="ant-input"
-          id="error2"
-          placeholder="unavailable choice"
-          type="text"
-          value=""
-        />
-        <span
-          class="ant-form-item-children-icon"
-        >
-          <span
-            aria-label="close-circle"
-            class="anticon anticon-close-circle"
-            role="img"
-          >
-            <svg
-              aria-hidden="true"
-              class=""
-              data-icon="close-circle"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm165.4 618.2l-66-.3L512 563.4l-99.3 118.4-66.1.3c-4.4 0-8-3.5-8-8 0-1.9.7-3.7 1.9-5.2l130.1-155L340.5 359a8.32 8.32 0 01-1.9-5.2c0-4.4 3.6-8 8-8l66.1.3L512 464.6l99.3-118.4 66-.3c4.4 0 8 3.5 8 8 0 1.9-.7 3.7-1.9 5.2L553.5 514l130 155c1.2 1.5 1.9 3.3 1.9 5.2 0 4.4-3.6 8-8 8z"
-              />
-            </svg>
-          </span>
-        </span>
-      </div>
-      <div
-        class="ant-form-item-explain"
-      >
-        <div>
-          Should be combination of numbers & alphabets
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
     class="ant-row ant-form-item ant-form-item-has-feedback ant-form-item-has-success"
   >
     <div
@@ -5099,43 +6116,21 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
         class="ant-form-item-control-input"
       >
         <div
-          class="ant-picker"
-          style="width:100%"
+          class="ant-form-item-control-input-content"
         >
-          <div
-            class="ant-picker-input"
+          <span
+            class="ant-input-affix-wrapper"
           >
             <input
-              placeholder="Select date"
-              readonly=""
-              size="12"
+              class="ant-input"
+              placeholder="with allowClear"
+              type="text"
               value=""
             />
             <span
-              class="ant-picker-suffix"
-            >
-              <span
-                aria-label="calendar"
-                class="anticon anticon-calendar"
-                role="img"
-              >
-                <svg
-                  aria-hidden="true"
-                  class=""
-                  data-icon="calendar"
-                  fill="currentColor"
-                  focusable="false"
-                  height="1em"
-                  viewBox="64 64 896 896"
-                  width="1em"
-                >
-                  <path
-                    d="M880 184H712v-64c0-4.4-3.6-8-8-8h-56c-4.4 0-8 3.6-8 8v64H384v-64c0-4.4-3.6-8-8-8h-56c-4.4 0-8 3.6-8 8v64H144c-17.7 0-32 14.3-32 32v664c0 17.7 14.3 32 32 32h736c17.7 0 32-14.3 32-32V216c0-17.7-14.3-32-32-32zm-40 656H184V460h656v380zM184 392V256h128v48c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8v-48h256v48c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8v-48h128v136H184z"
-                  />
-                </svg>
-              </span>
-            </span>
-          </div>
+              class="ant-input-suffix"
+            />
+          </span>
         </div>
         <span
           class="ant-form-item-children-icon"
@@ -5184,30 +6179,31 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
         class="ant-form-item-control-input"
       >
         <div
-          class="ant-picker"
-          style="width:100%"
+          class="ant-form-item-control-input-content"
         >
-          <div
-            class="ant-picker-input"
+          <span
+            class="ant-input-password ant-input-affix-wrapper"
           >
             <input
-              placeholder="Select time"
-              readonly=""
-              size="10"
+              action="click"
+              class="ant-input"
+              placeholder="with input password"
+              type="password"
               value=""
             />
             <span
-              class="ant-picker-suffix"
+              class="ant-input-suffix"
             >
               <span
-                aria-label="clock-circle"
-                class="anticon anticon-clock-circle"
+                aria-label="eye-invisible"
+                class="anticon anticon-eye-invisible ant-input-password-icon"
                 role="img"
+                tabindex="-1"
               >
                 <svg
                   aria-hidden="true"
                   class=""
-                  data-icon="clock-circle"
+                  data-icon="eye-invisible"
                   fill="currentColor"
                   focusable="false"
                   height="1em"
@@ -5215,15 +6211,15 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
                   width="1em"
                 >
                   <path
-                    d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+                    d="M942.2 486.2Q889.47 375.11 816.7 305l-50.88 50.88C807.31 395.53 843.45 447.4 874.7 512 791.5 684.2 673.4 766 512 766q-72.67 0-133.87-22.38L323 798.75Q408 838 512 838q288.3 0 430.2-300.3a60.29 60.29 0 000-51.5zm-63.57-320.64L836 122.88a8 8 0 00-11.32 0L715.31 232.2Q624.86 186 512 186q-288.3 0-430.2 300.3a60.3 60.3 0 000 51.5q56.69 119.4 136.5 191.41L112.48 835a8 8 0 000 11.31L155.17 889a8 8 0 0011.31 0l712.15-712.12a8 8 0 000-11.32zM149.3 512C232.6 339.8 350.7 258 512 258c54.54 0 104.13 9.36 149.12 28.39l-70.3 70.3a176 176 0 00-238.13 238.13l-83.42 83.42C223.1 637.49 183.3 582.28 149.3 512zm246.7 0a112.11 112.11 0 01146.2-106.69L401.31 546.2A112 112 0 01396 512z"
                   />
                   <path
-                    d="M686.7 638.6L544.1 535.5V288c0-4.4-3.6-8-8-8H488c-4.4 0-8 3.6-8 8v275.4c0 2.6 1.2 5 3.3 6.5l165.4 120.6c3.6 2.6 8.6 1.8 11.2-1.7l28.6-39c2.6-3.7 1.8-8.7-1.8-11.2z"
+                    d="M508 624c-3.46 0-6.87-.16-10.25-.47l-52.82 52.82a176.09 176.09 0 00227.42-227.42l-52.82 52.82c.31 3.38.47 6.79.47 10.25a111.94 111.94 0 01-112 112z"
                   />
                 </svg>
               </span>
             </span>
-          </div>
+          </span>
         </div>
         <span
           class="ant-form-item-children-icon"
@@ -5272,640 +6268,48 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
         class="ant-form-item-control-input"
       >
         <div
-          class="ant-select ant-select-single ant-select-show-arrow"
-        >
-          <div
-            class="ant-select-selector"
-          >
-            <span
-              class="ant-select-selection-search"
-            >
-              <input
-                aria-activedescendant="undefined_list_0"
-                aria-autocomplete="list"
-                aria-controls="undefined_list"
-                aria-haspopup="listbox"
-                aria-owns="undefined_list"
-                autocomplete="off"
-                class="ant-select-selection-search-input"
-                readonly=""
-                role="combobox"
-                style="opacity:0"
-                value=""
-              />
-            </span>
-            <span
-              class="ant-select-selection-placeholder"
-            />
-          </div>
-          <span
-            aria-hidden="true"
-            class="ant-select-arrow"
-            style="user-select:none;-webkit-user-select:none"
-            unselectable="on"
-          >
-            <span
-              aria-label="down"
-              class="anticon anticon-down"
-              role="img"
-            >
-              <svg
-                aria-hidden="true"
-                class=""
-                data-icon="down"
-                fill="currentColor"
-                focusable="false"
-                height="1em"
-                viewBox="64 64 896 896"
-                width="1em"
-              >
-                <path
-                  d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
-                />
-              </svg>
-            </span>
-          </span>
-        </div>
-        <span
-          class="ant-form-item-children-icon"
+          class="ant-form-item-control-input-content"
         >
           <span
-            aria-label="close-circle"
-            class="anticon anticon-close-circle"
-            role="img"
-          >
-            <svg
-              aria-hidden="true"
-              class=""
-              data-icon="close-circle"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm165.4 618.2l-66-.3L512 563.4l-99.3 118.4-66.1.3c-4.4 0-8-3.5-8-8 0-1.9.7-3.7 1.9-5.2l130.1-155L340.5 359a8.32 8.32 0 01-1.9-5.2c0-4.4 3.6-8 8-8l66.1.3L512 464.6l99.3-118.4 66-.3c4.4 0 8 3.5 8 8 0 1.9-.7 3.7-1.9 5.2L553.5 514l130 155c1.2 1.5 1.9 3.3 1.9 5.2 0 4.4-3.6 8-8 8z"
-              />
-            </svg>
-          </span>
-        </span>
-      </div>
-    </div>
-  </div>
-  <div
-    class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-feedback ant-form-item-is-validating"
-  >
-    <div
-      class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-5"
-    >
-      <label
-        class=""
-        title="Validating"
-      >
-        Validating
-      </label>
-    </div>
-    <div
-      class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-12"
-    >
-      <div
-        class="ant-form-item-control-input"
-      >
-        <span
-          class="ant-cascader-picker"
-          tabindex="0"
-        >
-          <span
-            class="ant-cascader-picker-label"
-          />
-          <input
-            autocomplete="off"
-            class="ant-input ant-cascader-input "
-            placeholder="Please select"
-            readonly=""
-            tabindex="-1"
-            type="text"
-            value=""
-          />
-          <span
-            aria-label="down"
-            class="anticon anticon-down ant-cascader-picker-arrow"
-            role="img"
-          >
-            <svg
-              aria-hidden="true"
-              class=""
-              data-icon="down"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
-              />
-            </svg>
-          </span>
-        </span>
-        <span
-          class="ant-form-item-children-icon"
-        >
-          <span
-            aria-label="loading"
-            class="anticon anticon-loading"
-            role="img"
-          >
-            <svg
-              aria-hidden="true"
-              class="anticon-spin"
-              data-icon="loading"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="0 0 1024 1024"
-              width="1em"
-            >
-              <path
-                d="M988 548c-19.9 0-36-16.1-36-36 0-59.4-11.6-117-34.6-171.3a440.45 440.45 0 00-94.3-139.9 437.71 437.71 0 00-139.9-94.3C629 83.6 571.4 72 512 72c-19.9 0-36-16.1-36-36s16.1-36 36-36c69.1 0 136.2 13.5 199.3 40.3C772.3 66 827 103 874 150c47 47 83.9 101.8 109.7 162.7 26.7 63.1 40.2 130.2 40.2 199.3.1 19.9-16 36-35.9 36z"
-              />
-            </svg>
-          </span>
-        </span>
-      </div>
-      <div
-        class="ant-form-item-explain"
-      >
-        <div>
-          The information is being validated...
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    class="ant-row ant-form-item"
-    style="margin-bottom:0"
-  >
-    <div
-      class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-5"
-    >
-      <label
-        class=""
-        title="inline"
-      >
-        inline
-      </label>
-    </div>
-    <div
-      class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-12"
-    >
-      <div
-        class="ant-form-item-control-input"
-      >
-        <div
-          class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-error"
-          style="display:inline-block;width:calc(50% - 12px)"
-        >
-          <div
-            class="ant-col ant-form-item-control"
-          >
-            <div
-              class="ant-form-item-control-input"
-            >
-              <div
-                class="ant-picker"
-              >
-                <div
-                  class="ant-picker-input"
-                >
-                  <input
-                    placeholder="Select date"
-                    readonly=""
-                    size="12"
-                    value=""
-                  />
-                  <span
-                    class="ant-picker-suffix"
-                  >
-                    <span
-                      aria-label="calendar"
-                      class="anticon anticon-calendar"
-                      role="img"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class=""
-                        data-icon="calendar"
-                        fill="currentColor"
-                        focusable="false"
-                        height="1em"
-                        viewBox="64 64 896 896"
-                        width="1em"
-                      >
-                        <path
-                          d="M880 184H712v-64c0-4.4-3.6-8-8-8h-56c-4.4 0-8 3.6-8 8v64H384v-64c0-4.4-3.6-8-8-8h-56c-4.4 0-8 3.6-8 8v64H144c-17.7 0-32 14.3-32 32v664c0 17.7 14.3 32 32 32h736c17.7 0 32-14.3 32-32V216c0-17.7-14.3-32-32-32zm-40 656H184V460h656v380zM184 392V256h128v48c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8v-48h256v48c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8v-48h128v136H184z"
-                        />
-                      </svg>
-                    </span>
-                  </span>
-                </div>
-              </div>
-            </div>
-            <div
-              class="ant-form-item-explain"
-            >
-              <div>
-                Please select the correct date
-              </div>
-            </div>
-          </div>
-        </div>
-        <span
-          style="display:inline-block;width:24px;text-align:center"
-        >
-          -
-        </span>
-        <div
-          class="ant-row ant-form-item"
-          style="display:inline-block;width:calc(50% - 12px)"
-        >
-          <div
-            class="ant-col ant-form-item-control"
-          >
-            <div
-              class="ant-form-item-control-input"
-            >
-              <div
-                class="ant-picker"
-              >
-                <div
-                  class="ant-picker-input"
-                >
-                  <input
-                    placeholder="Select date"
-                    readonly=""
-                    size="12"
-                    value=""
-                  />
-                  <span
-                    class="ant-picker-suffix"
-                  >
-                    <span
-                      aria-label="calendar"
-                      class="anticon anticon-calendar"
-                      role="img"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class=""
-                        data-icon="calendar"
-                        fill="currentColor"
-                        focusable="false"
-                        height="1em"
-                        viewBox="64 64 896 896"
-                        width="1em"
-                      >
-                        <path
-                          d="M880 184H712v-64c0-4.4-3.6-8-8-8h-56c-4.4 0-8 3.6-8 8v64H384v-64c0-4.4-3.6-8-8-8h-56c-4.4 0-8 3.6-8 8v64H144c-17.7 0-32 14.3-32 32v664c0 17.7 14.3 32 32 32h736c17.7 0 32-14.3 32-32V216c0-17.7-14.3-32-32-32zm-40 656H184V460h656v380zM184 392V256h128v48c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8v-48h256v48c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8v-48h128v136H184z"
-                        />
-                      </svg>
-                    </span>
-                  </span>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    class="ant-row ant-form-item ant-form-item-has-feedback ant-form-item-has-success"
-  >
-    <div
-      class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-5"
-    >
-      <label
-        class=""
-        title="Success"
-      >
-        Success
-      </label>
-    </div>
-    <div
-      class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-12"
-    >
-      <div
-        class="ant-form-item-control-input"
-      >
-        <div
-          class="ant-input-number"
-          style="width:100%"
-        >
-          <div
-            class="ant-input-number-handler-wrap"
-          >
-            <span
-              aria-disabled="false"
-              aria-label="Increase Value"
-              class="ant-input-number-handler ant-input-number-handler-up "
-              role="button"
-              unselectable="unselectable"
-            >
-              <span
-                aria-label="up"
-                class="anticon anticon-up ant-input-number-handler-up-inner"
-                role="img"
-              >
-                <svg
-                  aria-hidden="true"
-                  class=""
-                  data-icon="up"
-                  fill="currentColor"
-                  focusable="false"
-                  height="1em"
-                  viewBox="64 64 896 896"
-                  width="1em"
-                >
-                  <path
-                    d="M890.5 755.3L537.9 269.2c-12.8-17.6-39-17.6-51.7 0L133.5 755.3A8 8 0 00140 768h75c5.1 0 9.9-2.5 12.9-6.6L512 369.8l284.1 391.6c3 4.1 7.8 6.6 12.9 6.6h75c6.5 0 10.3-7.4 6.5-12.7z"
-                  />
-                </svg>
-              </span>
-            </span>
-            <span
-              aria-disabled="false"
-              aria-label="Decrease Value"
-              class="ant-input-number-handler ant-input-number-handler-down "
-              role="button"
-              unselectable="unselectable"
-            >
-              <span
-                aria-label="down"
-                class="anticon anticon-down ant-input-number-handler-down-inner"
-                role="img"
-              >
-                <svg
-                  aria-hidden="true"
-                  class=""
-                  data-icon="down"
-                  fill="currentColor"
-                  focusable="false"
-                  height="1em"
-                  viewBox="64 64 896 896"
-                  width="1em"
-                >
-                  <path
-                    d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
-                  />
-                </svg>
-              </span>
-            </span>
-          </div>
-          <div
-            class="ant-input-number-input-wrap"
+            class="ant-input-password ant-input-affix-wrapper"
           >
             <input
-              aria-valuemin="-9007199254740991"
-              autocomplete="off"
-              class="ant-input-number-input"
-              min="-9007199254740991"
-              role="spinbutton"
-              step="1"
+              action="click"
+              class="ant-input"
+              placeholder="with input password and allowClear"
+              type="password"
               value=""
             />
-          </div>
+            <span
+              class="ant-input-suffix"
+            >
+              <span
+                aria-label="eye-invisible"
+                class="anticon anticon-eye-invisible ant-input-password-icon"
+                role="img"
+                tabindex="-1"
+              >
+                <svg
+                  aria-hidden="true"
+                  class=""
+                  data-icon="eye-invisible"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M942.2 486.2Q889.47 375.11 816.7 305l-50.88 50.88C807.31 395.53 843.45 447.4 874.7 512 791.5 684.2 673.4 766 512 766q-72.67 0-133.87-22.38L323 798.75Q408 838 512 838q288.3 0 430.2-300.3a60.29 60.29 0 000-51.5zm-63.57-320.64L836 122.88a8 8 0 00-11.32 0L715.31 232.2Q624.86 186 512 186q-288.3 0-430.2 300.3a60.3 60.3 0 000 51.5q56.69 119.4 136.5 191.41L112.48 835a8 8 0 000 11.31L155.17 889a8 8 0 0011.31 0l712.15-712.12a8 8 0 000-11.32zM149.3 512C232.6 339.8 350.7 258 512 258c54.54 0 104.13 9.36 149.12 28.39l-70.3 70.3a176 176 0 00-238.13 238.13l-83.42 83.42C223.1 637.49 183.3 582.28 149.3 512zm246.7 0a112.11 112.11 0 01146.2-106.69L401.31 546.2A112 112 0 01396 512z"
+                  />
+                  <path
+                    d="M508 624c-3.46 0-6.87-.16-10.25-.47l-52.82 52.82a176.09 176.09 0 00227.42-227.42l-52.82 52.82c.31 3.38.47 6.79.47 10.25a111.94 111.94 0 01-112 112z"
+                  />
+                </svg>
+              </span>
+            </span>
+          </span>
         </div>
-        <span
-          class="ant-form-item-children-icon"
-        >
-          <span
-            aria-label="check-circle"
-            class="anticon anticon-check-circle"
-            role="img"
-          >
-            <svg
-              aria-hidden="true"
-              class=""
-              data-icon="check-circle"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm193.5 301.7l-210.6 292a31.8 31.8 0 01-51.7 0L318.5 484.9c-3.8-5.3 0-12.7 6.5-12.7h46.9c10.2 0 19.9 4.9 25.9 13.3l71.2 98.8 157.2-218c6-8.3 15.6-13.3 25.9-13.3H699c6.5 0 10.3 7.4 6.5 12.7z"
-              />
-            </svg>
-          </span>
-        </span>
-      </div>
-    </div>
-  </div>
-  <div
-    class="ant-row ant-form-item ant-form-item-has-feedback ant-form-item-has-success"
-  >
-    <div
-      class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-5"
-    >
-      <label
-        class=""
-        title="Success"
-      >
-        Success
-      </label>
-    </div>
-    <div
-      class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-12"
-    >
-      <div
-        class="ant-form-item-control-input"
-      >
-        <span
-          class="ant-input-affix-wrapper"
-        >
-          <input
-            class="ant-input"
-            placeholder="with allowClear"
-            type="text"
-            value=""
-          />
-          <span
-            class="ant-input-suffix"
-          />
-        </span>
-        <span
-          class="ant-form-item-children-icon"
-        >
-          <span
-            aria-label="check-circle"
-            class="anticon anticon-check-circle"
-            role="img"
-          >
-            <svg
-              aria-hidden="true"
-              class=""
-              data-icon="check-circle"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm193.5 301.7l-210.6 292a31.8 31.8 0 01-51.7 0L318.5 484.9c-3.8-5.3 0-12.7 6.5-12.7h46.9c10.2 0 19.9 4.9 25.9 13.3l71.2 98.8 157.2-218c6-8.3 15.6-13.3 25.9-13.3H699c6.5 0 10.3 7.4 6.5 12.7z"
-              />
-            </svg>
-          </span>
-        </span>
-      </div>
-    </div>
-  </div>
-  <div
-    class="ant-row ant-form-item ant-form-item-has-feedback ant-form-item-has-warning"
-  >
-    <div
-      class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-5"
-    >
-      <label
-        class=""
-        title="Warning"
-      >
-        Warning
-      </label>
-    </div>
-    <div
-      class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-12"
-    >
-      <div
-        class="ant-form-item-control-input"
-      >
-        <span
-          class="ant-input-password ant-input-affix-wrapper"
-        >
-          <input
-            action="click"
-            class="ant-input"
-            placeholder="with input password"
-            type="password"
-            value=""
-          />
-          <span
-            class="ant-input-suffix"
-          >
-            <span
-              aria-label="eye-invisible"
-              class="anticon anticon-eye-invisible ant-input-password-icon"
-              role="img"
-              tabindex="-1"
-            >
-              <svg
-                aria-hidden="true"
-                class=""
-                data-icon="eye-invisible"
-                fill="currentColor"
-                focusable="false"
-                height="1em"
-                viewBox="64 64 896 896"
-                width="1em"
-              >
-                <path
-                  d="M942.2 486.2Q889.47 375.11 816.7 305l-50.88 50.88C807.31 395.53 843.45 447.4 874.7 512 791.5 684.2 673.4 766 512 766q-72.67 0-133.87-22.38L323 798.75Q408 838 512 838q288.3 0 430.2-300.3a60.29 60.29 0 000-51.5zm-63.57-320.64L836 122.88a8 8 0 00-11.32 0L715.31 232.2Q624.86 186 512 186q-288.3 0-430.2 300.3a60.3 60.3 0 000 51.5q56.69 119.4 136.5 191.41L112.48 835a8 8 0 000 11.31L155.17 889a8 8 0 0011.31 0l712.15-712.12a8 8 0 000-11.32zM149.3 512C232.6 339.8 350.7 258 512 258c54.54 0 104.13 9.36 149.12 28.39l-70.3 70.3a176 176 0 00-238.13 238.13l-83.42 83.42C223.1 637.49 183.3 582.28 149.3 512zm246.7 0a112.11 112.11 0 01146.2-106.69L401.31 546.2A112 112 0 01396 512z"
-                />
-                <path
-                  d="M508 624c-3.46 0-6.87-.16-10.25-.47l-52.82 52.82a176.09 176.09 0 00227.42-227.42l-52.82 52.82c.31 3.38.47 6.79.47 10.25a111.94 111.94 0 01-112 112z"
-                />
-              </svg>
-            </span>
-          </span>
-        </span>
-        <span
-          class="ant-form-item-children-icon"
-        >
-          <span
-            aria-label="exclamation-circle"
-            class="anticon anticon-exclamation-circle"
-            role="img"
-          >
-            <svg
-              aria-hidden="true"
-              class=""
-              data-icon="exclamation-circle"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm-32 232c0-4.4 3.6-8 8-8h48c4.4 0 8 3.6 8 8v272c0 4.4-3.6 8-8 8h-48c-4.4 0-8-3.6-8-8V296zm32 440a48.01 48.01 0 010-96 48.01 48.01 0 010 96z"
-              />
-            </svg>
-          </span>
-        </span>
-      </div>
-    </div>
-  </div>
-  <div
-    class="ant-row ant-form-item ant-form-item-has-feedback ant-form-item-has-error"
-  >
-    <div
-      class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-5"
-    >
-      <label
-        class=""
-        title="Error"
-      >
-        Error
-      </label>
-    </div>
-    <div
-      class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-12"
-    >
-      <div
-        class="ant-form-item-control-input"
-      >
-        <span
-          class="ant-input-password ant-input-affix-wrapper"
-        >
-          <input
-            action="click"
-            class="ant-input"
-            placeholder="with input password and allowClear"
-            type="password"
-            value=""
-          />
-          <span
-            class="ant-input-suffix"
-          >
-            <span
-              aria-label="eye-invisible"
-              class="anticon anticon-eye-invisible ant-input-password-icon"
-              role="img"
-              tabindex="-1"
-            >
-              <svg
-                aria-hidden="true"
-                class=""
-                data-icon="eye-invisible"
-                fill="currentColor"
-                focusable="false"
-                height="1em"
-                viewBox="64 64 896 896"
-                width="1em"
-              >
-                <path
-                  d="M942.2 486.2Q889.47 375.11 816.7 305l-50.88 50.88C807.31 395.53 843.45 447.4 874.7 512 791.5 684.2 673.4 766 512 766q-72.67 0-133.87-22.38L323 798.75Q408 838 512 838q288.3 0 430.2-300.3a60.29 60.29 0 000-51.5zm-63.57-320.64L836 122.88a8 8 0 00-11.32 0L715.31 232.2Q624.86 186 512 186q-288.3 0-430.2 300.3a60.3 60.3 0 000 51.5q56.69 119.4 136.5 191.41L112.48 835a8 8 0 000 11.31L155.17 889a8 8 0 0011.31 0l712.15-712.12a8 8 0 000-11.32zM149.3 512C232.6 339.8 350.7 258 512 258c54.54 0 104.13 9.36 149.12 28.39l-70.3 70.3a176 176 0 00-238.13 238.13l-83.42 83.42C223.1 637.49 183.3 582.28 149.3 512zm246.7 0a112.11 112.11 0 01146.2-106.69L401.31 546.2A112 112 0 01396 512z"
-                />
-                <path
-                  d="M508 624c-3.46 0-6.87-.16-10.25-.47l-52.82 52.82a176.09 176.09 0 00227.42-227.42l-52.82 52.82c.31 3.38.47 6.79.47 10.25a111.94 111.94 0 01-112 112z"
-                />
-              </svg>
-            </span>
-          </span>
-        </span>
         <span
           class="ant-form-item-children-icon"
         >
@@ -5960,83 +6364,87 @@ exports[`renders ./components/form/demo/without-form-create.md correctly 1`] = `
         class="ant-form-item-control-input"
       >
         <div
-          class="ant-input-number"
+          class="ant-form-item-control-input-content"
         >
           <div
-            class="ant-input-number-handler-wrap"
+            class="ant-input-number"
           >
-            <span
-              aria-disabled="false"
-              aria-label="Increase Value"
-              class="ant-input-number-handler ant-input-number-handler-up "
-              role="button"
-              unselectable="unselectable"
+            <div
+              class="ant-input-number-handler-wrap"
             >
               <span
-                aria-label="up"
-                class="anticon anticon-up ant-input-number-handler-up-inner"
-                role="img"
+                aria-disabled="false"
+                aria-label="Increase Value"
+                class="ant-input-number-handler ant-input-number-handler-up "
+                role="button"
+                unselectable="unselectable"
               >
-                <svg
-                  aria-hidden="true"
-                  class=""
-                  data-icon="up"
-                  fill="currentColor"
-                  focusable="false"
-                  height="1em"
-                  viewBox="64 64 896 896"
-                  width="1em"
+                <span
+                  aria-label="up"
+                  class="anticon anticon-up ant-input-number-handler-up-inner"
+                  role="img"
                 >
-                  <path
-                    d="M890.5 755.3L537.9 269.2c-12.8-17.6-39-17.6-51.7 0L133.5 755.3A8 8 0 00140 768h75c5.1 0 9.9-2.5 12.9-6.6L512 369.8l284.1 391.6c3 4.1 7.8 6.6 12.9 6.6h75c6.5 0 10.3-7.4 6.5-12.7z"
-                  />
-                </svg>
+                  <svg
+                    aria-hidden="true"
+                    class=""
+                    data-icon="up"
+                    fill="currentColor"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M890.5 755.3L537.9 269.2c-12.8-17.6-39-17.6-51.7 0L133.5 755.3A8 8 0 00140 768h75c5.1 0 9.9-2.5 12.9-6.6L512 369.8l284.1 391.6c3 4.1 7.8 6.6 12.9 6.6h75c6.5 0 10.3-7.4 6.5-12.7z"
+                    />
+                  </svg>
+                </span>
               </span>
-            </span>
-            <span
-              aria-disabled="false"
-              aria-label="Decrease Value"
-              class="ant-input-number-handler ant-input-number-handler-down "
-              role="button"
-              unselectable="unselectable"
-            >
               <span
-                aria-label="down"
-                class="anticon anticon-down ant-input-number-handler-down-inner"
-                role="img"
+                aria-disabled="false"
+                aria-label="Decrease Value"
+                class="ant-input-number-handler ant-input-number-handler-down "
+                role="button"
+                unselectable="unselectable"
               >
-                <svg
-                  aria-hidden="true"
-                  class=""
-                  data-icon="down"
-                  fill="currentColor"
-                  focusable="false"
-                  height="1em"
-                  viewBox="64 64 896 896"
-                  width="1em"
+                <span
+                  aria-label="down"
+                  class="anticon anticon-down ant-input-number-handler-down-inner"
+                  role="img"
                 >
-                  <path
-                    d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
-                  />
-                </svg>
+                  <svg
+                    aria-hidden="true"
+                    class=""
+                    data-icon="down"
+                    fill="currentColor"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                    />
+                  </svg>
+                </span>
               </span>
-            </span>
-          </div>
-          <div
-            class="ant-input-number-input-wrap"
-          >
-            <input
-              aria-valuemax="12"
-              aria-valuemin="8"
-              aria-valuenow="11"
-              autocomplete="off"
-              class="ant-input-number-input"
-              max="12"
-              min="8"
-              role="spinbutton"
-              step="1"
-              value="11"
-            />
+            </div>
+            <div
+              class="ant-input-number-input-wrap"
+            >
+              <input
+                aria-valuemax="12"
+                aria-valuemin="8"
+                aria-valuenow="11"
+                autocomplete="off"
+                class="ant-input-number-input"
+                max="12"
+                min="8"
+                role="spinbutton"
+                step="1"
+                value="11"
+              />
+            </div>
           </div>
         </div>
       </div>

--- a/components/form/__tests__/__snapshots__/index.test.js.snap
+++ b/components/form/__tests__/__snapshots__/index.test.js.snap
@@ -16,7 +16,11 @@ exports[`Form Form.Item should support data-*、aria-* and custom attribute 1`] 
       <div
         class="ant-form-item-control-input"
       >
-        text
+        <div
+          class="ant-form-item-control-input-content"
+        >
+          text
+        </div>
       </div>
     </div>
   </div>
@@ -38,7 +42,11 @@ exports[`Form rtl render component should be rendered correctly in RTL direction
   >
     <div
       class="ant-form-item-control-input"
-    />
+    >
+      <div
+        class="ant-form-item-control-input-content"
+      />
+    </div>
   </div>
 </div>
 `;

--- a/components/form/demo/validate-other.md
+++ b/components/form/demo/validate-other.md
@@ -61,7 +61,7 @@ const Demo = () => {
         rate: 3.5,
       }}
     >
-      <Form.Item label="Plain Text" help="2333">
+      <Form.Item label="Plain Text">
         <span className="ant-form-text">China</span>
       </Form.Item>
       <Form.Item

--- a/components/form/demo/validate-other.md
+++ b/components/form/demo/validate-other.md
@@ -61,7 +61,7 @@ const Demo = () => {
         rate: 3.5,
       }}
     >
-      <Form.Item label="Plain Text">
+      <Form.Item label="Plain Text" help="2333">
         <span className="ant-form-text">China</span>
       </Form.Item>
       <Form.Item

--- a/components/form/style/index.less
+++ b/components/form/style/index.less
@@ -67,7 +67,7 @@
       display: inline-flex;
       align-items: center;
       height: 100%;
-      max-height: @input-height-base;
+      height: @input-height-base;
       color: @label-color;
       font-size: @form-item-label-font-size;
 
@@ -123,7 +123,13 @@
 
   &-control-input {
     position: relative;
-    .clearfix;
+    display: flex;
+    align-items: center;
+    min-height: @input-height-base;
+
+    &-content {
+      flex: auto;
+    }
   }
 
   &-explain,
@@ -136,292 +142,27 @@
     line-height: @line-height-base;
     transition: color 0.3s @ease-out; // sync input color transition
   }
+}
 
-  // ================================================================
-  // =                            Status                            =
-  // ================================================================
-  /* Some non-status related component style is in `components.less` */
-
-  &-has-feedback {
-    // ========================= Input =========================
-    .@{ant-prefix}-input {
-      padding-right: 24px;
-    }
-    // https://github.com/ant-design/ant-design/issues/19884
-    .@{ant-prefix}-input-affix-wrapper {
-      .@{ant-prefix}-input-suffix {
-        padding-right: 18px;
-      }
+// ==================================================================
+// =                              Size                              =
+// ==================================================================
+.@{form-prefix-cls} {
+  .formSize(@input-height) {
+    .@{form-item-prefix-cls}-label > label {
+      height: @input-height;
     }
 
-    // Fix issue: https://github.com/ant-design/ant-design/issues/7854
-    .@{ant-prefix}-input-search:not(.@{ant-prefix}-input-search-enter-button) {
-      .@{ant-prefix}-input-suffix {
-        right: 28px;
-
-        .@{form-prefix-cls}-rtl & {
-          right: auto;
-          left: 28px;
-        }
-      }
-    }
-
-    .@{ant-prefix}-input-password-icon {
-      .@{form-prefix-cls}-rtl & {
-        margin-right: 0;
-        margin-left: 18px;
-      }
-    }
-
-    // ======================== Switch =========================
-    .@{ant-prefix}-switch {
-      margin: 2px 0 4px;
-    }
-
-    // ======================== Select =========================
-    // Fix overlapping between feedback icon and <Select>'s arrow.
-    // https://github.com/ant-design/ant-design/issues/4431
-    > .@{ant-prefix}-select .@{ant-prefix}-select-arrow,
-    > .@{ant-prefix}-select .@{ant-prefix}-select-selection__clear,
-    :not(.@{ant-prefix}-input-group-addon) > .@{ant-prefix}-select .@{ant-prefix}-select-arrow,
-    :not(.@{ant-prefix}-input-group-addon)
-      > .@{ant-prefix}-select
-      .@{ant-prefix}-select-selection__clear {
-      right: 28px;
-
-      .@{form-prefix-cls}-rtl & {
-        right: auto;
-        left: 28px;
-      }
-    }
-    > .@{ant-prefix}-select .@{ant-prefix}-select-selection-selected-value,
-    :not(.@{ant-prefix}-input-group-addon)
-      > .@{ant-prefix}-select
-      .@{ant-prefix}-select-selection-selected-value {
-      padding-right: 42px;
-
-      .@{form-prefix-cls}-rtl & {
-        padding-right: 0;
-        padding-left: 42px;
-      }
-    }
-
-    // ======================= Cascader ========================
-    .@{ant-prefix}-cascader-picker {
-      &-arrow {
-        margin-right: 17px;
-
-        .@{form-prefix-cls}-rtl & {
-          margin-right: 0;
-          margin-left: 17px;
-        }
-      }
-      &-clear {
-        right: 28px;
-
-        .@{form-prefix-cls}-rtl & {
-          right: auto;
-          left: 28px;
-        }
-      }
-    }
-
-    // ======================== Picker =========================
-    // Fix issue: https://github.com/ant-design/ant-design/issues/4783
-    .@{ant-prefix}-picker {
-      padding-right: @input-padding-horizontal-base + @font-size-base * 1.3;
-
-      &-large {
-        padding-right: @input-padding-horizontal-lg + @font-size-base * 1.3;
-      }
-
-      &-small {
-        padding-right: @input-padding-horizontal-sm + @font-size-base * 1.3;
-      }
-    }
-
-    // ===================== Status Group ======================
-    &.@{form-item-prefix-cls} {
-      &-has-success,
-      &-has-warning,
-      &-has-error,
-      &-is-validating {
-        // ====================== Icon ======================
-        .@{form-item-prefix-cls}-children-icon {
-          position: absolute;
-          top: 50%;
-          right: 0;
-          z-index: 1;
-          width: @input-height-base;
-          height: 20px;
-          margin-top: -10px;
-          font-size: @font-size-base;
-          line-height: 20px;
-          text-align: center;
-          visibility: visible;
-          animation: zoomIn 0.3s @ease-out-back;
-          pointer-events: none;
-
-          .@{form-prefix-cls}-rtl & {
-            right: auto;
-            left: 0;
-          }
-
-          & svg {
-            position: absolute;
-            top: 0;
-            right: 0;
-            bottom: 0;
-            left: 0;
-            margin: auto;
-          }
-        }
-      }
+    .@{form-item-prefix-cls}-control-input {
+      min-height: @input-height;
     }
   }
 
-  // ======================== Success ========================
-  &-has-success {
-    &.@{form-item-prefix-cls}-has-feedback .@{form-item-prefix-cls}-children-icon {
-      color: @success-color;
-      animation-name: diffZoomIn1 !important;
-    }
+  &-small {
+    .formSize(@input-height-sm);
   }
-
-  // ======================== Warning ========================
-  &-has-warning {
-    .form-control-validation(@warning-color; @warning-color; @form-warning-input-bg);
-
-    &.@{form-item-prefix-cls}-has-feedback .@{form-item-prefix-cls}-children-icon {
-      color: @warning-color;
-      animation-name: diffZoomIn3 !important;
-    }
-
-    //select
-    .@{ant-prefix}-select {
-      .@{ant-prefix}-select-selector {
-        border-color: @warning-color !important;
-      }
-      &.@{ant-prefix}-select-open .@{ant-prefix}-select-selector,
-      &.@{ant-prefix}-select-focused .@{ant-prefix}-select-selector {
-        .active(@warning-color);
-      }
-    }
-
-    //input-number, timepicker
-    .@{ant-prefix}-input-number,
-    .@{ant-prefix}-picker {
-      border-color: @warning-color;
-      &-focused,
-      &:focus {
-        .active(@warning-color);
-      }
-      &:not([disabled]):hover {
-        border-color: @warning-color;
-      }
-    }
-
-    .@{ant-prefix}-cascader-picker:focus .@{ant-prefix}-cascader-input {
-      .active(@warning-color);
-    }
-  }
-
-  // ========================= Error =========================
-  &-has-error {
-    .form-control-validation(@error-color; @error-color; @form-error-input-bg);
-
-    &.@{form-item-prefix-cls}-has-feedback .@{form-item-prefix-cls}-children-icon {
-      color: @error-color;
-      animation-name: diffZoomIn2 !important;
-    }
-
-    //select
-    .@{ant-prefix}-select {
-      .@{ant-prefix}-select-selector {
-        border-color: @error-color !important;
-      }
-      &.@{ant-prefix}-select-open .@{ant-prefix}-select-selector,
-      &.@{ant-prefix}-select-focused .@{ant-prefix}-select-selector {
-        .active(@error-color);
-      }
-    }
-
-    // fixes https://github.com/ant-design/ant-design/issues/20482
-    .@{ant-prefix}-input-group-addon .@{ant-prefix}-select {
-      &.@{ant-prefix}-select-single:not(.@{ant-prefix}-select-customize-input)
-        .@{ant-prefix}-select-selector {
-        border: 0;
-      }
-    }
-
-    .@{ant-prefix}-select.@{ant-prefix}-select-auto-complete {
-      .@{ant-prefix}-input:focus {
-        border-color: @error-color;
-      }
-    }
-
-    //input-number, timepicker
-    .@{ant-prefix}-input-number,
-    .@{ant-prefix}-picker {
-      border-color: @error-color;
-      &-focused,
-      &:focus {
-        .active(@error-color);
-      }
-      &:not([disabled]):hover {
-        border-color: @error-color;
-      }
-    }
-    .@{ant-prefix}-mention-wrapper {
-      .@{ant-prefix}-mention-editor {
-        &,
-        &:not([disabled]):hover {
-          border-color: @error-color;
-        }
-      }
-      &.@{ant-prefix}-mention-active:not([disabled]) .@{ant-prefix}-mention-editor,
-      .@{ant-prefix}-mention-editor:not([disabled]):focus {
-        .active(@error-color);
-      }
-    }
-
-    .@{ant-prefix}-cascader-picker:focus .@{ant-prefix}-cascader-input {
-      .active(@error-color);
-    }
-
-    // transfer
-    .@{ant-prefix}-transfer {
-      &-list {
-        border-color: @error-color;
-
-        &-search:not([disabled]) {
-          border-color: @input-border-color;
-
-          &:hover {
-            .hover();
-          }
-
-          &:focus {
-            .active();
-          }
-        }
-      }
-    }
-  }
-
-  // Patch to keep error explain color
-  &-has-error-leave {
-    .@{form-item-prefix-cls}-explain {
-      color: @error-color;
-    }
-  }
-
-  // ====================== Validating =======================
-  &-is-validating {
-    &.@{form-item-prefix-cls}-has-feedback .@{form-item-prefix-cls}-children-icon {
-      display: inline-block;
-      color: @primary-color;
-    }
+  &-large {
+    .formSize(@input-height-lg);
   }
 }
 

--- a/components/form/style/index.less
+++ b/components/form/style/index.less
@@ -25,6 +25,26 @@
   &-rtl {
     direction: rtl;
   }
+
+  // ================================================================
+  // =                             Size                             =
+  // ================================================================
+  .formSize(@input-height) {
+    .@{form-item-prefix-cls}-label > label {
+      height: @input-height;
+    }
+
+    .@{form-item-prefix-cls}-control-input {
+      min-height: @input-height;
+    }
+  }
+
+  &-small {
+    .formSize(@input-height-sm);
+  }
+  &-large {
+    .formSize(@input-height-lg);
+  }
 }
 
 .explainAndExtraDistance(@num) when (@num>=0) {
@@ -141,28 +161,6 @@
     font-size: @font-size-base;
     line-height: @line-height-base;
     transition: color 0.3s @ease-out; // sync input color transition
-  }
-}
-
-// ==================================================================
-// =                              Size                              =
-// ==================================================================
-.@{form-prefix-cls} {
-  .formSize(@input-height) {
-    .@{form-item-prefix-cls}-label > label {
-      height: @input-height;
-    }
-
-    .@{form-item-prefix-cls}-control-input {
-      min-height: @input-height;
-    }
-  }
-
-  &-small {
-    .formSize(@input-height-sm);
-  }
-  &-large {
-    .formSize(@input-height-lg);
   }
 }
 

--- a/components/form/style/status.less
+++ b/components/form/style/status.less
@@ -1,0 +1,290 @@
+@import './index.less';
+
+.@{form-item-prefix-cls} {
+  // ================================================================
+  // =                            Status                            =
+  // ================================================================
+  /* Some non-status related component style is in `components.less` */
+
+  &-has-feedback {
+    // ========================= Input =========================
+    .@{ant-prefix}-input {
+      padding-right: 24px;
+    }
+    // https://github.com/ant-design/ant-design/issues/19884
+    .@{ant-prefix}-input-affix-wrapper {
+      .@{ant-prefix}-input-suffix {
+        padding-right: 18px;
+      }
+    }
+
+    // Fix issue: https://github.com/ant-design/ant-design/issues/7854
+    .@{ant-prefix}-input-search:not(.@{ant-prefix}-input-search-enter-button) {
+      .@{ant-prefix}-input-suffix {
+        right: 28px;
+
+        .@{form-prefix-cls}-rtl & {
+          right: auto;
+          left: 28px;
+        }
+      }
+    }
+
+    .@{ant-prefix}-input-password-icon {
+      .@{form-prefix-cls}-rtl & {
+        margin-right: 0;
+        margin-left: 18px;
+      }
+    }
+
+    // ======================== Switch =========================
+    .@{ant-prefix}-switch {
+      margin: 2px 0 4px;
+    }
+
+    // ======================== Select =========================
+    // Fix overlapping between feedback icon and <Select>'s arrow.
+    // https://github.com/ant-design/ant-design/issues/4431
+    > .@{ant-prefix}-select .@{ant-prefix}-select-arrow,
+    > .@{ant-prefix}-select .@{ant-prefix}-select-selection__clear,
+    :not(.@{ant-prefix}-input-group-addon) > .@{ant-prefix}-select .@{ant-prefix}-select-arrow,
+    :not(.@{ant-prefix}-input-group-addon)
+      > .@{ant-prefix}-select
+      .@{ant-prefix}-select-selection__clear {
+      right: 28px;
+
+      .@{form-prefix-cls}-rtl & {
+        right: auto;
+        left: 28px;
+      }
+    }
+    > .@{ant-prefix}-select .@{ant-prefix}-select-selection-selected-value,
+    :not(.@{ant-prefix}-input-group-addon)
+      > .@{ant-prefix}-select
+      .@{ant-prefix}-select-selection-selected-value {
+      padding-right: 42px;
+
+      .@{form-prefix-cls}-rtl & {
+        padding-right: 0;
+        padding-left: 42px;
+      }
+    }
+
+    // ======================= Cascader ========================
+    .@{ant-prefix}-cascader-picker {
+      &-arrow {
+        margin-right: 17px;
+
+        .@{form-prefix-cls}-rtl & {
+          margin-right: 0;
+          margin-left: 17px;
+        }
+      }
+      &-clear {
+        right: 28px;
+
+        .@{form-prefix-cls}-rtl & {
+          right: auto;
+          left: 28px;
+        }
+      }
+    }
+
+    // ======================== Picker =========================
+    // Fix issue: https://github.com/ant-design/ant-design/issues/4783
+    .@{ant-prefix}-picker {
+      padding-right: @input-padding-horizontal-base + @font-size-base * 1.3;
+
+      &-large {
+        padding-right: @input-padding-horizontal-lg + @font-size-base * 1.3;
+      }
+
+      &-small {
+        padding-right: @input-padding-horizontal-sm + @font-size-base * 1.3;
+      }
+    }
+
+    // ===================== Status Group ======================
+    &.@{form-item-prefix-cls} {
+      &-has-success,
+      &-has-warning,
+      &-has-error,
+      &-is-validating {
+        // ====================== Icon ======================
+        .@{form-item-prefix-cls}-children-icon {
+          position: absolute;
+          top: 50%;
+          right: 0;
+          z-index: 1;
+          width: @input-height-base;
+          height: 20px;
+          margin-top: -10px;
+          font-size: @font-size-base;
+          line-height: 20px;
+          text-align: center;
+          visibility: visible;
+          animation: zoomIn 0.3s @ease-out-back;
+          pointer-events: none;
+
+          .@{form-prefix-cls}-rtl & {
+            right: auto;
+            left: 0;
+          }
+
+          & svg {
+            position: absolute;
+            top: 0;
+            right: 0;
+            bottom: 0;
+            left: 0;
+            margin: auto;
+          }
+        }
+      }
+    }
+  }
+
+  // ======================== Success ========================
+  &-has-success {
+    &.@{form-item-prefix-cls}-has-feedback .@{form-item-prefix-cls}-children-icon {
+      color: @success-color;
+      animation-name: diffZoomIn1 !important;
+    }
+  }
+
+  // ======================== Warning ========================
+  &-has-warning {
+    .form-control-validation(@warning-color; @warning-color; @form-warning-input-bg);
+
+    &.@{form-item-prefix-cls}-has-feedback .@{form-item-prefix-cls}-children-icon {
+      color: @warning-color;
+      animation-name: diffZoomIn3 !important;
+    }
+
+    //select
+    .@{ant-prefix}-select {
+      .@{ant-prefix}-select-selector {
+        border-color: @warning-color !important;
+      }
+      &.@{ant-prefix}-select-open .@{ant-prefix}-select-selector,
+      &.@{ant-prefix}-select-focused .@{ant-prefix}-select-selector {
+        .active(@warning-color);
+      }
+    }
+
+    //input-number, timepicker
+    .@{ant-prefix}-input-number,
+    .@{ant-prefix}-picker {
+      border-color: @warning-color;
+      &-focused,
+      &:focus {
+        .active(@warning-color);
+      }
+      &:not([disabled]):hover {
+        border-color: @warning-color;
+      }
+    }
+
+    .@{ant-prefix}-cascader-picker:focus .@{ant-prefix}-cascader-input {
+      .active(@warning-color);
+    }
+  }
+
+  // ========================= Error =========================
+  &-has-error {
+    .form-control-validation(@error-color; @error-color; @form-error-input-bg);
+
+    &.@{form-item-prefix-cls}-has-feedback .@{form-item-prefix-cls}-children-icon {
+      color: @error-color;
+      animation-name: diffZoomIn2 !important;
+    }
+
+    //select
+    .@{ant-prefix}-select {
+      .@{ant-prefix}-select-selector {
+        border-color: @error-color !important;
+      }
+      &.@{ant-prefix}-select-open .@{ant-prefix}-select-selector,
+      &.@{ant-prefix}-select-focused .@{ant-prefix}-select-selector {
+        .active(@error-color);
+      }
+    }
+
+    // fixes https://github.com/ant-design/ant-design/issues/20482
+    .@{ant-prefix}-input-group-addon .@{ant-prefix}-select {
+      &.@{ant-prefix}-select-single:not(.@{ant-prefix}-select-customize-input)
+        .@{ant-prefix}-select-selector {
+        border: 0;
+      }
+    }
+
+    .@{ant-prefix}-select.@{ant-prefix}-select-auto-complete {
+      .@{ant-prefix}-input:focus {
+        border-color: @error-color;
+      }
+    }
+
+    //input-number, timepicker
+    .@{ant-prefix}-input-number,
+    .@{ant-prefix}-picker {
+      border-color: @error-color;
+      &-focused,
+      &:focus {
+        .active(@error-color);
+      }
+      &:not([disabled]):hover {
+        border-color: @error-color;
+      }
+    }
+    .@{ant-prefix}-mention-wrapper {
+      .@{ant-prefix}-mention-editor {
+        &,
+        &:not([disabled]):hover {
+          border-color: @error-color;
+        }
+      }
+      &.@{ant-prefix}-mention-active:not([disabled]) .@{ant-prefix}-mention-editor,
+      .@{ant-prefix}-mention-editor:not([disabled]):focus {
+        .active(@error-color);
+      }
+    }
+
+    .@{ant-prefix}-cascader-picker:focus .@{ant-prefix}-cascader-input {
+      .active(@error-color);
+    }
+
+    // transfer
+    .@{ant-prefix}-transfer {
+      &-list {
+        border-color: @error-color;
+
+        &-search:not([disabled]) {
+          border-color: @input-border-color;
+
+          &:hover {
+            .hover();
+          }
+
+          &:focus {
+            .active();
+          }
+        }
+      }
+    }
+  }
+
+  // Patch to keep error explain color
+  &-has-error-leave {
+    .@{form-item-prefix-cls}-explain {
+      color: @error-color;
+    }
+  }
+
+  // ====================== Validating =======================
+  &-is-validating {
+    &.@{form-item-prefix-cls}-has-feedback .@{form-item-prefix-cls}-children-icon {
+      display: inline-block;
+      color: @primary-color;
+    }
+  }
+}

--- a/components/input/__tests__/__snapshots__/index.test.js.snap
+++ b/components/input/__tests__/__snapshots__/index.test.js.snap
@@ -175,7 +175,7 @@ exports[`Input should support size 1`] = `
 
 exports[`Input should support size in form 1`] = `
 <form
-  class="ant-form ant-form-horizontal"
+  class="ant-form ant-form-horizontal ant-form-large"
 >
   <div
     class="ant-row ant-form-item"
@@ -186,11 +186,15 @@ exports[`Input should support size in form 1`] = `
       <div
         class="ant-form-item-control-input"
       >
-        <input
-          class="ant-input ant-input-lg"
-          type="text"
-          value=""
-        />
+        <div
+          class="ant-form-item-control-input-content"
+        >
+          <input
+            class="ant-input ant-input-lg"
+            type="text"
+            value=""
+          />
+        </div>
       </div>
     </div>
   </div>

--- a/components/mentions/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/mentions/__tests__/__snapshots__/demo.test.js.snap
@@ -49,12 +49,16 @@ exports[`renders ./components/mentions/demo/form.md correctly 1`] = `
         class="ant-form-item-control-input"
       >
         <div
-          class="ant-mentions"
+          class="ant-form-item-control-input-content"
         >
-          <textarea
-            id="coders"
-            rows="1"
-          />
+          <div
+            class="ant-mentions"
+          >
+            <textarea
+              id="coders"
+              rows="1"
+            />
+          </div>
         </div>
       </div>
     </div>
@@ -80,13 +84,17 @@ exports[`renders ./components/mentions/demo/form.md correctly 1`] = `
         class="ant-form-item-control-input"
       >
         <div
-          class="ant-mentions"
+          class="ant-form-item-control-input-content"
         >
-          <textarea
-            id="bio"
-            placeholder="You can use @ to ref user here"
-            rows="3"
-          />
+          <div
+            class="ant-mentions"
+          >
+            <textarea
+              id="bio"
+              placeholder="You can use @ to ref user here"
+              rows="3"
+            />
+          </div>
         </div>
       </div>
     </div>
@@ -100,23 +108,27 @@ exports[`renders ./components/mentions/demo/form.md correctly 1`] = `
       <div
         class="ant-form-item-control-input"
       >
-        <button
-          class="ant-btn ant-btn-primary"
-          type="submit"
+        <div
+          class="ant-form-item-control-input-content"
         >
-          <span>
-            Submit
-          </span>
-        </button>
-           
-        <button
-          class="ant-btn"
-          type="button"
-        >
-          <span>
-            Reset
-          </span>
-        </button>
+          <button
+            class="ant-btn ant-btn-primary"
+            type="submit"
+          >
+            <span>
+              Submit
+            </span>
+          </button>
+             
+          <button
+            class="ant-btn"
+            type="button"
+          >
+            <span>
+              Reset
+            </span>
+          </button>
+        </div>
       </div>
     </div>
   </div>

--- a/components/skeleton/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/skeleton/__tests__/__snapshots__/demo.test.js.snap
@@ -127,16 +127,20 @@ exports[`renders ./components/skeleton/demo/element.md correctly 1`] = `
           <div
             class="ant-form-item-control-input"
           >
-            <button
-              aria-checked="false"
-              class="ant-switch"
-              role="switch"
-              type="button"
+            <div
+              class="ant-form-item-control-input-content"
             >
-              <span
-                class="ant-switch-inner"
-              />
-            </button>
+              <button
+                aria-checked="false"
+                class="ant-switch"
+                role="switch"
+                type="button"
+              >
+                <span
+                  class="ant-switch-inner"
+                />
+              </button>
+            </div>
           </div>
         </div>
       </div>
@@ -160,66 +164,70 @@ exports[`renders ./components/skeleton/demo/element.md correctly 1`] = `
             class="ant-form-item-control-input"
           >
             <div
-              class="ant-radio-group ant-radio-group-outline"
+              class="ant-form-item-control-input-content"
             >
-              <label
-                class="ant-radio-button-wrapper ant-radio-button-wrapper-checked"
+              <div
+                class="ant-radio-group ant-radio-group-outline"
               >
-                <span
-                  class="ant-radio-button ant-radio-button-checked"
+                <label
+                  class="ant-radio-button-wrapper ant-radio-button-wrapper-checked"
                 >
-                  <input
-                    checked=""
-                    class="ant-radio-button-input"
-                    type="radio"
-                    value="default"
-                  />
                   <span
-                    class="ant-radio-button-inner"
-                  />
-                </span>
-                <span>
-                  Default
-                </span>
-              </label>
-              <label
-                class="ant-radio-button-wrapper"
-              >
-                <span
-                  class="ant-radio-button"
+                    class="ant-radio-button ant-radio-button-checked"
+                  >
+                    <input
+                      checked=""
+                      class="ant-radio-button-input"
+                      type="radio"
+                      value="default"
+                    />
+                    <span
+                      class="ant-radio-button-inner"
+                    />
+                  </span>
+                  <span>
+                    Default
+                  </span>
+                </label>
+                <label
+                  class="ant-radio-button-wrapper"
                 >
-                  <input
-                    class="ant-radio-button-input"
-                    type="radio"
-                    value="large"
-                  />
                   <span
-                    class="ant-radio-button-inner"
-                  />
-                </span>
-                <span>
-                  Large
-                </span>
-              </label>
-              <label
-                class="ant-radio-button-wrapper"
-              >
-                <span
-                  class="ant-radio-button"
+                    class="ant-radio-button"
+                  >
+                    <input
+                      class="ant-radio-button-input"
+                      type="radio"
+                      value="large"
+                    />
+                    <span
+                      class="ant-radio-button-inner"
+                    />
+                  </span>
+                  <span>
+                    Large
+                  </span>
+                </label>
+                <label
+                  class="ant-radio-button-wrapper"
                 >
-                  <input
-                    class="ant-radio-button-input"
-                    type="radio"
-                    value="small"
-                  />
                   <span
-                    class="ant-radio-button-inner"
-                  />
-                </span>
-                <span>
-                  Small
-                </span>
-              </label>
+                    class="ant-radio-button"
+                  >
+                    <input
+                      class="ant-radio-button-input"
+                      type="radio"
+                      value="small"
+                    />
+                    <span
+                      class="ant-radio-button-inner"
+                    />
+                  </span>
+                  <span>
+                    Small
+                  </span>
+                </label>
+              </div>
             </div>
           </div>
         </div>
@@ -244,66 +252,70 @@ exports[`renders ./components/skeleton/demo/element.md correctly 1`] = `
             class="ant-form-item-control-input"
           >
             <div
-              class="ant-radio-group ant-radio-group-outline"
+              class="ant-form-item-control-input-content"
             >
-              <label
-                class="ant-radio-button-wrapper ant-radio-button-wrapper-checked"
+              <div
+                class="ant-radio-group ant-radio-group-outline"
               >
-                <span
-                  class="ant-radio-button ant-radio-button-checked"
+                <label
+                  class="ant-radio-button-wrapper ant-radio-button-wrapper-checked"
                 >
-                  <input
-                    checked=""
-                    class="ant-radio-button-input"
-                    type="radio"
-                    value="default"
-                  />
                   <span
-                    class="ant-radio-button-inner"
-                  />
-                </span>
-                <span>
-                  Default
-                </span>
-              </label>
-              <label
-                class="ant-radio-button-wrapper"
-              >
-                <span
-                  class="ant-radio-button"
+                    class="ant-radio-button ant-radio-button-checked"
+                  >
+                    <input
+                      checked=""
+                      class="ant-radio-button-input"
+                      type="radio"
+                      value="default"
+                    />
+                    <span
+                      class="ant-radio-button-inner"
+                    />
+                  </span>
+                  <span>
+                    Default
+                  </span>
+                </label>
+                <label
+                  class="ant-radio-button-wrapper"
                 >
-                  <input
-                    class="ant-radio-button-input"
-                    type="radio"
-                    value="round"
-                  />
                   <span
-                    class="ant-radio-button-inner"
-                  />
-                </span>
-                <span>
-                  Round
-                </span>
-              </label>
-              <label
-                class="ant-radio-button-wrapper"
-              >
-                <span
-                  class="ant-radio-button"
+                    class="ant-radio-button"
+                  >
+                    <input
+                      class="ant-radio-button-input"
+                      type="radio"
+                      value="round"
+                    />
+                    <span
+                      class="ant-radio-button-inner"
+                    />
+                  </span>
+                  <span>
+                    Round
+                  </span>
+                </label>
+                <label
+                  class="ant-radio-button-wrapper"
                 >
-                  <input
-                    class="ant-radio-button-input"
-                    type="radio"
-                    value="circle"
-                  />
                   <span
-                    class="ant-radio-button-inner"
-                  />
-                </span>
-                <span>
-                  Circle
-                </span>
-              </label>
+                    class="ant-radio-button"
+                  >
+                    <input
+                      class="ant-radio-button-input"
+                      type="radio"
+                      value="circle"
+                    />
+                    <span
+                      class="ant-radio-button-inner"
+                    />
+                  </span>
+                  <span>
+                    Circle
+                  </span>
+                </label>
+              </div>
             </div>
           </div>
         </div>
@@ -342,16 +354,20 @@ exports[`renders ./components/skeleton/demo/element.md correctly 1`] = `
           <div
             class="ant-form-item-control-input"
           >
-            <button
-              aria-checked="false"
-              class="ant-switch"
-              role="switch"
-              type="button"
+            <div
+              class="ant-form-item-control-input-content"
             >
-              <span
-                class="ant-switch-inner"
-              />
-            </button>
+              <button
+                aria-checked="false"
+                class="ant-switch"
+                role="switch"
+                type="button"
+              >
+                <span
+                  class="ant-switch-inner"
+                />
+              </button>
+            </div>
           </div>
         </div>
       </div>
@@ -375,66 +391,70 @@ exports[`renders ./components/skeleton/demo/element.md correctly 1`] = `
             class="ant-form-item-control-input"
           >
             <div
-              class="ant-radio-group ant-radio-group-outline"
+              class="ant-form-item-control-input-content"
             >
-              <label
-                class="ant-radio-button-wrapper ant-radio-button-wrapper-checked"
+              <div
+                class="ant-radio-group ant-radio-group-outline"
               >
-                <span
-                  class="ant-radio-button ant-radio-button-checked"
+                <label
+                  class="ant-radio-button-wrapper ant-radio-button-wrapper-checked"
                 >
-                  <input
-                    checked=""
-                    class="ant-radio-button-input"
-                    type="radio"
-                    value="default"
-                  />
                   <span
-                    class="ant-radio-button-inner"
-                  />
-                </span>
-                <span>
-                  Default
-                </span>
-              </label>
-              <label
-                class="ant-radio-button-wrapper"
-              >
-                <span
-                  class="ant-radio-button"
+                    class="ant-radio-button ant-radio-button-checked"
+                  >
+                    <input
+                      checked=""
+                      class="ant-radio-button-input"
+                      type="radio"
+                      value="default"
+                    />
+                    <span
+                      class="ant-radio-button-inner"
+                    />
+                  </span>
+                  <span>
+                    Default
+                  </span>
+                </label>
+                <label
+                  class="ant-radio-button-wrapper"
                 >
-                  <input
-                    class="ant-radio-button-input"
-                    type="radio"
-                    value="large"
-                  />
                   <span
-                    class="ant-radio-button-inner"
-                  />
-                </span>
-                <span>
-                  Large
-                </span>
-              </label>
-              <label
-                class="ant-radio-button-wrapper"
-              >
-                <span
-                  class="ant-radio-button"
+                    class="ant-radio-button"
+                  >
+                    <input
+                      class="ant-radio-button-input"
+                      type="radio"
+                      value="large"
+                    />
+                    <span
+                      class="ant-radio-button-inner"
+                    />
+                  </span>
+                  <span>
+                    Large
+                  </span>
+                </label>
+                <label
+                  class="ant-radio-button-wrapper"
                 >
-                  <input
-                    class="ant-radio-button-input"
-                    type="radio"
-                    value="small"
-                  />
                   <span
-                    class="ant-radio-button-inner"
-                  />
-                </span>
-                <span>
-                  Small
-                </span>
-              </label>
+                    class="ant-radio-button"
+                  >
+                    <input
+                      class="ant-radio-button-input"
+                      type="radio"
+                      value="small"
+                    />
+                    <span
+                      class="ant-radio-button-inner"
+                    />
+                  </span>
+                  <span>
+                    Small
+                  </span>
+                </label>
+              </div>
             </div>
           </div>
         </div>
@@ -459,47 +479,51 @@ exports[`renders ./components/skeleton/demo/element.md correctly 1`] = `
             class="ant-form-item-control-input"
           >
             <div
-              class="ant-radio-group ant-radio-group-outline"
+              class="ant-form-item-control-input-content"
             >
-              <label
-                class="ant-radio-button-wrapper"
+              <div
+                class="ant-radio-group ant-radio-group-outline"
               >
-                <span
-                  class="ant-radio-button"
+                <label
+                  class="ant-radio-button-wrapper"
                 >
-                  <input
-                    class="ant-radio-button-input"
-                    type="radio"
-                    value="square"
-                  />
                   <span
-                    class="ant-radio-button-inner"
-                  />
-                </span>
-                <span>
-                  Square
-                </span>
-              </label>
-              <label
-                class="ant-radio-button-wrapper ant-radio-button-wrapper-checked"
-              >
-                <span
-                  class="ant-radio-button ant-radio-button-checked"
+                    class="ant-radio-button"
+                  >
+                    <input
+                      class="ant-radio-button-input"
+                      type="radio"
+                      value="square"
+                    />
+                    <span
+                      class="ant-radio-button-inner"
+                    />
+                  </span>
+                  <span>
+                    Square
+                  </span>
+                </label>
+                <label
+                  class="ant-radio-button-wrapper ant-radio-button-wrapper-checked"
                 >
-                  <input
-                    checked=""
-                    class="ant-radio-button-input"
-                    type="radio"
-                    value="circle"
-                  />
                   <span
-                    class="ant-radio-button-inner"
-                  />
-                </span>
-                <span>
-                  Circle
-                </span>
-              </label>
+                    class="ant-radio-button ant-radio-button-checked"
+                  >
+                    <input
+                      checked=""
+                      class="ant-radio-button-input"
+                      type="radio"
+                      value="circle"
+                    />
+                    <span
+                      class="ant-radio-button-inner"
+                    />
+                  </span>
+                  <span>
+                    Circle
+                  </span>
+                </label>
+              </div>
             </div>
           </div>
         </div>
@@ -538,16 +562,20 @@ exports[`renders ./components/skeleton/demo/element.md correctly 1`] = `
           <div
             class="ant-form-item-control-input"
           >
-            <button
-              aria-checked="false"
-              class="ant-switch"
-              role="switch"
-              type="button"
+            <div
+              class="ant-form-item-control-input-content"
             >
-              <span
-                class="ant-switch-inner"
-              />
-            </button>
+              <button
+                aria-checked="false"
+                class="ant-switch"
+                role="switch"
+                type="button"
+              >
+                <span
+                  class="ant-switch-inner"
+                />
+              </button>
+            </div>
           </div>
         </div>
       </div>
@@ -571,66 +599,70 @@ exports[`renders ./components/skeleton/demo/element.md correctly 1`] = `
             class="ant-form-item-control-input"
           >
             <div
-              class="ant-radio-group ant-radio-group-outline"
+              class="ant-form-item-control-input-content"
             >
-              <label
-                class="ant-radio-button-wrapper ant-radio-button-wrapper-checked"
+              <div
+                class="ant-radio-group ant-radio-group-outline"
               >
-                <span
-                  class="ant-radio-button ant-radio-button-checked"
+                <label
+                  class="ant-radio-button-wrapper ant-radio-button-wrapper-checked"
                 >
-                  <input
-                    checked=""
-                    class="ant-radio-button-input"
-                    type="radio"
-                    value="default"
-                  />
                   <span
-                    class="ant-radio-button-inner"
-                  />
-                </span>
-                <span>
-                  Default
-                </span>
-              </label>
-              <label
-                class="ant-radio-button-wrapper"
-              >
-                <span
-                  class="ant-radio-button"
+                    class="ant-radio-button ant-radio-button-checked"
+                  >
+                    <input
+                      checked=""
+                      class="ant-radio-button-input"
+                      type="radio"
+                      value="default"
+                    />
+                    <span
+                      class="ant-radio-button-inner"
+                    />
+                  </span>
+                  <span>
+                    Default
+                  </span>
+                </label>
+                <label
+                  class="ant-radio-button-wrapper"
                 >
-                  <input
-                    class="ant-radio-button-input"
-                    type="radio"
-                    value="large"
-                  />
                   <span
-                    class="ant-radio-button-inner"
-                  />
-                </span>
-                <span>
-                  Large
-                </span>
-              </label>
-              <label
-                class="ant-radio-button-wrapper"
-              >
-                <span
-                  class="ant-radio-button"
+                    class="ant-radio-button"
+                  >
+                    <input
+                      class="ant-radio-button-input"
+                      type="radio"
+                      value="large"
+                    />
+                    <span
+                      class="ant-radio-button-inner"
+                    />
+                  </span>
+                  <span>
+                    Large
+                  </span>
+                </label>
+                <label
+                  class="ant-radio-button-wrapper"
                 >
-                  <input
-                    class="ant-radio-button-input"
-                    type="radio"
-                    value="small"
-                  />
                   <span
-                    class="ant-radio-button-inner"
-                  />
-                </span>
-                <span>
-                  Small
-                </span>
-              </label>
+                    class="ant-radio-button"
+                  >
+                    <input
+                      class="ant-radio-button-input"
+                      type="radio"
+                      value="small"
+                    />
+                    <span
+                      class="ant-radio-button-inner"
+                    />
+                  </span>
+                  <span>
+                    Small
+                  </span>
+                </label>
+              </div>
             </div>
           </div>
         </div>

--- a/components/table/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/table/__tests__/__snapshots__/demo.test.js.snap
@@ -1634,16 +1634,20 @@ exports[`renders ./components/table/demo/dynamic-settings.md correctly 1`] = `
         <div
           class="ant-form-item-control-input"
         >
-          <button
-            aria-checked="false"
-            class="ant-switch"
-            role="switch"
-            type="button"
+          <div
+            class="ant-form-item-control-input-content"
           >
-            <span
-              class="ant-switch-inner"
-            />
-          </button>
+            <button
+              aria-checked="false"
+              class="ant-switch"
+              role="switch"
+              type="button"
+            >
+              <span
+                class="ant-switch-inner"
+              />
+            </button>
+          </div>
         </div>
       </div>
     </div>
@@ -1666,16 +1670,20 @@ exports[`renders ./components/table/demo/dynamic-settings.md correctly 1`] = `
         <div
           class="ant-form-item-control-input"
         >
-          <button
-            aria-checked="false"
-            class="ant-switch"
-            role="switch"
-            type="button"
+          <div
+            class="ant-form-item-control-input-content"
           >
-            <span
-              class="ant-switch-inner"
-            />
-          </button>
+            <button
+              aria-checked="false"
+              class="ant-switch"
+              role="switch"
+              type="button"
+            >
+              <span
+                class="ant-switch-inner"
+              />
+            </button>
+          </div>
         </div>
       </div>
     </div>
@@ -1698,16 +1706,20 @@ exports[`renders ./components/table/demo/dynamic-settings.md correctly 1`] = `
         <div
           class="ant-form-item-control-input"
         >
-          <button
-            aria-checked="false"
-            class="ant-switch"
-            role="switch"
-            type="button"
+          <div
+            class="ant-form-item-control-input-content"
           >
-            <span
-              class="ant-switch-inner"
-            />
-          </button>
+            <button
+              aria-checked="false"
+              class="ant-switch"
+              role="switch"
+              type="button"
+            >
+              <span
+                class="ant-switch-inner"
+              />
+            </button>
+          </div>
         </div>
       </div>
     </div>
@@ -1730,17 +1742,21 @@ exports[`renders ./components/table/demo/dynamic-settings.md correctly 1`] = `
         <div
           class="ant-form-item-control-input"
         >
-          <button
-            aria-checked="true"
-            checked=""
-            class="ant-switch ant-switch-checked"
-            role="switch"
-            type="button"
+          <div
+            class="ant-form-item-control-input-content"
           >
-            <span
-              class="ant-switch-inner"
-            />
-          </button>
+            <button
+              aria-checked="true"
+              checked=""
+              class="ant-switch ant-switch-checked"
+              role="switch"
+              type="button"
+            >
+              <span
+                class="ant-switch-inner"
+              />
+            </button>
+          </div>
         </div>
       </div>
     </div>
@@ -1763,17 +1779,21 @@ exports[`renders ./components/table/demo/dynamic-settings.md correctly 1`] = `
         <div
           class="ant-form-item-control-input"
         >
-          <button
-            aria-checked="true"
-            checked=""
-            class="ant-switch ant-switch-checked"
-            role="switch"
-            type="button"
+          <div
+            class="ant-form-item-control-input-content"
           >
-            <span
-              class="ant-switch-inner"
-            />
-          </button>
+            <button
+              aria-checked="true"
+              checked=""
+              class="ant-switch ant-switch-checked"
+              role="switch"
+              type="button"
+            >
+              <span
+                class="ant-switch-inner"
+              />
+            </button>
+          </div>
         </div>
       </div>
     </div>
@@ -1796,17 +1816,21 @@ exports[`renders ./components/table/demo/dynamic-settings.md correctly 1`] = `
         <div
           class="ant-form-item-control-input"
         >
-          <button
-            aria-checked="true"
-            checked=""
-            class="ant-switch ant-switch-checked"
-            role="switch"
-            type="button"
+          <div
+            class="ant-form-item-control-input-content"
           >
-            <span
-              class="ant-switch-inner"
-            />
-          </button>
+            <button
+              aria-checked="true"
+              checked=""
+              class="ant-switch ant-switch-checked"
+              role="switch"
+              type="button"
+            >
+              <span
+                class="ant-switch-inner"
+              />
+            </button>
+          </div>
         </div>
       </div>
     </div>
@@ -1829,17 +1853,21 @@ exports[`renders ./components/table/demo/dynamic-settings.md correctly 1`] = `
         <div
           class="ant-form-item-control-input"
         >
-          <button
-            aria-checked="true"
-            checked=""
-            class="ant-switch ant-switch-checked"
-            role="switch"
-            type="button"
+          <div
+            class="ant-form-item-control-input-content"
           >
-            <span
-              class="ant-switch-inner"
-            />
-          </button>
+            <button
+              aria-checked="true"
+              checked=""
+              class="ant-switch ant-switch-checked"
+              role="switch"
+              type="button"
+            >
+              <span
+                class="ant-switch-inner"
+              />
+            </button>
+          </div>
         </div>
       </div>
     </div>
@@ -1862,16 +1890,20 @@ exports[`renders ./components/table/demo/dynamic-settings.md correctly 1`] = `
         <div
           class="ant-form-item-control-input"
         >
-          <button
-            aria-checked="false"
-            class="ant-switch"
-            role="switch"
-            type="button"
+          <div
+            class="ant-form-item-control-input-content"
           >
-            <span
-              class="ant-switch-inner"
-            />
-          </button>
+            <button
+              aria-checked="false"
+              class="ant-switch"
+              role="switch"
+              type="button"
+            >
+              <span
+                class="ant-switch-inner"
+              />
+            </button>
+          </div>
         </div>
       </div>
     </div>
@@ -1894,17 +1926,21 @@ exports[`renders ./components/table/demo/dynamic-settings.md correctly 1`] = `
         <div
           class="ant-form-item-control-input"
         >
-          <button
-            aria-checked="true"
-            checked=""
-            class="ant-switch ant-switch-checked"
-            role="switch"
-            type="button"
+          <div
+            class="ant-form-item-control-input-content"
           >
-            <span
-              class="ant-switch-inner"
-            />
-          </button>
+            <button
+              aria-checked="true"
+              checked=""
+              class="ant-switch ant-switch-checked"
+              role="switch"
+              type="button"
+            >
+              <span
+                class="ant-switch-inner"
+              />
+            </button>
+          </div>
         </div>
       </div>
     </div>
@@ -1927,16 +1963,20 @@ exports[`renders ./components/table/demo/dynamic-settings.md correctly 1`] = `
         <div
           class="ant-form-item-control-input"
         >
-          <button
-            aria-checked="false"
-            class="ant-switch"
-            role="switch"
-            type="button"
+          <div
+            class="ant-form-item-control-input-content"
           >
-            <span
-              class="ant-switch-inner"
-            />
-          </button>
+            <button
+              aria-checked="false"
+              class="ant-switch"
+              role="switch"
+              type="button"
+            >
+              <span
+                class="ant-switch-inner"
+              />
+            </button>
+          </div>
         </div>
       </div>
     </div>
@@ -1960,66 +2000,70 @@ exports[`renders ./components/table/demo/dynamic-settings.md correctly 1`] = `
           class="ant-form-item-control-input"
         >
           <div
-            class="ant-radio-group ant-radio-group-outline"
+            class="ant-form-item-control-input-content"
           >
-            <label
-              class="ant-radio-button-wrapper ant-radio-button-wrapper-checked"
+            <div
+              class="ant-radio-group ant-radio-group-outline"
             >
-              <span
-                class="ant-radio-button ant-radio-button-checked"
+              <label
+                class="ant-radio-button-wrapper ant-radio-button-wrapper-checked"
               >
-                <input
-                  checked=""
-                  class="ant-radio-button-input"
-                  type="radio"
-                  value="default"
-                />
                 <span
-                  class="ant-radio-button-inner"
-                />
-              </span>
-              <span>
-                Default
-              </span>
-            </label>
-            <label
-              class="ant-radio-button-wrapper"
-            >
-              <span
-                class="ant-radio-button"
+                  class="ant-radio-button ant-radio-button-checked"
+                >
+                  <input
+                    checked=""
+                    class="ant-radio-button-input"
+                    type="radio"
+                    value="default"
+                  />
+                  <span
+                    class="ant-radio-button-inner"
+                  />
+                </span>
+                <span>
+                  Default
+                </span>
+              </label>
+              <label
+                class="ant-radio-button-wrapper"
               >
-                <input
-                  class="ant-radio-button-input"
-                  type="radio"
-                  value="middle"
-                />
                 <span
-                  class="ant-radio-button-inner"
-                />
-              </span>
-              <span>
-                Middle
-              </span>
-            </label>
-            <label
-              class="ant-radio-button-wrapper"
-            >
-              <span
-                class="ant-radio-button"
+                  class="ant-radio-button"
+                >
+                  <input
+                    class="ant-radio-button-input"
+                    type="radio"
+                    value="middle"
+                  />
+                  <span
+                    class="ant-radio-button-inner"
+                  />
+                </span>
+                <span>
+                  Middle
+                </span>
+              </label>
+              <label
+                class="ant-radio-button-wrapper"
               >
-                <input
-                  class="ant-radio-button-input"
-                  type="radio"
-                  value="small"
-                />
                 <span
-                  class="ant-radio-button-inner"
-                />
-              </span>
-              <span>
-                Small
-              </span>
-            </label>
+                  class="ant-radio-button"
+                >
+                  <input
+                    class="ant-radio-button-input"
+                    type="radio"
+                    value="small"
+                  />
+                  <span
+                    class="ant-radio-button-inner"
+                  />
+                </span>
+                <span>
+                  Small
+                </span>
+              </label>
+            </div>
           </div>
         </div>
       </div>
@@ -2044,65 +2088,69 @@ exports[`renders ./components/table/demo/dynamic-settings.md correctly 1`] = `
           class="ant-form-item-control-input"
         >
           <div
-            class="ant-radio-group ant-radio-group-outline"
+            class="ant-form-item-control-input-content"
           >
-            <label
-              class="ant-radio-button-wrapper ant-radio-button-wrapper-checked"
+            <div
+              class="ant-radio-group ant-radio-group-outline"
             >
-              <span
-                class="ant-radio-button ant-radio-button-checked"
+              <label
+                class="ant-radio-button-wrapper ant-radio-button-wrapper-checked"
               >
-                <input
-                  checked=""
-                  class="ant-radio-button-input"
-                  type="radio"
-                />
                 <span
-                  class="ant-radio-button-inner"
-                />
-              </span>
-              <span>
-                Unset
-              </span>
-            </label>
-            <label
-              class="ant-radio-button-wrapper"
-            >
-              <span
-                class="ant-radio-button"
+                  class="ant-radio-button ant-radio-button-checked"
+                >
+                  <input
+                    checked=""
+                    class="ant-radio-button-input"
+                    type="radio"
+                  />
+                  <span
+                    class="ant-radio-button-inner"
+                  />
+                </span>
+                <span>
+                  Unset
+                </span>
+              </label>
+              <label
+                class="ant-radio-button-wrapper"
               >
-                <input
-                  class="ant-radio-button-input"
-                  type="radio"
-                  value="scroll"
-                />
                 <span
-                  class="ant-radio-button-inner"
-                />
-              </span>
-              <span>
-                Scroll
-              </span>
-            </label>
-            <label
-              class="ant-radio-button-wrapper"
-            >
-              <span
-                class="ant-radio-button"
+                  class="ant-radio-button"
+                >
+                  <input
+                    class="ant-radio-button-input"
+                    type="radio"
+                    value="scroll"
+                  />
+                  <span
+                    class="ant-radio-button-inner"
+                  />
+                </span>
+                <span>
+                  Scroll
+                </span>
+              </label>
+              <label
+                class="ant-radio-button-wrapper"
               >
-                <input
-                  class="ant-radio-button-input"
-                  type="radio"
-                  value="fixed"
-                />
                 <span
-                  class="ant-radio-button-inner"
-                />
-              </span>
-              <span>
-                Fixed Columns
-              </span>
-            </label>
+                  class="ant-radio-button"
+                >
+                  <input
+                    class="ant-radio-button-input"
+                    type="radio"
+                    value="fixed"
+                  />
+                  <span
+                    class="ant-radio-button-inner"
+                  />
+                </span>
+                <span>
+                  Fixed Columns
+                </span>
+              </label>
+            </div>
           </div>
         </div>
       </div>
@@ -2127,46 +2175,50 @@ exports[`renders ./components/table/demo/dynamic-settings.md correctly 1`] = `
           class="ant-form-item-control-input"
         >
           <div
-            class="ant-radio-group ant-radio-group-outline"
+            class="ant-form-item-control-input-content"
           >
-            <label
-              class="ant-radio-button-wrapper ant-radio-button-wrapper-checked"
+            <div
+              class="ant-radio-group ant-radio-group-outline"
             >
-              <span
-                class="ant-radio-button ant-radio-button-checked"
+              <label
+                class="ant-radio-button-wrapper ant-radio-button-wrapper-checked"
               >
-                <input
-                  checked=""
-                  class="ant-radio-button-input"
-                  type="radio"
-                />
                 <span
-                  class="ant-radio-button-inner"
-                />
-              </span>
-              <span>
-                Unset
-              </span>
-            </label>
-            <label
-              class="ant-radio-button-wrapper"
-            >
-              <span
-                class="ant-radio-button"
+                  class="ant-radio-button ant-radio-button-checked"
+                >
+                  <input
+                    checked=""
+                    class="ant-radio-button-input"
+                    type="radio"
+                  />
+                  <span
+                    class="ant-radio-button-inner"
+                  />
+                </span>
+                <span>
+                  Unset
+                </span>
+              </label>
+              <label
+                class="ant-radio-button-wrapper"
               >
-                <input
-                  class="ant-radio-button-input"
-                  type="radio"
-                  value="fixed"
-                />
                 <span
-                  class="ant-radio-button-inner"
-                />
-              </span>
-              <span>
-                Fixed
-              </span>
-            </label>
+                  class="ant-radio-button"
+                >
+                  <input
+                    class="ant-radio-button-input"
+                    type="radio"
+                    value="fixed"
+                  />
+                  <span
+                    class="ant-radio-button-inner"
+                  />
+                </span>
+                <span>
+                  Fixed
+                </span>
+              </label>
+            </div>
           </div>
         </div>
       </div>
@@ -2191,85 +2243,89 @@ exports[`renders ./components/table/demo/dynamic-settings.md correctly 1`] = `
           class="ant-form-item-control-input"
         >
           <div
-            class="ant-radio-group ant-radio-group-outline"
+            class="ant-form-item-control-input-content"
           >
-            <label
-              class="ant-radio-button-wrapper"
+            <div
+              class="ant-radio-group ant-radio-group-outline"
             >
-              <span
-                class="ant-radio-button"
+              <label
+                class="ant-radio-button-wrapper"
               >
-                <input
-                  class="ant-radio-button-input"
-                  type="radio"
-                  value="top"
-                />
                 <span
-                  class="ant-radio-button-inner"
-                />
-              </span>
-              <span>
-                Top
-              </span>
-            </label>
-            <label
-              class="ant-radio-button-wrapper ant-radio-button-wrapper-checked"
-            >
-              <span
-                class="ant-radio-button ant-radio-button-checked"
+                  class="ant-radio-button"
+                >
+                  <input
+                    class="ant-radio-button-input"
+                    type="radio"
+                    value="top"
+                  />
+                  <span
+                    class="ant-radio-button-inner"
+                  />
+                </span>
+                <span>
+                  Top
+                </span>
+              </label>
+              <label
+                class="ant-radio-button-wrapper ant-radio-button-wrapper-checked"
               >
-                <input
-                  checked=""
-                  class="ant-radio-button-input"
-                  type="radio"
-                  value="bottom"
-                />
                 <span
-                  class="ant-radio-button-inner"
-                />
-              </span>
-              <span>
-                Bottom
-              </span>
-            </label>
-            <label
-              class="ant-radio-button-wrapper"
-            >
-              <span
-                class="ant-radio-button"
+                  class="ant-radio-button ant-radio-button-checked"
+                >
+                  <input
+                    checked=""
+                    class="ant-radio-button-input"
+                    type="radio"
+                    value="bottom"
+                  />
+                  <span
+                    class="ant-radio-button-inner"
+                  />
+                </span>
+                <span>
+                  Bottom
+                </span>
+              </label>
+              <label
+                class="ant-radio-button-wrapper"
               >
-                <input
-                  class="ant-radio-button-input"
-                  type="radio"
-                  value="both"
-                />
                 <span
-                  class="ant-radio-button-inner"
-                />
-              </span>
-              <span>
-                Both
-              </span>
-            </label>
-            <label
-              class="ant-radio-button-wrapper"
-            >
-              <span
-                class="ant-radio-button"
+                  class="ant-radio-button"
+                >
+                  <input
+                    class="ant-radio-button-input"
+                    type="radio"
+                    value="both"
+                  />
+                  <span
+                    class="ant-radio-button-inner"
+                  />
+                </span>
+                <span>
+                  Both
+                </span>
+              </label>
+              <label
+                class="ant-radio-button-wrapper"
               >
-                <input
-                  class="ant-radio-button-input"
-                  type="radio"
-                  value="none"
-                />
                 <span
-                  class="ant-radio-button-inner"
-                />
-              </span>
-              <span>
-                None
-              </span>
-            </label>
+                  class="ant-radio-button"
+                >
+                  <input
+                    class="ant-radio-button-input"
+                    type="radio"
+                    value="none"
+                  />
+                  <span
+                    class="ant-radio-button-inner"
+                  />
+                </span>
+                <span>
+                  None
+                </span>
+              </label>
+            </div>
           </div>
         </div>
       </div>

--- a/components/upload/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/upload/__tests__/__snapshots__/demo.test.js.snap
@@ -3005,56 +3005,60 @@ exports[`renders ./components/upload/demo/upload-with-aliyun-oss.md correctly 1`
       <div
         class="ant-form-item-control-input"
       >
-        <span
-          class=""
+        <div
+          class="ant-form-item-control-input-content"
         >
-          <div
-            class="ant-upload ant-upload-select ant-upload-select-text"
+          <span
+            class=""
           >
-            <span
-              class="ant-upload"
-              role="button"
-              tabindex="0"
+            <div
+              class="ant-upload ant-upload-select ant-upload-select-text"
             >
-              <input
-                accept=""
-                style="display:none"
-                type="file"
-              />
-              <button
-                class="ant-btn"
-                type="button"
+              <span
+                class="ant-upload"
+                role="button"
+                tabindex="0"
               >
-                <span
-                  aria-label="upload"
-                  class="anticon anticon-upload"
-                  role="img"
+                <input
+                  accept=""
+                  style="display:none"
+                  type="file"
+                />
+                <button
+                  class="ant-btn"
+                  type="button"
                 >
-                  <svg
-                    aria-hidden="true"
-                    class=""
-                    data-icon="upload"
-                    fill="currentColor"
-                    focusable="false"
-                    height="1em"
-                    viewBox="64 64 896 896"
-                    width="1em"
+                  <span
+                    aria-label="upload"
+                    class="anticon anticon-upload"
+                    role="img"
                   >
-                    <path
-                      d="M400 317.7h73.9V656c0 4.4 3.6 8 8 8h60c4.4 0 8-3.6 8-8V317.7H624c6.7 0 10.4-7.7 6.3-12.9L518.3 163a8 8 0 00-12.6 0l-112 141.7c-4.1 5.3-.4 13 6.3 13zM878 626h-60c-4.4 0-8 3.6-8 8v154H214V634c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v198c0 17.7 14.3 32 32 32h684c17.7 0 32-14.3 32-32V634c0-4.4-3.6-8-8-8z"
-                    />
-                  </svg>
-                </span>
-                <span>
-                   Click to Upload
-                </span>
-              </button>
-            </span>
-          </div>
-          <div
-            class="ant-upload-list ant-upload-list-text"
-          />
-        </span>
+                    <svg
+                      aria-hidden="true"
+                      class=""
+                      data-icon="upload"
+                      fill="currentColor"
+                      focusable="false"
+                      height="1em"
+                      viewBox="64 64 896 896"
+                      width="1em"
+                    >
+                      <path
+                        d="M400 317.7h73.9V656c0 4.4 3.6 8 8 8h60c4.4 0 8-3.6 8-8V317.7H624c6.7 0 10.4-7.7 6.3-12.9L518.3 163a8 8 0 00-12.6 0l-112 141.7c-4.1 5.3-.4 13 6.3 13zM878 626h-60c-4.4 0-8 3.6-8 8v154H214V634c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v198c0 17.7 14.3 32 32 32h684c17.7 0 32-14.3 32-32V634c0-4.4-3.6-8-8-8z"
+                      />
+                    </svg>
+                  </span>
+                  <span>
+                     Click to Upload
+                  </span>
+                </button>
+              </span>
+            </div>
+            <div
+              class="ant-upload-list ant-upload-list-text"
+            />
+          </span>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

fix #21468

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Fix Form.Item with `help` align style.       |
| 🇨🇳 Chinese |    修复 Form.Item 设置 `help` 时的样式问题。        |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/form/demo/validate-other.md](https://github.com/ant-design/ant-design/blob/form-help/components/form/demo/validate-other.md)