### PR TITLE
docs: 📖 TreeSelect switcherIcon doc 

### DIFF
--- a/components/tree-select/index.en-US.md
+++ b/components/tree-select/index.en-US.md
@@ -34,6 +34,7 @@ Tree selection control.
 | placeholder | Placeholder of the select input | string | - |  |
 | searchValue | work with `onSearch` to make search value controlled. | string | - |  |
 | treeIcon | Shows the icon before a TreeNode's title. There is no default style; you must set a custom style for it if set to `true` | boolean | false |  |
+| switcherIcon | customize collapse/expand icon of tree node | ReactNode | - |
 | showCheckedStrategy | The way show selected item in box. **Default:** just show child nodes. **`TreeSelect.SHOW_ALL`:** show all checked treeNodes (include parent treeNode). **`TreeSelect.SHOW_PARENT`:** show checked treeNodes (just show parent treeNode). | enum { TreeSelect.SHOW_ALL, TreeSelect.SHOW_PARENT, TreeSelect.SHOW_CHILD } | TreeSelect.SHOW_CHILD |  |
 | showSearch | Support search or not | boolean | single: `false` \| multiple: `true` |  |
 | size | To set the size of the select input | `large` \| `middle` \| `small` |  |  |

--- a/components/tree-select/index.zh-CN.md
+++ b/components/tree-select/index.zh-CN.md
@@ -35,6 +35,7 @@ title: TreeSelect
 | placeholder | 选择框默认文字 | string | - |  |
 | searchValue | 搜索框的值，可以通过 `onSearch` 获取用户输入 | string | - |  |
 | treeIcon | 是否展示 TreeNode title 前的图标，没有默认样式，如设置为 true，需要自行定义图标相关样式 | boolean | false |  |
+| switcherIcon | 自定义树节点的展开/折叠图标 | ReactNode | - |
 | showCheckedStrategy | 定义选中项回填的方式。`TreeSelect.SHOW_ALL`: 显示所有选中节点(包括父节点). `TreeSelect.SHOW_PARENT`: 只显示父节点(当父节点下所有子节点都选中时). 默认只显示子节点. | enum{TreeSelect.SHOW_ALL, TreeSelect.SHOW_PARENT, TreeSelect.SHOW_CHILD } | TreeSelect.SHOW_CHILD |  |
 | showSearch | 是否支持搜索框 | boolean | 单选：`false` \| 多选：`true` |  |
 | size | 选择框大小 | `large` \| `middle` \| `small` | 无 |  |

--- a/components/tree/index.en-US.md
+++ b/components/tree/index.en-US.md
@@ -36,7 +36,7 @@ Almost anything can be represented in a tree structure. Examples include directo
 | selectable | whether can be selected | boolean | true |
 | selectedKeys | (Controlled) Specifies the keys of the selected treeNodes | string\[] | - |
 | showIcon | Shows the icon before a TreeNode's title. There is no default style; you must set a custom style for it if set to `true` | boolean | false |
-| switcherIcon | customize collapse/expand icon of tree node | React.ReactElement | - |
+| switcherIcon | customize collapse/expand icon of tree node | ReactNode | - |
 | showLine | Shows a connecting line | boolean | false |
 | onCheck | Callback function for when the onCheck event occurs | function(checkedKeys, e:{checked: bool, checkedNodes, node, event, halfCheckedKeys}) | - |
 | onDragEnd | Callback function for when the onDragEnd event occurs | function({event, node}) | - |

--- a/components/tree/index.zh-CN.md
+++ b/components/tree/index.zh-CN.md
@@ -37,7 +37,7 @@ subtitle: 树形控件
 | selectable | 是否可选中 | boolean | true |
 | selectedKeys | （受控）设置选中的树节点 | string\[] | - |
 | showIcon | 是否展示 TreeNode title 前的图标，没有默认样式，如设置为 true，需要自行定义图标相关样式 | boolean | false |
-| switcherIcon | 自定义树节点的展开/折叠图标 | React.ReactElement | - |
+| switcherIcon | 自定义树节点的展开/折叠图标 | ReactNode | - |
 | showLine | 是否展示连接线 | boolean | false |
 | onCheck | 点击复选框触发 | function(checkedKeys, e:{checked: bool, checkedNodes, node, event, halfCheckedKeys}) | - |
 | onDragEnd | dragend 触发时调用 | function({event, node}) | - |


### PR DESCRIPTION


<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close #22487

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️ 

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/tree-select/index.en-US.md](https://github.com/ant-design/ant-design/blob/docs-tree-select/components/tree-select/index.en-US.md)
[View rendered components/tree-select/index.zh-CN.md](https://github.com/ant-design/ant-design/blob/docs-tree-select/components/tree-select/index.zh-CN.md)
[View rendered components/tree/index.en-US.md](https://github.com/ant-design/ant-design/blob/docs-tree-select/components/tree/index.en-US.md)
[View rendered components/tree/index.zh-CN.md](https://github.com/ant-design/ant-design/blob/docs-tree-select/components/tree/index.zh-CN.md)