### PR TITLE
docs: Address diverse users without gender assumption

### DIFF
--- a/components/form/demo/control-hooks.md
+++ b/components/form/demo/control-hooks.md
@@ -34,9 +34,17 @@ const Demo = () => {
   const [form] = Form.useForm();
 
   const onGenderChange = value => {
-    form.setFieldsValue({
-      note: `Hi, ${value === 'male' ? 'man' : 'lady'}!`,
-    });
+    switch (value) {
+      case "male":
+        form.setFieldsValue({ note: "Hi, man!" });
+        return;
+      case "female":
+        form.setFieldsValue({ note: "Hi, lady!" });
+        return;
+      case "other":
+        form.setFieldsValue({ note: "Hi there!" });
+        return;
+    }
   };
 
   const onFinish = values => {


### PR DESCRIPTION
### 🤔 This is a ...

- [x] Site / document update

### 🔗 Related issue link

-

### 💡 Background and solution

Not all diverse users don't want to be addressed as "lady" - if they wanted to, they'd have put in "lady".
This commit fixes this potential offense and replaces it using a less specific "hi there".

### 📝 Changelog

Fixed gender-related issue in form docs.

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed gender-related issue in form docs |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/form/demo/control-hooks.md](https://github.com/Skn0tt/ant-design/blob/patch-1/components/form/demo/control-hooks.md)