### PR TITLE
fix: TreeSelect.SHOW_* should have constant type

### DIFF
--- a/components/tree-select/index.tsx
+++ b/components/tree-select/index.tsx
@@ -38,11 +38,11 @@ export interface TreeSelectProps<T>
 class TreeSelect<T> extends React.Component<TreeSelectProps<T>, {}> {
   static TreeNode = TreeNode;
 
-  static SHOW_ALL = SHOW_ALL;
+  static SHOW_ALL: typeof SHOW_ALL = SHOW_ALL;
 
-  static SHOW_PARENT = SHOW_PARENT;
+  static SHOW_PARENT: typeof SHOW_PARENT = SHOW_PARENT;
 
-  static SHOW_CHILD = SHOW_CHILD;
+  static SHOW_CHILD: typeof SHOW_CHILD = SHOW_CHILD;
 
   static defaultProps = {
     transitionName: 'slide-up',


### PR DESCRIPTION
Signed-off-by: TennyZhuang <zty0826@gmail.com>

<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

While use TreeSelect in typescript, constants `TreeSelect.SHOW_*` cannot be passed to `showCheckedStrategy` due to all of them are string type, but `type CheckedStrategy = typeof SHOW_ALL | typeof SHOW_PARENT | typeof SHOW_CHILD` is required.

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  fix TreeSelect.SHOW_* type |
| 🇨🇳 Chinese |   修复了 TreeSelect.SHOW_* 的类型问题|

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
