### PR TITLE
fix: cascader expand icon disacled color

### DIFF
--- a/components/cascader/style/index.less
+++ b/components/cascader/style/index.less
@@ -228,6 +228,10 @@
       position: absolute;
       right: @control-padding-horizontal;
       color: @text-color-secondary;
+
+      .@{cascader-prefix-cls}-menu-item-disabled& {
+        color: @disabled-color;
+      }
     }
 
     & &-keyword {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Perfermance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

#### Before
![image](https://user-images.githubusercontent.com/29775873/83090575-a711fa80-a0cb-11ea-9bfd-9f805f9d5635.png)

#### After
![image](https://user-images.githubusercontent.com/29775873/83090592-b2fdbc80-a0cb-11ea-9215-e16a9d801af6.png)

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fix Cascader expand icon color when disabled.          |
| 🇨🇳 Chinese | 修复 Cascader 下拉框中扩展按钮在禁用时的颜色。          |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
