### PR TITLE
feat: 🔢 improve default pagination switch experience

### DIFF
--- a/components/list/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/list/__tests__/__snapshots__/demo.test.js.snap
@@ -1380,7 +1380,7 @@ exports[`renders ./components/list/demo/vertical.md correctly 1`] = `
         </a>
       </li>
       <li
-        class="ant-pagination-item ant-pagination-item-5"
+        class="ant-pagination-item ant-pagination-item-5 ant-pagination-item-before-jump-next"
         tabindex="0"
         title="5"
       >
@@ -1389,21 +1389,42 @@ exports[`renders ./components/list/demo/vertical.md correctly 1`] = `
         </a>
       </li>
       <li
-        class="ant-pagination-item ant-pagination-item-6"
+        class="ant-pagination-jump-next ant-pagination-jump-next-custom-icon"
         tabindex="0"
-        title="6"
+        title="Next 5 Pages"
       >
-        <a>
-          6
-        </a>
-      </li>
-      <li
-        class="ant-pagination-item ant-pagination-item-7"
-        tabindex="0"
-        title="7"
-      >
-        <a>
-          7
+        <a
+          class="ant-pagination-item-link"
+        >
+          <div
+            class="ant-pagination-item-container"
+          >
+            <span
+              aria-label="double-right"
+              class="anticon anticon-double-right ant-pagination-item-link-icon"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                class=""
+                data-icon="double-right"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M533.2 492.3L277.9 166.1c-3-3.9-7.7-6.1-12.6-6.1H188c-6.7 0-10.4 7.7-6.3 12.9L447.1 512 181.7 851.1A7.98 7.98 0 00188 864h77.3c4.9 0 9.6-2.3 12.6-6.1l255.3-326.1c9.1-11.7 9.1-27.9 0-39.5zm304 0L581.9 166.1c-3-3.9-7.7-6.1-12.6-6.1H492c-6.7 0-10.4 7.7-6.3 12.9L751.1 512 485.7 851.1A7.98 7.98 0 00492 864h77.3c4.9 0 9.6-2.3 12.6-6.1l255.3-326.1c9.1-11.7 9.1-27.9 0-39.5z"
+                />
+              </svg>
+            </span>
+            <span
+              class="ant-pagination-item-ellipsis"
+            >
+              •••
+            </span>
+          </div>
         </a>
       </li>
       <li

--- a/components/list/__tests__/__snapshots__/pagination.test.js.snap
+++ b/components/list/__tests__/__snapshots__/pagination.test.js.snap
@@ -392,7 +392,7 @@ exports[`List.pagination should change page size work 2`] = `
                 id="rc_select_TEST_OR_SSR_list_1"
                 role="option"
               >
-                25
+                20
               </div>
             </div>
             <div
@@ -427,7 +427,7 @@ exports[`List.pagination should change page size work 2`] = `
                     <div
                       class="ant-select-item-option-content"
                     >
-                      25 / page
+                      20 / page
                     </div>
                     <span
                       aria-hidden="true"

--- a/components/list/__tests__/__snapshots__/pagination.test.js.snap
+++ b/components/list/__tests__/__snapshots__/pagination.test.js.snap
@@ -366,7 +366,7 @@ exports[`List.pagination should change page size work 2`] = `
         <span
           class="ant-select-selection-item"
         >
-          30 / page
+          50 / page
         </span>
       </div>
       <div>
@@ -392,7 +392,7 @@ exports[`List.pagination should change page size work 2`] = `
                 id="rc_select_TEST_OR_SSR_list_1"
                 role="option"
               >
-                20
+                25
               </div>
             </div>
             <div
@@ -427,7 +427,7 @@ exports[`List.pagination should change page size work 2`] = `
                     <div
                       class="ant-select-item-option-content"
                     >
-                      20 / page
+                      25 / page
                     </div>
                     <span
                       aria-hidden="true"
@@ -443,7 +443,7 @@ exports[`List.pagination should change page size work 2`] = `
                     <div
                       class="ant-select-item-option-content"
                     >
