### PR TITLE
docs: Add `lessOptions` in the use-with-create-react-app document

### DIFF
--- a/docs/react/use-with-create-react-app.en-US.md
+++ b/docs/react/use-with-create-react-app.en-US.md
@@ -191,8 +191,10 @@ module.exports = override(
 +   style: true,
   }),
 + addLessLoader({
-+   javascriptEnabled: true,
-+   modifyVars: { '@primary-color': '#1DA57A' },
++   lessOptions: {
++     javascriptEnabled: true,
++     modifyVars: { '@primary-color': '#1DA57A' },
++   },
 + }),
 );
 ```

--- a/docs/react/use-with-create-react-app.zh-CN.md
+++ b/docs/react/use-with-create-react-app.zh-CN.md
@@ -191,8 +191,10 @@ module.exports = override(
 +   style: true,
   }),
 + addLessLoader({
-+   javascriptEnabled: true,
-+   modifyVars: { '@primary-color': '#1DA57A' },
++   lessOptions: {
++     javascriptEnabled: true,
++     modifyVars: { '@primary-color': '#1DA57A' },
++   },
 + }),
 );
 ```


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

https://github.com/arackaf/customize-cra/issues/231

### 💡 Background and solution

- `lessOptions` has been added in `customize-cra`, but it did not updated `use-with-create-react-app` document yet.

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Add `lessOptions` in the use-with-create-react-app document |
| 🇨🇳 Chinese | 将 `lessOptions` 添加到 use-with-create-react-app 文件中 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️ 

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered docs/react/use-with-create-react-app.en-US.md](https://github.com/channprj/ant-design/blob/master/docs/react/use-with-create-react-app.en-US.md)
[View rendered docs/react/use-with-create-react-app.zh-CN.md](https://github.com/channprj/ant-design/blob/master/docs/react/use-with-create-react-app.zh-CN.md)