### PR TITLE
fix: config provider size

### DIFF
--- a/components/config-provider/demo/size.md
+++ b/components/config-provider/demo/size.md
@@ -53,6 +53,9 @@ const FormSizeDemo = () => {
           <DatePicker />
         </div>
         <div className="example">
+          <DatePicker.RangePicker />
+        </div>
+        <div className="example">
           <Button>Button</Button>
         </div>
         <div className="example">

--- a/components/date-picker/generatePicker.tsx
+++ b/components/date-picker/generatePicker.tsx
@@ -273,7 +273,7 @@ function generatePicker<DateType>(generateConfig: GenerateConfig<DateType>) {
       const {
         prefixCls: customizePrefixCls,
         className,
-        size,
+        size: customizeSize,
         bordered = true,
         ...restProps
       } = this.props;
@@ -289,30 +289,38 @@ function generatePicker<DateType>(generateConfig: GenerateConfig<DateType>) {
       };
 
       return (
-        <RCRangePicker<DateType>
-          separator={<span className={`${prefixCls}-separator`}>→</span>}
-          ref={this.pickerRef}
-          placeholder={getRangePlaceholder(picker, locale)}
-          suffixIcon={picker === 'time' ? <ClockCircleOutlined /> : <CalendarOutlined />}
-          clearIcon={<CloseCircleFilled />}
-          allowClear
-          transitionName="slide-up"
-          {...restProps}
-          className={classNames(className, {
-            [`${prefixCls}-${size}`]: size,
-            [`${prefixCls}-borderless`]: !bordered,
-          })}
-          {...additionalOverrideProps}
-          locale={locale!.lang}
-          prefixCls={prefixCls}
-          generateConfig={generateConfig}
-          prevIcon={<span className={`${prefixCls}-prev-icon`} />}
-          nextIcon={<span className={`${prefixCls}-next-icon`} />}
-          superPrevIcon={<span className={`${prefixCls}-super-prev-icon`} />}
-          superNextIcon={<span className={`${prefixCls}-super-next-icon`} />}
-          components={Components}
-          direction={direction}
-        />
+        <SizeContext.Consumer>
+          {size => {
+            const mergedSize = customizeSize || size;
+
+            return (
+              <RCRangePicker<DateType>
+                separator={<span className={`${prefixCls}-separator`}>→</span>}
+                ref={this.pickerRef}
+                placeholder={getRangePlaceholder(picker, locale)}
+                suffixIcon={picker === 'time' ? <ClockCircleOutlined /> : <CalendarOutlined />}
+                clearIcon={<CloseCircleFilled />}
+                allowClear
+                transitionName="slide-up"
+                {...restProps}
+                className={classNames(className, {
+                  [`${prefixCls}-${mergedSize}`]: mergedSize,
+                  [`${prefixCls}-borderless`]: !bordered,
+                })}
+                {...additionalOverrideProps}
+                locale={locale!.lang}
+                prefixCls={prefixCls}
+                generateConfig={generateConfig}
+                prevIcon={<span className={`${prefixCls}-prev-icon`} />}
+                nextIcon={<span className={`${prefixCls}-next-icon`} />}
+                superPrevIcon={<span className={`${prefixCls}-super-prev-icon`} />}
+                superNextIcon={<span className={`${prefixCls}-super-next-icon`} />}
+                components={Components}
+                direction={direction}
+              />
+            );
+          }}
+        </SizeContext.Consumer>
       );
     };
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

fix #22485

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fix ConfigProvider `componentSize` not works on DatePicker.RangePicker.      |
| 🇨🇳 Chinese |     修复 ConfigProvider `componentSize` 对 DatePicker.RangePicker 无效的问题。       |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️ 

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [] Changelog is provided or not needed


-----
[View rendered components/config-provider/demo/size.md](https://github.com/ant-design/ant-design/blob/config-size/components/config-provider/demo/size.md)