### PR TITLE
fix: Replace NativeButtonProps with ButtonProps for okButtonProps and canc…

### DIFF
--- a/components/modal/ActionButton.tsx
+++ b/components/modal/ActionButton.tsx
@@ -1,14 +1,14 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import Button from '../button';
-import { ButtonType, NativeButtonProps } from '../button/button';
+import { ButtonType, ButtonProps } from '../button/button';
 
 export interface ActionButtonProps {
   type?: ButtonType;
   actionFn?: (...args: any[]) => any | PromiseLike<any>;
   closeModal: Function;
   autoFocus?: boolean;
-  buttonProps?: NativeButtonProps;
+  buttonProps?: ButtonProps;
 }
 
 export interface ActionButtonState {

--- a/components/modal/Modal.tsx
+++ b/components/modal/Modal.tsx
@@ -7,7 +7,7 @@ import CloseOutlined from '@ant-design/icons/CloseOutlined';
 import useModal from './useModal';
 import { getConfirmLocale } from './locale';
 import Button from '../button';
-import { ButtonType, NativeButtonProps } from '../button/button';
+import { ButtonType, ButtonProps } from '../button/button';
 import LocaleReceiver from '../locale-provider/LocaleReceiver';
 import { ConfigConsumer, ConfigConsumerProps } from '../config-provider';
 
@@ -61,8 +61,8 @@ export interface ModalProps {
   maskClosable?: boolean;
   /** 强制渲染 Modal */
   forceRender?: boolean;
-  okButtonProps?: NativeButtonProps;
-  cancelButtonProps?: NativeButtonProps;
+  okButtonProps?: ButtonProps;
+  cancelButtonProps?: ButtonProps;
   destroyOnClose?: boolean;
   style?: React.CSSProperties;
   wrapClassName?: string;
@@ -91,8 +91,8 @@ export interface ModalFuncProps {
   // TODO: find out exact types
   onOk?: (...args: any[]) => any;
   onCancel?: (...args: any[]) => any;
-  okButtonProps?: NativeButtonProps;
-  cancelButtonProps?: NativeButtonProps;
+  okButtonProps?: ButtonProps;
+  cancelButtonProps?: ButtonProps;
   centered?: boolean;
   width?: string | number;
   okText?: React.ReactNode;


### PR DESCRIPTION
This PR is a copy of a similar PR made for version 3 of the library https://github.com/ant-design/ant-design/pull/21165 so I took the liberty to copy the initial description.

### 🤔 This is a ...

- [x] TypeScript definition update

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

When trying to use the modal and pass a href to `okButtonProps` like so:
```
    Modal.confirm({
      okButtonProps: {
        href: 'www.google.com',
        rel: 'noopener noreferrer',
        target: '_blank',
        style: { marginLeft: '10px' }
      }
    });
```
TS will raise the error: "Object literal may only specify known properties, and 'href' does not exist in type 'NativeButtonProps'.ts(2322)"

This is because `okButtonProps` are defined as having the type `NativeButtonProps`;
The `okButtonProps` are passed to `ActionButton` where they also had the type `NativeButtonProps`;
Then they are passed to `Button`, in this case `Button` has the prop type `Partial<AnchorButtonProps & NativeButtonProps>`;
It seems that it would be correct to allow to change `NativeButtonProps` with `ButtonProps` since they also contain definitions in case an anchor props is desired.

### 📝 Changelog

The changes are pretty straightforward, `NativeButtonProps` where replaced with `ButtonProps` in `ActionButton.tsx` and `Modal.tsx`.

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |       x   |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
