### PR TITLE
chore: Use unreachable exception in favor of type safety

### DIFF
--- a/components/_util/__tests__/unreachableException.test.js
+++ b/components/_util/__tests__/unreachableException.test.js
@@ -1,0 +1,8 @@
+import UnreachableException from '../unreachableException';
+
+describe('UnreachableException', () => {
+  it('error thrown matches snapshot', () => {
+    const exception = new UnreachableException('some value');
+    expect(exception.message).toMatchInlineSnapshot(`"unreachable case: \\"some value\\""`);
+  });
+});

--- a/components/_util/unreachableException.ts
+++ b/components/_util/unreachableException.ts
@@ -1,0 +1,5 @@
+export default class UnreachableException {
+  constructor(value: never) {
+    return new Error(`unreachable case: ${JSON.stringify(value)}`);
+  }
+}

--- a/components/button/__tests__/__snapshots__/index.test.js.snap
+++ b/components/button/__tests__/__snapshots__/index.test.js.snap
@@ -254,6 +254,12 @@ exports[`Button rtl render component should be rendered correctly in RTL directi
 />
 `;
 
+exports[`Button rtl render component should be rendered correctly in RTL direction 7`] = `
+<div
+  class="ant-btn-group ant-btn-group-rtl"
+/>
+`;
+
 exports[`Button should has click wave effect 1`] = `
 <button
   ant-click-animating-without-extra-node="true"

--- a/components/button/__tests__/index.test.js
+++ b/components/button/__tests__/index.test.js
@@ -15,6 +15,7 @@ describe('Button', () => {
   mountTest(Button.Group);
   mountTest(() => <Button.Group size="large" />);
   mountTest(() => <Button.Group size="small" />);
+  mountTest(() => <Button.Group size="middle" />);
 
   rtlTest(Button);
   rtlTest(() => <Button size="large" />);
@@ -22,6 +23,7 @@ describe('Button', () => {
   rtlTest(Button.Group);
   rtlTest(() => <Button.Group size="large" />);
   rtlTest(() => <Button.Group size="small" />);
+  rtlTest(() => <Button.Group size="middle" />);
 
   it('renders correctly', () => {
     const wrapper = render(<Button>Follow</Button>);
@@ -30,6 +32,16 @@ describe('Button', () => {
 
   it('mount correctly', () => {
     expect(() => renderer.create(<Button>Follow</Button>)).not.toThrow();
+  });
+
+  it('warns if size is wrong', () => {
+    const mockWarn = jest.fn();
+    jest.spyOn(console, 'warn').mockImplementation(mockWarn);
+    render(<Button.Group size="who am I" />);
+    expect(mockWarn).toHaveBeenCalledTimes(1);
+    expect(mockWarn.mock.calls[0][0]).toMatchObject({
+      message: 'unreachable case: "who am I"',
+    });
   });
 
   it('renders Chinese characters correctly', () => {
@@ -189,10 +201,7 @@ describe('Button', () => {
 
   it('should has click wave effect', async () => {
     const wrapper = mount(<Button type="primary">button</Button>);
-    wrapper
-      .find('.ant-btn')
-      .getDOMNode()
-      .click();
+    wrapper.find('.ant-btn').getDOMNode().click();
     await new Promise(resolve => setTimeout(resolve, 0));
     expect(wrapper.render()).toMatchSnapshot();
   });
@@ -265,9 +274,6 @@ describe('Button', () => {
         throw new Error('Should not called!!!');
       },
     });
-    wrapper
-      .find('Button')
-      .instance()
-      .forceUpdate();
+    wrapper.find('Button').instance().forceUpdate();
   });
 });

--- a/components/button/button-group.tsx
+++ b/components/button/button-group.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import classNames from 'classnames';
 import { SizeType } from '../config-provider/SizeContext';
 import { ConfigConsumer, ConfigConsumerProps } from '../config-provider';
+import UnreachableException from '../_util/unreachableException';
 
 export interface ButtonGroupProps {
   size?: SizeType;
@@ -26,8 +27,11 @@ const ButtonGroup: React.FC<ButtonGroupProps> = props => (
         case 'small':
           sizeCls = 'sm';
           break;
-        default:
+        case 'middle':
+        case undefined:
           break;
+        default:
+          console.warn(new UnreachableException(size));
       }
 
       const classes = classNames(


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [x] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 👻 What's the background?
`Switch` is not type safe.
e.g.
```
type Pet = 'dog' | 'cat';

function getPet(pet: Pet) {
  switch(pet) {
    case 'dog':
        return new Dot();
    case 'cat':
        return new Cat();
    default:
        throw new Error('unknown pet');
  }
}
```
Which looks good now.

However, if another value is added to the enum, e.g. `type Pet = 'dog' | 'cat' | 'hamster'`.
The `getPet` function stay silent in the compile time.
It may (or may not) throw an error in the run time which is error prone.


### 💡 Solution
It is possible to utilize the `never` type in typescript to force the switch statement to behave like an exhaustive pattern match to enhance the type safety.

![B6A8D1EA-D2E6-4901-BE05-FC9A526B9C57](https://user-images.githubusercontent.com/10626756/61059222-0297b300-a43c-11e9-83cf-48c513c3a581.png)

All occurrence will be changed if the gist of this PR is preferred.
<!--
1. How to fix the problem, and list final API implementation and usage sample if that is an new feature.

2. GIF or snapshot should be provided if includes UI/interactive modification.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
