### PR TITLE
fix: Input affix prevent dropdown focus 

### DIFF
--- a/components/input/ClearableLabeledInput.tsx
+++ b/components/input/ClearableLabeledInput.tsx
@@ -42,6 +42,17 @@ interface ClearableInputProps extends BasicProps {
 }
 
 class ClearableLabeledInput extends React.Component<ClearableInputProps> {
+  /** @private Do not use out of this class. We do not promise this is always keep. */
+  private containerRef = React.createRef<HTMLSpanElement>();
+
+  onInputMouseDown: React.MouseEventHandler = e => {
+    if (this.containerRef.current?.contains(e.target as Element)) {
+      const { triggerFocus } = this.props;
+      e.preventDefault();
+      triggerFocus();
+    }
+  };
+
   renderClearIcon(prefixCls: string) {
     const { allowClear, value, disabled, readOnly, inputType, handleReset } = this.props;
     if (
@@ -86,7 +97,6 @@ class ClearableLabeledInput extends React.Component<ClearableInputProps> {
       allowClear,
       direction,
       style,
-      triggerFocus,
     } = this.props;
     const suffixNode = this.renderSuffix(prefixCls);
     if (!hasPrefixSuffix(this.props)) {
@@ -106,7 +116,12 @@ class ClearableLabeledInput extends React.Component<ClearableInputProps> {
       [`${prefixCls}-affix-wrapper-rtl`]: direction === 'rtl',
     });
     return (
-      <span className={affixWrapperCls} style={style} onMouseUp={triggerFocus}>
+      <span
+        ref={this.containerRef}
+        className={affixWrapperCls}
+        style={style}
+        onMouseDown={this.onInputMouseDown}
+      >
         {prefixNode}
         {React.cloneElement(element, {
           style: null,

--- a/components/input/ClearableLabeledInput.tsx
+++ b/components/input/ClearableLabeledInput.tsx
@@ -45,10 +45,9 @@ class ClearableLabeledInput extends React.Component<ClearableInputProps> {
   /** @private Do not use out of this class. We do not promise this is always keep. */
   private containerRef = React.createRef<HTMLSpanElement>();
 
-  onInputMouseDown: React.MouseEventHandler = e => {
+  onInputMouseUp: React.MouseEventHandler = e => {
     if (this.containerRef.current?.contains(e.target as Element)) {
       const { triggerFocus } = this.props;
-      e.preventDefault();
       triggerFocus();
     }
   };
@@ -120,7 +119,7 @@ class ClearableLabeledInput extends React.Component<ClearableInputProps> {
         ref={this.containerRef}
         className={affixWrapperCls}
         style={style}
-        onMouseDown={this.onInputMouseDown}
+        onMouseUp={this.onInputMouseUp}
       >
         {prefixNode}
         {React.cloneElement(element, {

--- a/components/input/__tests__/textarea.test.js
+++ b/components/input/__tests__/textarea.test.js
@@ -174,10 +174,7 @@ describe('TextArea allowClear', () => {
     wrapper.find('textarea').simulate('change', { target: { value: '111' } });
     expect(wrapper.find('textarea').getDOMNode().value).toEqual('111');
     expect(wrapper.render()).toMatchSnapshot();
-    wrapper
-      .find('.ant-input-textarea-clear-icon')
-      .at(0)
-      .simulate('click');
+    wrapper.find('.ant-input-textarea-clear-icon').at(0).simulate('click');
     expect(wrapper.render()).toMatchSnapshot();
     expect(wrapper.find('textarea').getDOMNode().value).toEqual('');
   });
@@ -210,18 +207,10 @@ describe('TextArea allowClear', () => {
       argumentEventObjectValue = e.target.value;
     };
     const wrapper = mount(<TextArea allowClear defaultValue="111" onChange={onChange} />);
-    wrapper
-      .find('.ant-input-textarea-clear-icon')
-      .at(0)
-      .simulate('click');
+    wrapper.find('.ant-input-textarea-clear-icon').at(0).simulate('click');
     expect(argumentEventObject.type).toBe('click');
     expect(argumentEventObjectValue).toBe('');
-    expect(
-      wrapper
-        .find('textarea')
-        .at(0)
-        .getDOMNode().value,
-    ).toBe('');
+    expect(wrapper.find('textarea').at(0).getDOMNode().value).toBe('');
   });
 
   it('should trigger event correctly on controlled mode', () => {
@@ -232,32 +221,16 @@ describe('TextArea allowClear', () => {
       argumentEventObjectValue = e.target.value;
     };
     const wrapper = mount(<TextArea allowClear value="111" onChange={onChange} />);
-    wrapper
-      .find('.ant-input-textarea-clear-icon')
-      .at(0)
-      .simulate('click');
+    wrapper.find('.ant-input-textarea-clear-icon').at(0).simulate('click');
     expect(argumentEventObject.type).toBe('click');
     expect(argumentEventObjectValue).toBe('');
-    expect(
-      wrapper
-        .find('textarea')
-        .at(0)
-        .getDOMNode().value,
-    ).toBe('111');
+    expect(wrapper.find('textarea').at(0).getDOMNode().value).toBe('111');
   });
 
   it('should focus textarea after clear', () => {
     const wrapper = mount(<TextArea allowClear defaultValue="111" />, { attachTo: document.body });
-    wrapper
-      .find('.ant-input-textarea-clear-icon')
-      .at(0)
-      .simulate('click');
-    expect(document.activeElement).toBe(
-      wrapper
-        .find('textarea')
-        .at(0)
-        .getDOMNode(),
-    );
+    wrapper.find('.ant-input-textarea-clear-icon').at(0).simulate('click');
+    expect(document.activeElement).toBe(wrapper.find('textarea').at(0).getDOMNode());
     wrapper.unmount();
   });
 
@@ -277,20 +250,31 @@ describe('TextArea allowClear', () => {
     expect(wrapper.find('input').props().value).toEqual('Light');
   });
 
-  it('click outside should also get focus', () => {
-    const wrapper = mount(<Input suffix={<span className="test-suffix" />} />);
-    const onFocus = jest.spyOn(wrapper.find('input').instance(), 'focus');
-    wrapper.find('.test-suffix').simulate('mouseUp');
-    expect(onFocus).toHaveBeenCalled();
+  describe('click focus', () => {
+    it('click outside should also get focus', () => {
+      const wrapper = mount(<Input suffix={<span className="test-suffix" />} />);
+      const onFocus = jest.spyOn(wrapper.find('input').instance(), 'focus');
+      wrapper.find('.test-suffix').simulate('mouseDown');
+      expect(onFocus).toHaveBeenCalled();
+    });
+
+    it('not get focus if out of component', () => {
+      const wrapper = mount(<Input suffix={<span className="test-suffix" />} />);
+      const onFocus = jest.spyOn(wrapper.find('input').instance(), 'focus');
+      const ele = document.createElement('span');
+      document.body.appendChild(ele);
+      wrapper.find('.test-suffix').simulate('mouseDown', {
+        target: ele,
+      });
+      expect(onFocus).not.toHaveBeenCalled();
+      document.body.removeChild(ele);
+    });
   });
 
   it('scroll to bottom when autoSize', async () => {
     const wrapper = mount(<Input.TextArea autoSize />, { attachTo: document.body });
     wrapper.find('textarea').simulate('focus');
-    wrapper
-      .find('textarea')
-      .getDOMNode()
-      .focus();
+    wrapper.find('textarea').getDOMNode().focus();
     const setSelectionRangeFn = jest.spyOn(
       wrapper.find('textarea').getDOMNode(),
       'setSelectionRange',

--- a/components/input/__tests__/textarea.test.js
+++ b/components/input/__tests__/textarea.test.js
@@ -254,7 +254,7 @@ describe('TextArea allowClear', () => {
     it('click outside should also get focus', () => {
       const wrapper = mount(<Input suffix={<span className="test-suffix" />} />);
       const onFocus = jest.spyOn(wrapper.find('input').instance(), 'focus');
-      wrapper.find('.test-suffix').simulate('mouseDown');
+      wrapper.find('.test-suffix').simulate('mouseUp');
       expect(onFocus).toHaveBeenCalled();
     });
 
@@ -263,7 +263,7 @@ describe('TextArea allowClear', () => {
       const onFocus = jest.spyOn(wrapper.find('input').instance(), 'focus');
       const ele = document.createElement('span');
       document.body.appendChild(ele);
-      wrapper.find('.test-suffix').simulate('mouseDown', {
+      wrapper.find('.test-suffix').simulate('mouseUp', {
         target: ele,
       });
       expect(onFocus).not.toHaveBeenCalled();


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

resolve #22881

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Fix Input affix with popup element can not get click focus.       |
| 🇨🇳 Chinese |     修复 Input 前后缀添加弹出元素不能点击获得焦点的问题。     |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️ 

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