-                      30 / page
+                      50 / page
                     </div>
                     <span
                       aria-hidden="true"
@@ -459,7 +459,7 @@ exports[`List.pagination should change page size work 2`] = `
                     <div
                       class="ant-select-item-option-content"
                     >
-                      40 / page
+                      100 / page
                     </div>
                     <span
                       aria-hidden="true"

--- a/components/pagination/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/pagination/__tests__/__snapshots__/demo.test.js.snap
@@ -799,6 +799,67 @@ exports[`renders ./components/pagination/demo/itemRender.md correctly 1`] = `
       Next
     </a>
   </li>
+  <li
+    class="ant-pagination-options"
+  >
+    <div
+      class="ant-select ant-pagination-options-size-changer ant-select-single ant-select-show-arrow"
+    >
+      <div
+        class="ant-select-selector"
+      >
+        <span
+          class="ant-select-selection-search"
+        >
+          <input
+            aria-activedescendant="undefined_list_0"
+            aria-autocomplete="list"
+            aria-controls="undefined_list"
+            aria-haspopup="listbox"
+            aria-owns="undefined_list"
+            autocomplete="off"
+            class="ant-select-selection-search-input"
+            readonly=""
+            role="combobox"
+            style="opacity:0"
+            value=""
+          />
+        </span>
+        <span
+          class="ant-select-selection-item"
+        >
+          10 / page
+        </span>
+      </div>
+      <span
+        aria-hidden="true"
+        class="ant-select-arrow"
+        style="user-select:none;-webkit-user-select:none"
+        unselectable="on"
+      >
+        <span
+          aria-label="down"
+          class="anticon anticon-down"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            class=""
+            data-icon="down"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+            />
+          </svg>
+        </span>
+      </span>
+    </div>
+  </li>
 </ul>
 `;
 
@@ -966,6 +1027,63 @@ exports[`renders ./components/pagination/demo/jump.md correctly 1`] = `
     <li
       class="ant-pagination-options"
     >
+      <div
+        class="ant-select ant-pagination-options-size-changer ant-select-single ant-select-show-arrow"
+      >
+        <div
+          class="ant-select-selector"
+        >
+          <span
+            class="ant-select-selection-search"
+          >
+            <input
+              aria-activedescendant="undefined_list_0"
+              aria-autocomplete="list"
+              aria-controls="undefined_list"
+              aria-haspopup="listbox"
+              aria-owns="undefined_list"
+              autocomplete="off"
+              class="ant-select-selection-search-input"
+              readonly=""
+              role="combobox"
+              style="opacity:0"
+              value=""
+            />
+          </span>
+          <span
+            class="ant-select-selection-item"
+          >
+            10 / page
+          </span>
+        </div>
+        <span
+          aria-hidden="true"
+          class="ant-select-arrow"
+          style="user-select:none;-webkit-user-select:none"
+          unselectable="on"
+        >
+          <span
+            aria-label="down"
+            class="anticon anticon-down"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              class=""
+              data-icon="down"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+              />
+            </svg>
+          </span>
+        </span>
+      </div>
       <div
         class="ant-pagination-options-quick-jumper"
       >
