### PR TITLE
feat: 🆕 Add keyboard prop to Tabs

### DIFF
--- a/components/card/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/card/__tests__/__snapshots__/demo.test.js.snap
@@ -846,7 +846,7 @@ exports[`renders ./components/card/demo/tabs.md correctly 1`] = `
         <div
           class="ant-tabs-bar ant-tabs-top-bar ant-tabs-large-bar"
           role="tablist"
-          tabindex="0"
+          tabindex="-1"
         >
           <div
             class="ant-tabs-nav-container"
@@ -920,18 +920,24 @@ exports[`renders ./components/card/demo/tabs.md correctly 1`] = `
                 >
                   <div>
                     <div
+                      aria-controls="tabpane-tab1"
                       aria-disabled="false"
                       aria-selected="true"
                       class="ant-tabs-tab-active ant-tabs-tab"
+                      id="tab-tab1"
                       role="tab"
+                      tabindex="0"
                     >
                       tab1
                     </div>
                     <div
+                      aria-controls="tabpane-tab2"
                       aria-disabled="false"
                       aria-selected="false"
                       class=" ant-tabs-tab"
+                      id="tab-tab2"
                       role="tab"
+                      tabindex="-1"
                     >
                       tab2
                     </div>
@@ -945,11 +951,6 @@ exports[`renders ./components/card/demo/tabs.md correctly 1`] = `
           </div>
         </div>
         <div
-          role="presentation"
-          style="width:0;height:0;overflow:hidden;position:absolute"
-          tabindex="0"
-        />
-        <div
           class="ant-tabs-content ant-tabs-content-animated ant-tabs-top-content"
           style="margin-left:0%"
         >
@@ -957,29 +958,17 @@ exports[`renders ./components/card/demo/tabs.md correctly 1`] = `
             aria-hidden="false"
             class="ant-tabs-tabpane ant-tabs-tabpane-active"
             role="tabpanel"
-          >
-            <div
-              role="presentation"
-              style="width:0;height:0;overflow:hidden;position:absolute"
-              tabindex="0"
-            />
-            <div
-              role="presentation"
-              style="width:0;height:0;overflow:hidden;position:absolute"
-              tabindex="0"
-            />
-          </div>
+            style="visibility:visible"
+            tabindex="0"
+          />
           <div
             aria-hidden="true"
             class="ant-tabs-tabpane ant-tabs-tabpane-inactive"
             role="tabpanel"
+            style="visibility:hidden"
+            tabindex="-1"
           />
         </div>
-        <div
-          role="presentation"
-          style="width:0;height:0;overflow:hidden;position:absolute"
-          tabindex="0"
-        />
       </div>
     </div>
     <div
@@ -1008,7 +997,7 @@ exports[`renders ./components/card/demo/tabs.md correctly 1`] = `
         <div
           class="ant-tabs-bar ant-tabs-top-bar ant-tabs-large-bar"
           role="tablist"
-          tabindex="0"
+          tabindex="-1"
         >
           <div
             class="ant-tabs-extra-content"
@@ -1092,26 +1081,35 @@ exports[`renders ./components/card/demo/tabs.md correctly 1`] = `
                 >
                   <div>
                     <div
+                      aria-controls="tabpane-article"
                       aria-disabled="false"
                       aria-selected="false"
                       class=" ant-tabs-tab"
+                      id="tab-article"
                       role="tab"
+                      tabindex="-1"
                     >
                       article
                     </div>
                     <div
+                      aria-controls="tabpane-app"
                       aria-disabled="false"
                       aria-selected="true"
                       class="ant-tabs-tab-active ant-tabs-tab"
+                      id="tab-app"
                       role="tab"
+                      tabindex="0"
                     >
                       app
                     </div>
                     <div
+                      aria-controls="tabpane-project"
                       aria-disabled="false"
                       aria-selected="false"
                       class=" ant-tabs-tab"
+                      id="tab-project"
                       role="tab"
+                      tabindex="-1"
                     >
                       project
                     </div>
@@ -1125,11 +1123,6 @@ exports[`renders ./components/card/demo/tabs.md correctly 1`] = `
           </div>
         </div>
         <div
-          role="presentation"
-          style="width:0;height:0;overflow:hidden;position:absolute"
-          tabindex="0"
-        />
-        <div
           class="ant-tabs-content ant-tabs-content-animated ant-tabs-top-content"
           style="margin-left:-100%"
         >
@@ -1137,34 +1130,24 @@ exports[`renders ./components/card/demo/tabs.md correctly 1`] = `
             aria-hidden="true"
             class="ant-tabs-tabpane ant-tabs-tabpane-inactive"
             role="tabpanel"
+            style="visibility:hidden"
+            tabindex="-1"
           />
           <div
             aria-hidden="false"
             class="ant-tabs-tabpane ant-tabs-tabpane-active"
             role="tabpanel"
-          >
-            <div
-              role="presentation"
-              style="width:0;height:0;overflow:hidden;position:absolute"
-              tabindex="0"
-            />
-            <div
-              role="presentation"
-              style="width:0;height:0;overflow:hidden;position:absolute"
-              tabindex="0"
-            />
-          </div>
+            style="visibility:visible"
+            tabindex="0"
+          />
           <div
             aria-hidden="true"
             class="ant-tabs-tabpane ant-tabs-tabpane-inactive"
             role="tabpanel"
+            style="visibility:hidden"
+            tabindex="-1"
           />
         </div>
-        <div
-          role="presentation"
-          style="width:0;height:0;overflow:hidden;position:absolute"
-          tabindex="0"
-        />
       </div>
     </div>
     <div

--- a/components/config-provider/__tests__/__snapshots__/components.test.js.snap
+++ b/components/config-provider/__tests__/__snapshots__/components.test.js.snap
@@ -12631,7 +12631,7 @@ exports[`ConfigProvider components Tabs configProvider 1`] = `
   <div
     class="config-tabs-bar config-tabs-top-bar"
     role="tablist"
-    tabindex="0"
+    tabindex="-1"
   >
     <div
       class="config-tabs-nav-container"
@@ -12705,10 +12705,13 @@ exports[`ConfigProvider components Tabs configProvider 1`] = `
           >
             <div>
               <div
+                aria-controls="tabpane-Light"
                 aria-disabled="false"
                 aria-selected="true"
                 class="config-tabs-tab-active config-tabs-tab"
+                id="tab-Light"
                 role="tab"
+                tabindex="0"
               >
                 Bamboo
               </div>
@@ -12722,11 +12725,6 @@ exports[`ConfigProvider components Tabs configProvider 1`] = `
     </div>
   </div>
   <div
-    role="presentation"
-    style="width:0;height:0;overflow:hidden;position:absolute"
-    tabindex="0"
-  />
-  <div
     class="config-tabs-content config-tabs-content-animated config-tabs-top-content"
     style="margin-left:0%"
   >
@@ -12734,24 +12732,10 @@ exports[`ConfigProvider components Tabs configProvider 1`] = `
       aria-hidden="false"
       class="config-tabs-tabpane config-tabs-tabpane-active"
       role="tabpanel"
-    >
-      <div
-        role="presentation"
-        style="width:0;height:0;overflow:hidden;position:absolute"
-        tabindex="0"
-      />
-      <div
-        role="presentation"
-        style="width:0;height:0;overflow:hidden;position:absolute"
-        tabindex="0"
-      />
-    </div>
+      style="visibility:visible"
+      tabindex="0"
+    />
   </div>
-  <div
-    role="presentation"
-    style="width:0;height:0;overflow:hidden;position:absolute"
-    tabindex="0"
-  />
 </div>
 `;
 
@@ -12762,7 +12746,7 @@ exports[`ConfigProvider components Tabs normal 1`] = `
   <div
     class="ant-tabs-bar ant-tabs-top-bar"
     role="tablist"
-    tabindex="0"
+    tabindex="-1"
   >
     <div
       class="ant-tabs-nav-container"
@@ -12836,10 +12820,13 @@ exports[`ConfigProvider components Tabs normal 1`] = `
           >
             <div>
               <div
+                aria-controls="tabpane-Light"
                 aria-disabled="false"
                 aria-selected="true"
                 class="ant-tabs-tab-active ant-tabs-tab"
+                id="tab-Light"
                 role="tab"
+                tabindex="0"
               >
                 Bamboo
               </div>
@@ -12853,11 +12840,6 @@ exports[`ConfigProvider components Tabs normal 1`] = `
     </div>
   </div>
   <div
-    role="presentation"
-    style="width:0;height:0;overflow:hidden;position:absolute"
-    tabindex="0"
-  />
-  <div
     class="ant-tabs-content ant-tabs-content-animated ant-tabs-top-content"
     style="margin-left:0%"
   >
@@ -12865,24 +12847,10 @@ exports[`ConfigProvider components Tabs normal 1`] = `
       aria-hidden="false"
       class="ant-tabs-tabpane ant-tabs-tabpane-active"
       role="tabpanel"
-    >
-      <div
-        role="presentation"
-        style="width:0;height:0;overflow:hidden;position:absolute"
-        tabindex="0"
-      />
-      <div
-        role="presentation"
-        style="width:0;height:0;overflow:hidden;position:absolute"
-        tabindex="0"
-      />
-    </div>
+      style="visibility:visible"
+      tabindex="0"
+    />
   </div>
-  <div
-    role="presentation"
-    style="width:0;height:0;overflow:hidden;position:absolute"
-    tabindex="0"
-  />
 </div>
 `;
 
@@ -12893,7 +12861,7 @@ exports[`ConfigProvider components Tabs prefixCls 1`] = `
   <div
     class="prefix-Tabs-bar prefix-Tabs-top-bar"
     role="tablist"
-    tabindex="0"
+    tabindex="-1"
   >
     <div
       class="prefix-Tabs-nav-container"
@@ -12967,10 +12935,13 @@ exports[`ConfigProvider components Tabs prefixCls 1`] = `
           >
             <div>
               <div
+                aria-controls="tabpane-Light"
                 aria-disabled="false"
                 aria-selected="true"
                 class="prefix-Tabs-tab-active prefix-Tabs-tab"
+                id="tab-Light"
                 role="tab"
+                tabindex="0"
               >
                 Bamboo
               </div>
@@ -12984,11 +12955,6 @@ exports[`ConfigProvider components Tabs prefixCls 1`] = `
     </div>
   </div>
   <div
-    role="presentation"
-    style="width:0;height:0;overflow:hidden;position:absolute"
-    tabindex="0"
-  />
-  <div
     class="prefix-Tabs-content prefix-Tabs-content-animated prefix-Tabs-top-content"
     style="margin-left:0%"
   >
@@ -12996,24 +12962,10 @@ exports[`ConfigProvider components Tabs prefixCls 1`] = `
       aria-hidden="false"
       class="prefix-Tabs-tabpane prefix-Tabs-tabpane-active"
       role="tabpanel"
-    >
-      <div
-        role="presentation"
-        style="width:0;height:0;overflow:hidden;position:absolute"
-        tabindex="0"
-      />
-      <div
-        role="presentation"
-        style="width:0;height:0;overflow:hidden;position:absolute"
-        tabindex="0"
-      />
-    </div>
+      style="visibility:visible"
+      tabindex="0"
+    />
   </div>
