### PR TITLE
fix(switch): loading color for dark theme

### DIFF
--- a/components/switch/style/index.less
+++ b/components/switch/style/index.less
@@ -70,7 +70,7 @@
 
   &-loading &-loading-icon {
     display: inline-block;
-    color: @text-color;
+    color: rgba(0, 0, 0, 0.65);
   }
 
   &-checked&-loading &-loading-icon {


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

![ant-design-switch-problem](https://user-images.githubusercontent.com/3757319/80655200-be3ad980-8a86-11ea-9317-aca16b8eaecd.gif)

### 💡 Background and solution

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix switch loading color for dark theme |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️ 

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
