### PR TITLE
release: 3.26.12

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -15,6 +15,13 @@ timeline: true
 
 ---
 
+## 3.26.12
+
+`2020-02-24`
+
+- 🐞 Fix Input with `readOnly` still clearable by `allowClear`. [#21492](https://github.com/ant-design/ant-design/pull/21492)
+- 🐞 Fix Upload won't showing download icon defaultly. [#21496](https://github.com/ant-design/ant-design/pull/21496)
+
 ## 3.26.11
 
 `2020-02-17`

--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -21,6 +21,7 @@ timeline: true
 
 - 🐞 Fix Input with `readOnly` still clearable by `allowClear`. [#21492](https://github.com/ant-design/ant-design/pull/21492)
 - 🐞 Fix Upload won't showing download icon defaultly. [#21496](https://github.com/ant-design/ant-design/pull/21496)
+- 💄 Tweak Button render performance. [#21217](https://github.com/ant-design/ant-design/pull/21217)
 
 ## 3.26.11
 

--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -21,7 +21,7 @@ timeline: true
 
 - 🐞 Fix Input with `readOnly` still clearable by `allowClear`. [#21492](https://github.com/ant-design/ant-design/pull/21492)
 - 🐞 Fix Upload won't showing download icon defaultly. [#21496](https://github.com/ant-design/ant-design/pull/21496)
-- 💄 Tweak Button render performance. [#21217](https://github.com/ant-design/ant-design/pull/21217)
+- ⚡️  Improve Button render performance. [#21217](https://github.com/ant-design/ant-design/pull/21217)
 
 ## 3.26.11
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -21,6 +21,7 @@ timeline: true
 
 - 🐞 修复 Input 在设置 `readOnly` 时 `allowClear` 仍然可以清除的问题。[#21492](https://github.com/ant-design/ant-design/pull/21492)
 - 🐞 修复 Upload 列表默认情况下不展现下载按钮。[#21496](https://github.com/ant-design/ant-design/pull/21496)
+- 💄 优化 Button 渲染性能。[#21217](https://github.com/ant-design/ant-design/pull/21217)
 
 
 ## 3.26.11

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -15,6 +15,14 @@ timeline: true
 
 ---
 
+## 3.26.12
+
+`2020-02-24`
+
+- 🐞 修复 Input 在设置 `readOnly` 时 `allowClear` 仍然可以清除的问题。[#21492](https://github.com/ant-design/ant-design/pull/21492)
+- 🐞 修复 Upload 列表默认情况下不展现下载按钮。[#21496](https://github.com/ant-design/ant-design/pull/21496)
+
+
 ## 3.26.11
 
 `2020-02-17`

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -21,7 +21,7 @@ timeline: true
 
 - 🐞 修复 Input 在设置 `readOnly` 时 `allowClear` 仍然可以清除的问题。[#21492](https://github.com/ant-design/ant-design/pull/21492)
 - 🐞 修复 Upload 列表默认情况下不展现下载按钮。[#21496](https://github.com/ant-design/ant-design/pull/21496)
-- 💄 优化 Button 渲染性能。[#21217](https://github.com/ant-design/ant-design/pull/21217)
+- ⚡️ 提升 Button 渲染性能。[#21217](https://github.com/ant-design/ant-design/pull/21217)
 
 
 ## 3.26.11

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "antd",
-  "version": "3.26.11",
+  "version": "3.26.12",
   "description": "An enterprise-class UI design language and React components implementation",
   "keywords": [
     "ant",


### PR DESCRIPTION
## 3.26.12

`2020-02-24`

- 🐞 Fix Input with `readOnly` still clearable by `allowClear`. [#21492](https://github.com/ant-design/ant-design/pull/21492)
- 🐞 Fix Upload won't showing download icon defaultly. [#21496](https://github.com/ant-design/ant-design/pull/21496)
- ⚡️  Improve Button render performance. [#21217](https://github.com/ant-design/ant-design/pull/21217)
-----
[View rendered CHANGELOG.en-US.md](https://github.com/ant-design/ant-design/blob/release-3.26.12/CHANGELOG.en-US.md)
[View rendered CHANGELOG.zh-CN.md](https://github.com/ant-design/ant-design/blob/release-3.26.12/CHANGELOG.zh-CN.md)