### PR TITLE
fix: table selection with empty children error

### DIFF
--- a/components/table/__tests__/Table.rowSelection.test.js
+++ b/components/table/__tests__/Table.rowSelection.test.js
@@ -779,4 +779,18 @@ describe('Table.rowSelection', () => {
     expect(wrapper.find('thead .ant-checkbox-input').props().disabled).toBeTruthy();
     expect(wrapper.find('thead .ant-checkbox-input').props().checked).toBeFalsy();
   });
+
+  it('should not crash when children is empty', () => {
+    const wrapper = mount(
+      createTable({ dataSource: [{ id: 1, name: 'Hello', age: 10, children: null }] }),
+    );
+    wrapper.find('.ant-table-row-expand-icon').simulate('click');
+
+    expect(() => {
+      wrapper
+        .find('input')
+        .last()
+        .simulate('change');
+    }).not.toThrow();
+  });
 });

--- a/components/table/hooks/useLazyKVMap.ts
+++ b/components/table/hooks/useLazyKVMap.ts
@@ -31,7 +31,7 @@ export default function useLazyKVMap<RecordType>(
           kvMap.set(rowKey, record);
 
           if (childrenColumnName in record) {
-            dig((record as any)[childrenColumnName]);
+            dig((record as any)[childrenColumnName] || []);
           }
         });
       }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

fix https://github.com/ant-design/ant-design-pro/issues/5996

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fix Table selection crash when record children is `null`.      |
| 🇨🇳 Chinese |   修复 Table 选择在树形结构子节点为 `null` 会崩溃的问题。      |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
