### PR TITLE
refactor: Adjust Radio.Group logic that value is undefined should be uncontrolled mode.

### DIFF
--- a/components/radio/__tests__/group.test.js
+++ b/components/radio/__tests__/group.test.js
@@ -170,10 +170,35 @@ describe('Radio Group', () => {
   });
 
   it('passes prefixCls down to radio', () => {
-    const options = [{ label: 'Apple', value: 'Apple' }, { label: 'Orange', value: 'Orange', style: { fontSize: 12 } }];
+    const options = [
+      { label: 'Apple', value: 'Apple' },
+      { label: 'Orange', value: 'Orange', style: { fontSize: 12 } },
+    ];
 
     const wrapper = render(<RadioGroup prefixCls="my-radio" options={options} />);
 
     expect(wrapper).toMatchSnapshot();
+  });
+
+  describe('value is null or undefined', () => {
+    it('use `defaultValue` when `value` is undefined', () => {
+      const options = [{ label: 'Bamboo', value: 'bamboo' }];
+      const wrapper = mount(
+        <RadioGroup defaultValue="bamboo" value={undefined} options={options} />,
+      );
+
+      expect(wrapper.state().value).toEqual('bamboo');
+    });
+
+    [undefined, null].forEach(newValue => {
+      it(`should set value back when value change back to ${newValue}`, () => {
+        const options = [{ label: 'Bamboo', value: 'bamboo' }];
+        const wrapper = mount(<RadioGroup value="bamboo" options={options} />);
+        expect(wrapper.state().value).toEqual('bamboo');
+
+        wrapper.setProps({ value: newValue });
+        expect(wrapper.state().value).toEqual(undefined);
+      });
+    });
   });
 });

--- a/components/radio/__tests__/group.test.js
+++ b/components/radio/__tests__/group.test.js
@@ -197,7 +197,7 @@ describe('Radio Group', () => {
         expect(wrapper.state().value).toEqual('bamboo');
 
         wrapper.setProps({ value: newValue });
-        expect(wrapper.state().value).toEqual(undefined);
+        expect(wrapper.state().value).toEqual(newValue);
       });
     });
   });

--- a/components/radio/group.tsx
+++ b/components/radio/group.tsx
@@ -28,28 +28,29 @@ class RadioGroup extends React.PureComponent<RadioGroupProps, RadioGroupState> {
     buttonStyle: 'outline' as RadioGroupButtonStyle,
   };
 
-  static getDerivedStateFromProps(nextProps: RadioGroupProps) {
-    if ('value' in nextProps) {
-      return {
-        value: nextProps.value,
-      };
-    }
-    const checkedValue = getCheckedValue(nextProps.children);
-    if (checkedValue) {
-      return {
-        value: checkedValue.value,
-      };
+  static getDerivedStateFromProps(nextProps: RadioGroupProps, prevState: RadioGroupState) {
+    const newState: Partial<RadioGroupState> = {
+      prevPropValue: nextProps.value,
+    };
+
+    if (nextProps.value !== undefined || prevState.prevPropValue !== nextProps.value) {
+      newState.value = nextProps.value;
+    } else {
+      const checkedValue = getCheckedValue(nextProps.children);
+      if (checkedValue) {
+        newState.value = checkedValue.value;
+      }
     }
 
-    return null;
+    return newState;
   }
 
   constructor(props: RadioGroupProps) {
     super(props);
     let value;
-    if ('value' in props) {
+    if (props.value !== undefined) {
       value = props.value;
-    } else if ('defaultValue' in props) {
+    } else if (props.defaultValue !== undefined) {
       value = props.defaultValue;
     } else {
       const checkedValue = getCheckedValue(props.children);
@@ -57,6 +58,7 @@ class RadioGroup extends React.PureComponent<RadioGroupProps, RadioGroupState> {
     }
     this.state = {
       value,
+      prevPropValue: props.value,
     };
   }
 

--- a/components/radio/interface.tsx
+++ b/components/radio/interface.tsx
@@ -20,6 +20,7 @@ export interface RadioGroupProps extends AbstractCheckboxGroupProps {
 
 export interface RadioGroupState {
   value: any;
+  prevPropValue: any;
 }
 
 export interface RadioGroupContextProps {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [x] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

resolve #22209

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Adjust Radio.Group logic that `value` is `undefined` should be uncontrolled mode.       |
| 🇨🇳 Chinese |    调整 Radio.Group 逻辑，`value` 为 `undefined` 时为非受控状态。       |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️ 

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
