### PR TITLE
fix(steps): Add flex on steps to fix ie11

### DIFF
--- a/components/steps/style/vertical.less
+++ b/components/steps/style/vertical.less
@@ -1,7 +1,7 @@
 .steps-vertical() {
   display: flex;
-  flex-direction: column;
   flex: 1 0 auto;
+  flex-direction: column;
   .@{steps-prefix-cls}-item {
     display: block;
     overflow: visible;

--- a/components/steps/style/vertical.less
+++ b/components/steps/style/vertical.less
@@ -1,6 +1,7 @@
 .steps-vertical() {
   display: flex;
   flex-direction: column;
+  flex: 1 0 auto;
   .@{steps-prefix-cls}-item {
     display: block;
     overflow: visible;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
https://github.com/ant-design/ant-design/issues/23453
<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->
The problem is the flex default value on ie11 isn't the same as on chrome/ff. Setting `flex: 1 0 auto;` Make the Steps being displayed correctly.

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | - |
| 🇨🇳 Chinese |   -        |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️ 

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
