### PR TITLE
fix: crash when user doesn't pass icon props to  message.open

### DIFF
--- a/components/message/__tests__/index.test.js
+++ b/components/message/__tests__/index.test.js
@@ -91,6 +91,10 @@ describe('message', () => {
     message.open({ content: 'Message', icon: <span /> });
     expect(document.querySelectorAll('.ant-message-notice .anticon').length).toBe(0);
   });
+  it('should have no icon when not pass icon props', () => {
+    message.open({ content: 'Message' });
+    expect(document.querySelectorAll('.ant-message-notice .anticon').length).toBe(0);
+  });
 
   // https://github.com/ant-design/ant-design/issues/8201
   it('should destroy messages correctly', () => {

--- a/components/message/index.tsx
+++ b/components/message/index.tsx
@@ -93,7 +93,7 @@ function notice(args: ArgsProps): MessageType {
               args.type ? ` ${prefixCls}-${args.type}` : ''
             }`}
           >
-            {args.icon ? args.icon : <IconComponent />}
+            {args.icon || (IconComponent && <IconComponent />)}
             <span>{args.content}</span>
           </div>
         ),


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
https://github.com/ant-design/ant-design/issues/21745
<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    fix crash when the user doesn't pass `icon` props to `message.open`       |
| 🇨🇳 Chinese |      修复了`message.open`中`icon`为空的时候报错    |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
