### PR TITLE
fix: 🔷 Result status type to string & number

### DIFF
--- a/components/result/__tests__/type.test.tsx
+++ b/components/result/__tests__/type.test.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react';
+import Result from '..';
+
+describe('Result.typescript', () => {
+  it('status', () => {
+    const result = (
+      <>
+        <Result
+          status="404"
+          title="404"
+          subTitle="Sorry, the page you visited does not exist."
+        />
+        <Result
+          status={404}
+          title="404"
+          subTitle="Sorry, the page you visited does not exist."
+        />
+      </>
+    );
+
+    expect(result).toBeTruthy();
+  });
+});

--- a/components/result/index.tsx
+++ b/components/result/index.tsx
@@ -27,7 +27,7 @@ export const ExceptionMap = {
   '403': unauthorized,
 };
 
-export type ExceptionStatusType = keyof typeof ExceptionMap;
+export type ExceptionStatusType = 403 | 404 | 500 | '403' | '404' | '500';
 export type ResultStatusType = ExceptionStatusType | keyof typeof IconMap;
 
 export interface ResultProps {
@@ -60,7 +60,7 @@ const renderIcon = (prefixCls: string, { status, icon }: ResultProps) => {
     `\`icon\` is using ReactNode instead of string naming in v4. Please check \`${icon}\` at https://ant.design/components/icon`,
   );
 
-  if (ExceptionStatus.includes(status as ResultStatusType)) {
+  if (ExceptionStatus.includes(`${status}`)) {
     const SVGComponent = ExceptionMap[status as ExceptionStatusType];
     return (
       <div className={`${className} ${prefixCls}-image`}>


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close #21592
close #21741

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Result `status` cannot assigned to string or number type.  |
| 🇨🇳 Chinese | 修复 Result `status` 属性不能赋值 `string` 或者 `number` 类型的问题。 |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
