### PR TITLE
fix: Password value still exists after blur it

### DIFF
--- a/components/input/Input.tsx
+++ b/components/input/Input.tsx
@@ -190,7 +190,7 @@ class Input extends React.Component<InputProps, InputState> {
 
   onFocus: React.FocusEventHandler<HTMLInputElement> = e => {
     const { onFocus } = this.props;
-    this.setState({ focused: true });
+    this.setState({ focused: true }, this.clearPasswordValueAttribute);
     if (onFocus) {
       onFocus(e);
     }
@@ -198,7 +198,7 @@ class Input extends React.Component<InputProps, InputState> {
 
   onBlur: React.FocusEventHandler<HTMLInputElement> = e => {
     const { onBlur } = this.props;
-    this.setState({ focused: false });
+    this.setState({ focused: false }, this.clearPasswordValueAttribute);
     if (onBlur) {
       onBlur(e);
     }

--- a/components/input/__tests__/Password.test.js
+++ b/components/input/__tests__/Password.test.js
@@ -70,6 +70,23 @@ describe('Input.Password', () => {
     expect(wrapper.find('input').at('0').getDOMNode().getAttribute('value')).toBeFalsy();
   });
 
+  // https://github.com/ant-design/ant-design/issues/24526
+  it('should not show value attribute in input element after blur it', async () => {
+    const wrapper = mount(<Input.Password />);
+    wrapper
+      .find('input')
+      .at('0')
+      .simulate('change', { target: { value: 'value' } });
+    await sleep();
+    expect(wrapper.find('input').at('0').getDOMNode().getAttribute('value')).toBeFalsy();
+    wrapper.find('input').at('0').simulate('blur');
+    await sleep();
+    expect(wrapper.find('input').at('0').getDOMNode().getAttribute('value')).toBeFalsy();
+    wrapper.find('input').at('0').simulate('focus');
+    await sleep();
+    expect(wrapper.find('input').at('0').getDOMNode().getAttribute('value')).toBeFalsy();
+  });
+
   // https://github.com/ant-design/ant-design/issues/20541
   it('could be unmount without errors', () => {
     expect(() => {


### PR DESCRIPTION


<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Perfermance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close #24526

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fix Input.Password still show `value` attribute in DOM after blur it. |
| 🇨🇳 Chinese | 修复 Input.Password 一个明文显示 `value` 的问题。 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
