### PR TITLE
fix: Upload should not showing download icon defaultly

### DIFF
--- a/components/config-provider/__tests__/__snapshots__/components.test.js.snap
+++ b/components/config-provider/__tests__/__snapshots__/components.test.js.snap
@@ -17396,7 +17396,7 @@ exports[`ConfigProvider components Upload configProvider 1`] = `
                 </svg>
               </i>
               <span
-                class="config-upload-list-item-name config-upload-list-item-name-icon-count-2"
+                class="config-upload-list-item-name config-upload-list-item-name-icon-count-1"
                 title="xxx.png"
               >
                 xxx.png
@@ -17404,31 +17404,6 @@ exports[`ConfigProvider components Upload configProvider 1`] = `
               <span
                 class="config-upload-list-item-card-actions "
               >
-                <a
-                  title="Download file"
-                >
-                  <i
-                    aria-label="icon: download"
-                    class="anticon anticon-download"
-                    tabindex="-1"
-                    title="Download file"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      class=""
-                      data-icon="download"
-                      fill="currentColor"
-                      focusable="false"
-                      height="1em"
-                      viewBox="64 64 896 896"
-                      width="1em"
-                    >
-                      <path
-                        d="M505.7 661a8 8 0 0 0 12.6 0l112-141.7c4.1-5.2.4-12.9-6.3-12.9h-74.1V168c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v338.3H400c-6.7 0-10.4 7.7-6.3 12.9l112 141.8zM878 626h-60c-4.4 0-8 3.6-8 8v154H214V634c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v198c0 17.7 14.3 32 32 32h684c17.7 0 32-14.3 32-32V634c0-4.4-3.6-8-8-8z"
-                      />
-                    </svg>
-                  </i>
-                </a>
                 <a
                   title="Remove file"
                 >
@@ -17505,7 +17480,7 @@ exports[`ConfigProvider components Upload normal 1`] = `
                 </svg>
               </i>
               <span
-                class="ant-upload-list-item-name ant-upload-list-item-name-icon-count-2"
+                class="ant-upload-list-item-name ant-upload-list-item-name-icon-count-1"
                 title="xxx.png"
               >
                 xxx.png
@@ -17513,31 +17488,6 @@ exports[`ConfigProvider components Upload normal 1`] = `
               <span
                 class="ant-upload-list-item-card-actions "
               >
-                <a
-                  title="Download file"
-                >
-                  <i
-                    aria-label="icon: download"
-                    class="anticon anticon-download"
-                    tabindex="-1"
-                    title="Download file"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      class=""
-                      data-icon="download"
-                      fill="currentColor"
-                      focusable="false"
-                      height="1em"
-                      viewBox="64 64 896 896"
-                      width="1em"
-                    >
-                      <path
-                        d="M505.7 661a8 8 0 0 0 12.6 0l112-141.7c4.1-5.2.4-12.9-6.3-12.9h-74.1V168c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v338.3H400c-6.7 0-10.4 7.7-6.3 12.9l112 141.8zM878 626h-60c-4.4 0-8 3.6-8 8v154H214V634c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v198c0 17.7 14.3 32 32 32h684c17.7 0 32-14.3 32-32V634c0-4.4-3.6-8-8-8z"
-                      />
-                    </svg>
-                  </i>
-                </a>
                 <a
                   title="Remove file"
                 >
@@ -17614,7 +17564,7 @@ exports[`ConfigProvider components Upload prefixCls 1`] = `
                 </svg>
               </i>
               <span
-                class="ant-upload-list-item-name ant-upload-list-item-name-icon-count-2"
+                class="ant-upload-list-item-name ant-upload-list-item-name-icon-count-1"
                 title="xxx.png"
               >
                 xxx.png
@@ -17622,31 +17572,6 @@ exports[`ConfigProvider components Upload prefixCls 1`] = `
               <span
                 class="ant-upload-list-item-card-actions "
               >
-                <a
-                  title="Download file"
-                >
-                  <i
-                    aria-label="icon: download"
-                    class="anticon anticon-download"
-                    tabindex="-1"
-                    title="Download file"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      class=""
-                      data-icon="download"
-                      fill="currentColor"
-                      focusable="false"
-                      height="1em"
-                      viewBox="64 64 896 896"
-                      width="1em"
-                    >
-                      <path
-                        d="M505.7 661a8 8 0 0 0 12.6 0l112-141.7c4.1-5.2.4-12.9-6.3-12.9h-74.1V168c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v338.3H400c-6.7 0-10.4 7.7-6.3 12.9l112 141.8zM878 626h-60c-4.4 0-8 3.6-8 8v154H214V634c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v198c0 17.7 14.3 32 32 32h684c17.7 0 32-14.3 32-32V634c0-4.4-3.6-8-8-8z"
-                      />
-                    </svg>
-                  </i>
-                </a>
                 <a
                   title="Remove file"
                 >

--- a/components/upload/UploadList.tsx
+++ b/components/upload/UploadList.tsx
@@ -16,7 +16,7 @@ export default class UploadList extends React.Component<UploadListProps, any> {
       showInfo: false,
     },
     showRemoveIcon: true,
-    showDownloadIcon: true,
+    showDownloadIcon: false,
     showPreviewIcon: true,
     previewFile: previewImage,
   };

