### PR TITLE
fix: Form.Item defaulting to error color when help text leaves

### DIFF
--- a/components/form/FormItem.tsx
+++ b/components/form/FormItem.tsx
@@ -165,8 +165,6 @@ function FormItem(props: FormItemProps): React.ReactElement {
       [`${prefixCls}-item-has-success`]: mergedValidateStatus === 'success',
       [`${prefixCls}-item-has-warning`]: mergedValidateStatus === 'warning',
       [`${prefixCls}-item-has-error`]: mergedValidateStatus === 'error',
-      [`${prefixCls}-item-has-error-leave`]:
-        !help && domErrorVisible && mergedValidateStatus !== 'error',
       [`${prefixCls}-item-is-validating`]: mergedValidateStatus === 'validating',
     };
 

--- a/components/form/style/status.less
+++ b/components/form/style/status.less
@@ -236,13 +236,6 @@
     }
   }
 
-  // Patch to keep error explain color
-  &-has-error-leave {
-    .@{form-item-prefix-cls}-explain {
-      color: @error-color;
-    }
-  }
-
   // ====================== Validating =======================
   &-is-validating {
     &.@{form-item-prefix-cls}-has-feedback .@{form-item-prefix-cls}-children-icon {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

[#23882](https://github.com/ant-design/ant-design/issues/23882)

### 💡 Background and solution

1. When help text disappears on a `Form.Item` component, the help text always defaults to the
error color right before disappearing.

2. 
![antd_form_item_error](https://user-images.githubusercontent.com/8882806/81065700-fb013900-8ea9-11ea-8b58-538bcad6253b.gif)

 
3. Remove the CSS rule that defaults has-error-leave. 

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

Remove CSS rule patch when Form.Item help text disappears

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Remove CSS rule patch when Form.Item help text disappears  |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️ 

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
