### PR TITLE
fix: inputgroup search icon

### DIFF
--- a/components/input/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/input/__tests__/__snapshots__/demo.test.js.snap
@@ -1075,6 +1075,52 @@ exports[`renders ./components/input/demo/group.md correctly 1`] = `
   <span
     class="ant-input-group ant-input-group-compact"
   >
+    <input
+      class="ant-input"
+      style="width:20%"
+      type="text"
+      value="0571"
+    />
+    <span
+      class="ant-input-search ant-input-affix-wrapper"
+      style="width:30%"
+    >
+      <input
+        class="ant-input"
+        type="text"
+        value="26888888"
+      />
+      <span
+        class="ant-input-suffix"
+      >
+        <span
+          aria-label="search"
+          class="anticon anticon-search ant-input-search-icon"
+          role="img"
+          tabindex="-1"
+        >
+          <svg
+            aria-hidden="true"
+            class=""
+            data-icon="search"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M909.6 854.5L649.9 594.8C690.2 542.7 712 479 712 412c0-80.2-31.3-155.4-87.9-212.1-56.6-56.7-132-87.9-212.1-87.9s-155.5 31.3-212.1 87.9C143.2 256.5 112 331.8 112 412c0 80.1 31.3 155.5 87.9 212.1C256.5 680.8 331.8 712 412 712c67 0 130.6-21.8 182.7-62l259.7 259.6a8.2 8.2 0 0011.6 0l43.6-43.5a8.2 8.2 0 000-11.6zM570.4 570.4C528 612.7 471.8 636 412 636s-116-23.3-158.4-65.6C211.3 528 188 471.8 188 412s23.3-116.1 65.6-158.4C296 211.3 352.2 188 412 188s116.1 23.2 158.4 65.6S636 352.2 636 412s-23.3 116.1-65.6 158.4z"
+            />
+          </svg>
+        </span>
+      </span>
+    </span>
+  </span>
+  <br />
+  <span
+    class="ant-input-group ant-input-group-compact"
+  >
     <div
       class="ant-select ant-select-single ant-select-show-arrow"
     >

--- a/components/input/demo/group.md
+++ b/components/input/demo/group.md
@@ -84,6 +84,11 @@ const App = () => (
     </Input.Group>
     <br />
     <Input.Group compact>
+      <Input style={{ width: '20%' }} defaultValue="0571" />
+      <Input.Search style={{ width: '30%' }} defaultValue="26888888" />
+    </Input.Group>
+    <br />
+    <Input.Group compact>
       <Select defaultValue="Option1">
         <Option value="Option1">Option1</Option>
         <Option value="Option2">Option2</Option>

--- a/components/input/style/mixin.less
+++ b/components/input/style/mixin.less
@@ -339,7 +339,7 @@
     }
 
     & > * {
-      display: inline-block;
+      display: inline-flex;
       float: none;
       vertical-align: top; // https://github.com/ant-design/ant-design-pro/issues/139
       border-radius: 0;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
close https://github.com/ant-design/ant-design/issues/22193
<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |Fixed the problem of using custom icons to wrap in Input.Group  |
| 🇨🇳 Chinese | 修复Input.Group 中使用 自定义图标换行的问题           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️ 

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/input/demo/group.md](https://github.com/ant-design/ant-design/blob/fix-inputgroup-style/components/input/demo/group.md)