### PR TITLE
docs: 📝 documentation for DatePicker inputReadOnly

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -331,6 +331,7 @@ Ant Design 4.0-rc released! Here is the release [document](https://github.com/an
   - 🌟 The range selector can be set to `disabled` separately for the start and end time.
   - 🌟 The range selector allows empty start and end times.
   - 🌟 Optimized manual input and keyboard interaction support.
+  - 🌟 Added `inputReadOnly` to disable manual input.
 - 🌟 Remove Icon and use `@ ant-design / icons` instead. [#18217](https://github.com/ant-design/ant-design/pull/18217)
 - Skeleton
   - 🌟 Support Skeleton.Avatar placeholder component. [#19898](https://github.com/ant-design/ant-design/pull/19898) [@Rustin-Liu](https://github.com/Rustin-Liu)

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -331,6 +331,7 @@ Ant Design 4.0-rc 发布，发布文档请查看[此处](https://github.com/ant-
   - 🌟 范围选择器可以为开始与结束时间单独设置 `disabled`。
   - 🌟 范围选择器可以允许开始与结束时间为空。
   - 🌟 优化手工输入与键盘交互支持。
+  - 🌟 支持 `inputReadOnly` 禁用手动输入。
 - 🌟 移除 Icon，使用 `@ant-design/icons` 代替。[#18217](https://github.com/ant-design/ant-design/pull/18217)
 - Skeleton
   - 🌟 支持 Skeleton.Avatar 占位组件。[#19898](https://github.com/ant-design/ant-design/pull/19898) [@Rustin-Liu](https://github.com/Rustin-Liu)

--- a/components/date-picker/index.en-US.md
+++ b/components/date-picker/index.en-US.md
@@ -65,6 +65,7 @@ The following APIs are shared by DatePicker, YearPicker, MonthPicker, RangePicke
 | style | to customize the style of the input box | object | {} |  |
 | onOpenChange | a callback function, can be executed whether the popup calendar is popped up or closed | function(status) | - |  |
 | onPanelChange | callback when picker panel mode is changed | function(value, mode) | - |  |
+| inputReadOnly | Set the `readonly` attribute of the input tag (avoids virtual keyboard on touch devices) | boolean | false |  |
 
 ### Common Methods
 

--- a/components/date-picker/index.zh-CN.md
+++ b/components/date-picker/index.zh-CN.md
@@ -67,6 +67,7 @@ import 'moment/locale/zh-cn';
 | style | 自定义输入框样式 | object | {} |  |
 | onOpenChange | 弹出日历和关闭日历的回调 | function(status) | 无 |  |
 | onPanelChange | 日历面板切换的回调 | function(value, mode) | - |  |
+| inputReadOnly | 设置输入框为只读（避免在移动设备上打开虚拟键盘） | boolean | false |  |
 
 ### 共同的方法
 


### PR DESCRIPTION

<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close #20442
close #21831
close #20816

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix DatePicker `inputReadOnly` missing in documentation. |
| 🇨🇳 Chinese |  文档里增加 DatePicker `inputReadOnly` 属性的描述。   |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️ 

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered CHANGELOG.en-US.md](https://github.com/ant-design/ant-design/blob/docs-inputReadOnly/CHANGELOG.en-US.md)
[View rendered CHANGELOG.zh-CN.md](https://github.com/ant-design/ant-design/blob/docs-inputReadOnly/CHANGELOG.zh-CN.md)
[View rendered components/date-picker/index.en-US.md](https://github.com/ant-design/ant-design/blob/docs-inputReadOnly/components/date-picker/index.en-US.md)
[View rendered components/date-picker/index.zh-CN.md](https://github.com/ant-design/ant-design/blob/docs-inputReadOnly/components/date-picker/index.zh-CN.md)