### PR TITLE
style: 💄 Slider marks should not be selected

### DIFF
--- a/components/slider/index.en-US.md
+++ b/components/slider/index.en-US.md
@@ -25,14 +25,14 @@ To input a value in a range.
 | range | dual thumb mode | boolean | false |  |
 | reverse | reverse the component | boolean | false |  |
 | step | The granularity the slider can step through values. Must greater than 0, and be divided by (max - min) . When `marks` no null, `step` can be `null`. | number\|null | 1 |  |
-| tipFormatter | Slider will pass its value to `tipFormatter`, and display its value in Tooltip, and hide Tooltip when return value is null. | Function\|null | IDENTITY |  |
+| tipFormatter | Slider will pass its value to `tipFormatter`, and display its value in Tooltip, and hide Tooltip when return value is null. | value => ReactNode\|null | IDENTITY |  |
 | value | The value of slider. When `range` is `false`, use `number`, otherwise, use `[number, number]` | number\|\[number, number] |  |
 | vertical | If true, the slider will be vertical. | Boolean | false |  |
-| onAfterChange | Fire when `onmouseup` is fired. | Function(value) | NOOP |  |
-| onChange | Callback function that is fired when the user changes the slider's value. | Function(value) | NOOP |  |
+| onAfterChange | Fire when `onmouseup` is fired. | (value) => void | NOOP |  |
+| onChange | Callback function that is fired when the user changes the slider's value. | (value) => void | NOOP |  |
 | tooltipPlacement | Set Tooltip display position. Ref [`Tooltip`](/components/tooltip/). | string |  |  |
 | tooltipVisible | If true, Tooltip will show always, or it will not show anyway, even if dragging or hovering. | Boolean |  |  |
-| getTooltipPopupContainer | The DOM container of the Tooltip, the default behavior is to create a div element in body. | Function | () => document.body |  |
+| getTooltipPopupContainer | The DOM container of the Tooltip, the default behavior is to create a div element in body. | (triggerNode) => HTMLElement | () => document.body |  |
 
 ## Methods
 

--- a/components/slider/index.zh-CN.md
+++ b/components/slider/index.zh-CN.md
@@ -26,14 +26,14 @@ title: Slider
 | range | 双滑块模式 | boolean | false |  |
 | reverse | 反向坐标轴 | boolean | false |  |
 | step | 步长，取值必须大于 0，并且可被 (max - min) 整除。当 `marks` 不为空对象时，可以设置 `step` 为 `null`，此时 Slider 的可选值仅有 marks 标出来的部分。 | number\|null | 1 |  |
-| tipFormatter | Slider 会把当前值传给 `tipFormatter`，并在 Tooltip 中显示 `tipFormatter` 的返回值，若为 null，则隐藏 Tooltip。 | Function\|null | IDENTITY |  |
+| tipFormatter | Slider 会把当前值传给 `tipFormatter`，并在 Tooltip 中显示 `tipFormatter` 的返回值，若为 null，则隐藏 Tooltip。 | value => ReactNode\|null | IDENTITY |  |
 | value | 设置当前取值。当 `range` 为 `false` 时，使用 `number`，否则用 `[number, number]` | number\|\[number, number] |  |  |
 | vertical | 值为 `true` 时，Slider 为垂直方向 | Boolean | false |  |
-| onAfterChange | 与 `onmouseup` 触发时机一致，把当前值作为参数传入。 | Function(value) | NOOP |  |
-| onChange | 当 Slider 的值发生改变时，会触发 onChange 事件，并把改变后的值作为参数传入。 | Function(value) | NOOP |  |
+| onAfterChange | 与 `onmouseup` 触发时机一致，把当前值作为参数传入。 | (value) => void | NOOP |  |
+| onChange | 当 Slider 的值发生改变时，会触发 onChange 事件，并把改变后的值作为参数传入。 | (value) => void | NOOP |  |
 | tooltipPlacement | 设置 Tooltip 展示位置。参考 [`Tooltip`](/components/tooltip/)。 | string |  |  |
 | tooltipVisible | 值为`true`时，Tooltip 将会始终显示；否则始终不显示，哪怕在拖拽及移入时。 | Boolean |  |  |
-| getTooltipPopupContainer | Tooltip 渲染父节点，默认渲染到 body 上。 | Function | () => document.body |  |
+| getTooltipPopupContainer | Tooltip 渲染父节点，默认渲染到 body 上。 | (triggerNode) => HTMLElement | () => document.body |  |
 
 ## 方法
 

--- a/components/slider/style/index.less
+++ b/components/slider/style/index.less
@@ -92,6 +92,7 @@
     text-align: center;
     word-break: keep-all;
     cursor: pointer;
+    user-select: none;
 
     &-active {
       color: @text-color;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Slider `marks` selected problem when dragging.  |
| 🇨🇳 Chinese | 修复 Slider 拖拽中选中 `marks` 文本的问题。  |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️ 

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/slider/index.en-US.md](https://github.com/ant-design/ant-design/blob/fix-slider-text-select/components/slider/index.en-US.md)
[View rendered components/slider/index.zh-CN.md](https://github.com/ant-design/ant-design/blob/fix-slider-text-select/components/slider/index.zh-CN.md)