### PR TITLE
fix: PageHeader style breaks when title is too long

### DIFF
--- a/components/config-provider/__tests__/__snapshots__/components.test.js.snap
+++ b/components/config-provider/__tests__/__snapshots__/components.test.js.snap
@@ -8345,11 +8345,16 @@ exports[`ConfigProvider components PageHeader configProvider 1`] = `
     <div
       class="config-page-header-heading"
     >
-      <span
-        class="config-page-header-heading-title"
+      <div
+        class="config-page-header-heading-left"
       >
-        pageHeader
-      </span>
+        <span
+          class="config-page-header-heading-title"
+          title="pageHeader"
+        >
+          pageHeader
+        </span>
+      </div>
     </div>
   </div>
 </div>
@@ -8363,11 +8368,16 @@ exports[`ConfigProvider components PageHeader normal 1`] = `
     <div
       class="ant-page-header-heading"
     >
-      <span
-        class="ant-page-header-heading-title"
+      <div
+        class="ant-page-header-heading-left"
       >
-        pageHeader
-      </span>
+        <span
+          class="ant-page-header-heading-title"
+          title="pageHeader"
+        >
+          pageHeader
+        </span>
+      </div>
     </div>
   </div>
 </div>
@@ -8381,11 +8391,16 @@ exports[`ConfigProvider components PageHeader prefixCls 1`] = `
     <div
       class="prefix-PageHeader-heading"
     >
-      <span
-        class="prefix-PageHeader-heading-title"
+      <div
+        class="prefix-PageHeader-heading-left"
       >
-        pageHeader
-      </span>
+        <span
+          class="prefix-PageHeader-heading-title"
+          title="pageHeader"
+        >
+          pageHeader
+        </span>
+      </div>
     </div>
   </div>
 </div>

--- a/components/page-header/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/page-header/__tests__/__snapshots__/demo.test.js.snap
@@ -9,47 +9,53 @@ exports[`renders ./components/page-header/demo/actions.md correctly 1`] = `
       class="ant-page-header-heading"
     >
       <div
-        class="ant-page-header-back"
+        class="ant-page-header-heading-left"
       >
         <div
-          aria-label="Back"
-          class="ant-page-header-back-button"
-          role="button"
-          style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-block"
-          tabindex="0"
+          class="ant-page-header-back"
         >
-          <span
-            aria-label="arrow-left"
-            class="anticon anticon-arrow-left"
-            role="img"
+          <div
+            aria-label="Back"
+            class="ant-page-header-back-button"
+            role="button"
+            style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-block"
+            tabindex="0"
           >
-            <svg
-              aria-hidden="true"
-              class=""
-              data-icon="arrow-left"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
+            <span
+              aria-label="arrow-left"
+              class="anticon anticon-arrow-left"
+              role="img"
             >
-              <path
-                d="M872 474H286.9l350.2-304c5.6-4.9 2.2-14-5.2-14h-88.5c-3.9 0-7.6 1.4-10.5 3.9L155 487.8a31.96 31.96 0 000 48.3L535.1 866c1.5 1.3 3.3 2 5.2 2h91.5c7.4 0 10.8-9.2 5.2-14L286.9 550H872c4.4 0 8-3.6 8-8v-60c0-4.4-3.6-8-8-8z"
-              />
-            </svg>
-          </span>
+              <svg
+                aria-hidden="true"
+                class=""
+                data-icon="arrow-left"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M872 474H286.9l350.2-304c5.6-4.9 2.2-14-5.2-14h-88.5c-3.9 0-7.6 1.4-10.5 3.9L155 487.8a31.96 31.96 0 000 48.3L535.1 866c1.5 1.3 3.3 2 5.2 2h91.5c7.4 0 10.8-9.2 5.2-14L286.9 550H872c4.4 0 8-3.6 8-8v-60c0-4.4-3.6-8-8-8z"
+                />
+              </svg>
+            </span>
+          </div>
         </div>
+        <span
+          class="ant-page-header-heading-title"
+          title="Title"
+        >
+          Title
+        </span>
+        <span
+          class="ant-page-header-heading-sub-title"
+          title="This is a subtitle"
+        >
+          This is a subtitle
+        </span>
       </div>