@@ -1140,6 +1258,65 @@ exports[`renders ./components/pagination/demo/jump.md correctly 1`] = `
     <li
       class="ant-pagination-options"
     >
+      <div
+        class="ant-select ant-pagination-options-size-changer ant-select-single ant-select-show-arrow ant-select-disabled"
+      >
+        <div
+          class="ant-select-selector"
+        >
+          <span
+            class="ant-select-selection-search"
+          >
+            <input
+              aria-activedescendant="undefined_list_0"
+              aria-autocomplete="list"
+              aria-controls="undefined_list"
+              aria-expanded="false"
+              aria-haspopup="listbox"
+              aria-owns="undefined_list"
+              autocomplete="off"
+              class="ant-select-selection-search-input"
+              disabled=""
+              readonly=""
+              role="combobox"
+              style="opacity:0"
+              value=""
+            />
+          </span>
+          <span
+            class="ant-select-selection-item"
+          >
+            10 / page
+          </span>
+        </div>
+        <span
+          aria-hidden="true"
+          class="ant-select-arrow"
+          style="user-select:none;-webkit-user-select:none"
+          unselectable="on"
+        >
+          <span
+            aria-label="down"
+            class="anticon anticon-down"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              class=""
+              data-icon="down"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+              />
+            </svg>
+          </span>
+        </span>
+      </div>
       <div
         class="ant-pagination-options-quick-jumper"
       >
@@ -1778,6 +1955,67 @@ exports[`renders ./components/pagination/demo/more.md correctly 1`] = `
         </svg>
       </span>
     </a>
+  </li>
+  <li
+    class="ant-pagination-options"
+  >
+    <div
+      class="ant-select ant-pagination-options-size-changer ant-select-single ant-select-show-arrow"
+    >
+      <div
+        class="ant-select-selector"
+      >
+        <span
+          class="ant-select-selection-search"
+        >
+          <input
+            aria-activedescendant="undefined_list_0"
+            aria-autocomplete="list"
+            aria-controls="undefined_list"
+            aria-haspopup="listbox"
+            aria-owns="undefined_list"
+            autocomplete="off"
+            class="ant-select-selection-search-input"
+            readonly=""
+            role="combobox"
+            style="opacity:0"
+            value=""
+          />
+        </span>
+        <span
+          class="ant-select-selection-item"
+        >
+          10 / page
+        </span>
+      </div>
+      <span
+        aria-hidden="true"
+        class="ant-select-arrow"
+        style="user-select:none;-webkit-user-select:none"
+        unselectable="on"
+      >
+        <span
+          aria-label="down"
+          class="anticon anticon-down"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            class=""
+            data-icon="down"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+            />
+          </svg>
+        </span>
+      </span>
+    </div>
   </li>
 </ul>
 `;

--- a/components/pagination/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/pagination/__tests__/__snapshots__/demo.test.js.snap
@@ -2223,6 +2223,67 @@ exports[`renders ./components/pagination/demo/total.md correctly 1`] = `
         </span>
       </a>
     </li>
+    <li
+      class="ant-pagination-options"
+    >
+      <div
+        class="ant-select ant-pagination-options-size-changer ant-select-single ant-select-show-arrow"
+      >
+        <div
+          class="ant-select-selector"
+        >
+          <span
+            class="ant-select-selection-search"
+          >
+            <input
+              aria-activedescendant="undefined_list_0"
+              aria-autocomplete="list"
+              aria-controls="undefined_list"
+              aria-haspopup="listbox"
+              aria-owns="undefined_list"
+              autocomplete="off"
+              class="ant-select-selection-search-input"
+              readonly=""
+              role="combobox"
+              style="opacity:0"
+              value=""
+            />
+          </span>
+          <span
+            class="ant-select-selection-item"
+          >
+            20 / page
+          </span>
+        </div>
+        <span
+          aria-hidden="true"
+          class="ant-select-arrow"
+          style="user-select:none;-webkit-user-select:none"
+          unselectable="on"
+        >
+          <span
+            aria-label="down"
+            class="anticon anticon-down"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              class=""
+              data-icon="down"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+              />
+            </svg>
+          </span>
+        </span>
+      </div>
+    </li>
   </ul>
   <br />
   <ul
