### PR TITLE
fix: `help` change cause react warning

### DIFF
--- a/components/form/FormItemInput.tsx
+++ b/components/form/FormItemInput.tsx
@@ -59,7 +59,14 @@ const FormItemInput: React.FC<FormItemInputProps & FormItemInputMiscProps> = ({
     errors,
     changedVisible => {
       if (changedVisible) {
-        onDomErrorVisibleChange(true);
+        /**
+         * We trigger in sync to avoid dom shaking but this get warning in react 16.13.
+         * So use Promise to keep in micro async to handle this.
+         * https://github.com/ant-design/ant-design/issues/21698#issuecomment-593743485
+         */
+        Promise.resolve().then(() => {
+          onDomErrorVisibleChange(true);
+        });
       }
       forceUpdate({});
     },

--- a/components/form/__tests__/index.test.js
+++ b/components/form/__tests__/index.test.js
@@ -563,4 +563,34 @@ describe('Form', () => {
       wrapper.find(CustomComponent).simulate('change', { value: '123' });
     }).not.toThrow();
   });
+
+  it('change `help` should not warning', () => {
+    const Demo = () => {
+      const [error, setError] = React.useState(null);
+
+      return (
+        <Form>
+          <Form.Item
+            help={error ? 'This is an error msg' : undefined}
+            validateStatus={error ? 'error' : ''}
+            label="Username"
+            name="username"
+          >
+            <input />
+          </Form.Item>
+
+          <Form.Item>
+            <button type="button" onClick={() => setError(!error)}>
+              Trigger
+            </button>
+          </Form.Item>
+        </Form>
+      );
+    };
+
+    const wrapper = mount(<Demo />);
+    wrapper.find('button').simulate('click');
+
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

fix #21698

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fix Form `help` control will get React 16.13 warning.      |
| 🇨🇳 Chinese |    修复 Form `help` 受控时会导致 React 16.13 报警告的问题。       |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