-      <span
-        class="ant-page-header-heading-title"
-      >
-        Title
-      </span>
-      <span
-        class="ant-page-header-heading-sub-title"
-      >
-        This is a subtitle
-      </span>
       <span
         class="ant-page-header-heading-extra"
       >
@@ -189,56 +195,62 @@ exports[`renders ./components/page-header/demo/actions.md correctly 1`] = `
       class="ant-page-header-heading"
     >
       <div
-        class="ant-page-header-back"
+        class="ant-page-header-heading-left"
       >
         <div
-          aria-label="Back"
-          class="ant-page-header-back-button"
-          role="button"
-          style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-block"
-          tabindex="0"
+          class="ant-page-header-back"
+        >
+          <div
+            aria-label="Back"
+            class="ant-page-header-back-button"
+            role="button"
+            style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-block"
+            tabindex="0"
+          >
+            <span
+              aria-label="arrow-left"
+              class="anticon anticon-arrow-left"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                class=""
+                data-icon="arrow-left"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M872 474H286.9l350.2-304c5.6-4.9 2.2-14-5.2-14h-88.5c-3.9 0-7.6 1.4-10.5 3.9L155 487.8a31.96 31.96 0 000 48.3L535.1 866c1.5 1.3 3.3 2 5.2 2h91.5c7.4 0 10.8-9.2 5.2-14L286.9 550H872c4.4 0 8-3.6 8-8v-60c0-4.4-3.6-8-8-8z"
+                />
+              </svg>
+            </span>
+          </div>
+        </div>
+        <span
+          class="ant-page-header-heading-title"
+          title="Title"
+        >
+          Title
+        </span>
+        <span
+          class="ant-page-header-heading-sub-title"
+          title="This is a subtitle"
+        >
+          This is a subtitle
+        </span>
+        <span
+          class="ant-page-header-heading-tags"
         >
           <span
-            aria-label="arrow-left"
-            class="anticon anticon-arrow-left"
-            role="img"
+            class="ant-tag ant-tag-blue"
           >
-            <svg
-              aria-hidden="true"
-              class=""
-              data-icon="arrow-left"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M872 474H286.9l350.2-304c5.6-4.9 2.2-14-5.2-14h-88.5c-3.9 0-7.6 1.4-10.5 3.9L155 487.8a31.96 31.96 0 000 48.3L535.1 866c1.5 1.3 3.3 2 5.2 2h91.5c7.4 0 10.8-9.2 5.2-14L286.9 550H872c4.4 0 8-3.6 8-8v-60c0-4.4-3.6-8-8-8z"
-              />
-            </svg>
+            Running
           </span>
-        </div>
-      </div>
-      <span
-        class="ant-page-header-heading-title"
-      >
-        Title
-      </span>
-      <span
-        class="ant-page-header-heading-sub-title"
-      >
-        This is a subtitle
-      </span>
-      <span
-        class="ant-page-header-heading-tags"
-      >
-        <span
-          class="ant-tag ant-tag-blue"
-        >
-          Running
         </span>
-      </span>
+      </div>
       <span
         class="ant-page-header-heading-extra"
       >
@@ -371,47 +383,53 @@ exports[`renders ./components/page-header/demo/basic.md correctly 1`] = `
     class="ant-page-header-heading"
   >
     <div
-      class="ant-page-header-back"
+      class="ant-page-header-heading-left"
     >
       <div
-        aria-label="Back"
-        class="ant-page-header-back-button"
-        role="button"
-        style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-block"
-        tabindex="0"
+        class="ant-page-header-back"
       >
-        <span
-          aria-label="arrow-left"
-          class="anticon anticon-arrow-left"
-          role="img"
+        <div
+          aria-label="Back"
+          class="ant-page-header-back-button"
+          role="button"
+          style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-block"
+          tabindex="0"
         >
-          <svg
-            aria-hidden="true"
-            class=""
-            data-icon="arrow-left"
-            fill="currentColor"
-            focusable="false"
-            height="1em"
-            viewBox="64 64 896 896"
-            width="1em"
+          <span
+            aria-label="arrow-left"
+            class="anticon anticon-arrow-left"
+            role="img"
           >