-  <div
-    role="presentation"
-    style="width:0;height:0;overflow:hidden;position:absolute"
-    tabindex="0"
-  />
 </div>
 `;
 

--- a/components/list/__tests__/__snapshots__/pagination.test.js.snap
+++ b/components/list/__tests__/__snapshots__/pagination.test.js.snap
@@ -348,7 +348,7 @@ exports[`List.pagination should change page size work 2`] = `
           class="ant-select-selection-search"
         >
           <input
-            aria-activedescendant="rc_select_TEST_OR_SSR_list_2"
+            aria-activedescendant="rc_select_TEST_OR_SSR_list_0"
             aria-autocomplete="list"
             aria-controls="rc_select_TEST_OR_SSR_list"
             aria-expanded="true"
@@ -382,24 +382,17 @@ exports[`List.pagination should change page size work 2`] = `
             >
               <div
                 aria-selected="false"
+                id="rc_select_TEST_OR_SSR_list_0"
+                role="option"
+              >
+                10
+              </div>
+              <div
+                aria-selected="false"
                 id="rc_select_TEST_OR_SSR_list_1"
                 role="option"
               >
                 20
-              </div>
-              <div
-                aria-selected="true"
-                id="rc_select_TEST_OR_SSR_list_2"
-                role="option"
-              >
-                30
-              </div>
-              <div
-                aria-selected="false"
-                id="rc_select_TEST_OR_SSR_list_3"
-                role="option"
-              >
-                40
               </div>
             </div>
             <div
@@ -413,7 +406,7 @@ exports[`List.pagination should change page size work 2`] = `
                 >
                   <div
                     aria-selected="false"
-                    class="ant-select-item ant-select-item-option"
+                    class="ant-select-item ant-select-item-option ant-select-item-option-active"
                   >
                     <div
                       class="ant-select-item-option-content"
@@ -445,7 +438,7 @@ exports[`List.pagination should change page size work 2`] = `
                   </div>
                   <div
                     aria-selected="true"
-                    class="ant-select-item ant-select-item-option ant-select-item-option-active ant-select-item-option-selected"
+                    class="ant-select-item ant-select-item-option ant-select-item-option-selected"
                   >
                     <div
                       class="ant-select-item-option-content"
@@ -508,9 +501,6 @@ exports[`List.pagination should change page size work 2`] = `
           </svg>
         </span>
       </span>
-      <div
-        style="position: absolute; top: 0px; left: 0px; width: 100%;"
-      />
       <div
         style="position: absolute; top: 0px; left: 0px; width: 100%;"
       />

--- a/components/page-header/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/page-header/__tests__/__snapshots__/demo.test.js.snap
@@ -1138,7 +1138,7 @@ exports[`renders ./components/page-header/demo/responsive.md correctly 1`] = `
         <div
           class="ant-tabs-bar ant-tabs-top-bar"
           role="tablist"
-          tabindex="0"
+          tabindex="-1"
         >
           <div
             class="ant-tabs-nav-container"
@@ -1212,18 +1212,24 @@ exports[`renders ./components/page-header/demo/responsive.md correctly 1`] = `
                 >
                   <div>
                     <div
+                      aria-controls="tabpane-1"
                       aria-disabled="false"
                       aria-selected="true"
                       class="ant-tabs-tab-active ant-tabs-tab"
+                      id="tab-1"
                       role="tab"
+                      tabindex="0"
                     >
                       Details
                     </div>
                     <div
+                      aria-controls="tabpane-2"
                       aria-disabled="false"
                       aria-selected="false"
                       class=" ant-tabs-tab"
+                      id="tab-2"
                       role="tab"
+                      tabindex="-1"
                     >
                       Rule
                     </div>
@@ -1237,11 +1243,6 @@ exports[`renders ./components/page-header/demo/responsive.md correctly 1`] = `
           </div>
         </div>
         <div
-          role="presentation"
-          style="width:0;height:0;overflow:hidden;position:absolute"
-          tabindex="0"
-        />
-        <div
           class="ant-tabs-content ant-tabs-content-animated ant-tabs-top-content"
           style="margin-left:0%"
         >
@@ -1249,29 +1250,17 @@ exports[`renders ./components/page-header/demo/responsive.md correctly 1`] = `
             aria-hidden="false"
             class="ant-tabs-tabpane ant-tabs-tabpane-active"
             role="tabpanel"
-          >
-            <div
-              role="presentation"
-              style="width:0;height:0;overflow:hidden;position:absolute"
-              tabindex="0"
-            />
-            <div
-              role="presentation"
-              style="width:0;height:0;overflow:hidden;position:absolute"
-              tabindex="0"
-            />
-          </div>
+            style="visibility:visible"
+            tabindex="0"
+          />
           <div
             aria-hidden="true"
             class="ant-tabs-tabpane ant-tabs-tabpane-inactive"
             role="tabpanel"
+            style="visibility:hidden"
+            tabindex="-1"
           />
         </div>
-        <div
-          role="presentation"
-          style="width:0;height:0;overflow:hidden;position:absolute"
-          tabindex="0"
-        />
       </div>
     </div>
   </div>

--- a/components/tabs/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/tabs/__tests__/__snapshots__/demo.test.js.snap
@@ -7,7 +7,7 @@ exports[`renders ./components/tabs/demo/basic.md correctly 1`] = `
   <div
     class="ant-tabs-bar ant-tabs-top-bar"
     role="tablist"
-    tabindex="0"
+    tabindex="-1"
   >
     <div
       class="ant-tabs-nav-container"
@@ -81,26 +81,35 @@ exports[`renders ./components/tabs/demo/basic.md correctly 1`] = `
           >
             <div>
               <div
+                aria-controls="tabpane-1"
                 aria-disabled="false"
                 aria-selected="true"
                 class="ant-tabs-tab-active ant-tabs-tab"
+                id="tab-1"
                 role="tab"
+                tabindex="0"
               >
                 Tab 1
               </div>
               <div
+                aria-controls="tabpane-2"
                 aria-disabled="false"
                 aria-selected="false"
                 class=" ant-tabs-tab"
+                id="tab-2"
                 role="tab"
+                tabindex="-1"
               >
                 Tab 2
               </div>
               <div
+                aria-controls="tabpane-3"
                 aria-disabled="false"
                 aria-selected="false"
                 class=" ant-tabs-tab"
+                id="tab-3"
                 role="tab"
+                tabindex="-1"
               >
                 Tab 3
               </div>
@@ -114,11 +123,6 @@ exports[`renders ./components/tabs/demo/basic.md correctly 1`] = `
     </div>
   </div>
   <div
-    role="presentation"
-    style="width:0;height:0;overflow:hidden;position:absolute"
-    tabindex="0"
-  />
-  <div
     class="ant-tabs-content ant-tabs-content-animated ant-tabs-top-content"
     style="margin-left:0%"
   >
@@ -126,35 +130,26 @@ exports[`renders ./components/tabs/demo/basic.md correctly 1`] = `
       aria-hidden="false"
       class="ant-tabs-tabpane ant-tabs-tabpane-active"
       role="tabpanel"
+      style="visibility:visible"
+      tabindex="0"
     >
-      <div
-        role="presentation"
-        style="width:0;height:0;overflow:hidden;position:absolute"
-        tabindex="0"
-      />
       Content of Tab Pane 1
-      <div
-        role="presentation"
-        style="width:0;height:0;overflow:hidden;position:absolute"
-        tabindex="0"
-      />
     </div>
     <div
       aria-hidden="true"
       class="ant-tabs-tabpane ant-tabs-tabpane-inactive"
       role="tabpanel"
+      style="visibility:hidden"
+      tabindex="-1"
     />
     <div
       aria-hidden="true"
       class="ant-tabs-tabpane ant-tabs-tabpane-inactive"
       role="tabpanel"
+      style="visibility:hidden"
+      tabindex="-1"
     />
   </div>
-  <div
-    role="presentation"
-    style="width:0;height:0;overflow:hidden;position:absolute"
-    tabindex="0"
-  />
 </div>
 `;
 
@@ -165,7 +160,7 @@ exports[`renders ./components/tabs/demo/card.md correctly 1`] = `
   <div
     class="ant-tabs-bar ant-tabs-top-bar ant-tabs-card-bar"
     role="tablist"
-    tabindex="0"
+    tabindex="-1"
   >
     <div
       class="ant-tabs-nav-container"
@@ -239,26 +234,35 @@ exports[`renders ./components/tabs/demo/card.md correctly 1`] = `
           >
             <div>
               <div
+                aria-controls="tabpane-1"
                 aria-disabled="false"
                 aria-selected="true"
                 class="ant-tabs-tab-active ant-tabs-tab"
+                id="tab-1"
                 role="tab"
+                tabindex="0"
               >
                 Tab 1
               </div>
               <div
+                aria-controls="tabpane-2"
                 aria-disabled="false"
                 aria-selected="false"
                 class=" ant-tabs-tab"
+                id="tab-2"
                 role="tab"
+                tabindex="-1"
               >
                 Tab 2
               </div>
               <div
+                aria-controls="tabpane-3"
                 aria-disabled="false"
                 aria-selected="false"
                 class=" ant-tabs-tab"
+                id="tab-3"
                 role="tab"
+                tabindex="-1"
               >
                 Tab 3
               </div>
@@ -272,46 +276,32 @@ exports[`renders ./components/tabs/demo/card.md correctly 1`] = `
     </div>
   </div>
   <div
-    role="presentation"
-    style="width:0;height:0;overflow:hidden;position:absolute"
-    tabindex="0"
-  />
-  <div
     class="ant-tabs-content ant-tabs-content-no-animated ant-tabs-top-content ant-tabs-card-content"
   >
     <div
       aria-hidden="false"
       class="ant-tabs-tabpane ant-tabs-tabpane-active"
       role="tabpanel"
+      style="visibility:visible"
+      tabindex="0"
     >
-      <div
-        role="presentation"
-        style="width:0;height:0;overflow:hidden;position:absolute"
-        tabindex="0"
-      />
       Content of Tab Pane 1
-      <div
-        role="presentation"
-        style="width:0;height:0;overflow:hidden;position:absolute"
-        tabindex="0"
-      />
     </div>
     <div
       aria-hidden="true"
       class="ant-tabs-tabpane ant-tabs-tabpane-inactive"
       role="tabpanel"
+      style="visibility:hidden"
+      tabindex="-1"
     />
     <div
       aria-hidden="true"
       class="ant-tabs-tabpane ant-tabs-tabpane-inactive"
       role="tabpanel"
+      style="visibility:hidden"
+      tabindex="-1"
     />
   </div>
-  <div
-    role="presentation"
-    style="width:0;height:0;overflow:hidden;position:absolute"
-    tabindex="0"
-  />
 </div>
 `;
 
@@ -325,7 +315,7 @@ exports[`renders ./components/tabs/demo/card-top.md correctly 1`] = `
     <div
       class="ant-tabs-bar ant-tabs-top-bar ant-tabs-card-bar"
       role="tablist"
