### PR TITLE
fix: Upload.Dragger triggered by label when disabled

### DIFF
--- a/components/upload/Dragger.tsx
+++ b/components/upload/Dragger.tsx
@@ -9,7 +9,7 @@ export type DraggerProps = UploadProps & { height?: number };
 // eslint-disable-next-line react/prefer-stateless-function
 export default class Dragger extends React.Component<DraggerProps, any> {
   render() {
-    const { props } = this;
-    return <Upload {...props} type="drag" style={{ ...props.style, height: props.height }} />;
+    const { style, height, ...restProps } = this.props;
+    return <Upload {...restProps} type="drag" style={{ ...style, height }} />;
   }
 }

--- a/components/upload/Upload.tsx
+++ b/components/upload/Upload.tsx
@@ -299,6 +299,14 @@ class Upload extends React.Component<UploadProps, UploadState> {
     delete rcUploadProps.className;
     delete rcUploadProps.style;
 
+    // Remove id to avoid open by label when trigger is hidden
+    // !children: https://github.com/ant-design/ant-design/issues/14298
+    // disabled: https://github.com/ant-design/ant-design/issues/16478
+    //           https://github.com/ant-design/ant-design/issues/24197
+    if (!children || disabled) {
+      delete rcUploadProps.id;
+    }
+
     const uploadList = showUploadList ? (
       <LocaleReceiver componentName="Upload" defaultLocale={defaultLocale.Upload}>
         {this.renderUploadList}
@@ -341,13 +349,6 @@ class Upload extends React.Component<UploadProps, UploadState> {
       [`${prefixCls}-disabled`]: disabled,
       [`${prefixCls}-rtl`]: direction === 'rtl',
     });
-
-    // Remove id to avoid open by label when trigger is hidden
-    // https://github.com/ant-design/ant-design/issues/14298
-    // https://github.com/ant-design/ant-design/issues/16478
-    if (!children || disabled) {
-      delete rcUploadProps.id;
-    }
 
     const uploadButton = (
       <div className={uploadButtonCls} style={children ? undefined : { display: 'none' }}>

--- a/components/upload/__tests__/upload.test.js
+++ b/components/upload/__tests__/upload.test.js
@@ -219,13 +219,31 @@ describe('Upload', () => {
   });
 
   // https://github.com/ant-design/ant-design/issues/16478
-  it('should not have id if upload is disabled, avoid being triggered by label', () => {
+  it('should not have id if Upload is disabled, avoid being triggered by label', () => {
     const Demo = ({ disabled }) => (
       <Form>
         <Form.Item name="upload" label="Upload" valuePropName="fileList">
           <Upload disabled={disabled}>
             <div>upload</div>
           </Upload>
+        </Form.Item>
+      </Form>
+    );
+
+    const wrapper = mount(<Demo />);
+    expect(wrapper.find('input#upload').length).toBe(1);
+    wrapper.setProps({ disabled: true });
+    expect(wrapper.find('input#upload').length).toBe(0);
+  });
+
+  // https://github.com/ant-design/ant-design/issues/24197
+  it('should not have id if upload.Dragger is disabled, avoid being triggered by label', () => {
+    const Demo = ({ disabled }) => (
+      <Form>
+        <Form.Item name="upload" label="Upload" valuePropName="fileList">
+          <Upload.Dragger disabled={disabled}>
+            <div>upload</div>
+          </Upload.Dragger>
         </Form.Item>
       </Form>
     );


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Perfermance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close #24197

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->
#16483 didn't handle Upload.Dragger.

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Avoid disabled Upload.Dragger being triggered by clicking Form `label`.  |
| 🇨🇳 Chinese | 修复 Upload.Dragger 禁用时依然会被 Form `label` 触发的问题。 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
