### PR TITLE
fix: Textarea height

### DIFF
--- a/components/input/style/affix.less
+++ b/components/input/style/affix.less
@@ -7,15 +7,6 @@
   &-affix-wrapper {
     .input();
     display: inline-flex;
-    max-height: @input-height-base;
-
-    &-lg {
-      max-height: @input-height-lg;
-    }
-
-    &-sm {
-      max-height: @input-height-sm;
-    }
 
     &-disabled {
       .@{ant-prefix}-input[disabled] {
@@ -24,8 +15,7 @@
     }
 
     > input.@{ant-prefix}-input {
-      padding-right: 0;
-      padding-left: 0;
+      padding: 0;
       border: none;
       outline: none;
 

--- a/components/table/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/table/__tests__/__snapshots__/demo.test.js.snap
@@ -2713,7 +2713,7 @@ exports[`renders ./components/table/demo/dynamic-settings.md correctly 1`] = `
                         <a
                           class="ant-dropdown-link"
                         >
-                          More actions
+                          More actions 
                           <span
                             aria-label="down"
                             class="anticon anticon-down"
@@ -2797,7 +2797,7 @@ exports[`renders ./components/table/demo/dynamic-settings.md correctly 1`] = `
                         <a
                           class="ant-dropdown-link"
                         >
-                          More actions
+                          More actions 
                           <span
                             aria-label="down"
                             class="anticon anticon-down"
@@ -2881,7 +2881,7 @@ exports[`renders ./components/table/demo/dynamic-settings.md correctly 1`] = `
                         <a
                           class="ant-dropdown-link"
                         >
-                          More actions
+                          More actions 
                           <span
                             aria-label="down"
                             class="anticon anticon-down"
@@ -2965,7 +2965,7 @@ exports[`renders ./components/table/demo/dynamic-settings.md correctly 1`] = `
                         <a
                           class="ant-dropdown-link"
                         >
-                          More actions
+                          More actions 
                           <span
                             aria-label="down"
                             class="anticon anticon-down"
@@ -3049,7 +3049,7 @@ exports[`renders ./components/table/demo/dynamic-settings.md correctly 1`] = `
                         <a
                           class="ant-dropdown-link"
                         >
-                          More actions
+                          More actions 
                           <span
                             aria-label="down"
                             class="anticon anticon-down"
@@ -3133,7 +3133,7 @@ exports[`renders ./components/table/demo/dynamic-settings.md correctly 1`] = `
                         <a
                           class="ant-dropdown-link"
                         >
-                          More actions
+                          More actions 
                           <span
                             aria-label="down"
                             class="anticon anticon-down"
@@ -3217,7 +3217,7 @@ exports[`renders ./components/table/demo/dynamic-settings.md correctly 1`] = `
                         <a
                           class="ant-dropdown-link"
                         >
-                          More actions
+                          More actions 
                           <span
                             aria-label="down"
                             class="anticon anticon-down"
@@ -3301,7 +3301,7 @@ exports[`renders ./components/table/demo/dynamic-settings.md correctly 1`] = `
                         <a
                           class="ant-dropdown-link"
                         >
-                          More actions
+                          More actions 
                           <span
                             aria-label="down"
                             class="anticon anticon-down"
@@ -3385,7 +3385,7 @@ exports[`renders ./components/table/demo/dynamic-settings.md correctly 1`] = `
                         <a
                           class="ant-dropdown-link"
                         >
-                          More actions
+                          More actions 
                           <span
                             aria-label="down"
                             class="anticon anticon-down"
@@ -3469,7 +3469,7 @@ exports[`renders ./components/table/demo/dynamic-settings.md correctly 1`] = `
                         <a
                           class="ant-dropdown-link"
                         >
-                          More actions
+                          More actions 
                           <span
                             aria-label="down"
                             class="anticon anticon-down"
@@ -13516,7 +13516,7 @@ exports[`renders ./components/table/demo/row-selection-custom-debug.md correctly
                     class="ant-table-cell ant-table-selection-column"
                     rowspan="2"
                   >
-                    false:
+                    false: 
                     <label
                       class="ant-checkbox-wrapper"
                     >
@@ -13557,7 +13557,7 @@ exports[`renders ./components/table/demo/row-selection-custom-debug.md correctly
                     class="ant-table-cell ant-table-selection-column"
                     rowspan="2"
                   >
-                    false:
+                    false: 
                     <label
                       class="ant-checkbox-wrapper"
                     >
@@ -13598,7 +13598,7 @@ exports[`renders ./components/table/demo/row-selection-custom-debug.md correctly
                     class="ant-table-cell ant-table-selection-column"
                     rowspan="2"
                   >
-                    false:
+                    false: 
                     <label
                       class="ant-checkbox-wrapper"
                     >
@@ -13639,7 +13639,7 @@ exports[`renders ./components/table/demo/row-selection-custom-debug.md correctly
                     class="ant-table-cell ant-table-selection-column"
                     rowspan="2"
                   >
-                    false:
+                    false: 
                     <label
                       class="ant-checkbox-wrapper"
                     >
@@ -13680,7 +13680,7 @@ exports[`renders ./components/table/demo/row-selection-custom-debug.md correctly
                     class="ant-table-cell ant-table-selection-column"
                     rowspan="2"
                   >
-                    false:
+                    false: 
                     <label
                       class="ant-checkbox-wrapper"
                     >


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

resolve #23688

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Fix Textarea with `allowClear` has error height style.       |
| 🇨🇳 Chinese |     修复 Textarea 开启 `allowClear` 时高度错误的问题。     |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️ 

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
