### PR TITLE
perf(Form): FormContext use a memoized value(#21976)

### DIFF
--- a/components/form/Form.tsx
+++ b/components/form/Form.tsx
@@ -74,6 +74,18 @@ const InternalForm: React.ForwardRefRenderFunction<unknown, FormProps> = (props,
   const [wrapForm] = useForm(form);
   wrapForm.__INTERNAL__.name = name;
 
+  const formContextValue = React.memo(
+    () => ({
+      name,
+      labelAlign,
+      labelCol,
+      wrapperCol,
+      vertical: layout === 'vertical',
+      colon,
+    }),
+    [name, labelAlign, labelCol, wrapperCol, layout, colon],
+  );
+
   React.useImperativeHandle(ref, () => wrapForm);
 
   const onInternalFinishFailed = (errorInfo: ValidateErrorEntity) => {
@@ -89,14 +101,7 @@ const InternalForm: React.ForwardRefRenderFunction<unknown, FormProps> = (props,
   return (
     <SizeContextProvider size={size}>
       <FormContext.Provider
-        value={{
-          name,
-          labelAlign,
-          labelCol,
-          wrapperCol,
-          vertical: layout === 'vertical',
-          colon,
-        }}
+        value={formContextValue}
       >
         <FieldForm
           id={name}

--- a/components/form/Form.tsx
+++ b/components/form/Form.tsx
@@ -74,7 +74,7 @@ const InternalForm: React.ForwardRefRenderFunction<unknown, FormProps> = (props,
   const [wrapForm] = useForm(form);
   wrapForm.__INTERNAL__.name = name;
 
-  const formContextValue = React.memo(
+  const formContextValue = React.useMemo(
     () => ({
       name,
       labelAlign,


### PR DESCRIPTION
* fix #21976

<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

#21976

### 💡 Background and solution

In current, `FormContext.Provider` use an inline Object variable as the value, it will always trigger unintentional renders in consumers when `Form` or `Form`'s parent re-renders.

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  `FormContext` use a `memoized` value to avoid trigger `FormItem`'s unintentional renders   |
| 🇨🇳 Chinese |  `FormContext`使用`memoized`值避免`FormItem`产生额外的渲染         |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️ 

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