-            <path
-              d="M872 474H286.9l350.2-304c5.6-4.9 2.2-14-5.2-14h-88.5c-3.9 0-7.6 1.4-10.5 3.9L155 487.8a31.96 31.96 0 000 48.3L535.1 866c1.5 1.3 3.3 2 5.2 2h91.5c7.4 0 10.8-9.2 5.2-14L286.9 550H872c4.4 0 8-3.6 8-8v-60c0-4.4-3.6-8-8-8z"
-            />
-          </svg>
-        </span>
+            <svg
+              aria-hidden="true"
+              class=""
+              data-icon="arrow-left"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M872 474H286.9l350.2-304c5.6-4.9 2.2-14-5.2-14h-88.5c-3.9 0-7.6 1.4-10.5 3.9L155 487.8a31.96 31.96 0 000 48.3L535.1 866c1.5 1.3 3.3 2 5.2 2h91.5c7.4 0 10.8-9.2 5.2-14L286.9 550H872c4.4 0 8-3.6 8-8v-60c0-4.4-3.6-8-8-8z"
+              />
+            </svg>
+          </span>
+        </div>
       </div>
+      <span
+        class="ant-page-header-heading-title"
+        title="Title"
+      >
+        Title
+      </span>
+      <span
+        class="ant-page-header-heading-sub-title"
+        title="This is a subtitle"
+      >
+        This is a subtitle
+      </span>
     </div>
-    <span
-      class="ant-page-header-heading-title"
-    >
-      Title
-    </span>
-    <span
-      class="ant-page-header-heading-sub-title"
-    >
-      This is a subtitle
-    </span>
   </div>
 </div>
 `;
@@ -473,16 +491,22 @@ exports[`renders ./components/page-header/demo/breadcrumb.md correctly 1`] = `
   <div
     class="ant-page-header-heading"
   >
-    <span
-      class="ant-page-header-heading-title"
+    <div
+      class="ant-page-header-heading-left"
     >
-      Title
-    </span>
-    <span
-      class="ant-page-header-heading-sub-title"
-    >
-      This is a subtitle
-    </span>
+      <span
+        class="ant-page-header-heading-title"
+        title="Title"
+      >
+        Title
+      </span>
+      <span
+        class="ant-page-header-heading-sub-title"
+        title="This is a subtitle"
+      >
+        This is a subtitle
+      </span>
+    </div>
   </div>
 </div>
 `;
@@ -544,32 +568,38 @@ exports[`renders ./components/page-header/demo/content.md correctly 1`] = `
   <div
     class="ant-page-header-heading"
   >
-    <span
-      class="ant-avatar ant-avatar-circle ant-avatar-image"
-    >
-      <img
-        src="https://avatars1.githubusercontent.com/u/8186664?s=460&v=4"
-      />
-    </span>
-    <span
-      class="ant-page-header-heading-title"
-    >
-      Title
-    </span>
-    <span
-      class="ant-page-header-heading-sub-title"
-    >
-      This is a subtitle
-    </span>
-    <span
-      class="ant-page-header-heading-tags"
+    <div
+      class="ant-page-header-heading-left"
     >
       <span
-        class="ant-tag ant-tag-blue"
+        class="ant-avatar ant-avatar-circle ant-avatar-image"
       >
-        Running
+        <img
+          src="https://avatars1.githubusercontent.com/u/8186664?s=460&v=4"
+        />
       </span>
-    </span>
+      <span
+        class="ant-page-header-heading-title"
+        title="Title"
+      >
+        Title
+      </span>
+      <span
+        class="ant-page-header-heading-sub-title"
+        title="This is a subtitle"
+      >
+        This is a subtitle
+      </span>
+      <span
+        class="ant-page-header-heading-tags"
+      >
+        <span
+          class="ant-tag ant-tag-blue"
+        >
+          Running
+        </span>
+      </span>
+    </div>
     <span
       class="ant-page-header-heading-extra"
     >
