### PR TITLE
fix: Form.Item warning for initialValue

### DIFF
--- a/components/form/FormItem.tsx
+++ b/components/form/FormItem.tsx
@@ -184,6 +184,7 @@ function FormItem(props: FormItemProps): React.ReactElement {
           'help',
           'htmlFor',
           'id', // It is deprecated because `htmlFor` is its replacement.
+          'initialValue',
           'label',
           'labelAlign',
           'labelCol',

--- a/components/form/__tests__/index.test.js
+++ b/components/form/__tests__/index.test.js
@@ -696,7 +696,7 @@ describe('Form', () => {
   });
 
   it('no warning of initialValue', () => {
-    const wrapper = mount(
+    mount(
       <Form>
         <Form.Item initialValue="bamboo">
           <Input />

--- a/components/form/__tests__/index.test.js
+++ b/components/form/__tests__/index.test.js
@@ -694,4 +694,17 @@ describe('Form', () => {
     wrapper.update();
     expect(wrapper.find('.ant-form-item').last().hasClass('ant-form-item-with-help')).toBeFalsy();
   });
+
+  it('no warning of initialValue', () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const wrapper = mount(
+      <Form>
+        <Form.Item initialValue="bamboo">
+          <Input />
+        </Form.Item>
+      </Form>,
+    );
+    expect(errorSpy).not.toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
 });

--- a/components/form/__tests__/index.test.js
+++ b/components/form/__tests__/index.test.js
@@ -696,7 +696,6 @@ describe('Form', () => {
   });
 
   it('no warning of initialValue', () => {
-    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
     const wrapper = mount(
       <Form>
         <Form.Item initialValue="bamboo">
@@ -705,6 +704,5 @@ describe('Form', () => {
       </Form>,
     );
     expect(errorSpy).not.toHaveBeenCalled();
-    errorSpy.mockRestore();
   });
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

resolve #23839

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Fix Form.Item warning illegal dom attribute with `initialValue`.       |
| 🇨🇳 Chinese |     修复 Form.Item 使用 `initialValue` 报错不是合法 dom 属性的问题。      |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️ 

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
