### PR TITLE
fix: 🐛 empty disabled Button align issue

### DIFF
--- a/components/button/style/index.less
+++ b/components/button/style/index.less
@@ -227,8 +227,12 @@
   }
 
   // https://github.com/ant-design/ant-design/issues/12681
+  // same method as Select
   &:empty {
-    vertical-align: top;
+    display: inline-block;
+    width: 0;
+    visibility: hidden;
+    content: '\a0';
   }
 }
 

--- a/components/tooltip/__tests__/__snapshots__/tooltip.test.js.snap
+++ b/components/tooltip/__tests__/__snapshots__/tooltip.test.js.snap
@@ -4,6 +4,7 @@ exports[`Tooltip rtl render component should be rendered correctly in RTL direct
 
 exports[`Tooltip should hide when mouse leave antd disabled component Button 1`] = `
 <span
+  class="ant-tooltip-disabled-compatible-wrapper"
   style="display: inline-block; cursor: not-allowed;"
 >
   <button
@@ -17,6 +18,7 @@ exports[`Tooltip should hide when mouse leave antd disabled component Button 1`]
 
 exports[`Tooltip should hide when mouse leave antd disabled component Checkbox 1`] = `
 <span
+  class="ant-tooltip-disabled-compatible-wrapper"
   style="display: inline-block; cursor: not-allowed;"
 >
   <label
@@ -42,6 +44,7 @@ exports[`Tooltip should hide when mouse leave antd disabled component Checkbox 1
 
 exports[`Tooltip should hide when mouse leave antd disabled component Switch 1`] = `
 <span
+  class="ant-tooltip-disabled-compatible-wrapper"
   style="display: inline-block; cursor: not-allowed;"
 >
   <button

--- a/components/tooltip/index.tsx
+++ b/components/tooltip/index.tsx
@@ -74,7 +74,7 @@ const splitObject = (obj: any, keys: string[]) => {
 // Fix Tooltip won't hide at disabled button
 // mouse events don't trigger at disabled button in Chrome
 // https://github.com/react-component/tooltip/issues/18
-function getDisabledCompatibleChildren(element: React.ReactElement<any>) {
+function getDisabledCompatibleChildren(element: React.ReactElement<any>, prefixCls: string) {
   const elementType = element.type as any;
   if (
     (elementType.__ANT_BUTTON === true ||
@@ -110,7 +110,10 @@ function getDisabledCompatibleChildren(element: React.ReactElement<any>) {
       className: null,
     });
     return (
-      <span style={spanStyle} className={element.props.className}>
+      <span
+        style={spanStyle}
+        className={classNames(element.props.className, `${prefixCls}-disabled-compatible-wrapper`)}
+      >
         {child}
       </span>
     );
@@ -238,6 +241,7 @@ class Tooltip extends React.Component<TooltipProps, any> {
 
     const child = getDisabledCompatibleChildren(
       React.isValidElement(children) ? children : <span>{children}</span>,
+      prefixCls,
     );
 
     const childProps = child.props;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close #22453

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Button align issue when is disabled and wrapped by Tooltip . |
| 🇨🇳 Chinese | 修复 Button 为 `disabled` 时被 Tooltip 包裹时的对齐问题。 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️ 

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
