### PR TITLE
docs: demo on Typography.paragraph

### DIFF
--- a/components/typography/demo/ellipsis.md
+++ b/components/typography/demo/ellipsis.md
@@ -29,7 +29,7 @@ ReactDOM.render(
       language for background applications, is refined by Ant UED Team.
     </Paragraph>
 
-    <Paragraph ellipsis={{ rows: 1, expandable: true, symbol: 'more' }}>
+    <Paragraph ellipsis={{ rows: 2, expandable: true, symbol: 'more' }}>
       Ant Design, a design language for background applications, is refined by Ant UED Team. Ant
       Design, a design language for background applications, is refined by Ant UED Team. Ant Design,
       a design language for background applications, is refined by Ant UED Team. Ant Design, a

--- a/components/typography/demo/ellipsis.md
+++ b/components/typography/demo/ellipsis.md
@@ -29,7 +29,7 @@ ReactDOM.render(
       language for background applications, is refined by Ant UED Team.
     </Paragraph>
 
-    <Paragraph ellipsis={{ rows: 3, expandable: true, symbol: 'more' }}>
+    <Paragraph ellipsis={{ rows: 1, expandable: true, symbol: 'more' }}>
       Ant Design, a design language for background applications, is refined by Ant UED Team. Ant
       Design, a design language for background applications, is refined by Ant UED Team. Ant Design,
       a design language for background applications, is refined by Ant UED Team. Ant Design, a


### PR DESCRIPTION
[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [x] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Perfermance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link


### 💡 Background and solution
![image](https://user-images.githubusercontent.com/32598811/83372631-6e8a5d80-a3f8-11ea-802a-f93365b7ff32.png)
Typography.paragraph 的这个demo在一些屏幕宽一点的屏幕上可能显示效果没有那么好，导致自定义的隐藏没有显示出来，因此把行数调少一点，和上面那一行形成一个对照。

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     None     |
| 🇨🇳 Chinese |   无      |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/typography/demo/ellipsis.md](https://github.com/fireairforce/ant-design/blob/typography-demo/components/typography/demo/ellipsis.md)