### PR TITLE
fix: 🐛 Input.Search height affected by suffix

### DIFF
--- a/components/input/ClearableLabeledInput.tsx
+++ b/components/input/ClearableLabeledInput.tsx
@@ -197,16 +197,12 @@ class ClearableLabeledInput extends React.Component<ClearableInputProps> {
     );
   }
 
-  renderClearableLabeledInput() {
+  render() {
     const { prefixCls, inputType, element } = this.props;
     if (inputType === ClearableInputType[0]) {
       return this.renderTextAreaWithClearIcon(prefixCls, element);
     }
     return this.renderInputWithLabel(prefixCls, this.renderLabeledIcon(prefixCls, element));
-  }
-
-  render() {
-    return this.renderClearableLabeledInput();
   }
 }
 

--- a/components/input/Search.tsx
+++ b/components/input/Search.tsx
@@ -70,14 +70,9 @@ export default class Search extends React.Component<SearchProps, any> {
 
     if (enterButton) {
       return (
-        <SizeContext.Consumer>
+        <SizeContext.Consumer key="enterButton">
           {size => (
-            <Button
-              className={`${prefixCls}-button`}
-              type="primary"
-              size={customizeSize || size}
-              key="enterButton"
-            >
+            <Button className={`${prefixCls}-button`} type="primary" size={customizeSize || size}>
               <LoadingOutlined />
             </Button>
           )}

--- a/components/input/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/input/__tests__/__snapshots__/demo.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders ./components/input/demo/addon.md correctly 1`] = `
-<div>
+Array [
   <div
     style="margin-bottom:16px"
   >
@@ -28,7 +28,7 @@ exports[`renders ./components/input/demo/addon.md correctly 1`] = `
         </span>
       </span>
     </span>
-  </div>
+  </div>,
   <div
     style="margin-bottom:16px"
   >
@@ -167,7 +167,7 @@ exports[`renders ./components/input/demo/addon.md correctly 1`] = `
         </span>
       </span>
     </span>
-  </div>
+  </div>,
   <div
     style="margin-bottom:16px"
   >
@@ -208,7 +208,7 @@ exports[`renders ./components/input/demo/addon.md correctly 1`] = `
         </span>
       </span>
     </span>
-  </div>
+  </div>,
   <div
     style="margin-bottom:16px"
   >
@@ -239,12 +239,12 @@ exports[`renders ./components/input/demo/addon.md correctly 1`] = `
         </span>
       </span>
     </span>
-  </div>
-</div>
+  </div>,
+]
 `;
 
 exports[`renders ./components/input/demo/align.md correctly 1`] = `
-<div>
+Array [
   <div
     class="ant-mentions"
     style="width:100px"
@@ -252,12 +252,12 @@ exports[`renders ./components/input/demo/align.md correctly 1`] = `
     <textarea
       rows="1"
     />
-  </div>
+  </div>,
   <textarea
     class="ant-input"
     rows="1"
     style="width:100px"
-  />
+  />,
   <button
     class="ant-btn ant-btn-primary"
     type="button"
@@ -265,13 +265,13 @@ exports[`renders ./components/input/demo/align.md correctly 1`] = `
     <span>
       Button
     </span>
-  </button>
+  </button>,
   <input
     class="ant-input"
     style="width:100px"
     type="text"
     value=""
-  />
+  />,
   <span
     class="ant-typography"
   >
@@ -304,7 +304,7 @@ exports[`renders ./components/input/demo/align.md correctly 1`] = `
         </svg>
       </span>
     </div>
-  </span>
+  </span>,
   <span
     class="ant-input-affix-wrapper"
     style="width:100px"
@@ -324,7 +324,7 @@ exports[`renders ./components/input/demo/align.md correctly 1`] = `
     >
       2
     </span>
-  </span>
+  </span>,
   <span
     class="ant-input-group-wrapper"
     style="width:100px"
@@ -348,7 +348,7 @@ exports[`renders ./components/input/demo/align.md correctly 1`] = `
         2
       </span>
     </span>
-  </span>
+  </span>,
   <div
     class="ant-input-number"
     style="width:100px"
@@ -426,7 +426,7 @@ exports[`renders ./components/input/demo/align.md correctly 1`] = `
         value=""
       />
     </div>
-  </div>
+  </div>,
   <div
     class="ant-picker"
     style="width:100px"
@@ -466,7 +466,7 @@ exports[`renders ./components/input/demo/align.md correctly 1`] = `
         </span>
       </span>
     </div>
-  </div>
+  </div>,
   <div
     class="ant-picker"
     style="width:100px"
@@ -509,7 +509,7 @@ exports[`renders ./components/input/demo/align.md correctly 1`] = `
         </span>
       </span>
     </div>
-  </div>
+  </div>,
   <div
     class="ant-select ant-select-single ant-select-show-arrow"
     style="width:100px"
@@ -567,7 +567,7 @@ exports[`renders ./components/input/demo/align.md correctly 1`] = `
         </svg>
       </span>
     </span>
-  </div>
+  </div>,
   <div
     class="ant-select ant-tree-select ant-select-single ant-select-show-arrow"
     style="width:100px"
@@ -623,7 +623,7 @@ exports[`renders ./components/input/demo/align.md correctly 1`] = `
         </svg>
       </span>
     </span>
-  </div>
+  </div>,
   <span
     class="ant-cascader-picker"
     tabindex="0"
@@ -682,7 +682,7 @@ exports[`renders ./components/input/demo/align.md correctly 1`] = `
         />
       </svg>
     </span>
-  </span>
+  </span>,
   <div
     class="ant-picker ant-picker-range"
   >
@@ -763,7 +763,7 @@ exports[`renders ./components/input/demo/align.md correctly 1`] = `
         </svg>
       </span>
     </span>
-  </div>
+  </div>,
   <div
     class="ant-picker"
   >
@@ -802,7 +802,7 @@ exports[`renders ./components/input/demo/align.md correctly 1`] = `
         </span>
       </span>
     </div>
-  </div>
+  </div>,
   <div
     class="ant-radio-group ant-radio-group-outline"
   >
@@ -845,7 +845,7 @@ exports[`renders ./components/input/demo/align.md correctly 1`] = `
         Shanghai
       </span>
     </label>
-  </div>
+  </div>,
   <div
     class="ant-select ant-select-auto-complete ant-select-single ant-select-show-search"
     style="width:100px"
@@ -874,8 +874,8 @@ exports[`renders ./components/input/demo/align.md correctly 1`] = `
         input here
       </span>
     </div>
-  </div>
-  <br />
+  </div>,
+  <br />,
   <span
     class="ant-input-group-wrapper"
   >
@@ -907,7 +907,7 @@ exports[`renders ./components/input/demo/align.md correctly 1`] = `
         .com
       </span>
     </span>
-  </span>
+  </span>,
   <span
     class="ant-input-affix-wrapper"
     style="width:50px"
@@ -922,13 +922,13 @@ exports[`renders ./components/input/demo/align.md correctly 1`] = `
     >
       Y
     </span>
-  </span>
+  </span>,
   <input
     class="ant-input"
     style="width:50px"
     type="text"
     value=""
-  />
+  />,
   <span
     class="ant-input-affix-wrapper"
     style="width:50px"
@@ -943,12 +943,12 @@ exports[`renders ./components/input/demo/align.md correctly 1`] = `
     >
       Y
     </span>
-  </span>
-</div>
+  </span>,
+]
 `;
 
 exports[`renders ./components/input/demo/allowClear.md correctly 1`] = `
-<div>
+Array [
   <span
     class="ant-input-affix-wrapper"
   >
@@ -983,9 +983,9 @@ exports[`renders ./components/input/demo/allowClear.md correctly 1`] = `
         </svg>
       </span>
     </span>
-  </span>
-  <br />
-  <br />
+  </span>,
+  <br />,
+  <br />,
   <span
     class="ant-input-affix-wrapper ant-input-affix-wrapper-textarea-with-clear-btn"
   >
@@ -1014,31 +1014,31 @@ exports[`renders ./components/input/demo/allowClear.md correctly 1`] = `
         />
       </svg>
     </span>
-  </span>
-</div>
+  </span>,
+]
 `;
 
 exports[`renders ./components/input/demo/autosize-textarea.md correctly 1`] = `
-<div>
+Array [
   <textarea
     class="ant-input"
     placeholder="Autosize height based on content lines"
-  />
+  />,
   <div
     style="margin:24px 0"
-  />
+  />,
   <textarea
     class="ant-input"
     placeholder="Autosize height with minimum and maximum number of lines"
-  />
+  />,
   <div
     style="margin:24px 0"
-  />
+  />,
   <textarea
     class="ant-input"
     placeholder="Controlled autosize"
-  />
-</div>
+  />,
+]
 `;
 
 exports[`renders ./components/input/demo/basic.md correctly 1`] = `
@@ -1945,7 +1945,7 @@ exports[`renders ./components/input/demo/password-input.md correctly 1`] = `
 `;
 
 exports[`renders ./components/input/demo/presuffix.md correctly 1`] = `
-<div>
+Array [
   <span
     class="ant-input-affix-wrapper"
   >
@@ -2007,9 +2007,9 @@ exports[`renders ./components/input/demo/presuffix.md correctly 1`] = `
         </svg>
       </span>
     </span>
-  </span>
-  <br />
-  <br />
+  </span>,
+  <br />,
+  <br />,
   <span
     class="ant-input-affix-wrapper"
   >
@@ -2028,9 +2028,9 @@ exports[`renders ./components/input/demo/presuffix.md correctly 1`] = `
     >
       RMB
     </span>
-  </span>
-  <br />
-  <br />
+  </span>,
+  <br />,
+  <br />,
   <span
     class="ant-input-affix-wrapper ant-input-affix-wrapper-disabled"
   >
@@ -2050,12 +2050,12 @@ exports[`renders ./components/input/demo/presuffix.md correctly 1`] = `
     >
       RMB
     </span>
-  </span>
-</div>
+  </span>,
+]
 `;
 
 exports[`renders ./components/input/demo/search-input.md correctly 1`] = `
-<div>
+Array [
   <span
     class="ant-input-search ant-input-affix-wrapper"
     style="width:200px"
@@ -2091,9 +2091,9 @@ exports[`renders ./components/input/demo/search-input.md correctly 1`] = `
         </svg>
       </span>
     </span>
-  </span>
-  <br />
-  <br />
+  </span>,
+  <br />,
+  <br />,
   <span
     class="ant-input-search ant-input-search-enter-button ant-input-group-wrapper"
   >
@@ -2136,9 +2136,9 @@ exports[`renders ./components/input/demo/search-input.md correctly 1`] = `
         </button>
       </span>
     </span>
-  </span>
-  <br />
-  <br />
+  </span>,
+  <br />,
+  <br />,
   <span
     class="ant-input-search ant-input-search-enter-button ant-input-search-large ant-input-group-wrapper ant-input-group-wrapper-lg"
   >
@@ -2164,12 +2164,12 @@ exports[`renders ./components/input/demo/search-input.md correctly 1`] = `
         </button>
       </span>
     </span>
-  </span>
-</div>
+  </span>,
+]
 `;
 
 exports[`renders ./components/input/demo/search-input-loading.md correctly 1`] = `
-<div>
+Array [
   <span
     class="ant-input-search ant-input-affix-wrapper"
   >
@@ -2203,9 +2203,9 @@ exports[`renders ./components/input/demo/search-input-loading.md correctly 1`] =
         </svg>
       </span>
     </span>
-  </span>
-  <br />
-  <br />
+  </span>,
+  <br />,
+  <br />,
   <span
     class="ant-input-search ant-input-search-enter-button ant-input-group-wrapper"
   >
@@ -2248,14 +2248,12 @@ exports[`renders ./components/input/demo/search-input-loading.md correctly 1`] =
         </button>
       </span>
     </span>
-  </span>
-</div>
+  </span>,
+]
 `;
 
 exports[`renders ./components/input/demo/size.md correctly 1`] = `
-<div
-  class="example-input"
->
+Array [
   <span
     class="ant-input-affix-wrapper ant-input-affix-wrapper-lg"
   >
@@ -2289,7 +2287,9 @@ exports[`renders ./components/input/demo/size.md correctly 1`] = `
       type="text"
       value=""
     />
-  </span>
+  </span>,
+  <br />,
+  <br />,
   <span
     class="ant-input-affix-wrapper"
   >
@@ -2323,7 +2323,9 @@ exports[`renders ./components/input/demo/size.md correctly 1`] = `
       type="text"
       value=""
     />
-  </span>
+  </span>,
+  <br />,
+  <br />,
   <span
     class="ant-input-affix-wrapper ant-input-affix-wrapper-sm"
   >
@@ -2357,47 +2359,8 @@ exports[`renders ./components/input/demo/size.md correctly 1`] = `
       type="text"
       value=""
     />
-  </span>
-  <span
-    class="ant-input-password ant-input-password-large ant-input-affix-wrapper ant-input-affix-wrapper-lg"
-  >
-    <input
-      action="click"
-      class="ant-input ant-input-lg"
-      placeholder="large Password"
-      type="password"
-      value=""
-    />
-    <span
-      class="ant-input-suffix"
-    >
-      <span
-        aria-label="eye-invisible"
-        class="anticon anticon-eye-invisible ant-input-password-icon"
-        role="img"
-        tabindex="-1"
-      >
-        <svg
-          aria-hidden="true"
-          class=""
-          data-icon="eye-invisible"
-          fill="currentColor"
-          focusable="false"
-          height="1em"
-          viewBox="64 64 896 896"
-          width="1em"
-        >
-          <path
-            d="M942.2 486.2Q889.47 375.11 816.7 305l-50.88 50.88C807.31 395.53 843.45 447.4 874.7 512 791.5 684.2 673.4 766 512 766q-72.67 0-133.87-22.38L323 798.75Q408 838 512 838q288.3 0 430.2-300.3a60.29 60.29 0 000-51.5zm-63.57-320.64L836 122.88a8 8 0 00-11.32 0L715.31 232.2Q624.86 186 512 186q-288.3 0-430.2 300.3a60.3 60.3 0 000 51.5q56.69 119.4 136.5 191.41L112.48 835a8 8 0 000 11.31L155.17 889a8 8 0 0011.31 0l712.15-712.12a8 8 0 000-11.32zM149.3 512C232.6 339.8 350.7 258 512 258c54.54 0 104.13 9.36 149.12 28.39l-70.3 70.3a176 176 0 00-238.13 238.13l-83.42 83.42C223.1 637.49 183.3 582.28 149.3 512zm246.7 0a112.11 112.11 0 01146.2-106.69L401.31 546.2A112 112 0 01396 512z"
-          />
-          <path
-            d="M508 624c-3.46 0-6.87-.16-10.25-.47l-52.82 52.82a176.09 176.09 0 00227.42-227.42l-52.82 52.82c.31 3.38.47 6.79.47 10.25a111.94 111.94 0 01-112 112z"
-          />
-        </svg>
-      </span>
-    </span>
-  </span>
-</div>
+  </span>,
+]
 `;
 
 exports[`renders ./components/input/demo/textarea.md correctly 1`] = `
@@ -2408,7 +2371,7 @@ exports[`renders ./components/input/demo/textarea.md correctly 1`] = `
 `;
 
 exports[`renders ./components/input/demo/textarea-resize.md correctly 1`] = `
-<div>
+Array [
   <button
     class="ant-btn"
     style="margin-bottom:16px"
@@ -2417,14 +2380,14 @@ exports[`renders ./components/input/demo/textarea-resize.md correctly 1`] = `
     <span>
       Auto Resize: false
     </span>
-  </button>
+  </button>,
   <textarea
     class="ant-input"
     rows="4"
   >
     The autoSize property applies to textarea nodes, and only the height changes automatically. In addition, autoSize can be set to an object, specifying the minimum number of rows and the maximum number of rows. The autoSize property applies to textarea nodes, and only the height changes automatically. In addition, autoSize can be set to an object, specifying the minimum number of rows and the maximum number of rows.
-  </textarea>
-</div>
+  </textarea>,
+]
 `;
 
 exports[`renders ./components/input/demo/tooltip.md correctly 1`] = `

--- a/components/input/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/input/__tests__/__snapshots__/demo.test.js.snap
@@ -2165,6 +2165,63 @@ Array [
       </span>
     </span>
   </span>,
+  <br />,
+  <br />,
+  <span
+    class="ant-input-search ant-input-search-enter-button ant-input-search-large ant-input-group-wrapper ant-input-group-wrapper-lg"
+  >
+    <span
+      class="ant-input-wrapper ant-input-group"
+    >
+      <span
+        class="ant-input-search ant-input-search-enter-button ant-input-search-large ant-input-affix-wrapper ant-input-affix-wrapper-lg"
+      >
+        <input
+          class="ant-input ant-input-lg"
+          placeholder="input search text"
+          type="text"
+          value=""
+        />
+        <span
+          class="ant-input-suffix"
+        >
+          <span
+            aria-label="audio"
+            class="anticon anticon-audio"
+            role="img"
+            style="font-size:16px;color:#1890ff;padding-right:4px"
+          >
+            <svg
+              aria-hidden="true"
+              class=""
+              data-icon="audio"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M842 454c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8 0 140.3-113.7 254-254 254S258 594.3 258 454c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8 0 168.7 126.6 307.9 290 327.6V884H326.7c-13.7 0-24.7 14.3-24.7 32v36c0 4.4 2.8 8 6.2 8h407.6c3.4 0 6.2-3.6 6.2-8v-36c0-17.7-11-32-24.7-32H548V782.1c165.3-18 294-158 294-328.1zM512 624c93.9 0 170-75.2 170-168V232c0-92.8-76.1-168-170-168s-170 75.2-170 168v224c0 92.8 76.1 168 170 168zm-94-392c0-50.6 41.9-92 94-92s94 41.4 94 92v224c0 50.6-41.9 92-94 92s-94-41.4-94-92V232z"
+              />
+            </svg>
+          </span>
+        </span>
+      </span>
+      <span
+        class="ant-input-group-addon"
+      >
+        <button
+          class="ant-btn ant-input-search-button ant-btn-primary ant-btn-lg"
+          type="button"
+        >
+          <span>
+            Search
+          </span>
+        </button>
+      </span>
+    </span>
+  </span>,
 ]
 `;
 

--- a/components/input/demo/addon.md
+++ b/components/input/demo/addon.md
@@ -35,7 +35,7 @@ const selectAfter = (
 );
 
 ReactDOM.render(
-  <div>
+  <>
     <div style={{ marginBottom: 16 }}>
       <Input addonBefore="http://" addonAfter=".com" defaultValue="mysite" />
     </div>
@@ -48,7 +48,7 @@ ReactDOM.render(
     <div style={{ marginBottom: 16 }}>
       <Input addonBefore="http://" suffix=".com" defaultValue="mysite" />
     </div>
-  </div>,
+  </>,
   mountNode,
 );
 ```

--- a/components/input/demo/align.md
+++ b/components/input/demo/align.md
@@ -68,7 +68,7 @@ const options = [
 ];
 
 ReactDOM.render(
-  <div>
+  <>
     <Mentions style={{ width: 100 }} rows={1} />
     <Input.TextArea rows={1} style={{ width: 100 }} />
     <Button type="primary">Button</Button>
@@ -101,7 +101,7 @@ ReactDOM.render(
     <Input style={narrowStyle} suffix="Y" />
     <Input style={narrowStyle} />
     <Input style={narrowStyle} defaultValue="1" suffix="Y" />
-  </div>,
+  </>,
   mountNode,
 );
 ```

--- a/components/input/demo/allowClear.md
+++ b/components/input/demo/allowClear.md
@@ -23,12 +23,12 @@ const onChange = e => {
 };
 
 ReactDOM.render(
-  <div>
+  <>
     <Input placeholder="input with clear icon" allowClear onChange={onChange} />
     <br />
     <br />
     <TextArea placeholder="textarea with clear icon" allowClear onChange={onChange} />
-  </div>,
+  </>,
   mountNode,
 );
 ```

--- a/components/input/demo/autosize-textarea.md
+++ b/components/input/demo/autosize-textarea.md
@@ -31,7 +31,7 @@ class Demo extends React.Component {
     const { value } = this.state;
 
     return (
-      <div>
+      <>
         <TextArea placeholder="Autosize height based on content lines" autoSize />
         <div style={{ margin: '24px 0' }} />
         <TextArea
@@ -45,7 +45,7 @@ class Demo extends React.Component {
           placeholder="Controlled autosize"
           autoSize={{ minRows: 3, maxRows: 5 }}
         />
-      </div>
+      </>
     );
   }
 }

--- a/components/input/demo/presuffix.md
+++ b/components/input/demo/presuffix.md
@@ -18,7 +18,7 @@ import { Input, Tooltip } from 'antd';
 import { InfoCircleOutlined, UserOutlined } from '@ant-design/icons';
 
 ReactDOM.render(
-  <div>
+  <>
     <Input
       placeholder="Enter your username"
       prefix={<UserOutlined className="site-form-item-icon" />}
@@ -31,12 +31,10 @@ ReactDOM.render(
     <br />
     <br />
     <Input prefix="￥" suffix="RMB" />
-
     <br />
     <br />
-
     <Input prefix="￥" suffix="RMB" disabled />
-  </div>,
+  </>,
   mountNode,
 );
 ```

--- a/components/input/demo/search-input-loading.md
+++ b/components/input/demo/search-input-loading.md
@@ -19,12 +19,12 @@ import { Input } from 'antd';
 const { Search } = Input;
 
 ReactDOM.render(
-  <div>
+  <>
     <Search placeholder="input search loading deault" loading />
     <br />
     <br />
     <Search placeholder="input search loading with enterButton" loading enterButton />
-  </div>,
+  </>,
   mountNode,
 );
 ```

--- a/components/input/demo/search-input.md
+++ b/components/input/demo/search-input.md
@@ -15,8 +15,19 @@ Example of creating a search box by grouping a standard input with a search butt
 
 ```jsx
 import { Input } from 'antd';
+import { AudioOutlined } from '@ant-design/icons';
 
 const { Search } = Input;
+
+const suffix = (
+  <AudioOutlined
+    style={{
+      fontSize: 16,
+      color: '#1890ff',
+      paddingRight: 4,
+    }}
+  />
+);
 
 ReactDOM.render(
   <>
@@ -34,6 +45,15 @@ ReactDOM.render(
       placeholder="input search text"
       enterButton="Search"
       size="large"
+      onSearch={value => console.log(value)}
+    />
+    <br />
+    <br />
+    <Search
+      placeholder="input search text"
+      enterButton="Search"
+      size="large"
+      suffix={suffix}
       onSearch={value => console.log(value)}
     />
   </>,

--- a/components/input/demo/search-input.md
+++ b/components/input/demo/search-input.md
@@ -19,7 +19,7 @@ import { Input } from 'antd';
 const { Search } = Input;
 
 ReactDOM.render(
-  <div>
+  <>
     <Search
       placeholder="input search text"
       onSearch={value => console.log(value)}
@@ -36,7 +36,7 @@ ReactDOM.render(
       size="large"
       onSearch={value => console.log(value)}
     />
-  </div>,
+  </>,
   mountNode,
 );
 ```

--- a/components/input/demo/size.md
+++ b/components/input/demo/size.md
@@ -18,19 +18,15 @@ import { Input } from 'antd';
 import { UserOutlined } from '@ant-design/icons';
 
 ReactDOM.render(
-  <div className="example-input">
+  <>
     <Input size="large" placeholder="large size" prefix={<UserOutlined />} />
+    <br />
+    <br />
     <Input placeholder="default size" prefix={<UserOutlined />} />
+    <br />
+    <br />
     <Input size="small" placeholder="small size" prefix={<UserOutlined />} />
-    <Input.Password size="large" placeholder="large Password" />
-  </div>,
+  </>,
   mountNode,
 );
-```
-
-```css
-.example-input > span {
-  width: 200px;
-  margin: 0 8px 8px 0;
-}
 ```

--- a/components/input/demo/textarea-resize.md
+++ b/components/input/demo/textarea-resize.md
@@ -31,7 +31,7 @@ class Demo extends React.Component {
     const { autoResize } = this.state;
 
     return (
-      <div>
+      <>
         <Button
           onClick={() => this.setState({ autoResize: !autoResize })}
           style={{ marginBottom: 16 }}
@@ -39,7 +39,7 @@ class Demo extends React.Component {
           Auto Resize: {String(autoResize)}
         </Button>
         <TextArea rows={4} autoSize={autoResize} defaultValue={defaultValue} />
-      </div>
+      </>
     );
   }
 }

--- a/components/input/style/affix.less
+++ b/components/input/style/affix.less
@@ -7,6 +7,21 @@
   &-affix-wrapper {
     .input();
     display: inline-flex;
+    height: @input-height-base;
+    padding-top: 0;
+    padding-bottom: 0;
+
+    &-lg {
+      height: @input-height-lg;
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+
+    &-sm {
+      height: @input-height-sm;
+      padding-top: 0;
+      padding-bottom: 0;
+    }
 
     &-disabled {
       .@{ant-prefix}-input[disabled] {
@@ -15,7 +30,8 @@
     }
 
     > input.@{ant-prefix}-input {
-      padding: 0;
+      padding-right: 0;
+      padding-left: 0;
       border: none;
       outline: none;
 
@@ -33,7 +49,9 @@
 
   &-prefix,
   &-suffix {
+    display: flex;
     flex: none;
+    align-items: center;
   }
 
   &-prefix {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->
close #23523

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | - Fix Input.Search height affected by `suffix`. <br />- Fix Input.Seach react key warning. |
| 🇨🇳 Chinese | - 修复 Input.Search 高度被 `suffix` 撑高的问题。<br />- 修复 Input.Search 报 `react key` 重复警告的问题。  |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️ 

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/input/demo/addon.md](https://github.com/ant-design/ant-design/blob/fix-search/components/input/demo/addon.md)
[View rendered components/input/demo/align.md](https://github.com/ant-design/ant-design/blob/fix-search/components/input/demo/align.md)
[View rendered components/input/demo/allowClear.md](https://github.com/ant-design/ant-design/blob/fix-search/components/input/demo/allowClear.md)
[View rendered components/input/demo/autosize-textarea.md](https://github.com/ant-design/ant-design/blob/fix-search/components/input/demo/autosize-textarea.md)
[View rendered components/input/demo/presuffix.md](https://github.com/ant-design/ant-design/blob/fix-search/components/input/demo/presuffix.md)
[View rendered components/input/demo/search-input-loading.md](https://github.com/ant-design/ant-design/blob/fix-search/components/input/demo/search-input-loading.md)
[View rendered components/input/demo/search-input.md](https://github.com/ant-design/ant-design/blob/fix-search/components/input/demo/search-input.md)
[View rendered components/input/demo/size.md](https://github.com/ant-design/ant-design/blob/fix-search/components/input/demo/size.md)
[View rendered components/input/demo/textarea-resize.md](https://github.com/ant-design/ant-design/blob/fix-search/components/input/demo/textarea-resize.md)