### PR TITLE
refactor: 📦 use webpack-plugin-esbuild

### DIFF
--- a/.antd-tools.config.js
+++ b/.antd-tools.config.js
@@ -156,4 +156,5 @@ module.exports = {
   },
   generateThemeFileContent,
 };
+
 finalizeDist();

--- a/.antd-tools.config.js
+++ b/.antd-tools.config.js
@@ -156,5 +156,3 @@ module.exports = {
   },
   generateThemeFileContent,
 };
-
-finalizeDist();

--- a/package.json
+++ b/package.json
@@ -258,6 +258,7 @@
     "theme-switcher": "^1.0.2",
     "typescript": "~3.8.2",
     "webpack-bundle-analyzer": "^3.6.0",
+    "webpack-plugin-esbuild": "^1.0.0-beta.2",
     "xhr-mock": "^2.4.1",
     "xhr2": "^0.2.0",
     "yaml-front-matter": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -181,6 +181,7 @@
     "enzyme": "^3.10.0",
     "enzyme-adapter-react-16": "^1.14.0",
     "enzyme-to-json": "^3.3.5",
+    "esbuild-webpack-plugin": "^1.0.0-beta.3",
     "eslint": "^6.8.0",
     "eslint-config-airbnb": "^18.0.0",
     "eslint-config-prettier": "^6.0.0",
@@ -258,7 +259,6 @@
     "theme-switcher": "^1.0.2",
     "typescript": "~3.8.2",
     "webpack-bundle-analyzer": "^3.6.0",
-    "webpack-plugin-esbuild": "^1.0.0-beta.2",
     "xhr-mock": "^2.4.1",
     "xhr2": "^0.2.0",
     "yaml-front-matter": "^4.0.0"

--- a/site/bisheng.config.js
+++ b/site/bisheng.config.js
@@ -1,7 +1,7 @@
 const path = require('path');
 const replaceLib = require('@ant-design/tools/lib/replaceLib');
 const getWebpackConfig = require('@ant-design/tools/lib/getWebpackConfig');
-const EsbuildPlugin = require('webpack-plugin-esbuild').default;
+const EsbuildPlugin = require('esbuild-webpack-plugin').default;
 const { version } = require('../package.json');
 
 const { webpack } = getWebpackConfig;

--- a/site/bisheng.config.js
+++ b/site/bisheng.config.js
@@ -135,7 +135,8 @@ module.exports = {
       // Resolve use react hook fail when yarn link or npm link
       // https://github.com/webpack/webpack/issues/8607#issuecomment-453068938
       config.resolve.alias = { ...config.resolve.alias, react: require.resolve('react') };
-    } else {
+    } else if (process.env.ESBUILD) {
+      // use esbuild
       config.optimization.minimizer = [new EsbuildPlugin()];
     }
 

--- a/site/bisheng.config.js
+++ b/site/bisheng.config.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const replaceLib = require('@ant-design/tools/lib/replaceLib');
 const getWebpackConfig = require('@ant-design/tools/lib/getWebpackConfig');
+const EsbuildPlugin = require('webpack-plugin-esbuild').default;
 const { version } = require('../package.json');
 
 const { webpack } = getWebpackConfig;
