### PR TITLE
feat: add getThemeVar file to support theme config and fix 4.1.2 them…

### DIFF
--- a/.antd-tools.config.js
+++ b/.antd-tools.config.js
@@ -61,11 +61,31 @@ function buildThemeFile(theme, vars) {
   // eslint-disable-next-line no-console
   console.log(`Built a entry less file to dist/antd.${theme}.less`);
 
+  if (theme === 'default') {
+    fs.writeFileSync(
+      path.join(process.cwd(), 'dist', `default-theme.js`),
+      `module.exports = ${JSON.stringify(vars, null, 2)};\n`,
+    );
+    return;
+  }
+
   // Build ${theme}.js: dist/${theme}-theme.js, for less-loader
 
   fs.writeFileSync(
+    path.join(process.cwd(), 'dist', `getThemeVar.js`),
+    `const ${theme}ThemeSingle = ${JSON.stringify(vars, null, 2)};\n`,
+    {
+      flag: 'a',
+    },
+  );
+
+  fs.writeFileSync(
     path.join(process.cwd(), 'dist', `${theme}-theme.js`),
-    `module.exports = ${JSON.stringify(vars, null, 2)};`,
+    `const { ${theme}ThemeSingle } = require('./getThemeVar');\nconst defaultTheme = require('./defaultTheme');\n
+module.exports = {
+  ...${theme}ThemeSingle,
+  ...defaultTheme
+}`,
   );
 
   // eslint-disable-next-line no-console
@@ -80,10 +100,46 @@ function finalizeDist() {
       '@import "../lib/style/index.less";\n@import "../lib/style/components.less";',
     );
     // eslint-disable-next-line no-console
+    fs.writeFileSync(
+      path.join(process.cwd(), 'dist', 'getThemeVar.js'),
+      `const defaultTheme = require('./default-theme.js');\n`,
+    );
     console.log('Built a entry less file to dist/antd.less');
     buildThemeFile('default', defaultVars);
     buildThemeFile('dark', darkVars);
     buildThemeFile('compact', compactVars);
+    fs.writeFileSync(
+      path.join(process.cwd(), 'dist', `getThemeVar.js`),
+      `
+function getThemeVar(options = {}) {
+  let themeVar = {
+    'hack': \`true;@import "\${require.resolve('antd/lib/style/color/colorPalette.less')}";\`,
+    ...defaultTheme
+  };
+  if(options.dark) {
+    themeVar = {
+      ...themeVar,
+      ...darkThemeSingle
+    }
+  }
+  if(options.compact){
+    themeVar = {
+      ...themeVar,
+      ...compactThemeSingle
+    }
+  }
+  return themeVar;
+}
+
+module.exports = {
+  darkThemeSingle,
+  compactThemeSingle,
+  getThemeVar
+}`,
+      {
+        flag: 'a',
+      },
+    );
   }
 }
 

