### PR TITLE
fix: Fix date_picker et time_picker locale for 🇫🇷

### DIFF
--- a/components/date-picker/locale/fr_FR.tsx
+++ b/components/date-picker/locale/fr_FR.tsx
@@ -7,6 +7,7 @@ const locale: PickerLocale = {
   lang: {
     placeholder: 'Sélectionner une date',
     yearPlaceholder: 'Sélectionner une année',
+    quarterPlaceholder: 'Sélectionner le trimestre',
     monthPlaceholder: 'Sélectionner un mois',
     weekPlaceholder: 'Sélectionner une semaine',
     rangePlaceholder: ['Date de début', 'Date de fin'],

--- a/components/date-picker/locale/fr_FR.tsx
+++ b/components/date-picker/locale/fr_FR.tsx
@@ -7,7 +7,7 @@ const locale: PickerLocale = {
   lang: {
     placeholder: 'Sélectionner une date',
     yearPlaceholder: 'Sélectionner une année',
-    quarterPlaceholder: 'Sélectionner le trimestre',
+    quarterPlaceholder: 'Sélectionner un trimestre',
     monthPlaceholder: 'Sélectionner un mois',
     weekPlaceholder: 'Sélectionner une semaine',
     rangePlaceholder: ['Date de début', 'Date de fin'],

--- a/components/time-picker/locale/fr_FR.tsx
+++ b/components/time-picker/locale/fr_FR.tsx
@@ -2,6 +2,7 @@ import { TimePickerLocale } from '../index';
 
 const locale: TimePickerLocale = {
   placeholder: "Sélectionner l'heure",
+  rangePlaceholder: ['Heure de début', 'Heure de fin'],
 };
 
 export default locale;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close #22674

<!--
1. Describe the source of requirement, like related issue link.
-->

Open `antd/lib/date-picker/locale/fr_FR.d.ts` and `antd/lib/date-picker/locale/en_US.d.ts`, type lang looks different. The type `rangePlaceholder: string[]` is missing.

Additional attribute `placeholderQuarter: []` was missing as well.

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

Adding fields in target files.

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 🇫🇷 Date picker and time picker update |
| 🇨🇳 Chinese |  🇫🇷 日期选择器和时间选择器更新 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️ 

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
