### PR TITLE
Improve typing of `UploadProps` interface

### DIFF
--- a/components/upload/interface.tsx
+++ b/components/upload/interface.tsx
@@ -73,14 +73,14 @@ type TransformFileHandler = (
   file: RcFile,
 ) => string | Blob | File | PromiseLike<string | Blob | File>;
 
-export interface UploadProps {
+export interface UploadProps<T = any> {
   type?: UploadType;
   name?: string;
-  defaultFileList?: Array<UploadFile>;
-  fileList?: Array<UploadFile>;
+  defaultFileList?: Array<UploadFile<T>>;
+  fileList?: Array<UploadFile<T>>;
   action?: string | ((file: RcFile) => string) | ((file: RcFile) => PromiseLike<string>);
   directory?: boolean;
-  data?: object | ((file: UploadFile) => object);
+  data?: object | ((file: UploadFile<T>) => object);
   method?: 'POST' | 'PUT' | 'post' | 'put';
   headers?: HttpRequestHeader;
   showUploadList?: boolean | ShowUploadListInterface;
@@ -90,9 +90,9 @@ export interface UploadProps {
   onChange?: (info: UploadChangeParam) => void;
   listType?: UploadListType;
   className?: string;
-  onPreview?: (file: UploadFile) => void;
-  onDownload?: (file: UploadFile) => void;
-  onRemove?: (file: UploadFile) => void | boolean | Promise<void | boolean>;
+  onPreview?: (file: UploadFile<T>) => void;
+  onDownload?: (file: UploadFile<T>) => void;
+  onRemove?: (file: UploadFile<T>) => void | boolean | Promise<void | boolean>;
   supportServerRender?: boolean;
   style?: React.CSSProperties;
   disabled?: boolean;
@@ -104,20 +104,20 @@ export interface UploadProps {
   id?: string;
   previewFile?: PreviewFileHandler;
   transformFile?: TransformFileHandler;
-  iconRender?: (file: UploadFile, listType?: UploadListType) => React.ReactNode;
+  iconRender?: (file: UploadFile<T>, listType?: UploadListType) => React.ReactNode;
 }
 
-export interface UploadState {
-  fileList: UploadFile[];
+export interface UploadState<T = any> {
+  fileList: UploadFile<T>[];
   dragState: string;
 }
 
-export interface UploadListProps {
+export interface UploadListProps<T = any> {
   listType?: UploadListType;
-  onPreview?: (file: UploadFile) => void;
-  onDownload?: (file: UploadFile) => void;
-  onRemove?: (file: UploadFile) => void | boolean;
-  items?: Array<UploadFile>;
+  onPreview?: (file: UploadFile<T>) => void;
+  onDownload?: (file: UploadFile<T>) => void;
+  onRemove?: (file: UploadFile<T>) => void | boolean;
+  items?: Array<UploadFile<T>>;
   progressAttr?: Object;
   prefixCls?: string;
   showRemoveIcon?: boolean;
@@ -127,5 +127,5 @@ export interface UploadListProps {
   downloadIcon?: React.ReactNode;
   locale: UploadLocale;
   previewFile?: PreviewFileHandler;
-  iconRender?: (file: UploadFile, listType?: UploadListType) => React.ReactNode;
+  iconRender?: (file: UploadFile<T>, listType?: UploadListType) => React.ReactNode;
 }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

Currently generic type for `UploadFile.response` is not passed down from `UploadProps`, we can add it to `UploadProps` to make the response fully typed.

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️ 

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
