### PR TITLE
fix: #23986 [Comment] Should not render avatar wrapper when avatar is…

### DIFF
--- a/components/comment/__tests__/__snapshots__/index.test.js.snap
+++ b/components/comment/__tests__/__snapshots__/index.test.js.snap
@@ -8,9 +8,6 @@ exports[`Comment rtl render component should be rendered correctly in RTL direct
     class="ant-comment-inner"
   >
     <div
-      class="ant-comment-avatar"
-    />
-    <div
       class="ant-comment-content"
     >
       <div

--- a/components/comment/index.tsx
+++ b/components/comment/index.tsx
@@ -52,11 +52,11 @@ const Comment: React.FC<CommentProps> = ({
 
   const prefixCls = getPrefixCls('comment', customizePrefixCls);
 
-  const avatarDom = (
+  const avatarDom = avatar ? (
     <div className={`${prefixCls}-avatar`}>
       {typeof avatar === 'string' ? <img src={avatar} alt="comment-avatar" /> : avatar}
     </div>
-  );
+  ) : null;
 
   const actionDom =
     actions && actions.length ? (

--- a/components/config-provider/__tests__/__snapshots__/components.test.js.snap
+++ b/components/config-provider/__tests__/__snapshots__/components.test.js.snap
@@ -9418,9 +9418,6 @@ exports[`ConfigProvider components Comment configProvider 1`] = `
     class="config-comment-inner"
   >
     <div
-      class="config-comment-avatar"
-    />
-    <div
       class="config-comment-content"
     >
       <div
@@ -9442,9 +9439,6 @@ exports[`ConfigProvider components Comment configProvider 1`] = `
       <div
         class="config-comment-inner"
       >
-        <div
-          class="config-comment-avatar"
-        />
         <div
           class="config-comment-content"
         >
@@ -9471,9 +9465,6 @@ exports[`ConfigProvider components Comment configProvider componentSize large 1`
     class="config-comment-inner"
   >
     <div
-      class="config-comment-avatar"
-    />
-    <div
       class="config-comment-content"
     >
       <div
@@ -9495,9 +9486,6 @@ exports[`ConfigProvider components Comment configProvider componentSize large 1`
       <div
         class="config-comment-inner"
       >
-        <div
-          class="config-comment-avatar"
-        />
         <div
           class="config-comment-content"
         >
@@ -9524,9 +9512,6 @@ exports[`ConfigProvider components Comment configProvider componentSize middle 1
     class="config-comment-inner"
   >
     <div
-      class="config-comment-avatar"
-    />
-    <div
       class="config-comment-content"
     >
       <div
@@ -9548,9 +9533,6 @@ exports[`ConfigProvider components Comment configProvider componentSize middle 1
       <div
         class="config-comment-inner"
       >
-        <div
-          class="config-comment-avatar"
-        />
         <div
           class="config-comment-content"
         >
@@ -9577,9 +9559,6 @@ exports[`ConfigProvider components Comment normal 1`] = `
     class="ant-comment-inner"
   >
     <div
-      class="ant-comment-avatar"
-    />
-    <div
       class="ant-comment-content"
     >
       <div
@@ -9601,9 +9580,6 @@ exports[`ConfigProvider components Comment normal 1`] = `
       <div
         class="ant-comment-inner"
       >
-        <div
-          class="ant-comment-avatar"
-        />
         <div
           class="ant-comment-content"
         >
@@ -9630,9 +9606,6 @@ exports[`ConfigProvider components Comment prefixCls 1`] = `
     class="prefix-Comment-inner"
   >
     <div
-      class="prefix-Comment-avatar"
-    />
-    <div
       class="prefix-Comment-content"
     >
       <div
@@ -9654,9 +9627,6 @@ exports[`ConfigProvider components Comment prefixCls 1`] = `
       <div
         class="prefix-Comment-inner"
       >
-        <div
-          class="prefix-Comment-avatar"
-        />
         <div
           class="prefix-Comment-content"
         >


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

Closes: #23986

### 💡 Background and solution

When avatar prop of Comment not present, it will render an empty wrapper div with css class "ant-comment-avatar" which is hold style `margin-right: 12px;`,  so `12px` blank space left there to broken the page style.

So, this PR just remove this `empty wrapper div` as render nothing when avatar not provide.

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      [Comment] render nothing when avatar not present    |
| 🇨🇳 Chinese |     [Comment] 当 `avatar` 为空时，不再渲染空白的包装div，避免影响页面样式      |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️ 

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
