### PR TITLE
fix: Drawer close btn style

### DIFF
--- a/components/config-provider/__tests__/__snapshots__/components.test.js.snap
+++ b/components/config-provider/__tests__/__snapshots__/components.test.js.snap
@@ -6477,6 +6477,7 @@ exports[`ConfigProvider components Drawer configProvider 1`] = `
             <button
               aria-label="Close"
               class="config-drawer-close"
+              style="--scroll-bar:0px"
             >
               <span
                 aria-label="close"
@@ -6537,6 +6538,7 @@ exports[`ConfigProvider components Drawer normal 1`] = `
             <button
               aria-label="Close"
               class="ant-drawer-close"
+              style="--scroll-bar:0px"
             >
               <span
                 aria-label="close"
@@ -6597,6 +6599,7 @@ exports[`ConfigProvider components Drawer prefixCls 1`] = `
             <button
               aria-label="Close"
               class="prefix-Drawer-close"
+              style="--scroll-bar:0px"
             >
               <span
                 aria-label="close"

--- a/components/drawer/__tests__/__snapshots__/Drawer.test.js.snap
+++ b/components/drawer/__tests__/__snapshots__/Drawer.test.js.snap
@@ -28,6 +28,7 @@ exports[`Drawer className is test_drawer 1`] = `
             <button
               aria-label="Close"
               class="ant-drawer-close"
+              style="--scroll-bar:0px"
             >
               <span
                 aria-label="close"
@@ -124,6 +125,7 @@ exports[`Drawer destroyOnClose is true 1`] = `
             <button
               aria-label="Close"
               class="ant-drawer-close"
+              style="--scroll-bar:0px"
             >
               <span
                 aria-label="close"
@@ -186,6 +188,7 @@ exports[`Drawer have a footer 1`] = `
             <button
               aria-label="Close"
               class="ant-drawer-close"
+              style="--scroll-bar:0px"
             >
               <span
                 aria-label="close"
@@ -258,6 +261,7 @@ exports[`Drawer have a title 1`] = `
             <button
               aria-label="Close"
               class="ant-drawer-close"
+              style="--scroll-bar:0px"
             >
               <span
                 aria-label="close"
@@ -320,6 +324,7 @@ exports[`Drawer render correctly 1`] = `
             <button
               aria-label="Close"
               class="ant-drawer-close"
+              style="--scroll-bar:0px"
             >
               <span
                 aria-label="close"
@@ -382,6 +387,7 @@ exports[`Drawer render top drawer 1`] = `
             <button
               aria-label="Close"
               class="ant-drawer-close"
+              style="--scroll-bar:0px"
             >
               <span
                 aria-label="close"
@@ -449,6 +455,7 @@ exports[`Drawer style/drawerStyle/headerStyle/bodyStyle should work 1`] = `
             <button
               aria-label="Close"
               class="ant-drawer-close"
+              style="--scroll-bar:0px"
             >
               <span
                 aria-label="close"

--- a/components/drawer/__tests__/__snapshots__/DrawerEvent.test.js.snap
+++ b/components/drawer/__tests__/__snapshots__/DrawerEvent.test.js.snap
@@ -36,6 +36,7 @@ exports[`Drawer render correctly 1`] = `
               <button
                 aria-label="Close"
                 class="ant-drawer-close"
+                style="--scroll-bar: 0px;"
               >
                 <span
                   aria-label="close"

--- a/components/drawer/index.tsx
+++ b/components/drawer/index.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import RcDrawer from 'rc-drawer';
+import getScrollBarSize from 'rc-util/lib/getScrollBarSize';
 import CloseOutlined from '@ant-design/icons/CloseOutlined';
 import classNames from 'classnames';
 import omit from 'omit.js';
@@ -179,7 +180,16 @@ class Drawer extends React.Component<DrawerProps & ConfigConsumerProps, IDrawerS
     return (
       closable && (
         // eslint-disable-next-line react/button-has-type
-        <button onClick={onClose} aria-label="Close" className={`${prefixCls}-close`}>
+        <button
+          onClick={onClose}
+          aria-label="Close"
+          className={`${prefixCls}-close`}
+          style={
+            {
+              '--scroll-bar': `${getScrollBarSize()}px`,
+            } as any
+          }
+        >
           <CloseOutlined />
         </button>
       )

--- a/components/drawer/style/drawer.less
+++ b/components/drawer/style/drawer.less
@@ -157,14 +157,12 @@
     right: 0;
     z-index: @zindex-popup-close;
     display: block;
-    width: 56px;
-    height: 56px;
-    padding: 0;
+    padding: 20px;
+    line-height: 1;
     color: @text-color-secondary;
     font-weight: 700;
     font-size: @font-size-lg;
     font-style: normal;
-    line-height: 56px;
     text-align: center;
     text-transform: none;
     text-decoration: none;
@@ -179,6 +177,11 @@
     &:hover {
       color: @icon-color-hover;
       text-decoration: none;
+    }
+
+    .@{drawer-prefix-cls}-header-no-title & {
+      padding-right: calc(20px - var(--scroll-bar));
+      margin-right: var(--scroll-bar);
     }
   }
 

--- a/components/drawer/style/drawer.less
+++ b/components/drawer/style/drawer.less
@@ -158,11 +158,11 @@
     z-index: @zindex-popup-close;
     display: block;
     padding: 20px;
-    line-height: 1;
     color: @text-color-secondary;
     font-weight: 700;
     font-size: @font-size-lg;
     font-style: normal;
+    line-height: 1;
     text-align: center;
     text-transform: none;
     text-decoration: none;
@@ -180,8 +180,8 @@
     }
 
     .@{drawer-prefix-cls}-header-no-title & {
-      padding-right: calc(20px - var(--scroll-bar));
       margin-right: var(--scroll-bar);
+      padding-right: calc(20px - var(--scroll-bar));
     }
   }
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

resolve #22705

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Adjust Drawer close button without `title` style to avoid overlap with scroll bar.      |
| 🇨🇳 Chinese |     调整 Drawer 无 `title` 时关闭按钮样式以避免遮挡滚动条。      |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️ 

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
