### PR TITLE
fix: 🐛 Fix Input.Search border when has prefix

### DIFF
--- a/components/input/style/search-input.less
+++ b/components/input/style/search-input.less
@@ -29,6 +29,10 @@
       }
     }
 
+    &.@{ant-prefix}-input-affix-wrapper {
+      border-right: 0;
+    }
+
     & + .@{ant-prefix}-input-group-addon,
     input + .@{ant-prefix}-input-group-addon {
       padding: 0;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

https://codesandbox.io/s/exciting-cache-hvipk

<img width="95" alt="image" src="https://user-images.githubusercontent.com/507615/75644820-91cd3180-5c7e-11ea-8cf0-27d926e00ea1.png">

There is extra border-right here.

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Input.Search extra border when has `prefix` |
| 🇨🇳 Chinese | 修复 Input.Search 有 `prefix` 时的右边框样式问题。 |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/input/demo/search-input.md](https://github.com/ant-design/ant-design/blob/fix-search-border/components/input/demo/search-input.md)