### PR TITLE
fix: Menu inlineCollpsed item title

### DIFF
--- a/components/menu/style/index.less
+++ b/components/menu/style/index.less
@@ -520,6 +520,11 @@
         }
       }
     }
+
+    .@{iconfont-css-prefix} {
+      display: inline-block;
+    }
+
     &-tooltip {
       pointer-events: none;
       .@{iconfont-css-prefix} {
@@ -536,9 +541,6 @@
       overflow: hidden;
       white-space: nowrap;
       text-overflow: ellipsis;
-    }
-    .anticon {
-      display: inline-block;
     }
   }
 


### PR DESCRIPTION




<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close #22180

### 💡 Background and solution

When set getPopupContainer to trigger node.

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Menu item wrong `title` when setting `getPopupContainer`. |
| 🇨🇳 Chinese | 修复 Menu `inlineCollpased` 模式下设置 `getPopupContainer` 时 `title` 显示错误的问题。 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️ 

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