@@ -703,47 +733,53 @@ exports[`renders ./components/page-header/demo/ghost.md correctly 1`] = `
       class="ant-page-header-heading"
     >
       <div
-        class="ant-page-header-back"
+        class="ant-page-header-heading-left"
       >
         <div
-          aria-label="Back"
-          class="ant-page-header-back-button"
-          role="button"
-          style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-block"
-          tabindex="0"
+          class="ant-page-header-back"
         >
-          <span
-            aria-label="arrow-left"
-            class="anticon anticon-arrow-left"
-            role="img"
+          <div
+            aria-label="Back"
+            class="ant-page-header-back-button"
+            role="button"
+            style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-block"
+            tabindex="0"
           >
-            <svg
-              aria-hidden="true"
-              class=""
-              data-icon="arrow-left"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
+            <span
+              aria-label="arrow-left"
+              class="anticon anticon-arrow-left"
+              role="img"
             >
-              <path
-                d="M872 474H286.9l350.2-304c5.6-4.9 2.2-14-5.2-14h-88.5c-3.9 0-7.6 1.4-10.5 3.9L155 487.8a31.96 31.96 0 000 48.3L535.1 866c1.5 1.3 3.3 2 5.2 2h91.5c7.4 0 10.8-9.2 5.2-14L286.9 550H872c4.4 0 8-3.6 8-8v-60c0-4.4-3.6-8-8-8z"
-              />
-            </svg>
-          </span>
+              <svg
+                aria-hidden="true"
+                class=""
+                data-icon="arrow-left"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M872 474H286.9l350.2-304c5.6-4.9 2.2-14-5.2-14h-88.5c-3.9 0-7.6 1.4-10.5 3.9L155 487.8a31.96 31.96 0 000 48.3L535.1 866c1.5 1.3 3.3 2 5.2 2h91.5c7.4 0 10.8-9.2 5.2-14L286.9 550H872c4.4 0 8-3.6 8-8v-60c0-4.4-3.6-8-8-8z"
+                />
+              </svg>
+            </span>
+          </div>
         </div>
+        <span
+          class="ant-page-header-heading-title"
+          title="Title"
+        >
+          Title
+        </span>
+        <span
+          class="ant-page-header-heading-sub-title"
+          title="This is a subtitle"
+        >
+          This is a subtitle
+        </span>
       </div>
-      <span
-        class="ant-page-header-heading-title"
-      >
-        Title
-      </span>
-      <span
-        class="ant-page-header-heading-sub-title"
-      >
-        This is a subtitle
-      </span>
       <span
         class="ant-page-header-heading-extra"
       >
@@ -887,47 +923,53 @@ exports[`renders ./components/page-header/demo/responsive.md correctly 1`] = `
       class="ant-page-header-heading"
     >
       <div
-        class="ant-page-header-back"
+        class="ant-page-header-heading-left"
       >
         <div
-          aria-label="Back"
-          class="ant-page-header-back-button"
-          role="button"
-          style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-block"
-          tabindex="0"
+          class="ant-page-header-back"
         >
-          <span
-            aria-label="arrow-left"
-            class="anticon anticon-arrow-left"
-            role="img"
+          <div
+            aria-label="Back"
+            class="ant-page-header-back-button"
+            role="button"
+            style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-block"
+            tabindex="0"
           >
-            <svg
-              aria-hidden="true"
-              class=""
-              data-icon="arrow-left"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
+            <span
+              aria-label="arrow-left"
+              class="anticon anticon-arrow-left"
+              role="img"
             >
-              <path
-                d="M872 474H286.9l350.2-304c5.6-4.9 2.2-14-5.2-14h-88.5c-3.9 0-7.6 1.4-10.5 3.9L155 487.8a31.96 31.96 0 000 48.3L535.1 866c1.5 1.3 3.3 2 5.2 2h91.5c7.4 0 10.8-9.2 5.2-14L286.9 550H872c4.4 0 8-3.6 8-8v-60c0-4.4-3.6-8-8-8z"
-              />
-            </svg>
-          </span>
+              <svg
+                aria-hidden="true"
+                class=""
+                data-icon="arrow-left"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M872 474H286.9l350.2-304c5.6-4.9 2.2-14-5.2-14h-88.5c-3.9 0-7.6 1.4-10.5 3.9L155 487.8a31.96 31.96 0 000 48.3L535.1 866c1.5 1.3 3.3 2 5.2 2h91.5c7.4 0 10.8-9.2 5.2-14L286.9 550H872c4.4 0 8-3.6 8-8v-60c0-4.4-3.6-8-8-8z"
+                />
+              </svg>
+            </span>
+          </div>
         </div>
