### PR TITLE
fix: Extract type of the element of a tuple without indexing.

### DIFF
--- a/components/_util/type.ts
+++ b/components/_util/type.ts
@@ -5,6 +5,7 @@ export const tuple = <T extends string[]>(...args: T) => args;
 export const tupleNum = <T extends number[]>(...args: T) => args;
 
 /**
+ * https://stackoverflow.com/a/59187769
  * Extract the type of an element of an array/tuple without performing indexing
  */
-export type ElementOf<T extends unknown[]> = T extends (infer R)[] ? R : never;
+export type ElementOf<T> = T extends (infer E)[] ? E : T extends readonly (infer E)[] ? E : never;

--- a/components/_util/type.ts
+++ b/components/_util/type.ts
@@ -3,3 +3,8 @@ export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 export const tuple = <T extends string[]>(...args: T) => args;
 
 export const tupleNum = <T extends number[]>(...args: T) => args;
+
+/**
+ * Extract the type of an element of an array/tuple without performing indexing
+ */
+export type ElementOf<T extends unknown[]> = T extends (infer R)[] ? R : never;

--- a/components/transfer/renderListBody.tsx
+++ b/components/transfer/renderListBody.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
-import { Omit, tuple } from '../_util/type';
+import { ElementOf, Omit, tuple } from '../_util/type';
 import { TransferItem } from '.';
 import { TransferListProps, RenderedItem } from './list';
 import ListItem from './ListItem';
 
 export const OmitProps = tuple('handleFilter', 'handleClear', 'checkedKeys');
-export type OmitProp = typeof OmitProps[number];
+export type OmitProp = ElementOf<typeof OmitProps>;
 type PartialTransferListProps = Omit<TransferListProps, OmitProp>;
 
 export interface TransferListBodyProps extends PartialTransferListProps {


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

https://github.com/microsoft/TypeScript/issues/13778

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution
This is a long running issue regarding array indexing in TS.
Basically, when performing indexing on an array TS will not show an error if the element is not present:
```TS
const arr: number[] = [];
// No errors
const num: number = arr[0];
```

One of the approaches in the thread linked above is to amend the definition of indexing of an element from:
```
  [n: number]: T;
```
to
```
  [n: number]: T | undefined;
```

The only downside is that this also restricts the indexing of array Types.
The solution is pretty straightforward, instead of:
```
export type OmitProp = typeof OmitProps[number];
```
we can use: 
```
export type OmitProp = ElementOf<typeof OmitProps>;
```

This will not cause any changes to existing users but will greatly improve the experience of those who use a stricter version of TS.

### 📝 Changelog

Users will not see any change but those who use the stricter versions of TS will be able to not use @ts-ignore or something similar

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     x      |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️ 

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
