### PR TITLE
chore: disabled ESBUILD

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "pretty-quick": "pretty-quick",
     "pub": "npm run version && antd-tools run pub",
     "prepublishOnly": "antd-tools run guard",
-    "site": "cross-env NODE_ICU_DATA=node_modules/full-icu ESBUILD=1 concurrently \"bisheng build --ssr -c ./site/bisheng.config.js\" \"npm run color-less\"",
+    "site": "cross-env NODE_ICU_DATA=node_modules/full-icu concurrently \"bisheng build --ssr -c ./site/bisheng.config.js\" \"npm run color-less\"",
     "sort": "npx sort-package-json",
     "sort-api": "antd-tools run sort-api-table",
     "start": "antd-tools run clean && cross-env NODE_ENV=development concurrently \"npm run color-less\" \"bisheng start -c ./site/bisheng.config.js\"",


### PR DESCRIPTION
暂时先关掉 ESBUILD。

- ❌ 本地 `npm run deploy`
- ❌ github action 触发的部署服务。
- ✅ 构建预览服务。https://preview-24611-ant-design.surge.sh

---

报错内容

<img width="420" alt="image" src="https://user-images.githubusercontent.com/507615/83346199-f581fc00-a34c-11ea-8874-0f9e3b3fcea4.png">

详见：https://github.com/ant-design/ant-design/pull/24611