### PR TITLE
docs: 🚀 Release 3.26.17

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -15,6 +15,15 @@ timeline: true
 
 ---
 
+## 3.26.17
+
+`2020-05-16`
+
+- 🐞 Avoid disabled Upload.Dragger being triggered by clicking Form `label`. [#24202](https://github.com/ant-design/ant-design/pull/24202)
+- 🐞 Fix Tabs cannot be displayed in Safair. [#23151](https://github.com/ant-design/ant-design/pull/23151)
+- 🐞 Fix Form.Item control icon shaking when `hasFeedback` is not set. [#23924](https://github.com/ant-design/ant-design/pull/23924)
+- 🐞 Fix `loading` Button using Badge style. [#23691](https://github.com/ant-design/ant-design/pull/23691)
+
 ## 3.26.16
 
 `2020-04-26`

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -15,6 +15,15 @@ timeline: true
 
 ---
 
+## 3.26.17
+
+`2020-05-16`
+
+- 🐞 修复 Upload.Dragger 禁用时依然会被 Form `label` 触发的问题。[#24202](https://github.com/ant-design/ant-design/pull/24202)
+- 🐞 修复 Tabs 开启动画时 Safair 下无法显示的问题。[#23151](https://github.com/ant-design/ant-design/pull/23151)
+- 🐞 修复 Form.Item 不设置 `hasFeedback` 时校验图标闪动问题。[#23924](https://github.com/ant-design/ant-design/pull/23924)
+- 🐞 修复 `loading` Button 使用 Badge 时的样式问题。[#23691](https://github.com/ant-design/ant-design/pull/23691)
+
 ## 3.26.16
 
 `2020-04-26`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "antd",
-  "version": "3.26.16",
+  "version": "3.26.17",
   "description": "An enterprise-class UI design language and React components implementation",
   "keywords": [
     "ant",


### PR DESCRIPTION
- 🐞 Avoid disabled Upload.Dragger being triggered by clicking Form `label`. [#24202](https://github.com/ant-design/ant-design/pull/24202)
- 🐞 Fix Tabs cannot be displayed in Safair. [#23151](https://github.com/ant-design/ant-design/pull/23151)
- 🐞 Fix Form.Item control icon shaking when `hasFeedback` is not set. [#23924](https://github.com/ant-design/ant-design/pull/23924)
- 🐞 Fix `loading` Button using Badge style. [#23691](https://github.com/ant-design/ant-design/pull/23691)

---

- 🐞 修复 Upload.Dragger 禁用时依然会被 Form `label` 触发的问题。[#24202](https://github.com/ant-design/ant-design/pull/24202)
- 🐞 修复 Tabs 开启动画时 Safair 下无法显示的问题。[#23151](https://github.com/ant-design/ant-design/pull/23151)
- 🐞 修复 Form.Item 不设置 `hasFeedback` 时校验图标闪动问题。[#23924](https://github.com/ant-design/ant-design/pull/23924)
- 🐞 修复 `loading` Button 使用 Badge 时的样式问题。[#23691](https://github.com/ant-design/ant-design/pull/23691)

-----
[View rendered CHANGELOG.en-US.md](https://github.com/ant-design/ant-design/blob/changelog-3.26.17/CHANGELOG.en-US.md)
[View rendered CHANGELOG.zh-CN.md](https://github.com/ant-design/ant-design/blob/changelog-3.26.17/CHANGELOG.zh-CN.md)