--- a/components/upload/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/upload/__tests__/__snapshots__/demo.test.js.snap
@@ -64,7 +64,7 @@ exports[`renders ./components/upload/demo/defaultFileList.md correctly 1`] = `
                 </svg>
               </i>
               <a
-                class="ant-upload-list-item-name ant-upload-list-item-name-icon-count-2"
+                class="ant-upload-list-item-name ant-upload-list-item-name-icon-count-1"
                 href="http://www.baidu.com/xxx.png"
                 rel="noopener noreferrer"
                 target="_blank"
@@ -75,31 +75,6 @@ exports[`renders ./components/upload/demo/defaultFileList.md correctly 1`] = `
               <span
                 class="ant-upload-list-item-card-actions "
               >
-                <a
-                  title="Download file"
-                >
-                  <i
-                    aria-label="icon: download"
-                    class="anticon anticon-download"
-                    tabindex="-1"
-                    title="Download file"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      class=""
-                      data-icon="download"
-                      fill="currentColor"
-                      focusable="false"
-                      height="1em"
-                      viewBox="64 64 896 896"
-                      width="1em"
-                    >
-                      <path
-                        d="M505.7 661a8 8 0 0 0 12.6 0l112-141.7c4.1-5.2.4-12.9-6.3-12.9h-74.1V168c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v338.3H400c-6.7 0-10.4 7.7-6.3 12.9l112 141.8zM878 626h-60c-4.4 0-8 3.6-8 8v154H214V634c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v198c0 17.7 14.3 32 32 32h684c17.7 0 32-14.3 32-32V634c0-4.4-3.6-8-8-8z"
-                      />
-                    </svg>
-                  </i>
-                </a>
                 <a
                   title="Remove file"
                 >
@@ -162,7 +137,7 @@ exports[`renders ./components/upload/demo/defaultFileList.md correctly 1`] = `
                 </svg>
               </i>
               <a
-                class="ant-upload-list-item-name ant-upload-list-item-name-icon-count-2"
+                class="ant-upload-list-item-name ant-upload-list-item-name-icon-count-1"
                 href="http://www.baidu.com/yyy.png"
                 rel="noopener noreferrer"
                 target="_blank"
@@ -173,31 +148,6 @@ exports[`renders ./components/upload/demo/defaultFileList.md correctly 1`] = `
               <span
                 class="ant-upload-list-item-card-actions "
               >
-                <a
-                  title="Download file"
-                >
-                  <i
-                    aria-label="icon: download"
-                    class="anticon anticon-download"
-                    tabindex="-1"
-                    title="Download file"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      class=""
-                      data-icon="download"
-                      fill="currentColor"
-                      focusable="false"
-                      height="1em"
-                      viewBox="64 64 896 896"
-                      width="1em"
-                    >
-                      <path
-                        d="M505.7 661a8 8 0 0 0 12.6 0l112-141.7c4.1-5.2.4-12.9-6.3-12.9h-74.1V168c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v338.3H400c-6.7 0-10.4 7.7-6.3 12.9l112 141.8zM878 626h-60c-4.4 0-8 3.6-8 8v154H214V634c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v198c0 17.7 14.3 32 32 32h684c17.7 0 32-14.3 32-32V634c0-4.4-3.6-8-8-8z"
-                      />
-                    </svg>
-                  </i>
-                </a>
                 <a
                   title="Remove file"
                 >
@@ -369,7 +319,7 @@ exports[`renders ./components/upload/demo/fileList.md correctly 1`] = `
                 </svg>
               </i>
               <a
-                class="ant-upload-list-item-name ant-upload-list-item-name-icon-count-2"
+                class="ant-upload-list-item-name ant-upload-list-item-name-icon-count-1"
                 href="http://www.baidu.com/xxx.png"
                 rel="noopener noreferrer"
                 target="_blank"
@@ -380,31 +330,6 @@ exports[`renders ./components/upload/demo/fileList.md correctly 1`] = `
               <span
                 class="ant-upload-list-item-card-actions "
               >
-                <a
-                  title="Download file"
-                >
-                  <i
-                    aria-label="icon: download"
-                    class="anticon anticon-download"
-                    tabindex="-1"
-                    title="Download file"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      class=""
-                      data-icon="download"
-                      fill="currentColor"
-                      focusable="false"
-                      height="1em"
-                      viewBox="64 64 896 896"
-                      width="1em"
-                    >
-                      <path
-                        d="M505.7 661a8 8 0 0 0 12.6 0l112-141.7c4.1-5.2.4-12.9-6.3-12.9h-74.1V168c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v338.3H400c-6.7 0-10.4 7.7-6.3 12.9l112 141.8zM878 626h-60c-4.4 0-8 3.6-8 8v154H214V634c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v198c0 17.7 14.3 32 32 32h684c17.7 0 32-14.3 32-32V634c0-4.4-3.6-8-8-8z"
-                      />
-                    </svg>
-                  </i>
-                </a>
                 <a
                   title="Remove file"
                 >
@@ -474,7 +399,7 @@ exports[`renders ./components/upload/demo/picture-card.md correctly 1`] = `
                   />
                 </a>
                 <a
-                  class="ant-upload-list-item-name ant-upload-list-item-name-icon-count-2"
+                  class="ant-upload-list-item-name ant-upload-list-item-name-icon-count-1"
                   href="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png"
                   rel="noopener noreferrer"
                   target="_blank"
@@ -513,27 +438,6 @@ exports[`renders ./components/upload/demo/picture-card.md correctly 1`] = `
                   </svg>
                 </i>
               </a>
