### PR TITLE
feat: Card component, adding headClassName and bodyClassName

### DIFF
--- a/components/card/__tests__/index.test.js
+++ b/components/card/__tests__/index.test.js
@@ -85,11 +85,11 @@ describe('Card', () => {
 
   it('with headClassName', () => {
     const wrapper = mount(
-      <Card headClassName="head-test-class">
+      <Card title="Card Title" headClassName="head-test-class">
         <p>Card content</p>
       </Card>,
     );
-    expect(wrapper.find('.ant-head').hasClass('head-test-class')).toBe(true);
+    expect(wrapper.find('.ant-card-head').hasClass('head-test-class')).toBe(true);
   });
 
   it('with bodyClassName', () => {
@@ -98,6 +98,6 @@ describe('Card', () => {
         <p>Card content</p>
       </Card>,
     );
-    expect(wrapper.find('.ant-body').hasClass('body-test-class')).toBe(true);
+    expect(wrapper.find('.ant-card-body').hasClass('body-test-class')).toBe(true);
   });
 });

--- a/components/card/__tests__/index.test.js
+++ b/components/card/__tests__/index.test.js
@@ -52,10 +52,7 @@ describe('Card', () => {
         xxx
       </Card>,
     );
-    wrapper
-      .find('.ant-tabs-tab')
-      .at(1)
-      .simulate('click');
+    wrapper.find('.ant-tabs-tab').at(1).simulate('click');
     expect(onTabChange).toHaveBeenCalledWith('tab2');
   });
 
@@ -84,5 +81,23 @@ describe('Card', () => {
       </Card>,
     );
     expect(wrapper.find('Tabs').get(0).props.size).toBe('small');
+  });
+
+  it('with headClassName', () => {
+    const wrapper = mount(
+      <Card headClassName="head-test-class">
+        <p>Card content</p>
+      </Card>,
+    );
+    expect(wrapper.find('.ant-head').hasClass('head-test-class')).toBe(true);
+  });
+
+  it('with bodyClassName', () => {
+    const wrapper = mount(
+      <Card bodyClassName="body-test-class">
+        <p>Card content</p>
+      </Card>,
+    );
+    expect(wrapper.find('.ant-body').hasClass('body-test-class')).toBe(true);
   });
 });

--- a/components/card/index.en-US.md
+++ b/components/card/index.en-US.md
@@ -24,7 +24,9 @@ A card can be used to display content related to a single subject. The content c
 | actions | The action list, shows at the bottom of the Card. | Array&lt;ReactNode> | - |  |
 | activeTabKey | Current TabPane's key | string | - |  |
 | headStyle | Inline style to apply to the card head | object | - |  |
+| headClassName | className of card head | string | - |  |
 | bodyStyle | Inline style to apply to the card content | object | - |  |
+| bodyClassName | className of card body | string | - |  |
 | bordered | Toggles rendering of the border around the card | boolean | `true` |  |
 | cover | Card cover | ReactNode | - |  |
 | defaultActiveTabKey | Initial active TabPane's key, if `activeTabKey` is not set. | string | - |  |

--- a/components/card/index.tsx
+++ b/components/card/index.tsx
@@ -38,7 +38,9 @@ export interface CardProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 't
   extra?: React.ReactNode;
   bordered?: boolean;
   headStyle?: React.CSSProperties;
+  headClassName?: string;
   bodyStyle?: React.CSSProperties;
+  bodyClassName?: string;
   style?: React.CSSProperties;
   loading?: boolean;
   hoverable?: boolean;
@@ -84,7 +86,9 @@ export default class Card extends React.Component<CardProps, {}> {
       className,
       extra,
       headStyle = {},
+      headClassName,
       bodyStyle = {},
+      bodyClassName,
       title,
       loading,
       bordered = true,
@@ -177,7 +181,7 @@ export default class Card extends React.Component<CardProps, {}> {
       ) : null;
     if (title || extra || tabs) {
       head = (
-        <div className={`${prefixCls}-head`} style={headStyle}>
+        <div className={classNames(`${prefixCls}-head`, headClassName)} style={headStyle}>
           <div className={`${prefixCls}-head-wrapper`}>
             {title && <div className={`${prefixCls}-head-title`}>{title}</div>}
             {extra && <div className={`${prefixCls}-extra`}>{extra}</div>}
@@ -188,7 +192,7 @@ export default class Card extends React.Component<CardProps, {}> {
     }
     const coverDom = cover ? <div className={`${prefixCls}-cover`}>{cover}</div> : null;
     const body = (
-      <div className={`${prefixCls}-body`} style={bodyStyle}>
+      <div className={classNames(`${prefixCls}-body`, bodyClassName)} style={bodyStyle}>
         {loading ? loadingBlock : children}
       </div>
     );

--- a/components/card/index.zh-CN.md
+++ b/components/card/index.zh-CN.md
@@ -25,7 +25,9 @@ cols: 1
 | actions | 卡片操作组，位置在卡片底部 | Array&lt;ReactNode> | - |  |
 | activeTabKey | 当前激活页签的 key | string | - |  |
 | headStyle | 自定义标题区域样式 | object | - |  |
+| headClassName | - | object | - |  |
 | bodyStyle | 内容区域自定义样式 | object | - |  |
+| bodyClassName | - | object | - |  |
 | bordered | 是否有边框 | boolean | true |  |
 | cover | 卡片封面 | ReactNode | - |  |
 | defaultActiveTabKey | 初始化选中页签的 key，如果没有设置 activeTabKey | string | 第一个页签 |  |


### PR DESCRIPTION
### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

https://github.com/ant-design/ant-design/pull/19199
Adding possibility to pass className to Card head and body, like:

```
<Card headClassName="head-class" bodyClassName="body-class"/>
```

### 💡 Background and solution

Today we can inject only style using "bodyStyle" and "headStyle".
I would like to inject classNames to both head and/or body of the Card component.

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Added two props to Card component: headClassName (string) and bodyClassName (string), both non-mandatory. |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️ 

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/card/index.en-US.md](https://github.com/marceloadsj/ant-design/blob/feat-class-props-card/components/card/index.en-US.md)
[View rendered components/card/index.zh-CN.md](https://github.com/marceloadsj/ant-design/blob/feat-class-props-card/components/card/index.zh-CN.md)