### PR TITLE
docs: Update react-dnd Table example docs

### DIFF
--- a/components/table/demo/drag-sorting.md
+++ b/components/table/demo/drag-sorting.md
@@ -19,7 +19,7 @@ import { DndProvider, useDrag, useDrop } from 'react-dnd';
 import HTML5Backend from 'react-dnd-html5-backend';
 import update from 'immutability-helper';
 
-const type = 'DragbleBodyRow';
+const type = 'DragableBodyRow';
 
 const DragableBodyRow = ({ index, moveRow, className, style, ...restProps }) => {
   const ref = React.useRef();


### PR DESCRIPTION
### 🤔 This is a ...
- [x] Site / document update

### 💡 Background and solution

The documentation for the react-dnd `Table` example had a typo.


-----
[View rendered components/table/demo/drag-sorting.md](https://github.com/jenvanc/ant-design/blob/jv/fix-docs-typo/components/table/demo/drag-sorting.md)