-              <i
-                aria-label="icon: download"
-                class="anticon anticon-download"
-                tabindex="-1"
-                title="Download file"
-              >
-                <svg
-                  aria-hidden="true"
-                  class=""
-                  data-icon="download"
-                  fill="currentColor"
-                  focusable="false"
-                  height="1em"
-                  viewBox="64 64 896 896"
-                  width="1em"
-                >
-                  <path
-                    d="M505.7 661a8 8 0 0 0 12.6 0l112-141.7c4.1-5.2.4-12.9-6.3-12.9h-74.1V168c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v338.3H400c-6.7 0-10.4 7.7-6.3 12.9l112 141.8zM878 626h-60c-4.4 0-8 3.6-8 8v154H214V634c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v198c0 17.7 14.3 32 32 32h684c17.7 0 32-14.3 32-32V634c0-4.4-3.6-8-8-8z"
-                  />
-                </svg>
-              </i>
               <i
                 aria-label="icon: delete"
                 class="anticon anticon-delete"
@@ -583,7 +487,7 @@ exports[`renders ./components/upload/demo/picture-card.md correctly 1`] = `
                   />
                 </a>
                 <a
-                  class="ant-upload-list-item-name ant-upload-list-item-name-icon-count-2"
+                  class="ant-upload-list-item-name ant-upload-list-item-name-icon-count-1"
                   href="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png"
                   rel="noopener noreferrer"
                   target="_blank"
@@ -622,27 +526,6 @@ exports[`renders ./components/upload/demo/picture-card.md correctly 1`] = `
                   </svg>
                 </i>
               </a>
-              <i
-                aria-label="icon: download"
-                class="anticon anticon-download"
-                tabindex="-1"
-                title="Download file"
-              >
-                <svg
-                  aria-hidden="true"
-                  class=""
-                  data-icon="download"
-                  fill="currentColor"
-                  focusable="false"
-                  height="1em"
-                  viewBox="64 64 896 896"
-                  width="1em"
-                >
-                  <path
-                    d="M505.7 661a8 8 0 0 0 12.6 0l112-141.7c4.1-5.2.4-12.9-6.3-12.9h-74.1V168c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v338.3H400c-6.7 0-10.4 7.7-6.3 12.9l112 141.8zM878 626h-60c-4.4 0-8 3.6-8 8v154H214V634c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v198c0 17.7 14.3 32 32 32h684c17.7 0 32-14.3 32-32V634c0-4.4-3.6-8-8-8z"
-                  />
-                </svg>
-              </i>
               <i
                 aria-label="icon: delete"
                 class="anticon anticon-delete"
@@ -692,7 +575,7 @@ exports[`renders ./components/upload/demo/picture-card.md correctly 1`] = `
                   />
                 </a>
                 <a
-                  class="ant-upload-list-item-name ant-upload-list-item-name-icon-count-2"
+                  class="ant-upload-list-item-name ant-upload-list-item-name-icon-count-1"
                   href="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png"
                   rel="noopener noreferrer"
                   target="_blank"
@@ -731,27 +614,6 @@ exports[`renders ./components/upload/demo/picture-card.md correctly 1`] = `
                   </svg>
                 </i>
               </a>
-              <i
-                aria-label="icon: download"
-                class="anticon anticon-download"
-                tabindex="-1"
-                title="Download file"
-              >
-                <svg
-                  aria-hidden="true"
-                  class=""
-                  data-icon="download"
-                  fill="currentColor"
-                  focusable="false"
-                  height="1em"
-                  viewBox="64 64 896 896"
-                  width="1em"
-                >
-                  <path
-                    d="M505.7 661a8 8 0 0 0 12.6 0l112-141.7c4.1-5.2.4-12.9-6.3-12.9h-74.1V168c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v338.3H400c-6.7 0-10.4 7.7-6.3 12.9l112 141.8zM878 626h-60c-4.4 0-8 3.6-8 8v154H214V634c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v198c0 17.7 14.3 32 32 32h684c17.7 0 32-14.3 32-32V634c0-4.4-3.6-8-8-8z"
-                  />
-                </svg>
-              </i>
               <i
                 aria-label="icon: delete"
                 class="anticon anticon-delete"
@@ -801,7 +663,7 @@ exports[`renders ./components/upload/demo/picture-card.md correctly 1`] = `
                   />
                 </a>
                 <a
-                  class="ant-upload-list-item-name ant-upload-list-item-name-icon-count-2"
+                  class="ant-upload-list-item-name ant-upload-list-item-name-icon-count-1"
                   href="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png"
                   rel="noopener noreferrer"
                   target="_blank"
@@ -840,27 +702,6 @@ exports[`renders ./components/upload/demo/picture-card.md correctly 1`] = `
                   </svg>
                 </i>
               </a>
-              <i
-                aria-label="icon: download"
-                class="anticon anticon-download"
-                tabindex="-1"
-                title="Download file"
-              >
-                <svg
-                  aria-hidden="true"
-                  class=""
-                  data-icon="download"
-                  fill="currentColor"
-                  focusable="false"
-                  height="1em"
-                  viewBox="64 64 896 896"
-                  width="1em"
-                >
-                  <path
-                    d="M505.7 661a8 8 0 0 0 12.6 0l112-141.7c4.1-5.2.4-12.9-6.3-12.9h-74.1V168c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v338.3H400c-6.7 0-10.4 7.7-6.3 12.9l112 141.8zM878 626h-60c-4.4 0-8 3.6-8 8v154H214V634c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v198c0 17.7 14.3 32 32 32h684c17.7 0 32-14.3 32-32V634c0-4.4-3.6-8-8-8z"
-                  />
-                </svg>
-              </i>
               <i
                 aria-label="icon: delete"
                 class="anticon anticon-delete"
