### PR TITLE
fix(#16659): support className and style for message

### DIFF
--- a/components/message/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/message/__tests__/__snapshots__/demo.test.js.snap
@@ -1,5 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`renders ./components/message/demo/custom-style.md correctly 1`] = `
+<button
+  class="ant-btn"
+  type="button"
+>
+  <span>
+    Customized style
+  </span>
+</button>
+`;
+
 exports[`renders ./components/message/demo/duration.md correctly 1`] = `
 <button
   class="ant-btn"

--- a/components/message/demo/custom-style.md
+++ b/components/message/demo/custom-style.md
@@ -1,0 +1,30 @@
+---
+order: 6
+title:
+  zh-CN: 自定义样式
+  en-US: Customized style
+---
+
+## zh-CN
+
+使用 style 和 className 来定义样式。
+
+## en-US
+
+The style and className are available to customize Message.
+
+```jsx
+import { message, Button } from 'antd';
+
+const success = () => {
+  message.success({
+    content: 'This is a prompt message with custom className and style',
+    className: 'custom-class',
+    style: {
+      marginTop: '50%',
+    },
+  });
+};
+
+ReactDOM.render(<Button onClick={success}>Customized style</Button>, mountNode);
+```

--- a/components/message/index.en-US.md
+++ b/components/message/index.en-US.md
@@ -55,6 +55,8 @@ The properties of config are as follows:
 | onClose | Specify a function that will be called when the message is closed | function | - |
 | icon | Customized Icon | ReactNode | - |
 | key | The unique identifier of the Message | string\|number | - |
+| className | Customized CSS class | string | - |
+| style | Customized inline style | [React.CSSProperties](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/e434515761b36830c3e58a970abf5186f005adac/types/react/index.d.ts#L794) | - |
 
 ### Global static methods
 

--- a/components/message/index.tsx
+++ b/components/message/index.tsx
@@ -60,6 +60,8 @@ export interface ArgsProps {
   onClose?: () => void;
   icon?: React.ReactNode;
   key?: string | number;
+  style?: React.CSSProperties;
+  className?: string;
 }
 
 const iconMap = {
@@ -91,7 +93,8 @@ function notice(args: ArgsProps): MessageType {
       instance.notice({
         key: target,
         duration,
-        style: {},
+        style: args.style || {},
+        className: args.className,
         content: (
           <div className={messageClass}>
             {args.icon || (IconComponent && <IconComponent />)}

--- a/components/message/index.zh-CN.md
+++ b/components/message/index.zh-CN.md
@@ -49,13 +49,15 @@ title: Message
 
 `config` 对象属性如下：
 
-| 参数     | 说明                                          | 类型           | 默认值 |
-| -------- | --------------------------------------------- | -------------- | ------ |
-| content  | 提示内容                                      | ReactNode      | -      |
-| duration | 自动关闭的延时，单位秒。设为 0 时不自动关闭。 | number         | 3      |
-| onClose  | 关闭时触发的回调函数                          | Function       | -      |
-| icon     | 自定义图标                                    | ReactNode      | -      |
-| key      | 当前提示的唯一标志                            | string\|number | -      |
+| 参数 | 说明 | 类型 | 默认值 |
+| --- | --- | --- | --- |
+| content | 提示内容 | ReactNode | - |
+| duration | 自动关闭的延时，单位秒。设为 0 时不自动关闭。 | number | 3 |
+| onClose | 关闭时触发的回调函数 | Function | - |
+| icon | 自定义图标 | ReactNode | - |
+| key | 当前提示的唯一标志 | string\|number | - |
+| className | 自定义 CSS class | string | - |
+| style | 自定义内联样式 | [React.CSSProperties](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/e434515761b36830c3e58a970abf5186f005adac/types/react/index.d.ts#L794) | - |
 
 ### 全局方法
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [x] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

[#16659](https://github.com/ant-design/ant-design/issues/16659) 

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Support customize Message with `className` and `style`       |
| 🇨🇳 Chinese |     全局消息支持自定义样式通过使用`className`和`style`     |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️ 

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/message/demo/custom-style.md](https://github.com/Kermit-Xuan/ant-design/blob/message-custom-style/components/message/demo/custom-style.md)
[View rendered components/message/index.en-US.md](https://github.com/Kermit-Xuan/ant-design/blob/message-custom-style/components/message/index.en-US.md)
[View rendered components/message/index.zh-CN.md](https://github.com/Kermit-Xuan/ant-design/blob/message-custom-style/components/message/index.zh-CN.md)