### PR TITLE
fix: empty in cascader/select/table/treeSelect

### DIFF
--- a/components/cascader/__tests__/__snapshots__/index.test.js.snap
+++ b/components/cascader/__tests__/__snapshots__/index.test.js.snap
@@ -608,7 +608,7 @@ exports[`Cascader have a notFoundContent that fit trigger input width 1`] = `
         class="ant-cascader-menu"
       >
         <li
-          class="ant-cascader-menu-item ant-cascader-menu-item-disabled"
+          class="ant-cascader-menu-item"
           role="menuitem"
           title=""
         >
@@ -1493,7 +1493,7 @@ exports[`Cascader should render not found content 1`] = `
       ],
     }
   }
-  className=""
+  className="ant-cascader-menu-empty"
   destroyPopupOnHide={false}
   getClassNameFromAlign={[Function]}
   getRootDomNode={[Function]}
@@ -1552,7 +1552,7 @@ exports[`Cascader should render not found content 1`] = `
           target={[Function]}
         >
           <PopupInner
-            className="ant-cascader-menus"
+            className="ant-cascader-menus ant-cascader-menu-empty"
             hiddenClassName="ant-cascader-menus-hidden"
             onMouseDown={[Function]}
             onTouchStart={[Function]}
@@ -1566,7 +1566,7 @@ exports[`Cascader should render not found content 1`] = `
             visible={true}
           >
             <div
-              className="ant-cascader-menus"
+              className="ant-cascader-menus ant-cascader-menu-empty"
               onMouseDown={[Function]}
               onTouchStart={[Function]}
               style={
@@ -1687,7 +1687,7 @@ exports[`Cascader should render not found content 1`] = `
                     },
                   ]
                 }
-                popupClassName=""
+                popupClassName="ant-cascader-menu-empty"
                 popupPlacement="bottomLeft"
                 popupVisible={true}
                 prefixCls="ant-cascader"
@@ -1808,7 +1808,7 @@ exports[`Cascader should show not found content when options.length is 0 1`] = `
       ],
     }
   }
-  className=""
+  className="ant-cascader-menu-empty"
   destroyPopupOnHide={false}
   getClassNameFromAlign={[Function]}
   getRootDomNode={[Function]}
@@ -1867,7 +1867,7 @@ exports[`Cascader should show not found content when options.length is 0 1`] = `
           target={[Function]}
         >
           <PopupInner
-            className="ant-cascader-menus"
+            className="ant-cascader-menus ant-cascader-menu-empty"
             hiddenClassName="ant-cascader-menus-hidden"
             onMouseDown={[Function]}
             onTouchStart={[Function]}
@@ -1881,7 +1881,7 @@ exports[`Cascader should show not found content when options.length is 0 1`] = `
             visible={true}
           >
             <div
-              className="ant-cascader-menus"
+              className="ant-cascader-menus ant-cascader-menu-empty"
               onMouseDown={[Function]}
               onTouchStart={[Function]}
               style={
@@ -1988,7 +1988,6 @@ exports[`Cascader should show not found content when options.length is 0 1`] = `
                 options={
                   Array [
                     Object {
-                      "disabled": true,
                       "label": <Context.Consumer>
                         [Function]
                       </Context.Consumer>,
@@ -1996,7 +1995,7 @@ exports[`Cascader should show not found content when options.length is 0 1`] = `
                     },
                   ]
                 }
-                popupClassName=""
+                popupClassName="ant-cascader-menu-empty"
                 popupPlacement="bottomLeft"
                 popupVisible={true}
                 prefixCls="ant-cascader"
