### PR TITLE
fix: Grid rows overlapping when using vertical gutter and having columns of different heights

### DIFF
--- a/components/grid/style/index.less
+++ b/components/grid/style/index.less
@@ -10,6 +10,10 @@
   box-sizing: border-box;
 }
 
+.@{ant-prefix}-row + .@{ant-prefix}-row::before {
+  clear: both;
+}
+
 .@{ant-prefix}-row-flex {
   display: flex;
   flex-flow: row wrap;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
#21282
<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

The clearfix was not enough when having columns of different heights because we have negative margin-top and margin-bottom on the grid rows when using vertical gutter. Instead of setting `clear: both` just for the `::after` pseudo-element, we should also set it for the `::before` one when we are dealing with an ant-row that is immediately preceded by another ant-row.

[![Edit sharp-surf-lcsio](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/sharp-surf-lcsio?fontsize=14&hidenavigation=1&module=%2Findex.css&theme=dark)

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix grid rows overlapping when using vertical gutter |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
