### PR TITLE
fix: Input with readOnly should not clearable

### DIFF
--- a/components/input/ClearableLabeledInput.tsx
+++ b/components/input/ClearableLabeledInput.tsx
@@ -16,7 +16,7 @@ export function hasPrefixSuffix(props: InputProps | ClearableInputProps) {
  */
 interface BasicProps {
   prefixCls: string;
-  inputType: (typeof ClearableInputType)[number];
+  inputType: typeof ClearableInputType[number];
   value?: any;
   defaultValue?: any;
   allowClear?: boolean;
@@ -25,13 +25,14 @@ interface BasicProps {
   className?: string;
   style?: object;
   disabled?: boolean;
+  readOnly?: boolean;
 }
 
 /**
  * This props only for input.
  */
 interface ClearableInputProps extends BasicProps {
-  size?: (typeof InputSizes)[number];
+  size?: typeof InputSizes[number];
   suffix?: React.ReactNode;
   prefix?: React.ReactNode;
   addonBefore?: React.ReactNode;
@@ -40,8 +41,15 @@ interface ClearableInputProps extends BasicProps {
 
 class ClearableLabeledInput extends React.Component<ClearableInputProps> {
   renderClearIcon(prefixCls: string) {
-    const { allowClear, value, disabled, inputType, handleReset } = this.props;
-    if (!allowClear || disabled || value === undefined || value === null || value === '') {
+    const { allowClear, value, disabled, readOnly, inputType, handleReset } = this.props;
+    if (
+      !allowClear ||
+      disabled ||
+      readOnly ||
+      value === undefined ||
+      value === null ||
+      value === ''
+    ) {
       return null;
     }
     const className =

--- a/components/input/__tests__/index.test.js
+++ b/components/input/__tests__/index.test.js
@@ -312,9 +312,11 @@ describe('Input allowClear', () => {
     );
   });
 
-  it('should not support allowClear when it is disabled', () => {
-    const wrapper = mount(<Input allowClear defaultValue="111" disabled />);
-    expect(wrapper.find('.ant-input-clear-icon').length).toBe(0);
+  ['disabled', 'readOnly'].forEach(prop => {
+    it(`should not support allowClear when it is ${prop}`, () => {
+      const wrapper = mount(<Input allowClear defaultValue="111" {...{ [prop]: true }} />);
+      expect(wrapper.find('.ant-input-clear-icon').length).toBe(0);
+    });
   });
 });
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

fix #21488

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Fix Input with `readOnly` still clearable by `allowClear`.     |
| 🇨🇳 Chinese |     修复 Input 在设置 `readOnly` 时 `allowClear` 仍然可以清除的问题。     |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
