### PR TITLE
fix: InputNumber onChange type

### DIFF
--- a/components/input-number/index.tsx
+++ b/components/input-number/index.tsx
@@ -20,7 +20,7 @@ export interface InputNumberProps
   step?: number | string;
   defaultValue?: number;
   tabIndex?: number;
-  onChange?: (value: number | undefined) => void;
+  onChange?: (value: number | string | undefined) => void;
   disabled?: boolean;
   size?: SizeType;
   formatter?: (value: number | string | undefined) => string;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
The type of `InputNumber`'s `onChange` function was incomplete, leading to confusion and TypeErrors when used the wrong way. Fixes: #12795, which may have been prematurely closed.

Would be great if this could also be backported to 3.x! ❤️ 

### 💡 Background and solution

Simply extended the union type, as explained by https://github.com/ant-design/ant-design/issues/12795#issuecomment-432185737

### 📝 Changelog

As this is just a correction of the typedef I do not expect any breaking changes. Users may need to adjust their downstream code a bit to please the typechecker.

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️ 

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
