### PR TITLE
fix: Use ElementOf<T> instead of array indexing

### DIFF
--- a/components/_util/colors.ts
+++ b/components/_util/colors.ts
@@ -1,4 +1,4 @@
-import { tuple } from './type';
+import { ElementOf, tuple } from './type';
 
 export const PresetStatusColorTypes = tuple('success', 'processing', 'error', 'default', 'warning');
 // eslint-disable-next-line import/prefer-default-export
@@ -18,5 +18,5 @@ export const PresetColorTypes = tuple(
   'lime',
 );
 
-export type PresetColorType = typeof PresetColorTypes[number];
-export type PresetStatusColorType = typeof PresetStatusColorTypes[number];
+export type PresetColorType = ElementOf<typeof PresetColorTypes>;
+export type PresetStatusColorType = ElementOf<typeof PresetStatusColorTypes>;


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

https://github.com/ant-design/ant-design/pull/22916

https://github.com/microsoft/TypeScript/issues/13778

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution
This is a long running issue regarding array indexing in TS.
Basically, when performing indexing on an array TS will not show an error if the element is not present:
```TS
const arr: number[] = [];
// No errors
const num: number = arr[0];
```

One of the approaches in the thread linked above is to amend the definition of indexing of an element from:
```
  [n: number]: T;
```
to
```
  [n: number]: T | undefined;
```

The only downside is that this also restricts the indexing of array Types.
The solution is pretty straightforward, instead of:
```
export type PresetColorType = typeof PresetColorTypes[number];
export type PresetStatusColorType = typeof PresetStatusColorTypes[number];
```
we can use: 
```
export type PresetColorType = ElementOf<typeof PresetColorTypes>;
export type PresetStatusColorType = ElementOf<typeof PresetStatusColorTypes>;
```

This will not cause any changes to existing users but will greatly improve the experience of those who use a stricter version of TS.

### 📝 Changelog

Users will not see any change but those who use the stricter versions of TS will be able to not use @ts-ignore or something similar

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     x      |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️ 

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