@@ -2340,6 +2401,67 @@ exports[`renders ./components/pagination/demo/total.md correctly 1`] = `
           </svg>
         </span>
       </a>
+    </li>
+    <li
+      class="ant-pagination-options"
+    >
+      <div
+        class="ant-select ant-pagination-options-size-changer ant-select-single ant-select-show-arrow"
+      >
+        <div
+          class="ant-select-selector"
+        >
+          <span
+            class="ant-select-selection-search"
+          >
+            <input
+              aria-activedescendant="undefined_list_0"
+              aria-autocomplete="list"
+              aria-controls="undefined_list"
+              aria-haspopup="listbox"
+              aria-owns="undefined_list"
+              autocomplete="off"
+              class="ant-select-selection-search-input"
+              readonly=""
+              role="combobox"
+              style="opacity:0"
+              value=""
+            />
+          </span>
+          <span
+            class="ant-select-selection-item"
+          >
+            20 / page
+          </span>
+        </div>
+        <span
+          aria-hidden="true"
+          class="ant-select-arrow"
+          style="user-select:none;-webkit-user-select:none"
+          unselectable="on"
+        >
+          <span
+            aria-label="down"
+            class="anticon anticon-down"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              class=""
+              data-icon="down"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+              />
+            </svg>
+          </span>
+        </span>
+      </div>
     </li>
   </ul>
 </div>

--- a/components/pagination/index.en-US.md
+++ b/components/pagination/index.en-US.md
@@ -27,10 +27,10 @@ A long list can be divided into several pages using `Pagination`, and only one p
 | hideOnSinglePage | Whether to hide pager on single page | boolean | false |  |
 | itemRender | To customize item's innerHTML | (page, type: 'page' \| 'prev' \| 'next', originalElement) => React.ReactNode | - |  |
 | pageSize | Number of data items per page | number | - |  |
-| pageSizeOptions | Specify the sizeChanger options | string\[] | \['10', '20', '30', '40'] |  |
+| pageSizeOptions | Specify the sizeChanger options | string\[] | \['10', '25', '50', '100'] |  |
 | showLessItems | Show less page items | boolean | false |  |
 | showQuickJumper | Determine whether you can jump to pages directly | boolean \| `{ goButton: ReactNode }` | false |  |
-| showSizeChanger | Determine whether `pageSize` can be changed | boolean | false |  |
+| showSizeChanger | Determine whether to show `pageSize` select, it will be `true` when `total>=100` | boolean | - |  |
 | showTitle | Show page item's title | boolean | true |  |
 | showTotal | To display the total number and range | Function(total, range) | - |  |
 | simple | Whether to use simple mode | boolean | - |  |

--- a/components/pagination/index.zh-CN.md
+++ b/components/pagination/index.zh-CN.md
@@ -31,7 +31,7 @@ cols: 1
 | pageSizeOptions | 指定每页可以显示多少条 | string\[] | \['10', '20', '30', '40'] |  |
 | showLessItems | 是否显示较少页面内容 | boolean | false |  |
 | showQuickJumper | 是否可以快速跳转至某页 | boolean \| `{ goButton: ReactNode }` | false |  |
-| showSizeChanger | 是否可以改变 pageSize | boolean | false |  |
+| showSizeChanger | 是否展示 `pageSize` 切换器，当 `total` 大于 `100` 时默认为 `true` | boolean | - |  |
 | showTotal | 用于显示数据总量和当前数据顺序 | Function(total, range) | - |  |
 | simple | 当添加该属性时，显示为简单分页 | boolean | - |  |
 | size | 当为「small」时，是小尺寸分页 | 'default' \| 'small' | "" |  |

--- a/components/table/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/table/__tests__/__snapshots__/demo.test.js.snap
@@ -3991,6 +3991,67 @@ exports[`renders ./components/table/demo/edit-row.md correctly 1`] = `
             </span>
           </a>
         </li>