@@ -1036,7 +877,7 @@ exports[`renders ./components/upload/demo/picture-style.md correctly 1`] = `
                   />
                 </a>
                 <a
-                  class="ant-upload-list-item-name ant-upload-list-item-name-icon-count-2"
+                  class="ant-upload-list-item-name ant-upload-list-item-name-icon-count-1"
                   href="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png"
                   rel="noopener noreferrer"
                   target="_blank"
@@ -1047,31 +888,6 @@ exports[`renders ./components/upload/demo/picture-style.md correctly 1`] = `
                 <span
                   class="ant-upload-list-item-card-actions picture"
                 >
-                  <a
-                    title="Download file"
-                  >
-                    <i
-                      aria-label="icon: download"
-                      class="anticon anticon-download"
-                      tabindex="-1"
-                      title="Download file"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class=""
-                        data-icon="download"
-                        fill="currentColor"
-                        focusable="false"
-                        height="1em"
-                        viewBox="64 64 896 896"
-                        width="1em"
-                      >
-                        <path
-                          d="M505.7 661a8 8 0 0 0 12.6 0l112-141.7c4.1-5.2.4-12.9-6.3-12.9h-74.1V168c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v338.3H400c-6.7 0-10.4 7.7-6.3 12.9l112 141.8zM878 626h-60c-4.4 0-8 3.6-8 8v154H214V634c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v198c0 17.7 14.3 32 32 32h684c17.7 0 32-14.3 32-32V634c0-4.4-3.6-8-8-8z"
-                        />
-                      </svg>
-                    </i>
-                  </a>
                   <a
                     title="Remove file"
                   >
@@ -1225,7 +1041,7 @@ exports[`renders ./components/upload/demo/picture-style.md correctly 1`] = `
                   />
                 </a>
                 <a
-                  class="ant-upload-list-item-name ant-upload-list-item-name-icon-count-2"
+                  class="ant-upload-list-item-name ant-upload-list-item-name-icon-count-1"
                   href="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png"
                   rel="noopener noreferrer"
                   target="_blank"
@@ -1236,31 +1052,6 @@ exports[`renders ./components/upload/demo/picture-style.md correctly 1`] = `
                 <span
                   class="ant-upload-list-item-card-actions picture"
                 >
-                  <a
-                    title="Download file"
-                  >
-                    <i
-                      aria-label="icon: download"
-                      class="anticon anticon-download"
-                      tabindex="-1"
-                      title="Download file"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class=""
-                        data-icon="download"
-                        fill="currentColor"
-                        focusable="false"
-                        height="1em"
-                        viewBox="64 64 896 896"
-                        width="1em"
-                      >
-                        <path
-                          d="M505.7 661a8 8 0 0 0 12.6 0l112-141.7c4.1-5.2.4-12.9-6.3-12.9h-74.1V168c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v338.3H400c-6.7 0-10.4 7.7-6.3 12.9l112 141.8zM878 626h-60c-4.4 0-8 3.6-8 8v154H214V634c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v198c0 17.7 14.3 32 32 32h684c17.7 0 32-14.3 32-32V634c0-4.4-3.6-8-8-8z"
-                        />
-                      </svg>
-                    </i>
-                  </a>
                   <a
                     title="Remove file"
                   >

--- a/components/upload/__tests__/__snapshots__/uploadlist.test.js.snap
+++ b/components/upload/__tests__/__snapshots__/uploadlist.test.js.snap
@@ -280,7 +280,7 @@ exports[`Upload List should be uploading when upload a file 2`] = `
                 </svg>
               </i>
               <span
-                class="ant-upload-list-item-name ant-upload-list-item-name-icon-count-2"
+                class="ant-upload-list-item-name ant-upload-list-item-name-icon-count-1"
                 title="foo.png"
               >
                 foo.png
@@ -288,31 +288,6 @@ exports[`Upload List should be uploading when upload a file 2`] = `
               <span
                 class="ant-upload-list-item-card-actions "
               >
-                <a
-                  title="Download file"
-                >
-                  <i
-                    aria-label="icon: download"
-                    class="anticon anticon-download"
-                    tabindex="-1"
-                    title="Download file"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      class=""
-                      data-icon="download"
-                      fill="currentColor"
-                      focusable="false"
-                      height="1em"
-                      viewBox="64 64 896 896"
-                      width="1em"
-                    >
-                      <path
-                        d="M505.7 661a8 8 0 0 0 12.6 0l112-141.7c4.1-5.2.4-12.9-6.3-12.9h-74.1V168c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v338.3H400c-6.7 0-10.4 7.7-6.3 12.9l112 141.8zM878 626h-60c-4.4 0-8 3.6-8 8v154H214V634c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v198c0 17.7 14.3 32 32 32h684c17.7 0 32-14.3 32-32V634c0-4.4-3.6-8-8-8z"
-                      />
-                    </svg>
-                  </i>
-                </a>
                 <a
                   title="Remove file"
                 >
@@ -440,7 +415,7 @@ exports[`Upload List should non-image format file preview 1`] = `
                 </i>
               </a>
               <a
-                class="ant-upload-list-item-name ant-upload-list-item-name-icon-count-2"
+                class="ant-upload-list-item-name ant-upload-list-item-name-icon-count-1"
                 href="https://cdn.xxx.com/aaa.zip"
                 rel="noopener noreferrer"
                 target="_blank"
@@ -451,31 +426,6 @@ exports[`Upload List should non-image format file preview 1`] = `
               <span
                 class="ant-upload-list-item-card-actions picture"
               >
