### PR TITLE
fix: Drawer with percentage width cannot show when no mask

### DIFF
--- a/components/drawer/style/drawer.less
+++ b/components/drawer/style/drawer.less
@@ -3,8 +3,6 @@
 @drawer-prefix-cls: ~'@{ant-prefix}-drawer';
 @picker-prefix-cls: ~'@{ant-prefix}-picker';
 
-
-
 .@{drawer-prefix-cls} {
   @drawer-header-close-padding: ceil((@drawer-header-close-size - @font-size-lg) / 2);
 
@@ -40,7 +38,11 @@
       transition: transform @animation-duration-slow @ease-base-out;
     }
     &.@{drawer-prefix-cls}-open.no-mask {
-      width: 0%;
+      height: 0%;
+
+      .@{drawer-prefix-cls}-content-wrapper {
+        height: 100vh;
+      }
     }
   }
 
@@ -94,7 +96,11 @@
       transition: transform @animation-duration-slow @ease-base-out;
     }
     &.@{drawer-prefix-cls}-open.no-mask {
-      height: 0%;
+      width: 0%;
+
+      .@{drawer-prefix-cls}-content-wrapper {
+        width: 100vw;
+      }
     }
   }
 


### PR DESCRIPTION


<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->
close #23910

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Drawer `width="50%"` hidden problem when no mask. |
| 🇨🇳 Chinese | 修复无遮罩的 Drawer 设置 `50%` 宽度时不显示的问题。 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️ 

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
