### PR TITLE
feat: TimePicker.RangePicker support `order`

### DIFF
--- a/components/time-picker/index.en-US.md
+++ b/components/time-picker/index.en-US.md
@@ -59,6 +59,14 @@ import moment from 'moment';
 | blur()  | remove focus |         |
 | focus() | get focus    |         |
 
+### RangePicker
+
+Same props from [RangePicker](/components/date-picker/#RangePicker) of DatePicker. And includes additional props:
+
+| Property | Description              | Type    | Default | Version |
+| -------- | ------------------------ | ------- | ------- | ------- |
+| order    | Order start and end time | boolean | true    | 4.1.0   |
+
 <style>.code-box-demo .ant-picker { margin: 0 8px 12px 0; }</style>
 
 ## FAQ

--- a/components/time-picker/index.zh-CN.md
+++ b/components/time-picker/index.zh-CN.md
@@ -60,6 +60,14 @@ import moment from 'moment';
 | blur()  | 移除焦点 |      |
 | focus() | 获取焦点 |      |
 
+### RangePicker
+
+属性与 DatePicker 的 [RangePicker](/components/date-picker/#RangePicker) 相同。还包含以下属性：
+
+| 参数  | 说明                 | 类型    | 默认值 | 版本  |
+| ----- | -------------------- | ------- | ------ | ----- |
+| order | 始末时间是否自动排序 | boolean | true   | 4.1.0 |
+
 <style>.code-box-demo .ant-picker { margin: 0 8px 12px 0; }</style>
 
 ## FAQ

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "rc-menu": "~8.0.1",
     "rc-notification": "~4.0.0",
     "rc-pagination": "~2.0.1",
-    "rc-picker": "~1.1.0",
+    "rc-picker": "~1.2.0",
     "rc-progress": "~2.5.0",
     "rc-rate": "~2.5.1",
     "rc-resize-observer": "^0.1.0",


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

resolve #21916

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    TimePicker.RangePicker support `order` prop.       |
| 🇨🇳 Chinese |    TimePicker.RangePicker 支持 `order` 属性用于设置排序行为。       |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️ 

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/time-picker/index.en-US.md](https://github.com/ant-design/ant-design/blob/time-range-no-order/components/time-picker/index.en-US.md)
[View rendered components/time-picker/index.zh-CN.md](https://github.com/ant-design/ant-design/blob/time-range-no-order/components/time-picker/index.zh-CN.md)