### PR TITLE
fix: Table className & style in wrong place

### DIFF
--- a/components/empty/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/empty/__tests__/__snapshots__/demo.test.js.snap
@@ -496,6 +496,7 @@ exports[`renders ./components/empty/demo/config-provider.md correctly 1`] = `
     </h3>
     <div
       class="ant-table-wrapper"
+      style="margin-top:8px"
     >
       <div
         class="ant-spin-nested-loading"
@@ -505,7 +506,6 @@ exports[`renders ./components/empty/demo/config-provider.md correctly 1`] = `
         >
           <div
             class="ant-table"
-            style="margin-top:8px"
           >
             <div
               class="ant-table-container"

--- a/components/table/Table.tsx
+++ b/components/table/Table.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import classNames from 'classnames';
+import omit from 'omit.js';
 import RcTable from 'rc-table';
 import { TableProps as RcTableProps, INTERNAL_HOOKS } from 'rc-table/lib/Table';
 import Spin, { SpinProps } from '../spin';
@@ -84,6 +85,7 @@ function Table<RecordType extends object = any>(props: TableProps<RecordType>) {
   const {
     prefixCls: customizePrefixCls,
     className,
+    style,
     size: customizeSize,
     bordered,
     dropdownPrefixCls,
@@ -107,6 +109,9 @@ function Table<RecordType extends object = any>(props: TableProps<RecordType>) {
     sortDirections,
     locale,
   } = props;
+
+  const tableProps = omit(props, ['className', 'style']) as TableProps<RecordType>;
+
   const size = React.useContext(SizeContext);
   const { locale: contextLocale = defaultLocale, renderEmpty, direction } = React.useContext(
     ConfigContext,
@@ -401,12 +406,13 @@ function Table<RecordType extends object = any>(props: TableProps<RecordType>) {
     spinProps = loading;
   }
 
-  const wrapperClassNames = classNames(`${prefixCls}-wrapper`, {
+  const wrapperClassNames = classNames(`${prefixCls}-wrapper`, className, {
     [`${prefixCls}-wrapper-rtl`]: direction === 'rtl',
   });
   return (
     <div
       className={wrapperClassNames}
+      style={style}
       onTouchMove={e => {
         e.preventDefault();
       }}
@@ -414,10 +420,10 @@ function Table<RecordType extends object = any>(props: TableProps<RecordType>) {
       <Spin spinning={false} {...spinProps}>
         {topPaginationNode}
         <RcTable<RecordType>
-          {...props}
+          {...tableProps}
           expandable={mergedExpandable}
           prefixCls={prefixCls}
-          className={classNames(className, {
+          className={classNames({
             [`${prefixCls}-middle`]: mergedSize === 'middle',
             [`${prefixCls}-small`]: mergedSize === 'small',
             [`${prefixCls}-bordered`]: bordered,

--- a/components/table/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/table/__tests__/__snapshots__/demo.test.js.snap
@@ -9544,7 +9544,7 @@ exports[`renders ./components/table/demo/multiple-sorter.md correctly 1`] = `
 
 exports[`renders ./components/table/demo/nested-table.md correctly 1`] = `
 <div
-  class="ant-table-wrapper"
+  class="ant-table-wrapper components-table-demo-nested"
 >
   <div
     class="ant-spin-nested-loading"
@@ -9553,7 +9553,7 @@ exports[`renders ./components/table/demo/nested-table.md correctly 1`] = `
       class="ant-spin-container"
     >
       <div
-        class="ant-table components-table-demo-nested"
+        class="ant-table"
       >
         <div
           class="ant-table-container"
@@ -12788,7 +12788,7 @@ exports[`renders ./components/table/demo/summary.md correctly 1`] = `
 
 exports[`renders ./components/table/demo/virtual-list.md correctly 1`] = `
 <div
-  class="ant-table-wrapper"
+  class="ant-table-wrapper virtual-table"
 >
   <div
     class="ant-spin-nested-loading"
@@ -12797,7 +12797,7 @@ exports[`renders ./components/table/demo/virtual-list.md correctly 1`] = `
       class="ant-spin-container"
     >
       <div
-        class="ant-table virtual-table ant-table-fixed-header ant-table-fixed-column"
+        class="ant-table ant-table-fixed-header ant-table-fixed-column"
       >
         <div
           class="ant-table-container"


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

fix #21951

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fix Table `className` & `style` works on wrong dom.      |
| 🇨🇳 Chinese |      修复 Table `className` 和 `style` 作用在错误的元素上的问题。     |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️ 

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
