### PR TITLE
fix: DatePicker miss placeholder when it's undefined

### DIFF
--- a/components/date-picker/__tests__/DatePicker.test.js
+++ b/components/date-picker/__tests__/DatePicker.test.js
@@ -73,4 +73,9 @@ describe('DatePicker', () => {
 
     expect(wrapper.render()).toMatchSnapshot();
   });
+
+  it('placeholder', () => {
+    const wrapper = mount(<DatePicker placeholder={undefined} />);
+    expect(wrapper.find('input').props().placeholder).toEqual('Select date');
+  });
 });

--- a/components/date-picker/__tests__/RangePicker.test.js
+++ b/components/date-picker/__tests__/RangePicker.test.js
@@ -90,4 +90,10 @@ describe('RangePicker', () => {
       expect(wrapper).toMatchRenderedSnapshot();
     });
   });
+
+  it('placeholder', () => {
+    const wrapper = mount(<RangePicker placeholder={undefined} />);
+    expect(wrapper.find('input').first().props().placeholder).toEqual('Start date');
+    expect(wrapper.find('input').last().props().placeholder).toEqual('End date');
+  });
 });

--- a/components/date-picker/generatePicker/generateRangePicker.tsx
+++ b/components/date-picker/generatePicker/generateRangePicker.tsx
@@ -56,6 +56,7 @@ export default function generateRangePicker<DateType>(
         className,
         size: customizeSize,
         bordered = true,
+        placeholder,
         ...restProps
       } = this.props;
       const { format, showTime, picker } = this.props as any;
@@ -82,7 +83,7 @@ export default function generateRangePicker<DateType>(
                   </span>
                 }
                 ref={this.pickerRef}
-                placeholder={getRangePlaceholder(picker, locale)}
+                placeholder={getRangePlaceholder(picker, locale, placeholder)}
                 suffixIcon={picker === 'time' ? <ClockCircleOutlined /> : <CalendarOutlined />}
                 clearIcon={<CloseCircleFilled />}
                 allowClear

--- a/components/date-picker/generatePicker/generateSinglePicker.tsx
+++ b/components/date-picker/generatePicker/generateSinglePicker.tsx
@@ -69,6 +69,7 @@ export default function generatePicker<DateType>(generateConfig: GenerateConfig<
           className,
           size: customizeSize,
           bordered = true,
+          placeholder,
           ...restProps
         } = this.props;
         const { format, showTime } = this.props as any;
@@ -100,7 +101,7 @@ export default function generatePicker<DateType>(generateConfig: GenerateConfig<
               return (
                 <RCPicker<DateType>
                   ref={this.pickerRef}
-                  placeholder={getPlaceholder(mergedPicker, locale)}
+                  placeholder={getPlaceholder(mergedPicker, locale, placeholder)}
                   suffixIcon={
                     mergedPicker === 'time' ? <ClockCircleOutlined /> : <CalendarOutlined />
                   }

--- a/components/date-picker/util.ts
+++ b/components/date-picker/util.ts
@@ -1,7 +1,15 @@
 import { PickerMode } from 'rc-picker/lib/interface';
 import { PickerLocale } from './generatePicker';
 
-export function getPlaceholder(picker: PickerMode | undefined, locale: PickerLocale): string {
+export function getPlaceholder(
+  picker: PickerMode | undefined,
+  locale: PickerLocale,
+  customizePlaceholder?: string,
+): string {
+  if (customizePlaceholder !== undefined) {
+    return customizePlaceholder;
+  }
+
   if (picker === 'year' && locale.lang.yearPlaceholder) {
     return locale.lang.yearPlaceholder;
   }
@@ -20,7 +28,15 @@ export function getPlaceholder(picker: PickerMode | undefined, locale: PickerLoc
   return locale.lang.placeholder;
 }
 
-export function getRangePlaceholder(picker: PickerMode | undefined, locale: PickerLocale) {
+export function getRangePlaceholder(
+  picker: PickerMode | undefined,
+  locale: PickerLocale,
+  customizePlaceholder?: [string, string],
+) {
+  if (customizePlaceholder !== undefined) {
+    return customizePlaceholder;
+  }
+
   if (picker === 'year' && locale.lang.yearPlaceholder) {
     return locale.lang.rangeYearPlaceholder;
   }

--- a/components/form/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/form/__tests__/__snapshots__/demo.test.js.snap
@@ -3340,6 +3340,7 @@ exports[`renders ./components/form/demo/time-related-controls.md correctly 1`] =
               class="ant-picker-input"
             >
               <input
+                id="time_related_controls_date-picker"
                 placeholder="Select date"
                 readonly=""
                 size="12"
@@ -3406,6 +3407,7 @@ exports[`renders ./components/form/demo/time-related-controls.md correctly 1`] =
               class="ant-picker-input"
             >
               <input
+                id="time_related_controls_date-time-picker"
                 placeholder="Select date"
                 readonly=""
                 size="21"
@@ -3472,6 +3474,7 @@ exports[`renders ./components/form/demo/time-related-controls.md correctly 1`] =
               class="ant-picker-input"
             >
               <input
+                id="time_related_controls_month-picker"
                 placeholder="Select month"
                 readonly=""
                 size="12"
@@ -3538,6 +3541,7 @@ exports[`renders ./components/form/demo/time-related-controls.md correctly 1`] =
               class="ant-picker-input ant-picker-input-active"
             >
               <input
+                id="time_related_controls_range-picker"
                 placeholder="Start date"
                 readonly=""
                 size="12"
@@ -3646,6 +3650,7 @@ exports[`renders ./components/form/demo/time-related-controls.md correctly 1`] =
               class="ant-picker-input ant-picker-input-active"
             >
               <input
+                id="time_related_controls_range-time-picker"
                 placeholder="Start date"
                 readonly=""
                 size="21"
@@ -3754,6 +3759,7 @@ exports[`renders ./components/form/demo/time-related-controls.md correctly 1`] =
               class="ant-picker-input"
             >
               <input
+                id="time_related_controls_time-picker"
                 placeholder="Select time"
                 readonly=""
                 size="10"


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

fix #23744

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Fix DatePicker miss placeholder when `placeholder` is `undefined`.       |
| 🇨🇳 Chinese |     修复 DatePicker 在 `placeholder` 为 `undefined` 时不展示的问题。      |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️ 

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
