### PR TITLE
fix: #24519 Upload delete icon cannot be navigate via keyboard

### DIFF
--- a/components/config-provider/__tests__/__snapshots__/components.test.js.snap
+++ b/components/config-provider/__tests__/__snapshots__/components.test.js.snap
@@ -37627,15 +37627,16 @@ exports[`ConfigProvider components Upload configProvider 1`] = `
               <span
                 class="config-upload-list-item-card-actions "
               >
-                <a
+                <button
+                  class="config-btn config-upload-list-item-card-actions-btn config-btn-text config-btn-sm config-btn-icon-only"
                   title="Remove file"
+                  type="button"
                 >
                   <span
                     aria-label="delete"
                     class="anticon anticon-delete"
                     role="img"
                     tabindex="-1"
-                    title="Remove file"
                   >
                     <svg
                       aria-hidden="true"
@@ -37652,7 +37653,7 @@ exports[`ConfigProvider components Upload configProvider 1`] = `
                       />
                     </svg>
                   </span>
-                </a>
+                </button>
               </span>
             </span>
           </div>
@@ -37730,15 +37731,16 @@ exports[`ConfigProvider components Upload configProvider componentSize large 1`]
               <span
                 class="config-upload-list-item-card-actions "
               >
-                <a
+                <button
+                  class="config-btn config-upload-list-item-card-actions-btn config-btn-text config-btn-sm config-btn-icon-only"
                   title="Remove file"
+                  type="button"
                 >
                   <span
                     aria-label="delete"
                     class="anticon anticon-delete"
                     role="img"
                     tabindex="-1"
-                    title="Remove file"
                   >
                     <svg
                       aria-hidden="true"
@@ -37755,7 +37757,7 @@ exports[`ConfigProvider components Upload configProvider componentSize large 1`]
                       />
                     </svg>
                   </span>
-                </a>
+                </button>
               </span>
             </span>
           </div>
