### PR TITLE
fix: #24614 text button style inconsistent in `danger`

### DIFF
--- a/components/button/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/button/__tests__/__snapshots__/demo.test.ts.snap
@@ -110,6 +110,14 @@ Array [
     </span>
   </button>,
   <button
+    class="ant-btn ant-btn-text ant-btn-dangerous"
+    type="button"
+  >
+    <span>
+      Text
+    </span>
+  </button>,
+  <button
     class="ant-btn ant-btn-link ant-btn-dangerous"
     type="button"
   >
@@ -177,24 +185,6 @@ exports[`renders ./components/button/demo/disabled.md correctly 1`] = `
   </button>
   <br />
   <button
-    class="ant-btn ant-btn-link"
-    type="button"
-  >
-    <span>
-      Link
-    </span>
-  </button>
-  <button
-    class="ant-btn ant-btn-link"
-    disabled=""
-    type="button"
-  >
-    <span>
-      Link(disabled)
-    </span>
-  </button>
-  <br />
-  <button
     class="ant-btn ant-btn-text"
     type="button"
   >
@@ -213,20 +203,20 @@ exports[`renders ./components/button/demo/disabled.md correctly 1`] = `
   </button>
   <br />
   <button
-    class="ant-btn ant-btn-link ant-btn-dangerous"
+    class="ant-btn ant-btn-link"
     type="button"
   >
     <span>
-      Danger Link
+      Link
     </span>
   </button>
   <button
-    class="ant-btn ant-btn-link ant-btn-dangerous"
+    class="ant-btn ant-btn-link"
     disabled=""
     type="button"
   >
     <span>
-      Danger Link(disabled)
+      Link(disabled)
     </span>
   </button>
   <br />
@@ -245,6 +235,42 @@ exports[`renders ./components/button/demo/disabled.md correctly 1`] = `
   >
     <span>
       Danger Default(disabled)
+    </span>
+  </button>
+  <br />
+  <button
+    class="ant-btn ant-btn-text ant-btn-dangerous"
+    type="button"
+  >
+    <span>
+      Danger Text
+    </span>
+  </button>
+  <button
+    class="ant-btn ant-btn-text ant-btn-dangerous"
+    disabled=""
+    type="button"
+  >
+    <span>
+      Danger Text(disabled)
+    </span>
+  </button>
+  <br />
+  <button
+    class="ant-btn ant-btn-link ant-btn-dangerous"
+    type="button"
+  >
+    <span>
+      Danger Link
+    </span>
+  </button>
+  <button
+    class="ant-btn ant-btn-link ant-btn-dangerous"
+    disabled=""
+    type="button"
+  >
+    <span>
+      Danger Link(disabled)
     </span>
   </button>
   <div

--- a/components/button/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/button/__tests__/__snapshots__/demo.test.ts.snap
@@ -122,7 +122,7 @@ Array [
     type="button"
   >
     <span>
-      link
+      Link
     </span>
   </button>,
 ]

--- a/components/button/demo/danger.md
+++ b/components/button/demo/danger.md
@@ -29,7 +29,7 @@ ReactDOM.render(
       Text
     </Button>
     <Button type="link" danger>
-      link
+      Link
     </Button>
   </>,
   mountNode,

--- a/components/button/demo/danger.md
+++ b/components/button/demo/danger.md
@@ -25,6 +25,9 @@ ReactDOM.render(
     <Button type="dashed" danger>
       Dashed
     </Button>
+    <Button type="text" danger>
+      Text
+    </Button>
     <Button type="link" danger>
       link
     </Button>

--- a/components/button/demo/disabled.md
+++ b/components/button/demo/disabled.md
@@ -31,14 +31,26 @@ ReactDOM.render(
       Dashed(disabled)
     </Button>
     <br />
+    <Button type="text">Text</Button>
+    <Button type="text" disabled>
+      Text(disabled)
+    </Button>
+    <br />
     <Button type="link">Link</Button>
     <Button type="link" disabled>
       Link(disabled)
     </Button>
     <br />
-    <Button type="text">Text</Button>
-    <Button type="text" disabled>
-      Text(disabled)
+    <Button danger>Danger Default</Button>
+    <Button danger disabled>
+      Danger Default(disabled)
+    </Button>
+    <br />
+    <Button danger type="text">
+      Danger Text
+    </Button>
+    <Button danger type="text" disabled>
+      Danger Text(disabled)
     </Button>
     <br />
     <Button type="link" danger>
@@ -46,11 +58,6 @@ ReactDOM.render(
     </Button>
     <Button type="link" danger disabled>
       Danger Link(disabled)
-    </Button>
-    <br />
-    <Button danger>Danger Default</Button>
-    <Button danger disabled>
-      Danger Default(disabled)
     </Button>
     <div className="site-button-ghost-wrapper">
       <Button ghost>Ghost</Button>

--- a/components/button/style/index.less
+++ b/components/button/style/index.less
@@ -22,7 +22,7 @@
   line-height: @line-height-base;
   .btn;
   .btn-default;
-  
+
   // Fix loading button animation
   // https://github.com/ant-design/ant-design/issues/24323
   > span {
@@ -93,6 +93,10 @@
 
   &-dangerous&-link {
     .btn-danger-link;
+  }
+
+  &-dangerous&-text {
+    .btn-danger-text;
   }
 
   &-icon-only {

--- a/components/button/style/mixin.less
+++ b/components/button/style/mixin.less
@@ -375,6 +375,29 @@
 
   .button-disabled(@disabled-color; transparent; transparent);
 }
+.btn-danger-text() {
+  .button-variant-other(@error-color, transparent, transparent);
+  box-shadow: none;
+  &:hover,
+  &:focus {
+    & when (@theme = dark) {
+      .button-color(~`colorPalette('@{error-color}', 7) `; @btn-text-hover-bg; transparent);
+    }
+    & when not (@theme = dark) {
+      .button-color(~`colorPalette('@{error-color}', 5) `; @btn-text-hover-bg; transparent);
+    }
+  }
+
+  &:active {
+    & when (@theme = dark) {
+      .button-color(~`colorPalette('@{error-color}', 5) `  , fadein(@btn-text-hover-bg, 1%) ,transparent);
+    }
+    & when not (@theme = dark) {
+      .button-color(~`colorPalette('@{error-color}', 7) `  ,   fadein(@btn-text-hover-bg, 1%) ,transparent);
+    }
+  }
+  .button-disabled(@disabled-color; transparent; transparent);
+}
 // round button
 .btn-round(@btnClassName: btn) {
   .button-size(@btn-circle-size; @btn-circle-size / 2; @font-size-base; @btn-circle-size);

--- a/components/button/style/mixin.less
+++ b/components/button/style/mixin.less
@@ -390,10 +390,10 @@
 
   &:active {
     & when (@theme = dark) {
-      .button-color(~`colorPalette('@{error-color}', 5) `  , fadein(@btn-text-hover-bg, 1%) ,transparent);
+      .button-color(~`colorPalette('@{error-color}', 5) `; fadein(@btn-text-hover-bg, 1%); transparent);
     }
     & when not (@theme = dark) {
-      .button-color(~`colorPalette('@{error-color}', 7) `  ,   fadein(@btn-text-hover-bg, 1%) ,transparent);
+      .button-color(~`colorPalette('@{error-color}', 7) `; fadein(@btn-text-hover-bg, 1%); transparent);
     }
   }
   .button-disabled(@disabled-color; transparent; transparent);


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

close #24614

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [x] Demo update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Perfermance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

https://github.com/ant-design/ant-design/issues/24614
<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

![ezgif com-video-to-gif (1)](https://user-images.githubusercontent.com/15653996/83354298-54199b00-a38a-11ea-9805-de78f84f936f.gif)

Reorder the `disabled` demo following: `normal`, `text`, `link`
![image](https://user-images.githubusercontent.com/15653996/83354404-fcc7fa80-a38a-11ea-88bd-d924173747fd.png)


<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the inconsistent style of Text Button in `danger`. |
| 🇨🇳 Chinese | 修复 Text Button 在 `danger` 时样式不一致的问题。 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/button/demo/danger.md](https://github.com/morenyang/ant-design/blob/text-btn-danger-border/components/button/demo/danger.md)
[View rendered components/button/demo/disabled.md](https://github.com/morenyang/ant-design/blob/text-btn-danger-border/components/button/demo/disabled.md)