### PR TITLE
Fix MonthPicker props documentation

### DIFF
--- a/components/date-picker/index.en-US.md
+++ b/components/date-picker/index.en-US.md
@@ -123,7 +123,7 @@ Added in `4.1.0`.
 | defaultValue | to set default date | [moment](http://momentjs.com/) | - |  |
 | defaultPickerValue | to set default picker date | [moment](http://momentjs.com/) | - |  |
 | format | to set the date format, refer to [moment.js](http://momentjs.com/) | string | "YYYY-MM" |  |
-| monthCellContentRender | Custom month cell content render method | function(date, locale): ReactNode | - |  |
+| monthCellRender | Custom month cell content render method | function(date, locale): ReactNode | - |  |
 | renderExtraFooter | render extra footer in panel | () => React.ReactNode | - |  |
 | value | to set date | [moment](http://momentjs.com/) | - |  |
 | onChange | a callback function, can be executed when the selected time is changing | function(date: moment, dateString: string) | - |  |

--- a/components/date-picker/index.zh-CN.md
+++ b/components/date-picker/index.zh-CN.md
@@ -125,7 +125,7 @@ import 'moment/locale/zh-cn';
 | defaultValue | 默认日期 | [moment](http://momentjs.com/) | 无 |  |
 | defaultPickerValue | 默认面板日期 | [moment](http://momentjs.com/) | 无 |  |
 | format | 展示的日期格式，配置参考 [moment.js](http://momentjs.com/) | string | "YYYY-MM" |  |
-| monthCellContentRender | 自定义的月份内容渲染方法 | function(date, locale): ReactNode | - |  |
+| monthCellRender | 自定义的月份内容渲染方法 | function(date, locale): ReactNode | - |  |
 | renderExtraFooter | 在面板中添加额外的页脚 | () => React.ReactNode | - |  |
 | value | 日期 | [moment](http://momentjs.com/) | 无 |  |
 | onChange | 时间发生变化的回调，发生在用户选择时间时 | function(date: moment, dateString: string) | - |  |


### PR DESCRIPTION
Update DatePicker docs to specify correct monthCellRender prop instead of monthCellContentRender


### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

No related issue

### 💡 Background and solution

I found that in the `MonthPicker`'s documentation, the prop that customizes the month cell component is called `monthCellContentRender`, but the underlying component (`rc-picker/lib/Picker`) uses `monthCellRender`. I updated the documentation (english and chinese) to reflect this. 

On https://www.npmjs.com/package/rc-picker the prop is also called `monthCellrender`


### 📝 Changelog

No breaking changes, just a very very very small documentation update. I'm not even sure if this change deserves a changelog entry.

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️ 

- [x] Doc is updated/provided or not needed
- [ ] ~~Demo is updated/provided or not needed~~ (not needed)
- [ ] ~~TypeScript definition is updated/provided or not needed~~ (not needed)
- [ ] ~~Changelog is provided or not needed~~ (not needed)


-----
[View rendered components/date-picker/index.en-US.md](https://github.com/vladcalin/ant-design/blob/doc-fix/fix-date-picker-parameter/components/date-picker/index.en-US.md)
[View rendered components/date-picker/index.zh-CN.md](https://github.com/vladcalin/ant-design/blob/doc-fix/fix-date-picker-parameter/components/date-picker/index.zh-CN.md)