### PR TITLE
fix: fix trailColor in line-type progress and add trailColor in docs

### DIFF
--- a/components/progress/Line.tsx
+++ b/components/progress/Line.tsx
@@ -69,6 +69,7 @@ const Line: React.SFC<LineProps> = props => {
     strokeColor,
     strokeLinecap,
     children,
+    trailColor,
   } = props;
   let backgroundProps;
   if (strokeColor && typeof strokeColor !== 'string') {
@@ -76,6 +77,12 @@ const Line: React.SFC<LineProps> = props => {
   } else {
     backgroundProps = {
       background: strokeColor,
+    };
+  }
+  let trailStyle;
+  if (trailColor && typeof trailColor === 'string') {
+    trailStyle = {
+      backgroundColor: trailColor,
     };
   }
   const percentStyle = {
@@ -96,7 +103,7 @@ const Line: React.SFC<LineProps> = props => {
   return (
     <>
       <div className={`${prefixCls}-outer`}>
-        <div className={`${prefixCls}-inner`}>
+        <div className={`${prefixCls}-inner`} style={trailStyle}>
           <div className={`${prefixCls}-bg`} style={percentStyle} />
           {successSegment}
         </div>

--- a/components/progress/__tests__/__snapshots__/index.test.js.snap
+++ b/components/progress/__tests__/__snapshots__/index.test.js.snap
@@ -368,6 +368,32 @@ exports[`Progress render strokeColor 3`] = `
 </Progress>
 `;
 
+exports[`Progress render trailColor progress 1`] = `
+<div
+  class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default"
+>
+  <div
+    class="ant-progress-outer"
+  >
+    <div
+      class="ant-progress-inner"
+      style="background-color: rgb(255, 255, 255);"
+    >
+      <div
+        class="ant-progress-bg"
+        style="width: 0%; height: 8px;"
+      />
+    </div>
+  </div>
+  <span
+    class="ant-progress-text"
+    title="0%"
+  >
+    0%
+  </span>
+</div>
+`;
+
 exports[`Progress rtl render component should be rendered correctly in RTL direction 1`] = `
 <div
   class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default ant-progress-rtl"

--- a/components/progress/__tests__/index.test.js
+++ b/components/progress/__tests__/index.test.js
@@ -76,6 +76,11 @@ describe('Progress', () => {
     expect(wrapper.render()).toMatchSnapshot();
   });
 
+  it('render trailColor progress', () => {
+    const wrapper = mount(<Progress status="normal" trailColor="#ffffff" />);
+    expect(wrapper.render()).toMatchSnapshot();
+  });
+
   it('get correct line-gradient', () => {
     expect(handleGradient({ from: 'test', to: 'test' }).backgroundImage).toBe(
       'linear-gradient(to right, test, test)',

--- a/components/progress/index.en-US.md
+++ b/components/progress/index.en-US.md
@@ -27,6 +27,7 @@ Properties that shared by all types.
 | strokeLinecap | to set the style of the progress linecap | `round` \| `square` | `round` |
 | strokeColor | color of progress bar | string | - |
 | successPercent | segmented success percent | number | 0 |
+| trailColor | color of unfilled part | string | - |
 
 ### `type="line"`
 

--- a/components/progress/index.zh-CN.md
+++ b/components/progress/index.zh-CN.md
@@ -28,6 +28,7 @@ title: Progress
 | strokeLinecap | - | `round` \| `square` | `round` |
 | strokeColor | 进度条的色彩 | string | - |
 | successPercent | 已完成的分段百分比 | number | 0 |
+| trailColor | 未完成的分段的颜色 | string | - |
 
 ### `type="line"`
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [] New feature
- [x] Bug fix
- [x] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
https://github.com/ant-design/ant-design/issues/21550
<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution
fix `trailColor` props in `type=line` progress and add trailColor in docs
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Fix Progress `trailColor` not working when `type=line`.        |
| 🇨🇳 Chinese |     修复 Progress `trailColor`属性在 `type=line` 时无效果的问题。    |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/progress/demo/line.md](https://github.com/AshoneA/ant-design/blob/fix/progress-trail-color/components/progress/demo/line.md)
[View rendered components/progress/index.en-US.md](https://github.com/AshoneA/ant-design/blob/fix/progress-trail-color/components/progress/index.en-US.md)
[View rendered components/progress/index.zh-CN.md](https://github.com/AshoneA/ant-design/blob/fix/progress-trail-color/components/progress/index.zh-CN.md)