### PR TITLE
chore: Use override instead of env to control eslint on markdown

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,8 @@
-const eslintrc = {
+const commonGlobals = {
+  gtag: true,
+};
+
+module.exports = {
   extends: [
     'airbnb',
     'prettier',
@@ -29,6 +33,30 @@ const eslintrc = {
         '@typescript-eslint/no-unused-vars': [2, { args: 'none' }],
         'no-unused-expressions': 'off',
         '@typescript-eslint/no-unused-expressions': 2,
+      },
+    },
+    {
+      files: ['*.md'],
+      globals: {
+        ...commonGlobals,
+        React: true,
+        ReactDOM: true,
+        mountNode: true,
+      },
+      rules: {
+        indent: 0,
+        'no-console': 0,
+        'no-plusplus': 0,
+        'eol-last': 0,
+        'no-script-url': 0,
+        'prefer-rest-params': 0,
+        'react/no-access-state-in-setstate': 0,
+        'react/destructuring-assignment': 0,
+        'react/no-multi-comp': 0,
+        'jsx-a11y/href-no-hash': 0,
+        'import/no-extraneous-dependencies': 0,
+        'import/no-unresolved': 0,
+        'jsx-a11y/control-has-associated-label': 0,
       },
     },
   ],
@@ -91,38 +119,10 @@ const eslintrc = {
     'jest/no-test-callback': 0,
     'jest/expect-expect': 0,
     'react-hooks/rules-of-hooks': 2, // Checks rules of Hooks
-    "unicorn/better-regex": 2,
-    "unicorn/prefer-trim-start-end": 2,
-    "unicorn/expiring-todo-comments": 2,
-    "unicorn/no-abusive-eslint-disable": 2,
+    'unicorn/better-regex': 2,
+    'unicorn/prefer-trim-start-end': 2,
+    'unicorn/expiring-todo-comments': 2,
+    'unicorn/no-abusive-eslint-disable': 2,
   },
-  globals: {
-    gtag: true,
-  },
+  globals: commonGlobals,
 };
-
-if (process.env.RUN_ENV === 'DEMO') {
-  eslintrc.globals = Object.assign(eslintrc.globals, {
-    React: true,
-    ReactDOM: true,
-    mountNode: true,
-  });
-
-  Object.assign(eslintrc.rules, {
-    indent: 0,
-    'no-console': 0,
-    'no-plusplus': 0,
-    'eol-last': 0,
-    'no-script-url': 0,
-    'prefer-rest-params': 0,
-    'react/no-access-state-in-setstate': 0,
-    'react/destructuring-assignment': 0,
-    'react/no-multi-comp': 0,
-    'jsx-a11y/href-no-hash': 0,
-    'import/no-extraneous-dependencies': 0,
-    'import/no-unresolved': 0,
-    'jsx-a11y/control-has-associated-label': 0,
-  });
-}
-
-module.exports = eslintrc;

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "lint-fix:demo": "eslint-tinker ./components/*/demo/*.md",
     "lint-fix:script": "npm run lint:script -- --fix",
     "lint-fix:style": "npm run lint:style -- --fix",
-    "lint:demo": "cross-env RUN_ENV=DEMO eslint components/*/demo/*.md --ext '.md'",
+    "lint:demo": "eslint components/*/demo/*.md",
     "lint:deps": "antd-tools run deps-lint",
     "lint:md": "remark components/",
     "lint:script": "eslint . --ext '.js,.jsx,.ts,.tsx'",


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [x] Other (about what?) Linting

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution
Currently linting on markdown file is controlled by an environmental variable.

The problem with that is that the plugin of the IDE won't be smart enough to read them.
As a result, the corresponding markdown files will be full of red lines and is a bit annoying...

Using `overrides` should solve this issue nicely.
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️ 

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