@@ -37833,15 +37835,16 @@ exports[`ConfigProvider components Upload configProvider componentSize middle 1`
               <span
                 class="config-upload-list-item-card-actions "
               >
-                <a
+                <button
+                  class="config-btn config-upload-list-item-card-actions-btn config-btn-text config-btn-sm config-btn-icon-only"
                   title="Remove file"
+                  type="button"
                 >
                   <span
                     aria-label="delete"
                     class="anticon anticon-delete"
                     role="img"
                     tabindex="-1"
-                    title="Remove file"
                   >
                     <svg
                       aria-hidden="true"
@@ -37858,7 +37861,7 @@ exports[`ConfigProvider components Upload configProvider componentSize middle 1`
                       />
                     </svg>
                   </span>
-                </a>
+                </button>
               </span>
             </span>
           </div>
@@ -37936,15 +37939,16 @@ exports[`ConfigProvider components Upload configProvider virtual and dropdownMat
               <span
                 class="ant-upload-list-item-card-actions "
               >
-                <a
+                <button
+                  class="ant-btn ant-upload-list-item-card-actions-btn ant-btn-text ant-btn-sm ant-btn-icon-only"
                   title="Remove file"
+                  type="button"
                 >
                   <span
                     aria-label="delete"
                     class="anticon anticon-delete"
                     role="img"
                     tabindex="-1"
-                    title="Remove file"
                   >
                     <svg
                       aria-hidden="true"
@@ -37961,7 +37965,7 @@ exports[`ConfigProvider components Upload configProvider virtual and dropdownMat
                       />
                     </svg>
                   </span>
-                </a>
+                </button>
               </span>
             </span>
           </div>
@@ -38039,15 +38043,16 @@ exports[`ConfigProvider components Upload normal 1`] = `
               <span
                 class="ant-upload-list-item-card-actions "
               >
-                <a
+                <button
+                  class="ant-btn ant-upload-list-item-card-actions-btn ant-btn-text ant-btn-sm ant-btn-icon-only"
                   title="Remove file"
+                  type="button"
                 >
                   <span
                     aria-label="delete"
                     class="anticon anticon-delete"
                     role="img"
                     tabindex="-1"
-                    title="Remove file"
                   >
                     <svg
                       aria-hidden="true"
@@ -38064,7 +38069,7 @@ exports[`ConfigProvider components Upload normal 1`] = `
                       />
                     </svg>
                   </span>
-                </a>
+                </button>
               </span>
             </span>
           </div>
@@ -38142,15 +38147,16 @@ exports[`ConfigProvider components Upload prefixCls 1`] = `
               <span
                 class="ant-upload-list-item-card-actions "
               >
-                <a
+                <button
+                  class="ant-btn ant-upload-list-item-card-actions-btn ant-btn-text ant-btn-sm ant-btn-icon-only"
                   title="Remove file"
+                  type="button"
                 >
                   <span
                     aria-label="delete"
                     class="anticon anticon-delete"
                     role="img"
                     tabindex="-1"
-                    title="Remove file"
                   >
                     <svg
                       aria-hidden="true"
@@ -38167,7 +38173,7 @@ exports[`ConfigProvider components Upload prefixCls 1`] = `
                       />
                     </svg>
                   </span>
-                </a>
+                </button>
               </span>
             </span>
           </div>

--- a/components/upload/UploadList.tsx
+++ b/components/upload/UploadList.tsx
@@ -9,12 +9,13 @@ import EyeOutlined from '@ant-design/icons/EyeOutlined';
 import DeleteOutlined from '@ant-design/icons/DeleteOutlined';
 import DownloadOutlined from '@ant-design/icons/DownloadOutlined';
 
+import { cloneElement, isValidElement } from '../_util/reactNode';
 import { UploadListProps, UploadFile, UploadListType } from './interface';
 import { previewImage, isImageUrl } from './utils';
 import Tooltip from '../tooltip';
 import Progress from '../progress';
 import { ConfigConsumer, ConfigConsumerProps } from '../config-provider';
-import { cloneElement, isValidElement } from '../_util/reactNode';
+import Button, { ButtonProps } from '../button';
 
 export default class UploadList extends React.Component<UploadListProps, any> {
   static defaultProps = {
@@ -98,23 +99,36 @@ export default class UploadList extends React.Component<UploadListProps, any> {
     return icon;
   };
 
-  handleActionIconRender = (customIcon: React.ReactNode, callback: () => void, title?: string) => {
+  handleActionIconRender = (
+    customIcon: React.ReactNode,
+    callback: () => void,
+    prefixCls: string,
+    title?: string,
+  ) => {
+    const btnProps: ButtonProps = {
+      type: 'text',
+      size: 'small',
+      title,
+      onClick: (e: React.MouseEvent<HTMLElement>) => {
+        callback();
+        if (isValidElement(customIcon) && customIcon.props.onClick) {
+          customIcon.props.onClick(e);
+        }
+      },
+      className: `${prefixCls}-list-item-card-actions-btn`,
+    };
     if (isValidElement(customIcon)) {
-      return cloneElement(customIcon, {
+      const btnIcon = cloneElement(customIcon, {
         ...customIcon.props,
-        title,
-        onClick: (e: React.MouseEvent<HTMLElement>) => {
-          callback();
-          if (customIcon.props.onClick) {
-            customIcon.props.onClick(e);
-          }
-        },
+        onClick: () => {},
       });
+
+      return <Button {...btnProps} icon={btnIcon} />;
     }
     return (
-      <span title={title} onClick={callback}>
-        {customIcon}
-      </span>
+      <Button {...btnProps}>
+        <span>{customIcon}</span>
+      </Button>
     );
   };
 
@@ -195,28 +209,21 @@ export default class UploadList extends React.Component<UploadListProps, any> {
         typeof file.linkProps === 'string' ? JSON.parse(file.linkProps) : file.linkProps;
 
       const removeIcon = showRemoveIcon
-        ? (customRemoveIcon &&
-            this.handleActionIconRender(
-              customRemoveIcon,
-              () => this.handleClose(file),
-              locale.removeFile,
-            )) || (
-            <DeleteOutlined title={locale.removeFile} onClick={() => this.handleClose(file)} />
+        ? this.handleActionIconRender(
+            customRemoveIcon || <DeleteOutlined />,
+            () => this.handleClose(file),
+            prefixCls,
+            locale.removeFile,
           )
         : null;
 
       const downloadIcon =
         showDownloadIcon && file.status === 'done'
-          ? (customDownloadIcon &&
-              this.handleActionIconRender(
-                customDownloadIcon,
-                () => this.handleDownload(file),
-                locale.downloadFile,
-              )) || (
-              <DownloadOutlined
-                title={locale.downloadFile}
-                onClick={() => this.handleDownload(file)}
-              />
+          ? this.handleActionIconRender(
+              customDownloadIcon || <DownloadOutlined />,
+              () => this.handleDownload(file),
+              prefixCls,
+              locale.downloadFile,
             )
           : null;
       const downloadOrDelete = listType !== 'picture-card' && (
@@ -226,8 +233,8 @@ export default class UploadList extends React.Component<UploadListProps, any> {
             listType === 'picture' ? 'picture' : ''
           }`}
         >
-          {downloadIcon && <a title={locale.downloadFile}>{downloadIcon}</a>}
-          {removeIcon && <a title={locale.removeFile}>{removeIcon}</a>}
+          {downloadIcon}
+          {removeIcon}
         </span>
       );
       const listItemNameClass = classNames({

--- a/components/upload/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/upload/__tests__/__snapshots__/demo.test.js.snap
@@ -177,28 +177,33 @@ exports[`renders ./components/upload/demo/crop-image.md correctly 1`] = `
                 </svg>
               </span>
             </a>
-            <span
-              aria-label="delete"
-              class="anticon anticon-delete"
-              role="img"
-              tabindex="-1"
+            <button
+              class="ant-btn ant-upload-list-item-card-actions-btn ant-btn-text ant-btn-sm ant-btn-icon-only"
               title="Remove file"
+              type="button"
             >
-              <svg
-                aria-hidden="true"
-                class=""
-                data-icon="delete"
-                fill="currentColor"
-                focusable="false"
-                height="1em"
-                viewBox="64 64 896 896"
-                width="1em"
+              <span
+                aria-label="delete"
+                class="anticon anticon-delete"
+                role="img"
+                tabindex="-1"
               >
-                <path
-                  d="M360 184h-8c4.4 0 8-3.6 8-8v8h304v-8c0 4.4 3.6 8 8 8h-8v72h72v-80c0-35.3-28.7-64-64-64H352c-35.3 0-64 28.7-64 64v80h72v-72zm504 72H160c-17.7 0-32 14.3-32 32v32c0 4.4 3.6 8 8 8h60.4l24.7 523c1.6 34.1 29.8 61 63.9 61h454c34.2 0 62.3-26.8 63.9-61l24.7-523H888c4.4 0 8-3.6 8-8v-32c0-17.7-14.3-32-32-32zM731.3 840H292.7l-24.2-512h487l-24.2 512z"
-                />
-              </svg>
-            </span>
+                <svg
+                  aria-hidden="true"
+                  class=""
+                  data-icon="delete"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M360 184h-8c4.4 0 8-3.6 8-8v8h304v-8c0 4.4 3.6 8 8 8h-8v72h72v-80c0-35.3-28.7-64-64-64H352c-35.3 0-64 28.7-64 64v80h72v-72zm504 72H160c-17.7 0-32 14.3-32 32v32c0 4.4 3.6 8 8 8h60.4l24.7 523c1.6 34.1 29.8 61 63.9 61h454c34.2 0 62.3-26.8 63.9-61l24.7-523H888c4.4 0 8-3.6 8-8v-32c0-17.7-14.3-32-32-32zM731.3 840H292.7l-24.2-512h487l-24.2 512z"
+                  />
+                </svg>
+              </span>
+            </button>
           </span>
         </div>
       </span>
@@ -373,15 +378,16 @@ exports[`renders ./components/upload/demo/defaultFileList.md correctly 1`] = `
               <span
                 class="ant-upload-list-item-card-actions "
               >
-                <a
+                <button
+                  class="ant-btn ant-upload-list-item-card-actions-btn ant-btn-text ant-btn-sm ant-btn-icon-only"
                   title="Remove file"
+                  type="button"
                 >
                   <span
                     aria-label="delete"
                     class="anticon anticon-delete"
                     role="img"
                     tabindex="-1"
-                    title="Remove file"
                   >
                     <svg
                       aria-hidden="true"
@@ -398,7 +404,7 @@ exports[`renders ./components/upload/demo/defaultFileList.md correctly 1`] = `
                       />
                     </svg>
                   </span>
-                </a>
+                </button>
               </span>
             </span>
           </div>
@@ -452,15 +458,16 @@ exports[`renders ./components/upload/demo/defaultFileList.md correctly 1`] = `
               <span
                 class="ant-upload-list-item-card-actions "
               >
-                <a
+                <button
+                  class="ant-btn ant-upload-list-item-card-actions-btn ant-btn-text ant-btn-sm ant-btn-icon-only"
                   title="Remove file"
+                  type="button"
                 >
                   <span
                     aria-label="delete"
                     class="anticon anticon-delete"
                     role="img"
                     tabindex="-1"
-                    title="Remove file"
                   >
                     <svg
                       aria-hidden="true"
@@ -477,7 +484,7 @@ exports[`renders ./components/upload/demo/defaultFileList.md correctly 1`] = `
                       />
                     </svg>
                   </span>
-                </a>
+                </button>
               </span>
             </span>
           </div>
@@ -530,15 +537,16 @@ exports[`renders ./components/upload/demo/defaultFileList.md correctly 1`] = `
             <span
               class="ant-upload-list-item-card-actions "
             >
-              <a
+              <button
+                class="ant-btn ant-upload-list-item-card-actions-btn ant-btn-text ant-btn-sm ant-btn-icon-only"
                 title="Remove file"
+                type="button"
               >
                 <span
                   aria-label="delete"
                   class="anticon anticon-delete"
                   role="img"
                   tabindex="-1"
-                  title="Remove file"
                 >
                   <svg
                     aria-hidden="true"
@@ -555,7 +563,7 @@ exports[`renders ./components/upload/demo/defaultFileList.md correctly 1`] = `
                     />
                   </svg>
                 </span>
-              </a>
+              </button>
             </span>
           </span>
         </div>
@@ -788,28 +796,33 @@ exports[`renders ./components/upload/demo/file-type.md correctly 1`] = `
                   </svg>
                 </span>
               </a>
-              <span
-                aria-label="delete"
-                class="anticon anticon-delete"
-                role="img"
-                tabindex="-1"
+              <button
+                class="ant-btn ant-upload-list-item-card-actions-btn ant-btn-text ant-btn-sm ant-btn-icon-only"
                 title="Remove file"
+                type="button"
               >
-                <svg
-                  aria-hidden="true"
-                  class=""
-                  data-icon="delete"
-                  fill="currentColor"
-                  focusable="false"
-                  height="1em"
-                  viewBox="64 64 896 896"
-                  width="1em"
+                <span
+                  aria-label="delete"
+                  class="anticon anticon-delete"
+                  role="img"
+                  tabindex="-1"
                 >
-                  <path
-                    d="M360 184h-8c4.4 0 8-3.6 8-8v8h304v-8c0 4.4 3.6 8 8 8h-8v72h72v-80c0-35.3-28.7-64-64-64H352c-35.3 0-64 28.7-64 64v80h72v-72zm504 72H160c-17.7 0-32 14.3-32 32v32c0 4.4 3.6 8 8 8h60.4l24.7 523c1.6 34.1 29.8 61 63.9 61h454c34.2 0 62.3-26.8 63.9-61l24.7-523H888c4.4 0 8-3.6 8-8v-32c0-17.7-14.3-32-32-32zM731.3 840H292.7l-24.2-512h487l-24.2 512z"
-                  />
-                </svg>
-              </span>
+                  <svg
+                    aria-hidden="true"
+                    class=""
+                    data-icon="delete"
+                    fill="currentColor"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M360 184h-8c4.4 0 8-3.6 8-8v8h304v-8c0 4.4 3.6 8 8 8h-8v72h72v-80c0-35.3-28.7-64-64-64H352c-35.3 0-64 28.7-64 64v80h72v-72zm504 72H160c-17.7 0-32 14.3-32 32v32c0 4.4 3.6 8 8 8h60.4l24.7 523c1.6 34.1 29.8 61 63.9 61h454c34.2 0 62.3-26.8 63.9-61l24.7-523H888c4.4 0 8-3.6 8-8v-32c0-17.7-14.3-32-32-32zM731.3 840H292.7l-24.2-512h487l-24.2 512z"
+                    />
+                  </svg>
+                </span>
+              </button>
             </span>
           </div>
         </span>
@@ -902,28 +915,33 @@ exports[`renders ./components/upload/demo/file-type.md correctly 1`] = `
                   </svg>
                 </span>
               </a>
-              <span
-                aria-label="delete"
-                class="anticon anticon-delete"
-                role="img"
-                tabindex="-1"
+              <button
+                class="ant-btn ant-upload-list-item-card-actions-btn ant-btn-text ant-btn-sm ant-btn-icon-only"
                 title="Remove file"
+                type="button"
               >
-                <svg
-                  aria-hidden="true"
-                  class=""
-                  data-icon="delete"
-                  fill="currentColor"
-                  focusable="false"
-                  height="1em"
-                  viewBox="64 64 896 896"
-                  width="1em"
+                <span
+                  aria-label="delete"
+                  class="anticon anticon-delete"
+                  role="img"
+                  tabindex="-1"
                 >
-                  <path
-                    d="M360 184h-8c4.4 0 8-3.6 8-8v8h304v-8c0 4.4 3.6 8 8 8h-8v72h72v-80c0-35.3-28.7-64-64-64H352c-35.3 0-64 28.7-64 64v80h72v-72zm504 72H160c-17.7 0-32 14.3-32 32v32c0 4.4 3.6 8 8 8h60.4l24.7 523c1.6 34.1 29.8 61 63.9 61h454c34.2 0 62.3-26.8 63.9-61l24.7-523H888c4.4 0 8-3.6 8-8v-32c0-17.7-14.3-32-32-32zM731.3 840H292.7l-24.2-512h487l-24.2 512z"
-                  />
-                </svg>
-              </span>
+                  <svg
+                    aria-hidden="true"
+                    class=""
+                    data-icon="delete"
+                    fill="currentColor"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M360 184h-8c4.4 0 8-3.6 8-8v8h304v-8c0 4.4 3.6 8 8 8h-8v72h72v-80c0-35.3-28.7-64-64-64H352c-35.3 0-64 28.7-64 64v80h72v-72zm504 72H160c-17.7 0-32 14.3-32 32v32c0 4.4 3.6 8 8 8h60.4l24.7 523c1.6 34.1 29.8 61 63.9 61h454c34.2 0 62.3-26.8 63.9-61l24.7-523H888c4.4 0 8-3.6 8-8v-32c0-17.7-14.3-32-32-32zM731.3 840H292.7l-24.2-512h487l-24.2 512z"
+                    />
+                  </svg>
+                </span>
+              </button>
             </span>
           </div>
         </span>
@@ -1017,28 +1035,33 @@ exports[`renders ./components/upload/demo/file-type.md correctly 1`] = `
                 </svg>
               </span>
             </a>
-            <span
-              aria-label="delete"
-              class="anticon anticon-delete"
-              role="img"
-              tabindex="-1"
+            <button
+              class="ant-btn ant-upload-list-item-card-actions-btn ant-btn-text ant-btn-sm ant-btn-icon-only"
               title="Remove file"
+              type="button"
             >
-              <svg
-                aria-hidden="true"
-                class=""
-                data-icon="delete"
-                fill="currentColor"
-                focusable="false"
-                height="1em"
-                viewBox="64 64 896 896"
-                width="1em"
+              <span
+                aria-label="delete"
+                class="anticon anticon-delete"
+                role="img"
+                tabindex="-1"
               >
-                <path
-                  d="M360 184h-8c4.4 0 8-3.6 8-8v8h304v-8c0 4.4 3.6 8 8 8h-8v72h72v-80c0-35.3-28.7-64-64-64H352c-35.3 0-64 28.7-64 64v80h72v-72zm504 72H160c-17.7 0-32 14.3-32 32v32c0 4.4 3.6 8 8 8h60.4l24.7 523c1.6 34.1 29.8 61 63.9 61h454c34.2 0 62.3-26.8 63.9-61l24.7-523H888c4.4 0 8-3.6 8-8v-32c0-17.7-14.3-32-32-32zM731.3 840H292.7l-24.2-512h487l-24.2 512z"
-                />
-              </svg>
-            </span>
+                <svg
+                  aria-hidden="true"
+                  class=""
+                  data-icon="delete"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M360 184h-8c4.4 0 8-3.6 8-8v8h304v-8c0 4.4 3.6 8 8 8h-8v72h72v-80c0-35.3-28.7-64-64-64H352c-35.3 0-64 28.7-64 64v80h72v-72zm504 72H160c-17.7 0-32 14.3-32 32v32c0 4.4 3.6 8 8 8h60.4l24.7 523c1.6 34.1 29.8 61 63.9 61h454c34.2 0 62.3-26.8 63.9-61l24.7-523H888c4.4 0 8-3.6 8-8v-32c0-17.7-14.3-32-32-32zM731.3 840H292.7l-24.2-512h487l-24.2 512z"
+                  />
+                </svg>
+              </span>
+            </button>
           </span>
         </div>
       </div>
@@ -1131,28 +1154,33 @@ exports[`renders ./components/upload/demo/file-type.md correctly 1`] = `
                 </svg>
               </span>
             </a>
-            <span
-              aria-label="delete"
-              class="anticon anticon-delete"
-              role="img"
-              tabindex="-1"
+            <button
+              class="ant-btn ant-upload-list-item-card-actions-btn ant-btn-text ant-btn-sm ant-btn-icon-only"
               title="Remove file"
+              type="button"
             >
-              <svg
-                aria-hidden="true"
-                class=""
-                data-icon="delete"
-                fill="currentColor"
-                focusable="false"
-                height="1em"
-                viewBox="64 64 896 896"
-                width="1em"
+              <span
+                aria-label="delete"
+                class="anticon anticon-delete"
+                role="img"
+                tabindex="-1"
               >
-                <path
-                  d="M360 184h-8c4.4 0 8-3.6 8-8v8h304v-8c0 4.4 3.6 8 8 8h-8v72h72v-80c0-35.3-28.7-64-64-64H352c-35.3 0-64 28.7-64 64v80h72v-72zm504 72H160c-17.7 0-32 14.3-32 32v32c0 4.4 3.6 8 8 8h60.4l24.7 523c1.6 34.1 29.8 61 63.9 61h454c34.2 0 62.3-26.8 63.9-61l24.7-523H888c4.4 0 8-3.6 8-8v-32c0-17.7-14.3-32-32-32zM731.3 840H292.7l-24.2-512h487l-24.2 512z"
-                />
-              </svg>
-            </span>
+                <svg
+                  aria-hidden="true"
+                  class=""
+                  data-icon="delete"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M360 184h-8c4.4 0 8-3.6 8-8v8h304v-8c0 4.4 3.6 8 8 8h-8v72h72v-80c0-35.3-28.7-64-64-64H352c-35.3 0-64 28.7-64 64v80h72v-72zm504 72H160c-17.7 0-32 14.3-32 32v32c0 4.4 3.6 8 8 8h60.4l24.7 523c1.6 34.1 29.8 61 63.9 61h454c34.2 0 62.3-26.8 63.9-61l24.7-523H888c4.4 0 8-3.6 8-8v-32c0-17.7-14.3-32-32-32zM731.3 840H292.7l-24.2-512h487l-24.2 512z"
+                  />
+                </svg>
+              </span>
+            </button>
           </span>
         </div>
       </div>
@@ -1237,28 +1265,33 @@ exports[`renders ./components/upload/demo/file-type.md correctly 1`] = `
                 </svg>
               </span>
             </a>
-            <span
-              aria-label="delete"
-              class="anticon anticon-delete"
-              role="img"
-              tabindex="-1"
+            <button
+              class="ant-btn ant-upload-list-item-card-actions-btn ant-btn-text ant-btn-sm ant-btn-icon-only"
               title="Remove file"
+              type="button"
             >
-              <svg
-                aria-hidden="true"
-                class=""
-                data-icon="delete"
-                fill="currentColor"
-                focusable="false"
-                height="1em"
-                viewBox="64 64 896 896"
-                width="1em"
+              <span
+                aria-label="delete"
+                class="anticon anticon-delete"
+                role="img"
+                tabindex="-1"
               >
-                <path
-                  d="M360 184h-8c4.4 0 8-3.6 8-8v8h304v-8c0 4.4 3.6 8 8 8h-8v72h72v-80c0-35.3-28.7-64-64-64H352c-35.3 0-64 28.7-64 64v80h72v-72zm504 72H160c-17.7 0-32 14.3-32 32v32c0 4.4 3.6 8 8 8h60.4l24.7 523c1.6 34.1 29.8 61 63.9 61h454c34.2 0 62.3-26.8 63.9-61l24.7-523H888c4.4 0 8-3.6 8-8v-32c0-17.7-14.3-32-32-32zM731.3 840H292.7l-24.2-512h487l-24.2 512z"
-                />
-              </svg>
-            </span>
+                <svg
+                  aria-hidden="true"
+                  class=""
+                  data-icon="delete"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M360 184h-8c4.4 0 8-3.6 8-8v8h304v-8c0 4.4 3.6 8 8 8h-8v72h72v-80c0-35.3-28.7-64-64-64H352c-35.3 0-64 28.7-64 64v80h72v-72zm504 72H160c-17.7 0-32 14.3-32 32v32c0 4.4 3.6 8 8 8h60.4l24.7 523c1.6 34.1 29.8 61 63.9 61h454c34.2 0 62.3-26.8 63.9-61l24.7-523H888c4.4 0 8-3.6 8-8v-32c0-17.7-14.3-32-32-32zM731.3 840H292.7l-24.2-512h487l-24.2 512z"
+                  />
+                </svg>
+              </span>
+            </button>
           </span>
         </div>
       </div>
@@ -1411,15 +1444,16 @@ exports[`renders ./components/upload/demo/fileList.md correctly 1`] = `
               <span
                 class="ant-upload-list-item-card-actions "
               >
-                <a
+                <button
+                  class="ant-btn ant-upload-list-item-card-actions-btn ant-btn-text ant-btn-sm ant-btn-icon-only"
                   title="Remove file"
+                  type="button"
                 >
                   <span
                     aria-label="delete"
                     class="anticon anticon-delete"
                     role="img"
                     tabindex="-1"
-                    title="Remove file"
                   >
                     <svg
                       aria-hidden="true"
@@ -1436,7 +1470,7 @@ exports[`renders ./components/upload/demo/fileList.md correctly 1`] = `
                       />
                     </svg>
                   </span>
-                </a>
+                </button>
               </span>
             </span>
           </div>
@@ -1521,28 +1555,33 @@ exports[`renders ./components/upload/demo/picture-card.md correctly 1`] = `
                   </svg>
                 </span>
               </a>
-              <span
-                aria-label="delete"
-                class="anticon anticon-delete"
-                role="img"
-                tabindex="-1"
+              <button
+                class="ant-btn ant-upload-list-item-card-actions-btn ant-btn-text ant-btn-sm ant-btn-icon-only"
                 title="Remove file"
+                type="button"
               >
-                <svg
-                  aria-hidden="true"
-                  class=""
-                  data-icon="delete"
-                  fill="currentColor"
-                  focusable="false"
-                  height="1em"
-                  viewBox="64 64 896 896"
-                  width="1em"
+                <span
+                  aria-label="delete"
+                  class="anticon anticon-delete"
+                  role="img"
+                  tabindex="-1"
                 >
-                  <path
-                    d="M360 184h-8c4.4 0 8-3.6 8-8v8h304v-8c0 4.4 3.6 8 8 8h-8v72h72v-80c0-35.3-28.7-64-64-64H352c-35.3 0-64 28.7-64 64v80h72v-72zm504 72H160c-17.7 0-32 14.3-32 32v32c0 4.4 3.6 8 8 8h60.4l24.7 523c1.6 34.1 29.8 61 63.9 61h454c34.2 0 62.3-26.8 63.9-61l24.7-523H888c4.4 0 8-3.6 8-8v-32c0-17.7-14.3-32-32-32zM731.3 840H292.7l-24.2-512h487l-24.2 512z"
-                  />
-                </svg>
-              </span>
+                  <svg
+                    aria-hidden="true"
+                    class=""
+                    data-icon="delete"
+                    fill="currentColor"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M360 184h-8c4.4 0 8-3.6 8-8v8h304v-8c0 4.4 3.6 8 8 8h-8v72h72v-80c0-35.3-28.7-64-64-64H352c-35.3 0-64 28.7-64 64v80h72v-72zm504 72H160c-17.7 0-32 14.3-32 32v32c0 4.4 3.6 8 8 8h60.4l24.7 523c1.6 34.1 29.8 61 63.9 61h454c34.2 0 62.3-26.8 63.9-61l24.7-523H888c4.4 0 8-3.6 8-8v-32c0-17.7-14.3-32-32-32zM731.3 840H292.7l-24.2-512h487l-24.2 512z"
+                    />
+                  </svg>
+                </span>
+              </button>
             </span>
           </div>
         </span>
@@ -1611,28 +1650,33 @@ exports[`renders ./components/upload/demo/picture-card.md correctly 1`] = `
                   </svg>
                 </span>
               </a>
-              <span
-                aria-label="delete"
-                class="anticon anticon-delete"
-                role="img"
-                tabindex="-1"
+              <button
+                class="ant-btn ant-upload-list-item-card-actions-btn ant-btn-text ant-btn-sm ant-btn-icon-only"
                 title="Remove file"
+                type="button"
               >
-                <svg
-                  aria-hidden="true"
-                  class=""
-                  data-icon="delete"
-                  fill="currentColor"
-                  focusable="false"
-                  height="1em"
-                  viewBox="64 64 896 896"
-                  width="1em"
+                <span
+                  aria-label="delete"
+                  class="anticon anticon-delete"
+                  role="img"
+                  tabindex="-1"
                 >
-                  <path
-                    d="M360 184h-8c4.4 0 8-3.6 8-8v8h304v-8c0 4.4 3.6 8 8 8h-8v72h72v-80c0-35.3-28.7-64-64-64H352c-35.3 0-64 28.7-64 64v80h72v-72zm504 72H160c-17.7 0-32 14.3-32 32v32c0 4.4 3.6 8 8 8h60.4l24.7 523c1.6 34.1 29.8 61 63.9 61h454c34.2 0 62.3-26.8 63.9-61l24.7-523H888c4.4 0 8-3.6 8-8v-32c0-17.7-14.3-32-32-32zM731.3 840H292.7l-24.2-512h487l-24.2 512z"
-                  />
-                </svg>
-              </span>
+                  <svg
+                    aria-hidden="true"
+                    class=""
+                    data-icon="delete"
+                    fill="currentColor"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M360 184h-8c4.4 0 8-3.6 8-8v8h304v-8c0 4.4 3.6 8 8 8h-8v72h72v-80c0-35.3-28.7-64-64-64H352c-35.3 0-64 28.7-64 64v80h72v-72zm504 72H160c-17.7 0-32 14.3-32 32v32c0 4.4 3.6 8 8 8h60.4l24.7 523c1.6 34.1 29.8 61 63.9 61h454c34.2 0 62.3-26.8 63.9-61l24.7-523H888c4.4 0 8-3.6 8-8v-32c0-17.7-14.3-32-32-32zM731.3 840H292.7l-24.2-512h487l-24.2 512z"
+                    />
+                  </svg>
+                </span>
+              </button>
             </span>
           </div>
         </span>
@@ -1701,28 +1745,33 @@ exports[`renders ./components/upload/demo/picture-card.md correctly 1`] = `
                   </svg>
                 </span>
               </a>
-              <span
-                aria-label="delete"
-                class="anticon anticon-delete"
-                role="img"
-                tabindex="-1"
+              <button
+                class="ant-btn ant-upload-list-item-card-actions-btn ant-btn-text ant-btn-sm ant-btn-icon-only"
                 title="Remove file"
+                type="button"
               >
-                <svg
-                  aria-hidden="true"
-                  class=""
-                  data-icon="delete"
-                  fill="currentColor"
-                  focusable="false"
-                  height="1em"
-                  viewBox="64 64 896 896"
-                  width="1em"
+                <span
+                  aria-label="delete"
+                  class="anticon anticon-delete"
+                  role="img"
+                  tabindex="-1"
                 >
-                  <path
-                    d="M360 184h-8c4.4 0 8-3.6 8-8v8h304v-8c0 4.4 3.6 8 8 8h-8v72h72v-80c0-35.3-28.7-64-64-64H352c-35.3 0-64 28.7-64 64v80h72v-72zm504 72H160c-17.7 0-32 14.3-32 32v32c0 4.4 3.6 8 8 8h60.4l24.7 523c1.6 34.1 29.8 61 63.9 61h454c34.2 0 62.3-26.8 63.9-61l24.7-523H888c4.4 0 8-3.6 8-8v-32c0-17.7-14.3-32-32-32zM731.3 840H292.7l-24.2-512h487l-24.2 512z"
-                  />
-                </svg>
-              </span>
+                  <svg
+                    aria-hidden="true"
+                    class=""
+                    data-icon="delete"
+                    fill="currentColor"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M360 184h-8c4.4 0 8-3.6 8-8v8h304v-8c0 4.4 3.6 8 8 8h-8v72h72v-80c0-35.3-28.7-64-64-64H352c-35.3 0-64 28.7-64 64v80h72v-72zm504 72H160c-17.7 0-32 14.3-32 32v32c0 4.4 3.6 8 8 8h60.4l24.7 523c1.6 34.1 29.8 61 63.9 61h454c34.2 0 62.3-26.8 63.9-61l24.7-523H888c4.4 0 8-3.6 8-8v-32c0-17.7-14.3-32-32-32zM731.3 840H292.7l-24.2-512h487l-24.2 512z"
+                    />
+                  </svg>
+                </span>
+              </button>
             </span>
           </div>
         </span>
@@ -1791,28 +1840,33 @@ exports[`renders ./components/upload/demo/picture-card.md correctly 1`] = `
                   </svg>
                 </span>
               </a>
-              <span
-                aria-label="delete"
-                class="anticon anticon-delete"
-                role="img"
-                tabindex="-1"
+              <button
+                class="ant-btn ant-upload-list-item-card-actions-btn ant-btn-text ant-btn-sm ant-btn-icon-only"
                 title="Remove file"
+                type="button"
               >
-                <svg
-                  aria-hidden="true"
-                  class=""
-                  data-icon="delete"
-                  fill="currentColor"
-                  focusable="false"
-                  height="1em"
-                  viewBox="64 64 896 896"
-                  width="1em"
+                <span
+                  aria-label="delete"
+                  class="anticon anticon-delete"
+                  role="img"
+                  tabindex="-1"
                 >
-                  <path
-                    d="M360 184h-8c4.4 0 8-3.6 8-8v8h304v-8c0 4.4 3.6 8 8 8h-8v72h72v-80c0-35.3-28.7-64-64-64H352c-35.3 0-64 28.7-64 64v80h72v-72zm504 72H160c-17.7 0-32 14.3-32 32v32c0 4.4 3.6 8 8 8h60.4l24.7 523c1.6 34.1 29.8 61 63.9 61h454c34.2 0 62.3-26.8 63.9-61l24.7-523H888c4.4 0 8-3.6 8-8v-32c0-17.7-14.3-32-32-32zM731.3 840H292.7l-24.2-512h487l-24.2 512z"
-                  />
-                </svg>
-              </span>
+                  <svg
+                    aria-hidden="true"
+                    class=""
+                    data-icon="delete"
+                    fill="currentColor"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M360 184h-8c4.4 0 8-3.6 8-8v8h304v-8c0 4.4 3.6 8 8 8h-8v72h72v-80c0-35.3-28.7-64-64-64H352c-35.3 0-64 28.7-64 64v80h72v-72zm504 72H160c-17.7 0-32 14.3-32 32v32c0 4.4 3.6 8 8 8h60.4l24.7 523c1.6 34.1 29.8 61 63.9 61h454c34.2 0 62.3-26.8 63.9-61l24.7-523H888c4.4 0 8-3.6 8-8v-32c0-17.7-14.3-32-32-32zM731.3 840H292.7l-24.2-512h487l-24.2 512z"
+                    />
+                  </svg>
+                </span>
+              </button>
             </span>
           </div>
         </span>
@@ -1906,28 +1960,33 @@ exports[`renders ./components/upload/demo/picture-card.md correctly 1`] = `
                 </svg>
               </span>
             </a>
-            <span
-              aria-label="delete"
-              class="anticon anticon-delete"
-              role="img"
-              tabindex="-1"
+            <button
+              class="ant-btn ant-upload-list-item-card-actions-btn ant-btn-text ant-btn-sm ant-btn-icon-only"
               title="Remove file"
+              type="button"
             >
-              <svg
-                aria-hidden="true"
-                class=""
-                data-icon="delete"
-                fill="currentColor"
-                focusable="false"
-                height="1em"
-                viewBox="64 64 896 896"
-                width="1em"
+              <span
+                aria-label="delete"
+                class="anticon anticon-delete"
+                role="img"
+                tabindex="-1"
               >
-                <path
-                  d="M360 184h-8c4.4 0 8-3.6 8-8v8h304v-8c0 4.4 3.6 8 8 8h-8v72h72v-80c0-35.3-28.7-64-64-64H352c-35.3 0-64 28.7-64 64v80h72v-72zm504 72H160c-17.7 0-32 14.3-32 32v32c0 4.4 3.6 8 8 8h60.4l24.7 523c1.6 34.1 29.8 61 63.9 61h454c34.2 0 62.3-26.8 63.9-61l24.7-523H888c4.4 0 8-3.6 8-8v-32c0-17.7-14.3-32-32-32zM731.3 840H292.7l-24.2-512h487l-24.2 512z"
-                />
-              </svg>
-            </span>
+                <svg
+                  aria-hidden="true"
+                  class=""
+                  data-icon="delete"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M360 184h-8c4.4 0 8-3.6 8-8v8h304v-8c0 4.4 3.6 8 8 8h-8v72h72v-80c0-35.3-28.7-64-64-64H352c-35.3 0-64 28.7-64 64v80h72v-72zm504 72H160c-17.7 0-32 14.3-32 32v32c0 4.4 3.6 8 8 8h60.4l24.7 523c1.6 34.1 29.8 61 63.9 61h454c34.2 0 62.3-26.8 63.9-61l24.7-523H888c4.4 0 8-3.6 8-8v-32c0-17.7-14.3-32-32-32zM731.3 840H292.7l-24.2-512h487l-24.2 512z"
+                  />
+                </svg>
+              </span>
+            </button>
           </span>
         </div>
       </div>
@@ -2068,15 +2127,16 @@ exports[`renders ./components/upload/demo/picture-style.md correctly 1`] = `
                 <span
                   class="ant-upload-list-item-card-actions picture"
                 >
-                  <a
+                  <button
+                    class="ant-btn ant-upload-list-item-card-actions-btn ant-btn-text ant-btn-sm ant-btn-icon-only"
                     title="Remove file"
+                    type="button"
                   >
                     <span
                       aria-label="delete"
                       class="anticon anticon-delete"
                       role="img"
                       tabindex="-1"
-                      title="Remove file"
                     >
                       <svg
                         aria-hidden="true"
@@ -2093,7 +2153,7 @@ exports[`renders ./components/upload/demo/picture-style.md correctly 1`] = `
                         />
                       </svg>
                     </span>
-                  </a>
+                  </button>
                 </span>
               </span>
             </div>
@@ -2160,15 +2220,16 @@ exports[`renders ./components/upload/demo/picture-style.md correctly 1`] = `
               <span
                 class="ant-upload-list-item-card-actions picture"
               >
-                <a
+                <button
+                  class="ant-btn ant-upload-list-item-card-actions-btn ant-btn-text ant-btn-sm ant-btn-icon-only"
                   title="Remove file"
+                  type="button"
                 >
                   <span
                     aria-label="delete"
                     class="anticon anticon-delete"
                     role="img"
                     tabindex="-1"
-                    title="Remove file"
                   >
                     <svg
                       aria-hidden="true"
@@ -2185,7 +2246,7 @@ exports[`renders ./components/upload/demo/picture-style.md correctly 1`] = `
                       />
                     </svg>
                   </span>
-                </a>
+                </button>
               </span>
             </span>
           </div>
@@ -2279,15 +2340,16 @@ exports[`renders ./components/upload/demo/picture-style.md correctly 1`] = `
                 <span
                   class="ant-upload-list-item-card-actions picture"
                 >
-                  <a
+                  <button
+                    class="ant-btn ant-upload-list-item-card-actions-btn ant-btn-text ant-btn-sm ant-btn-icon-only"
                     title="Remove file"
+                    type="button"
                   >
                     <span
                       aria-label="delete"
                       class="anticon anticon-delete"
                       role="img"
                       tabindex="-1"
-                      title="Remove file"
                     >
                       <svg
                         aria-hidden="true"
@@ -2304,7 +2366,7 @@ exports[`renders ./components/upload/demo/picture-style.md correctly 1`] = `
                         />
                       </svg>
                     </span>
-                  </a>
+                  </button>
                 </span>
               </span>
             </div>
@@ -2371,15 +2433,16 @@ exports[`renders ./components/upload/demo/picture-style.md correctly 1`] = `
               <span
                 class="ant-upload-list-item-card-actions picture"
               >
-                <a
+                <button
+                  class="ant-btn ant-upload-list-item-card-actions-btn ant-btn-text ant-btn-sm ant-btn-icon-only"
                   title="Remove file"
+                  type="button"
                 >
                   <span
                     aria-label="delete"
                     class="anticon anticon-delete"
                     role="img"
                     tabindex="-1"
-                    title="Remove file"
                   >
                     <svg
                       aria-hidden="true"
@@ -2396,7 +2459,7 @@ exports[`renders ./components/upload/demo/picture-style.md correctly 1`] = `
                       />
                     </svg>
                   </span>
-                </a>
+                </button>
               </span>
             </span>
           </div>
@@ -2614,24 +2677,25 @@ exports[`renders ./components/upload/demo/upload-custom-action-icon.md correctly
               <span
                 class="ant-upload-list-item-card-actions "
               >
-                <a
+                <button
+                  class="ant-btn ant-upload-list-item-card-actions-btn ant-btn-text ant-btn-sm"
                   title="Download file"
+                  type="button"
                 >
-                  <span
-                    title="Download file"
-                  >
+                  <span>
                     download 
                   </span>
-                </a>
-                <a
+                </button>
+                <button
+                  class="ant-btn ant-upload-list-item-card-actions-btn ant-btn-text ant-btn-sm ant-btn-icon-only"
                   title="Remove file"
+                  type="button"
                 >
                   <span
                     aria-label="star"
                     class="anticon anticon-star"
                     role="img"
                     tabindex="-1"
-                    title="Remove file"
                   >
                     <svg
                       aria-hidden="true"
@@ -2648,7 +2712,7 @@ exports[`renders ./components/upload/demo/upload-custom-action-icon.md correctly
                       />
                     </svg>
                   </span>
-                </a>
+                </button>
               </span>
             </span>
           </div>
@@ -2702,24 +2766,25 @@ exports[`renders ./components/upload/demo/upload-custom-action-icon.md correctly
               <span
                 class="ant-upload-list-item-card-actions "
               >
-                <a
+                <button
+                  class="ant-btn ant-upload-list-item-card-actions-btn ant-btn-text ant-btn-sm"
                   title="Download file"
+                  type="button"
                 >
-                  <span
-                    title="Download file"
-                  >
+                  <span>
                     download 
                   </span>
-                </a>
-                <a
+                </button>
+                <button
+                  class="ant-btn ant-upload-list-item-card-actions-btn ant-btn-text ant-btn-sm ant-btn-icon-only"
                   title="Remove file"
+                  type="button"
                 >
                   <span
                     aria-label="star"
                     class="anticon anticon-star"
                     role="img"
                     tabindex="-1"
-                    title="Remove file"
                   >
                     <svg
                       aria-hidden="true"
@@ -2736,7 +2801,7 @@ exports[`renders ./components/upload/demo/upload-custom-action-icon.md correctly
                       />
                     </svg>
                   </span>
-                </a>
+                </button>
               </span>
             </span>
           </div>
@@ -2789,15 +2854,16 @@ exports[`renders ./components/upload/demo/upload-custom-action-icon.md correctly
             <span
               class="ant-upload-list-item-card-actions "
             >
-              <a
+              <button
+                class="ant-btn ant-upload-list-item-card-actions-btn ant-btn-text ant-btn-sm ant-btn-icon-only"
                 title="Remove file"
+                type="button"
               >
                 <span
                   aria-label="star"
                   class="anticon anticon-star"
                   role="img"
                   tabindex="-1"
-                  title="Remove file"
                 >
                   <svg
                     aria-hidden="true"
@@ -2814,7 +2880,7 @@ exports[`renders ./components/upload/demo/upload-custom-action-icon.md correctly
                     />
                   </svg>
                 </span>
-              </a>
+              </button>
             </span>
           </span>
         </div>

--- a/components/upload/__tests__/__snapshots__/uploadlist.test.js.snap
+++ b/components/upload/__tests__/__snapshots__/uploadlist.test.js.snap
@@ -70,15 +70,16 @@ exports[`Upload List handle error 1`] = `
             <span
               class="ant-upload-list-item-card-actions "
             >
-              <a
+              <button
+                class="ant-btn ant-upload-list-item-card-actions-btn ant-btn-text ant-btn-sm ant-btn-icon-only"
                 title="Remove file"
+                type="button"
               >
                 <span
                   aria-label="delete"
                   class="anticon anticon-delete"
                   role="img"
                   tabindex="-1"
-                  title="Remove file"
                 >
                   <svg
                     aria-hidden="true"
@@ -95,7 +96,7 @@ exports[`Upload List handle error 1`] = `
                     />
                   </svg>
                 </span>
-              </a>
+              </button>
             </span>
           </span>
         </div>
@@ -176,15 +177,16 @@ exports[`Upload List should be uploading when upload a file 1`] = `
               <span
                 class="ant-upload-list-item-card-actions "
               >
-                <a
+                <button
+                  class="ant-btn ant-upload-list-item-card-actions-btn ant-btn-text ant-btn-sm ant-btn-icon-only"
                   title="Remove file"
+                  type="button"
                 >
                   <span
                     aria-label="delete"
                     class="anticon anticon-delete"
                     role="img"
                     tabindex="-1"
-                    title="Remove file"
                   >
                     <svg
                       aria-hidden="true"
@@ -201,7 +203,7 @@ exports[`Upload List should be uploading when upload a file 1`] = `
                       />
                     </svg>
                   </span>
-                </a>
+                </button>
               </span>
             </span>
           </div>
@@ -303,15 +305,16 @@ exports[`Upload List should be uploading when upload a file 2`] = `
               <span
                 class="ant-upload-list-item-card-actions "
               >
-                <a
+                <button
+                  class="ant-btn ant-upload-list-item-card-actions-btn ant-btn-text ant-btn-sm ant-btn-icon-only"
                   title="Remove file"
+                  type="button"
                 >
                   <span
                     aria-label="delete"
                     class="anticon anticon-delete"
                     role="img"
                     tabindex="-1"
-                    title="Remove file"
                   >
                     <svg
                       aria-hidden="true"
@@ -328,7 +331,7 @@ exports[`Upload List should be uploading when upload a file 2`] = `
                       />
                     </svg>
                   </span>
-                </a>
+                </button>
               </span>
             </span>
           </div>
@@ -441,15 +444,16 @@ exports[`Upload List should non-image format file preview 1`] = `
               <span
                 class="ant-upload-list-item-card-actions picture"
               >
-                <a
+                <button
+                  class="ant-btn ant-upload-list-item-card-actions-btn ant-btn-text ant-btn-sm ant-btn-icon-only"
                   title="Remove file"
+                  type="button"
                 >
                   <span
                     aria-label="delete"
                     class="anticon anticon-delete"
                     role="img"
                     tabindex="-1"
-                    title="Remove file"
                   >
                     <svg
                       aria-hidden="true"
@@ -466,7 +470,7 @@ exports[`Upload List should non-image format file preview 1`] = `
                       />
                     </svg>
                   </span>
-                </a>
+                </button>
               </span>
             </span>
           </div>
@@ -508,15 +512,16 @@ exports[`Upload List should non-image format file preview 1`] = `
               <span
                 class="ant-upload-list-item-card-actions picture"
               >
-                <a
+                <button
+                  class="ant-btn ant-upload-list-item-card-actions-btn ant-btn-text ant-btn-sm ant-btn-icon-only"
                   title="Remove file"
+                  type="button"
                 >
                   <span
                     aria-label="delete"
                     class="anticon anticon-delete"
                     role="img"
                     tabindex="-1"
-                    title="Remove file"
                   >
                     <svg
                       aria-hidden="true"
@@ -533,7 +538,7 @@ exports[`Upload List should non-image format file preview 1`] = `
                       />
                     </svg>
                   </span>
-                </a>
+                </button>
               </span>
             </span>
           </div>
@@ -595,15 +600,16 @@ exports[`Upload List should non-image format file preview 1`] = `
               <span
                 class="ant-upload-list-item-card-actions picture"
               >
-                <a
+                <button
+                  class="ant-btn ant-upload-list-item-card-actions-btn ant-btn-text ant-btn-sm ant-btn-icon-only"
                   title="Remove file"
+                  type="button"
                 >
                   <span
                     aria-label="delete"
                     class="anticon anticon-delete"
                     role="img"
                     tabindex="-1"
-                    title="Remove file"
                   >
                     <svg
                       aria-hidden="true"
@@ -620,7 +626,7 @@ exports[`Upload List should non-image format file preview 1`] = `
                       />
                     </svg>
                   </span>
-                </a>
+                </button>
               </span>
             </span>
           </div>
@@ -682,15 +688,16 @@ exports[`Upload List should non-image format file preview 1`] = `
               <span
                 class="ant-upload-list-item-card-actions picture"
               >
-                <a
+                <button
+                  class="ant-btn ant-upload-list-item-card-actions-btn ant-btn-text ant-btn-sm ant-btn-icon-only"
                   title="Remove file"
+                  type="button"
                 >
                   <span
                     aria-label="delete"
                     class="anticon anticon-delete"
                     role="img"
                     tabindex="-1"
-                    title="Remove file"
                   >
                     <svg
                       aria-hidden="true"
@@ -707,7 +714,7 @@ exports[`Upload List should non-image format file preview 1`] = `
                       />
                     </svg>
                   </span>
-                </a>
+                </button>
               </span>
             </span>
           </div>
@@ -749,15 +756,16 @@ exports[`Upload List should non-image format file preview 1`] = `
               <span
                 class="ant-upload-list-item-card-actions picture"
               >
-                <a
+                <button
+                  class="ant-btn ant-upload-list-item-card-actions-btn ant-btn-text ant-btn-sm ant-btn-icon-only"
                   title="Remove file"
+                  type="button"
                 >
                   <span
                     aria-label="delete"
                     class="anticon anticon-delete"
                     role="img"
                     tabindex="-1"
-                    title="Remove file"
                   >
                     <svg
                       aria-hidden="true"
@@ -774,7 +782,7 @@ exports[`Upload List should non-image format file preview 1`] = `
                       />
                     </svg>
                   </span>
-                </a>
+                </button>
               </span>
             </span>
           </div>
@@ -816,15 +824,16 @@ exports[`Upload List should non-image format file preview 1`] = `
               <span
                 class="ant-upload-list-item-card-actions picture"
               >
-                <a
+                <button
+                  class="ant-btn ant-upload-list-item-card-actions-btn ant-btn-text ant-btn-sm ant-btn-icon-only"
                   title="Remove file"
+                  type="button"
                 >
                   <span
                     aria-label="delete"
                     class="anticon anticon-delete"
                     role="img"
                     tabindex="-1"
-                    title="Remove file"
                   >
                     <svg
                       aria-hidden="true"
@@ -841,7 +850,7 @@ exports[`Upload List should non-image format file preview 1`] = `
                       />
                     </svg>
                   </span>
-                </a>
+                </button>
               </span>
             </span>
           </div>
@@ -883,15 +892,16 @@ exports[`Upload List should non-image format file preview 1`] = `
               <span
                 class="ant-upload-list-item-card-actions picture"
               >
-                <a
+                <button
+                  class="ant-btn ant-upload-list-item-card-actions-btn ant-btn-text ant-btn-sm ant-btn-icon-only"
                   title="Remove file"
+                  type="button"
                 >
                   <span
                     aria-label="delete"
                     class="anticon anticon-delete"
                     role="img"
                     tabindex="-1"
-                    title="Remove file"
                   >
                     <svg
                       aria-hidden="true"
@@ -908,7 +918,7 @@ exports[`Upload List should non-image format file preview 1`] = `
                       />
                     </svg>
                   </span>
-                </a>
+                </button>
               </span>
             </span>
           </div>
@@ -950,15 +960,16 @@ exports[`Upload List should non-image format file preview 1`] = `
               <span
                 class="ant-upload-list-item-card-actions picture"
               >
-                <a
+                <button
+                  class="ant-btn ant-upload-list-item-card-actions-btn ant-btn-text ant-btn-sm ant-btn-icon-only"
                   title="Remove file"
+                  type="button"
                 >
                   <span
                     aria-label="delete"
                     class="anticon anticon-delete"
                     role="img"
                     tabindex="-1"
-                    title="Remove file"
                   >
                     <svg
                       aria-hidden="true"
@@ -975,7 +986,7 @@ exports[`Upload List should non-image format file preview 1`] = `
                       />
                     </svg>
                   </span>
-                </a>
+                </button>
               </span>
             </span>
           </div>
@@ -1017,15 +1028,16 @@ exports[`Upload List should non-image format file preview 1`] = `
               <span
                 class="ant-upload-list-item-card-actions picture"
               >
-                <a
+                <button
+                  class="ant-btn ant-upload-list-item-card-actions-btn ant-btn-text ant-btn-sm ant-btn-icon-only"
                   title="Remove file"
+                  type="button"
                 >
                   <span
                     aria-label="delete"
                     class="anticon anticon-delete"
                     role="img"
                     tabindex="-1"
-                    title="Remove file"
                   >
                     <svg
                       aria-hidden="true"
@@ -1042,7 +1054,7 @@ exports[`Upload List should non-image format file preview 1`] = `
                       />
                     </svg>
                   </span>
-                </a>
+                </button>
               </span>
             </span>
           </div>
@@ -1084,15 +1096,16 @@ exports[`Upload List should non-image format file preview 1`] = `
               <span
                 class="ant-upload-list-item-card-actions picture"
               >
-                <a
+                <button
+                  class="ant-btn ant-upload-list-item-card-actions-btn ant-btn-text ant-btn-sm ant-btn-icon-only"
                   title="Remove file"
+                  type="button"
                 >
                   <span
                     aria-label="delete"
                     class="anticon anticon-delete"
                     role="img"
                     tabindex="-1"
-                    title="Remove file"
                   >
                     <svg
                       aria-hidden="true"
@@ -1109,7 +1122,7 @@ exports[`Upload List should non-image format file preview 1`] = `
                       />
                     </svg>
                   </span>
-                </a>
+                </button>
               </span>
             </span>
           </div>
@@ -1194,15 +1207,15 @@ exports[`Upload List should support removeIcon and downloadIcon 1`] = `
               <span
                 class="ant-upload-list-item-card-actions picture"
               >
-                <a
+                <button
+                  class="ant-btn ant-upload-list-item-card-actions-btn ant-btn-text ant-btn-sm ant-btn-icon-only"
                   title="Remove file"
+                  type="button"
                 >
-                  <i
-                    title="Remove file"
-                  >
+                  <i>
                     RM
                   </i>
-                </a>
+                </button>
               </span>
             </span>
           </div>
@@ -1247,24 +1260,24 @@ exports[`Upload List should support removeIcon and downloadIcon 1`] = `
               <span
                 class="ant-upload-list-item-card-actions picture"
               >
-                <a
+                <button
+                  class="ant-btn ant-upload-list-item-card-actions-btn ant-btn-text ant-btn-sm ant-btn-icon-only"
                   title="Download file"
+                  type="button"
                 >
-                  <i
-                    title="Download file"
-                  >
+                  <i>
                     DL
                   </i>
-                </a>
-                <a
+                </button>
+                <button
+                  class="ant-btn ant-upload-list-item-card-actions-btn ant-btn-text ant-btn-sm ant-btn-icon-only"
                   title="Remove file"
+                  type="button"
                 >
-                  <i
-                    title="Remove file"
-                  >
+                  <i>
                     RM
                   </i>
-                </a>
+                </button>
               </span>
             </span>
           </div>

--- a/components/upload/style/index.less
+++ b/components/upload/style/index.less
@@ -119,6 +119,7 @@
       color: @text-color-secondary;
       font-size: @font-size-base;
     }
+
     .@{iconfont-css-prefix}-plus {
       color: @disabled-color;
       font-size: 30px;
@@ -176,15 +177,26 @@
     &-card-actions {
       position: absolute;
       right: 0;
-      opacity: 0;
+
+      &-btn {
+        opacity: 0;
+      }
+      &-btn.@{ant-prefix}-btn-sm {
+        height: 20px;
+        line-height: 1;
+      }
 
       &.picture {
-        top: 25px;
-        line-height: 1;
+        top: 22px;
+        line-height: 0;
+      }
+
+      &-btn:focus,
+      &.picture &-btn {
         opacity: 1;
       }
+
       .@{iconfont-css-prefix} {
-        padding-right: 6px;
         color: @upload-actions-color;
       }
     }
@@ -236,7 +248,7 @@
       opacity: 1;
     }
 
-    &:hover &-card-actions {
+    &:hover &-card-actions-btn {
       opacity: 1;
     }
 
@@ -250,7 +262,9 @@
       .@{iconfont-css-prefix} {
         color: @error-color;
       }
-      opacity: 1;
+      &-btn {
+        opacity: 1;
+      }
     }
 
     &-progress {
@@ -271,9 +285,11 @@
       padding: @padding-xs;
       border: @border-width-base @upload-picture-card-border-style @border-color-base;
       border-radius: @border-radius-base;
+
       &:hover {
         background: transparent;
       }
+
       &-error {
         border-color: @error-color;
       }
@@ -313,6 +329,7 @@
           &[fill='#e6f7ff'] {
             fill: color(~`colorPalette('@{error-color}', 1) `);
           }
+
           &[fill='#1890ff'] {
             fill: @error-color;
           }
@@ -389,12 +406,14 @@
     &.@{upload-prefix-cls}-list::after {
       display: none;
     }
+
     &-container {
       float: left;
       width: @upload-picture-card-size;
       height: @upload-picture-card-size;
       margin: 0 @margin-xs @margin-xs 0;
     }
+
     .@{upload-item} {
       float: left;
       width: @upload-picture-card-size;
@@ -443,6 +462,7 @@
         font-size: 16px;
         cursor: pointer;
         transition: all 0.3s;
+
         &:hover {
           color: @text-color-inverse;
         }
@@ -484,6 +504,7 @@
 
       .@{upload-item}-info {
         height: auto;
+
         &::before,
         .@{iconfont-css-prefix}-eye,
         .@{iconfont-css-prefix}-delete {

--- a/components/upload/style/index.tsx
+++ b/components/upload/style/index.tsx
@@ -2,5 +2,6 @@ import '../../style/index.less';
 import './index.less';
 
 // style dependencies
+import '../../button/style';
 import '../../progress/style';
 import '../../tooltip/style';


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

close #24519

change the upload file actions implementation, pls review the code first.
I am still checking if there are some style impacts.

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Perfermance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

- https://github.com/ant-design/ant-design/issues/24519
- https://github.com/ant-design/ant-design/pull/24604

### 💡 Background and solution

- use `Button` to wrap action icons 
- update opacity control to actions-btn

![ezgif-3-f02e72d7b713](https://user-images.githubusercontent.com/15653996/83347423-8a89f280-a357-11ea-9a9b-a0a9ccf21c98.gif)

![ezgif com-gif-maker](https://user-images.githubusercontent.com/15653996/83347556-611d9680-a358-11ea-972b-0bdd250baa25.gif)

Custom icon have been changed to buttons:
![image](https://user-images.githubusercontent.com/15653996/83347567-72ff3980-a358-11ea-98d0-05a17513c7cf.png)

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Upload delete icon cannot be navigate via keyboard. |
| 🇨🇳 Chinese | 解决 Upload 删除图标键盘无法导航操作的问题。 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
