### PR TITLE
fix: Drawer cover other elements when closed

### DIFF
--- a/components/drawer/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/drawer/__tests__/__snapshots__/demo.test.js.snap
@@ -57,6 +57,17 @@ exports[`renders ./components/drawer/demo/multi-level-drawer.md correctly 1`] = 
 </button>
 `;
 
+exports[`renders ./components/drawer/demo/no-mask.md correctly 1`] = `
+<button
+  class="ant-btn ant-btn-primary"
+  type="button"
+>
+  <span>
+    Open
+  </span>
+</button>
+`;
+
 exports[`renders ./components/drawer/demo/placement.md correctly 1`] = `
 <div
   class="ant-space ant-space-horizontal ant-space-align-center"

--- a/components/drawer/demo/basic-right.md
+++ b/components/drawer/demo/basic-right.md
@@ -13,51 +13,43 @@ title:
 
 Basic drawer.
 
-```jsx
+```tsx
+import React, { useState } from 'react';
 import { Drawer, Button } from 'antd';
 
-class App extends React.Component {
-  state = { visible: false };
-
-  showDrawer = () => {
-    this.setState({
-      visible: true,
-    });
+const App: React.FC = () => {
+  const [visible, setVisible] = useState(false);
+  const showDrawer = () => {
+    setVisible(true);
   };
-
-  onClose = () => {
-    this.setState({
-      visible: false,
-    });
+  const onClose = () => {
+    setVisible(false);
   };
-
-  render() {
-    return (
-      <>
-        <Button type="primary" onClick={this.showDrawer}>
-          Open
-        </Button>
-        <Drawer
-          title="Basic Drawer"
-          placement="right"
-          closable={false}
-          onClose={this.onClose}
-          visible={this.state.visible}
-        >
-          <p>Some contents...</p>
-          <p>Some contents...</p>
-          <p>Some contents...</p>
-        </Drawer>
-      </>
-    );
-  }
-}
+  return (
+    <>
+      <Button type="primary" onClick={showDrawer}>
+        Open
+      </Button>
+      <Drawer
+        title="Basic Drawer"
+        placement="right"
+        closable={false}
+        onClose={onClose}
+        visible={visible}
+      >
+        <p>Some contents...</p>
+        <p>Some contents...</p>
+        <p>Some contents...</p>
+      </Drawer>
+    </>
+  );
+};
 
 ReactDOM.render(<App />, mountNode);
 ```
 
-```css
+<style>
 [data-theme='compact'] .ant-drawer-body p {
-  margin-bottom: 0px;
+  margin-bottom: 0;
 }
-```
+</style>

--- a/components/drawer/demo/no-mask.md
+++ b/components/drawer/demo/no-mask.md
@@ -1,0 +1,50 @@
+---
+order: 99
+title:
+  zh-CN: 无遮罩
+  en-US: No mask
+debug: true
+---
+
+## zh-CN
+
+通过 `mask={false}` 去掉遮罩。
+
+## en-US
+
+Remove mask.
+
+```tsx
+import React, { useState } from 'react';
+import { Drawer, Button } from 'antd';
+
+const App: React.FC = () => {
+  const [visible, setVisible] = useState(false);
+  const showDrawer = () => {
+    setVisible(true);
+  };
+  const onClose = () => {
+    setVisible(false);
+  };
+  return (
+    <>
+      <Button type="primary" onClick={showDrawer}>
+        Open
+      </Button>
+      <Drawer
+        title="Drawer without mask"
+        placement="right"
+        mask={false}
+        onClose={onClose}
+        visible={visible}
+      >
+        <p>Some contents...</p>
+        <p>Some contents...</p>
+        <p>Some contents...</p>
+      </Drawer>
+    </>
+  );
+};
+
+ReactDOM.render(<App />, mountNode);
+```

--- a/components/drawer/demo/placement.md
+++ b/components/drawer/demo/placement.md
@@ -16,8 +16,6 @@ The Drawer can appear from any edge of the screen.
 ```jsx
 import { Drawer, Button, Radio, Space } from 'antd';
 
-const RadioGroup = Radio.Group;
-
 class App extends React.Component {
   state = { visible: false, placement: 'left' };
 
@@ -44,12 +42,12 @@ class App extends React.Component {
     return (
       <>
         <Space>
-          <RadioGroup defaultValue={placement} onChange={this.onChange}>
+          <Radio.Group defaultValue={placement} onChange={this.onChange}>
             <Radio value="top">top</Radio>
             <Radio value="right">right</Radio>
             <Radio value="bottom">bottom</Radio>
             <Radio value="left">left</Radio>
-          </RadioGroup>
+          </Radio.Group>
           <Button type="primary" onClick={this.showDrawer}>
             Open
           </Button>

--- a/components/drawer/index.tsx
+++ b/components/drawer/index.tsx
@@ -137,7 +137,11 @@ class Drawer extends React.Component<DrawerProps & ConfigConsumerProps, IDrawerS
   };
 
   getOffsetStyle() {
-    const { placement, width, height } = this.props;
+    const { placement, width, height, visible, mask } = this.props;
+    // https://github.com/ant-design/ant-design/issues/24287
+    if (!visible && !mask) {
+      return {};
+    }
     const offsetStyle: any = {};
     if (placement === 'left' || placement === 'right') {
       offsetStyle.width = width;


### PR DESCRIPTION


<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Perfermance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close #24287

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fix Drawer cover background elements when it is not visible. |
| 🇨🇳 Chinese | 修复 Drawer 关闭后依然会遮挡页面元素的问题。  |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/drawer/demo/basic-right.md](https://github.com/ant-design/ant-design/blob/fix-drawer/components/drawer/demo/basic-right.md)