### PR TITLE
test: npm run site

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,8 +1,0 @@
-ports:
-- port: 8001
-  onOpen: open-preview
-tasks:
-- before: >
-    export DEV_HOST=$(gp url 8001)
-  init: npm install
-  command: npm start


### PR DESCRIPTION
见鬼，本地 `npm run deploy` 到 gh-pages，官网会报错。

<img width="420" alt="image" src="https://user-images.githubusercontent.com/507615/83346199-f581fc00-a34c-11ea-8874-0f9e3b3fcea4.png">

下面的 preview 却是好的：https://preview-24611-ant-design.surge.sh