-      tabindex="0"
+      tabindex="-1"
     >
       <div
         class="ant-tabs-nav-container"
@@ -399,26 +389,35 @@ exports[`renders ./components/tabs/demo/card-top.md correctly 1`] = `
             >
               <div>
                 <div
+                  aria-controls="tabpane-1"
                   aria-disabled="false"
                   aria-selected="true"
                   class="ant-tabs-tab-active ant-tabs-tab"
+                  id="tab-1"
                   role="tab"
+                  tabindex="0"
                 >
                   Tab Title 1
                 </div>
                 <div
+                  aria-controls="tabpane-2"
                   aria-disabled="false"
                   aria-selected="false"
                   class=" ant-tabs-tab"
+                  id="tab-2"
                   role="tab"
+                  tabindex="-1"
                 >
                   Tab Title 2
                 </div>
                 <div
+                  aria-controls="tabpane-3"
                   aria-disabled="false"
                   aria-selected="false"
                   class=" ant-tabs-tab"
+                  id="tab-3"
                   role="tab"
+                  tabindex="-1"
                 >
                   Tab Title 3
                 </div>
@@ -432,23 +431,15 @@ exports[`renders ./components/tabs/demo/card-top.md correctly 1`] = `
       </div>
     </div>
     <div
-      role="presentation"
-      style="width:0;height:0;overflow:hidden;position:absolute"
-      tabindex="0"
-    />
-    <div
       class="ant-tabs-content ant-tabs-content-no-animated ant-tabs-top-content ant-tabs-card-content"
     >
       <div
         aria-hidden="false"
         class="ant-tabs-tabpane ant-tabs-tabpane-active"
         role="tabpanel"
+        style="visibility:visible"
+        tabindex="0"
       >
-        <div
-          role="presentation"
-          style="width:0;height:0;overflow:hidden;position:absolute"
-          tabindex="0"
-        />
         <p>
           Content of Tab Pane 1
         </p>
@@ -458,28 +449,22 @@ exports[`renders ./components/tabs/demo/card-top.md correctly 1`] = `
         <p>
           Content of Tab Pane 1
         </p>
-        <div
-          role="presentation"
-          style="width:0;height:0;overflow:hidden;position:absolute"
-          tabindex="0"
-        />
       </div>
       <div
         aria-hidden="true"
         class="ant-tabs-tabpane ant-tabs-tabpane-inactive"
         role="tabpanel"
+        style="visibility:hidden"
+        tabindex="-1"
       />
       <div
         aria-hidden="true"
         class="ant-tabs-tabpane ant-tabs-tabpane-inactive"
         role="tabpanel"
+        style="visibility:hidden"
+        tabindex="-1"
       />
     </div>
-    <div
-      role="presentation"
-      style="width:0;height:0;overflow:hidden;position:absolute"
-      tabindex="0"
-    />
   </div>
 </div>
 `;
@@ -504,7 +489,7 @@ exports[`renders ./components/tabs/demo/custom-add-trigger.md correctly 1`] = `
     <div
       class="ant-tabs-bar ant-tabs-top-bar ant-tabs-card-bar"
       role="tablist"
-      tabindex="0"
+      tabindex="-1"
     >
       <div
         class="ant-tabs-nav-container"
@@ -578,10 +563,13 @@ exports[`renders ./components/tabs/demo/custom-add-trigger.md correctly 1`] = `
             >
               <div>
                 <div
+                  aria-controls="tabpane-1"
                   aria-disabled="false"
                   aria-selected="true"
                   class="ant-tabs-tab-active ant-tabs-tab"
+                  id="tab-1"
                   role="tab"
+                  tabindex="0"
                 >
                   <div>
                     Tab 1
@@ -609,10 +597,13 @@ exports[`renders ./components/tabs/demo/custom-add-trigger.md correctly 1`] = `
                   </div>
                 </div>
                 <div
+                  aria-controls="tabpane-2"
                   aria-disabled="false"
                   aria-selected="false"
                   class=" ant-tabs-tab"
+                  id="tab-2"
                   role="tab"
+                  tabindex="-1"
                 >
                   <div>
                     Tab 2
@@ -649,41 +640,25 @@ exports[`renders ./components/tabs/demo/custom-add-trigger.md correctly 1`] = `
       </div>
     </div>
     <div
-      role="presentation"
-      style="width:0;height:0;overflow:hidden;position:absolute"
-      tabindex="0"
-    />
-    <div
       class="ant-tabs-content ant-tabs-content-no-animated ant-tabs-top-content ant-tabs-card-content"
     >
       <div
         aria-hidden="false"
         class="ant-tabs-tabpane ant-tabs-tabpane-active"
         role="tabpanel"
+        style="visibility:visible"
+        tabindex="0"
       >
-        <div
-          role="presentation"
-          style="width:0;height:0;overflow:hidden;position:absolute"
-          tabindex="0"
-        />
         Content of Tab Pane 1
-        <div
-          role="presentation"
-          style="width:0;height:0;overflow:hidden;position:absolute"
-          tabindex="0"
-        />
       </div>
       <div
         aria-hidden="true"
         class="ant-tabs-tabpane ant-tabs-tabpane-inactive"
         role="tabpanel"
+        style="visibility:hidden"
+        tabindex="-1"
       />
     </div>
-    <div
-      role="presentation"
-      style="width:0;height:0;overflow:hidden;position:absolute"
-      tabindex="0"
-    />
   </div>
 </div>
 `;
@@ -698,7 +673,7 @@ exports[`renders ./components/tabs/demo/custom-tab-bar.md correctly 1`] = `
       <div
         class="ant-tabs-bar site-custom-tab-bar"
         role="tablist"
-        tabindex="0"
+        tabindex="-1"
       >
         <div
           class="ant-tabs-nav-container"
@@ -772,26 +747,35 @@ exports[`renders ./components/tabs/demo/custom-tab-bar.md correctly 1`] = `
               >
                 <div>
                   <div
+                    aria-controls="tabpane-1"
                     aria-disabled="false"
                     aria-selected="true"
                     class="ant-tabs-tab-active ant-tabs-tab"
+                    id="tab-1"
                     role="tab"
+                    tabindex="0"
                   >
                     Tab 1
                   </div>
                   <div
+                    aria-controls="tabpane-2"
                     aria-disabled="false"
                     aria-selected="false"
                     class=" ant-tabs-tab"
+                    id="tab-2"
                     role="tab"
+                    tabindex="-1"
                   >
                     Tab 2
                   </div>
                   <div
+                    aria-controls="tabpane-3"
                     aria-disabled="false"
                     aria-selected="false"
                     class=" ant-tabs-tab"
+                    id="tab-3"
                     role="tab"
+                    tabindex="-1"
                   >
                     Tab 3
                   </div>
@@ -806,11 +790,6 @@ exports[`renders ./components/tabs/demo/custom-tab-bar.md correctly 1`] = `
       </div>
     </div>
     <div
-      role="presentation"
-      style="width:0;height:0;overflow:hidden;position:absolute"
-      tabindex="0"
-    />
-    <div
       class="ant-tabs-content ant-tabs-content-animated ant-tabs-top-content"
       style="margin-left:0%"
     >
@@ -818,36 +797,26 @@ exports[`renders ./components/tabs/demo/custom-tab-bar.md correctly 1`] = `
         aria-hidden="false"
         class="ant-tabs-tabpane ant-tabs-tabpane-active"
         role="tabpanel"
-        style="height:200px"
+        style="height:200px;visibility:visible"
+        tabindex="0"
       >
-        <div
-          role="presentation"
-          style="width:0;height:0;overflow:hidden;position:absolute"
-          tabindex="0"
-        />
         Content of Tab Pane 1
-        <div
-          role="presentation"
-          style="width:0;height:0;overflow:hidden;position:absolute"
-          tabindex="0"
-        />
       </div>
       <div
         aria-hidden="true"
         class="ant-tabs-tabpane ant-tabs-tabpane-inactive"
         role="tabpanel"
+        style="visibility:hidden"
+        tabindex="-1"
       />
       <div
         aria-hidden="true"
         class="ant-tabs-tabpane ant-tabs-tabpane-inactive"
         role="tabpanel"
+        style="visibility:hidden"
+        tabindex="-1"
       />
     </div>
-    <div
-      role="presentation"
-      style="width:0;height:0;overflow:hidden;position:absolute"
-      tabindex="0"
-    />
   </div>
 </div>
 `;
@@ -859,7 +828,7 @@ exports[`renders ./components/tabs/demo/custom-tab-bar-node.md correctly 1`] = `
   <div
     class="ant-tabs-bar ant-tabs-top-bar"
     role="tablist"
-    tabindex="0"
+    tabindex="-1"
   >
     <div
       class="ant-tabs-nav-container"
@@ -933,26 +902,35 @@ exports[`renders ./components/tabs/demo/custom-tab-bar-node.md correctly 1`] = `
           >
             <div>
               <div
+                aria-controls="tabpane-1"
                 aria-disabled="false"
                 aria-selected="true"
                 class="ant-tabs-tab-active ant-tabs-tab"
+                id="tab-1"
                 role="tab"
+                tabindex="0"
               >
                 tab 1
               </div>
               <div
+                aria-controls="tabpane-2"
                 aria-disabled="false"
                 aria-selected="false"
                 class=" ant-tabs-tab"
+                id="tab-2"
                 role="tab"
+                tabindex="-1"
               >
                 tab 2
               </div>
               <div
+                aria-controls="tabpane-3"
                 aria-disabled="false"
                 aria-selected="false"
                 class=" ant-tabs-tab"
+                id="tab-3"
                 role="tab"
+                tabindex="-1"
               >
                 tab 3
               </div>
@@ -966,11 +944,6 @@ exports[`renders ./components/tabs/demo/custom-tab-bar-node.md correctly 1`] = `
     </div>
   </div>
   <div
-    role="presentation"
-    style="width:0;height:0;overflow:hidden;position:absolute"
-    tabindex="0"
-  />
-  <div
     class="ant-tabs-content ant-tabs-content-animated ant-tabs-top-content"
     style="margin-left:0%"
   >
@@ -978,35 +951,26 @@ exports[`renders ./components/tabs/demo/custom-tab-bar-node.md correctly 1`] = `
       aria-hidden="false"
       class="ant-tabs-tabpane ant-tabs-tabpane-active"
       role="tabpanel"
+      style="visibility:visible"
+      tabindex="0"
     >
-      <div
-        role="presentation"
-        style="width:0;height:0;overflow:hidden;position:absolute"
-        tabindex="0"
-      />
       Content of Tab Pane 1
-      <div
-        role="presentation"
-        style="width:0;height:0;overflow:hidden;position:absolute"
-        tabindex="0"
-      />
     </div>
     <div
       aria-hidden="true"
       class="ant-tabs-tabpane ant-tabs-tabpane-inactive"
       role="tabpanel"
