### PR TITLE
feat: add successColor for Progress

### DIFF
--- a/components/progress/Circle.tsx
+++ b/components/progress/Circle.tsx
@@ -10,8 +10,12 @@ interface CircleProps extends ProgressProps {
   progressStatus: string;
 }
 
-function getPercentage({ percent, successPercent }: CircleProps) {
+function getPercentage({ percent, success }: CircleProps) {
   const ptg = validProgress(percent);
+  let successPercent;
+  if (success && 'progress' in success) {
+    successPercent = success.progress;
+  }
   if (!successPercent) {
     return ptg;
   }
@@ -20,8 +24,12 @@ function getPercentage({ percent, successPercent }: CircleProps) {
   return [successPercent, validProgress(ptg - successPtg)];
 }
 
-function getStrokeColor({ successPercent, strokeColor }: CircleProps) {
+function getStrokeColor({ success, strokeColor }: CircleProps) {
   const color = strokeColor || null;
+  let successPercent;
+  if (success && 'progress' in success) {
+    successPercent = success.progress;
+  }
   if (!successPercent) {
     return color;
   }

--- a/components/progress/Circle.tsx
+++ b/components/progress/Circle.tsx
@@ -10,9 +10,8 @@ interface CircleProps extends ProgressProps {
   progressStatus: string;
 }
 
-function getPercentage({ percent, success }: CircleProps) {
+function getPercentage({ percent, success, successPercent }: CircleProps) {
   const ptg = validProgress(percent);
-  let successPercent;
   if (success && 'progress' in success) {
     successPercent = success.progress;
   }
@@ -24,9 +23,8 @@ function getPercentage({ percent, success }: CircleProps) {
   return [successPercent, validProgress(ptg - successPtg)];
 }
 
-function getStrokeColor({ success, strokeColor }: CircleProps) {
+function getStrokeColor({ success, strokeColor, successPercent }: CircleProps) {
   const color = strokeColor || null;
-  let successPercent;
   if (success && 'progress' in success) {
     successPercent = success.progress;
   }

--- a/components/progress/Line.tsx
+++ b/components/progress/Line.tsx
@@ -61,15 +61,15 @@ const Line: React.FC<LineProps> = props => {
   const {
     prefixCls,
     percent,
-    successPercent,
     strokeWidth,
     size,
     strokeColor,
     strokeLinecap,
     children,
     trailColor,
-    successColor,
+    success,
   } = props;
+
   let backgroundProps;
   if (strokeColor && typeof strokeColor !== 'string') {
     backgroundProps = handleGradient(strokeColor);
@@ -78,12 +78,19 @@ const Line: React.FC<LineProps> = props => {
       background: strokeColor,
     };
   }
+
   let trailStyle;
   if (trailColor && typeof trailColor === 'string') {
     trailStyle = {
       backgroundColor: trailColor,
     };
   }
+
+  let successColor;
+  if (success && 'strokeColor' in success) {
+    successColor = success.strokeColor;
+  }
+
   let successStyle;
   if (successColor && typeof successColor === 'string') {
     successStyle = {
@@ -96,6 +103,12 @@ const Line: React.FC<LineProps> = props => {
     borderRadius: strokeLinecap === 'square' ? 0 : '',
     ...backgroundProps,
   };
+
+  let successPercent;
+  if (success && 'progress' in success) {
+    successPercent = success.progress;
+  }
+
   let successPercentStyle = {
     width: `${validProgress(successPercent)}%`,
     height: strokeWidth || (size === 'small' ? 6 : 8),

--- a/components/progress/Line.tsx
+++ b/components/progress/Line.tsx
@@ -68,6 +68,7 @@ const Line: React.FC<LineProps> = props => {
     strokeLinecap,
     children,
     trailColor,
+    successColor,
   } = props;
   let backgroundProps;
   if (strokeColor && typeof strokeColor !== 'string') {
@@ -93,6 +94,7 @@ const Line: React.FC<LineProps> = props => {
     width: `${validProgress(successPercent)}%`,
     height: strokeWidth || (size === 'small' ? 6 : 8),
     borderRadius: strokeLinecap === 'square' ? 0 : '',
+    backgroundColor: successColor || '',
   };
   const successSegment =
     successPercent !== undefined ? (

--- a/components/progress/Line.tsx
+++ b/components/progress/Line.tsx
@@ -84,18 +84,26 @@ const Line: React.FC<LineProps> = props => {
       backgroundColor: trailColor,
     };
   }
+  let successStyle;
+  if (successColor && typeof successColor === 'string') {
+    successStyle = {
+      backgroundColor: successColor,
+    };
+  }
   const percentStyle = {
     width: `${validProgress(percent)}%`,
     height: strokeWidth || (size === 'small' ? 6 : 8),
     borderRadius: strokeLinecap === 'square' ? 0 : '',
     ...backgroundProps,
   };
-  const successPercentStyle = {
+  let successPercentStyle = {
     width: `${validProgress(successPercent)}%`,
     height: strokeWidth || (size === 'small' ? 6 : 8),
     borderRadius: strokeLinecap === 'square' ? 0 : '',
-    backgroundColor: successColor || '',
   };
+  if (successStyle) {
+    successPercentStyle = { ...successPercentStyle, ...successStyle };
+  }
   const successSegment =
     successPercent !== undefined ? (
       <div className={`${prefixCls}-success-bg`} style={successPercentStyle} />

--- a/components/progress/Line.tsx
+++ b/components/progress/Line.tsx
@@ -104,7 +104,7 @@ const Line: React.FC<LineProps> = props => {
     ...backgroundProps,
   };
 
-  let successPercent;
+  let { successPercent } = props;
   if (success && 'progress' in success) {
     successPercent = success.progress;
   }

--- a/components/progress/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/progress/__tests__/__snapshots__/demo.test.js.snap
@@ -1280,7 +1280,6 @@ exports[`renders ./components/progress/demo/segment.md correctly 1`] = `
 Array [
   <div
     class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default"
-    success="[object Object]"
   >
     <div
       class="ant-progress-outer"
@@ -1307,7 +1306,6 @@ Array [
   </div>,
   <div
     class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default"
-    success="[object Object]"
   >
     <div
       class="ant-progress-inner"
@@ -1362,7 +1360,6 @@ Array [
   </div>,
   <div
     class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default"
-    success="[object Object]"
   >
     <div
       class="ant-progress-inner"

--- a/components/progress/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/progress/__tests__/__snapshots__/demo.test.js.snap
@@ -1293,7 +1293,7 @@ Array [
         />
         <div
           class="ant-progress-success-bg"
-          style="width:30%;height:8px;border-radius:"
+          style="width:30%;height:8px;border-radius:;background-color:"
         />
       </div>
     </div>

--- a/components/progress/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/progress/__tests__/__snapshots__/demo.test.js.snap
@@ -1293,7 +1293,7 @@ Array [
         />
         <div
           class="ant-progress-success-bg"
-          style="width:30%;height:8px;border-radius:;background-color:"
+          style="width:30%;height:8px;border-radius:"
         />
       </div>
     </div>

--- a/components/progress/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/progress/__tests__/__snapshots__/demo.test.js.snap
@@ -1280,6 +1280,7 @@ exports[`renders ./components/progress/demo/segment.md correctly 1`] = `
 Array [
   <div
     class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default"
+    success="[object Object]"
   >
     <div
       class="ant-progress-outer"
@@ -1306,6 +1307,7 @@ Array [
   </div>,
   <div
     class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default"
+    success="[object Object]"
   >
     <div
       class="ant-progress-inner"
@@ -1360,6 +1362,7 @@ Array [
   </div>,
   <div
     class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default"
+    success="[object Object]"
   >
     <div
       class="ant-progress-inner"

--- a/components/progress/__tests__/__snapshots__/index.test.js.snap
+++ b/components/progress/__tests__/__snapshots__/index.test.js.snap
@@ -504,31 +504,6 @@ exports[`Progress render strokeColor 3`] = `
 </Progress>
 `;
 
-exports[`Progress render successColor progress 1`] = `
-<div
-  class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default"
->
-  <div
-    class="ant-progress-outer"
-  >
-    <div
-      class="ant-progress-inner"
-    >
-      <div
-        class="ant-progress-bg"
-        style="width: 0%; height: 8px;"
-      />
-    </div>
-  </div>
-  <span
-    class="ant-progress-text"
-    title="0%"
-  >
-    0%
-  </span>
-</div>
-`;
-
 exports[`Progress render trailColor progress 1`] = `
 <div
   class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default"

--- a/components/progress/__tests__/__snapshots__/index.test.js.snap
+++ b/components/progress/__tests__/__snapshots__/index.test.js.snap
@@ -504,6 +504,35 @@ exports[`Progress render strokeColor 3`] = `
 </Progress>
 `;
 
+exports[`Progress render successColor progress 1`] = `
+<div
+  class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default"
+>
+  <div
+    class="ant-progress-outer"
+  >
+    <div
+      class="ant-progress-inner"
+    >
+      <div
+        class="ant-progress-bg"
+        style="width: 60%; height: 8px;"
+      />
+      <div
+        class="ant-progress-success-bg"
+        style="width: 30%; height: 8px; background-color: rgb(255, 255, 255);"
+      />
+    </div>
+  </div>
+  <span
+    class="ant-progress-text"
+    title="60%"
+  >
+    60%
+  </span>
+</div>
+`;
+
 exports[`Progress render trailColor progress 1`] = `
 <div
   class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default"

--- a/components/progress/__tests__/__snapshots__/index.test.js.snap
+++ b/components/progress/__tests__/__snapshots__/index.test.js.snap
@@ -138,7 +138,6 @@ exports[`Progress render dashboard zero gapDegree 1`] = `
 exports[`Progress render format 1`] = `
 <div
   class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default"
-  success="[object Object]"
 >
   <div
     class="ant-progress-outer"
@@ -193,7 +192,6 @@ exports[`Progress render negative progress 1`] = `
 exports[`Progress render negative successPercent 1`] = `
 <div
   class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default"
-  success="[object Object]"
 >
   <div
     class="ant-progress-outer"
@@ -505,7 +503,6 @@ exports[`Progress render strokeColor 3`] = `
 exports[`Progress render successColor progress 1`] = `
 <div
   class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default"
-  success="[object Object]"
 >
   <div
     class="ant-progress-outer"

--- a/components/progress/__tests__/__snapshots__/index.test.js.snap
+++ b/components/progress/__tests__/__snapshots__/index.test.js.snap
@@ -503,7 +503,7 @@ exports[`Progress render strokeColor 3`] = `
 exports[`Progress render successColor progress 1`] = `
 <div
   class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default"
-  successcolor="#000"
+  successcolor="#ffffff"
 >
   <div
     class="ant-progress-outer"

--- a/components/progress/__tests__/__snapshots__/index.test.js.snap
+++ b/components/progress/__tests__/__snapshots__/index.test.js.snap
@@ -500,6 +500,32 @@ exports[`Progress render strokeColor 3`] = `
 </Progress>
 `;
 
+exports[`Progress render successColor progress 1`] = `
+<div
+  class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default"
+  successcolor="#000"
+>
+  <div
+    class="ant-progress-outer"
+  >
+    <div
+      class="ant-progress-inner"
+    >
+      <div
+        class="ant-progress-bg"
+        style="width: 0%; height: 8px;"
+      />
+    </div>
+  </div>
+  <span
+    class="ant-progress-text"
+    title="0%"
+  >
+    0%
+  </span>
+</div>
+`;
+
 exports[`Progress render trailColor progress 1`] = `
 <div
   class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default"

--- a/components/progress/__tests__/__snapshots__/index.test.js.snap
+++ b/components/progress/__tests__/__snapshots__/index.test.js.snap
@@ -138,6 +138,7 @@ exports[`Progress render dashboard zero gapDegree 1`] = `
 exports[`Progress render format 1`] = `
 <div
   class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default"
+  success="[object Object]"
 >
   <div
     class="ant-progress-outer"
@@ -192,6 +193,7 @@ exports[`Progress render negative progress 1`] = `
 exports[`Progress render negative successPercent 1`] = `
 <div
   class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default"
+  success="[object Object]"
 >
   <div
     class="ant-progress-outer"
@@ -386,7 +388,6 @@ exports[`Progress render strokeColor 2`] = `
     }
   }
   strokeLinecap="round"
-  successColor={null}
   trailColor={null}
   type="line"
 >
@@ -405,7 +406,6 @@ exports[`Progress render strokeColor 2`] = `
         }
       }
       strokeLinecap="round"
-      successColor={null}
       trailColor={null}
       type="line"
     >
@@ -451,7 +451,6 @@ exports[`Progress render strokeColor 3`] = `
     }
   }
   strokeLinecap="round"
-  successColor={null}
   trailColor={null}
   type="line"
 >
@@ -470,7 +469,6 @@ exports[`Progress render strokeColor 3`] = `
         }
       }
       strokeLinecap="round"
-      successColor={null}
       trailColor={null}
       type="line"
     >
@@ -507,6 +505,7 @@ exports[`Progress render strokeColor 3`] = `
 exports[`Progress render successColor progress 1`] = `
 <div
   class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default"
+  success="[object Object]"
 >
   <div
     class="ant-progress-outer"

--- a/components/progress/__tests__/__snapshots__/index.test.js.snap
+++ b/components/progress/__tests__/__snapshots__/index.test.js.snap
@@ -386,6 +386,7 @@ exports[`Progress render strokeColor 2`] = `
     }
   }
   strokeLinecap="round"
+  successColor={null}
   trailColor={null}
   type="line"
 >
@@ -404,6 +405,7 @@ exports[`Progress render strokeColor 2`] = `
         }
       }
       strokeLinecap="round"
+      successColor={null}
       trailColor={null}
       type="line"
     >
@@ -449,6 +451,7 @@ exports[`Progress render strokeColor 3`] = `
     }
   }
   strokeLinecap="round"
+  successColor={null}
   trailColor={null}
   type="line"
 >
@@ -467,6 +470,7 @@ exports[`Progress render strokeColor 3`] = `
         }
       }
       strokeLinecap="round"
+      successColor={null}
       trailColor={null}
       type="line"
     >
@@ -503,7 +507,6 @@ exports[`Progress render strokeColor 3`] = `
 exports[`Progress render successColor progress 1`] = `
 <div
   class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default"
-  successcolor="#ffffff"
 >
   <div
     class="ant-progress-outer"

--- a/components/progress/__tests__/index.test.js
+++ b/components/progress/__tests__/index.test.js
@@ -10,13 +10,13 @@ describe('Progress', () => {
   rtlTest(Progress);
 
   it('successPercent should decide the progress status when it exists', () => {
-    const wrapper = mount(<Progress percent={100} successPercent={50} />);
+    const wrapper = mount(<Progress percent={100} success={{ progress: 50 }} />);
     expect(wrapper.find('.ant-progress-status-success')).toHaveLength(0);
 
-    wrapper.setProps({ percent: 50, successPercent: 100 });
+    wrapper.setProps({ percent: 50, success: { progress: 100 } });
     expect(wrapper.find('.ant-progress-status-success')).toHaveLength(1);
 
-    wrapper.setProps({ percent: 100, successPercent: 0 });
+    wrapper.setProps({ percent: 100, success: { progress: 0 } });
     expect(wrapper.find('.ant-progress-status-success')).toHaveLength(0);
   });
 
@@ -36,7 +36,7 @@ describe('Progress', () => {
   });
 
   it('render negative successPercent', () => {
-    const wrapper = mount(<Progress percent={50} successPercent={-20} />);
+    const wrapper = mount(<Progress percent={50} success={{ progress: -20 }} />);
     expect(wrapper.render()).toMatchSnapshot();
   });
 
@@ -44,7 +44,7 @@ describe('Progress', () => {
     const wrapper = mount(
       <Progress
         percent={50}
-        successPercent={10}
+        success={{ progress: 10 }}
         format={(percent, successPercent) => `${percent} ${successPercent}`}
       />,
     );
@@ -82,7 +82,9 @@ describe('Progress', () => {
   });
 
   it('render successColor progress', () => {
-    const wrapper = mount(<Progress percent={60} successPercent={30} successColor="#ffffff" />);
+    const wrapper = mount(
+      <Progress percent={60} success={{ progress: 30, strokeColor: '#ffffff' }} />,
+    );
     expect(wrapper.render()).toMatchSnapshot();
   });
 

--- a/components/progress/__tests__/index.test.js
+++ b/components/progress/__tests__/index.test.js
@@ -82,7 +82,7 @@ describe('Progress', () => {
   });
 
   it('render successColor progress', () => {
-    const wrapper = mount(<Progress status="normal" successColor="#ffffff" />);
+    const wrapper = mount(<Progress status="normal" successColor="#000000" />);
     expect(wrapper.render()).toMatchSnapshot();
   });
 

--- a/components/progress/__tests__/index.test.js
+++ b/components/progress/__tests__/index.test.js
@@ -82,7 +82,7 @@ describe('Progress', () => {
   });
 
   it('render successColor progress', () => {
-    const wrapper = mount(<Progress status="normal" successColor="#000" />);
+    const wrapper = mount(<Progress status="normal" successColor="#ffffff" />);
     expect(wrapper.render()).toMatchSnapshot();
   });
 

--- a/components/progress/__tests__/index.test.js
+++ b/components/progress/__tests__/index.test.js
@@ -81,6 +81,11 @@ describe('Progress', () => {
     expect(wrapper.render()).toMatchSnapshot();
   });
 
+  it('render successColor progress', () => {
+    const wrapper = mount(<Progress status="normal" successColor="#000" />);
+    expect(wrapper.render()).toMatchSnapshot();
+  });
+
   it('render dashboard zero gapDegree', () => {
     const wrapper = mount(<Progress type="dashboard" gapDegree={0} />);
     expect(wrapper.render()).toMatchSnapshot();

--- a/components/progress/__tests__/index.test.js
+++ b/components/progress/__tests__/index.test.js
@@ -81,11 +81,6 @@ describe('Progress', () => {
     expect(wrapper.render()).toMatchSnapshot();
   });
 
-  it('render successColor progress', () => {
-    const wrapper = mount(<Progress status="normal" successColor="#000000" />);
-    expect(wrapper.render()).toMatchSnapshot();
-  });
-
   it('render dashboard zero gapDegree', () => {
     const wrapper = mount(<Progress type="dashboard" gapDegree={0} />);
     expect(wrapper.render()).toMatchSnapshot();

--- a/components/progress/__tests__/index.test.js
+++ b/components/progress/__tests__/index.test.js
@@ -81,6 +81,11 @@ describe('Progress', () => {
     expect(wrapper.render()).toMatchSnapshot();
   });
 
+  it('render successColor progress', () => {
+    const wrapper = mount(<Progress percent={60} successPercent={30} successColor="#ffffff" />);
+    expect(wrapper.render()).toMatchSnapshot();
+  });
+
   it('render dashboard zero gapDegree', () => {
     const wrapper = mount(<Progress type="dashboard" gapDegree={0} />);
     expect(wrapper.render()).toMatchSnapshot();

--- a/components/progress/demo/segment.md
+++ b/components/progress/demo/segment.md
@@ -19,15 +19,15 @@ import { Tooltip, Progress } from 'antd';
 ReactDOM.render(
   <>
     <Tooltip title="3 done / 3 in progress / 4 to do">
-      <Progress percent={60} successPercent={30} />
+      <Progress percent={60} success={{ progress: 30 }} />
     </Tooltip>
 
     <Tooltip title="3 done / 3 in progress / 4 to do">
-      <Progress percent={60} successPercent={30} type="circle" />
+      <Progress percent={60} success={{ progress: 30 }} type="circle" />
     </Tooltip>
 
     <Tooltip title="3 done / 3 in progress / 4 to do">
-      <Progress percent={60} successPercent={30} type="dashboard" />
+      <Progress percent={60} success={{ progress: 30 }} type="dashboard" />
     </Tooltip>
   </>,
   mountNode,

--- a/components/progress/index.en-US.md
+++ b/components/progress/index.en-US.md
@@ -27,9 +27,8 @@ Properties that shared by all types.
 | status | to set the status of the Progress, options: `success` `exception` `normal` `active`(line only) | string | - |
 | strokeLinecap | to set the style of the progress linecap | `round` \| `square` | `round` |
 | strokeColor | color of progress bar | string | - |
-| successPercent | segmented success percent | number | 0 |
 | trailColor | color of unfilled part | string | - |
-| successColor | color of filled part | string | `#52c41a` |
+| success | configs of successfully progress bar | { progress: number, strokeColor: string } | - |
 
 ### `type="line"`
 

--- a/components/progress/index.en-US.md
+++ b/components/progress/index.en-US.md
@@ -29,6 +29,7 @@ Properties that shared by all types.
 | strokeColor | color of progress bar | string | - |
 | successPercent | segmented success percent | number | 0 |
 | trailColor | color of unfilled part | string | - |
+| successColor | color of filled part | string | `#52c41a` |
 
 ### `type="line"`
 

--- a/components/progress/index.zh-CN.md
+++ b/components/progress/index.zh-CN.md
@@ -28,9 +28,8 @@ cover: https://gw.alipayobjects.com/zos/antfincdn/%24X8q%26OILIY/Progress.svg
 | status | 状态，可选：`success` `exception` `normal` `active`(仅限 line) | string | - |
 | strokeLinecap | - | `round` \| `square` | `round` |
 | strokeColor | 进度条的色彩 | string | - |
-| successPercent | 已完成的分段百分比 | number | 0 |
 | trailColor | 未完成的分段的颜色 | string | - |
-| successColor | 已完成的分段的颜色 | string | `#52c41a` |
+| success | 成功进度条相关配置 | { progress: number, strokeColor: string } | - |
 
 ### `type="line"`
 

--- a/components/progress/index.zh-CN.md
+++ b/components/progress/index.zh-CN.md
@@ -30,6 +30,7 @@ cover: https://gw.alipayobjects.com/zos/antfincdn/%24X8q%26OILIY/Progress.svg
 | strokeColor | 进度条的色彩 | string | - |
 | successPercent | 已完成的分段百分比 | number | 0 |
 | trailColor | 未完成的分段的颜色 | string | - |
+| successColor | 已完成的分段的颜色 | string | `#52c41a` |
 
 ### `type="line"`
 

--- a/components/progress/progress.tsx
+++ b/components/progress/progress.tsx
@@ -20,12 +20,17 @@ export type ProgressSize = 'default' | 'small';
 export type StringGradients = { [percentage: string]: string };
 type FromToGradients = { from: string; to: string };
 export type ProgressGradient = { direction?: string } & (StringGradients | FromToGradients);
+
+export interface SuccessProps {
+  progress?: number;
+  strokeColor?: string;
+}
+
 export interface ProgressProps {
   prefixCls?: string;
   className?: string;
   type?: ProgressType;
   percent?: number;
-  successPercent?: number;
   format?: (percent?: number, successPercent?: number) => React.ReactNode;
   status?: typeof ProgressStatuses[number];
   showInfo?: boolean;
@@ -33,8 +38,8 @@ export interface ProgressProps {
   strokeLinecap?: 'butt' | 'square' | 'round';
   strokeColor?: string | ProgressGradient;
   trailColor?: string;
-  successColor?: string;
   width?: number;
+  success?: SuccessProps;
   style?: React.CSSProperties;
   gapDegree?: number;
   gapPosition?: 'top' | 'bottom' | 'left' | 'right';
@@ -49,14 +54,17 @@ export default class Progress extends React.Component<ProgressProps> {
     showInfo: true,
     // null for different theme definition
     trailColor: null,
-    successColor: null,
     size: 'default' as ProgressProps['size'],
     gapDegree: undefined,
     strokeLinecap: 'round' as ProgressProps['strokeLinecap'],
   };
 
   getPercentNumber() {
-    const { successPercent, percent = 0 } = this.props;
+    const { percent = 0, success } = this.props;
+    let successPercent;
+    if (success) {
+      successPercent = success.progress;
+    }
     return parseInt(
       successPercent !== undefined ? successPercent.toString() : percent.toString(),
       10,
@@ -72,7 +80,11 @@ export default class Progress extends React.Component<ProgressProps> {
   }
 
   renderProcessInfo(prefixCls: string, progressStatus: typeof ProgressStatuses[number]) {
-    const { showInfo, format, type, percent, successPercent } = this.props;
+    const { showInfo, format, type, percent, success } = this.props;
+    let successPercent;
+    if (success && 'progress' in success) {
+      successPercent = success.progress;
+    }
     if (!showInfo) return null;
 
     let text;
@@ -150,8 +162,6 @@ export default class Progress extends React.Component<ProgressProps> {
           'status',
           'format',
           'trailColor',
-          'successColor',
-          'successPercent',
           'strokeWidth',
           'width',
           'gapDegree',

--- a/components/progress/progress.tsx
+++ b/components/progress/progress.tsx
@@ -33,6 +33,7 @@ export interface ProgressProps {
   strokeLinecap?: 'butt' | 'square' | 'round';
   strokeColor?: string | ProgressGradient;
   trailColor?: string;
+  successColor?: string;
   width?: number;
   style?: React.CSSProperties;
   gapDegree?: number;

--- a/components/progress/progress.tsx
+++ b/components/progress/progress.tsx
@@ -170,6 +170,7 @@ export default class Progress extends React.Component<ProgressProps> {
           'strokeLinecap',
           'percent',
           'steps',
+          'success',
         ])}
         className={classString}
       >

--- a/components/progress/progress.tsx
+++ b/components/progress/progress.tsx
@@ -8,6 +8,7 @@ import CloseCircleFilled from '@ant-design/icons/CloseCircleFilled';
 
 import { ConfigConsumer, ConfigConsumerProps } from '../config-provider';
 import { tuple } from '../_util/type';
+import devWarning from '../_util/devWarning';
 import Line from './Line';
 import Circle from './Circle';
 import Steps from './Steps';
@@ -45,6 +46,8 @@ export interface ProgressProps {
   gapPosition?: 'top' | 'bottom' | 'left' | 'right';
   size?: ProgressSize;
   steps?: number;
+  /** @deprecated Use `success` instead */
+  successPercent?: number;
 }
 
 export default class Progress extends React.Component<ProgressProps> {
@@ -61,8 +64,8 @@ export default class Progress extends React.Component<ProgressProps> {
 
   getPercentNumber() {
     const { percent = 0, success } = this.props;
-    let successPercent;
-    if (success) {
+    let { successPercent } = this.props;
+    if (success && 'progress' in success) {
       successPercent = success.progress;
     }
     return parseInt(
@@ -81,7 +84,7 @@ export default class Progress extends React.Component<ProgressProps> {
 
   renderProcessInfo(prefixCls: string, progressStatus: typeof ProgressStatuses[number]) {
     const { showInfo, format, type, percent, success } = this.props;
-    let successPercent;
+    let { successPercent } = this.props;
     if (success && 'progress' in success) {
       successPercent = success.progress;
     }
@@ -119,6 +122,13 @@ export default class Progress extends React.Component<ProgressProps> {
     const prefixCls = getPrefixCls('progress', customizePrefixCls);
     const progressStatus = this.getProgressStatus();
     const progressInfo = this.renderProcessInfo(prefixCls, progressStatus);
+
+    devWarning(
+      'successPercent' in props,
+      'Progress',
+      '`successPercent` is deprecated. Please use `success` instead.',
+    );
+
     let progress;
     // Render progress shape
     if (type === 'line') {
@@ -171,6 +181,7 @@ export default class Progress extends React.Component<ProgressProps> {
           'percent',
           'steps',
           'success',
+          'successPercent',
         ])}
         className={classString}
       >

--- a/components/progress/progress.tsx
+++ b/components/progress/progress.tsx
@@ -49,6 +49,7 @@ export default class Progress extends React.Component<ProgressProps> {
     showInfo: true,
     // null for different theme definition
     trailColor: null,
+    successColor: null,
     size: 'default' as ProgressProps['size'],
     gapDegree: undefined,
     strokeLinecap: 'round' as ProgressProps['strokeLinecap'],
@@ -149,6 +150,7 @@ export default class Progress extends React.Component<ProgressProps> {
           'status',
           'format',
           'trailColor',
+          'successColor',
           'successPercent',
           'strokeWidth',
           'width',


### PR DESCRIPTION
[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Perfermance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
https://github.com/ant-design/ant-design/issues/20770

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Progress support customise filled Progress color      |
| 🇨🇳 Chinese |    Progress组件新增自定义已完成进度条颜色      |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/progress/index.en-US.md](https://github.com/fireairforce/ant-design/blob/process-successPercent/components/progress/index.en-US.md)
[View rendered components/progress/index.zh-CN.md](https://github.com/fireairforce/ant-design/blob/process-successPercent/components/progress/index.zh-CN.md)