### PR TITLE
fix: en_GB does not mean global english

### DIFF
--- a/docs/react/i18n.en-US.md
+++ b/docs/react/i18n.en-US.md
@@ -26,60 +26,60 @@ Note: `fr_FR` is the filename, follow below.
 
 Supported languages:
 
-| Language              | Filename |
-| --------------------- | -------- |
-| Arabic                | ar_EG    |
-| Azerbaijani           | az_AZ    |
-| Bulgarian             | bg_BG    |
-| Catalan               | ca_ES    |
-| Czech                 | cs_CZ    |
-| Danish                | da_DK    |
-| German                | de_DE    |
-| Greek                 | el_GR    |
-| English (Global)      | en_GB    |
-| English               | en_US    |
-| Spanish               | es_ES    |
-| Estonian              | et_EE    |
-| Persian               | fa_IR    |
-| Finnish               | fi_FI    |
-| French (Belgium)      | fr_BE    |
-| French (France)       | fr_FR    |
-| Hebrew                | he_IL    |
-| Hindi                 | hi_IN    |
-| Croatian              | hr_HR    |
-| Hungarian             | hu_HU    |
-| Armenian              | hy_AM    |
-| Indonesian            | id_ID    |
-| Italian               | it_IT    |
-| Icelandic             | is_IS    |
-| Japanese              | ja_JP    |
-| Kurdish (Iraq)        | ku_IQ    |
-| Kannada               | kn_IN    |
-| Korean                | ko_KR    |
-| Latvian               | lv_LV    |
-| Macedonian            | mk_MK    |
-| Mongolian             | mn_MN    |
-| Malay (Malaysia)      | ms_MY    |
-| Norwegian             | nb_NO    |
-| Nepal                 | ne_NP    |
-| Dutch (Belgium)       | nl_BE    |
-| Dutch                 | nl_NL    |
-| Polish                | pl_PL    |
-| Portuguese (Brazil)   | pt_BR    |
-| Portuguese            | pt_PT    |
-| Romanian              | ro_RO    |
-| Russian               | ru_RU    |
-| Slovak                | sk_SK    |
-| Serbian               | sr_RS    |
-| Slovenian             | sl_SI    |
-| Swedish               | sv_SE    |
-| Tamil                 | ta_IN    |
-| Thai                  | th_TH    |
-| Turkish               | tr_TR    |
-| Ukrainian             | uk_UA    |
-| Vietnamese            | vi_VN    |
-| Chinese (Simplified)  | zh_CN    |
-| Chinese (Traditional) | zh_TW    |
+| Language                 | Filename |
+| ------------------------ | -------- |
+| Arabic                   | ar_EG    |
+| Azerbaijani              | az_AZ    |
+| Bulgarian                | bg_BG    |
+| Catalan                  | ca_ES    |
+| Czech                    | cs_CZ    |
+| Danish                   | da_DK    |
+| German                   | de_DE    |
+| Greek                    | el_GR    |
+| English (United Kingdom) | en_GB    |
+| English                  | en_US    |
+| Spanish                  | es_ES    |
+| Estonian                 | et_EE    |
+| Persian                  | fa_IR    |
+| Finnish                  | fi_FI    |
+| French (Belgium)         | fr_BE    |
+| French (France)          | fr_FR    |
+| Hebrew                   | he_IL    |
+| Hindi                    | hi_IN    |
+| Croatian                 | hr_HR    |
+| Hungarian                | hu_HU    |
+| Armenian                 | hy_AM    |
+| Indonesian               | id_ID    |
+| Italian                  | it_IT    |
+| Icelandic                | is_IS    |
+| Japanese                 | ja_JP    |
+| Kurdish (Iraq)           | ku_IQ    |
+| Kannada                  | kn_IN    |
+| Korean                   | ko_KR    |
+| Latvian                  | lv_LV    |
+| Macedonian               | mk_MK    |
+| Mongolian                | mn_MN    |
+| Malay (Malaysia)         | ms_MY    |
+| Norwegian                | nb_NO    |
+| Nepal                    | ne_NP    |
+| Dutch (Belgium)          | nl_BE    |
+| Dutch                    | nl_NL    |
+| Polish                   | pl_PL    |
+| Portuguese (Brazil)      | pt_BR    |
+| Portuguese               | pt_PT    |
+| Romanian                 | ro_RO    |
+| Russian                  | ru_RU    |
+| Slovak                   | sk_SK    |
+| Serbian                  | sr_RS    |
+| Slovenian                | sl_SI    |
+| Swedish                  | sv_SE    |
+| Tamil                    | ta_IN    |
+| Thai                     | th_TH    |
+| Turkish                  | tr_TR    |
+| Ukrainian                | uk_UA    |
+| Vietnamese               | vi_VN    |
+| Chinese (Simplified)     | zh_CN    |
+| Chinese (Traditional)    | zh_TW    |
 
 See usage and ways to contribute a new locale package at [ConfigProvider](/components/config-provider).
 


### PR DESCRIPTION

### 🤔 This is a ...
- [x] Bug fix

### 🔗 Related issue link

### 💡 Background and solution

GB in en_GB means Great Britain. but most time people would call it United Kingdom English.


-----
[View rendered docs/react/i18n.en-US.md](https://github.com/rinick/ant-design/blob/patch-3/docs/react/i18n.en-US.md)