### PR TITLE
chore: removes erroniously present comment

### DIFF
--- a/components/alert/ErrorBoundary.tsx
+++ b/components/alert/ErrorBoundary.tsx
@@ -33,7 +33,6 @@ export default class ErrorBoundary extends React.Component<
     const errorMessage = typeof message === 'undefined' ? (error || '').toString() : message;
     const errorDescription = typeof description === 'undefined' ? componentStack : description;
     if (error) {
-      // You can render any custom fallback UI
       return (
         <Alert type="error" message={errorMessage} description={<pre>{errorDescription}</pre>} />
       );


### PR DESCRIPTION
This comment was an accidental copy/pasta from https://reactjs.org/docs/error-boundaries.html.  Also, it is inaccurate since the user (i.e. AntD user) cannot actually render any fallback component.

### 🤔 This is a ...

- [x] Bug fix

### 🔗 Related issue link

https://reactjs.org/docs/error-boundaries.html

### 💡 Background and solution

removal of the comment

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