-                <a
-                  title="Download file"
-                >
-                  <i
-                    aria-label="icon: download"
-                    class="anticon anticon-download"
-                    tabindex="-1"
-                    title="Download file"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      class=""
-                      data-icon="download"
-                      fill="currentColor"
-                      focusable="false"
-                      height="1em"
-                      viewBox="64 64 896 896"
-                      width="1em"
-                    >
-                      <path
-                        d="M505.7 661a8 8 0 0 0 12.6 0l112-141.7c4.1-5.2.4-12.9-6.3-12.9h-74.1V168c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v338.3H400c-6.7 0-10.4 7.7-6.3 12.9l112 141.8zM878 626h-60c-4.4 0-8 3.6-8 8v154H214V634c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v198c0 17.7 14.3 32 32 32h684c17.7 0 32-14.3 32-32V634c0-4.4-3.6-8-8-8z"
-                      />
-                    </svg>
-                  </i>
-                </a>
                 <a
                   title="Remove file"
                 >
@@ -531,7 +481,7 @@ exports[`Upload List should non-image format file preview 1`] = `
                 />
               </a>
               <a
-                class="ant-upload-list-item-name ant-upload-list-item-name-icon-count-2"
+                class="ant-upload-list-item-name ant-upload-list-item-name-icon-count-1"
                 href="https://cdn.xxx.com/aaa"
                 rel="noopener noreferrer"
                 target="_blank"
@@ -543,31 +493,6 @@ exports[`Upload List should non-image format file preview 1`] = `
                 class="ant-upload-list-item-card-actions picture"
               >
                 <a
-                  title="Download file"
-                >
-                  <i
-                    aria-label="icon: download"
-                    class="anticon anticon-download"
-                    tabindex="-1"
-                    title="Download file"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      class=""
-                      data-icon="download"
-                      fill="currentColor"
-                      focusable="false"
-                      height="1em"
-                      viewBox="64 64 896 896"
-                      width="1em"
-                    >
-                      <path
-                        d="M505.7 661a8 8 0 0 0 12.6 0l112-141.7c4.1-5.2.4-12.9-6.3-12.9h-74.1V168c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v338.3H400c-6.7 0-10.4 7.7-6.3 12.9l112 141.8zM878 626h-60c-4.4 0-8 3.6-8 8v154H214V634c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v198c0 17.7 14.3 32 32 32h684c17.7 0 32-14.3 32-32V634c0-4.4-3.6-8-8-8z"
-                      />
-                    </svg>
-                  </i>
-                </a>
-                <a
                   title="Remove file"
                 >
                   <i
@@ -641,7 +566,7 @@ exports[`Upload List should non-image format file preview 1`] = `
                 </i>
               </a>
               <a
-                class="ant-upload-list-item-name ant-upload-list-item-name-icon-count-2"
+                class="ant-upload-list-item-name ant-upload-list-item-name-icon-count-1"
                 href="https://cdn.xxx.com/aaa.xx"
                 rel="noopener noreferrer"
                 target="_blank"
@@ -652,31 +577,6 @@ exports[`Upload List should non-image format file preview 1`] = `
               <span
                 class="ant-upload-list-item-card-actions picture"
               >
-                <a
-                  title="Download file"
-                >
-                  <i
-                    aria-label="icon: download"
-                    class="anticon anticon-download"
-                    tabindex="-1"
-                    title="Download file"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      class=""
-                      data-icon="download"
-                      fill="currentColor"
-                      focusable="false"
-                      height="1em"
-                      viewBox="64 64 896 896"
-                      width="1em"
-                    >
-                      <path
-                        d="M505.7 661a8 8 0 0 0 12.6 0l112-141.7c4.1-5.2.4-12.9-6.3-12.9h-74.1V168c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v338.3H400c-6.7 0-10.4 7.7-6.3 12.9l112 141.8zM878 626h-60c-4.4 0-8 3.6-8 8v154H214V634c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v198c0 17.7 14.3 32 32 32h684c17.7 0 32-14.3 32-32V634c0-4.4-3.6-8-8-8z"
-                      />
-                    </svg>
-                  </i>
-                </a>
                 <a
                   title="Remove file"
                 >
@@ -751,7 +651,7 @@ exports[`Upload List should non-image format file preview 1`] = `
                 </i>
               </a>
               <a
-                class="ant-upload-list-item-name ant-upload-list-item-name-icon-count-2"
+                class="ant-upload-list-item-name ant-upload-list-item-name-icon-count-1"
                 href="https://cdn.xxx.com/aaa.png/xx.xx"
                 rel="noopener noreferrer"
                 target="_blank"
@@ -762,31 +662,6 @@ exports[`Upload List should non-image format file preview 1`] = `
               <span
                 class="ant-upload-list-item-card-actions picture"
               >
-                <a
-                  title="Download file"
-                >
-                  <i
-                    aria-label="icon: download"
-                    class="anticon anticon-download"
-                    tabindex="-1"
-                    title="Download file"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      class=""
-                      data-icon="download"
-                      fill="currentColor"
-                      focusable="false"
-                      height="1em"
-                      viewBox="64 64 896 896"
-                      width="1em"
-                    >
-                      <path
-                        d="M505.7 661a8 8 0 0 0 12.6 0l112-141.7c4.1-5.2.4-12.9-6.3-12.9h-74.1V168c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v338.3H400c-6.7 0-10.4 7.7-6.3 12.9l112 141.8zM878 626h-60c-4.4 0-8 3.6-8 8v154H214V634c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v198c0 17.7 14.3 32 32 32h684c17.7 0 32-14.3 32-32V634c0-4.4-3.6-8-8-8z"
-                      />
-                    </svg>
-                  </i>
-                </a>
                 <a
                   title="Remove file"
                 >
