### PR TITLE
fix: preserve caret position🐛

### DIFF
--- a/components/input/Password.tsx
+++ b/components/input/Password.tsx
@@ -57,6 +57,8 @@ export default class Password extends React.Component<PasswordProps, PasswordSta
         e.preventDefault();
       },
       onMouseUp: (e: MouseEvent) => {
+        // Prevent caret position change
+        // https://github.com/ant-design/ant-design/issues/23524
         e.preventDefault();
       },
     };

--- a/components/input/Password.tsx
+++ b/components/input/Password.tsx
@@ -56,6 +56,9 @@ export default class Password extends React.Component<PasswordProps, PasswordSta
         // https://github.com/ant-design/ant-design/issues/15173
         e.preventDefault();
       },
+      onMouseUp: (e: MouseEvent) => {
+        e.preventDefault();
+      },
     };
     return React.createElement(icon as React.ComponentType, iconProps);
   };

--- a/components/input/__tests__/Password.test.js
+++ b/components/input/__tests__/Password.test.js
@@ -69,7 +69,7 @@ describe('Input.Password', () => {
     wrapper
       .find('.ant-input-password-icon')
       .at(0)
-      .simulate('up');
+      .simulate('mouseup');
     wrapper
       .find('.ant-input-password-icon')
       .at(0)

--- a/components/input/__tests__/Password.test.js
+++ b/components/input/__tests__/Password.test.js
@@ -60,6 +60,8 @@ describe('Input.Password', () => {
         .at(0)
         .getDOMNode(),
     );
+    document.activeElement.setSelectionRange(2, 2);
+    expect(document.activeElement.selectionStart).toBe(2);
     wrapper
       .find('.ant-input-password-icon')
       .at(0)
@@ -74,6 +76,7 @@ describe('Input.Password', () => {
         .at(0)
         .getDOMNode(),
     );
+    expect(document.activeElement.selectionStart).toBe(2);
     wrapper.unmount();
   });
 

--- a/components/input/__tests__/Password.test.js
+++ b/components/input/__tests__/Password.test.js
@@ -69,6 +69,10 @@ describe('Input.Password', () => {
     wrapper
       .find('.ant-input-password-icon')
       .at(0)
+      .simulate('up');
+    wrapper
+      .find('.ant-input-password-icon')
+      .at(0)
       .simulate('click');
     expect(document.activeElement).toBe(
       wrapper


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
fix #23524
ref: #15173
<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution
The caret in `Password` component will move to the start position of text after change display mode
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix `Password` caret position          |
| 🇨🇳 Chinese | 修复`Password`组件输入光标位置          |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️ 

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
