### PR TITLE
fix: 🐛 TextArea[autoSize] don't scroll bottom in Firefox

### DIFF
--- a/components/input/ResizableTextArea.tsx
+++ b/components/input/ResizableTextArea.tsx
@@ -88,6 +88,7 @@ class ResizableTextArea extends React.Component<TextAreaProps, TextAreaState> {
         this.setState({ resizeStatus: RESIZE_STATUS_RESIZED }, () => {
           this.resizeFrameId = raf(() => {
             this.setState({ resizeStatus: RESIZE_STATUS_NONE });
+            this.fixFirefoxAutoScroll();
           });
         });
       });
@@ -97,6 +98,21 @@ class ResizableTextArea extends React.Component<TextAreaProps, TextAreaState> {
   componentWillUnmount() {
     raf.cancel(this.nextFrameActionId);
     raf.cancel(this.resizeFrameId);
+  }
+
+  // https://github.com/ant-design/ant-design/issues/21870
+  fixFirefoxAutoScroll() {
+    try {
+      if (document.activeElement === this.textArea) {
+        const currentStart = this.textArea.selectionStart;
+        const currentEnd = this.textArea.selectionEnd;
+        this.textArea.setSelectionRange(currentStart, currentEnd);
+      }
+    } catch (e) {
+      // Fix error in Chrome:
+      // Failed to read the 'selectionStart' property from 'HTMLInputElement'
+      // http://stackoverflow.com/q/21177489/3040605
+    }
   }
 
   renderTextArea = () => {

--- a/components/input/__tests__/textarea.test.js
+++ b/components/input/__tests__/textarea.test.js
@@ -284,4 +284,23 @@ describe('TextArea allowClear', () => {
     wrapper.find('.test-suffix').simulate('mouseUp');
     expect(onFocus).toHaveBeenCalled();
   });
+
+  it('scroll to bottom when autoSize', () => {
+    jest.useFakeTimers();
+    const wrapper = mount(<Input.TextArea autoSize />, { attachTo: document.body });
+    wrapper.find('textarea').simulate('focus');
+    wrapper
+      .find('textarea')
+      .getDOMNode()
+      .focus();
+    const setSelectionRangeFn = jest.spyOn(
+      wrapper.find('textarea').getDOMNode(),
+      'setSelectionRange',
+    );
+    wrapper.find('textarea').simulate('input', { target: { value: '\n1' } });
+    jest.runAllTimers();
+    jest.useRealTimers();
+    expect(setSelectionRangeFn).toHaveBeenCalled();
+    wrapper.unmount();
+  });
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close #21870

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix TextArea `autoSize` don't scroll bottom in Firefox. |
| 🇨🇳 Chinese | 修复 TextArea `autoSize` 时在 Firefox 下不会自动滚动到底的问题。 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️ 

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
