### PR TITLE
fix: timeline pendingDot default value in docs

### DIFF
--- a/components/timeline/index.en-US.md
+++ b/components/timeline/index.en-US.md
@@ -29,7 +29,7 @@ Timeline
 | Property | Description | Type | Default |
 | --- | --- | --- | --- |
 | pending | Set the last ghost node's existence or its content | boolean\|string\|ReactNode | `false` |
-| pendingDot | Set the dot of the last ghost node when pending is true | string\|ReactNode | `<Icon type="loading" />` |
+| pendingDot | Set the dot of the last ghost node when pending is true | string\|ReactNode | `<LoadingOutlined />` |
 | reverse | reverse nodes or not | boolean | false |
 | mode | By sending `alternate` the timeline will distribute the nodes to the left and right. | `left` \| `alternate` \| `right` | - |
 

--- a/components/timeline/index.zh-CN.md
+++ b/components/timeline/index.zh-CN.md
@@ -30,7 +30,7 @@ title: Timeline
 | 参数 | 说明 | 类型 | 默认值 |
 | --- | --- | --- | --- |
 | pending | 指定最后一个幽灵节点是否存在或内容 | boolean\|string\|ReactNode | false |
-| pendingDot | 当最后一个幽灵节点存在時，指定其时间图点 | string\|ReactNode | `<Icon type="loading" />` |
+| pendingDot | 当最后一个幽灵节点存在時，指定其时间图点 | string\|ReactNode | `<LoadingOutlined />` |
 | reverse | 节点排序 | boolean | false |
 | mode | 通过设置 `mode` 可以改变时间轴和内容的相对位置 | `left` \| `alternate` \| `right` | - |
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | timeline pendingDot default value docs |
| 🇨🇳 Chinese | timeline pendingDot default value docs |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️ 

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/timeline/index.en-US.md](https://github.com/Eslam-Yahya/ant-design/blob/master/components/timeline/index.en-US.md)
[View rendered components/timeline/index.zh-CN.md](https://github.com/Eslam-Yahya/ant-design/blob/master/components/timeline/index.zh-CN.md)