+      style="visibility:hidden"
+      tabindex="-1"
     />
     <div
       aria-hidden="true"
       class="ant-tabs-tabpane ant-tabs-tabpane-inactive"
       role="tabpanel"
+      style="visibility:hidden"
+      tabindex="-1"
     />
   </div>
-  <div
-    role="presentation"
-    style="width:0;height:0;overflow:hidden;position:absolute"
-    tabindex="0"
-  />
 </div>
 `;
 
@@ -1017,7 +981,7 @@ exports[`renders ./components/tabs/demo/disabled.md correctly 1`] = `
   <div
     class="ant-tabs-bar ant-tabs-top-bar"
     role="tablist"
-    tabindex="0"
+    tabindex="-1"
   >
     <div
       class="ant-tabs-nav-container"
@@ -1091,26 +1055,35 @@ exports[`renders ./components/tabs/demo/disabled.md correctly 1`] = `
           >
             <div>
               <div
+                aria-controls="tabpane-1"
                 aria-disabled="false"
                 aria-selected="true"
                 class="ant-tabs-tab-active ant-tabs-tab"
+                id="tab-1"
                 role="tab"
+                tabindex="0"
               >
                 Tab 1
               </div>
               <div
+                aria-controls="tabpane-2"
                 aria-disabled="true"
                 aria-selected="false"
                 class=" ant-tabs-tab ant-tabs-tab-disabled"
+                id="tab-2"
                 role="tab"
+                tabindex="-1"
               >
                 Tab 2
               </div>
               <div
+                aria-controls="tabpane-3"
                 aria-disabled="false"
                 aria-selected="false"
                 class=" ant-tabs-tab"
+                id="tab-3"
                 role="tab"
+                tabindex="-1"
               >
                 Tab 3
               </div>
@@ -1124,11 +1097,6 @@ exports[`renders ./components/tabs/demo/disabled.md correctly 1`] = `
     </div>
   </div>
   <div
-    role="presentation"
-    style="width:0;height:0;overflow:hidden;position:absolute"
-    tabindex="0"
-  />
-  <div
     class="ant-tabs-content ant-tabs-content-animated ant-tabs-top-content"
     style="margin-left:0%"
   >
@@ -1136,35 +1104,26 @@ exports[`renders ./components/tabs/demo/disabled.md correctly 1`] = `
       aria-hidden="false"
       class="ant-tabs-tabpane ant-tabs-tabpane-active"
       role="tabpanel"
+      style="visibility:visible"
+      tabindex="0"
     >
-      <div
-        role="presentation"
-        style="width:0;height:0;overflow:hidden;position:absolute"
-        tabindex="0"
-      />
       Tab 1
-      <div
-        role="presentation"
-        style="width:0;height:0;overflow:hidden;position:absolute"
-        tabindex="0"
-      />
     </div>
     <div
       aria-hidden="true"
       class="ant-tabs-tabpane ant-tabs-tabpane-inactive"
       role="tabpanel"
+      style="visibility:hidden"
+      tabindex="-1"
     />
     <div
       aria-hidden="true"
       class="ant-tabs-tabpane ant-tabs-tabpane-inactive"
       role="tabpanel"
+      style="visibility:hidden"
+      tabindex="-1"
     />
   </div>
-  <div
-    role="presentation"
-    style="width:0;height:0;overflow:hidden;position:absolute"
-    tabindex="0"
-  />
 </div>
 `;
 
@@ -1175,7 +1134,7 @@ exports[`renders ./components/tabs/demo/editable-card.md correctly 1`] = `
   <div
     class="ant-tabs-bar ant-tabs-top-bar ant-tabs-card-bar"
     role="tablist"
-    tabindex="0"
+    tabindex="-1"
   >
     <div
       class="ant-tabs-extra-content"
@@ -1281,10 +1240,13 @@ exports[`renders ./components/tabs/demo/editable-card.md correctly 1`] = `
           >
             <div>
               <div
+                aria-controls="tabpane-1"
                 aria-disabled="false"
                 aria-selected="true"
                 class="ant-tabs-tab-active ant-tabs-tab"
+                id="tab-1"
                 role="tab"
+                tabindex="0"
               >
                 <div>
                   Tab 1
@@ -1312,10 +1274,13 @@ exports[`renders ./components/tabs/demo/editable-card.md correctly 1`] = `
                 </div>
               </div>
               <div
+                aria-controls="tabpane-2"
                 aria-disabled="false"
                 aria-selected="false"
                 class=" ant-tabs-tab"
+                id="tab-2"
                 role="tab"
+                tabindex="-1"
               >
                 <div>
                   Tab 2
@@ -1343,10 +1308,13 @@ exports[`renders ./components/tabs/demo/editable-card.md correctly 1`] = `
                 </div>
               </div>
               <div
+                aria-controls="tabpane-3"
                 aria-disabled="false"
                 aria-selected="false"
                 class=" ant-tabs-tab"
+                id="tab-3"
                 role="tab"
+                tabindex="-1"
               >
                 <div
                   class="ant-tabs-tab-unclosable"
@@ -1364,46 +1332,32 @@ exports[`renders ./components/tabs/demo/editable-card.md correctly 1`] = `
     </div>
   </div>
   <div
-    role="presentation"
-    style="width:0;height:0;overflow:hidden;position:absolute"
-    tabindex="0"
-  />
-  <div
     class="ant-tabs-content ant-tabs-content-no-animated ant-tabs-top-content ant-tabs-card-content"
   >
     <div
       aria-hidden="false"
       class="ant-tabs-tabpane ant-tabs-tabpane-active"
       role="tabpanel"
+      style="visibility:visible"
+      tabindex="0"
     >
-      <div
-        role="presentation"
-        style="width:0;height:0;overflow:hidden;position:absolute"
-        tabindex="0"
-      />
       Content of Tab 1
-      <div
-        role="presentation"
-        style="width:0;height:0;overflow:hidden;position:absolute"
-        tabindex="0"
-      />
     </div>
     <div
       aria-hidden="true"
       class="ant-tabs-tabpane ant-tabs-tabpane-inactive"
       role="tabpanel"
+      style="visibility:hidden"
+      tabindex="-1"
     />
     <div
       aria-hidden="true"
       class="ant-tabs-tabpane ant-tabs-tabpane-inactive"
       role="tabpanel"
+      style="visibility:hidden"
+      tabindex="-1"
     />
   </div>
-  <div
-    role="presentation"
-    style="width:0;height:0;overflow:hidden;position:absolute"
-    tabindex="0"
-  />
 </div>
 `;
 
@@ -1414,7 +1368,7 @@ exports[`renders ./components/tabs/demo/extra.md correctly 1`] = `
   <div
     class="ant-tabs-bar ant-tabs-top-bar"
     role="tablist"
-    tabindex="0"
+    tabindex="-1"
   >
     <div
       class="ant-tabs-extra-content"
@@ -1501,26 +1455,35 @@ exports[`renders ./components/tabs/demo/extra.md correctly 1`] = `
           >
             <div>
               <div
+                aria-controls="tabpane-1"
                 aria-disabled="false"
                 aria-selected="true"
                 class="ant-tabs-tab-active ant-tabs-tab"
+                id="tab-1"
                 role="tab"
+                tabindex="0"
               >
                 Tab 1
               </div>
               <div
+                aria-controls="tabpane-2"
                 aria-disabled="false"
                 aria-selected="false"
                 class=" ant-tabs-tab"
+                id="tab-2"
                 role="tab"
+                tabindex="-1"
               >
                 Tab 2
               </div>
               <div
+                aria-controls="tabpane-3"
                 aria-disabled="false"
                 aria-selected="false"
                 class=" ant-tabs-tab"
+                id="tab-3"
                 role="tab"
+                tabindex="-1"
               >
                 Tab 3
               </div>
@@ -1534,11 +1497,6 @@ exports[`renders ./components/tabs/demo/extra.md correctly 1`] = `
     </div>
   </div>
   <div
-    role="presentation"
-    style="width:0;height:0;overflow:hidden;position:absolute"
-    tabindex="0"
-  />
-  <div
     class="ant-tabs-content ant-tabs-content-animated ant-tabs-top-content"
     style="margin-left:0%"
   >
@@ -1546,35 +1504,26 @@ exports[`renders ./components/tabs/demo/extra.md correctly 1`] = `
       aria-hidden="false"
       class="ant-tabs-tabpane ant-tabs-tabpane-active"
       role="tabpanel"
+      style="visibility:visible"
+      tabindex="0"
     >
-      <div
-        role="presentation"
-        style="width:0;height:0;overflow:hidden;position:absolute"
-        tabindex="0"
-      />
       Content of tab 1
-      <div
-        role="presentation"
-        style="width:0;height:0;overflow:hidden;position:absolute"
-        tabindex="0"
-      />
     </div>
     <div
       aria-hidden="true"
       class="ant-tabs-tabpane ant-tabs-tabpane-inactive"
       role="tabpanel"
+      style="visibility:hidden"
+      tabindex="-1"
     />
     <div
       aria-hidden="true"
       class="ant-tabs-tabpane ant-tabs-tabpane-inactive"
       role="tabpanel"
+      style="visibility:hidden"
+      tabindex="-1"
     />
   </div>
-  <div
-    role="presentation"
-    style="width:0;height:0;overflow:hidden;position:absolute"
-    tabindex="0"
-  />
 </div>
 `;
 
@@ -1585,7 +1534,7 @@ exports[`renders ./components/tabs/demo/icon.md correctly 1`] = `
   <div
     class="ant-tabs-bar ant-tabs-top-bar"
     role="tablist"
-    tabindex="0"
+    tabindex="-1"
   >
     <div
       class="ant-tabs-nav-container"
@@ -1659,10 +1608,13 @@ exports[`renders ./components/tabs/demo/icon.md correctly 1`] = `
           >
             <div>
               <div
+                aria-controls="tabpane-1"
                 aria-disabled="false"
                 aria-selected="false"
                 class=" ant-tabs-tab"
+                id="tab-1"
                 role="tab"
+                tabindex="-1"
               >
                 <span>
                   <span
@@ -1689,10 +1641,13 @@ exports[`renders ./components/tabs/demo/icon.md correctly 1`] = `
                 </span>
               </div>
               <div
+                aria-controls="tabpane-2"
                 aria-disabled="false"
                 aria-selected="true"
                 class="ant-tabs-tab-active ant-tabs-tab"
+                id="tab-2"
                 role="tab"
+                tabindex="0"
               >
                 <span>
                   <span
@@ -1728,11 +1683,6 @@ exports[`renders ./components/tabs/demo/icon.md correctly 1`] = `
     </div>
   </div>
   <div
-    role="presentation"
-    style="width:0;height:0;overflow:hidden;position:absolute"
-    tabindex="0"
-  />
-  <div
     class="ant-tabs-content ant-tabs-content-animated ant-tabs-top-content"
     style="margin-left:-100%"
   >
@@ -1740,30 +1690,19 @@ exports[`renders ./components/tabs/demo/icon.md correctly 1`] = `
       aria-hidden="true"
       class="ant-tabs-tabpane ant-tabs-tabpane-inactive"
       role="tabpanel"
