### PR TITLE
feat: Menu.Item Tooltip could be hidden by title prop

### DIFF
--- a/components/menu/MenuItem.tsx
+++ b/components/menu/MenuItem.tsx
@@ -47,6 +47,8 @@ export default class MenuItem extends React.Component<MenuItemProps> {
           let tooltipTitle = title;
           if (typeof title === 'undefined') {
             tooltipTitle = level === 1 ? children : '';
+          } else if (title === false) {
+            tooltipTitle = '';
           }
           const tooltipProps: TooltipProps = {
             title: tooltipTitle,

--- a/components/menu/MenuItem.tsx
+++ b/components/menu/MenuItem.tsx
@@ -44,8 +44,12 @@ export default class MenuItem extends React.Component<MenuItemProps> {
     return (
       <MenuContext.Consumer>
         {({ inlineCollapsed, direction }: MenuContextProps) => {
+          let tooltipTitle = title;
+          if (typeof title === 'undefined') {
+            tooltipTitle = level === 1 ? children : '';
+          }
           const tooltipProps: TooltipProps = {
-            title: title || (level === 1 ? children : ''),
+            title: tooltipTitle,
           };
 
           if (!siderCollapsed && !inlineCollapsed) {

--- a/components/menu/__tests__/index.test.js
+++ b/components/menu/__tests__/index.test.js
@@ -396,12 +396,16 @@ describe('Menu', () => {
         <Menu.Item key="menu5" title="">
           item
         </Menu.Item>
+        <Menu.Item key="menu6" title={false}>
+          item
+        </Menu.Item>
       </Menu>,
     );
     expect(wrapper.find(Menu.Item).at(0).find(Tooltip).props().title).toBe('item');
     expect(wrapper.find(Menu.Item).at(1).find(Tooltip).props().title).toBe('title');
     expect(wrapper.find(Menu.Item).at(2).find(Tooltip).props().title).toBe('item');
     expect(wrapper.find(Menu.Item).at(3).find(Tooltip).props().title).toBe(null);
+    expect(wrapper.find(Menu.Item).at(4).find(Tooltip).props().title).toBe('');
     expect(wrapper.find(Menu.Item).at(4).find(Tooltip).props().title).toBe('');
   });
 

--- a/components/menu/__tests__/index.test.js
+++ b/components/menu/__tests__/index.test.js
@@ -3,6 +3,7 @@ import { mount } from 'enzyme';
 import Menu from '..';
 import Icon from '../../icon';
 import Layout from '../../layout';
+import Tooltip from '../../tooltip';
 import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
 import { resetWarned } from '../../_util/warning';
@@ -370,6 +371,38 @@ describe('Menu', () => {
         .at(0)
         .hasClass('ant-menu-hidden'),
     ).toBe(false);
+  });
+
+  it('inlineCollapsed Menu.Item Tooltip can be removed', () => {
+    const wrapper = mount(
+      <Menu
+        defaultOpenKeys={['not-existed']}
+        mode="inline"
+        inlineCollapsed
+        getPopupContainer={node => node.parentNode}
+      >
+        <Menu.Item key="menu1">
+          item
+        </Menu.Item>
+        <Menu.Item key="menu2" title="title">
+          item
+        </Menu.Item>
+        <Menu.Item key="menu3" title={undefined}>
+          item
+        </Menu.Item>
+        <Menu.Item key="menu4" title={null}>
+          item
+        </Menu.Item>
+        <Menu.Item key="menu5" title="">
+          item
+        </Menu.Item>
+      </Menu>,
+    );
+    expect(wrapper.find(Menu.Item).at(0).find(Tooltip).props().title).toBe('item');
+    expect(wrapper.find(Menu.Item).at(1).find(Tooltip).props().title).toBe('title');
+    expect(wrapper.find(Menu.Item).at(2).find(Tooltip).props().title).toBe('item');
+    expect(wrapper.find(Menu.Item).at(3).find(Tooltip).props().title).toBe(null);
+    expect(wrapper.find(Menu.Item).at(4).find(Tooltip).props().title).toBe('');
   });
 
   describe('open submenu when click submenu title', () => {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close #11252

### 💡 Background and solution

This will allow us using `title` to hide default Tooltip on menu item.

```jsx
        <Menu.Item key="menu4" title={null}>
          item
        </Menu.Item>
        <Menu.Item key="menu5" title="">
          item
        </Menu.Item>
```

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Menu.Item Tooltip could be hidden by falsy `title` prop. |
| 🇨🇳 Chinese | Menu.Item 上的 Tooltip 现在可以使用 `title={null}` 来禁用。|

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️ 

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
