### PR TITLE
fix: FormItem with help

### DIFF
--- a/components/form/FormItem.tsx
+++ b/components/form/FormItem.tsx
@@ -85,15 +85,6 @@ function FormItem(props: FormItemProps): React.ReactElement {
   const [prevValidateStatus, setPrevValidateStatus] = React.useState(validateStatus);
   const [inlineErrors, setInlineErrors] = useFrameState<Record<string, string[]>>({});
 
-  function setDomErrorVisible(visible: boolean) {
-    if (!destroyRef.current) {
-      innerSetDomErrorVisible(visible);
-      if (visible) {
-        setPrevValidateStatus(validateStatus);
-      }
-    }
-  }
-
   const { name: formName } = formContext;
   const hasName = hasValidName(name);
 
@@ -145,6 +136,15 @@ function FormItem(props: FormItemProps): React.ReactElement {
           mergedErrors = [...mergedErrors, ...subErrors];
         }
       });
+    }
+
+    function setDomErrorVisible(visible: boolean) {
+      if (!destroyRef.current) {
+        innerSetDomErrorVisible(visible);
+        if (visible) {
+          setPrevValidateStatus(mergedValidateStatus);
+        }
+      }
     }
 
     // ======================== Status ========================

--- a/components/form/FormItem.tsx
+++ b/components/form/FormItem.tsx
@@ -82,7 +82,7 @@ function FormItem(props: FormItemProps): React.ReactElement {
   const formContext = React.useContext(FormContext);
   const { updateItemErrors } = React.useContext(FormItemContext);
   const [domErrorVisible, innerSetDomErrorVisible] = React.useState(!!help);
-  const prevValidateStatusRef = React.useRef<ValidateStatus>(null);
+  const prevValidateStatusRef = React.useRef<ValidateStatus | undefined>(validateStatus);
   const [inlineErrors, setInlineErrors] = useFrameState<Record<string, string[]>>({});
 
   function setDomErrorVisible(visible: boolean) {

--- a/components/form/FormItem.tsx
+++ b/components/form/FormItem.tsx
@@ -82,11 +82,15 @@ function FormItem(props: FormItemProps): React.ReactElement {
   const formContext = React.useContext(FormContext);
   const { updateItemErrors } = React.useContext(FormItemContext);
   const [domErrorVisible, innerSetDomErrorVisible] = React.useState(!!help);
+  const [prevValidateStatus, setPrevValidateStatus] = React.useState(validateStatus);
   const [inlineErrors, setInlineErrors] = useFrameState<Record<string, string[]>>({});
 
   function setDomErrorVisible(visible: boolean) {
     if (!destroyRef.current) {
       innerSetDomErrorVisible(visible);
+      if (visible) {
+        setPrevValidateStatus(validateStatus);
+      }
     }
   }
 
@@ -166,7 +170,7 @@ function FormItem(props: FormItemProps): React.ReactElement {
       [`${prefixCls}-item-has-warning`]: mergedValidateStatus === 'warning',
       [`${prefixCls}-item-has-error`]: mergedValidateStatus === 'error',
       [`${prefixCls}-item-has-error-leave`]:
-        !help && domErrorVisible && mergedValidateStatus !== 'error',
+        !help && domErrorVisible && prevValidateStatus === 'error',
       [`${prefixCls}-item-is-validating`]: mergedValidateStatus === 'validating',
     };
 

--- a/components/form/FormItem.tsx
+++ b/components/form/FormItem.tsx
@@ -156,7 +156,7 @@ function FormItem(props: FormItemProps): React.ReactElement {
       mergedValidateStatus = 'success';
     }
 
-    if (domErrorVisible) {
+    if (domErrorVisible && help) {
       prevValidateStatusRef.current = mergedValidateStatus;
     }
 

--- a/components/form/FormItem.tsx
+++ b/components/form/FormItem.tsx
@@ -82,8 +82,14 @@ function FormItem(props: FormItemProps): React.ReactElement {
   const formContext = React.useContext(FormContext);
   const { updateItemErrors } = React.useContext(FormItemContext);
   const [domErrorVisible, innerSetDomErrorVisible] = React.useState(!!help);
-  const [prevValidateStatus, setPrevValidateStatus] = React.useState(validateStatus);
+  const prevValidateStatusRef = React.useRef<ValidateStatus>(null);
   const [inlineErrors, setInlineErrors] = useFrameState<Record<string, string[]>>({});
+
+  function setDomErrorVisible(visible: boolean) {
+    if (!destroyRef.current) {
+      innerSetDomErrorVisible(visible);
+    }
+  }
 
   const { name: formName } = formContext;
   const hasName = hasValidName(name);
@@ -138,15 +144,6 @@ function FormItem(props: FormItemProps): React.ReactElement {
       });
     }
 
-    function setDomErrorVisible(visible: boolean) {
-      if (!destroyRef.current) {
-        innerSetDomErrorVisible(visible);
-        if (visible) {
-          setPrevValidateStatus(mergedValidateStatus);
-        }
-      }
-    }
-
     // ======================== Status ========================
     let mergedValidateStatus: ValidateStatus = '';
     if (validateStatus !== undefined) {
@@ -157,6 +154,10 @@ function FormItem(props: FormItemProps): React.ReactElement {
       mergedValidateStatus = 'error';
     } else if (meta && meta.touched) {
       mergedValidateStatus = 'success';
+    }
+
+    if (domErrorVisible) {
+      prevValidateStatusRef.current = mergedValidateStatus;
     }
 
     const itemClassName = {
@@ -170,7 +171,7 @@ function FormItem(props: FormItemProps): React.ReactElement {
       [`${prefixCls}-item-has-warning`]: mergedValidateStatus === 'warning',
       [`${prefixCls}-item-has-error`]: mergedValidateStatus === 'error',
       [`${prefixCls}-item-has-error-leave`]:
-        !help && domErrorVisible && prevValidateStatus === 'error',
+        !help && domErrorVisible && prevValidateStatusRef.current === 'error',
       [`${prefixCls}-item-is-validating`]: mergedValidateStatus === 'validating',
     };
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

resolve #23882

close #23883

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Fix Form.Item `help` style issue when `validateStatus` is not `error`.     |
| 🇨🇳 Chinese |      修复 Form.Item `help` 在 `validateStatus` 不是 `error` 时的样式问题。     |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️ 

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
