### PR TITLE
fix: Modify table size.less to accomodate size prop for footer padding

### DIFF
--- a/components/table/style/size.less
+++ b/components/table/style/size.less
@@ -1,11 +1,13 @@
 @import './index';
 
 .table-size(@size, @padding-vertical, @padding-horizontal) {
-  .@{table-prefix-cls}-@{size} {
+  .@{table-prefix-cls}.@{table-prefix-cls}-@{size} {
     .@{table-prefix-cls}-title,
     .@{table-prefix-cls}-footer,
     .@{table-prefix-cls}-thead > tr > th,
-    .@{table-prefix-cls}-tbody > tr > td {
+    .@{table-prefix-cls}-tbody > tr > td,
+    tfoot > tr > th,
+    tfoot > tr > td {
       padding: @padding-vertical @padding-horizontal;
     }
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->
[Table Summary Property Size Styling #23139 ](https://github.com/ant-design/ant-design/issues/23139)

### 💡 Background and solution

While using the `<Table>` element with a `summary` property I realized that the `size` property styling was not applied to the `tfoot` element. This fix is to include the `tfoot > tr > th` and `tfoot > tr > td` in the styles for tables that use the `size` property.

![image](https://user-images.githubusercontent.com/1868262/79013482-78958b80-7b2e-11ea-8ca1-0c60e1123010.png)

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     x      |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️ 

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