+      style="visibility:hidden"
+      tabindex="-1"
     />
     <div
       aria-hidden="false"
       class="ant-tabs-tabpane ant-tabs-tabpane-active"
       role="tabpanel"
+      style="visibility:visible"
+      tabindex="0"
     >
-      <div
-        role="presentation"
-        style="width:0;height:0;overflow:hidden;position:absolute"
-        tabindex="0"
-      />
       Tab 2
-      <div
-        role="presentation"
-        style="width:0;height:0;overflow:hidden;position:absolute"
-        tabindex="0"
-      />
     </div>
   </div>
-  <div
-    role="presentation"
-    style="width:0;height:0;overflow:hidden;position:absolute"
-    tabindex="0"
-  />
 </div>
 `;
 
@@ -1999,7 +1938,7 @@ exports[`renders ./components/tabs/demo/nest.md correctly 1`] = `
     <div
       class="ant-tabs-bar ant-tabs-top-bar"
       role="tablist"
-      tabindex="0"
+      tabindex="-1"
     >
       <div
         class="ant-tabs-nav-container"
@@ -2073,18 +2012,24 @@ exports[`renders ./components/tabs/demo/nest.md correctly 1`] = `
             >
               <div>
                 <div
+                  aria-controls="tabpane-1"
                   aria-disabled="false"
                   aria-selected="true"
                   class="ant-tabs-tab-active ant-tabs-tab"
+                  id="tab-1"
                   role="tab"
+                  tabindex="0"
                 >
                   Tab 1
                 </div>
                 <div
+                  aria-controls="tabpane-2"
                   aria-disabled="false"
                   aria-selected="false"
                   class=" ant-tabs-tab"
+                  id="tab-2"
                   role="tab"
+                  tabindex="-1"
                 >
                   Tab 2
                 </div>
@@ -2098,11 +2043,6 @@ exports[`renders ./components/tabs/demo/nest.md correctly 1`] = `
       </div>
     </div>
     <div
-      role="presentation"
-      style="width:0;height:0;overflow:hidden;position:absolute"
-      tabindex="0"
-    />
-    <div
       class="ant-tabs-content ant-tabs-content-animated ant-tabs-top-content"
       style="margin-left:0%"
     >
@@ -2110,12 +2050,9 @@ exports[`renders ./components/tabs/demo/nest.md correctly 1`] = `
         aria-hidden="false"
         class="ant-tabs-tabpane ant-tabs-tabpane-active"
         role="tabpanel"
+        style="visibility:visible"
+        tabindex="0"
       >
-        <div
-          role="presentation"
-          style="width:0;height:0;overflow:hidden;position:absolute"
-          tabindex="0"
-        />
         <div
           class="ant-tabs ant-tabs-top ant-tabs-line"
           style="height:300px"
@@ -2123,7 +2060,7 @@ exports[`renders ./components/tabs/demo/nest.md correctly 1`] = `
           <div
             class="ant-tabs-bar ant-tabs-top-bar"
             role="tablist"
-            tabindex="0"
+            tabindex="-1"
           >
             <div
               class="ant-tabs-nav-container"
@@ -2197,162 +2134,222 @@ exports[`renders ./components/tabs/demo/nest.md correctly 1`] = `
                   >
                     <div>
                       <div
+                        aria-controls="tabpane-0"
                         aria-disabled="false"
                         aria-selected="false"
                         class=" ant-tabs-tab"
+                        id="tab-0"
                         role="tab"
+                        tabindex="-1"
                       >
                         Tab 0
                       </div>
                       <div
+                        aria-controls="tabpane-1"
                         aria-disabled="false"
                         aria-selected="true"
                         class="ant-tabs-tab-active ant-tabs-tab"
+                        id="tab-1"
                         role="tab"
+                        tabindex="0"
                       >
                         Tab 1
                       </div>
                       <div
+                        aria-controls="tabpane-2"
                         aria-disabled="false"
                         aria-selected="false"
                         class=" ant-tabs-tab"
+                        id="tab-2"
                         role="tab"
+                        tabindex="-1"
                       >
                         Tab 2
                       </div>
                       <div
+                        aria-controls="tabpane-3"
                         aria-disabled="false"
                         aria-selected="false"
                         class=" ant-tabs-tab"
+                        id="tab-3"
                         role="tab"
+                        tabindex="-1"
                       >
                         Tab 3
                       </div>
                       <div
+                        aria-controls="tabpane-4"
                         aria-disabled="false"
                         aria-selected="false"
                         class=" ant-tabs-tab"
+                        id="tab-4"
                         role="tab"
+                        tabindex="-1"
                       >
                         Tab 4
                       </div>
                       <div
+                        aria-controls="tabpane-5"
                         aria-disabled="false"
                         aria-selected="false"
                         class=" ant-tabs-tab"
+                        id="tab-5"
                         role="tab"
+                        tabindex="-1"
                       >
                         Tab 5
                       </div>
                       <div
+                        aria-controls="tabpane-6"
                         aria-disabled="false"
                         aria-selected="false"
                         class=" ant-tabs-tab"
+                        id="tab-6"
                         role="tab"
+                        tabindex="-1"
                       >
                         Tab 6
                       </div>
                       <div
+                        aria-controls="tabpane-7"
                         aria-disabled="false"
                         aria-selected="false"
                         class=" ant-tabs-tab"
+                        id="tab-7"
                         role="tab"
+                        tabindex="-1"
                       >
                         Tab 7
                       </div>
                       <div
+                        aria-controls="tabpane-8"
                         aria-disabled="false"
                         aria-selected="false"
                         class=" ant-tabs-tab"
+                        id="tab-8"
                         role="tab"
+                        tabindex="-1"
                       >
                         Tab 8
                       </div>
                       <div
+                        aria-controls="tabpane-9"
                         aria-disabled="false"
                         aria-selected="false"
                         class=" ant-tabs-tab"
+                        id="tab-9"
                         role="tab"
+                        tabindex="-1"
                       >
                         Tab 9
                       </div>
                       <div
+                        aria-controls="tabpane-10"
                         aria-disabled="false"
                         aria-selected="false"
                         class=" ant-tabs-tab"
+                        id="tab-10"
                         role="tab"
+                        tabindex="-1"
                       >
                         Tab 10
                       </div>
                       <div
+                        aria-controls="tabpane-11"
                         aria-disabled="false"
                         aria-selected="false"
                         class=" ant-tabs-tab"
+                        id="tab-11"
                         role="tab"
+                        tabindex="-1"
                       >
                         Tab 11
                       </div>
                       <div
+                        aria-controls="tabpane-12"
                         aria-disabled="false"
                         aria-selected="false"
                         class=" ant-tabs-tab"
+                        id="tab-12"
                         role="tab"
+                        tabindex="-1"
                       >
                         Tab 12
                       </div>
                       <div
+                        aria-controls="tabpane-13"
                         aria-disabled="false"
                         aria-selected="false"
                         class=" ant-tabs-tab"
+                        id="tab-13"
                         role="tab"
+                        tabindex="-1"
                       >
                         Tab 13
                       </div>
                       <div
+                        aria-controls="tabpane-14"
                         aria-disabled="false"
                         aria-selected="false"
                         class=" ant-tabs-tab"
+                        id="tab-14"
                         role="tab"
+                        tabindex="-1"
                       >
                         Tab 14
                       </div>
                       <div
+                        aria-controls="tabpane-15"
                         aria-disabled="false"
                         aria-selected="false"
                         class=" ant-tabs-tab"
+                        id="tab-15"
                         role="tab"
+                        tabindex="-1"
                       >
                         Tab 15
                       </div>
                       <div
+                        aria-controls="tabpane-16"
                         aria-disabled="false"
                         aria-selected="false"
                         class=" ant-tabs-tab"
+                        id="tab-16"
                         role="tab"
+                        tabindex="-1"
                       >
                         Tab 16
                       </div>
                       <div
+                        aria-controls="tabpane-17"
                         aria-disabled="false"
                         aria-selected="false"
                         class=" ant-tabs-tab"
+                        id="tab-17"
                         role="tab"
+                        tabindex="-1"
                       >
                         Tab 17
                       </div>
                       <div
+                        aria-controls="tabpane-18"
                         aria-disabled="false"
                         aria-selected="false"
                         class=" ant-tabs-tab"
+                        id="tab-18"
                         role="tab"
+                        tabindex="-1"
                       >
                         Tab 18
                       </div>
                       <div
+                        aria-controls="tabpane-19"
                         aria-disabled="false"
                         aria-selected="false"
                         class=" ant-tabs-tab"
+                        id="tab-19"
                         role="tab"
+                        tabindex="-1"
                       >
                         Tab 19
                       </div>
@@ -2366,11 +2363,6 @@ exports[`renders ./components/tabs/demo/nest.md correctly 1`] = `
             </div>
           </div>
           <div
-            role="presentation"
-            style="width:0;height:0;overflow:hidden;position:absolute"
-            tabindex="0"
-          />
-          <div
             class="ant-tabs-content ant-tabs-content-animated ant-tabs-top-content"
             style="margin-left:-100%"
           >
