### PR TITLE
Reduce unnecesary render with gutter={[7,9]} #22474

### DIFF
--- a/components/grid/row.tsx
+++ b/components/grid/row.tsx
@@ -46,7 +46,7 @@ export default class Row extends React.Component<RowProps, RowState> {
     this.token = ResponsiveObserve.subscribe(screens => {
       const { gutter } = this.props;
       if (
-        typeof gutter === 'object' ||
+        (!Array.isArray(gutter) && typeof gutter === 'object') ||
         (Array.isArray(gutter) && (typeof gutter[0] === 'object' || typeof gutter[1] === 'object'))
       ) {
         this.setState({ screens });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

1. Reduce the rerenders of the row #22474

### 💡 Background and solution

1. Problem is that there are multiple renders
3. Is is because the code thinks that screens is important, while that is only the case with an object type gutter

### 📝 Changelog

No userside changes

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️ 

- [ not needed ] Doc is updated/provided or not needed
- [ not needed ] Demo is updated/provided or not needed
- [ not needed ] TypeScript definition is updated/provided or not needed
- [ not needed  ] Changelog is provided or not needed
