### PR TITLE
fix: Picker disabled today

### DIFF
--- a/components/date-picker/__tests__/__snapshots__/DatePicker.test.js.snap
+++ b/components/date-picker/__tests__/__snapshots__/DatePicker.test.js.snap
@@ -587,7 +587,8 @@ Array [
             class="ant-picker-footer"
           >
             <a
-              class="ant-picker-today-btn"
+              aria-disabled="true"
+              class="ant-picker-today-btn ant-picker-today-btn-disabled"
             >
               Today
             </a>

--- a/components/date-picker/style/panel.less
+++ b/components/date-picker/style/panel.less
@@ -436,6 +436,11 @@
     &:active {
       color: @link-active-color;
     }
+
+    &&-disabled {
+      color: @disabled-color;
+      cursor: not-allowed;
+    }
   }
 
   // ========================================================

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "rc-menu": "~8.1.0",
     "rc-notification": "~4.3.0",
     "rc-pagination": "~2.2.0",
-    "rc-picker": "~1.4.0",
+    "rc-picker": "~1.4.16",
     "rc-progress": "~3.0.0",
     "rc-rate": "~2.6.0",
     "rc-resize-observer": "^0.2.0",


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Perfermance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

fix #24178

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Fix DatePicker with `showToday` not work with `disabledDate`.        |
| 🇨🇳 Chinese |     修复 DatePicker `disabledDate` 不会作用到 `showToday` 上的问题。       |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
