### PR TITLE
fix: 🐛 Table filter onChange trigger bug

### DIFF
--- a/components/table/__tests__/Table.filter.test.js
+++ b/components/table/__tests__/Table.filter.test.js
@@ -11,12 +11,7 @@ import ConfigProvider from '../../config-provider';
 const nativeEvent = { nativeEvent: { stopImmediatePropagation: () => {} } };
 
 function getDropdownWrapper(wrapper) {
-  return mount(
-    wrapper
-      .find('Trigger')
-      .instance()
-      .getComponent(),
-  );
+  return mount(wrapper.find('Trigger').instance().getComponent());
 }
 
 describe('Table.filter', () => {
@@ -213,7 +208,10 @@ describe('Table.filter', () => {
 
     expect(wrapper.find('FilterDropdown').props().filterState.filteredKeys).toBeFalsy();
     wrapper.find('FilterDropdown').find('input[type="checkbox"]').first().simulate('click');
-    wrapper.find('FilterDropdown').find('.ant-table-filter-dropdown-btns .ant-btn-primary').simulate('click');
+    wrapper
+      .find('FilterDropdown')
+      .find('.ant-table-filter-dropdown-btns .ant-btn-primary')
+      .simulate('click');
     expect(wrapper.find('FilterDropdown').props().filterState.filteredKeys).toEqual(['boy']);
     wrapper.setProps({ dataSource: [...data, { key: 999, name: 'Chris' }] });
     expect(wrapper.find('FilterDropdown').props().filterState.filteredKeys).toEqual(['boy']);
@@ -342,7 +340,10 @@ describe('Table.filter', () => {
     const wrapper = mount(createTable({ onChange: handleChange }));
     wrapper.find('.ant-dropdown-trigger').first().simulate('click');
     wrapper.find('FilterDropdown').find('MenuItem').first().simulate('click');
-    wrapper.find('FilterDropdown').find('.ant-table-filter-dropdown-btns .ant-btn-primary').simulate('click');
+    wrapper
+      .find('FilterDropdown')
+      .find('.ant-table-filter-dropdown-btns .ant-btn-primary')
+      .simulate('click');
     expect(handleChange).toHaveBeenCalledWith(
       {},
       { name: ['boy'] },
@@ -358,17 +359,40 @@ describe('Table.filter', () => {
     const wrapper = mount(createTable({ pagination: { onChange: onPaginationChange } }));
     wrapper.find('.ant-dropdown-trigger').first().simulate('click');
     wrapper.find('FilterDropdown').find('MenuItem').first().simulate('click');
-    wrapper.find('FilterDropdown').find('.ant-table-filter-dropdown-btns .ant-btn-primary').simulate('click');
+    wrapper
+      .find('FilterDropdown')
+      .find('.ant-table-filter-dropdown-btns .ant-btn-primary')
+      .simulate('click');
 
     expect(onPaginationChange).toHaveBeenCalledWith(1, 10);
   });
 
-  it('should not fire change event on close filterDropdown without changing anything', () => {
+  it('should not fire change event when close filterDropdown without changing anything', () => {
     const handleChange = jest.fn();
     const wrapper = mount(createTable({ onChange: handleChange }));
 
     wrapper.find('.ant-dropdown-trigger').first().simulate('click');
     wrapper.find('.ant-table-filter-dropdown-btns .ant-btn-link').simulate('click');
+
+    expect(handleChange).not.toHaveBeenCalled();
+  });
+
+  it('should not fire change event when close a filtered filterDropdown without changing anything', () => {
+    const handleChange = jest.fn();
+    const wrapper = mount(
+      createTable({
+        onChange: handleChange,
+        columns: [
+          {
+            ...column,
+            defaultFilteredValue: ['boy', 'designer'],
+          },
+        ],
+      }),
+    );
+
+    wrapper.find('.ant-dropdown-trigger').first().simulate('click');
+    wrapper.find('.ant-table-filter-dropdown-btns .ant-btn-primary').simulate('click');
 
     expect(handleChange).not.toHaveBeenCalled();
   });
@@ -410,29 +434,17 @@ describe('Table.filter', () => {
     let dropdownWrapper = getDropdownWrapper(wrapper);
     expect(renderedNames(wrapper)).toEqual(['Jack', 'Lucy', 'Tom', 'Jerry']);
     // select
-    dropdownWrapper
-      .find('.ant-dropdown-menu-submenu-title')
-      .at(0)
-      .simulate('mouseEnter');
+    dropdownWrapper.find('.ant-dropdown-menu-submenu-title').at(0).simulate('mouseEnter');
     jest.runAllTimers();
     dropdownWrapper = getDropdownWrapper(wrapper);
-    dropdownWrapper
-      .find('.ant-dropdown-menu-submenu-title')
-      .at(1)
-      .simulate('mouseEnter');
+    dropdownWrapper.find('.ant-dropdown-menu-submenu-title').at(1).simulate('mouseEnter');
     jest.runAllTimers();
     dropdownWrapper = getDropdownWrapper(wrapper);
-    dropdownWrapper
-      .find('MenuItem')
-      .last()
-      .simulate('click');
+    dropdownWrapper.find('MenuItem').last().simulate('click');
     dropdownWrapper.find('.ant-table-filter-dropdown-btns .ant-btn-primary').simulate('click');
     wrapper.update();
     expect(renderedNames(wrapper)).toEqual(['Jack']);
-    dropdownWrapper
-      .find('MenuItem')
-      .last()
-      .simulate('click');
+    dropdownWrapper.find('MenuItem').last().simulate('click');
     jest.useRealTimers();
   });
 
@@ -1060,12 +1072,9 @@ describe('Table.filter', () => {
     expect(wrapper.find('.ant-table-filter-dropdown-btns .ant-btn-primary').text()).toEqual(
       'Bamboo',
     );
-    expect(
-      wrapper
-        .find('.ant-table-filter-dropdown-btns .ant-btn-link')
-        .last()
-        .text(),
-    ).toEqual('Reset');
+    expect(wrapper.find('.ant-table-filter-dropdown-btns .ant-btn-link').last().text()).toEqual(
+      'Reset',
+    );
   });
 
   it('filtered should work', () => {

--- a/components/table/hooks/useFilter/FilterDropdown.tsx
+++ b/components/table/hooks/useFilter/FilterDropdown.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import classNames from 'classnames';
+import isEqual from 'lodash/isEqual';
 import FilterFilled from '@ant-design/icons/FilterFilled';
 import Button from '../../../button';
 import Menu from '../../../menu';
@@ -128,6 +129,10 @@ function FilterDropdown<RecordType>(props: FilterDropdownProps<RecordType>) {
 
     const mergedKeys = keys && keys.length ? keys : null;
     if (mergedKeys === null && (!filterState || !filterState.filteredKeys)) {
+      return null;
+    }
+
+    if (isEqual(mergedKeys, filterState?.filteredKeys)) {
       return null;
     }
 

--- a/components/table/index.en-US.md
+++ b/components/table/index.en-US.md
@@ -92,14 +92,14 @@ Same as `onRow` `onHeaderRow` `onCell` `onHeaderCell`
 <Table
   onRow={(record, rowIndex) => {
     return {
-      onClick: (event) => {}, // click row
-      onDoubleClick: (event) => {}, // double click row
-      onContextMenu: (event) => {}, // right button click row
-      onMouseEnter: (event) => {}, // mouse enter row
-      onMouseLeave: (event) => {}, // mouse leave row
+      onClick: event => {}, // click row
+      onDoubleClick: event => {}, // double click row
+      onContextMenu: event => {}, // right button click row
+      onMouseEnter: event => {}, // mouse enter row
+      onMouseLeave: event => {}, // mouse leave row
     };
   }}
-  onHeaderRow={(column) => {
+  onHeaderRow={column => {
     return {
       onClick: () => {}, // click header row
     };
@@ -265,7 +265,7 @@ If `dataSource[i].key` is not provided, then you should specify the primary key 
 // primary key is uid
 return <Table rowKey="uid" />;
 // or
-return <Table rowKey={(record) => record.uid} />;
+return <Table rowKey={record => record.uid} />;
 ```
 
 ## Migrate to v4
@@ -276,6 +276,12 @@ Besides, the breaking change is changing `dataIndex` from nest string path like 
 
 ## FAQ
 
-### How to hide pagination when single page or not data
+### How to hide pagination when single page or not data?
 
 You can set `hideOnSinglePage` with `pagination` prop.
+
+### Table will return to first page when filter data.
+
+Table total page count usually reduce after filter data, we defaultly return to first page in case of current page is out of filtered results.
+
+You may need to keep current page after filtering when fetch data from remote service, please check [this demo](https://codesandbox.io/s/yuanchengjiazaishuju-ant-design-demo-7y2uf) as workaround.

--- a/components/table/index.zh-CN.md
+++ b/components/table/index.zh-CN.md
@@ -95,16 +95,16 @@ const columns = [
 
 ```jsx
 <Table
-  onRow={(record) => {
+  onRow={record => {
     return {
-      onClick: (event) => {}, // 点击行
-      onDoubleClick: (event) => {},
-      onContextMenu: (event) => {},
-      onMouseEnter: (event) => {}, // 鼠标移入行
-      onMouseLeave: (event) => {},
+      onClick: event => {}, // 点击行
+      onDoubleClick: event => {},
+      onContextMenu: event => {},
+      onMouseEnter: event => {}, // 鼠标移入行
+      onMouseLeave: event => {},
     };
   }}
-  onHeaderRow={(column) => {
+  onHeaderRow={column => {
     return {
       onClick: () => {}, // 点击表头行
     };
@@ -269,7 +269,7 @@ class NameColumn extends Table.Column<User> {}
 // 比如你的数据主键是 uid
 return <Table rowKey="uid" />;
 // 或
-return <Table rowKey={(record) => record.uid} />;
+return <Table rowKey={record => record.uid} />;
 ```
 
 ## 从 v3 升级到 v4
@@ -283,3 +283,9 @@ Table 移除了在 v3 中废弃的 `onRowClick`、`onRowDoubleClick`、`onRowMou
 ### 如何在没有数据或只有一页数据时隐藏分页栏
 
 你可以设置 `pagination` 的 `hideOnSinglePage` 属性为 `true`。
+
+### 表格过滤时会回到第一页？
+
+ 前端过滤时通常条目总数会减少，从而导致总页数小于筛选前的当前页数，为了防止当前页面没有数据，我们默认会返回第一页。
+
+如果你在使用远程分页，很可能需要保持当前页面，你可以参照这个 [受控例子](https://codesandbox.io/s/yuanchengjiazaishuju-ant-design-demo-7y2uf) 控制当前页面不变。


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [x] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)
 
### 🔗 Related issue link

close #22819

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

补充了 FAQ 文档解决 #22819 的疑惑，修复 https://github.com/ant-design/ant-design/issues/22819#issuecomment-607171024 这里做的例子的一个问题。

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Table filter unexpectedly trigger `onChange` when no changes. |
| 🇨🇳 Chinese | 修复 Table 筛选项没有变化时触发 `onChange` 的问题。  |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️ 

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/table/index.en-US.md](https://github.com/ant-design/ant-design/blob/docs-table-faq/components/table/index.en-US.md)
[View rendered components/table/index.zh-CN.md](https://github.com/ant-design/ant-design/blob/docs-table-faq/components/table/index.zh-CN.md)