### PR TITLE
docs: fix link in ConfigProvider

### DIFF
--- a/components/config-provider/index.en-US.md
+++ b/components/config-provider/index.en-US.md
@@ -45,7 +45,7 @@ Some components use dynamic style to support wave effect. You can config `csp` p
 | getPopupContainer | to set the container of the popup element. The default is to create a `div` element in `body`. | Function(triggerNode) | `() => document.body` |  |
 | locale | language package setting, you can find the packages in [antd/es/locale](http://unpkg.com/antd/es/locale/) | object |  |
 | prefixCls | set prefix class. `Note:` This will discard default styles from `antd`. | string | ant |  |
-| pageHeader | Unify the ghost of PageHeader ,Ref [PageHeader](/components/page-header) | { ghost:boolean } | 'true' |  |
+| pageHeader | Unify the ghost of PageHeader, ref [PageHeader](/components/page-header) | { ghost:boolean } | 'true' |  |
 | direction | set direction of layout. See [demo](#components-config-provider-demo-direction) | `ltr` \| `rtl` | `ltr` |  |
 
 ## FAQ

--- a/components/config-provider/index.en-US.md
+++ b/components/config-provider/index.en-US.md
@@ -45,7 +45,7 @@ Some components use dynamic style to support wave effect. You can config `csp` p
 | getPopupContainer | to set the container of the popup element. The default is to create a `div` element in `body`. | Function(triggerNode) | `() => document.body` |  |
 | locale | language package setting, you can find the packages in [antd/es/locale](http://unpkg.com/antd/es/locale/) | object |  |
 | prefixCls | set prefix class. `Note:` This will discard default styles from `antd`. | string | ant |  |
-| pageHeader | Unify the ghost of pageHeader ,Ref [pageHeader](<(/components/page-header)> | { ghost:boolean } | 'true' |  |
+| pageHeader | Unify the ghost of PageHeader ,Ref [PageHeader](/components/page-header) | { ghost:boolean } | 'true' |  |
 | direction | set direction of layout. See [demo](#components-config-provider-demo-direction) | `ltr` \| `rtl` | `ltr` |  |
 
 ## FAQ

--- a/components/config-provider/index.zh-CN.md
+++ b/components/config-provider/index.zh-CN.md
@@ -45,8 +45,8 @@ return (
 | renderEmpty | 自定义组件空状态。参考 [空状态](/components/empty/) | Function(componentName: string): ReactNode | - |  |
 | getPopupContainer | 弹出框（Select, Tooltip, Menu 等等）渲染父节点，默认渲染到 body 上。 | Function(triggerNode) | () => document.body |  |
 | locale | 语言包配置，语言包可到 [antd/es/locale](http://unpkg.com/antd/es/locale/) 目录下寻找 | object | - |  |
-| prefixCls | 设置统一样式前缀。`注意：这将不会应用由 antd 提供的默认样式`| string | ant |  |
-| pageHeader | 统一设置 pageHeader 的 ghost，参考 [pageHeader](<(/components/page-header)>) | { ghost: boolean } | 'true' |  |
+| prefixCls | 设置统一样式前缀。`注意：这将不会应用由 antd 提供的默认样式` | string | ant |  |
+| pageHeader | 统一设置 PageHeader 的 ghost，参考 [PageHeader](/components/page-header) | { ghost: boolean } | 'true' |  |
 | direction | 设置文本展示方向。 [示例](#components-config-provider-demo-direction) | `ltr` \| `rtl` | `ltr` |  |
 
 ## FAQ


### PR DESCRIPTION

### 🤔 This is a ...

- [x] Site / document update

### 🔗 Related issue link

### 💡 Background and solution

![image](https://user-images.githubusercontent.com/7264444/75435396-ebd3ab80-598d-11ea-8489-74f5af6fdf09.png)

directed to

![image](https://user-images.githubusercontent.com/7264444/75435270-c21a8480-598d-11ea-9200-3c7962d03439.png)

### 📝 Changelog

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/config-provider/index.en-US.md](https://github.com/dancerphil/ant-design/blob/master/components/config-provider/index.en-US.md)
[View rendered components/config-provider/index.zh-CN.md](https://github.com/dancerphil/ant-design/blob/master/components/config-provider/index.zh-CN.md)