### PR TITLE
fix: Input with suffix align issue

### DIFF
--- a/components/input/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/input/__tests__/__snapshots__/demo.test.js.snap
@@ -890,6 +890,42 @@ exports[`renders ./components/input/demo/align.md correctly 1`] = `
       </span>
     </span>
   </span>
+  <span
+    class="ant-input-affix-wrapper"
+    style="width:50px"
+  >
+    <input
+      class="ant-input"
+      type="text"
+      value=""
+    />
+    <span
+      class="ant-input-suffix"
+    >
+      Y
+    </span>
+  </span>
+  <input
+    class="ant-input"
+    style="width:50px"
+    type="text"
+    value=""
+  />
+  <span
+    class="ant-input-affix-wrapper"
+    style="width:50px"
+  >
+    <input
+      class="ant-input"
+      type="text"
+      value="1"
+    />
+    <span
+      class="ant-input-suffix"
+    >
+      Y
+    </span>
+  </span>
 </div>
 `;
 

--- a/components/input/demo/align.md
+++ b/components/input/demo/align.md
@@ -28,6 +28,10 @@ const RadioGroup = Radio.Group;
 const Option = Select.Option;
 const { MonthPicker, RangePicker } = DatePicker;
 
+const narrowStyle = {
+  width: 50,
+};
+
 const options = [
   {
     value: 'zhejiang',
@@ -94,6 +98,9 @@ ReactDOM.render(
     <AutoComplete style={{ width: 100 }} placeholder="input here" />
     <br />
     <Input prefix="$" addonBefore="Http://" addonAfter=".com" defaultValue="mysite" />
+    <Input style={narrowStyle} suffix="Y" />
+    <Input style={narrowStyle} />
+    <Input style={narrowStyle} defaultValue="1" suffix="Y" />
   </div>,
   mountNode,
 );

--- a/components/input/style/affix.less
+++ b/components/input/style/affix.less
@@ -17,6 +17,12 @@
         box-shadow: none;
       }
     }
+
+    &:before {
+      width: 0;
+      visibility: hidden;
+      content: '\a0';
+    }
   }
 
   &-prefix,

--- a/components/input/style/affix.less
+++ b/components/input/style/affix.less
@@ -18,7 +18,7 @@
       }
     }
 
-    &:before {
+    &::before {
       width: 0;
       visibility: hidden;
       content: '\a0';


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

fix #22588

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fix Input with `suffix` only align style issue.      |
| 🇨🇳 Chinese |    修复 Input 只配置 `suffix` 时的样式对齐问题。       |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️ 

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/input/demo/align.md](https://github.com/ant-design/ant-design/blob/input-affix/components/input/demo/align.md)