+        <span
+          class="ant-page-header-heading-title"
+          title="Title"
+        >
+          Title
+        </span>
+        <span
+          class="ant-page-header-heading-sub-title"
+          title="This is a subtitle"
+        >
+          This is a subtitle
+        </span>
       </div>
-      <span
-        class="ant-page-header-heading-title"
-      >
-        Title
-      </span>
-      <span
-        class="ant-page-header-heading-sub-title"
-      >
-        This is a subtitle
-      </span>
       <span
         class="ant-page-header-heading-extra"
       >

--- a/components/page-header/__tests__/__snapshots__/index.test.js.snap
+++ b/components/page-header/__tests__/__snapshots__/index.test.js.snap
@@ -13,11 +13,16 @@ exports[`PageHeader pageHeader should render correctly int RTL direction 1`] = `
   <div
     class="ant-page-header-heading"
   >
-    <span
-      class="ant-page-header-heading-title"
+    <div
+      class="ant-page-header-heading-left"
     >
-      Page Title
-    </span>
+      <span
+        class="ant-page-header-heading-title"
+        title="Page Title"
+      >
+        Page Title
+      </span>
+    </div>
   </div>
 </div>
 `;
@@ -29,11 +34,16 @@ exports[`PageHeader pageHeader should support className 1`] = `
   <div
     class="ant-page-header-heading"
   >
-    <span
-      class="ant-page-header-heading-title"
+    <div
+      class="ant-page-header-heading-left"
     >
-      Page Title
-    </span>
+      <span
+        class="ant-page-header-heading-title"
+        title="Page Title"
+      >
+        Page Title
+      </span>
+    </div>
   </div>
 </div>
 `;

--- a/components/page-header/demo/responsive.md
+++ b/components/page-header/demo/responsive.md
@@ -1,6 +1,6 @@
 ---
 order: 6
-iframe: 210
+iframe: 228
 title:
   zh-CN: 响应式
   en-US: responsive
