### PR TITLE
chore: Fix console warning typo (validate -> a valid)

### DIFF
--- a/components/checkbox/Checkbox.tsx
+++ b/components/checkbox/Checkbox.tsx
@@ -63,7 +63,7 @@ class Checkbox extends React.PureComponent<CheckboxProps, {}> {
     warning(
       'checked' in this.props || this.context || !('value' in this.props),
       'Checkbox',
-      '`value` is not validate prop, do you mean `checked`?',
+      '`value` is not a valid prop, do you mean `checked`?',
     );
   }
 

--- a/components/checkbox/__tests__/checkbox.test.js
+++ b/components/checkbox/__tests__/checkbox.test.js
@@ -30,7 +30,7 @@ describe('Checkbox', () => {
     const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
     mount(<Checkbox value />);
     expect(errorSpy).toHaveBeenCalledWith(
-      'Warning: [antd: Checkbox] `value` is not validate prop, do you mean `checked`?',
+      'Warning: [antd: Checkbox] `value` is not a valid prop, do you mean `checked`?',
     );
     errorSpy.mockRestore();
   });

--- a/components/switch/__tests__/index.test.js
+++ b/components/switch/__tests__/index.test.js
@@ -13,10 +13,7 @@ describe('Switch', () => {
 
   it('should has click wave effect', async () => {
     const wrapper = mount(<Switch />);
-    wrapper
-      .find('.ant-switch')
-      .getDOMNode()
-      .click();
+    wrapper.find('.ant-switch').getDOMNode().click();
     await new Promise(resolve => setTimeout(resolve, 0));
     expect(wrapper.render()).toMatchSnapshot();
   });
@@ -27,7 +24,7 @@ describe('Switch', () => {
     const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
     mount(<Switch value />);
     expect(errorSpy).toHaveBeenCalledWith(
-      'Warning: [antd: Switch] `value` is not validate prop, do you mean `checked`?',
+      'Warning: [antd: Switch] `value` is not a valid prop, do you mean `checked`?',
     );
     errorSpy.mockRestore();
   });

--- a/components/switch/index.tsx
+++ b/components/switch/index.tsx
@@ -41,7 +41,7 @@ export default class Switch extends React.Component<SwitchProps, {}> {
     warning(
       'checked' in props || !('value' in props),
       'Switch',
-      '`value` is not validate prop, do you mean `checked`?',
+      '`value` is not a valid prop, do you mean `checked`?',
     );
   }
 

--- a/components/upload/Upload.tsx
+++ b/components/upload/Upload.tsx
@@ -64,7 +64,7 @@ class Upload extends React.Component<UploadProps, UploadState> {
     warning(
       'fileList' in props || !('value' in props),
       'Upload',
-      '`value` is not validate prop, do you mean `fileList`?',
+      '`value` is not a valid prop, do you mean `fileList`?',
     );
   }
 

--- a/components/upload/__tests__/upload.test.js
+++ b/components/upload/__tests__/upload.test.js
@@ -495,7 +495,7 @@ describe('Upload', () => {
     const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
     mount(<Upload value={[]} />);
     expect(errorSpy).toHaveBeenCalledWith(
-      'Warning: [antd: Upload] `value` is not validate prop, do you mean `fileList`?',
+      'Warning: [antd: Upload] `value` is not a valid prop, do you mean `fileList`?',
     );
     errorSpy.mockRestore();
   });

--- a/scripts/previewEditor/umi.js
+++ b/scripts/previewEditor/umi.js
@@ -34843,7 +34843,7 @@
                   lt(
                     'checked' in this.props || this.context || !('value' in this.props),
                     'Checkbox',
-                    '`value` is not validate prop, do you mean `checked`?',
+                    '`value` is not a valid prop, do you mean `checked`?',
                   );
               },
             },


### PR DESCRIPTION
Clean up the typos in the helpful console warning messages which get
emitted if the incorrect prop is passed to certain components.

<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [X] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [X] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

No related issue; I just noticed this while doing some development.

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

Problem: bad grammar is used in the console warning.
Solution: correct the emitted log message text

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️ 

- [X] Doc is updated/provided or not needed
- [X] Demo is updated/provided or not needed
- [X] TypeScript definition is updated/provided or not needed
- [X] Changelog is provided or not needed
