### PR TITLE
docs: Fixing incorrect URL. Previous URL resulted in 404.

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ See [i18n](http://ant.design/docs/react/i18n).
 ## 🔗 Links
 
 - [Home page](http://ant.design/)
-- [Components](http://ant.design/docs/react/components/button)
+- [Components](https://ant.design/components/button/)
 - [Ant Design Pro](http://pro.ant.design/)
 - [Change Log](CHANGELOG.en-US.md)
 - [rc-components](http://react-component.github.io/)

--- a/docs/react/introduce.en-US.md
+++ b/docs/react/introduce.en-US.md
@@ -122,7 +122,7 @@ import 'antd/dist/antd.css'; // or 'antd/dist/antd.less'
 ## Links
 
 - [Home page](https://ant.design/)
-- [Components](http://ant.design/docs/react/components/button)
+- [Components](https://ant.design/components/button/)
 - [Ant Design Pro](https://pro.ant.design/)
 - [Change Log](/changelog)
 - [rc-components](http://react-component.github.io/)


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

### 💡 Background and solution
Amended the URL so it now navigates to the correct component listing.

### 📝 Changelog
| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️ 

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered README.md](https://github.com/Sonjeet/ant-design/blob/fix-incorrect-url/README.md)
[View rendered docs/react/introduce.en-US.md](https://github.com/Sonjeet/ant-design/blob/fix-incorrect-url/docs/react/introduce.en-US.md)