### PR TITLE
fix: Table column group with controlled sorter

### DIFF
--- a/components/table/__tests__/Table.sorter.test.js
+++ b/components/table/__tests__/Table.sorter.test.js
@@ -728,7 +728,7 @@ describe('Table.sorter', () => {
       {
         title: 'Math Score',
         dataIndex: 'math1',
-        sortOrder: 'asc',
+        sortOrder: 'ascend',
         sorter: { multiple: 1 },
         children: [
           {
@@ -740,7 +740,7 @@ describe('Table.sorter', () => {
       {
         title: 'English Score',
         dataIndex: 'english',
-        sortOrder: 'desc',
+        sortOrder: 'descend',
         sorter: { multiple: 2 },
       },
     ];
@@ -757,7 +757,6 @@ describe('Table.sorter', () => {
 
     const wrapper = mount(<Table columns={groupColumns} data={groupData} />);
     wrapper.update();
-    console.log(wrapper.find('thead').html());
     expect(
       wrapper
         .find('.ant-table-column-sorter-full')

--- a/components/table/__tests__/Table.sorter.test.js
+++ b/components/table/__tests__/Table.sorter.test.js
@@ -722,4 +722,57 @@ describe('Table.sorter', () => {
         .hasClass('active'),
     ).toBeFalsy();
   });
+
+  it('controlled multiple group', () => {
+    const groupColumns = [
+      {
+        title: 'Math Score',
+        dataIndex: 'math1',
+        sortOrder: 'asc',
+        sorter: { multiple: 1 },
+        children: [
+          {
+            title: 'math',
+            dataIndex: 'math',
+          },
+        ],
+      },
+      {
+        title: 'English Score',
+        dataIndex: 'english',
+        sortOrder: 'desc',
+        sorter: { multiple: 2 },
+      },
+    ];
+
+    const groupData = [
+      {
+        key: '1',
+        name: 'John Brown',
+        chinese: 98,
+        math: 60,
+        english: 70,
+      },
+    ];
+
+    const wrapper = mount(<Table columns={groupColumns} data={groupData} />);
+    wrapper.update();
+    console.log(wrapper.find('thead').html());
+    expect(
+      wrapper
+        .find('.ant-table-column-sorter-full')
+        .first()
+        .find('.ant-table-column-sorter-up')
+        .first()
+        .hasClass('active'),
+    ).toBeTruthy();
+    expect(
+      wrapper
+        .find('.ant-table-column-sorter-full')
+        .last()
+        .find('.ant-table-column-sorter-down')
+        .first()
+        .hasClass('active'),
+    ).toBeTruthy();
+  });
 });

--- a/components/table/hooks/useSorter.tsx
+++ b/components/table/hooks/useSorter.tsx
@@ -94,8 +94,6 @@ function collectSortStates<RecordType>(
     }
   });
 
-  console.log('=>', sortStates);
-
   return sortStates;
 }
 
@@ -304,12 +302,9 @@ export default function useFilterSorter<RecordType>({
     collectSortStates(mergedColumns, true),
   );
 
-  console.log('sortStates', sortStates);
-
   const mergedSorterStates = React.useMemo(() => {
     let validate = true;
     const collectedStates = collectSortStates(mergedColumns, false);
-    console.log('collectedStates', collectedStates, sortStates);
 
     // Return if not controlled
     if (!collectedStates.length) {
@@ -383,7 +378,6 @@ export default function useFilterSorter<RecordType>({
       ];
     }
 
-    console.log('SetSortState:', newSorterStates);
     setSortStates(newSorterStates);
     onSorterChange(generateSorterInfo(newSorterStates), newSorterStates);
   }

--- a/components/table/interface.tsx
+++ b/components/table/interface.tsx
@@ -88,7 +88,7 @@ export interface ColumnType<RecordType> extends RcColumnType<RecordType> {
   onFilterDropdownVisibleChange?: (visible: boolean) => void;
 }
 
-export interface ColumnGroupType<RecordType> extends ColumnType<RecordType> {
+export interface ColumnGroupType<RecordType> extends Omit<ColumnType<RecordType>, 'dataIndex'> {
   children: ColumnsType<RecordType>;
 }
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

resolve #22448

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Fix Table ColumnGroup with controlled `sorterOrder` not working issue.       |
| 🇨🇳 Chinese |      修复 Table ColumnGroup 使用受控 `sorterOrder` 无效的问题。     |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️ 

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