@@ -89,16 +89,7 @@ ReactDOM.render(
 );
 ```
 
-```css
-.site-page-header-responsive {
-  border: 1px solid rgb(235, 237, 240);
-}
-```
-
 <style>
-[data-theme="dark"] .site-page-header-responsive {
-  border: 1px solid #303030;
-}
 tr:last-child td {
   padding-bottom: 0;
 }

--- a/components/page-header/index.tsx
+++ b/components/page-header/index.tsx
@@ -74,11 +74,13 @@ const renderTitle = (prefixCls: string, props: PageHeaderProps, direction: strin
     const backIconDom = renderBack(prefixCls, backIcon, onBack);
     return (
       <div className={headingPrefixCls}>
-        {backIconDom}
-        {avatar && <Avatar {...avatar} />}
-        {title && <span className={`${headingPrefixCls}-title`}>{title}</span>}
-        {subTitle && <span className={`${headingPrefixCls}-sub-title`}>{subTitle}</span>}
-        {tags && <span className={`${headingPrefixCls}-tags`}>{tags}</span>}
+        <div className={`${headingPrefixCls}-left`}>
+          {backIconDom}
+          {avatar && <Avatar {...avatar} />}
+          {title && <span className={`${headingPrefixCls}-title`}>{title}</span>}
+          {subTitle && <span className={`${headingPrefixCls}-sub-title`}>{subTitle}</span>}
+          {tags && <span className={`${headingPrefixCls}-tags`}>{tags}</span>}
+        </div>
         {extra && <span className={`${headingPrefixCls}-extra`}>{extra}</span>}
       </div>
     );

--- a/components/page-header/index.tsx
+++ b/components/page-header/index.tsx
@@ -77,8 +77,22 @@ const renderTitle = (prefixCls: string, props: PageHeaderProps, direction: strin
         <div className={`${headingPrefixCls}-left`}>
           {backIconDom}
           {avatar && <Avatar {...avatar} />}
-          {title && <span className={`${headingPrefixCls}-title`}>{title}</span>}
-          {subTitle && <span className={`${headingPrefixCls}-sub-title`}>{subTitle}</span>}
+          {title && (
+            <span
+              className={`${headingPrefixCls}-title`}
+              title={typeof title === 'string' ? title : undefined}
+            >
+              {title}
+            </span>
+          )}
+          {subTitle && (
+            <span
+              className={`${headingPrefixCls}-sub-title`}
+              title={typeof subTitle === 'string' ? subTitle : undefined}
+            >
+              {subTitle}
+            </span>
+          )}
           {tags && <span className={`${headingPrefixCls}-tags`}>{tags}</span>}
         </div>
         {extra && <span className={`${headingPrefixCls}-extra`}>{extra}</span>}

--- a/components/page-header/index.tsx
+++ b/components/page-header/index.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import classnames from 'classnames';
 import ArrowLeftOutlined from '@ant-design/icons/ArrowLeftOutlined';
 import ArrowRightOutlined from '@ant-design/icons/ArrowRightOutlined';
-
+import ResizeObserver from 'rc-resize-observer';
 import { ConfigConsumer, ConfigConsumerProps } from '../config-provider';
 import Tag from '../tag';
 import Breadcrumb, { BreadcrumbProps } from '../breadcrumb';
@@ -113,45 +113,54 @@ const renderChildren = (prefixCls: string, children: React.ReactNode) => {
   return <div className={`${prefixCls}-content`}>{children}</div>;
 };
 
-const PageHeader: React.FC<PageHeaderProps> = props => (
-  <ConfigConsumer>
-    {({ getPrefixCls, pageHeader, direction }: ConfigConsumerProps) => {
-      const {
-        prefixCls: customizePrefixCls,
-        style,
-        footer,
-        children,
-        breadcrumb,
-        className: customizeClassName,
-      } = props;
-      let ghost: undefined | boolean = true;
+const PageHeader: React.FC<PageHeaderProps> = props => {
+  const [compact, updateCompact] = React.useState(false);
+  const onResize = ({ width }: { width: number }) => {
+    updateCompact(width < 540);
+  };
+  return (
+    <ConfigConsumer>
+      {({ getPrefixCls, pageHeader, direction }: ConfigConsumerProps) => {
+        const {
+          prefixCls: customizePrefixCls,
+          style,
+          footer,
+          children,
+          breadcrumb,
+          className: customizeClassName,
+        } = props;
+        let ghost: undefined | boolean = true;
 
-      // Use `ghost` from `props` or from `ConfigProvider` instead.
-      if ('ghost' in props) {
-        ghost = props.ghost;
-      } else if (pageHeader && 'ghost' in pageHeader) {
-        ghost = pageHeader.ghost;
-      }
+        // Use `ghost` from `props` or from `ConfigProvider` instead.
+        if ('ghost' in props) {
+          ghost = props.ghost;
+        } else if (pageHeader && 'ghost' in pageHeader) {
+          ghost = pageHeader.ghost;
+        }
 
-      const prefixCls = getPrefixCls('page-header', customizePrefixCls);
-      const breadcrumbDom = breadcrumb && breadcrumb.routes ? renderBreadcrumb(breadcrumb) : null;
-      const className = classnames(prefixCls, customizeClassName, {
-        'has-breadcrumb': breadcrumbDom,
-        'has-footer': footer,
-        [`${prefixCls}-ghost`]: ghost,
-        [`${prefixCls}-rtl`]: direction === 'rtl',
-      });
+        const prefixCls = getPrefixCls('page-header', customizePrefixCls);
+        const breadcrumbDom = breadcrumb && breadcrumb.routes ? renderBreadcrumb(breadcrumb) : null;
+        const className = classnames(prefixCls, customizeClassName, {
+          'has-breadcrumb': breadcrumbDom,
+          'has-footer': footer,
+          [`${prefixCls}-ghost`]: ghost,
+          [`${prefixCls}-rtl`]: direction === 'rtl',
+          [`${prefixCls}-compact`]: compact,
+        });
 
-      return (
-        <div className={className} style={style}>
-          {breadcrumbDom}
-          {renderTitle(prefixCls, props, direction)}
-          {children && renderChildren(prefixCls, children)}
-          {renderFooter(prefixCls, footer)}
-        </div>
-      );
-    }}
-  </ConfigConsumer>
-);
+        return (
+          <ResizeObserver onResize={onResize}>
+            <div className={className} style={style}>
+              {breadcrumbDom}
+              {renderTitle(prefixCls, props, direction)}
+              {children && renderChildren(prefixCls, children)}
+              {renderFooter(prefixCls, footer)}
+            </div>
+          </ResizeObserver>
+        );
+      }}
+    </ConfigConsumer>
+  );
+};
 
 export default PageHeader;

--- a/components/page-header/style/index.less
+++ b/components/page-header/style/index.less
@@ -22,7 +22,6 @@
   }
 
   &-back {
-    margin: 8px 0;
     margin-right: @margin-md;
     font-size: 16px;
     line-height: 1;
@@ -112,14 +111,11 @@
     }
   }
 
-  @media (max-width: @screen-md) {
-    &-heading {
-      &-extra {
-        display: block;
-        clear: both;
-        width: 100%;
-        padding-top: @padding-sm;
-      }
+  &-compact &-heading {
+    flex-direction: column;
+
+    &-extra {
+      margin-top: @margin-xs;
     }
   }
 }

--- a/components/page-header/style/index.less
+++ b/components/page-header/style/index.less
@@ -22,7 +22,6 @@
   }
 
   &-back {
-    float: left;
     margin: 8px 0;
     margin-right: @margin-md;
     font-size: 16px;
@@ -45,45 +44,49 @@
     margin-top: @margin-xs;
   }
 
+  .text-overflow-ellipsis() {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
+
   &-heading {
-    width: 100%;
-    .clearfix;
+    display: flex;
+    justify-content: space-between;
+
+    &-left {
+      display: flex;
+      align-items: center;
+      overflow: hidden;
+    }
 
     &-title {
-      display: block;
-      float: left;
+      margin-right: @margin-sm;
       margin-bottom: 0;
-      padding-right: @padding-sm;
       color: @heading-color;
       font-weight: 600;
       font-size: @heading-4-size;
       line-height: 32px;
+      .text-overflow-ellipsis;
     }
 
     .@{ant-prefix}-avatar {
-      float: left;
       margin-right: @margin-sm;
     }
 
     &-sub-title {
-      float: left;
-      margin: 5px 0;
       margin-right: @margin-sm;
       color: @text-color-secondary;
       font-size: 14px;
       line-height: 22px;
-    }
-
-    &-tags {
-      float: left;
-      margin: 4px 0;
+      .text-overflow-ellipsis;
     }
 
     &-extra {
-      float: right;
-
+      white-space: nowrap;
       > * {
-        margin-left: 8px;
+        margin-left: @margin-sm;
+        white-space: unset;
       }
       > *:first-child {
         margin-left: 0;
@@ -113,7 +116,6 @@
     &-heading {
       &-extra {
         display: block;
-        float: unset;
         clear: both;
         width: 100%;
         padding-top: @padding-sm;


### PR DESCRIPTION


<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close #15664

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

before ❌ | after ✅
---|---
<img width="1237" alt="image" src="https://user-images.githubusercontent.com/507615/78985954-af829600-7b5c-11ea-9a58-57a87af77eb2.png"> | <img width="1122" alt="image" src="https://user-images.githubusercontent.com/507615/78985943-a85b8800-7b5c-11ea-9bf2-5dcaa43fea97.png">


### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix PageHeader style breaks when `title` is too long and improve it's responsive design. |
| 🇨🇳 Chinese | 修复 PageHeader `title` 超长时布局被破坏的问题并优化响应式表现。 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️ 

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/page-header/demo/responsive.md](https://github.com/ant-design/ant-design/blob/fix-page-header-style/components/page-header/demo/responsive.md)