### PR TITLE
feat: ellipsis onExpand function takes event parameter

### DIFF
--- a/components/typography/Base.tsx
+++ b/components/typography/Base.tsx
@@ -40,7 +40,7 @@ interface EllipsisConfig {
   rows?: number;
   expandable?: boolean;
   suffix?: string;
-  onExpand?: () => void;
+  onExpand?: React.MouseEventHandler<HTMLElement>;
 }
 
 export interface BlockProps extends TypographyProps {
@@ -165,13 +165,13 @@ class Base extends React.Component<InternalBlockProps & ConfigConsumerProps, Bas
     raf.cancel(this.rafId);
   }
 
-  // =============== Expend ===============
-  onExpandClick = () => {
+  // =============== Expand ===============
+  onExpandClick: React.MouseEventHandler<HTMLElement> = e => {
     const { onExpand } = this.getEllipsis();
     this.setState({ expanded: true });
 
     if (onExpand) {
-      onExpand();
+      (onExpand as React.MouseEventHandler<HTMLElement>)(e);
     }
   };
 

--- a/components/typography/index.en-US.md
+++ b/components/typography/index.en-US.md
@@ -39,7 +39,7 @@ Basic text writing, including headings, body text, lists, and more.
 | delete | Deleted line style | boolean | false |  |
 | disabled | Disabled content | boolean | false |  |
 | editable | Editable. Can control edit state when is object | boolean \| { editing: boolean, onStart: Function, onChange: Function(string) } | false |  |
-| ellipsis | Display ellipsis when text overflows. Can configure rows and expandable by using object | boolean \| { rows: number, expandable: boolean, onExpand: Function } | false |  |
+| ellipsis | Display ellipsis when text overflows. Can configure rows and expandable by using object | boolean \| { rows: number, expandable: boolean, onExpand: Function(event) } | false |  |
 | level | Set content importance. Match with `h1`, `h2`, `h3`, `h4` | number: `1`, `2`, `3`, `4` | 1 |  |
 | mark | Marked style | boolean | false |  |
 | underline | Underlined style | boolean | false |  |
@@ -55,7 +55,7 @@ Basic text writing, including headings, body text, lists, and more.
 | delete | Deleted line style | boolean | false |  |
 | disabled | Disabled content | boolean | false |  |
 | editable | Editable. Can control edit state when is object | boolean \| { editing: boolean, onStart: Function, onChange: Function(string) } | false |  |
-| ellipsis | Display ellipsis when text overflows. Can configure rows expandable and suffix by using object | boolean \| { rows: number, expandable: boolean suffix: string, onExpand: Function } | false |  |
+| ellipsis | Display ellipsis when text overflows. Can configure rows expandable and suffix by using object | boolean \| { rows: number, expandable: boolean suffix: string, onExpand: Function(event) } | false |  |
 | mark | Marked style | boolean | false |  |
 | underline | Underlined style | boolean | false |  |
 | onChange | Trigger when user edits the content | Function(string) | - |  |


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->
The Ellipses `onExpand` function in `Typography.Paragraph` doesn't have an event parameter, meaning you can't handle browser events `onClick`. An example I ran into was wanting to have an expandable ellipses on a table with it's own row click event. Without this event handler, I cannot stop propagation and prevent the row click event from executing.
### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->
Current usage: ` { rows: 1, expandable: true, onExpand: () => {// do something} }`
New usage: ` { rows: 1, expandable: true, onExpand: (e) => {// do something with e} }`

This shouldn't break any existing usage as passing a function prototype with no parameters works the same as before.
| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️ 

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/typography/index.en-US.md](https://github.com/BlazPocrnja/ant-design/blob/feature/components/typography/index.en-US.md)