### PR TITLE
fix: Form flex inline style

### DIFF
--- a/components/form/style/index.less
+++ b/components/form/style/index.less
@@ -71,7 +71,7 @@
   // ==============================================================
   &-label {
     display: inline-block;
-    flex: none;
+    flex-grow: 0;
     overflow: hidden;
     white-space: nowrap;
     text-align: right;

--- a/components/form/style/inline.less
+++ b/components/form/style/inline.less
@@ -20,6 +20,10 @@
       vertical-align: top;
     }
 
+    > .@{form-item-prefix-cls}-label {
+      flex: none;
+    }
+
     .@{form-prefix-cls}-text {
       display: inline-block;
     }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Perfermance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

resolve #24523
patch for #24128

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Fix Form.Item inline label collapsed when in narrow space.        |
| 🇨🇳 Chinese |  修复 Form.Item 内联样式下 label 在狭窄空间被挤压的问题。        |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
