### PR TITLE
fix: Remove useless form textarea height

### DIFF
--- a/components/form/style/components.less
+++ b/components/form/style/components.less
@@ -7,7 +7,6 @@
   .@{ant-prefix}-mentions,
   textarea.@{ant-prefix}-input {
     height: auto;
-    margin-bottom: 4px;
   }
 
   // input[type=file]


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

resolve #22785

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Fix Textarea with `clearIcon` additional margin in Form.Item.       |
| 🇨🇳 Chinese |     修复 Textarea 配置 `clearIcon` 在 Form.Item 下会有额外的 `margin` 的问题。      |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️ 

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
