### PR TITLE
feat: add avatar gap api

### DIFF
--- a/components/avatar/__tests__/Avatar.test.js
+++ b/components/avatar/__tests__/Avatar.test.js
@@ -40,19 +40,10 @@ describe('Avatar Render', () => {
     global.document.body.appendChild(div);
 
     const wrapper = mount(<Avatar src="http://error.url">Fallback</Avatar>, { attachTo: div });
-    wrapper.instance().setScale = jest.fn(() => {
-      if (wrapper.state().scale === 0.5) {
-        return;
-      }
-      wrapper.instance().setState({ scale: 0.5 });
-    });
     wrapper.find('img').simulate('error');
-
     const children = wrapper.find('.ant-avatar-string');
     expect(children.length).toBe(1);
     expect(children.text()).toBe('Fallback');
-    expect(wrapper.instance().setScale).toHaveBeenCalled();
-    expect(div.querySelector('.ant-avatar-string').style.transform).toContain('scale(0.5)');
 
     wrapper.detach();
     global.document.body.removeChild(div);
@@ -134,6 +125,11 @@ describe('Avatar Render', () => {
     });
     wrapper.setProps({ children: 'xx' });
     expect(wrapper.state().scale).toBe(0.32);
+  });
+
+  it('should calculate scale of avatar children correctly with gap', () => {
+    const wrapper = mount(<Avatar gap={2}>Avatar</Avatar>);
+    expect(wrapper.state().scale).toBe(0.36);
   });
 
   it('should warning when pass a string as icon props', () => {

--- a/components/avatar/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/avatar/__tests__/__snapshots__/demo.test.js.snap
@@ -439,6 +439,7 @@ exports[`renders ./components/avatar/demo/dynamic.md correctly 1`] = `
 <div>
   <span
     class="ant-avatar ant-avatar-lg ant-avatar-circle"
+    gap="4"
     style="background-color:#f56a00;vertical-align:middle"
   >
     <span
@@ -454,7 +455,16 @@ exports[`renders ./components/avatar/demo/dynamic.md correctly 1`] = `
     type="button"
   >
     <span>
-      Change
+      ChangeUser
+    </span>
+  </button>
+  <button
+    class="ant-btn ant-btn-sm"
+    style="vertical-align:middle"
+    type="button"
+  >
+    <span>
+      changeGap
     </span>
   </button>
 </div>

--- a/components/avatar/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/avatar/__tests__/__snapshots__/demo.test.js.snap
@@ -439,7 +439,6 @@ exports[`renders ./components/avatar/demo/dynamic.md correctly 1`] = `
 <div>
   <span
     class="ant-avatar ant-avatar-lg ant-avatar-circle"
-    gap="4"
     style="background-color:#f56a00;vertical-align:middle"
   >
     <span

--- a/components/avatar/demo/dynamic.md
+++ b/components/avatar/demo/dynamic.md
@@ -7,11 +7,11 @@ title:
 
 ## zh-CN
 
-对于字符型的头像，当字符串较长时，字体大小可以根据头像宽度自动调整。
+对于字符型的头像，当字符串较长时，字体大小可以根据头像宽度自动调整。也可使用 `gap` 来设置字符距离左右两侧边界间隙。
 
 ## en-US
 
-For letter type Avatar, when the letters are too long to display, the font size can be automatically adjusted according to the width of the Avatar.
+For letter type Avatar, when the letters are too long to display, the font size can be automatically adjusted according to the width of the Avatar. You can also use `gap` to set the distance between left and right sides.
 
 ```tsx
 import React, { useState } from 'react';

--- a/components/avatar/demo/dynamic.md
+++ b/components/avatar/demo/dynamic.md
@@ -19,18 +19,24 @@ import { Avatar, Button } from 'antd';
 
 const UserList = ['U', 'Lucy', 'Tom', 'Edward'];
 const ColorList = ['#f56a00', '#7265e6', '#ffbf00', '#00a2ae'];
+const GapList = [4, 3, 2, 1];
 
 const Autoset: React.FC = () => {
   const [user, setUser] = useState(UserList[0]);
   const [color, setColor] = useState(ColorList[0]);
+  const [gap, setGap] = useState(GapList[0]);
   const changeUser = () => {
     const index = UserList.indexOf(user);
     setUser(index < UserList.length - 1 ? UserList[index + 1] : UserList[0]);
     setColor(index < ColorList.length - 1 ? ColorList[index + 1] : ColorList[0]);
   };
+  const changeGap = () => {
+    const index = GapList.indexOf(gap);
+    setGap(index < GapList.length - 1 ? GapList[index + 1] : GapList[0]);
+  };
   return (
     <div>
-      <Avatar style={{ backgroundColor: color, verticalAlign: 'middle' }} size="large">
+      <Avatar style={{ backgroundColor: color, verticalAlign: 'middle' }} size="large" gap={gap}>
         {user}
       </Avatar>
       <Button
@@ -38,7 +44,10 @@ const Autoset: React.FC = () => {
         style={{ margin: '0 16px', verticalAlign: 'middle' }}
         onClick={changeUser}
       >
-        Change
+        ChangeUser
+      </Button>
+      <Button size="small" style={{ verticalAlign: 'middle' }} onClick={changeGap}>
+        changeGap
       </Button>
     </div>
   );

--- a/components/avatar/demo/dynamic.md
+++ b/components/avatar/demo/dynamic.md
@@ -7,11 +7,11 @@ title:
 
 ## zh-CN
 
-对于字符型的头像，当字符串较长时，字体大小可以根据头像宽度自动调整。也可使用 `gap` 来设置字符距离左右两侧边界间隙。
+对于字符型的头像，当字符串较长时，字体大小可以根据头像宽度自动调整。也可使用 `gap` 来设置字符距离左右两侧边界单位像素。
 
 ## en-US
 
-For letter type Avatar, when the letters are too long to display, the font size can be automatically adjusted according to the width of the Avatar. You can also use `gap` to set the distance between left and right sides.
+For letter type Avatar, when the letters are too long to display, the font size can be automatically adjusted according to the width of the Avatar. You can also use `gap` to set the unit distance between left and right sides.
 
 ```tsx
 import React, { useState } from 'react';

--- a/components/avatar/index.en-US.md
+++ b/components/avatar/index.en-US.md
@@ -17,3 +17,4 @@ Avatars can be used to represent people or objects. It supports images, `Icon`s,
 | srcSet | a list of sources to use for different screen resolutions | string | - |  |
 | alt | This attribute defines the alternative text describing the image | string | - |  |
 | onError | handler when img load error, return false to prevent default fallback behavior | () => boolean | - |  |
+| gap | Letter type distance between left and right sides | number | 4 | 4.3.0 |

--- a/components/avatar/index.en-US.md
+++ b/components/avatar/index.en-US.md
@@ -17,4 +17,4 @@ Avatars can be used to represent people or objects. It supports images, `Icon`s,
 | srcSet | a list of sources to use for different screen resolutions | string | - |  |
 | alt | This attribute defines the alternative text describing the image | string | - |  |
 | onError | handler when img load error, return false to prevent default fallback behavior | () => boolean | - |  |
-| gap | Letter type distance between left and right sides | number | 4 | 4.3.0 |
+| gap | Letter type unit distance between left and right sides | number | 4 | 4.3.0 |

--- a/components/avatar/index.tsx
+++ b/components/avatar/index.tsx
@@ -12,6 +12,7 @@ export interface AvatarProps {
    * or a custom number size
    * */
   size?: 'large' | 'small' | 'default' | number;
+  gap?: number;
   /** Src of image avatar */
   src?: string;
   /** Srcset of image avatar */
@@ -55,15 +56,19 @@ export default class Avatar extends React.Component<AvatarProps, AvatarState> {
 
   private lastNodeWidth: number;
 
+  private lastGap: number;
+
   componentDidMount() {
     this.setScale();
     this.setState({ mounted: true });
   }
 
   componentDidUpdate(prevProps: AvatarProps) {
-    this.setScale();
     if (prevProps.src !== this.props.src) {
       this.setState({ isImgExist: true, scale: 1 });
+    }
+    if (prevProps.children !== this.props.children || prevProps.gap !== this.props.gap) {
+      this.setScale();
     }
   }
 
@@ -73,20 +78,26 @@ export default class Avatar extends React.Component<AvatarProps, AvatarState> {
     }
     const childrenWidth = this.avatarChildren.offsetWidth; // offsetWidth avoid affecting be transform scale
     const nodeWidth = this.avatarNode.offsetWidth;
+    const { gap = 4 } = this.props;
     // denominator is 0 is no meaning
     if (
-      childrenWidth === 0 ||
-      nodeWidth === 0 ||
-      (this.lastChildrenWidth === childrenWidth && this.lastNodeWidth === nodeWidth)
+      childrenWidth !== 0 &&
+      nodeWidth !== 0 &&
+      (this.lastChildrenWidth !== childrenWidth || this.lastNodeWidth !== nodeWidth)
     ) {
-      return;
+      this.lastChildrenWidth = childrenWidth;
+      this.lastNodeWidth = nodeWidth;
     }
-    this.lastChildrenWidth = childrenWidth;
-    this.lastNodeWidth = nodeWidth;
-    // add 4px gap for each side to get better performance
-    this.setState({
-      scale: nodeWidth - 8 < childrenWidth ? (nodeWidth - 8) / childrenWidth : 1,
-    });
+
+    if (this.lastGap !== gap) {
+      this.lastGap = gap;
+    }
+
+    if (gap * 2 < nodeWidth) {
+      this.setState({
+        scale: nodeWidth - gap * 2 < childrenWidth ? (nodeWidth - gap * 2) / childrenWidth : 1,
+      });
+    }
   };
 
   handleImgLoadError = () => {

--- a/components/avatar/index.tsx
+++ b/components/avatar/index.tsx
@@ -210,7 +210,6 @@ export default class Avatar extends React.Component<AvatarProps, AvatarState> {
     }
     return (
       <span
-        {...others}
         style={{ ...sizeStyle, ...others.style }}
         className={classString}
         ref={(node: HTMLElement) => (this.avatarNode = node)}

--- a/components/avatar/index.tsx
+++ b/components/avatar/index.tsx
@@ -56,8 +56,6 @@ export default class Avatar extends React.Component<AvatarProps, AvatarState> {
 
   private lastNodeWidth: number;
 
-  private lastGap: number;
-
   componentDidMount() {
     this.setScale();
     this.setState({ mounted: true });
@@ -87,10 +85,6 @@ export default class Avatar extends React.Component<AvatarProps, AvatarState> {
     ) {
       this.lastChildrenWidth = childrenWidth;
       this.lastNodeWidth = nodeWidth;
-    }
-
-    if (this.lastGap !== gap) {
-      this.lastGap = gap;
     }
 
     if (gap * 2 < nodeWidth) {

--- a/components/avatar/index.zh-CN.md
+++ b/components/avatar/index.zh-CN.md
@@ -22,4 +22,4 @@ title: Avatar
 | srcSet | 设置图片类头像响应式资源地址 | string | - |  |
 | alt | 图像无法显示时的替代文本 | string | - |  |
 | onError | 图片加载失败的事件，返回 false 会关闭组件默认的 fallback 行为 | () => boolean | - |  |
-| gap | 字符类型距离左右边界间隙 | number | 4 | 4.3.0 |
+| gap | 字符类型距离左右两侧边界间隙 | number | 4 | 4.3.0 |

--- a/components/avatar/index.zh-CN.md
+++ b/components/avatar/index.zh-CN.md
@@ -22,3 +22,4 @@ title: Avatar
 | srcSet | 设置图片类头像响应式资源地址 | string | - |  |
 | alt | 图像无法显示时的替代文本 | string | - |  |
 | onError | 图片加载失败的事件，返回 false 会关闭组件默认的 fallback 行为 | () => boolean | - |  |
+| gap | 字符类型距离左右边界间隙 | number | 4 | 4.3.0 |

--- a/components/avatar/index.zh-CN.md
+++ b/components/avatar/index.zh-CN.md
@@ -22,4 +22,4 @@ title: Avatar
 | srcSet | 设置图片类头像响应式资源地址 | string | - |  |
 | alt | 图像无法显示时的替代文本 | string | - |  |
 | onError | 图片加载失败的事件，返回 false 会关闭组件默认的 fallback 行为 | () => boolean | - |  |
-| gap | 字符类型距离左右两侧边界间隙 | number | 4 | 4.3.0 |
+| gap | 字符类型距离左右两侧边界单位像素 | number | 4 | 4.3.0 |


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Perfermance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution
https://github.com/ant-design/ant-design/pull/24330#issuecomment-631851588

#### Demo show

![2020-05-21 18 03 29](https://user-images.githubusercontent.com/29775873/82548822-865b1980-9b8e-11ea-9fa8-323eb81deb87.gif)

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |Avatar add new api `gap` to set the unit distance between left and right sides.           |
| 🇨🇳 Chinese | Avatar 新增 `gap` 来设置字符类型距离左右两侧边界单位像素。           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/avatar/demo/dynamic.md](https://github.com/ant-design/ant-design/blob/add-avatar-sizePadding/components/avatar/demo/dynamic.md)
[View rendered components/avatar/index.en-US.md](https://github.com/ant-design/ant-design/blob/add-avatar-sizePadding/components/avatar/index.en-US.md)
[View rendered components/avatar/index.zh-CN.md](https://github.com/ant-design/ant-design/blob/add-avatar-sizePadding/components/avatar/index.zh-CN.md)