@@ -2011,7 +2010,7 @@ exports[`Cascader should show not found content when options.length is 0 1`] = `
                     style={Object {}}
                   >
                     <li
-                      className="ant-cascader-menu-item ant-cascader-menu-item-disabled"
+                      className="ant-cascader-menu-item"
                       key="ANT_CASCADER_NOT_FOUND"
                       onClick={[Function]}
                       onDoubleClick={[Function]}

--- a/components/cascader/index.tsx
+++ b/components/cascader/index.tsx
@@ -535,7 +535,6 @@ class Cascader extends React.Component<CascaderProps, CascaderState> {
             {
               [names.label]: notFoundContent || renderEmpty('Cascader'),
               [names.value]: 'ANT_CASCADER_NOT_FOUND',
-              disabled: true,
             },
           ];
         }
@@ -610,8 +609,10 @@ class Cascader extends React.Component<CascaderProps, CascaderState> {
 
         const getPopupContainer = props.getPopupContainer || getContextPopupContainer;
         const rest = omit(props, ['inputIcon', 'expandIcon', 'loadingIcon', 'bordered']);
-        const rcCascaderRtlPopupClassName = classNames(popupClassName, {
+        const rcCascaderPopupClassName = classNames(popupClassName, {
           [`${prefixCls}-menu-${direction}`]: direction === 'rtl',
+          [`${prefixCls}-menu-empty`]:
+            options.length === 1 && options[0].value === 'ANT_CASCADER_NOT_FOUND',
         });
         return (
           <RcCascader
@@ -626,7 +627,7 @@ class Cascader extends React.Component<CascaderProps, CascaderState> {
             dropdownMenuColumnStyle={dropdownMenuColumnStyle}
             expandIcon={expandIcon}
             loadingIcon={loadingIcon}
-            popupClassName={rcCascaderRtlPopupClassName}
+            popupClassName={rcCascaderPopupClassName}
             popupPlacement={this.getPopupPlacement(direction)}
           >
             {input}

--- a/components/cascader/style/index.less
+++ b/components/cascader/style/index.less
@@ -204,6 +204,11 @@
         background: transparent;
       }
     }
+    .@{cascader-prefix-cls}-menu-empty & {
+      color: @disabled-color;
+      cursor: default;
+      pointer-events: none;
+    }
     &-active:not(&-disabled) {
       &,
       &:hover {

--- a/components/config-provider/__tests__/__snapshots__/components.test.js.snap
+++ b/components/config-provider/__tests__/__snapshots__/components.test.js.snap
@@ -19481,7 +19481,7 @@ exports[`ConfigProvider components Table configProvider 1`] = `
       class="config-spin-container"
     >
       <div
-        class="config-table"
+        class="config-table config-table-empty"
       >
         <div
           class="config-table-container"
@@ -19755,7 +19755,7 @@ exports[`ConfigProvider components Table configProvider componentSize large 1`] 
       class="config-spin-container"
     >
       <div
-        class="config-table"
+        class="config-table config-table-empty"
       >
         <div
           class="config-table-container"
@@ -20029,7 +20029,7 @@ exports[`ConfigProvider components Table configProvider componentSize middle 1`]
       class="config-spin-container"
     >
       <div
-        class="config-table config-table-middle"
+        class="config-table config-table-middle config-table-empty"
       >
         <div
           class="config-table-container"
@@ -20303,7 +20303,7 @@ exports[`ConfigProvider components Table normal 1`] = `
       class="ant-spin-container"
     >
       <div
-        class="ant-table"
+        class="ant-table ant-table-empty"
       >
         <div
           class="ant-table-container"
@@ -20577,7 +20577,7 @@ exports[`ConfigProvider components Table prefixCls 1`] = `
       class="ant-spin-container"
     >
       <div
-        class="prefix-Table"
+        class="prefix-Table prefix-Table-empty"
       >
         <div
           class="prefix-Table-container"

