### PR TITLE
fix: fix sortGradient function ignore incorrect percent

### DIFF
--- a/components/progress/Line.tsx
+++ b/components/progress/Line.tsx
@@ -18,19 +18,17 @@ interface LineProps extends ProgressProps {
  *   '100%': '#ffffff'
  * }
  */
-export const sortGradient = (gradients: ProgressGradient) => {
-  let tempArr = [];
-  // eslint-disable-next-line no-restricted-syntax
-  for (const [key, value] of Object.entries(gradients)) {
-    const formatKey = parseFloat(key.replace(/%/g, ''));
-    if (isNaN(formatKey)) {
-      return {};
+export const sortGradient = (gradients: StringGradients) => {
+  let tempArr: any[] = [];
+  Object.keys(gradients).forEach(key => {
+    const formattedKey = parseFloat(key.replace(/%/g, ''));
+    if (!isNaN(formattedKey)) {
+      tempArr.push({
+        key: formattedKey,
+        value: gradients[key],
+      });
     }
-    tempArr.push({
-      key: formatKey,
-      value,
-    });
-  }
+  });
   tempArr = tempArr.sort((a, b) => a.key - b.key);
   return tempArr.map(({ key, value }) => `${value} ${key}%`).join(', ');
 };

--- a/components/progress/__tests__/index.test.js
+++ b/components/progress/__tests__/index.test.js
@@ -90,6 +90,9 @@ describe('Progress', () => {
     expect(sortGradient({ '10%': 'test10', '30%': 'test30', '20%': 'test20' })).toBe(
       'test10 10%, test20 20%, test30 30%',
     );
+    expect(sortGradient({ '10%': 'test10', '30%': 'test30', '20%': 'test20', dummy: 'test' })).toBe(
+      'test10 10%, test20 20%, test30 30%',
+    );
   });
 
   it('should show success status when percent is 100', () => {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->
fix `sortGradient` function ignore incorrect percent
### 💡 Background and solution
如果传入了错误的参数, 应该忽略掉而不是拿到一个空对象, 添加了新的测试用例并增加了覆盖率
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    progress `strokeColor ` props ignore incorrect percent      |
| 🇨🇳 Chinese |     progress中`strokeColor `属性忽略错误的百分比参数      |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
