### PR TITLE
fix: Ant Table Border Radius

### DIFF
--- a/components/table/style/index.less
+++ b/components/table/style/index.less
@@ -21,6 +21,7 @@
   z-index: 0;
   clear: both;
   background: @table-bg;
+  border-radius: @border-radius-base;
 
   // https://github.com/ant-design/ant-design/issues/17611
   table {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

Ant Table shows white background on the edges instead of proper border-radius.

### 💡 Background and solution

Ant does not apply border-radius to table container element leading to a white background on the edges (instead of the correct border radius).

![image](https://user-images.githubusercontent.com/1667481/77079901-acddc680-6a1e-11ea-81a7-05e6c8e971d9.png)

Solution: Add border-radius to table container element.

![image](https://user-images.githubusercontent.com/1667481/77079978-c67f0e00-6a1e-11ea-9497-d76b1925b006.png)

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

Does not break anything.
<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️ 

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