+        <li
+          class="ant-pagination-options"
+        >
+          <div
+            class="ant-select ant-pagination-options-size-changer ant-select-single ant-select-show-arrow"
+          >
+            <div
+              class="ant-select-selector"
+            >
+              <span
+                class="ant-select-selection-search"
+              >
+                <input
+                  aria-activedescendant="undefined_list_0"
+                  aria-autocomplete="list"
+                  aria-controls="undefined_list"
+                  aria-haspopup="listbox"
+                  aria-owns="undefined_list"
+                  autocomplete="off"
+                  class="ant-select-selection-search-input"
+                  readonly=""
+                  role="combobox"
+                  style="opacity:0"
+                  value=""
+                />
+              </span>
+              <span
+                class="ant-select-selection-item"
+              >
+                10 / page
+              </span>
+            </div>
+            <span
+              aria-hidden="true"
+              class="ant-select-arrow"
+              style="user-select:none;-webkit-user-select:none"
+              unselectable="on"
+            >
+              <span
+                aria-label="down"
+                class="anticon anticon-down"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  class=""
+                  data-icon="down"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                  />
+                </svg>
+              </span>
+            </span>
+          </div>
+        </li>
       </ul>
     </div>
   </div>
@@ -6181,6 +6242,67 @@ exports[`renders ./components/table/demo/fixed-columns-header.md correctly 1`] =
             </span>
           </a>
         </li>
+        <li
+          class="ant-pagination-options"
+        >
+          <div
+            class="ant-select ant-pagination-options-size-changer ant-select-single ant-select-show-arrow"
+          >
+            <div
+              class="ant-select-selector"
+            >
+              <span
+                class="ant-select-selection-search"
+              >
+                <input
+                  aria-activedescendant="undefined_list_0"
+                  aria-autocomplete="list"
+                  aria-controls="undefined_list"
+                  aria-haspopup="listbox"
+                  aria-owns="undefined_list"
+                  autocomplete="off"
+                  class="ant-select-selection-search-input"
+                  readonly=""
+                  role="combobox"
+                  style="opacity:0"
+                  value=""
+                />
+              </span>
+              <span
+                class="ant-select-selection-item"
+              >
+                10 / page
+              </span>
+            </div>
+            <span
+              aria-hidden="true"
+              class="ant-select-arrow"
+              style="user-select:none;-webkit-user-select:none"
+              unselectable="on"
+            >
+              <span
+                aria-label="down"
+                class="anticon anticon-down"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  class=""
+                  data-icon="down"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                  />
+                </svg>
+              </span>
+            </span>
+          </div>
+        </li>
       </ul>
     </div>
   </div>
@@ -7356,6 +7478,67 @@ exports[`renders ./components/table/demo/fixed-header.md correctly 1`] = `
             </span>
           </a>
         </li>
+        <li
+          class="ant-pagination-options"
+        >
+          <div
+            class="ant-select ant-pagination-options-size-changer ant-select-single ant-select-show-arrow"
+          >
+            <div
+              class="ant-select-selector"
+            >
+              <span
+                class="ant-select-selection-search"
+              >
+                <input
+                  aria-activedescendant="undefined_list_0"
+                  aria-autocomplete="list"
+                  aria-controls="undefined_list"
+                  aria-haspopup="listbox"
+                  aria-owns="undefined_list"
+                  autocomplete="off"
+                  class="ant-select-selection-search-input"
+                  readonly=""
+                  role="combobox"
+                  style="opacity:0"
+                  value=""
+                />
+              </span>
+              <span
+                class="ant-select-selection-item"
+              >
+                50 / page
+              </span>
+            </div>
+            <span
+              aria-hidden="true"
+              class="ant-select-arrow"
+              style="user-select:none;-webkit-user-select:none"
+              unselectable="on"
+            >
+              <span
+                aria-label="down"
+                class="anticon anticon-down"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  class=""
+                  data-icon="down"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                  />
+                </svg>
+              </span>
+            </span>
+          </div>
+        </li>
       </ul>
     </div>
   </div>
@@ -8261,6 +8444,67 @@ exports[`renders ./components/table/demo/grouping-columns.md correctly 1`] = `
               </svg>
             </span>
           </a>
