### PR TITLE
feat: Export form list props

### DIFF
--- a/components/form/FormList.tsx
+++ b/components/form/FormList.tsx
@@ -15,7 +15,7 @@ interface Operation {
   move: (from: number, to: number) => void;
 }
 
-interface FormListProps {
+export interface FormListProps {
   name: string | number | (string | number)[];
   children: (fields: FieldData[], operation: Operation) => React.ReactNode;
 }
@@ -26,7 +26,10 @@ const FormList: React.FC<FormListProps> = ({ children, ...props }) => {
   return (
     <List {...props}>
       {(fields, operation) => {
-        return children(fields.map(field => ({ ...field, fieldKey: field.key })), operation);
+        return children(
+          fields.map(field => ({ ...field, fieldKey: field.key })),
+          operation,
+        );
       }}
     </List>
   );

--- a/components/form/index.tsx
+++ b/components/form/index.tsx
@@ -1,7 +1,7 @@
 import { Rule } from 'rc-field-form/lib/interface';
 import InternalForm, { useForm, FormInstance, FormProps } from './Form';
 import Item, { FormItemProps } from './FormItem';
-import List from './FormList';
+import List, { FormListProps } from './FormList';
 import { FormProvider } from './context';
 import warning from '../_util/warning';
 
@@ -30,6 +30,6 @@ Form.create = () => {
   );
 };
 
-export { FormInstance, FormProps, FormItemProps, Rule };
+export { FormInstance, FormProps, FormItemProps, FormListProps, Rule };
 
 export default Form;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)



### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->
Form.Item & FormList are both public api's. While FormItemProps is exported, FormListProps is not. 
