### PR TITLE
style: preventing parent components changing steps component text align property.

### DIFF
--- a/components/steps/style/index.less
+++ b/components/steps/style/index.less
@@ -26,6 +26,7 @@
   display: flex;
   width: 100%;
   font-size: 0;
+  text-align: initial;
 }
 
 .@{steps-prefix-cls}-item {


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [X] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Perfermance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
close #24484

### 💡 Background and solution

Setting text-align anywhere above the dom tree causes problematic view on steps component.

![image](https://user-images.githubusercontent.com/34946061/82933912-5a2b0880-9f93-11ea-9e44-3902fa04d60b.png)

Setting align to inital will solve the issue.

`.ant-steps{
text-align: initial;
}`
### 📝 Changelog

There is no risk of implementing this style change.

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |       X    |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [X] Doc is updated/provided or not needed
- [X] Demo is updated/provided or not needed
- [X] TypeScript definition is updated/provided or not needed
- [X] Changelog is provided or not needed
