### PR TITLE
fix: narrow down types of string literals in a few defaultProps declarations

### DIFF
--- a/components/button/button.tsx
+++ b/components/button/button.tsx
@@ -120,7 +120,7 @@ class Button extends React.Component<ButtonProps, ButtonState> {
     loading: false,
     ghost: false,
     block: false,
-    htmlType: 'button',
+    htmlType: 'button' as ButtonProps['htmlType'],
   };
 
   private delayTimeout: number;

--- a/components/collapse/Collapse.tsx
+++ b/components/collapse/Collapse.tsx
@@ -40,7 +40,7 @@ export default class Collapse extends React.Component<CollapseProps, any> {
 
   static defaultProps = {
     bordered: true,
-    expandIconPosition: 'left',
+    expandIconPosition: 'left' as CollapseProps['expandIconPosition'],
   };
 
   renderExpandIcon = (panelProps: PanelProps = {}, prefixCls: string) => {

--- a/components/progress/progress.tsx
+++ b/components/progress/progress.tsx
@@ -43,14 +43,14 @@ export interface ProgressProps {
 
 export default class Progress extends React.Component<ProgressProps> {
   static defaultProps = {
-    type: 'line',
+    type: 'line' as ProgressProps['type'],
     percent: 0,
     showInfo: true,
     // null for different theme definition
     trailColor: null,
-    size: 'default',
+    size: 'default' as ProgressProps['size'],
     gapDegree: undefined,
-    strokeLinecap: 'round',
+    strokeLinecap: 'round' as ProgressProps['strokeLinecap'],
   };
 
   getPercentNumber() {

--- a/components/tabs/TabBar.tsx
+++ b/components/tabs/TabBar.tsx
@@ -12,7 +12,7 @@ import { ConfigConsumerProps, ConfigConsumer } from '../config-provider';
 export default class TabBar extends React.Component<TabsProps> {
   static defaultProps = {
     animated: true,
-    type: 'line',
+    type: 'line' as TabsProps['type'],
   };
 
   renderTabBar = ({ direction }: ConfigConsumerProps) => {

--- a/components/timeline/Timeline.tsx
+++ b/components/timeline/Timeline.tsx
@@ -21,7 +21,7 @@ export default class Timeline extends React.Component<TimelineProps, any> {
 
   static defaultProps = {
     reverse: false,
-    mode: '',
+    mode: '' as TimelineProps['mode'],
   };
 
   renderTimeline = ({ getPrefixCls, direction }: ConfigConsumerProps) => {

--- a/components/tree/DirectoryTree.tsx
+++ b/components/tree/DirectoryTree.tsx
@@ -39,7 +39,7 @@ function getTreeData({ treeData, children }: DirectoryTreeProps) {
 class DirectoryTree extends React.Component<DirectoryTreeProps, DirectoryTreeState> {
   static defaultProps = {
     showIcon: true,
-    expandAction: 'click',
+    expandAction: 'click' as DirectoryTreeProps['expandAction'],
   };
 
   static getDerivedStateFromProps(nextProps: DirectoryTreeProps) {


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

https://github.com/emotion-js/emotion/issues/1824

### 💡 Background and solution

I got a report for https://github.com/emotion-js/emotion that our typings do not work with antd components. After a quick investigation, I've discovered that this happens because of some of your components have mismatched types between their Props and .defaultProps. I've looked through all of the components and fixed the problem.

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Narrow down types of string literals used for `defaultProps` declarations to their respective enums/unions.           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