--- a/components/empty/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/empty/__tests__/__snapshots__/demo.test.js.snap
@@ -510,7 +510,7 @@ exports[`renders ./components/empty/demo/config-provider.md correctly 1`] = `
           class="ant-spin-container"
         >
           <div
-            class="ant-table"
+            class="ant-table ant-table-empty"
           >
             <div
               class="ant-table-container"

--- a/components/select/style/index.less
+++ b/components/select/style/index.less
@@ -198,6 +198,10 @@
     &-hidden {
       display: none;
     }
+
+    &-empty {
+      color: @disabled-color;
+    }
   }
 
   // ========================= Options =========================
@@ -214,6 +218,7 @@
 
   &-item-empty {
     .item();
+    color: @disabled-color;
   }
 
   &-item {

--- a/components/table/Table.tsx
+++ b/components/table/Table.tsx
@@ -459,6 +459,7 @@ function Table<RecordType extends object = any>(props: TableProps<RecordType>) {
             [`${prefixCls}-middle`]: mergedSize === 'middle',
             [`${prefixCls}-small`]: mergedSize === 'small',
             [`${prefixCls}-bordered`]: bordered,
+            [`${prefixCls}-empty`]: rawData.length === 0,
           })}
           data={pageData}
           rowKey={getRowKey}

--- a/components/table/__tests__/__snapshots__/Table.test.js.snap
+++ b/components/table/__tests__/__snapshots__/Table.test.js.snap
@@ -117,7 +117,7 @@ exports[`Table rtl render component should be rendered correctly in RTL directio
       class="ant-spin-container"
     >
       <div
-        class="ant-table ant-table-rtl"
+        class="ant-table ant-table-empty ant-table-rtl"
       >
         <div
           class="ant-table-container"

--- a/components/table/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/table/__tests__/__snapshots__/demo.test.js.snap
@@ -11,7 +11,7 @@ exports[`renders ./components/table/demo/ajax.md correctly 1`] = `
       class="ant-spin-container"
     >
       <div
-        class="ant-table"
+        class="ant-table ant-table-empty"
       >
         <div
           class="ant-table-container"

--- a/components/table/__tests__/__snapshots__/empty.test.js.snap
+++ b/components/table/__tests__/__snapshots__/empty.test.js.snap
@@ -11,7 +11,7 @@ exports[`Table renders empty table 1`] = `
       class="ant-spin-container"
     >
       <div
-        class="ant-table"
+        class="ant-table ant-table-empty"
       >
         <div
           class="ant-table-container"
@@ -148,7 +148,7 @@ exports[`Table renders empty table with custom emptyText 1`] = `
       class="ant-spin-container"
     >
       <div
-        class="ant-table"
+        class="ant-table ant-table-empty"
       >
         <div
           class="ant-table-container"
@@ -240,7 +240,7 @@ exports[`Table renders empty table with fixed columns 1`] = `
       class="ant-spin-container"
     >
       <div
-        class="ant-table ant-table-fixed-column ant-table-scroll-horizontal ant-table-has-fix-left ant-table-has-fix-right"
+        class="ant-table ant-table-empty ant-table-fixed-column ant-table-scroll-horizontal ant-table-has-fix-left ant-table-has-fix-right"
       >
         <div
           class="ant-table-container"
@@ -480,7 +480,7 @@ exports[`Table renders empty table without emptyText when loading 1`] = `
       class="ant-spin-container ant-spin-blur"
     >
       <div
-        class="ant-table"
+        class="ant-table ant-table-empty"
       >
         <div
           class="ant-table-container"

--- a/components/table/style/index.less
+++ b/components/table/style/index.less
@@ -494,6 +494,9 @@
   // ========================= Placeholder ==========================
   &-tbody > tr&-placeholder {
     text-align: center;
+    .@{table-prefix-cls}-empty & {
+      color: @disabled-color;
+    }
     &:hover {
       > td {
         background: @component-background;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Perfermance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
close https://github.com/ant-design/ant-design/issues/24276
<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |Fix Cascader/Select/Table/TresSelect text color when data empty           |
| 🇨🇳 Chinese |修复 Cascader/Select/Table/TreeSelect 空数据时字体的颜色           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
