### PR TITLE
docs: 📝 Added expandIconColumnIndex property description of Table.

### DIFF
--- a/components/table/index.en-US.md
+++ b/components/table/index.en-US.md
@@ -71,7 +71,7 @@ const columns = [
 | expandedRowRender | Expanded container render for each row | Function(record, index, indent, expanded):ReactNode | - |  |
 | expandIcon | Customize row expand Icon. Ref [example](http://react-component.github.io/table/examples/expandIcon.html) | Function(props):ReactNode | - | 3.11.3 |
 | expandRowByClick | Whether to expand row by clicking anywhere in the whole row | boolean | `false` | 3.0.1 |
-| expandIconColumnIndex | The index of expandIcon which column will be inserted when expandIconAsCell is false | 0 |  |
+| expandIconColumnIndex | The index of `expandIcon` which column will be inserted when `expandIconAsCell` is false | 0 |  |
 | footer | Table footer renderer | Function(currentPageData) |  |  |
 | indentSize | Indent size in pixels of tree data | number | 15 |  |
 | loading | Loading status of table | boolean\|[object](https://ant.design/components/spin-cn/#API) ([more](https://github.com/ant-design/ant-design/issues/4544#issuecomment-271533135)) | `false` |  |

--- a/components/table/index.en-US.md
+++ b/components/table/index.en-US.md
@@ -71,6 +71,7 @@ const columns = [
 | expandedRowRender | Expanded container render for each row | Function(record, index, indent, expanded):ReactNode | - |  |
 | expandIcon | Customize row expand Icon. Ref [example](http://react-component.github.io/table/examples/expandIcon.html) | Function(props):ReactNode | - | 3.11.3 |
 | expandRowByClick | Whether to expand row by clicking anywhere in the whole row | boolean | `false` | 3.0.1 |
+| expandIconColumnIndex | The index of expandIcon which column will be inserted when expandIconAsCell is false | 0 |  |
 | footer | Table footer renderer | Function(currentPageData) |  |  |
 | indentSize | Indent size in pixels of tree data | number | 15 |  |
 | loading | Loading status of table | boolean\|[object](https://ant.design/components/spin-cn/#API) ([more](https://github.com/ant-design/ant-design/issues/4544#issuecomment-271533135)) | `false` |  |

--- a/components/table/index.zh-CN.md
+++ b/components/table/index.zh-CN.md
@@ -76,6 +76,7 @@ const columns = [
 | expandedRowRender | 额外的展开行 | Function(record, index, indent, expanded):ReactNode | - |  |
 | expandIcon | 自定义展开图标，参考[示例](http://react-component.github.io/table/examples/expandIcon.html) | Function(props):ReactNode | - | 3.11.3 |
 | expandRowByClick | 通过点击行来展开子行 | boolean | `false` | 3.0.1 |
+| expandIconColumnIndex | 展开的图标显示在哪一列，如果没有rowSelection，默认显示在第一列，否则显示在选择框后面| `number` | |
 | footer | 表格尾部 | Function(currentPageData) |  |  |
 | indentSize | 展示树形数据时，每层缩进的宽度，以 px 为单位 | number | 15 |  |
 | loading | 页面是否加载中 | boolean\|[object](https://ant.design/components/spin-cn/#API) ([更多](https://github.com/ant-design/ant-design/issues/4544#issuecomment-271533135)) | false |  |

--- a/components/table/index.zh-CN.md
+++ b/components/table/index.zh-CN.md
@@ -76,7 +76,7 @@ const columns = [
 | expandedRowRender | 额外的展开行 | Function(record, index, indent, expanded):ReactNode | - |  |
 | expandIcon | 自定义展开图标，参考[示例](http://react-component.github.io/table/examples/expandIcon.html) | Function(props):ReactNode | - | 3.11.3 |
 | expandRowByClick | 通过点击行来展开子行 | boolean | `false` | 3.0.1 |
-| expandIconColumnIndex | 展开的图标显示在哪一列，如果没有rowSelection，默认显示在第一列，否则显示在选择框后面| `number` | |
+| expandIconColumnIndex | 展开的图标显示在哪一列，如果没有 `rowSelection`，默认显示在第一列，否则显示在选择框后面 | `number` |  |
 | footer | 表格尾部 | Function(currentPageData) |  |  |
 | indentSize | 展示树形数据时，每层缩进的宽度，以 px 为单位 | number | 15 |  |
 | loading | 页面是否加载中 | boolean\|[object](https://ant.design/components/spin-cn/#API) ([更多](https://github.com/ant-design/ant-design/issues/4544#issuecomment-271533135)) | false |  |


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


在以下代码中发现存在此属性，但是文档上并没有对此属性进行补充 

![image](https://user-images.githubusercontent.com/24241052/74944038-546fd500-5430-11ea-9ce7-30de6e6a4f8c.png)


https://github.com/ant-design/ant-design/blob/be19e4e65f5142e87298ace35342ddf0f4d56d4b/components/table/Table.tsx#L1300-L1303

-----
[View rendered components/table/index.en-US.md](https://github.com/Kotomi-Team/ant-design/blob/3.x-stable/components/table/index.en-US.md)
[View rendered components/table/index.zh-CN.md](https://github.com/Kotomi-Team/ant-design/blob/3.x-stable/components/table/index.zh-CN.md)