### PR TITLE
fix: Table selection cache

### DIFF
--- a/components/table/__tests__/Table.rowSelection.test.js
+++ b/components/table/__tests__/Table.rowSelection.test.js
@@ -798,7 +798,7 @@ describe('Table.rowSelection', () => {
     expect(onChange.mock.calls[0][1]).toEqual([expect.objectContaining({ name: 'bamboo' })]);
   });
 
-  it.only('do not cache selected keys', () => {
+  it('do not cache selected keys', () => {
     const onChange = jest.fn();
     const wrapper = mount(
       <Table

--- a/components/table/__tests__/Table.rowSelection.test.js
+++ b/components/table/__tests__/Table.rowSelection.test.js
@@ -797,4 +797,28 @@ describe('Table.rowSelection', () => {
       .simulate('change', { target: { checked: true } });
     expect(onChange.mock.calls[0][1]).toEqual([expect.objectContaining({ name: 'bamboo' })]);
   });
+
+  it.only('do not cache selected keys', () => {
+    const onChange = jest.fn();
+    const wrapper = mount(
+      <Table
+        dataSource={[{ name: 'light' }, { name: 'bamboo' }]}
+        rowSelection={{ onChange }}
+        rowKey="name"
+      />,
+    );
+
+    wrapper
+      .find('tbody input')
+      .first()
+      .simulate('change', { target: { checked: true } });
+    expect(onChange).toHaveBeenCalledWith(['light'], [{ name: 'light' }]);
+
+    wrapper.setProps({ dataSource: [{ name: 'bamboo' }] });
+    wrapper
+      .find('tbody input')
+      .first()
+      .simulate('change', { target: { checked: true } });
+    expect(onChange).toHaveBeenCalledWith(['bamboo'], [{ name: 'bamboo' }]);
+  });
 });

--- a/components/table/hooks/useSelection.tsx
+++ b/components/table/hooks/useSelection.tsx
@@ -117,12 +117,21 @@ export default function useSelection<RecordType>(
 
   const setSelectedKeys = React.useCallback(
     (keys: Key[]) => {
-      setInnerSelectedKeys(keys);
+      const availableKeys: Key[] = [];
+      const records: RecordType[] = [];
 
-      const records = keys.map(key => getRecordByKey(key));
+      keys.forEach(key => {
+        const record = getRecordByKey(key);
+        if (record !== undefined) {
+          availableKeys.push(key);
+          records.push(record);
+        }
+      });
+
+      setInnerSelectedKeys(availableKeys);
 
       if (onSelectionChange) {
-        onSelectionChange(keys, records);
+        onSelectionChange(availableKeys, records);
       }
     },
     [setInnerSelectedKeys, getRecordByKey, onSelectionChange],


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Perfermance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

resolve #24336

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Fix Table `rowSelection.onChange` return removed records by `dataSource`.       |
| 🇨🇳 Chinese |   修复 Table 在 `dataSource` 移除条目时，`rowSelection.onChange` 任然会缓存的问题。         |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