@@ -2378,138 +2370,155 @@ exports[`renders ./components/tabs/demo/nest.md correctly 1`] = `
               aria-hidden="true"
               class="ant-tabs-tabpane ant-tabs-tabpane-inactive"
               role="tabpanel"
+              style="visibility:hidden"
+              tabindex="-1"
             />
             <div
               aria-hidden="false"
               class="ant-tabs-tabpane ant-tabs-tabpane-active"
               role="tabpanel"
+              style="visibility:visible"
+              tabindex="0"
             >
-              <div
-                role="presentation"
-                style="width:0;height:0;overflow:hidden;position:absolute"
-                tabindex="0"
-              />
               TTTT 1
-              <div
-                role="presentation"
-                style="width:0;height:0;overflow:hidden;position:absolute"
-                tabindex="0"
-              />
             </div>
             <div
               aria-hidden="true"
               class="ant-tabs-tabpane ant-tabs-tabpane-inactive"
               role="tabpanel"
+              style="visibility:hidden"
+              tabindex="-1"
             />
             <div
               aria-hidden="true"
               class="ant-tabs-tabpane ant-tabs-tabpane-inactive"
               role="tabpanel"
+              style="visibility:hidden"
+              tabindex="-1"
             />
             <div
               aria-hidden="true"
               class="ant-tabs-tabpane ant-tabs-tabpane-inactive"
               role="tabpanel"
+              style="visibility:hidden"
+              tabindex="-1"
             />
             <div
               aria-hidden="true"
               class="ant-tabs-tabpane ant-tabs-tabpane-inactive"
               role="tabpanel"
+              style="visibility:hidden"
+              tabindex="-1"
             />
             <div
               aria-hidden="true"
               class="ant-tabs-tabpane ant-tabs-tabpane-inactive"
               role="tabpanel"
+              style="visibility:hidden"
+              tabindex="-1"
             />
             <div
               aria-hidden="true"
               class="ant-tabs-tabpane ant-tabs-tabpane-inactive"
               role="tabpanel"
+              style="visibility:hidden"
+              tabindex="-1"
             />
             <div
               aria-hidden="true"
               class="ant-tabs-tabpane ant-tabs-tabpane-inactive"
               role="tabpanel"
+              style="visibility:hidden"
+              tabindex="-1"
             />
             <div
               aria-hidden="true"
               class="ant-tabs-tabpane ant-tabs-tabpane-inactive"
               role="tabpanel"
+              style="visibility:hidden"
+              tabindex="-1"
             />
             <div
               aria-hidden="true"
               class="ant-tabs-tabpane ant-tabs-tabpane-inactive"
               role="tabpanel"
+              style="visibility:hidden"
+              tabindex="-1"
             />
             <div
               aria-hidden="true"
               class="ant-tabs-tabpane ant-tabs-tabpane-inactive"
               role="tabpanel"
+              style="visibility:hidden"
+              tabindex="-1"
             />
             <div
               aria-hidden="true"
               class="ant-tabs-tabpane ant-tabs-tabpane-inactive"
               role="tabpanel"
+              style="visibility:hidden"
+              tabindex="-1"
             />
             <div
               aria-hidden="true"
               class="ant-tabs-tabpane ant-tabs-tabpane-inactive"
               role="tabpanel"
+              style="visibility:hidden"
+              tabindex="-1"
             />
             <div
               aria-hidden="true"
               class="ant-tabs-tabpane ant-tabs-tabpane-inactive"
               role="tabpanel"
+              style="visibility:hidden"
+              tabindex="-1"
             />
             <div
               aria-hidden="true"
               class="ant-tabs-tabpane ant-tabs-tabpane-inactive"
               role="tabpanel"
+              style="visibility:hidden"
+              tabindex="-1"
             />
             <div
               aria-hidden="true"
               class="ant-tabs-tabpane ant-tabs-tabpane-inactive"
               role="tabpanel"
+              style="visibility:hidden"
+              tabindex="-1"
             />
             <div
               aria-hidden="true"
               class="ant-tabs-tabpane ant-tabs-tabpane-inactive"
               role="tabpanel"
+              style="visibility:hidden"
+              tabindex="-1"
             />
             <div
               aria-hidden="true"
               class="ant-tabs-tabpane ant-tabs-tabpane-inactive"
               role="tabpanel"
+              style="visibility:hidden"
+              tabindex="-1"
             />
             <div
               aria-hidden="true"
               class="ant-tabs-tabpane ant-tabs-tabpane-inactive"
               role="tabpanel"
+              style="visibility:hidden"
+              tabindex="-1"
             />
           </div>
-          <div
-            role="presentation"
-            style="width:0;height:0;overflow:hidden;position:absolute"
-            tabindex="0"
-          />
         </div>
-        <div
-          role="presentation"
-          style="width:0;height:0;overflow:hidden;position:absolute"
-          tabindex="0"
-        />
       </div>
       <div
         aria-hidden="true"
         class="ant-tabs-tabpane ant-tabs-tabpane-inactive"
         role="tabpanel"
+        style="visibility:hidden"
+        tabindex="-1"
       />
     </div>
-    <div
-      role="presentation"
-      style="width:0;height:0;overflow:hidden;position:absolute"
-      tabindex="0"
-    />
   </div>
 </div>
 `;
@@ -2584,7 +2593,7 @@ exports[`renders ./components/tabs/demo/position.md correctly 1`] = `
     <div
       class="ant-tabs-bar ant-tabs-top-bar"
       role="tablist"
-      tabindex="0"
+      tabindex="-1"
     >
       <div
         class="ant-tabs-nav-container"
@@ -2658,26 +2667,35 @@ exports[`renders ./components/tabs/demo/position.md correctly 1`] = `
             >
               <div>
                 <div
+                  aria-controls="tabpane-1"
                   aria-disabled="false"
                   aria-selected="true"
                   class="ant-tabs-tab-active ant-tabs-tab"
+                  id="tab-1"
                   role="tab"
+                  tabindex="0"
                 >
                   Tab 1
                 </div>
                 <div
+                  aria-controls="tabpane-2"
                   aria-disabled="false"
                   aria-selected="false"
                   class=" ant-tabs-tab"
+                  id="tab-2"
                   role="tab"
+                  tabindex="-1"
                 >
                   Tab 2
                 </div>
                 <div
+                  aria-controls="tabpane-3"
                   aria-disabled="false"
                   aria-selected="false"
                   class=" ant-tabs-tab"
+                  id="tab-3"
                   role="tab"
+                  tabindex="-1"
                 >
                   Tab 3
                 </div>
@@ -2691,11 +2709,6 @@ exports[`renders ./components/tabs/demo/position.md correctly 1`] = `
       </div>
     </div>
     <div
-      role="presentation"
-      style="width:0;height:0;overflow:hidden;position:absolute"
-      tabindex="0"
-    />
-    <div
       class="ant-tabs-content ant-tabs-content-animated ant-tabs-top-content"
       style="margin-left:0%"
     >
@@ -2703,35 +2716,26 @@ exports[`renders ./components/tabs/demo/position.md correctly 1`] = `
         aria-hidden="false"
         class="ant-tabs-tabpane ant-tabs-tabpane-active"
         role="tabpanel"
+        style="visibility:visible"
+        tabindex="0"
       >
-        <div
-          role="presentation"
-          style="width:0;height:0;overflow:hidden;position:absolute"
-          tabindex="0"
-        />
         Content of Tab 1
-        <div
-          role="presentation"
-          style="width:0;height:0;overflow:hidden;position:absolute"
-          tabindex="0"
-        />
       </div>
       <div
         aria-hidden="true"
         class="ant-tabs-tabpane ant-tabs-tabpane-inactive"
         role="tabpanel"
+        style="visibility:hidden"
+        tabindex="-1"
       />
       <div
         aria-hidden="true"
         class="ant-tabs-tabpane ant-tabs-tabpane-inactive"
         role="tabpanel"
+        style="visibility:hidden"
+        tabindex="-1"
       />
     </div>
-    <div
-      role="presentation"
-      style="width:0;height:0;overflow:hidden;position:absolute"
-      tabindex="0"
-    />
   </div>
 </div>
 `;
@@ -2807,7 +2811,7 @@ exports[`renders ./components/tabs/demo/size.md correctly 1`] = `
     <div
       class="ant-tabs-bar ant-tabs-top-bar ant-tabs-small-bar"
       role="tablist"
-      tabindex="0"
+      tabindex="-1"
     >
       <div
         class="ant-tabs-nav-container"
@@ -2881,26 +2885,35 @@ exports[`renders ./components/tabs/demo/size.md correctly 1`] = `
             >
               <div>
                 <div
+                  aria-controls="tabpane-1"
                   aria-disabled="false"
                   aria-selected="true"
                   class="ant-tabs-tab-active ant-tabs-tab"
+                  id="tab-1"
                   role="tab"
+                  tabindex="0"
                 >
                   Tab 1
                 </div>
                 <div
+                  aria-controls="tabpane-2"
                   aria-disabled="false"
                   aria-selected="false"
                   class=" ant-tabs-tab"
+                  id="tab-2"
                   role="tab"
+                  tabindex="-1"
                 >
                   Tab 2
                 </div>
                 <div
+                  aria-controls="tabpane-3"
                   aria-disabled="false"
                   aria-selected="false"
                   class=" ant-tabs-tab"
+                  id="tab-3"
                   role="tab"
+                  tabindex="-1"
                 >
                   Tab 3
                 </div>
@@ -2914,11 +2927,6 @@ exports[`renders ./components/tabs/demo/size.md correctly 1`] = `
       </div>
     </div>
     <div
-      role="presentation"
-      style="width:0;height:0;overflow:hidden;position:absolute"
-      tabindex="0"
-    />
-    <div
       class="ant-tabs-content ant-tabs-content-animated ant-tabs-top-content"
       style="margin-left:0%"
     >
@@ -2926,35 +2934,26 @@ exports[`renders ./components/tabs/demo/size.md correctly 1`] = `
         aria-hidden="false"
         class="ant-tabs-tabpane ant-tabs-tabpane-active"
         role="tabpanel"
+        style="visibility:visible"
+        tabindex="0"
       >
-        <div
-          role="presentation"
-          style="width:0;height:0;overflow:hidden;position:absolute"
-          tabindex="0"
-        />
         Content of tab 1
-        <div
-          role="presentation"
-          style="width:0;height:0;overflow:hidden;position:absolute"
-          tabindex="0"
-        />
       </div>
       <div
         aria-hidden="true"
         class="ant-tabs-tabpane ant-tabs-tabpane-inactive"
         role="tabpanel"
+        style="visibility:hidden"
+        tabindex="-1"
       />
       <div
         aria-hidden="true"
         class="ant-tabs-tabpane ant-tabs-tabpane-inactive"
         role="tabpanel"
+        style="visibility:hidden"
+        tabindex="-1"
       />
     </div>
-    <div
-      role="presentation"
-      style="width:0;height:0;overflow:hidden;position:absolute"
-      tabindex="0"
-    />
   </div>
 </div>
 `;
@@ -3012,7 +3011,7 @@ exports[`renders ./components/tabs/demo/slide.md correctly 1`] = `
     <div
       class="ant-tabs-bar ant-tabs-top-bar"
       role="tablist"
-      tabindex="0"
+      tabindex="-1"
     >
       <div
         class="ant-tabs-nav-container"
@@ -3086,242 +3085,332 @@ exports[`renders ./components/tabs/demo/slide.md correctly 1`] = `
             >
               <div>
                 <div
+                  aria-controls="tabpane-0"
                   aria-disabled="false"
                   aria-selected="false"
                   class=" ant-tabs-tab"
+                  id="tab-0"
                   role="tab"
+                  tabindex="-1"
                 >
                   Tab-0
                 </div>
                 <div
+                  aria-controls="tabpane-1"
                   aria-disabled="false"
                   aria-selected="true"
                   class="ant-tabs-tab-active ant-tabs-tab"
+                  id="tab-1"
                   role="tab"
+                  tabindex="0"
                 >
                   Tab-1
                 </div>
                 <div
+                  aria-controls="tabpane-2"
                   aria-disabled="false"
                   aria-selected="false"
                   class=" ant-tabs-tab"
+                  id="tab-2"
                   role="tab"
+                  tabindex="-1"
                 >
                   Tab-2
                 </div>
                 <div
+                  aria-controls="tabpane-3"
                   aria-disabled="false"
                   aria-selected="false"
                   class=" ant-tabs-tab"
+                  id="tab-3"
                   role="tab"
+                  tabindex="-1"
                 >
                   Tab-3
                 </div>
                 <div
+                  aria-controls="tabpane-4"
                   aria-disabled="false"
                   aria-selected="false"
                   class=" ant-tabs-tab"
+                  id="tab-4"
                   role="tab"
+                  tabindex="-1"
                 >
                   Tab-4
                 </div>
                 <div
+                  aria-controls="tabpane-5"
                   aria-disabled="false"
                   aria-selected="false"
                   class=" ant-tabs-tab"
+                  id="tab-5"
                   role="tab"
