### PR TITLE
fix: Modal.info onOk execute times

### DIFF
--- a/components/modal/ActionButton.tsx
+++ b/components/modal/ActionButton.tsx
@@ -35,55 +35,57 @@ export default class ActionButton extends React.Component<ActionButtonProps, Act
     clearTimeout(this.timeoutId);
   }
 
+  handlePromiseOnOk(returnValueOfOnOk?: Promise<any>) {
+    const { closeModal } = this.props;
+    if (!returnValueOfOnOk || !returnValueOfOnOk.then) {
+      return;
+    }
+    this.setState({ loading: true });
+    returnValueOfOnOk.then(
+      (...args: any[]) => {
+        // It's unnecessary to set loading=false, for the Modal will be unmounted after close.
+        // this.setState({ loading: false });
+        closeModal(...args);
+      },
+      (e: Error) => {
+        // Emit error when catch promise reject
+        // eslint-disable-next-line no-console
+        console.error(e);
+        // See: https://github.com/ant-design/ant-design/issues/6183
+        this.setState({ loading: false });
+        this.clicked = false;
+      },
+    );
+  }
+
   onClick = () => {
     const { actionFn, closeModal } = this.props;
     if (this.clicked) {
       return;
     }
     this.clicked = true;
-    if (actionFn) {
-      let ret;
-      if (actionFn.length) {
-        ret = actionFn(closeModal);
-      } else {
-        ret = actionFn();
-        if (!ret) {
-          closeModal();
-        }
-      }
-      if (ret && ret.then) {
-        this.setState({ loading: true });
-        ret.then(
-          (...args: any[]) => {
-            // It's unnecessary to set loading=false, for the Modal will be unmounted after close.
-            // this.setState({ loading: false });
-            closeModal(...args);
-          },
-          (e: Error) => {
-            // Emit error when catch promise reject
-            // eslint-disable-next-line no-console
-            console.error(e);
-            // See: https://github.com/ant-design/ant-design/issues/6183
-            this.setState({ loading: false });
-            this.clicked = false;
-          },
-        );
-      }
-    } else {
+    if (!actionFn) {
       closeModal();
+      return;
     }
+    let returnValueOfOnOk;
+    if (actionFn.length) {
+      returnValueOfOnOk = actionFn(closeModal);
+    } else {
+      returnValueOfOnOk = actionFn();
+    }
+    if (!returnValueOfOnOk) {
+      closeModal();
+      return;
+    }
+    this.handlePromiseOnOk(returnValueOfOnOk);
   };
 
   render() {
     const { type, children, buttonProps } = this.props;
     const { loading } = this.state;
     return (
-      <Button
-        type={type}
-        onClick={this.onClick}
-        loading={loading}
-        {...buttonProps}
-       >
+      <Button type={type} onClick={this.onClick} loading={loading} {...buttonProps}>
         {children}
       </Button>
     );

--- a/components/modal/ActionButton.tsx
+++ b/components/modal/ActionButton.tsx
@@ -35,7 +35,7 @@ export default class ActionButton extends React.Component<ActionButtonProps, Act
     clearTimeout(this.timeoutId);
   }
 
-  handlePromiseOnOk(returnValueOfOnOk?: Promise<any>) {
+  handlePromiseOnOk(returnValueOfOnOk?: PromiseLike<any>) {
     const { closeModal } = this.props;
     if (!returnValueOfOnOk || !returnValueOfOnOk.then) {
       return;
@@ -71,12 +71,14 @@ export default class ActionButton extends React.Component<ActionButtonProps, Act
     let returnValueOfOnOk;
     if (actionFn.length) {
       returnValueOfOnOk = actionFn(closeModal);
+      // https://github.com/ant-design/ant-design/issues/23358
+      this.clicked = false;
     } else {
       returnValueOfOnOk = actionFn();
-    }
-    if (!returnValueOfOnOk) {
-      closeModal();
-      return;
+      if (!returnValueOfOnOk) {
+        closeModal();
+        return;
+      }
     }
     this.handlePromiseOnOk(returnValueOfOnOk);
   };

--- a/components/modal/__tests__/confirm.test.js
+++ b/components/modal/__tests__/confirm.test.js
@@ -1,5 +1,6 @@
 import Modal from '..';
 import { destroyFns } from '../Modal';
+import { sleep } from '../../../tests/utils';
 
 const { confirm } = Modal;
 
@@ -75,12 +76,19 @@ describe('Modal.confirm triggers callbacks correctly', () => {
     expect(errorSpy).not.toHaveBeenCalled();
   });
 
+  it('should not hide confirm when onOk return Promise.resolve', () => {
+    open({
+      onOk: () => Promise.resolve(''),
+    });
+    $$('.ant-btn-primary')[0].click();
+    expect($$('.ant-modal-confirm')).toHaveLength(1);
+  });
+
   it('should emit error when onOk return Promise.reject', () => {
     const error = new Error('something wrong');
     open({
       onOk: () => Promise.reject(error),
     });
-    // Fifth Modal
     $$('.ant-btn-primary')[0].click();
     // wait promise
     return Promise.resolve().then(() => {

--- a/components/modal/__tests__/confirm.test.js
+++ b/components/modal/__tests__/confirm.test.js
@@ -235,7 +235,6 @@ describe('Modal.confirm triggers callbacks correctly', () => {
   it('ok button should trigger onOk once when click it many times quickly', () => {
     const onOk = jest.fn();
     open({ onOk });
-    // Fifth Modal
     $$('.ant-btn-primary')[0].click();
     $$('.ant-btn-primary')[0].click();
     expect(onOk).toHaveBeenCalledTimes(1);

--- a/components/modal/__tests__/confirm.test.js
+++ b/components/modal/__tests__/confirm.test.js
@@ -9,6 +9,7 @@ describe('Modal.confirm triggers callbacks correctly', () => {
   afterEach(() => {
     errorSpy.mockReset();
     document.body.innerHTML = '';
+    Modal.destroyAll();
   });
 
   afterAll(() => {
@@ -121,6 +122,22 @@ describe('Modal.confirm triggers callbacks correctly', () => {
       $$('.ant-btn')[0].click();
       jest.runAllTimers();
       expect($$(`.ant-modal-confirm-${type}`)).toHaveLength(0);
+    });
+    jest.useRealTimers();
+  });
+
+  it('should not close modals when click confirm button when onOk has argument', () => {
+    jest.useFakeTimers();
+    ['info', 'success', 'warning', 'error'].forEach(type => {
+      Modal[type]({
+        title: 'title',
+        content: 'content',
+        onOk: close => null, // eslint-disable-line no-unused-vars
+      });
+      expect($$(`.ant-modal-confirm-${type}`)).toHaveLength(1);
+      $$('.ant-btn')[0].click();
+      jest.runAllTimers();
+      expect($$(`.ant-modal-confirm-${type}`)).toHaveLength(1);
     });
     jest.useRealTimers();
   });
@@ -238,5 +255,20 @@ describe('Modal.confirm triggers callbacks correctly', () => {
     $$('.ant-btn-primary')[0].click();
     $$('.ant-btn-primary')[0].click();
     expect(onOk).toHaveBeenCalledTimes(1);
+  });
+
+  // https://github.com/ant-design/ant-design/issues/23358
+  it('ok button should trigger onOk multiple times when onOk has close argument', () => {
+    const onOk = jest.fn();
+    open({
+      onOk: close => {
+        onOk();
+        (() => {})(close); // do nothing
+      },
+    });
+    $$('.ant-btn-primary')[0].click();
+    $$('.ant-btn-primary')[0].click();
+    $$('.ant-btn-primary')[0].click();
+    expect(onOk).toHaveBeenCalledTimes(3);
   });
 });

--- a/components/modal/__tests__/confirm.test.js
+++ b/components/modal/__tests__/confirm.test.js
@@ -1,6 +1,5 @@
 import Modal from '..';
 import { destroyFns } from '../Modal';
-import { sleep } from '../../../tests/utils';
 
 const { confirm } = Modal;
 

--- a/components/modal/index.en-US.md
+++ b/components/modal/index.en-US.md
@@ -75,8 +75,8 @@ The items listed above are all functions, expecting a settings object as paramet
 | title | Title | string\|ReactNode | - |
 | width | Width of the modal dialog | string\|number | 416 |
 | zIndex | The `z-index` of the Modal | Number | 1000 |
-| onCancel | Specify a function that will be called when the user clicks the Cancel button. The parameter of this function is a function whose execution should include closing the dialog. You can also just return a promise and when the promise is resolved, the modal dialog will also be closed | function | - |
-| onOk | Specify a function that will be called when the user clicks the OK button. The parameter of this function is a function whose execution should include closing the dialog. You can also just return a promise and when the promise is resolved, the modal dialog will also be closed | function | - |
+| onCancel | Specify a function that will be called when the user clicks the Cancel button. The parameter of this function is a function whose execution should include closing the dialog. You can also just return a promise and when the promise is resolved, the modal dialog will also be closed | function(close) | - |
+| onOk | Specify a function that will be called when the user clicks the OK button. The parameter of this function is a function whose execution should include closing the dialog. You can also just return a promise and when the promise is resolved, the modal dialog will also be closed | function(close) | - |
 
 All the `Modal.method`s will return a reference, and then we can update and close the modal dialog by the reference.
 

--- a/components/modal/index.zh-CN.md
+++ b/components/modal/index.zh-CN.md
@@ -77,8 +77,8 @@ title: Modal
 | title | 标题 | string\|ReactNode | - |
 | width | 宽度 | string\|number | 416 |
 | zIndex | 设置 Modal 的 `z-index` | Number | 1000 |
-| onCancel | 取消回调，参数为关闭函数，返回 promise 时 resolve 后自动关闭 | function | - |
-| onOk | 点击确定回调，参数为关闭函数，返回 promise 时 resolve 后自动关闭 | function | - |
+| onCancel | 取消回调，参数为关闭函数，返回 promise 时 resolve 后自动关闭 | function(close) | - |
+| onOk | 点击确定回调，参数为关闭函数，返回 promise 时 resolve 后自动关闭 | function(close) | - |
 
 以上函数调用后，会返回一个引用，可以通过该引用更新和关闭弹窗。
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close #23358

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fix Modal.info executed only once when has argument.     |
| 🇨🇳 Chinese |    修复 Modal.info 等方法的 `onOk` 函数有参数时只触发一次的问题。   |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️ 

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/modal/index.en-US.md](https://github.com/ant-design/ant-design/blob/fix-modal-confirm-logic/components/modal/index.en-US.md)
[View rendered components/modal/index.zh-CN.md](https://github.com/ant-design/ant-design/blob/fix-modal-confirm-logic/components/modal/index.zh-CN.md)