### PR TITLE
fix: Switch - no correct animation on the IOS/Chrome

### DIFF
--- a/components/switch/style/index.less
+++ b/components/switch/style/index.less
@@ -103,8 +103,8 @@
       height: @switch-sm-height - 4px;
     }
 
-    &:active::before,
-    &:active::after {
+    &:not(.@{switch-prefix-cls}-loading):active::before,
+    &:not(.@{switch-prefix-cls}-loading):active::after {
       width: 16px;
     }
   }
@@ -118,6 +118,12 @@
     .@{switch-prefix-cls}-inner {
       margin-right: 18px;
       margin-left: 3px;
+    }
+    &::after {
+      left: @switch-sm-min-width - (@switch-sm-height - 2px);
+    }
+    &:not(.@{switch-prefix-cls}-disabled):active::after {
+      left: 2px;
     }
   }
 
@@ -141,9 +147,11 @@
     }
 
     &::after {
-      left: 100%;
+      left: @switch-min-width - (@switch-height - 2px);
       margin-left: -1px;
-      transform: translateX(-100%);
+    }
+    &:not(.@{switch-prefix-cls}-disabled):active::after {
+      left: @switch-min-width - (@switch-height + 4px);
     }
   }
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

fix #24087
fix #19915
<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

1. The animation does not work correctly on the IOS in the Chrome browser
Step to reproduce:
- Open page
- Collapse browser tab
- Create new tab
- Open previous tab
- Animations not worked

2. GIF
![](https://user-images.githubusercontent.com/35931860/81672128-5efba280-9452-11ea-9dab-65eaee992062.gif)

3. Solution
Do not use relative units (`%`)
I use calculated values ​​from LESS variables

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Switch shake in safari and iOS Chrome. |
| 🇨🇳 Chinese | 修复 Switch 在 safari 和 iOS Chrome 上点击时错位的问题。 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️ 

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
