### PR TITLE
fix: optimize PageHeader responsive behavior

### DIFF
--- a/components/page-header/__tests__/index.test.js
+++ b/components/page-header/__tests__/index.test.js
@@ -4,10 +4,25 @@ import PageHeader from '..';
 import ConfigProvider from '../../config-provider';
 import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
+import { spyElementPrototypes } from '../../__tests__/util/domHook';
 
 describe('PageHeader', () => {
   mountTest(PageHeader);
   rtlTest(PageHeader);
+
+  let spy;
+
+  beforeAll(() => {
+    spy = spyElementPrototypes(HTMLElement, {
+      getBoundingClientRect: () => ({
+        width: 100,
+      }),
+    });
+  });
+
+  afterAll(() => {
+    spy.mockRestore();
+  });
 
   it('pageHeader should not contain back it back', () => {
     const routes = [
@@ -100,5 +115,12 @@ describe('PageHeader', () => {
     );
 
     expect(render(wrapper)).toMatchSnapshot();
+  });
+
+  it('change container width', () => {
+    const wrapper = mount(<PageHeader title="Page Title" extra="extra" />);
+    wrapper.triggerResize();
+    wrapper.update();
+    expect(wrapper.find('.ant-page-header').hasClass('ant-page-header-compact')).toBe(true);
   });
 });

--- a/components/page-header/index.tsx
+++ b/components/page-header/index.tsx
@@ -116,7 +116,7 @@ const renderChildren = (prefixCls: string, children: React.ReactNode) => {
 const PageHeader: React.FC<PageHeaderProps> = props => {
   const [compact, updateCompact] = React.useState(false);
   const onResize = ({ width }: { width: number }) => {
-    updateCompact(width < 540);
+    updateCompact(width < 768);
   };
   return (
     <ConfigConsumer>

--- a/components/page-header/index.tsx
+++ b/components/page-header/index.tsx
@@ -116,8 +116,10 @@ const renderChildren = (prefixCls: string, children: React.ReactNode) => {
 const PageHeader: React.FC<PageHeaderProps> = props => {
   const [compact, updateCompact] = React.useState(false);
   const onResize = ({ width }: { width: number }) => {
+    console.log('onResize', width);
     updateCompact(width < 768);
   };
+  console.log('compact', compact);
   return (
     <ConfigConsumer>
       {({ getPrefixCls, pageHeader, direction }: ConfigConsumerProps) => {

--- a/components/page-header/index.tsx
+++ b/components/page-header/index.tsx
@@ -116,10 +116,8 @@ const renderChildren = (prefixCls: string, children: React.ReactNode) => {
 const PageHeader: React.FC<PageHeaderProps> = props => {
   const [compact, updateCompact] = React.useState(false);
   const onResize = ({ width }: { width: number }) => {
-    console.log('onResize', width);
     updateCompact(width < 768);
   };
-  console.log('compact', compact);
   return (
     <ConfigConsumer>
       {({ getPrefixCls, pageHeader, direction }: ConfigConsumerProps) => {

--- a/components/page-header/style/index.less
+++ b/components/page-header/style/index.less
@@ -56,6 +56,7 @@
     &-left {
       display: flex;
       align-items: center;
+      margin: (@margin-xs / 2) 0;
       overflow: hidden;
     }
 
@@ -82,7 +83,9 @@
     }
 
     &-extra {
+      margin: (@margin-xs / 2) 0;
       white-space: nowrap;
+
       > * {
         margin-left: @margin-sm;
         white-space: unset;
@@ -112,11 +115,7 @@
   }
 
   &-compact &-heading {
-    flex-direction: column;
-
-    &-extra {
-      margin-top: @margin-xs;
-    }
+    flex-wrap: wrap;
   }
 }
 

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -28,3 +28,13 @@ const Enzyme = require('enzyme');
 const Adapter = require('enzyme-adapter-react-16');
 
 Enzyme.configure({ adapter: new Adapter() });
+
+Object.assign(Enzyme.ReactWrapper.prototype, {
+  findObserver() {
+    return this.find('ResizeObserver');
+  },
+  triggerResize() {
+    const ob = this.findObserver();
+    ob.instance().onResize([{ target: ob.getDOMNode() }]);
+  },
+});


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close #23260

### 💡 Background and solution

优化 PageHeader 的响应式表现，现在宽屏幕下会出现 ... ，小屏幕下会尽量保持一行，空间不够时才换行。

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Optimize PageHeader responsive behavior. |
| 🇨🇳 Chinese | 优化 PageHeader 的响应式表现。|

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️ 

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
