### PR TITLE
fix(#16762): should use cachedOptions when filtered options don't cange

### DIFF
--- a/components/cascader/__tests__/index.test.js
+++ b/components/cascader/__tests__/index.test.js
@@ -335,6 +335,18 @@ describe('Cascader', () => {
     expect(wrapper.find('.ant-cascader-menu-item').length).toBe(1);
   });
 
+  it('should select item immediately when searching and pressing down arrow key', () => {
+    const wrapper = mount(<Cascader options={options} showSearch={{ filter }} />);
+    wrapper.find('input').simulate('click');
+    wrapper.find('input').simulate('change', { target: { value: 'a' } });
+    expect(wrapper.find('.ant-cascader-menu-item').length).toBe(2);
+    expect(wrapper.find('.ant-cascader-menu-item-active').length).toBe(0);
+    wrapper.find('input').simulate('keyDown', {
+      keyCode: KeyCode.DOWN,
+    });
+    expect(wrapper.find('.ant-cascader-menu-item-active').length).toBe(1);
+  });
+
   it('can use fieldNames', () => {
     const customerOptions = [
       {

--- a/components/cascader/index.tsx
+++ b/components/cascader/index.tsx
@@ -3,6 +3,7 @@ import RcCascader from 'rc-cascader';
 import arrayTreeFilter from 'array-tree-filter';
 import classNames from 'classnames';
 import omit from 'omit.js';
+import isEqual from 'lodash/isEqual';
 import KeyCode from 'rc-util/lib/KeyCode';
 import CloseCircleFilled from '@ant-design/icons/CloseCircleFilled';
 import DownOutlined from '@ant-design/icons/DownOutlined';
@@ -522,6 +523,9 @@ class Cascader extends React.Component<CascaderProps, CascaderState> {
         if (options && options.length > 0) {
           if (state.inputValue) {
             options = this.generateFilteredOptions(prefixCls, renderEmpty);
+            if (isEqual(options, this.cachedOptions)) {
+              options = this.cachedOptions;
+            }
           }
         } else {
           options = [


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close #16762

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Cascader search need to press down arrow twice to select item(#16762)       |
| 🇨🇳 Chinese |  修复 Cascader 搜索时需要按两次向下箭头才能选中问题(#16762)         |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️ 

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
