### PR TITLE
fix: Progress steps didn't change when update percent

### DIFF
--- a/components/progress/Steps.tsx
+++ b/components/progress/Steps.tsx
@@ -4,6 +4,7 @@ import { ProgressProps, ProgressSize } from './progress';
 interface StepsProps extends ProgressProps {
   steps: number;
   size?: ProgressSize;
+  strokeColor?: string;
 }
 
 const Steps: React.FC<StepsProps> = props => {
@@ -13,14 +14,10 @@ const Steps: React.FC<StepsProps> = props => {
     const stepWidth = size === 'small' ? 2 : 14;
     const styleSteps = [];
     for (let i = 0; i < steps; i++) {
-      let color;
-      if (i <= current - 1) {
-        color = strokeColor;
-      }
       const stepStyle = {
-        backgroundColor: color,
-        width: `${stepWidth}px`,
-        height: `${strokeWidth}px`,
+        backgroundColor: i <= current - 1 ? strokeColor : undefined,
+        width: stepWidth,
+        height: strokeWidth,
       };
       styleSteps.push(<div key={i} className={`${prefixCls}-steps-item`} style={stepStyle} />);
     }

--- a/components/progress/Steps.tsx
+++ b/components/progress/Steps.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import classNames from 'classnames';
 import { ProgressProps, ProgressSize } from './progress';
 
 interface StepsProps extends ProgressProps {
@@ -9,23 +10,27 @@ interface StepsProps extends ProgressProps {
 
 const Steps: React.FC<StepsProps> = props => {
   const { size, steps, percent = 0, strokeWidth = 8, strokeColor, prefixCls, children } = props;
-  const getStyledSteps = () => {
-    const current = Math.floor(steps * (percent / 100));
-    const stepWidth = size === 'small' ? 2 : 14;
-    const styleSteps = [];
-    for (let i = 0; i < steps; i++) {
-      const stepStyle = {
-        backgroundColor: i <= current - 1 ? strokeColor : undefined,
-        width: stepWidth,
-        height: strokeWidth,
-      };
-      styleSteps.push(<div key={i} className={`${prefixCls}-steps-item`} style={stepStyle} />);
-    }
-    return styleSteps;
-  };
+  const current = Math.floor(steps * (percent / 100));
+  const stepWidth = size === 'small' ? 2 : 14;
+  const styledSteps = [];
+  for (let i = 0; i < steps; i += 1) {
+    styledSteps.push(
+      <div
+        key={i}
+        className={classNames(`${prefixCls}-steps-item`, {
+          [`${prefixCls}-steps-item-active`]: i <= current - 1,
+        })}
+        style={{
+          backgroundColor: i <= current - 1 ? strokeColor : undefined,
+          width: stepWidth,
+          height: strokeWidth,
+        }}
+      />,
+    );
+  }
   return (
     <div className={`${prefixCls}-steps-outer`}>
-      {getStyledSteps()}
+      {styledSteps}
       {children}
     </div>
   );

--- a/components/progress/Steps.tsx
+++ b/components/progress/Steps.tsx
@@ -18,7 +18,7 @@ const Steps: React.FC<StepsProps> = props => {
         color = strokeColor;
       }
       const stepStyle = {
-        backgroundColor: `${color}`,
+        ...(color !== undefined && { backgroundColor: `${color}` }),
         width: `${stepWidth}px`,
         height: `${strokeWidth}px`,
       };

--- a/components/progress/Steps.tsx
+++ b/components/progress/Steps.tsx
@@ -18,7 +18,7 @@ const Steps: React.FC<StepsProps> = props => {
         color = strokeColor;
       }
       const stepStyle = {
-        ...(color !== undefined && { backgroundColor: `${color}` }),
+        backgroundColor: color,
         width: `${stepWidth}px`,
         height: `${strokeWidth}px`,
       };

--- a/components/progress/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/progress/__tests__/__snapshots__/demo.test.js.snap
@@ -1429,11 +1429,11 @@ Array [
       />
       <div
         class="ant-progress-steps-item"
-        style="background-color:undefined;width:14px;height:8px"
+        style="width:14px;height:8px"
       />
       <div
         class="ant-progress-steps-item"
-        style="background-color:undefined;width:14px;height:8px"
+        style="width:14px;height:8px"
       />
       <span
         class="ant-progress-text"
@@ -1456,19 +1456,19 @@ Array [
       />
       <div
         class="ant-progress-steps-item"
-        style="background-color:undefined;width:14px;height:8px"
+        style="width:14px;height:8px"
       />
       <div
         class="ant-progress-steps-item"
-        style="background-color:undefined;width:14px;height:8px"
+        style="width:14px;height:8px"
       />
       <div
         class="ant-progress-steps-item"
-        style="background-color:undefined;width:14px;height:8px"
+        style="width:14px;height:8px"
       />
       <div
         class="ant-progress-steps-item"
-        style="background-color:undefined;width:14px;height:8px"
+        style="width:14px;height:8px"
       />
       <span
         class="ant-progress-text"

--- a/components/progress/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/progress/__tests__/__snapshots__/demo.test.js.snap
@@ -1424,8 +1424,8 @@ Array [
       class="ant-progress-steps-outer"
     >
       <div
-        class="ant-progress-steps-item"
-        style="background-color:#1890ff;width:14px;height:8px"
+        class="ant-progress-steps-item ant-progress-steps-item-active"
+        style="width:14px;height:8px"
       />
       <div
         class="ant-progress-steps-item"
@@ -1451,8 +1451,8 @@ Array [
       class="ant-progress-steps-outer"
     >
       <div
-        class="ant-progress-steps-item"
-        style="background-color:#1890ff;width:14px;height:8px"
+        class="ant-progress-steps-item ant-progress-steps-item-active"
+        style="width:14px;height:8px"
       />
       <div
         class="ant-progress-steps-item"
@@ -1486,24 +1486,24 @@ Array [
       class="ant-progress-steps-outer"
     >
       <div
-        class="ant-progress-steps-item"
-        style="background-color:#1890ff;width:2px;height:8px"
+        class="ant-progress-steps-item ant-progress-steps-item-active"
+        style="background-color:#52c41a;width:2px;height:8px"
       />
       <div
-        class="ant-progress-steps-item"
-        style="background-color:#1890ff;width:2px;height:8px"
+        class="ant-progress-steps-item ant-progress-steps-item-active"
+        style="background-color:#52c41a;width:2px;height:8px"
       />
       <div
-        class="ant-progress-steps-item"
-        style="background-color:#1890ff;width:2px;height:8px"
+        class="ant-progress-steps-item ant-progress-steps-item-active"
+        style="background-color:#52c41a;width:2px;height:8px"
       />
       <div
-        class="ant-progress-steps-item"
-        style="background-color:#1890ff;width:2px;height:8px"
+        class="ant-progress-steps-item ant-progress-steps-item-active"
+        style="background-color:#52c41a;width:2px;height:8px"
       />
       <div
-        class="ant-progress-steps-item"
-        style="background-color:#1890ff;width:2px;height:8px"
+        class="ant-progress-steps-item ant-progress-steps-item-active"
+        style="background-color:#52c41a;width:2px;height:8px"
       />
       <span
         class="ant-progress-text"

--- a/components/progress/__tests__/__snapshots__/index.test.js.snap
+++ b/components/progress/__tests__/__snapshots__/index.test.js.snap
@@ -560,15 +560,15 @@ exports[`Progress should support steps 1`] = `
   >
     <div
       class="ant-progress-steps-item"
-      style="background-color:undefined;width:14px;height:8px"
+      style="width:14px;height:8px"
     />
     <div
       class="ant-progress-steps-item"
-      style="background-color:undefined;width:14px;height:8px"
+      style="width:14px;height:8px"
     />
     <div
       class="ant-progress-steps-item"
-      style="background-color:undefined;width:14px;height:8px"
+      style="width:14px;height:8px"
     />
     <span
       class="ant-progress-text"

--- a/components/progress/__tests__/index.test.js
+++ b/components/progress/__tests__/index.test.js
@@ -138,4 +138,25 @@ describe('Progress', () => {
     const wrapper = mount(<Progress steps={3} />);
     expect(wrapper).toMatchRenderedSnapshot();
   });
+
+  it('steps should be changable', () => {
+    const wrapper = mount(<Progress steps={5} percent={60} />);
+    expect(wrapper.find('.ant-progress-steps-item-active').length).toBe(3);
+    wrapper.setProps({ percent: 40 });
+    expect(wrapper.find('.ant-progress-steps-item-active').length).toBe(2);
+  });
+
+  it('steps should be changable when has strokeColor', () => {
+    const wrapper = mount(<Progress steps={5} percent={60} strokeColor="#1890ff" />);
+    expect(wrapper.find('.ant-progress-steps-item').at(0).getDOMNode().style.backgroundColor).toBe(
+      'rgb(24, 144, 255)',
+    );
+    wrapper.setProps({ percent: 40 });
+    expect(wrapper.find('.ant-progress-steps-item').at(2).getDOMNode().style.backgroundColor).toBe(
+      '',
+    );
+    expect(wrapper.find('.ant-progress-steps-item').at(1).getDOMNode().style.backgroundColor).toBe(
+      'rgb(24, 144, 255)',
+    );
+  });
 });

--- a/components/progress/demo/steps.md
+++ b/components/progress/demo/steps.md
@@ -18,11 +18,11 @@ import { Progress } from 'antd';
 
 ReactDOM.render(
   <>
-    <Progress percent={50} steps={3} strokeColor="#1890ff" />
+    <Progress percent={50} steps={3} />
     <br />
-    <Progress percent={30} steps={5} strokeColor="#1890ff" />
+    <Progress percent={30} steps={5} />
     <br />
-    <Progress percent={100} steps={5} size="small" strokeColor="#1890ff" />
+    <Progress percent={100} steps={5} size="small" strokeColor="#52c41a" />
   </>,
   mountNode,
 );

--- a/components/progress/progress.tsx
+++ b/components/progress/progress.tsx
@@ -99,6 +99,7 @@ export default class Progress extends React.Component<ProgressProps> {
       type,
       steps,
       showInfo,
+      strokeColor,
       ...restProps
     } = props;
     const prefixCls = getPrefixCls('progress', customizePrefixCls);
@@ -108,7 +109,12 @@ export default class Progress extends React.Component<ProgressProps> {
     // Render progress shape
     if (type === 'line') {
       progress = steps ? (
-        <Steps {...this.props} prefixCls={prefixCls} steps={steps}>
+        <Steps
+          {...this.props}
+          strokeColor={typeof strokeColor === 'string' ? strokeColor : undefined}
+          prefixCls={prefixCls}
+          steps={steps}
+        >
           {progressInfo}
         </Steps>
       ) : (

--- a/components/progress/style/index.less
+++ b/components/progress/style/index.less
@@ -27,6 +27,10 @@
       margin-right: 2px;
       background: @progress-steps-item-bg;
       transition: all 0.3s;
+
+      &-active {
+        color: @success-color;
+      }
     }
   }
 

--- a/components/progress/style/index.less
+++ b/components/progress/style/index.less
@@ -29,7 +29,7 @@
       transition: all 0.3s;
 
       &-active {
-        background: @success-color;
+        background: @info-color;
       }
     }
   }

--- a/components/progress/style/index.less
+++ b/components/progress/style/index.less
@@ -29,7 +29,7 @@
       transition: all 0.3s;
 
       &-active {
-        color: @success-color;
+        background: @success-color;
       }
     }
   }

--- a/components/progress/style/index.less
+++ b/components/progress/style/index.less
@@ -26,6 +26,7 @@
       min-width: 2px;
       margin-right: 2px;
       background: @progress-steps-item-bg;
+      transition: all 0.3s;
     }
   }
 

--- a/components/progress/style/index.less
+++ b/components/progress/style/index.less
@@ -29,7 +29,7 @@
       transition: all 0.3s;
 
       &-active {
-        background: @info-color;
+        background: @progress-default-color;
       }
     }
   }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Perfermance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
fix #24532 
<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

Previously `background-color` was being set to `undefined`.  I updated the Progress `Step` component so it just omits the property if the `color` variable is not set.

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Progress with `steps` don't update `percent` expectedly.  |
| 🇨🇳 Chinese | 修复步骤 Progress `percent` 样式未正确更新的问题。  |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
