### PR TITLE
refactor: reverse Input.password suffix icon

### DIFF
--- a/components/input/Password.tsx
+++ b/components/input/Password.tsx
@@ -8,6 +8,7 @@ export interface PasswordProps extends InputProps {
   readonly inputPrefixCls?: string;
   readonly action?: string;
   visibilityToggle?: boolean;
+  reverseIcon?: boolean;
 }
 
 export interface PasswordState {
@@ -43,12 +44,19 @@ export default class Password extends React.Component<PasswordProps, PasswordSta
   };
 
   getIcon() {
-    const { prefixCls, action } = this.props;
+    const { prefixCls, action, reverseIcon } = this.props;
+    const { visible } = this.state;
+    let type;
+    if (reverseIcon) {
+      type = visible ? 'eye-invisible' : 'eye';
+    } else {
+      type = visible ? 'eye' : 'eye-invisible';
+    }
     const iconTrigger = ActionMap[action!] || '';
     const iconProps = {
       [iconTrigger]: this.onVisibleChange,
       className: `${prefixCls}-icon`,
-      type: this.state.visible ? 'eye' : 'eye-invisible',
+      type,
       key: 'passwordIcon',
       onMouseDown: (e: MouseEvent) => {
         // Prevent focused state lost

--- a/components/input/__tests__/Password.test.js
+++ b/components/input/__tests__/Password.test.js
@@ -48,6 +48,13 @@ describe('Input.Password', () => {
     expect(wrapper.find('.anticon-eye').length).toBe(0);
   });
 
+  it('reverseIcon should work', () => {
+    const wrapper = mount(<Input.Password reverseIcon />);
+    expect(wrapper.find('.anticon-eye').length).toBe(1);
+    wrapper.find('.anticon-eye').simulate('click');
+    expect(wrapper.find('.anticon-eye-invisible').length).toBe(1);
+  });
+
   it('should keep focus state', () => {
     const wrapper = mount(<Input.Password defaultValue="111" autoFocus />);
     expect(document.activeElement).toBe(

--- a/components/input/index.en-US.md
+++ b/components/input/index.en-US.md
@@ -81,6 +81,7 @@ Supports all props of `Input`.
 | Property         | Description                | Type    | Default | Version |
 | ---------------- | -------------------------- | ------- | ------- | ------- |
 | visibilityToggle | Whether show toggle button | boolean | true    | 3.12.2  |
+| reverseIcon      | reverse suffix icon        | boolean | true    | 3.26.16 |
 
 ## FAQ
 

--- a/components/input/index.zh-CN.md
+++ b/components/input/index.zh-CN.md
@@ -77,9 +77,10 @@ Input 的其他属性和 React 自带的 [input](https://facebook.github.io/reac
 
 #### Input.Password (3.12.0 中新增)
 
-| 参数             | 说明             | 类型    | 默认值 | 版本   |
-| ---------------- | ---------------- | ------- | ------ | ------ |
-| visibilityToggle | 是否显示切换按钮 | boolean | true   | 3.12.2 |
+| 参数             | 说明             | 类型    | 默认值 | 版本    |
+| ---------------- | ---------------- | ------- | ------ | ------- |
+| visibilityToggle | 是否显示切换按钮 | boolean | true   | 3.12.2  |
+| reverseIcon      | 是否反转图标     | boolean | true   | 3.26.16 |
 
 ## FAQ
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [x] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 💡 Background and solution

反转 Input.password 的后缀图标，做项目事，产品看了下谷歌的交互方式发现是反的，并要求一致。
增加一个反转标示 reverseIcon

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Input.Password support reverse suffix icon   |
| 🇨🇳 Chinese |  Input.Password 组件支持反转图标   |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️ 

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed


-----
[View rendered components/input/index.en-US.md](https://github.com/elevensky/ant-design/blob/fix-reverse-password-icon/components/input/index.en-US.md)
[View rendered components/input/index.zh-CN.md](https://github.com/elevensky/ant-design/blob/fix-reverse-password-icon/components/input/index.zh-CN.md)