### PR TITLE
fix: Add implementation support for propSize's string type

### DIFF
--- a/components/grid/col.tsx
+++ b/components/grid/col.tsx
@@ -65,7 +65,7 @@ export default class Col extends React.Component<ColProps, {}> {
     ['xs', 'sm', 'md', 'lg', 'xl', 'xxl'].forEach(size => {
       let sizeProps: ColSize = {};
       const propSize = (props as any)[size];
-      if (typeof propSize === 'number') {
+      if (typeof propSize === 'number' || typeof propSize === 'string') {
         sizeProps.span = propSize;
       } else if (typeof propSize === 'object') {
         sizeProps = propSize || {};

--- a/components/grid/index.en-US.md
+++ b/components/grid/index.en-US.md
@@ -101,13 +101,13 @@ If the Ant Design grid layout component does not meet your needs, you can use th
 | order | raster order | number | 0 |  |
 | pull | the number of cells that raster is moved to the left | number | 0 |  |
 | push | the number of cells that raster is moved to the right | number | 0 |  |
-| span | raster number of cells to occupy, 0 corresponds to `display: none` | number | none |  |
-| xs | `<576px` and also default setting, could be a `span` value or an object containing above props | number\|object | - |  |
-| sm | `≥576px`, could be a `span` value or an object containing above props | number\|object | - |  |
-| md | `≥768px`, could be a `span` value or an object containing above props | number\|object | - |  |
-| lg | `≥992px`, could be a `span` value or an object containing above props | number\|object | - |  |
-| xl | `≥1200px`, could be a `span` value or an object containing above props | number\|object | - |  |
-| xxl | `≥1600px`, could be a `span` value or an object containing above props | number\|object | - |  |
+| span | raster number of cells to occupy, 0 corresponds to `display: none` | number \| string | none |  |
+| xs | `<576px` and also default setting, could be a `span` value or an object containing above props | number \| string \| object | - |  |
+| sm | `≥576px`, could be a `span` value or an object containing above props | number \| string \| object | - |  |
+| md | `≥768px`, could be a `span` value or an object containing above props | number \| string \| object | - |  |
+| lg | `≥992px`, could be a `span` value or an object containing above props | number \| string \| object | - |  |
+| xl | `≥1200px`, could be a `span` value or an object containing above props | number \| string \| object | - |  |
+| xxl | `≥1600px`, could be a `span` value or an object containing above props | number \| string \| object | - |  |
 
 The breakpoints of responsive grid follow [BootStrap 4 media queries rules](https://getbootstrap.com/docs/4.0/layout/overview/#responsive-breakpoints) (not including `occasionally part`).
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [x] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

Currently, the type for `propSize` was updated to accommodate `number` or `string` but the logic for appending `propSize.span` only supports `number`.

```js
// span worked, but md will not append it's className
// although ColSpanType accepts both number and string 
<Col span="5" md="5" />
```

To support the type, I added a check for string type.

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Add implementation support for propSize's type |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
