### PR TITLE
fix: FormItem getValueProps warning

### DIFF
--- a/components/form/FormItem.tsx
+++ b/components/form/FormItem.tsx
@@ -180,6 +180,7 @@ function FormItem(props: FormItemProps): React.ReactElement {
           'colon',
           'extra',
           'getValueFromEvent',
+          'getValueProps',
           'hasFeedback',
           'help',
           'htmlFor',

--- a/components/form/__tests__/index.test.js
+++ b/components/form/__tests__/index.test.js
@@ -695,10 +695,10 @@ describe('Form', () => {
     expect(wrapper.find('.ant-form-item').last().hasClass('ant-form-item-with-help')).toBeFalsy();
   });
 
-  it('no warning of initialValue', () => {
+  it('no warning of initialValue & getValueProps', () => {
     mount(
       <Form>
-        <Form.Item initialValue="bamboo">
+        <Form.Item initialValue="bamboo" getValueProps={() => null}>
           <Input />
         </Form.Item>
       </Form>,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

fix #23873

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Fix Form.Item get React warning for `getValueProps`.       |
| 🇨🇳 Chinese |   修复 Form.Item 使用 `getValueProps` React 会报警的问题。          |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️ 

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