--- a/.antd-tools.config.js
+++ b/.antd-tools.config.js
@@ -72,7 +72,7 @@ function buildThemeFile(theme, vars) {
   // Build ${theme}.js: dist/${theme}-theme.js, for less-loader
 
   fs.writeFileSync(
-    path.join(process.cwd(), 'dist', `getThemeVar.js`),
+    path.join(process.cwd(), 'dist', `theme.js`),
     `const ${theme}ThemeSingle = ${JSON.stringify(vars, null, 2)};\n`,
     {
       flag: 'a',
@@ -81,7 +81,7 @@ function buildThemeFile(theme, vars) {
 
   fs.writeFileSync(
     path.join(process.cwd(), 'dist', `${theme}-theme.js`),
-    `const { ${theme}ThemeSingle } = require('./getThemeVar');\nconst defaultTheme = require('./defaultTheme');\n
+    `const { ${theme}ThemeSingle } = require('./theme');\nconst defaultTheme = require('./default-theme');\n
 module.exports = {
   ...${theme}ThemeSingle,
   ...defaultTheme
@@ -101,7 +101,7 @@ function finalizeDist() {
     );
     // eslint-disable-next-line no-console
     fs.writeFileSync(
-      path.join(process.cwd(), 'dist', 'getThemeVar.js'),
+      path.join(process.cwd(), 'dist', 'theme.js'),
       `const defaultTheme = require('./default-theme.js');\n`,
     );
     console.log('Built a entry less file to dist/antd.less');
@@ -109,9 +109,9 @@ function finalizeDist() {
     buildThemeFile('dark', darkVars);
     buildThemeFile('compact', compactVars);
     fs.writeFileSync(
-      path.join(process.cwd(), 'dist', `getThemeVar.js`),
+      path.join(process.cwd(), 'dist', `theme.js`),
       `
-function getThemeVar(options = {}) {
+function getThemeVariables(options = {}) {
   let themeVar = {
     'hack': \`true;@import "\${require.resolve('antd/lib/style/color/colorPalette.less')}";\`,
     ...defaultTheme
@@ -134,7 +134,7 @@ function getThemeVar(options = {}) {
 module.exports = {
   darkThemeSingle,
   compactThemeSingle,
-  getThemeVar
+  getThemeVariables
 }`,
       {
         flag: 'a',
@@ -151,3 +151,4 @@ module.exports = {
     finalize: finalizeDist,
   },
 };
+finalizeDist();

--- a/docs/react/customize-theme.en-US.md
+++ b/docs/react/customize-theme.en-US.md
@@ -182,9 +182,7 @@ If the project does not use Less, you can import [antd.dark.css](https://unpkg.c
 Method 3: using [less-loader](https://github.com/webpack-contrib/less-loader) in `webpack.config.js` to introduce as needed:
 
 ```diff
-const defaultTheme = require('antd/dist/default-theme');
-const darkTheme = require('antd/dist/dark-theme');
-const compactTheme = require('antd/dist/compact-theme');
+const { getThemeVar } = require('antd/dist/getThemeVar');
 
 // webpack.config.js
 module.exports = {
@@ -197,12 +195,10 @@ module.exports = {
     }, {
       loader: 'less-loader', // compiles Less to CSS
 +     options: {
-+       modifyVars: {
-+          'hack': `true;@import "${require.resolve('antd/lib/style/color/colorPalette.less')}";`,
-+          ...defaultTheme, // darkTheme and compactTheme depend on defaultTheme
-+          ...darkTheme,
-+          ...compactTheme,
-+       },
++       modifyVars: getThemeVar({
++         dark: true, // enable dark mode
++         compact: true, // enable compact mode
++       }),
 +       javascriptEnabled: true,
 +     },
     }],

--- a/docs/react/customize-theme.en-US.md
+++ b/docs/react/customize-theme.en-US.md
@@ -182,7 +182,7 @@ If the project does not use Less, you can import [antd.dark.css](https://unpkg.c
 Method 3: using [less-loader](https://github.com/webpack-contrib/less-loader) in `webpack.config.js` to introduce as needed:
 
 ```diff
-const { getThemeVar } = require('antd/dist/getThemeVar');
+const { getThemeVariables } = require('antd/dist/theme');
 
 // webpack.config.js
 module.exports = {
@@ -195,7 +195,7 @@ module.exports = {
     }, {
       loader: 'less-loader', // compiles Less to CSS
 +     options: {
-+       modifyVars: getThemeVar({
++       modifyVars: getThemeVariables({
 +         dark: true, // enable dark mode
 +         compact: true, // enable compact mode
 +       }),

--- a/docs/react/customize-theme.zh-CN.md
+++ b/docs/react/customize-theme.zh-CN.md
@@ -160,9 +160,7 @@ module.exports = {
 方式三：是用在 `webpack.config.js` 使用 [less-loader](https://github.com/webpack-contrib/less-loader) 按需引入：
 
 ```diff
-const defaultTheme = require('antd/dist/default-theme');
-const darkTheme = require('antd/dist/dark-theme');
-const compactTheme = require('antd/dist/compact-theme');
+const { getThemeVar } = require('antd/dist/getThemeVar');
 
 // webpack.config.js
 module.exports = {
@@ -175,12 +173,10 @@ module.exports = {
     }, {
       loader: 'less-loader', // compiles Less to CSS
 +     options: {
-+       modifyVars: {
-+          'hack': `true;@import "${require.resolve('antd/lib/style/color/colorPalette.less')}";`,
-+          ...defaultTheme, // darkTheme 和 compactTheme 依赖 defaultTheme
-+          ...darkTheme,
-+          ...compactTheme,
-+       },
++       modifyVars: getThemeVar({
++         dark: true, // 开启暗黑模式
++         compact: true, // 开启紧凑模式
++       }),
 +       javascriptEnabled: true,
 +     },
     }],

--- a/docs/react/customize-theme.zh-CN.md
+++ b/docs/react/customize-theme.zh-CN.md
@@ -160,7 +160,7 @@ module.exports = {
 方式三：是用在 `webpack.config.js` 使用 [less-loader](https://github.com/webpack-contrib/less-loader) 按需引入：
 
 ```diff
-const { getThemeVar } = require('antd/dist/getThemeVar');
+const { getThemeVariables } = require('antd/dist/theme');
 
 // webpack.config.js
 module.exports = {
@@ -173,7 +173,7 @@ module.exports = {
     }, {
       loader: 'less-loader', // compiles Less to CSS
 +     options: {
-+       modifyVars: getThemeVar({
++       modifyVars: getThemeVariables({
 +         dark: true, // 开启暗黑模式
 +         compact: true, // 开启紧凑模式
 +       }),


### PR DESCRIPTION
…e config breaking change

<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [x] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

Firstly, I have to say sorry for making a breaking change in 4.1.2 https://github.com/ant-design/ant-design/pull/22934 . It make issues like https://github.com/ant-design/ant-design/issues/23163 and https://github.com/ant-design/ant-design/issues/23154 . So, for not to breaking old config, dark-theme and compact-theme still like before 4.1.2.
Now, for more backward compatible and [simple](https://github.com/ant-design/ant-design/issues/22959) for config mode. Use `const { getThemeVar } = require('antd/dist/getThemeVar');`  to config theme.

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    fix `Variable is undefined` when using dark and compact theme. Support `getThemeVariables` for an easy way to get theme variables. |
| 🇨🇳 Chinese |  修复引用暗黑或紧凑主题时提示 `Variable is undefined` 的问题。  提供 `getThemeVariables` 方便获取对应主题变量。   |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️ 

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered docs/react/customize-theme.en-US.md](https://github.com/AshoneA/ant-design/blob/fix/mixin-mode/docs/react/customize-theme.en-US.md)
[View rendered docs/react/customize-theme.zh-CN.md](https://github.com/AshoneA/ant-design/blob/fix/mixin-mode/docs/react/customize-theme.zh-CN.md)