@@ -842,7 +717,7 @@ exports[`Upload List should non-image format file preview 1`] = `
                 />
               </a>
               <a
-                class="ant-upload-list-item-name ant-upload-list-item-name-icon-count-2"
+                class="ant-upload-list-item-name ant-upload-list-item-name-icon-count-1"
                 href="https://cdn.xxx.com/xx.xx/aaa.png"
                 rel="noopener noreferrer"
                 target="_blank"
@@ -853,31 +728,6 @@ exports[`Upload List should non-image format file preview 1`] = `
               <span
                 class="ant-upload-list-item-card-actions picture"
               >
-                <a
-                  title="Download file"
-                >
-                  <i
-                    aria-label="icon: download"
-                    class="anticon anticon-download"
-                    tabindex="-1"
-                    title="Download file"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      class=""
-                      data-icon="download"
-                      fill="currentColor"
-                      focusable="false"
-                      height="1em"
-                      viewBox="64 64 896 896"
-                      width="1em"
-                    >
-                      <path
-                        d="M505.7 661a8 8 0 0 0 12.6 0l112-141.7c4.1-5.2.4-12.9-6.3-12.9h-74.1V168c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v338.3H400c-6.7 0-10.4 7.7-6.3 12.9l112 141.8zM878 626h-60c-4.4 0-8 3.6-8 8v154H214V634c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v198c0 17.7 14.3 32 32 32h684c17.7 0 32-14.3 32-32V634c0-4.4-3.6-8-8-8z"
-                      />
-                    </svg>
-                  </i>
-                </a>
                 <a
                   title="Remove file"
                 >
@@ -933,7 +783,7 @@ exports[`Upload List should non-image format file preview 1`] = `
                 />
               </a>
               <a
-                class="ant-upload-list-item-name ant-upload-list-item-name-icon-count-2"
+                class="ant-upload-list-item-name ant-upload-list-item-name-icon-count-1"
                 href="https://cdn.xxx.com/xx.xx/aaa.png"
                 rel="noopener noreferrer"
                 target="_blank"
@@ -944,31 +794,6 @@ exports[`Upload List should non-image format file preview 1`] = `
               <span
                 class="ant-upload-list-item-card-actions picture"
               >
-                <a
-                  title="Download file"
-                >
-                  <i
-                    aria-label="icon: download"
-                    class="anticon anticon-download"
-                    tabindex="-1"
-                    title="Download file"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      class=""
-                      data-icon="download"
-                      fill="currentColor"
-                      focusable="false"
-                      height="1em"
-                      viewBox="64 64 896 896"
-                      width="1em"
-                    >
-                      <path
-                        d="M505.7 661a8 8 0 0 0 12.6 0l112-141.7c4.1-5.2.4-12.9-6.3-12.9h-74.1V168c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v338.3H400c-6.7 0-10.4 7.7-6.3 12.9l112 141.8zM878 626h-60c-4.4 0-8 3.6-8 8v154H214V634c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v198c0 17.7 14.3 32 32 32h684c17.7 0 32-14.3 32-32V634c0-4.4-3.6-8-8-8z"
-                      />
-                    </svg>
-                  </i>
-                </a>
                 <a
                   title="Remove file"
                 >
@@ -1024,7 +849,7 @@ exports[`Upload List should non-image format file preview 1`] = `
                 />
               </a>
               <a
-                class="ant-upload-list-item-name ant-upload-list-item-name-icon-count-2"
+                class="ant-upload-list-item-name ant-upload-list-item-name-icon-count-1"
                 href="https://cdn.xxx.com/xx.xx/aaa.png?query=123"
                 rel="noopener noreferrer"
                 target="_blank"
@@ -1035,31 +860,6 @@ exports[`Upload List should non-image format file preview 1`] = `
               <span
                 class="ant-upload-list-item-card-actions picture"
               >
-                <a
-                  title="Download file"
-                >
-                  <i
-                    aria-label="icon: download"
-                    class="anticon anticon-download"
-                    tabindex="-1"
-                    title="Download file"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      class=""
-                      data-icon="download"
-                      fill="currentColor"
-                      focusable="false"
-                      height="1em"
-                      viewBox="64 64 896 896"
-                      width="1em"
-                    >
-                      <path
-                        d="M505.7 661a8 8 0 0 0 12.6 0l112-141.7c4.1-5.2.4-12.9-6.3-12.9h-74.1V168c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v338.3H400c-6.7 0-10.4 7.7-6.3 12.9l112 141.8zM878 626h-60c-4.4 0-8 3.6-8 8v154H214V634c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v198c0 17.7 14.3 32 32 32h684c17.7 0 32-14.3 32-32V634c0-4.4-3.6-8-8-8z"
-                      />
-                    </svg>
-                  </i>
-                </a>
                 <a
                   title="Remove file"
                 >
@@ -1115,7 +915,7 @@ exports[`Upload List should non-image format file preview 1`] = `
                 />
               </a>
               <a
-                class="ant-upload-list-item-name ant-upload-list-item-name-icon-count-2"
+                class="ant-upload-list-item-name ant-upload-list-item-name-icon-count-1"
                 href="https://cdn.xxx.com/xx.xx/aaa.png#anchor"
                 rel="noopener noreferrer"
                 target="_blank"
@@ -1126,31 +926,6 @@ exports[`Upload List should non-image format file preview 1`] = `
               <span
                 class="ant-upload-list-item-card-actions picture"
               >
