### PR TITLE
refactor: Remove DatePicker legacy cell className

### DIFF
--- a/components/date-picker/demo/date-render.md
+++ b/components/date-picker/demo/date-render.md
@@ -28,7 +28,7 @@ ReactDOM.render(
           style.borderRadius = '50%';
         }
         return (
-          <div className="ant-calendar-date" style={style}>
+          <div className="ant-picker-cell-inner" style={style}>
             {current.date()}
           </div>
         );
@@ -42,7 +42,7 @@ ReactDOM.render(
           style.borderRadius = '50%';
         }
         return (
-          <div className="ant-calendar-date" style={style}>
+          <div className="ant-picker-cell-inner" style={style}>
             {current.date()}
           </div>
         );

--- a/components/date-picker/style/panel.less
+++ b/components/date-picker/style/panel.less
@@ -1,7 +1,6 @@
 @import './index';
 
 @picker-cell-inner-cls: ~'@{picker-prefix-cls}-cell-inner';
-@picker-legacy-cell-cls: ~'@{ant-prefix}-calendar-date';
 
 .@{picker-prefix-cls} {
   @picker-arrow-size: 7px;
@@ -428,7 +427,6 @@
     }
 
     .picker-cell-inner(~'@{picker-cell-inner-cls}');
-    .picker-cell-inner(~'@{picker-legacy-cell-cls}');
   }
 
   &-decade-panel,
@@ -707,7 +705,8 @@
 // https://github.com/ant-design/ant-design/issues/21559
 // https://codepen.io/afc163-1472555193/pen/mdJRaNj?editors=0110
 /* stylelint-disable-next-line */
-_:-ms-fullscreen, :root {
+_:-ms-fullscreen,
+:root {
   .@{picker-prefix-cls}-range-wrapper {
     .@{picker-prefix-cls}-month-panel .@{picker-prefix-cls}-cell,
     .@{picker-prefix-cls}-year-panel .@{picker-prefix-cls}-cell {

--- a/docs/react/migration-v4.en-US.md
+++ b/docs/react/migration-v4.en-US.md
@@ -116,6 +116,7 @@ const Demo = () => (
   - Provide the `picker` property for selector switching.
   - Range selection can now select start and end times individually.
   - `onPanelChange` will also trigger when panel value changed.
+  - [Date cell className of Custom style demo](/components/date-picker/#components-date-picker-demo-date-render) changed from `ant-calendar-date` to `ant-picker-cell-inner`.
 - Tree, Select, TreeSelect, AutoComplete rewrite
   - use virtual scrolling.
   - `onBlur` no longer trigger value change.

--- a/docs/react/migration-v4.zh-CN.md
+++ b/docs/react/migration-v4.zh-CN.md
@@ -116,6 +116,7 @@ const Demo = () => (
   - 提供 `picker` 属性用于选择器切换。
   - 范围选择现在可以单独选择开始和结束时间。
   - `onPanelChange` 在面板值变化时也会触发。
+  - [自定义单元格样式](/components/date-picker-cn/#components-date-picker-demo-date-render)的类名从 `ant-calendar-date` 改为 `ant-picker-cell-inner`。
 - Tree、Select、TreeSelect、AutoComplete 重新写
   - 使用虚拟滚动。
   - `onBlur` 时不再修改选中值。


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [x] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 🚮 Remove DatePicker legacy cell className for custom cell style.  |
| 🇨🇳 Chinese | 🚮 移除 DatePicker 针对自定义单元格的 3.x 的兼容类名。 |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
