### PR TITLE
docs: Fix English syntax in heading

### DIFF
--- a/docs/react/replace-moment.en-US.md
+++ b/docs/react/replace-moment.en-US.md
@@ -3,7 +3,7 @@ order: 7.1
 title: Replace Moment.js
 ---
 
-## How to use DatePicker with customize date library like dayjs？
+## How to use DatePicker with a custom date library like dayjs
 
 Consider of bundle size, you can replace momentjs with customize date library. We provide two ways to customize date library:
 


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

Updating the [Replace Moment.js](https://ant.design/docs/react/replace-moment) page.

### 💡 Background and solution

- Changing the verb "customize" to its adjective form "custom" so it can describe "date library".
- Removing the question mark, as the current wording is not in the form of a question.

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Documentation syntax fix? |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️ 

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered docs/react/replace-moment.en-US.md](https://github.com/tywmick/ant-design/blob/patch-1/docs/react/replace-moment.en-US.md)