+                  tabindex="-1"
                 >
                   Tab-5
                 </div>
                 <div
+                  aria-controls="tabpane-6"
                   aria-disabled="false"
                   aria-selected="false"
                   class=" ant-tabs-tab"
+                  id="tab-6"
                   role="tab"
+                  tabindex="-1"
                 >
                   Tab-6
                 </div>
                 <div
+                  aria-controls="tabpane-7"
                   aria-disabled="false"
                   aria-selected="false"
                   class=" ant-tabs-tab"
+                  id="tab-7"
                   role="tab"
+                  tabindex="-1"
                 >
                   Tab-7
                 </div>
                 <div
+                  aria-controls="tabpane-8"
                   aria-disabled="false"
                   aria-selected="false"
                   class=" ant-tabs-tab"
+                  id="tab-8"
                   role="tab"
+                  tabindex="-1"
                 >
                   Tab-8
                 </div>
                 <div
+                  aria-controls="tabpane-9"
                   aria-disabled="false"
                   aria-selected="false"
                   class=" ant-tabs-tab"
+                  id="tab-9"
                   role="tab"
+                  tabindex="-1"
                 >
                   Tab-9
                 </div>
                 <div
+                  aria-controls="tabpane-10"
                   aria-disabled="false"
                   aria-selected="false"
                   class=" ant-tabs-tab"
+                  id="tab-10"
                   role="tab"
+                  tabindex="-1"
                 >
                   Tab-10
                 </div>
                 <div
+                  aria-controls="tabpane-11"
                   aria-disabled="false"
                   aria-selected="false"
                   class=" ant-tabs-tab"
+                  id="tab-11"
                   role="tab"
+                  tabindex="-1"
                 >
                   Tab-11
                 </div>
                 <div
+                  aria-controls="tabpane-12"
                   aria-disabled="false"
                   aria-selected="false"
                   class=" ant-tabs-tab"
+                  id="tab-12"
                   role="tab"
+                  tabindex="-1"
                 >
                   Tab-12
                 </div>
                 <div
+                  aria-controls="tabpane-13"
                   aria-disabled="false"
                   aria-selected="false"
                   class=" ant-tabs-tab"
+                  id="tab-13"
                   role="tab"
+                  tabindex="-1"
                 >
                   Tab-13
                 </div>
                 <div
+                  aria-controls="tabpane-14"
                   aria-disabled="false"
                   aria-selected="false"
                   class=" ant-tabs-tab"
+                  id="tab-14"
                   role="tab"
+                  tabindex="-1"
                 >
                   Tab-14
                 </div>
                 <div
+                  aria-controls="tabpane-15"
                   aria-disabled="false"
                   aria-selected="false"
                   class=" ant-tabs-tab"
+                  id="tab-15"
                   role="tab"
+                  tabindex="-1"
                 >
                   Tab-15
                 </div>
                 <div
+                  aria-controls="tabpane-16"
                   aria-disabled="false"
                   aria-selected="false"
                   class=" ant-tabs-tab"
+                  id="tab-16"
                   role="tab"
+                  tabindex="-1"
                 >
                   Tab-16
                 </div>
                 <div
+                  aria-controls="tabpane-17"
                   aria-disabled="false"
                   aria-selected="false"
                   class=" ant-tabs-tab"
+                  id="tab-17"
                   role="tab"
+                  tabindex="-1"
                 >
                   Tab-17
                 </div>
                 <div
+                  aria-controls="tabpane-18"
                   aria-disabled="false"
                   aria-selected="false"
                   class=" ant-tabs-tab"
+                  id="tab-18"
                   role="tab"
+                  tabindex="-1"
                 >
                   Tab-18
                 </div>
                 <div
+                  aria-controls="tabpane-19"
                   aria-disabled="false"
                   aria-selected="false"
                   class=" ant-tabs-tab"
+                  id="tab-19"
                   role="tab"
+                  tabindex="-1"
                 >
                   Tab-19
                 </div>
                 <div
+                  aria-controls="tabpane-20"
                   aria-disabled="false"
                   aria-selected="false"
                   class=" ant-tabs-tab"
+                  id="tab-20"
                   role="tab"
+                  tabindex="-1"
                 >
                   Tab-20
                 </div>
                 <div
+                  aria-controls="tabpane-21"
                   aria-disabled="false"
                   aria-selected="false"
                   class=" ant-tabs-tab"
+                  id="tab-21"
                   role="tab"
+                  tabindex="-1"
                 >
                   Tab-21
                 </div>
                 <div
+                  aria-controls="tabpane-22"
                   aria-disabled="false"
                   aria-selected="false"
                   class=" ant-tabs-tab"
+                  id="tab-22"
                   role="tab"
+                  tabindex="-1"
                 >
                   Tab-22
                 </div>
                 <div
+                  aria-controls="tabpane-23"
                   aria-disabled="false"
                   aria-selected="false"
                   class=" ant-tabs-tab"
+                  id="tab-23"
                   role="tab"
+                  tabindex="-1"
                 >
                   Tab-23
                 </div>
                 <div
+                  aria-controls="tabpane-24"
                   aria-disabled="false"
                   aria-selected="false"
                   class=" ant-tabs-tab"
+                  id="tab-24"
                   role="tab"
+                  tabindex="-1"
                 >
                   Tab-24
                 </div>
                 <div
+                  aria-controls="tabpane-25"
                   aria-disabled="false"
                   aria-selected="false"
                   class=" ant-tabs-tab"
+                  id="tab-25"
                   role="tab"
+                  tabindex="-1"
                 >
                   Tab-25
                 </div>
                 <div
+                  aria-controls="tabpane-26"
                   aria-disabled="false"
                   aria-selected="false"
                   class=" ant-tabs-tab"
+                  id="tab-26"
                   role="tab"
+                  tabindex="-1"
                 >
                   Tab-26
                 </div>
                 <div
+                  aria-controls="tabpane-27"
                   aria-disabled="false"
                   aria-selected="false"
                   class=" ant-tabs-tab"
+                  id="tab-27"
                   role="tab"
+                  tabindex="-1"
                 >
                   Tab-27
                 </div>
                 <div
+                  aria-controls="tabpane-28"
                   aria-disabled="false"
                   aria-selected="false"
                   class=" ant-tabs-tab"
+                  id="tab-28"
                   role="tab"
+                  tabindex="-1"
                 >
                   Tab-28
                 </div>
                 <div
+                  aria-controls="tabpane-29"
                   aria-disabled="false"
                   aria-selected="false"
                   class=" ant-tabs-tab"
+                  id="tab-29"
                   role="tab"
+                  tabindex="-1"
                 >
                   Tab-29
                 </div>
@@ -3335,11 +3424,6 @@ exports[`renders ./components/tabs/demo/slide.md correctly 1`] = `
       </div>
     </div>
     <div
-      role="presentation"
-      style="width:0;height:0;overflow:hidden;position:absolute"
-      tabindex="0"
-    />
-    <div
       class="ant-tabs-content ant-tabs-content-animated ant-tabs-top-content"
       style="margin-left:-100%"
     >
@@ -3347,170 +3431,215 @@ exports[`renders ./components/tabs/demo/slide.md correctly 1`] = `
         aria-hidden="true"
         class="ant-tabs-tabpane ant-tabs-tabpane-inactive"
         role="tabpanel"
+        style="visibility:hidden"
+        tabindex="-1"
       />
       <div
         aria-hidden="false"
         class="ant-tabs-tabpane ant-tabs-tabpane-active"
         role="tabpanel"
+        style="visibility:visible"
+        tabindex="0"
       >
-        <div
-          role="presentation"
-          style="width:0;height:0;overflow:hidden;position:absolute"
-          tabindex="0"
-        />
         Content of tab 1
-        <div
-          role="presentation"
-          style="width:0;height:0;overflow:hidden;position:absolute"
-          tabindex="0"
-        />
       </div>
       <div
         aria-hidden="true"
         class="ant-tabs-tabpane ant-tabs-tabpane-inactive"
         role="tabpanel"
+        style="visibility:hidden"
+        tabindex="-1"
       />
       <div
         aria-hidden="true"
         class="ant-tabs-tabpane ant-tabs-tabpane-inactive"
         role="tabpanel"
+        style="visibility:hidden"
+        tabindex="-1"
       />
       <div
         aria-hidden="true"
         class="ant-tabs-tabpane ant-tabs-tabpane-inactive"
         role="tabpanel"
+        style="visibility:hidden"
+        tabindex="-1"
       />
       <div
         aria-hidden="true"
         class="ant-tabs-tabpane ant-tabs-tabpane-inactive"
         role="tabpanel"
+        style="visibility:hidden"
+        tabindex="-1"
       />
       <div
         aria-hidden="true"
         class="ant-tabs-tabpane ant-tabs-tabpane-inactive"
         role="tabpanel"
+        style="visibility:hidden"
+        tabindex="-1"
       />
       <div
         aria-hidden="true"
         class="ant-tabs-tabpane ant-tabs-tabpane-inactive"
         role="tabpanel"
+        style="visibility:hidden"
+        tabindex="-1"
       />
       <div
         aria-hidden="true"
         class="ant-tabs-tabpane ant-tabs-tabpane-inactive"
         role="tabpanel"
+        style="visibility:hidden"
+        tabindex="-1"
       />
       <div
         aria-hidden="true"
         class="ant-tabs-tabpane ant-tabs-tabpane-inactive"
         role="tabpanel"
+        style="visibility:hidden"
+        tabindex="-1"
       />
       <div
         aria-hidden="true"
         class="ant-tabs-tabpane ant-tabs-tabpane-inactive"
         role="tabpanel"
+        style="visibility:hidden"
+        tabindex="-1"
       />
       <div
         aria-hidden="true"
         class="ant-tabs-tabpane ant-tabs-tabpane-inactive"
         role="tabpanel"
+        style="visibility:hidden"
+        tabindex="-1"
       />
       <div
         aria-hidden="true"
         class="ant-tabs-tabpane ant-tabs-tabpane-inactive"
         role="tabpanel"
+        style="visibility:hidden"
+        tabindex="-1"
       />
       <div
         aria-hidden="true"
         class="ant-tabs-tabpane ant-tabs-tabpane-inactive"
         role="tabpanel"
+        style="visibility:hidden"
+        tabindex="-1"
       />
       <div
         aria-hidden="true"
         class="ant-tabs-tabpane ant-tabs-tabpane-inactive"
         role="tabpanel"
+        style="visibility:hidden"
+        tabindex="-1"
       />
       <div
         aria-hidden="true"
         class="ant-tabs-tabpane ant-tabs-tabpane-inactive"
         role="tabpanel"
+        style="visibility:hidden"
+        tabindex="-1"
       />
       <div
         aria-hidden="true"
         class="ant-tabs-tabpane ant-tabs-tabpane-inactive"
         role="tabpanel"
+        style="visibility:hidden"
+        tabindex="-1"
       />
       <div
         aria-hidden="true"
         class="ant-tabs-tabpane ant-tabs-tabpane-inactive"
         role="tabpanel"
