### PR TITLE
fix: Table selection `childrenColumnName` not work

### DIFF
--- a/components/table/Table.tsx
+++ b/components/table/Table.tsx
@@ -98,6 +98,7 @@ function Table<RecordType extends object = any>(props: TableProps<RecordType>) {
     rowClassName,
     columns,
     children,
+    childrenColumnName: legacyChildrenColumnName,
     onChange,
     getPopupContainer,
     loading,
@@ -127,6 +128,7 @@ function Table<RecordType extends object = any>(props: TableProps<RecordType>) {
   const dropdownPrefixCls = getPrefixCls('dropdown', customizeDropdownPrefixCls);
 
   const mergedExpandable: ExpandableConfig<RecordType> = {
+    childrenColumnName: legacyChildrenColumnName,
     expandIconColumnIndex,
     ...expandable,
   };

--- a/components/table/Table.tsx
+++ b/components/table/Table.tsx
@@ -106,7 +106,6 @@ function Table<RecordType extends object = any>(props: TableProps<RecordType>) {
     expandedRowRender,
     expandIconColumnIndex,
     indentSize,
-    childrenColumnName = 'children',
     scroll,
     sortDirections,
     locale,
@@ -131,6 +130,7 @@ function Table<RecordType extends object = any>(props: TableProps<RecordType>) {
     expandIconColumnIndex,
     ...expandable,
   };
+  const { childrenColumnName = 'children' } = mergedExpandable;
 
   const expandType: ExpandType = React.useMemo<ExpandType>(() => {
     if (rawData.some(item => (item as any)[childrenColumnName])) {

--- a/components/table/__tests__/Table.rowSelection.test.js
+++ b/components/table/__tests__/Table.rowSelection.test.js
@@ -779,4 +779,22 @@ describe('Table.rowSelection', () => {
     jest.runAllTimers();
     expect(wrapper.render()).toMatchSnapshot();
   });
+
+  it('Table selection should check', () => {
+    const onChange = jest.fn();
+    const wrapper = mount(
+      <Table
+        dataSource={[{ name: 'light', sub: [{ name: 'bamboo' }] }]}
+        expandable={{ expandedRowKeys: ['light'] }}
+        rowSelection={{ onChange }}
+        rowKey="name"
+      />,
+    );
+
+    wrapper
+      .find('input')
+      .last()
+      .simulate('change', { target: { checked: true } });
+    expect(onChange.mock.calls[0][1]).toEqual([expect.objectContaining({ name: 'bamboo' })]);
+  });
 });

--- a/components/table/__tests__/Table.rowSelection.test.js
+++ b/components/table/__tests__/Table.rowSelection.test.js
@@ -785,7 +785,7 @@ describe('Table.rowSelection', () => {
     const wrapper = mount(
       <Table
         dataSource={[{ name: 'light', sub: [{ name: 'bamboo' }] }]}
-        expandable={{ expandedRowKeys: ['light'] }}
+        expandable={{ expandedRowKeys: ['light'], childrenColumnName: 'sub' }}
         rowSelection={{ onChange }}
         rowKey="name"
       />,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

fix #23197

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Fix Table `rowSelection` params issue when `childrenColumnName` configured.        |
| 🇨🇳 Chinese |    修复 Table `rowSelection` 在设置 `childrenColumnName`时事件参数不正确的问题。      |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️ 

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
