### PR TITLE
fix: Table selections type when use Table.SELECTION_ALL or Table.SELECTION_INVERT

### DIFF
--- a/components/table/__tests__/type.test.tsx
+++ b/components/table/__tests__/type.test.tsx
@@ -24,6 +24,12 @@ describe('Table.typescript', () => {
     );
     expect(table).toBeTruthy();
   });
+  it('selections', () => {
+    const table = (
+      <Table rowSelection={{ selections: [Table.SELECTION_ALL] }} />
+    );
+    expect(table).toBeTruthy();
+  });
 });
 
 describe('Table.typescript types', () => {

--- a/components/table/hooks/useSelection.tsx
+++ b/components/table/hooks/useSelection.tsx
@@ -41,7 +41,10 @@ interface UseSelectionConfig<RecordType> {
   getPopupContainer?: GetPopupContainer;
 }
 
-type INTERNAL_SELECTION_ITEM = SelectionItem | typeof SELECTION_ALL | typeof SELECTION_INVERT;
+export type INTERNAL_SELECTION_ITEM =
+  | SelectionItem
+  | typeof SELECTION_ALL
+  | typeof SELECTION_INVERT;
 
 function flattenData<RecordType>(
   data: RecordType[] | undefined,

--- a/components/table/hooks/useSelection.tsx
+++ b/components/table/hooks/useSelection.tsx
@@ -21,8 +21,8 @@ import {
 const EMPTY_LIST: any[] = [];
 
 // TODO: warning if use ajax!!!
-export const SELECTION_ALL = 'SELECT_ALL';
-export const SELECTION_INVERT = 'SELECT_INVERT';
+export const SELECTION_ALL = 'SELECT_ALL' as const;
+export const SELECTION_INVERT = 'SELECT_INVERT' as const;
 
 function getFixedType<RecordType>(column: ColumnsType<RecordType>[number]): FixedType | undefined {
   return column && column.fixed;

--- a/components/table/interface.tsx
+++ b/components/table/interface.tsx
@@ -130,7 +130,7 @@ export interface TableRowSelection<T> {
   onSelectAll?: (selected: boolean, selectedRows: T[], changeRows: T[]) => void;
   /** @deprecated This function is meaningless and should use `onChange` instead */
   onSelectInvert?: (selectedRowKeys: Key[]) => void;
-  selections?: SelectionItem[] | boolean | string;
+  selections?: SelectionItem[] | boolean | string[];
   hideDefaultSelections?: boolean;
   fixed?: boolean;
   columnWidth?: string | number;

--- a/components/table/interface.tsx
+++ b/components/table/interface.tsx
@@ -6,6 +6,7 @@ import {
 } from 'rc-table/lib/interface';
 import { CheckboxProps } from '../checkbox';
 import { PaginationConfig } from '../pagination';
+import { INTERNAL_SELECTION_ITEM } from './hooks/useSelection';
 
 export { GetRowKey, ExpandableConfig };
 
@@ -72,13 +73,13 @@ export interface ColumnType<RecordType> extends RcColumnType<RecordType> {
 
   // Sorter
   sorter?:
-  | boolean
-  | CompareFn<RecordType>
-  | {
-    compare: CompareFn<RecordType>;
-    /** Config multiple sorter order priority */
-    multiple: number;
-  };
+    | boolean
+    | CompareFn<RecordType>
+    | {
+        compare: CompareFn<RecordType>;
+        /** Config multiple sorter order priority */
+        multiple: number;
+      };
   sortOrder?: SortOrder;
   defaultSortOrder?: SortOrder;
   sortDirections?: SortOrder[];
@@ -130,7 +131,7 @@ export interface TableRowSelection<T> {
   onSelectAll?: (selected: boolean, selectedRows: T[], changeRows: T[]) => void;
   /** @deprecated This function is meaningless and should use `onChange` instead */
   onSelectInvert?: (selectedRowKeys: Key[]) => void;
-  selections?: SelectionItem[] | boolean | string[];
+  selections?: INTERNAL_SELECTION_ITEM[] | boolean;
   hideDefaultSelections?: boolean;
   fixed?: boolean;
   columnWidth?: string | number;

--- a/components/table/interface.tsx
+++ b/components/table/interface.tsx
@@ -72,13 +72,13 @@ export interface ColumnType<RecordType> extends RcColumnType<RecordType> {
 
   // Sorter
   sorter?:
-    | boolean
-    | CompareFn<RecordType>
-    | {
-        compare: CompareFn<RecordType>;
-        /** Config multiple sorter order priority */
-        multiple: number;
-      };
+  | boolean
+  | CompareFn<RecordType>
+  | {
+    compare: CompareFn<RecordType>;
+    /** Config multiple sorter order priority */
+    multiple: number;
+  };
   sortOrder?: SortOrder;
   defaultSortOrder?: SortOrder;
   sortDirections?: SortOrder[];
@@ -130,7 +130,7 @@ export interface TableRowSelection<T> {
   onSelectAll?: (selected: boolean, selectedRows: T[], changeRows: T[]) => void;
   /** @deprecated This function is meaningless and should use `onChange` instead */
   onSelectInvert?: (selectedRowKeys: Key[]) => void;
-  selections?: SelectionItem[] | boolean;
+  selections?: SelectionItem[] | boolean | string;
   hideDefaultSelections?: boolean;
   fixed?: boolean;
   columnWidth?: string | number;


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)


### 💡 Background and solution
when use typescript to use Table selections,it will show me an error because of Table.SELECTION_ALL or Table.SELECTION_INVERT is a string type

### 📝 Changelog


| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      the type of Table's selections was changed from ` SelectionItem[]  |  boolean` to ` INTERNAL_SELECTION_ITEM[] | boolean`     |
| 🇨🇳 Chinese |    修改Table的selections类型定义从 ` SelectionItem[]  |  boolean` 到 ` INTERNAL_SELECTION_ITEM[] | boolean`       |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️ 

- [ ] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
