### PR TITLE
chore: Form.useForm return same instance now

### DIFF
--- a/components/form/__tests__/index.test.js
+++ b/components/form/__tests__/index.test.js
@@ -415,7 +415,6 @@ describe('Form', () => {
       await change(wrapper, 0, 'p');
       await delay(100);
       wrapper.update();
-
       expect(
         wrapper
           .find('.ant-form-item-explain')
@@ -595,5 +594,31 @@ describe('Form', () => {
     wrapper.find('button').simulate('click');
 
     expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it('return same form instance', () => {
+    const instances = new Set();
+
+    const App = () => {
+      const [form] = Form.useForm();
+      instances.add(form);
+      const [, forceUpdate] = React.useState({});
+      return (
+        <button
+          type="button"
+          onClick={() => {
+            forceUpdate({});
+          }}
+        >
+          Refresh
+        </button>
+      );
+    };
+
+    const wrapper = mount(<App />);
+    for (let i = 0; i < 5; i += 1) {
+      wrapper.find('button').simulate('click');
+    }
+    expect(instances.size).toEqual(1);
   });
 });

--- a/components/form/util.ts
+++ b/components/form/util.ts
@@ -73,23 +73,29 @@ export interface FormInstance extends RcFormInstance {
 }
 
 export function useForm(form?: FormInstance): [FormInstance] {
-  const wrapForm: FormInstance = form || {
-    ...useRcForm()[0],
-    __INTERNAL__: {},
-    scrollToField: (name: string, options: ScrollOptions = {}) => {
-      const namePath = toArray(name);
-      const fieldId = getFieldId(namePath, wrapForm.__INTERNAL__.name);
-      const node: HTMLElement | null = fieldId ? document.getElementById(fieldId) : null;
+  const [rcForm] = useRcForm();
 
-      if (node) {
-        scrollIntoView(node, {
-          scrollMode: 'if-needed',
-          block: 'nearest',
-          ...options,
-        });
-      }
-    },
-  };
+  const wrapForm: FormInstance = React.useMemo(
+    () =>
+      form || {
+        ...rcForm,
+        __INTERNAL__: {},
+        scrollToField: (name: string, options: ScrollOptions = {}) => {
+          const namePath = toArray(name);
+          const fieldId = getFieldId(namePath, wrapForm.__INTERNAL__.name);
+          const node: HTMLElement | null = fieldId ? document.getElementById(fieldId) : null;
+
+          if (node) {
+            scrollIntoView(node, {
+              scrollMode: 'if-needed',
+              block: 'nearest',
+              ...options,
+            });
+          }
+        },
+      },
+    [form, rcForm],
+  );
 
   return [wrapForm];
 }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [x] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close #21924

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Form.useForm return same instance in render now.       |
| 🇨🇳 Chinese |    Form.useForm 现在在 render 中将返回相同的实例。       |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️ 

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