@@ -134,6 +135,8 @@ module.exports = {
       // Resolve use react hook fail when yarn link or npm link
       // https://github.com/webpack/webpack/issues/8607#issuecomment-453068938
       config.resolve.alias = { ...config.resolve.alias, react: require.resolve('react') };
+    } else {
+      config.optimization.minimizer = [new EsbuildPlugin()];
     }
 
     alertBabelConfig(config.module.rules);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,7 +3,7 @@
 const getWebpackConfig = require('@ant-design/tools/lib/getWebpackConfig');
 const IgnoreEmitPlugin = require('ignore-emit-webpack-plugin');
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
-const EsbuildPlugin = require('webpack-plugin-esbuild').default;
+const EsbuildPlugin = require('esbuild-webpack-plugin').default;
 const darkVars = require('./scripts/dark-vars');
 const compactVars = require('./scripts/compact-vars');
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -36,6 +36,9 @@ function externalMoment(config) {
 
 function processWebpackThemeConfig(themeConfig, theme, vars) {
   themeConfig.forEach(config => {
+    ignoreMomentLocale(config);
+    externalMoment(config);
+
     // rename default entry to ${theme} entry
     Object.keys(config.entry).forEach(entryName => {
       config.entry[entryName.replace('antd', `antd.${theme}`)] = config.entry[entryName];

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -76,7 +76,9 @@ if (process.env.RUN_ENV === 'PRODUCTION') {
     // Reduce non-minified dist files size
     config.optimization.usedExports = true;
     // use esbuild
-    config.optimization.minimizer[0] = new EsbuildPlugin();
+    if (process.env.CSB_REPO) {
+      config.optimization.minimizer[0] = new EsbuildPlugin();
+    }
     // skip codesandbox ci
     if (!process.env.CSB_REPO) {
       config.plugins.push(

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -36,15 +36,6 @@ function externalMoment(config) {
 
 function processWebpackThemeConfig(themeConfig, theme, vars) {
   themeConfig.forEach(config => {
-    if (process.env.RUN_ENV === 'PRODUCTION') {
-      ignoreMomentLocale(config);
-      externalMoment(config);
-      // Reduce non-minified dist files size
-      config.optimization.usedExports = true;
-      // use esbuild
-      config.optimization.minimizer[0] = new EsbuildPlugin();
-    }
-
     // rename default entry to ${theme} entry
     Object.keys(config.entry).forEach(entryName => {
       config.entry[entryName.replace('antd', `antd.${theme}`)] = config.entry[entryName];

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -49,7 +49,12 @@ function processWebpackThemeConfig(themeConfig, theme, vars) {
     config.module.rules.forEach(rule => {
       // filter less rule
       if (rule.test instanceof RegExp && rule.test.test('.less')) {
-        rule.use[rule.use.length - 1].options.modifyVars = vars;
+        const lessRule = rule.use[rule.use.length - 1];
+        if (lessRule.options.lessOptions) {
+          lessRule.options.lessOptions.modifyVars = vars;
+        } else {
+          lessRule.options.modifyVars = vars;
+        }
       }
     });
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,6 +3,7 @@
 const getWebpackConfig = require('@ant-design/tools/lib/getWebpackConfig');
 const IgnoreEmitPlugin = require('ignore-emit-webpack-plugin');
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
+const EsbuildPlugin = require('webpack-plugin-esbuild').default;
 const darkVars = require('./scripts/dark-vars');
 const compactVars = require('./scripts/compact-vars');
 
@@ -35,8 +36,14 @@ function externalMoment(config) {
 
 function processWebpackThemeConfig(themeConfig, theme, vars) {
   themeConfig.forEach(config => {
-    ignoreMomentLocale(config);
-    externalMoment(config);
+    if (process.env.RUN_ENV === 'PRODUCTION') {
+      ignoreMomentLocale(config);
+      externalMoment(config);
+      // Reduce non-minified dist files size
+      config.optimization.usedExports = true;
+      // use esbuild
+      config.optimization.minimizer[0] = new EsbuildPlugin();
+    }
 
     // rename default entry to ${theme} entry
     Object.keys(config.entry).forEach(entryName => {
@@ -61,6 +68,7 @@ function processWebpackThemeConfig(themeConfig, theme, vars) {
 const webpackConfig = getWebpackConfig(false);
 const webpackDarkConfig = getWebpackConfig(false);
 const webpackCompactConfig = getWebpackConfig(false);
+
 if (process.env.RUN_ENV === 'PRODUCTION') {
   webpackConfig.forEach(config => {
     ignoreMomentLocale(config);
@@ -68,6 +76,8 @@ if (process.env.RUN_ENV === 'PRODUCTION') {
     addLocales(config);
     // Reduce non-minified dist files size
     config.optimization.usedExports = true;
+    // use esbuild
+    config.optimization.minimizer[0] = new EsbuildPlugin();
     // skip codesandbox ci
     if (!process.env.CSB_REPO) {
       config.plugins.push(


### PR DESCRIPTION
close #22035

https://github.com/sorrycc/webpack-plugin-esbuild

两个都跑不通，先加个 `process.env.ESBUILD` 开启，本地可测：

- [ ] `ESBUILD=1 npm run site`：`TypeError: ssr is not a function`
- [ ] `ESBUILD=1 npm run dist`：可以构建成功，但是不会自动结束，长久的卡住