### PR TITLE
fix: paramter type error

### DIFF
--- a/components/tree/Tree.tsx
+++ b/components/tree/Tree.tsx
@@ -41,7 +41,7 @@ export interface AntTreeNodeProps {
   selected?: boolean;
   selectable?: boolean;
   icon?: ((treeNode: AntdTreeNodeAttribute) => React.ReactNode) | React.ReactNode;
-  children?: React.ReactNode;
+  children?: React.ReactNode[];
   [customProp: string]: any;
 }
 

--- a/components/tree/Tree.tsx
+++ b/components/tree/Tree.tsx
@@ -41,7 +41,7 @@ export interface AntTreeNodeProps {
   selected?: boolean;
   selectable?: boolean;
   icon?: ((treeNode: AntdTreeNodeAttribute) => React.ReactNode) | React.ReactNode;
-  children?: React.ReactNode[];
+  children?: React.ReactElement[];
   [customProp: string]: any;
 }
 

--- a/components/tree/__tests__/type.test.tsx
+++ b/components/tree/__tests__/type.test.tsx
@@ -1,0 +1,13 @@
+/* eslint-disable */
+import * as React from 'react';
+import { AntTreeNodeProps } from '../Tree';
+
+describe('Tree TypeScript Test', async () => {
+  it('AntTreeNodeProps', () => {
+    const tree: AntTreeNodeProps = {
+      children: [React.createElement('h1')],
+    };
+
+    expect(tree).toBeTruthy();
+  });
+});


### PR DESCRIPTION
[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Perfermance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
fix #22040

### 💡 Background and solution
Here is a object type not a array type?
Before I make this fix,it will get:
![image](https://user-images.githubusercontent.com/32598811/82752705-7e031880-9df2-11ea-8d6e-dea931c696e7.png)
In https://3x.ant.design/components/tree/#components-tree-demo-draggable Will get some type error warning: `(info.node.props.children || []).length > 0`


### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
