### PR TITLE
fix: confirm button should only trigger once

### DIFF
--- a/components/modal/ActionButton.tsx
+++ b/components/modal/ActionButton.tsx
@@ -12,18 +12,17 @@ export interface ActionButtonProps {
 }
 
 export interface ActionButtonState {
-  loading: boolean;
+  loading: ButtonProps['loading'];
 }
 
 export default class ActionButton extends React.Component<ActionButtonProps, ActionButtonState> {
   timeoutId: number;
 
-  constructor(props: ActionButtonProps) {
-    super(props);
-    this.state = {
-      loading: false,
-    };
-  }
+  clicked: boolean;
+
+  state = {
+    loading: false,
+  };
 
   componentDidMount() {
     if (this.props.autoFocus) {
@@ -38,6 +37,10 @@ export default class ActionButton extends React.Component<ActionButtonProps, Act
 
   onClick = () => {
     const { actionFn, closeModal } = this.props;
+    if (this.clicked) {
+      return;
+    }
+    this.clicked = true;
     if (actionFn) {
       let ret;
       if (actionFn.length) {
@@ -62,6 +65,7 @@ export default class ActionButton extends React.Component<ActionButtonProps, Act
             console.error(e);
             // See: https://github.com/ant-design/ant-design/issues/6183
             this.setState({ loading: false });
+            this.clicked = false;
           },
         );
       }
@@ -74,7 +78,12 @@ export default class ActionButton extends React.Component<ActionButtonProps, Act
     const { type, children, buttonProps } = this.props;
     const { loading } = this.state;
     return (
-      <Button type={type} onClick={this.onClick} loading={loading} {...buttonProps}>
+      <Button
+        type={type}
+        onClick={this.onClick}
+        loading={loading}
+        {...buttonProps}
+       >
         {children}
       </Button>
     );

--- a/components/modal/__tests__/confirm.test.js
+++ b/components/modal/__tests__/confirm.test.js
@@ -231,4 +231,13 @@ describe('Modal.confirm triggers callbacks correctly', () => {
     );
     warnSpy.mockRestore();
   });
+
+  it('ok button should trigger onOk once when click it many times quickly', () => {
+    const onOk = jest.fn();
+    open({ onOk });
+    // Fifth Modal
+    $$('.ant-btn-primary')[0].click();
+    $$('.ant-btn-primary')[0].click();
+    expect(onOk).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION


<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close #22861

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Modal.confirm should not be triggered multiple times.  |
| 🇨🇳 Chinese | 修复 Modal.confirm `onOk` 可以被触发多次的问题。 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️ 

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
