### PR TITLE
fix: Fix popupClassName prop in timepicker

### DIFF
--- a/components/time-picker/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/time-picker/__tests__/__snapshots__/demo.test.js.snap
@@ -222,6 +222,51 @@ exports[`renders ./components/time-picker/demo/basic.md correctly 1`] = `
 </div>
 `;
 
+exports[`renders ./components/time-picker/demo/colored-popup.md correctly 1`] = `
+<div
+  class="ant-picker"
+>
+  <div
+    class="ant-picker-input"
+  >
+    <input
+      placeholder="Select time"
+      readonly=""
+      size="10"
+      title=""
+      value=""
+    />
+    <span
+      class="ant-picker-suffix"
+    >
+      <span
+        aria-label="clock-circle"
+        class="anticon anticon-clock-circle"
+        role="img"
+      >
+        <svg
+          aria-hidden="true"
+          class=""
+          data-icon="clock-circle"
+          fill="currentColor"
+          focusable="false"
+          height="1em"
+          viewBox="64 64 896 896"
+          width="1em"
+        >
+          <path
+            d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+          />
+          <path
+            d="M686.7 638.6L544.1 535.5V288c0-4.4-3.6-8-8-8H488c-4.4 0-8 3.6-8 8v275.4c0 2.6 1.2 5 3.3 6.5l165.4 120.6c3.6 2.6 8.6 1.8 11.2-1.7l28.6-39c2.6-3.7 1.8-8.7-1.8-11.2z"
+          />
+        </svg>
+      </span>
+    </span>
+  </div>
+</div>
+`;
+
 exports[`renders ./components/time-picker/demo/disabled.md correctly 1`] = `
 <div
   class="ant-picker ant-picker-disabled"

--- a/components/time-picker/__tests__/index.test.js
+++ b/components/time-picker/__tests__/index.test.js
@@ -72,30 +72,4 @@ describe('TimePicker', () => {
     );
     expect(wrapper.find('Picker').prop('dropdownClassName')).toEqual(popupClassName);
   });
-
-  it('should pass dropdownClassName prop to Picker as dropdownClassName prop', () => {
-    const dropdownClassName = 'myCustomClassName';
-    const wrapper = mount(
-      <TimePicker
-        defaultOpenValue={moment('00:00:00', 'HH:mm:ss')}
-        dropdownClassName={dropdownClassName}
-      />,
-    );
-    expect(wrapper.find('Picker').prop('dropdownClassName')).toEqual(dropdownClassName);
-  });
-
-  it('should combine dropdownClassName and popupClassName props and pass it to Picker as dropdownClassName prop', () => {
-    const dropdownClassName = 'myCustomClassNameOne';
-    const popupClassName = 'myCustomClassNameTwo';
-    const wrapper = mount(
-      <TimePicker
-        defaultOpenValue={moment('00:00:00', 'HH:mm:ss')}
-        dropdownClassName={dropdownClassName}
-        popupClassName={popupClassName}
-      />,
-    );
-    expect(wrapper.find('Picker').prop('dropdownClassName')).toEqual(
-      `${dropdownClassName} ${popupClassName}`,
-    );
-  });
 });

--- a/components/time-picker/__tests__/index.test.js
+++ b/components/time-picker/__tests__/index.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import moment from 'moment';
+import RCPicker from 'rc-picker';
 import TimePicker from '..';
 import focusTest from '../../../tests/shared/focusTest';
 import mountTest from '../../../tests/shared/mountTest';
@@ -60,5 +61,42 @@ describe('TimePicker', () => {
       <TimePicker defaultValue={moment('2000-01-01 00:00:00')} open locale={locale} />,
     );
     expect(wrapper.render()).toMatchSnapshot();
+  });
+
+  it('should pass popupClassName prop to RCPicker as dropdownClassName prop', () => {
+    const popupClassName = 'myCustomClassName';
+    const wrapper = mount(
+      <TimePicker
+        defaultOpenValue={moment('00:00:00', 'HH:mm:ss')}
+        popupClassName={popupClassName}
+      />,
+    );
+    expect(wrapper.find(RCPicker).prop('dropdownClassName')).toEqual(popupClassName);
+  });
+
+  it('should pass dropdownClassName prop to RCPicker as dropdownClassName prop', () => {
+    const dropdownClassName = 'myCustomClassName';
+    const wrapper = mount(
+      <TimePicker
+        defaultOpenValue={moment('00:00:00', 'HH:mm:ss')}
+        dropdownClassName={dropdownClassName}
+      />,
+    );
+    expect(wrapper.find(RCPicker).prop('dropdownClassName')).toEqual(dropdownClassName);
+  });
+
+  it('should combine dropdownClassName and popupClassName props and pass it to RCPicker as dropdownClassName prop', () => {
+    const dropdownClassName = 'myCustomClassNameOne';
+    const popupClassName = 'myCustomClassNameTwo';
+    const wrapper = mount(
+      <TimePicker
+        defaultOpenValue={moment('00:00:00', 'HH:mm:ss')}
+        dropdownClassName={dropdownClassName}
+        popupClassName={popupClassName}
+      />,
+    );
+    expect(wrapper.find(RCPicker).prop('dropdownClassName')).toEqual(
+      `${dropdownClassName} ${popupClassName}`,
+    );
   });
 });

--- a/components/time-picker/__tests__/index.test.js
+++ b/components/time-picker/__tests__/index.test.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import moment from 'moment';
-import RCPicker from 'rc-picker';
 import TimePicker from '..';
 import focusTest from '../../../tests/shared/focusTest';
 import mountTest from '../../../tests/shared/mountTest';
@@ -63,7 +62,7 @@ describe('TimePicker', () => {
     expect(wrapper.render()).toMatchSnapshot();
   });
 
-  it('should pass popupClassName prop to RCPicker as dropdownClassName prop', () => {
+  it('should pass popupClassName prop to Picker as dropdownClassName prop', () => {
     const popupClassName = 'myCustomClassName';
     const wrapper = mount(
       <TimePicker
@@ -71,10 +70,10 @@ describe('TimePicker', () => {
         popupClassName={popupClassName}
       />,
     );
-    expect(wrapper.find(RCPicker).prop('dropdownClassName')).toEqual(popupClassName);
+    expect(wrapper.find('Picker').prop('dropdownClassName')).toEqual(popupClassName);
   });
 
-  it('should pass dropdownClassName prop to RCPicker as dropdownClassName prop', () => {
+  it('should pass dropdownClassName prop to Picker as dropdownClassName prop', () => {
     const dropdownClassName = 'myCustomClassName';
     const wrapper = mount(
       <TimePicker
@@ -82,10 +81,10 @@ describe('TimePicker', () => {
         dropdownClassName={dropdownClassName}
       />,
     );
-    expect(wrapper.find(RCPicker).prop('dropdownClassName')).toEqual(dropdownClassName);
+    expect(wrapper.find('Picker').prop('dropdownClassName')).toEqual(dropdownClassName);
   });
 
-  it('should combine dropdownClassName and popupClassName props and pass it to RCPicker as dropdownClassName prop', () => {
+  it('should combine dropdownClassName and popupClassName props and pass it to Picker as dropdownClassName prop', () => {
     const dropdownClassName = 'myCustomClassNameOne';
     const popupClassName = 'myCustomClassNameTwo';
     const wrapper = mount(
@@ -95,7 +94,7 @@ describe('TimePicker', () => {
         popupClassName={popupClassName}
       />,
     );
-    expect(wrapper.find(RCPicker).prop('dropdownClassName')).toEqual(
+    expect(wrapper.find('Picker').prop('dropdownClassName')).toEqual(
       `${dropdownClassName} ${popupClassName}`,
     );
   });

--- a/components/time-picker/demo/colored-popup.md
+++ b/components/time-picker/demo/colored-popup.md
@@ -3,6 +3,7 @@ order: 9
 title:
   zh-CN: 色付きポップアップ
   en-US: Colored Popup
+debug: true
 ---
 
 ## zh-CN

--- a/components/time-picker/demo/colored-popup.md
+++ b/components/time-picker/demo/colored-popup.md
@@ -1,0 +1,38 @@
+---
+order: 9
+title:
+  zh-CN: 色付きポップアップ
+  en-US: Colored Popup
+---
+
+## zh-CN
+
+カスタムクラスを `TimePicker`ポップアップに渡す
+
+## en-US
+
+Passing custom class to `TimePicker` popup
+
+```jsx
+import { TimePicker } from 'antd';
+import moment from 'moment';
+
+const onChange = (time, timeString) => {
+  console.log(time, timeString);
+};
+
+ReactDOM.render(
+  <TimePicker
+    onChange={onChange}
+    defaultOpenValue={moment('00:00:00', 'HH:mm:ss')}
+    popupClassName="myCustomClassName"
+  />,
+  mountNode,
+);
+```
+
+```css
+.myCustomClassName .ant-picker-time-panel-cell-inner {
+  color: red !important;
+}
+```

--- a/components/time-picker/index.en-US.md
+++ b/components/time-picker/index.en-US.md
@@ -41,7 +41,7 @@ import moment from 'moment';
 | minuteStep | interval between minutes in picker | number | 1 |  |
 | open | whether to popup panel | boolean | false |  |
 | placeholder | display when there's no value | string | "Select a time" |  |
-| popupClassName | className of panel | string | '' |  |
+| popupClassName | className of panel | string | - |  |
 | popupStyle | style of panel | object | - |  |
 | secondStep | interval between seconds in picker | number | 1 |  |
 | suffixIcon | The custom suffix icon | ReactNode | - |  |

--- a/components/time-picker/index.tsx
+++ b/components/time-picker/index.tsx
@@ -57,9 +57,6 @@ const TimePicker = React.forwardRef<any, TimePickerProps>(
 );
 
 TimePicker.displayName = 'TimePicker';
-TimePicker.defaultProps = {
-  popupClassName: '',
-};
 
 type MergedTimePicker = typeof TimePicker & {
   RangePicker: typeof RangePicker;

--- a/components/time-picker/index.tsx
+++ b/components/time-picker/index.tsx
@@ -1,5 +1,6 @@
 import { Moment } from 'moment';
 import * as React from 'react';
+import classNames from 'classnames';
 import DatePicker from '../date-picker';
 import { PickerTimeProps, RangePickerTimeProps } from '../date-picker/generatePicker';
 import warning from '../_util/warning';
@@ -20,10 +21,11 @@ const RangePicker = React.forwardRef<any, TimeRangePickerProps>((props, ref) => 
 
 export interface TimePickerProps extends Omit<PickerTimeProps<Moment>, 'picker'> {
   addon?: () => React.ReactNode;
+  popupClassName?: string;
 }
 
 const TimePicker = React.forwardRef<any, TimePickerProps>(
-  ({ addon, renderExtraFooter, ...restProps }, ref) => {
+  ({ addon, renderExtraFooter, popupClassName, dropdownClassName, ...restProps }, ref) => {
     const internalRenderExtraFooter = React.useMemo(() => {
       if (renderExtraFooter) {
         return renderExtraFooter;
@@ -42,6 +44,10 @@ const TimePicker = React.forwardRef<any, TimePickerProps>(
     return (
       <InternalTimePicker
         {...restProps}
+        dropdownClassName={classNames({
+          [`${dropdownClassName}`]: dropdownClassName,
+          [`${popupClassName}`]: popupClassName,
+        })}
         mode={undefined}
         ref={ref}
         renderExtraFooter={internalRenderExtraFooter}
@@ -51,6 +57,9 @@ const TimePicker = React.forwardRef<any, TimePickerProps>(
 );
 
 TimePicker.displayName = 'TimePicker';
+TimePicker.defaultProps = {
+  popupClassName: '',
+};
 
 type MergedTimePicker = typeof TimePicker & {
   RangePicker: typeof RangePicker;

--- a/components/time-picker/index.tsx
+++ b/components/time-picker/index.tsx
@@ -1,6 +1,5 @@
 import { Moment } from 'moment';
 import * as React from 'react';
-import classNames from 'classnames';
 import DatePicker from '../date-picker';
 import { PickerTimeProps, RangePickerTimeProps } from '../date-picker/generatePicker';
 import warning from '../_util/warning';
@@ -25,7 +24,7 @@ export interface TimePickerProps extends Omit<PickerTimeProps<Moment>, 'picker'>
 }
 
 const TimePicker = React.forwardRef<any, TimePickerProps>(
-  ({ addon, renderExtraFooter, popupClassName, dropdownClassName, ...restProps }, ref) => {
+  ({ addon, renderExtraFooter, popupClassName, ...restProps }, ref) => {
     const internalRenderExtraFooter = React.useMemo(() => {
       if (renderExtraFooter) {
         return renderExtraFooter;
@@ -44,10 +43,7 @@ const TimePicker = React.forwardRef<any, TimePickerProps>(
     return (
       <InternalTimePicker
         {...restProps}
-        dropdownClassName={classNames({
-          [`${dropdownClassName}`]: dropdownClassName,
-          [`${popupClassName}`]: popupClassName,
-        })}
+        dropdownClassName={popupClassName}
         mode={undefined}
         ref={ref}
         renderExtraFooter={internalRenderExtraFooter}

--- a/components/time-picker/index.zh-CN.md
+++ b/components/time-picker/index.zh-CN.md
@@ -42,7 +42,7 @@ import moment from 'moment';
 | minuteStep | 分钟选项间隔 | number | 1 |  |
 | open | 面板是否打开 | boolean | false |  |
 | placeholder | 没有值的时候显示的内容 | string | "请选择时间" |  |
-| popupClassName | 弹出层类名 | string | '' |  |
+| popupClassName | 弹出层类名 | string | - |  |
 | popupStyle | 弹出层样式对象 | object | - |  |
 | secondStep | 秒选项间隔 | number | 1 |  |
 | suffixIcon | 自定义的选择框后缀图标 | ReactNode | - |  |


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

closes #22807

### 💡 Background and solution

In 3.x `rc-time-picker` is being used but in 4.x it has been replaced by `rc-picker`.
`rc-time-picker` has a prop called `popupClassName` but this prop is not available in `rc-picker`

Pass`popupClassName` prop to `rc-picker` through `dropdownClassName` prop

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | pass   popupClassName prop  to  `rc-picker` |
| 🇨🇳 Chinese | 修复`time-picker`自`4.0-alpha-0`以来`popupClassName`的支持 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️ 

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