+        </li>
+        <li
+          class="ant-pagination-options"
+        >
+          <div
+            class="ant-select ant-pagination-options-size-changer ant-select-sm ant-select-single ant-select-show-arrow"
+          >
+            <div
+              class="ant-select-selector"
+            >
+              <span
+                class="ant-select-selection-search"
+              >
+                <input
+                  aria-activedescendant="undefined_list_0"
+                  aria-autocomplete="list"
+                  aria-controls="undefined_list"
+                  aria-haspopup="listbox"
+                  aria-owns="undefined_list"
+                  autocomplete="off"
+                  class="ant-select-selection-search-input"
+                  readonly=""
+                  role="combobox"
+                  style="opacity:0"
+                  value=""
+                />
+              </span>
+              <span
+                class="ant-select-selection-item"
+              >
+                10 / page
+              </span>
+            </div>
+            <span
+              aria-hidden="true"
+              class="ant-select-arrow"
+              style="user-select:none;-webkit-user-select:none"
+              unselectable="on"
+            >
+              <span
+                aria-label="down"
+                class="anticon anticon-down"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  class=""
+                  data-icon="down"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                  />
+                </svg>
+              </span>
+            </span>
+          </div>
         </li>
       </ul>
     </div>

--- a/components/tooltip/__tests__/tooltip.test.js
+++ b/components/tooltip/__tests__/tooltip.test.js
@@ -286,7 +286,7 @@ describe('Tooltip', () => {
         </span>
       </Tooltip>,
     );
-    await sleep(600);
+    await sleep(1000);
     expect(wrapper.instance().getPopupDomNode().className).toContain('placement-bottomLeft');
   });
 

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "rc-mentions": "~1.0.0",
     "rc-menu": "~8.0.1",
     "rc-notification": "~4.0.0",
-    "rc-pagination": "~2.1.0",
+    "rc-pagination": "~2.2.0",
     "rc-picker": "~1.4.0",
     "rc-progress": "~2.5.0",
     "rc-rate": "~2.5.1",

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "rc-mentions": "~1.0.0",
     "rc-menu": "~8.0.1",
     "rc-notification": "~4.0.0",
-    "rc-pagination": "~2.0.1",
+    "rc-pagination": "~2.1.0",
     "rc-picker": "~1.4.0",
     "rc-progress": "~2.5.0",
     "rc-rate": "~2.5.1",


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

- https://github.com/react-component/pagination/pull/258
- https://github.com/react-component/pagination/pull/260

close https://github.com/ant-design/ant-design/issues/18201

### 💡 Background and solution

- [x] 当 `total` 大于 `50` 时，默认显示切换页数选择器。优化大数据下的默认分页体验。
- [x] 页数选择器的默认选项从 `10,20,30,40` 修改为 `10,20,50,100`。
   <img width="691" alt="image" src="https://user-images.githubusercontent.com/507615/77842698-fcaf5100-71c7-11ea-956b-a64ddb628e00.png">
- [x] 优化 10 页以内的分页器宽度，使其更统一，解决 #18201 的问题。

| 调整前 | 调整后 ✅ |
| --- | --- |
| <img width="392" alt="截屏2020-03-29下午5 14 20" src="https://user-images.githubusercontent.com/507615/77845592-b5828980-71e2-11ea-8304-c21a5d6846f5.png"> | <img width="324" alt="截屏2020-03-29下午5 13 37" src="https://user-images.githubusercontent.com/507615/77845597-bd422e00-71e2-11ea-9eb7-19040e7442be.png"> |

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  - Pagination will show size changer when `total>50`.<br />- Unify Pagination items  to fixed length.<br />- change default size options to `10, 20, 50, 100`.  |
| 🇨🇳 Chinese | - Pagination 当 `total>50` 时默认显示切换页数选择器。<br />- 统一 Pagination 十页以内的页码个数使其宽度更统一。<br />- Pagination 调整默认页数选项为 `10, 20, 50, 100`。 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️ 

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed