### PR TITLE
fix: Avatar.onError() event is triggered twice

### DIFF
--- a/components/avatar/index.tsx
+++ b/components/avatar/index.tsx
@@ -197,6 +197,11 @@ export default class Avatar extends React.Component<AvatarProps, AvatarState> {
         );
       }
     }
+
+    // The event is triggered twice from bubbling up the DOM tree.
+    // see https://codesandbox.io/s/kind-snow-9lidz
+    delete others.onError;
+
     return (
       <span
         {...others}


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Perfermance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

None

### 💡 Background and solution

The event is triggered twice from bubbling up the DOM tree.
Demo: [https://codesandbox.io/s/kind-snow-9lidz](https://codesandbox.io/s/kind-snow-9lidz)

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Avatar.onError() event is triggered twice  |
| 🇨🇳 Chinese | Avatar.onError() 事件会触发两次 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
