### PR TITLE
fix: Select custom suffixIcon should be accessible

### DIFF
--- a/components/select/style/index.less
+++ b/components/select/style/index.less
@@ -98,7 +98,6 @@
   // ========================== Arrow ==========================
   &-arrow {
     .iconfont-mixin();
-
     position: absolute;
     top: 53%;
     right: @control-padding-horizontal - 1px;
@@ -109,8 +108,6 @@
     font-size: @font-size-sm;
     line-height: 1;
     text-align: center;
-    // transform-origin: 50% 50%;
-    pointer-events: none;
 
     .anticon {
       vertical-align: top;
@@ -123,6 +120,10 @@
       .@{select-prefix-cls}-open &.anticon-down {
         transform: rotate(180deg);
       }
+    }
+
+    &.anticon-down {
+      pointer-events: none;
     }
   }
 


### PR DESCRIPTION


<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->
close #23263

### 💡 Background and solution

When custom suffixIcon of Select, it should be expected to be handable.

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Select custom `suffixIcon` cannot be access. |
| 🇨🇳 Chinese | 修复 Select 自定义 `suffixIcon` 无法交互的问题。 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️ 

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
