### PR TITLE
fix: correct Button `type="danger"` TypeScript definition

### DIFF
--- a/components/button/button.tsx
+++ b/components/button/button.tsx
@@ -65,7 +65,7 @@ function spaceChildren(children: React.ReactNode, needInserted: boolean) {
   );
 }
 
-const ButtonTypes = tuple('default', 'primary', 'ghost', 'dashed', 'danger', 'link');
+const ButtonTypes = tuple('default', 'primary', 'ghost', 'dashed', 'link');
 export type ButtonType = typeof ButtonTypes[number];
 const ButtonShapes = tuple('circle', 'circle-outline', 'round');
 export type ButtonShape = typeof ButtonShapes[number];

--- a/components/button/button.tsx
+++ b/components/button/button.tsx
@@ -187,7 +187,7 @@ const Button: ButtonTypeProps = ({ ...props }) => {
         );
 
         warning(
-          (type as any) === 'danger',
+          (type as string) !== 'danger',
           'Button',
           `\`type="danger"\` is deprecated. Please use \`danger\`.`,
         );

--- a/components/button/button.tsx
+++ b/components/button/button.tsx
@@ -186,6 +186,12 @@ const Button: ButtonTypeProps = ({ ...props }) => {
           `\`icon\` is using ReactNode instead of string naming in v4. Please check \`${icon}\` at https://ant.design/components/icon`,
         );
 
+        warning(
+          (type as any) === 'danger',
+          'Button',
+          `\`type="danger"\` is deprecated. Please use \`danger\`.`,
+        );
+
         const prefixCls = getPrefixCls('btn', customizePrefixCls);
         const autoInsertSpace = autoInsertSpaceInButton !== false;
 

--- a/components/table/index.en-US.md
+++ b/components/table/index.en-US.md
@@ -63,7 +63,7 @@ const columns = [
 | bordered | Whether to show all table borders | boolean | `false` |
 | columns | Columns of table | [ColumnProps](#Column)\[] | - |
 | components | Override default table elements | [TableComponents](https://git.io/fANxz) | - |
-| dataSource | Data record array to be displayed | any\[] | - |
+| dataSource | Data record array to be displayed | object\[] | - |
 | expandable | Config expandable content | [expandable](#expandable) | - |
 | footer | Table footer renderer | Function(currentPageData) | - |
 | loading | Loading status of table | boolean\|[object](/components/spin/#API) ([more](https://github.com/ant-design/ant-design/issues/4544#issuecomment-271533135)) | `false` |

--- a/components/table/index.zh-CN.md
+++ b/components/table/index.zh-CN.md
@@ -68,7 +68,7 @@ const columns = [
 | bordered | 是否展示外边框和列边框 | boolean | false |
 | columns | 表格列的配置描述，具体项见下表 | [ColumnProps](#Column)\[] | - |
 | components | 覆盖默认的 table 元素 | [TableComponents](https://git.io/fANxz) | - |
-| dataSource | 数据数组 | any\[] | - |
+| dataSource | 数据数组 | object\[] | - |
 | expandable | 配置展开属性 | [expandable](#expandable) | - |
 | footer | 表格尾部 | Function(currentPageData) | - |
 | loading | 页面是否加载中 | boolean\|[object](/components/spin/#API) ([更多](https://github.com/ant-design/ant-design/issues/4544#issuecomment-271533135)) | false |


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

close #23708
close #23697

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Remove Button deprecated `type="danger"` TypeScript definition and warn it. |
| 🇨🇳 Chinese | 移除已废弃的 Button `type="danger"` TypeScript 定义并增加警告信息。  |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️ 

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
