### PR TITLE
refactor: Form.Item with pure children will only render once

### DIFF
--- a/components/form/FormItem.tsx
+++ b/components/form/FormItem.tsx
@@ -21,6 +21,20 @@ type RenderChildren = (form: FormInstance) => React.ReactNode;
 type RcFieldProps = Omit<FieldProps, 'children'>;
 type ChildrenType = React.ReactElement | RenderChildren | React.ReactElement[] | null;
 
+interface MemoInputProps {
+  value: any;
+  children: any;
+}
+
+const MemoInput = React.memo<MemoInputProps>(
+  ({ children }) => {
+    return children;
+  },
+  (prev, next) => {
+    return prev.value === next.value;
+  },
+);
+
 export interface FormItemProps
   extends FormItemLabelProps,
     FormItemInputProps,
@@ -296,7 +310,11 @@ function FormItem(props: FormItemProps): React.ReactElement {
             };
           });
 
-          childNode = React.cloneElement(children, childProps);
+          childNode = (
+            <MemoInput value={mergedControl[props.valuePropName || 'value']}>
+              {React.cloneElement(children, childProps)}
+            </MemoInput>
+          );
         } else if (isRenderProps && shouldUpdate && !hasName) {
           childNode = (children as RenderChildren)(context);
         } else {

--- a/components/form/FormItem.tsx
+++ b/components/form/FormItem.tsx
@@ -23,6 +23,7 @@ type ChildrenType = React.ReactElement | RenderChildren | React.ReactElement[] |
 
 interface MemoInputProps {
   value: any;
+  update: number;
   children: any;
 }
 
@@ -31,7 +32,7 @@ const MemoInput = React.memo<MemoInputProps>(
     return children;
   },
   (prev, next) => {
-    return prev.value === next.value;
+    return prev.value === next.value && prev.update === next.update;
   },
 );
 
@@ -230,6 +231,10 @@ function FormItem(props: FormItemProps): React.ReactElement {
     return renderLayout(children);
   }
 
+  // Record for real component render
+  const updateRef = React.useRef(0);
+  updateRef.current += 1;
+
   return (
     <Field
       {...props}
@@ -311,7 +316,10 @@ function FormItem(props: FormItemProps): React.ReactElement {
           });
 
           childNode = (
-            <MemoInput value={mergedControl[props.valuePropName || 'value']}>
+            <MemoInput
+              value={mergedControl[props.valuePropName || 'value']}
+              update={updateRef.current}
+            >
               {React.cloneElement(children, childProps)}
             </MemoInput>
           );

--- a/components/form/__tests__/index.test.js
+++ b/components/form/__tests__/index.test.js
@@ -621,4 +621,35 @@ describe('Form', () => {
     }
     expect(instances.size).toEqual(1);
   });
+
+  it('avoid re-render', async () => {
+    let renderTimes = 0;
+
+    const MyInput = ({ value = '', ...props }) => {
+      renderTimes += 1;
+      return <input value={value} {...props} />;
+    };
+
+    const Demo = () => (
+      <Form>
+        <Form.Item name="username" rules={[{ required: true }]}>
+          <MyInput />
+        </Form.Item>
+      </Form>
+    );
+
+    const wrapper = mount(<Demo />);
+    renderTimes = 0;
+
+    wrapper.find('input').simulate('change', {
+      target: {
+        value: 'a',
+      },
+    });
+
+    await delay();
+
+    expect(renderTimes).toEqual(1);
+    expect(wrapper.find('input').props().value).toEqual('a');
+  });
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [x] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

resolve #21987

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Refactor Form.Item render logic that will only render once when children is a pure component.        |
| 🇨🇳 Chinese |      重构 Form.Item 渲染逻辑以使其子元素为纯组件时值变更只会渲染一次。    |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️ 

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