-                <a
-                  title="Download file"
-                >
-                  <i
-                    aria-label="icon: download"
-                    class="anticon anticon-download"
-                    tabindex="-1"
-                    title="Download file"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      class=""
-                      data-icon="download"
-                      fill="currentColor"
-                      focusable="false"
-                      height="1em"
-                      viewBox="64 64 896 896"
-                      width="1em"
-                    >
-                      <path
-                        d="M505.7 661a8 8 0 0 0 12.6 0l112-141.7c4.1-5.2.4-12.9-6.3-12.9h-74.1V168c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v338.3H400c-6.7 0-10.4 7.7-6.3 12.9l112 141.8zM878 626h-60c-4.4 0-8 3.6-8 8v154H214V634c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v198c0 17.7 14.3 32 32 32h684c17.7 0 32-14.3 32-32V634c0-4.4-3.6-8-8-8z"
-                      />
-                    </svg>
-                  </i>
-                </a>
                 <a
                   title="Remove file"
                 >
@@ -1206,7 +981,7 @@ exports[`Upload List should non-image format file preview 1`] = `
                 />
               </a>
               <a
-                class="ant-upload-list-item-name ant-upload-list-item-name-icon-count-2"
+                class="ant-upload-list-item-name ant-upload-list-item-name-icon-count-1"
                 href="https://cdn.xxx.com/xx.xx/aaa.png?query=some.query.with.dot"
                 rel="noopener noreferrer"
                 target="_blank"
@@ -1217,31 +992,6 @@ exports[`Upload List should non-image format file preview 1`] = `
               <span
                 class="ant-upload-list-item-card-actions picture"
               >
-                <a
-                  title="Download file"
-                >
-                  <i
-                    aria-label="icon: download"
-                    class="anticon anticon-download"
-                    tabindex="-1"
-                    title="Download file"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      class=""
-                      data-icon="download"
-                      fill="currentColor"
-                      focusable="false"
-                      height="1em"
-                      viewBox="64 64 896 896"
-                      width="1em"
-                    >
-                      <path
-                        d="M505.7 661a8 8 0 0 0 12.6 0l112-141.7c4.1-5.2.4-12.9-6.3-12.9h-74.1V168c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v338.3H400c-6.7 0-10.4 7.7-6.3 12.9l112 141.8zM878 626h-60c-4.4 0-8 3.6-8 8v154H214V634c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v198c0 17.7 14.3 32 32 32h684c17.7 0 32-14.3 32-32V634c0-4.4-3.6-8-8-8z"
-                      />
-                    </svg>
-                  </i>
-                </a>
                 <a
                   title="Remove file"
                 >
@@ -1297,7 +1047,7 @@ exports[`Upload List should non-image format file preview 1`] = `
                 />
               </a>
               <a
-                class="ant-upload-list-item-name ant-upload-list-item-name-icon-count-2"
+                class="ant-upload-list-item-name ant-upload-list-item-name-icon-count-1"
                 href="https://publish-pic-cpu.baidu.com/1296beb3-50d9-4276-885f-52645cbb378e.jpeg@w_228%2ch_152"
                 rel="noopener noreferrer"
                 target="_blank"
@@ -1308,31 +1058,6 @@ exports[`Upload List should non-image format file preview 1`] = `
               <span
                 class="ant-upload-list-item-card-actions picture"
               >
-                <a
-                  title="Download file"
-                >
-                  <i
-                    aria-label="icon: download"
-                    class="anticon anticon-download"
-                    tabindex="-1"
-                    title="Download file"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      class=""
-                      data-icon="download"
-                      fill="currentColor"
-                      focusable="false"
-                      height="1em"
-                      viewBox="64 64 896 896"
-                      width="1em"
-                    >
-                      <path
-                        d="M505.7 661a8 8 0 0 0 12.6 0l112-141.7c4.1-5.2.4-12.9-6.3-12.9h-74.1V168c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v338.3H400c-6.7 0-10.4 7.7-6.3 12.9l112 141.8zM878 626h-60c-4.4 0-8 3.6-8 8v154H214V634c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v198c0 17.7 14.3 32 32 32h684c17.7 0 32-14.3 32-32V634c0-4.4-3.6-8-8-8z"
-                      />
-                    </svg>
-                  </i>
-                </a>
                 <a
                   title="Remove file"
                 >
@@ -1462,7 +1187,7 @@ exports[`Upload List should support showRemoveIcon and showPreviewIcon 1`] = `
                 />
               </a>
               <a
-                class="ant-upload-list-item-name ant-upload-list-item-name-icon-count-1"
+                class="ant-upload-list-item-name ant-upload-list-item-name-icon-count-0"
                 href="https://cdn.xxx.com/aaa"
                 rel="noopener noreferrer"
                 target="_blank"
@@ -1472,33 +1197,7 @@ exports[`Upload List should support showRemoveIcon and showPreviewIcon 1`] = `
               </a>
               <span
                 class="ant-upload-list-item-card-actions picture"
-              >
-                <a
-                  title="Download file"
-                >
-                  <i
-                    aria-label="icon: download"
-                    class="anticon anticon-download"
-                    tabindex="-1"
-                    title="Download file"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      class=""
-                      data-icon="download"
-                      fill="currentColor"
-                      focusable="false"
-                      height="1em"
-                      viewBox="64 64 896 896"
-                      width="1em"
-                    >
-                      <path
-                        d="M505.7 661a8 8 0 0 0 12.6 0l112-141.7c4.1-5.2.4-12.9-6.3-12.9h-74.1V168c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v338.3H400c-6.7 0-10.4 7.7-6.3 12.9l112 141.8zM878 626h-60c-4.4 0-8 3.6-8 8v154H214V634c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v198c0 17.7 14.3 32 32 32h684c17.7 0 32-14.3 32-32V634c0-4.4-3.6-8-8-8z"
-                      />
-                    </svg>
-                  </i>
-                </a>
-              </span>
+              />
             </span>
           </div>
         </div>