+        style="visibility:hidden"
+        tabindex="-1"
       />
       <div
         aria-hidden="true"
         class="ant-tabs-tabpane ant-tabs-tabpane-inactive"
         role="tabpanel"
+        style="visibility:hidden"
+        tabindex="-1"
       />
       <div
         aria-hidden="true"
         class="ant-tabs-tabpane ant-tabs-tabpane-inactive"
         role="tabpanel"
+        style="visibility:hidden"
+        tabindex="-1"
       />
       <div
         aria-hidden="true"
         class="ant-tabs-tabpane ant-tabs-tabpane-inactive"
         role="tabpanel"
+        style="visibility:hidden"
+        tabindex="-1"
       />
       <div
         aria-hidden="true"
         class="ant-tabs-tabpane ant-tabs-tabpane-inactive"
         role="tabpanel"
+        style="visibility:hidden"
+        tabindex="-1"
       />
       <div
         aria-hidden="true"
         class="ant-tabs-tabpane ant-tabs-tabpane-inactive"
         role="tabpanel"
+        style="visibility:hidden"
+        tabindex="-1"
       />
       <div
         aria-hidden="true"
         class="ant-tabs-tabpane ant-tabs-tabpane-inactive"
         role="tabpanel"
+        style="visibility:hidden"
+        tabindex="-1"
       />
       <div
         aria-hidden="true"
         class="ant-tabs-tabpane ant-tabs-tabpane-inactive"
         role="tabpanel"
+        style="visibility:hidden"
+        tabindex="-1"
       />
       <div
         aria-hidden="true"
         class="ant-tabs-tabpane ant-tabs-tabpane-inactive"
         role="tabpanel"
+        style="visibility:hidden"
+        tabindex="-1"
       />
       <div
         aria-hidden="true"
         class="ant-tabs-tabpane ant-tabs-tabpane-inactive"
         role="tabpanel"
+        style="visibility:hidden"
+        tabindex="-1"
       />
       <div
         aria-hidden="true"
         class="ant-tabs-tabpane ant-tabs-tabpane-inactive"
         role="tabpanel"
+        style="visibility:hidden"
+        tabindex="-1"
       />
       <div
         aria-hidden="true"
         class="ant-tabs-tabpane ant-tabs-tabpane-inactive"
         role="tabpanel"
+        style="visibility:hidden"
+        tabindex="-1"
       />
       <div
         aria-hidden="true"
         class="ant-tabs-tabpane ant-tabs-tabpane-inactive"
         role="tabpanel"
+        style="visibility:hidden"
+        tabindex="-1"
       />
     </div>
-    <div
-      role="presentation"
-      style="width:0;height:0;overflow:hidden;position:absolute"
-      tabindex="0"
-    />
   </div>
 </div>
 `;

--- a/components/tabs/__tests__/__snapshots__/index.test.js.snap
+++ b/components/tabs/__tests__/__snapshots__/index.test.js.snap
@@ -8,11 +8,6 @@ exports[`Tabs renderTabBar custom-tab-bar 1`] = `
     custom-tab-bar
   </div>
   <div
-    role="presentation"
-    style="width:0;height:0;overflow:hidden;position:absolute"
-    tabindex="0"
-  />
-  <div
     class="ant-tabs-content ant-tabs-content-animated ant-tabs-top-content"
     style="margin-left:0%"
   >
@@ -20,25 +15,12 @@ exports[`Tabs renderTabBar custom-tab-bar 1`] = `
       aria-hidden="false"
       class="ant-tabs-tabpane ant-tabs-tabpane-active"
       role="tabpanel"
+      style="visibility:visible"
+      tabindex="0"
     >
-      <div
-        role="presentation"
-        style="width:0;height:0;overflow:hidden;position:absolute"
-        tabindex="0"
-      />
       foo
-      <div
-        role="presentation"
-        style="width:0;height:0;overflow:hidden;position:absolute"
-        tabindex="0"
-      />
     </div>
   </div>
-  <div
-    role="presentation"
-    style="width:0;height:0;overflow:hidden;position:absolute"
-    tabindex="0"
-  />
 </div>
 `;
 
@@ -49,7 +31,7 @@ exports[`Tabs rtl render component should be rendered correctly in RTL direction
   <div
     class="ant-tabs-bar ant-tabs-top-bar"
     role="tablist"
-    tabindex="0"
+    tabindex="-1"
   >
     <div
       class="ant-tabs-nav-container"
@@ -123,10 +105,13 @@ exports[`Tabs rtl render component should be rendered correctly in RTL direction
           >
             <div>
               <div
+                aria-controls="tabpane-xx"
                 aria-disabled="false"
                 aria-selected="true"
                 class="ant-tabs-tab-active ant-tabs-tab"
+                id="tab-xx"
                 role="tab"
+                tabindex="0"
               >
                 xx
               </div>
@@ -140,11 +125,6 @@ exports[`Tabs rtl render component should be rendered correctly in RTL direction
     </div>
   </div>
   <div
-    role="presentation"
-    style="width:0;height:0;overflow:hidden;position:absolute"
-    tabindex="0"
-  />
-  <div
     class="ant-tabs-content ant-tabs-content-animated ant-tabs-top-content"
     style="margin-left:100%"
   >
@@ -152,24 +132,10 @@ exports[`Tabs rtl render component should be rendered correctly in RTL direction
       aria-hidden="false"
       class="ant-tabs-tabpane ant-tabs-tabpane-active"
       role="tabpanel"
-    >
-      <div
-        role="presentation"
-        style="width:0;height:0;overflow:hidden;position:absolute"
-        tabindex="0"
-      />
-      <div
-        role="presentation"
-        style="width:0;height:0;overflow:hidden;position:absolute"
-        tabindex="0"
-      />
-    </div>
+      style="visibility:visible"
+      tabindex="0"
+    />
   </div>
-  <div
-    role="presentation"
-    style="width:0;height:0;overflow:hidden;position:absolute"
-    tabindex="0"
-  />
 </div>
 `;
 
@@ -180,7 +146,7 @@ exports[`Tabs tabPosition remove card 1`] = `
   <div
     class="ant-tabs-bar ant-tabs-left-bar"
     role="tablist"
-    tabindex="0"
+    tabindex="-1"
   >
     <div
       class="ant-tabs-nav-container"
@@ -254,10 +220,13 @@ exports[`Tabs tabPosition remove card 1`] = `
           >
             <div>
               <div
+                aria-controls="tabpane-1"
                 aria-disabled="false"
                 aria-selected="true"
                 class="ant-tabs-tab-active ant-tabs-tab"
+                id="tab-1"
                 role="tab"
+                tabindex="0"
               >
                 foo
               </div>
@@ -276,11 +245,6 @@ exports[`Tabs tabPosition remove card 1`] = `
     </div>
   </div>
   <div
-    role="presentation"
-    style="width:0;height:0;overflow:hidden;position:absolute"
-    tabindex="0"
-  />
-  <div
     class="ant-tabs-content ant-tabs-content-animated ant-tabs-left-content"
     style="margin-top:0%"
   >
@@ -288,24 +252,11 @@ exports[`Tabs tabPosition remove card 1`] = `
       aria-hidden="false"
       class="ant-tabs-tabpane ant-tabs-tabpane-active"
       role="tabpanel"
+      style="visibility:visible"
+      tabindex="0"
     >
-      <div
-        role="presentation"
-        style="width:0;height:0;overflow:hidden;position:absolute"
-        tabindex="0"
-      />
       foo
-      <div
-        role="presentation"
-        style="width:0;height:0;overflow:hidden;position:absolute"
-        tabindex="0"
-      />
     </div>
   </div>
-  <div
-    role="presentation"
-    style="width:0;height:0;overflow:hidden;position:absolute"
-    tabindex="0"
-  />
 </div>
 `;

--- a/components/tabs/index.en-US.md
+++ b/components/tabs/index.en-US.md
@@ -37,6 +37,7 @@ Ant Design has 3 types of Tabs for different situations.
 | onNextClick | Callback executed when next button is clicked | Function | - |
 | onPrevClick | Callback executed when prev button is clicked | Function | - |
 | onTabClick | Callback executed when tab is clicked | Function(key: string, event: MouseEvent) | - |
+| keyboard | whether to turn on keyboard navigation | boolean | true |
 
 More option at [rc-tabs option](https://github.com/react-component/tabs#tabs)
 

--- a/components/tabs/index.tsx
+++ b/components/tabs/index.tsx
@@ -39,6 +39,7 @@ export interface TabsProps {
     DefaultTabBar: React.ComponentClass<any>,
   ) => React.ReactElement<any>;
   destroyInactiveTabPane?: boolean;
+  keyboard?: boolean;
 }
 
 // Tabs

--- a/components/tabs/index.zh-CN.md
+++ b/components/tabs/index.zh-CN.md
@@ -40,6 +40,7 @@ Ant Design 依次提供了三级选项卡，分别用于不同的场景。
 | onNextClick | next 按钮被点击的回调 | Function | 无 |
 | onPrevClick | prev 按钮被点击的回调 | Function | 无 |
 | onTabClick | tab 被点击的回调 | Function | 无 |
+| keyboard | 开启键盘切换功能 | boolean | true |
 
 ### Tabs.TabPane
 

--- a/components/tabs/style/index.less
+++ b/components/tabs/style/index.less
@@ -247,6 +247,7 @@
       &-active {
         color: @tabs-highlight-color;
         font-weight: 500;
+        outline: none;
       }
 
       &-disabled {

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "rc-steps": "~3.5.0",
     "rc-switch": "~1.9.0",
     "rc-table": "~7.3.0",
-    "rc-tabs": "~10.0.0",
+    "rc-tabs": "~10.1.0",
     "rc-tooltip": "~4.0.2",
     "rc-tree": "~3.1.0",
     "rc-tree-select": "~3.1.0",


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [x] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

- [x] 🆕 Add keyboard prop
  - close ant-design/ant-design#22264
- [x] `extraContent` should not listen to keyborad navigation
  - close #242
  - close ant-design/ant-design#9768
  - close ant-design/ant-design#15610
  - close ant-design/ant-design#7948
- [x] 🚮 Remove `prop-types` and clean up dependencies.
- [x] ⌨️ Improve Tabs Accessibility
  - https://github.com/react-component/tabs/pull/218/
  - close #18798
  - close #11748

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | - ⌨️ Improve Tabs Accessibility.<br />- Add Tabs `keyboard` prop.<br />- Tabs `extraContent` don't trigger keyboard navigation now. |
| 🇨🇳 Chinese | - ⌨️ 增强 Tabs 可访问性。<br />- 新增 Tabs `keyboard` 属性用于开关键盘切换功能。<br />- Tabs `extraContent` 里的元素不再触发键盘切换功能。 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️ 

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/tabs/index.en-US.md](https://github.com/ant-design/ant-design/blob/upgrade-tabs/components/tabs/index.en-US.md)
[View rendered components/tabs/index.zh-CN.md](https://github.com/ant-design/ant-design/blob/upgrade-tabs/components/tabs/index.zh-CN.md)