### PR TITLE
feat: Extend Finnish locale by updating fi_FI.tsx

### DIFF
--- a/components/locale/fi_FI.tsx
+++ b/components/locale/fi_FI.tsx
@@ -42,6 +42,12 @@ const localeValues: Locale = {
   Empty: {
     description: 'Ei kohteita',
   },
+  Text: {
+    edit: 'Muokkaa',
+    copy: 'Kopioi',
+    copied: 'Kopioitu',
+    expand: 'Näytä lisää',
+  },
 };
 
 export default localeValues;


### PR DESCRIPTION
Added missing localization values for Finnish locale.

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Perfermance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [X] Other (about what?)

### 💡 Background and solution

Some localization values were missing from Finnish locale. For example tooltip text on a tooltip associated with the copyable paragraph icon was in English. This should fix it.

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [X] Doc is updated/provided or not needed
- [X] Demo is updated/provided or not needed
- [X] TypeScript definition is updated/provided or not needed
- [X] Changelog is provided or not needed
