### PR TITLE
docs: fixed link path for components

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ See [i18n](http://ant.design/docs/react/i18n).
 ## 🔗 Links
 
 - [Home page](http://ant.design/)
-- [Components](http://ant.design/docs/react/introduce)
+- [Components](http://ant.design/docs/react/components/button)
 - [Ant Design Pro](http://pro.ant.design/)
 - [Change Log](CHANGELOG.en-US.md)
 - [rc-components](http://react-component.github.io/)

--- a/docs/react/contributing.en-US.md
+++ b/docs/react/contributing.en-US.md
@@ -22,7 +22,7 @@ According to our [release schedule](changelog#Release-Schedule), we maintain two
 
 We are using [GitHub Issues](https://github.com/ant-design/ant-design/issues) for bug tracking. The best way to get your bug fixed is using our [issue helper](http://new-issue.ant.design) and provide reproduction steps with this [template](https://u.ant.design/codesandbox-repro).
 
-Before you report a bug, please make sure you've searched exists issues, and read our [FAQ](/docs/react/faq).
+Before you report a bug, please make sure you've searched existing issues, and read our [FAQ](/docs/react/faq).
 
 ## Proposing a Change
 

--- a/docs/react/introduce.en-US.md
+++ b/docs/react/introduce.en-US.md
@@ -122,7 +122,7 @@ import 'antd/dist/antd.css'; // or 'antd/dist/antd.less'
 ## Links
 
 - [Home page](https://ant.design/)
-- [Components](/docs/react/introduce)
+- [Components](http://ant.design/docs/react/components/button)
 - [Ant Design Pro](https://pro.ant.design/)
 - [Change Log](/changelog)
 - [rc-components](http://react-component.github.io/)


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
n/a

### 💡 Background and solution
I encountered a problem in the docs which I was reading on my mobile phone. Within the docs I kept trying to click the `Components` link from this page(https://ant.design/docs/react/introduce). However, the link never worked. Since I was on mobile, it took a while to find the hamburger menu that showed the actual component listing.


### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️ 

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered README.md](https://github.com/Sonjeet/ant-design/blob/fix-inactive-links-from-docs/README.md)
[View rendered docs/react/contributing.en-US.md](https://github.com/Sonjeet/ant-design/blob/fix-inactive-links-from-docs/docs/react/contributing.en-US.md)
[View rendered docs/react/introduce.en-US.md](https://github.com/Sonjeet/ant-design/blob/fix-inactive-links-from-docs/docs/react/introduce.en-US.md)