--- a/components/upload/__tests__/upload.test.js
+++ b/components/upload/__tests__/upload.test.js
@@ -523,6 +523,9 @@ describe('Upload', () => {
     const mockRemove = jest.fn(() => false);
     const props = {
       onRemove: mockRemove,
+      showUploadList: {
+        showDownloadIcon: true,
+      },
       fileList: [
         {
           uid: '-1',

--- a/components/upload/__tests__/uploadlist.test.js
+++ b/components/upload/__tests__/uploadlist.test.js
@@ -205,7 +205,7 @@ describe('Upload List', () => {
   it('In the case of listType=picture, the error status does not show the download.', () => {
     const file = { status: 'error', uid: 'file' };
     const wrapper = mount(
-      <Upload listType="picture" fileList={[file]}>
+      <Upload listType="picture" fileList={[file]} showUploadList={{ showDownloadIcon: true }}>
         <button type="button">upload</button>
       </Upload>,
     );
@@ -215,7 +215,7 @@ describe('Upload List', () => {
   it('In the case of listType=picture-card, the error status does not show the download.', () => {
     const file = { status: 'error', uid: 'file' };
     const wrapper = mount(
-      <Upload listType="picture-card" fileList={[file]}>
+      <Upload listType="picture-card" fileList={[file]} showUploadList={{ showDownloadIcon: true }}>
         <button type="button">upload</button>
       </Upload>,
     );
@@ -225,7 +225,7 @@ describe('Upload List', () => {
   it('In the case of listType=text, the error status does not show the download.', () => {
     const file = { status: 'error', uid: 'file' };
     const wrapper = mount(
-      <Upload listType="text" fileList={[file]}>
+      <Upload listType="text" fileList={[file]} showUploadList={{ showDownloadIcon: true }}>
         <button type="button">upload</button>
       </Upload>,
     );
@@ -292,6 +292,9 @@ describe('Upload List', () => {
           },
         ]}
         onDownload={handleDownload}
+        showUploadList={{
+          showDownloadIcon: true,
+        }}
       >
         <button type="button">upload</button>
       </Upload>,
@@ -302,7 +305,7 @@ describe('Upload List', () => {
       .simulate('click');
   });
 
-  it('should  support no onDownload', async () => {
+  it('should support no onDownload', async () => {
     const wrapper = mount(
       <Upload
         listType="picture-card"
@@ -314,6 +317,9 @@ describe('Upload List', () => {
             url: 'https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png',
           },
         ]}
+        showUploadList={{
+          showDownloadIcon: true,
+        }}
       >
         <button type="button">upload</button>
       </Upload>,
@@ -541,7 +547,13 @@ describe('Upload List', () => {
   it('return when prop onDownload not exists', () => {
     const file = new File([''], 'test.txt', { type: 'text/plain' });
     const items = [{ uid: 'upload-list-item', url: '' }];
-    const wrapper = mount(<UploadList items={items} locale={{ downloadFile: '' }} />).instance();
+    const wrapper = mount(
+      <UploadList
+        items={items}
+        locale={{ downloadFile: '' }}
+        showUploadList={{ showDownloadIcon: true }}
+       />,
+     ).instance();
     expect(wrapper.handleDownload(file)).toBe(undefined);
   });
 
@@ -563,6 +575,7 @@ describe('Upload List', () => {
         items={items}
         onDownload={() => {}}
         locale={{ downloadFile: '' }}
+        showUploadList={{ showDownloadIcon: true }}
       />,
     ).instance();
     return wrapper.props.onDownload(file);
@@ -576,16 +589,18 @@ describe('Upload List', () => {
     expect(wrapper.find('.ant-upload-list-item-thumbnail').length).toBe(2);
   });
 
-  it('extname should work correctly when url exists', () => {
+  it('extname should work correctly when url exists', (done) => {
     const items = [{ status: 'done', uid: 'upload-list-item', url: '/example' }];
     const wrapper = mount(
       <UploadList
         listType="picture"
         onDownload={file => {
           expect(file.url).toBe('/example');
+          done();
         }}
         items={items}
         locale={{ downloadFile: '' }}
+        showDownloadIcon
       />,
     );
     wrapper.find('div.ant-upload-list-item i.anticon-download').simulate('click');

--- a/components/upload/style/index.less
+++ b/components/upload/style/index.less
@@ -178,7 +178,7 @@
         opacity: 1;
       }
       .anticon {
-        padding-right: 5px;
+        padding-right: 6px;
         color: rgba(0, 0, 0, 0.45);
       }
     }
@@ -239,7 +239,6 @@
 
     &-error &-card-actions {
       .anticon {
-        padding-right: 5px;
         color: @error-color;
       }
       opacity: 1;


### PR DESCRIPTION
it should be false

<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

https://github.com/ant-design/ant-design/pull/18664#discussion_r382034255

https://github.com/ant-design/ant-design/issues/4351#issuecomment-555937943

https://github.com/ant-design/ant-design-pro/issues/5606

### 💡 Background and solution

<img width="478" alt="image" src="https://user-images.githubusercontent.com/507615/75002110-52dcf600-549e-11ea-9c25-063b5252e40c.png">

![6C254270-85E3-4776-A876-F004F7E07E8D](https://user-images.githubusercontent.com/507615/74945968-8a628880-5433-11ea-9c95-d1305e82a3af.png)

<img width="445" alt="image" src="https://user-images.githubusercontent.com/507615/75002013-0b566a00-549e-11ea-9b4b-c5171ce7d73e.png">

目前关于如何隐藏下载按钮的反馈很多，#18664 应保持向前兼容，默认不应该展现。

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Upload won't showing download icon defaultly. |
| 🇨🇳 Chinese | Upload 列表默认不展现下载按钮。|

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
