### PR TITLE
fix: Desctiption miss style when value is number 0

### DIFF
--- a/components/descriptions/Cell.tsx
+++ b/components/descriptions/Cell.tsx
@@ -31,15 +31,15 @@ const Cell: React.FC<CellProps> = ({
       <Component
         className={classNames(
           {
-            [`${itemPrefixCls}-item-label`]: label,
-            [`${itemPrefixCls}-item-content`]: content,
+            [`${itemPrefixCls}-item-label`]: label !== undefined,
+            [`${itemPrefixCls}-item-content`]: content !== undefined,
           },
           className,
         )}
         style={style}
         colSpan={span}
       >
-        {label || content}
+        {label !== undefined ? label : content}
       </Component>
     );
   }

--- a/components/descriptions/Cell.tsx
+++ b/components/descriptions/Cell.tsx
@@ -1,6 +1,10 @@
 import * as React from 'react';
 import classNames from 'classnames';
 
+function notEmpty(val: any) {
+  return val !== undefined && val !== null;
+}
+
 export interface CellProps {
   itemPrefixCls: string;
   span: number;
@@ -31,15 +35,15 @@ const Cell: React.FC<CellProps> = ({
       <Component
         className={classNames(
           {
-            [`${itemPrefixCls}-item-label`]: label !== undefined,
-            [`${itemPrefixCls}-item-content`]: content !== undefined,
+            [`${itemPrefixCls}-item-label`]: notEmpty(label),
+            [`${itemPrefixCls}-item-content`]: notEmpty(content),
           },
           className,
         )}
         style={style}
         colSpan={span}
       >
-        {label !== undefined ? label : content}
+        {notEmpty(label) ? label : content}
       </Component>
     );
   }

--- a/components/descriptions/__tests__/index.test.js
+++ b/components/descriptions/__tests__/index.test.js
@@ -216,4 +216,15 @@ describe('Descriptions', () => {
     matchSpan(2, [2, 2]);
     matchSpan(4, [3, 1]);
   });
+
+  it('number value should render correct', () => {
+    const wrapper = mount(
+      <Descriptions bordered>
+        <Descriptions.Item label={0}>{0}</Descriptions.Item>
+      </Descriptions>,
+    );
+
+    expect(wrapper.find('th').hasClass('ant-descriptions-item-label')).toBeTruthy();
+    expect(wrapper.find('td').hasClass('ant-descriptions-item-content')).toBeTruthy();
+  });
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

fix #21899

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fix Descriptions miss style when content is falsy.     |
| 🇨🇳 Chinese |     修复 Descriptions 内容为 falsy 值时样式丢失的问题。      |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️ 

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
