### PR TITLE
feat: add table onChange an action param

### DIFF
--- a/components/table/Table.tsx
+++ b/components/table/Table.tsx
@@ -43,7 +43,8 @@ export { ColumnsType, TablePaginationConfig };
 
 const EMPTY_LIST: any[] = [];
 
-export const TableActions = tuple('paginate', 'sort', 'filter');
+const TableActions = tuple('paginate', 'sort', 'filter');
+export type TableAction = typeof TableActions[number];
 
 interface ChangeEventInfo<RecordType> {
   pagination: {
@@ -79,7 +80,7 @@ export interface TableProps<RecordType>
     filters: Record<string, Key[] | null>,
     sorter: SorterResult<RecordType> | SorterResult<RecordType>[],
     extra: TableCurrentDataSource<RecordType>,
-    action: typeof TableActions[number],
+    action: TableAction,
   ) => void;
   rowSelection?: TableRowSelection<RecordType>;
 
@@ -184,7 +185,7 @@ function Table<RecordType extends object = any>(props: TableProps<RecordType>) {
 
   const triggerOnChange = (
     info: Partial<ChangeEventInfo<RecordType>>,
-    action: typeof TableActions[number],
+    action: TableAction,
     reset: boolean = false,
   ) => {
     const changeInfo = {

--- a/components/table/Table.tsx
+++ b/components/table/Table.tsx
@@ -42,6 +42,8 @@ export { ColumnsType, TablePaginationConfig };
 
 const EMPTY_LIST: any[] = [];
 
+export type TableAction = 'paginate' | 'sort' | 'filter';
+
 interface ChangeEventInfo<RecordType> {
   pagination: {
     current?: number;
@@ -76,7 +78,7 @@ export interface TableProps<RecordType>
     filters: Record<string, Key[] | null>,
     sorter: SorterResult<RecordType> | SorterResult<RecordType>[],
     extra: TableCurrentDataSource<RecordType>,
-    action: 'paginate' | 'sort' | 'filter',
+    action: TableAction,
   ) => void;
   rowSelection?: TableRowSelection<RecordType>;
 
@@ -181,7 +183,7 @@ function Table<RecordType extends object = any>(props: TableProps<RecordType>) {
 
   const triggerOnChange = (
     info: Partial<ChangeEventInfo<RecordType>>,
-    action: 'paginate' | 'sort' | 'filter',
+    action: TableAction,
     reset: boolean = false,
   ) => {
     const changeInfo = {

--- a/components/table/Table.tsx
+++ b/components/table/Table.tsx
@@ -37,12 +37,13 @@ import Column from './Column';
 import ColumnGroup from './ColumnGroup';
 import devWarning from '../_util/devWarning';
 import useBreakpoint from '../grid/hooks/useBreakpoint';
+import { tuple } from '../_util/type';
 
 export { ColumnsType, TablePaginationConfig };
 
 const EMPTY_LIST: any[] = [];
 
-export type TableAction = 'paginate' | 'sort' | 'filter';
+export const TableActions = tuple('paginate', 'sort', 'filter');
 
 interface ChangeEventInfo<RecordType> {
   pagination: {
@@ -78,7 +79,7 @@ export interface TableProps<RecordType>
     filters: Record<string, Key[] | null>,
     sorter: SorterResult<RecordType> | SorterResult<RecordType>[],
     extra: TableCurrentDataSource<RecordType>,
-    action: TableAction,
+    action: typeof TableActions[number],
   ) => void;
   rowSelection?: TableRowSelection<RecordType>;
 
@@ -183,7 +184,7 @@ function Table<RecordType extends object = any>(props: TableProps<RecordType>) {
 
   const triggerOnChange = (
     info: Partial<ChangeEventInfo<RecordType>>,
-    action: TableAction,
+    action: typeof TableActions[number],
     reset: boolean = false,
   ) => {
     const changeInfo = {

--- a/components/table/Table.tsx
+++ b/components/table/Table.tsx
@@ -24,6 +24,7 @@ import {
   TablePaginationConfig,
   SortOrder,
   TableLocale,
+  TableAction,
 } from './interface';
 import useSelection, { SELECTION_ALL, SELECTION_INVERT } from './hooks/useSelection';
 import useSorter, { getSortData, SortState } from './hooks/useSorter';
@@ -37,14 +38,10 @@ import Column from './Column';
 import ColumnGroup from './ColumnGroup';
 import devWarning from '../_util/devWarning';
 import useBreakpoint from '../grid/hooks/useBreakpoint';
-import { tuple } from '../_util/type';
 
 export { ColumnsType, TablePaginationConfig };
 
 const EMPTY_LIST: any[] = [];
-
-const TableActions = tuple('paginate', 'sort', 'filter');
-export type TableAction = typeof TableActions[number];
 
 interface ChangeEventInfo<RecordType> {
   pagination: {
@@ -80,7 +77,6 @@ export interface TableProps<RecordType>
     filters: Record<string, Key[] | null>,
     sorter: SorterResult<RecordType> | SorterResult<RecordType>[],
     extra: TableCurrentDataSource<RecordType>,
-    action: TableAction,
   ) => void;
   rowSelection?: TableRowSelection<RecordType>;
 
@@ -223,8 +219,8 @@ function Table<RecordType extends object = any>(props: TableProps<RecordType>) {
             getSortData(rawData, changeInfo.sorterStates!, childrenColumnName),
             changeInfo.filterStates!,
           ),
+          action,
         },
-        action,
       );
     }
   };

--- a/components/table/Table.tsx
+++ b/components/table/Table.tsx
@@ -76,6 +76,7 @@ export interface TableProps<RecordType>
     filters: Record<string, Key[] | null>,
     sorter: SorterResult<RecordType> | SorterResult<RecordType>[],
     extra: TableCurrentDataSource<RecordType>,
+    action: 'paginate' | 'sort' | 'filter',
   ) => void;
   rowSelection?: TableRowSelection<RecordType>;
 
@@ -178,7 +179,11 @@ function Table<RecordType extends object = any>(props: TableProps<RecordType>) {
   // ============================ Events =============================
   const changeEventInfo: Partial<ChangeEventInfo<RecordType>> = {};
 
-  const triggerOnChange = (info: Partial<ChangeEventInfo<RecordType>>, reset: boolean = false) => {
+  const triggerOnChange = (
+    info: Partial<ChangeEventInfo<RecordType>>,
+    action: 'paginate' | 'sort' | 'filter',
+    reset: boolean = false,
+  ) => {
     const changeInfo = {
       ...changeEventInfo,
       ...info,
@@ -205,12 +210,18 @@ function Table<RecordType extends object = any>(props: TableProps<RecordType>) {
     }
 
     if (onChange) {
-      onChange(changeInfo.pagination!, changeInfo.filters!, changeInfo.sorter!, {
-        currentDataSource: getFilterData(
-          getSortData(rawData, changeInfo.sorterStates!, childrenColumnName),
-          changeInfo.filterStates!,
-        ),
-      });
+      onChange(
+        changeInfo.pagination!,
+        changeInfo.filters!,
+        changeInfo.sorter!,
+        {
+          currentDataSource: getFilterData(
+            getSortData(rawData, changeInfo.sorterStates!, childrenColumnName),
+            changeInfo.filterStates!,
+          ),
+        },
+        action,
+      );
     }
   };
 
@@ -231,6 +242,7 @@ function Table<RecordType extends object = any>(props: TableProps<RecordType>) {
         sorter,
         sorterStates,
       },
+      'sort',
       false,
     );
   };
@@ -260,6 +272,7 @@ function Table<RecordType extends object = any>(props: TableProps<RecordType>) {
         filters,
         filterStates,
       },
+      'filter',
       true,
     );
   };
@@ -288,9 +301,12 @@ function Table<RecordType extends object = any>(props: TableProps<RecordType>) {
 
   // ========================== Pagination ==========================
   const onPaginationChange = (current: number, pageSize: number) => {
-    triggerOnChange({
-      pagination: { ...changeEventInfo.pagination, current, pageSize },
-    });
+    triggerOnChange(
+      {
+        pagination: { ...changeEventInfo.pagination, current, pageSize },
+      },
+      'paginate',
+    );
   };
 
   const [mergedPagination, resetPagination] = usePagination(

--- a/components/table/__tests__/Table.filter.test.js
+++ b/components/table/__tests__/Table.filter.test.js
@@ -363,6 +363,7 @@ describe('Table.filter', () => {
       {
         currentDataSource: [],
       },
+      'filter',
     );
   });
 
@@ -942,6 +943,7 @@ describe('Table.filter', () => {
       {
         currentDataSource: [],
       },
+      'filter',
     );
     expect(wrapper.find('.ant-pagination-item')).toHaveLength(0);
   });
@@ -973,6 +975,7 @@ describe('Table.filter', () => {
       {
         currentDataSource: [],
       },
+      'filter',
     );
   });
 
@@ -1045,6 +1048,7 @@ describe('Table.filter', () => {
         },
       }),
       expect.anything(),
+      'sort',
     );
 
     // Filter it
@@ -1065,6 +1069,7 @@ describe('Table.filter', () => {
         },
       }),
       expect.anything(),
+      'filter',
     );
   });
 

--- a/components/table/__tests__/Table.filter.test.js
+++ b/components/table/__tests__/Table.filter.test.js
@@ -362,8 +362,8 @@ describe('Table.filter', () => {
       {},
       {
         currentDataSource: [],
+        action: 'filter',
       },
-      'filter',
     );
   });
 
@@ -942,8 +942,8 @@ describe('Table.filter', () => {
       {},
       {
         currentDataSource: [],
+        action: 'filter',
       },
-      'filter',
     );
     expect(wrapper.find('.ant-pagination-item')).toHaveLength(0);
   });
@@ -974,8 +974,8 @@ describe('Table.filter', () => {
       {},
       {
         currentDataSource: [],
+        action: 'filter',
       },
-      'filter',
     );
   });
 
@@ -1047,8 +1047,10 @@ describe('Table.filter', () => {
           title: 'Name',
         },
       }),
-      expect.anything(),
-      'sort',
+      {
+        currentDataSource: expect.anything(),
+        action: 'sort',
+      },
     );
 
     // Filter it
@@ -1068,8 +1070,10 @@ describe('Table.filter', () => {
           title: 'Name',
         },
       }),
-      expect.anything(),
-      'filter',
+      {
+        currentDataSource: expect.anything(),
+        action: 'filter',
+      },
     );
   });
 

--- a/components/table/__tests__/Table.pagination.test.js
+++ b/components/table/__tests__/Table.pagination.test.js
@@ -131,8 +131,8 @@ describe('Table.pagination', () => {
           { key: 2, name: 'Tom' },
           { key: 3, name: 'Jerry' },
         ],
+        action: 'paginate',
       },
-      'paginate',
     );
 
     expect(handlePaginationChange).toHaveBeenCalledWith(2, 2);
@@ -245,8 +245,8 @@ describe('Table.pagination', () => {
           { key: 2, name: 'Tom' },
           { key: 3, name: 'Jerry' },
         ],
+        action: 'paginate',
       },
-      'paginate',
     );
     expect(onPaginationChange).toHaveBeenCalledWith(2, 10);
 

--- a/components/table/__tests__/Table.pagination.test.js
+++ b/components/table/__tests__/Table.pagination.test.js
@@ -132,6 +132,7 @@ describe('Table.pagination', () => {
           { key: 3, name: 'Jerry' },
         ],
       },
+      'paginate',
     );
 
     expect(handlePaginationChange).toHaveBeenCalledWith(2, 2);
@@ -245,6 +246,7 @@ describe('Table.pagination', () => {
           { key: 3, name: 'Jerry' },
         ],
       },
+      'paginate',
     );
     expect(onPaginationChange).toHaveBeenCalledWith(2, 10);
 

--- a/components/table/index.en-US.md
+++ b/components/table/index.en-US.md
@@ -78,7 +78,7 @@ const columns = [
 | size | Size of table | `default` \| `middle` \| `small` | `default` |
 | summary | Summary content | (currentData) => ReactNode | - |
 | title | Table title renderer | Function(currentPageData) | - |
-| onChange | Callback executed when pagination, filters or sorter is changed | Function(pagination, filters, sorter, extra: { currentDataSource: [] }, action: `paginate` \| `sort` \| `filter`) | - |
+| onChange | Callback executed when pagination, filters or sorter is changed | Function(pagination, filters, sorter, extra: { currentDataSource: [], action: `paginate` \| `sort` \| `filter` }) | - |
 | onHeaderRow | Set props on per header row | Function(column, index) | - |
 | onRow | Set props on per row | Function(record, index) | - |
 | getPopupContainer | the render container of dropdowns in table | (triggerNode) => HTMLElement | `() => TableHtmlElement` |

--- a/components/table/index.en-US.md
+++ b/components/table/index.en-US.md
@@ -289,7 +289,7 @@ Table total page count usually reduce after filter data, we defaultly return to 
 
 You may need to keep current page after filtering when fetch data from remote service, please check [this demo](https://codesandbox.io/s/yuanchengjiazaishuju-ant-design-demo-7y2uf) as workaround.
 
-Also you can use the action param to determine when return to first page.
+Also you can use the action from extra param to determine when return to first page.
 
 ### Why Table pagination show size changer?
 

--- a/components/table/index.en-US.md
+++ b/components/table/index.en-US.md
@@ -78,7 +78,7 @@ const columns = [
 | size | Size of table | `default` \| `middle` \| `small` | `default` |
 | summary | Summary content | (currentData) => ReactNode | - |
 | title | Table title renderer | Function(currentPageData) | - |
-| onChange | Callback executed when pagination, filters or sorter is changed | Function(pagination, filters, sorter, extra: { currentDataSource: [] }), action: `paginate` \| `sort` \| `filter` | - |
+| onChange | Callback executed when pagination, filters or sorter is changed | Function(pagination, filters, sorter, extra: { currentDataSource: [] }, action: `paginate` \| `sort` \| `filter`) | - |
 | onHeaderRow | Set props on per header row | Function(column, index) | - |
 | onRow | Set props on per row | Function(record, index) | - |
 | getPopupContainer | the render container of dropdowns in table | (triggerNode) => HTMLElement | `() => TableHtmlElement` |

--- a/components/table/index.en-US.md
+++ b/components/table/index.en-US.md
@@ -78,7 +78,7 @@ const columns = [
 | size | Size of table | `default` \| `middle` \| `small` | `default` |
 | summary | Summary content | (currentData) => ReactNode | - |
 | title | Table title renderer | Function(currentPageData) | - |
-| onChange | Callback executed when pagination, filters or sorter is changed | Function(pagination, filters, sorter, extra: { currentDataSource: [] }) | - |
+| onChange | Callback executed when pagination, filters or sorter is changed | Function(pagination, filters, sorter, extra: { currentDataSource: [] }), action: `paginate` \| `sort` \| `filter` | - |
 | onHeaderRow | Set props on per header row | Function(column, index) | - |
 | onRow | Set props on per row | Function(record, index) | - |
 | getPopupContainer | the render container of dropdowns in table | (triggerNode) => HTMLElement | `() => TableHtmlElement` |
@@ -288,6 +288,8 @@ You can set `hideOnSinglePage` with `pagination` prop.
 Table total page count usually reduce after filter data, we defaultly return to first page in case of current page is out of filtered results.
 
 You may need to keep current page after filtering when fetch data from remote service, please check [this demo](https://codesandbox.io/s/yuanchengjiazaishuju-ant-design-demo-7y2uf) as workaround.
+
+Also you can use the action param to determine when return to first page.
 
 ### Why Table pagination show size changer?
 

--- a/components/table/index.zh-CN.md
+++ b/components/table/index.zh-CN.md
@@ -83,7 +83,7 @@ const columns = [
 | size | 表格大小 | `default` \| `middle` \| `small` | default |
 | summary | 总结栏 | (currentData) => ReactNode | - |
 | title | 表格标题 | Function(currentPageData) | - |
-| onChange | 分页、排序、筛选变化时触发 | Function(pagination, filters, sorter, extra: { currentDataSource: [] }, action: `paginate` \| `sort` \| `filter`) | - |
+| onChange | 分页、排序、筛选变化时触发 | Function(pagination, filters, sorter, extra: { currentDataSource: [], action: `paginate` \| `sort` \| `filter` }) | - |
 | onHeaderRow | 设置头部行属性 | Function(column, index) | - |
 | onRow | 设置行属性 | Function(record, index) | - |
 | getPopupContainer | 设置表格内各类浮层的渲染节点，如筛选菜单 | (triggerNode) => HTMLElement | `() => TableHtmlElement` |

--- a/components/table/index.zh-CN.md
+++ b/components/table/index.zh-CN.md
@@ -293,8 +293,6 @@ Table 移除了在 v3 中废弃的 `onRowClick`、`onRowDoubleClick`、`onRowMou
 
 如果你在使用远程分页，很可能需要保持当前页面，你可以参照这个 [受控例子](https://codesandbox.io/s/yuanchengjiazaishuju-ant-design-demo-7y2uf) 控制当前页面不变。
 
-您還可以使用操作參數來確定何時返回首頁。
-
 ### 表格分页为何会出现 size 切换器？
 
 自 `4.1.0` 起，Pagination 在 `total` 大于 50 条时会默认显示 size 切换器以提升用户交互体验。如果你不需要该功能，可以通过设置 `showSizeChanger` 为 `false` 来关闭。

--- a/components/table/index.zh-CN.md
+++ b/components/table/index.zh-CN.md
@@ -83,7 +83,7 @@ const columns = [
 | size | 表格大小 | `default` \| `middle` \| `small` | default |
 | summary | 总结栏 | (currentData) => ReactNode | - |
 | title | 表格标题 | Function(currentPageData) | - |
-| onChange | 分页、排序、筛选变化时触发 | Function(pagination, filters, sorter, extra: { currentDataSource: [] }) | - |
+| onChange | 分页、排序、筛选变化时触发 | Function(pagination, filters, sorter, extra: { currentDataSource: [] }), action: `paginate` \| `sort` \| `filter` | - |
 | onHeaderRow | 设置头部行属性 | Function(column, index) | - |
 | onRow | 设置行属性 | Function(record, index) | - |
 | getPopupContainer | 设置表格内各类浮层的渲染节点，如筛选菜单 | (triggerNode) => HTMLElement | `() => TableHtmlElement` |
@@ -292,6 +292,8 @@ Table 移除了在 v3 中废弃的 `onRowClick`、`onRowDoubleClick`、`onRowMou
 前端过滤时通常条目总数会减少，从而导致总页数小于筛选前的当前页数，为了防止当前页面没有数据，我们默认会返回第一页。
 
 如果你在使用远程分页，很可能需要保持当前页面，你可以参照这个 [受控例子](https://codesandbox.io/s/yuanchengjiazaishuju-ant-design-demo-7y2uf) 控制当前页面不变。
+
+您還可以使用操作參數來確定何時返回首頁。
 
 ### 表格分页为何会出现 size 切换器？
 

--- a/components/table/index.zh-CN.md
+++ b/components/table/index.zh-CN.md
@@ -83,7 +83,7 @@ const columns = [
 | size | 表格大小 | `default` \| `middle` \| `small` | default |
 | summary | 总结栏 | (currentData) => ReactNode | - |
 | title | 表格标题 | Function(currentPageData) | - |
-| onChange | 分页、排序、筛选变化时触发 | Function(pagination, filters, sorter, extra: { currentDataSource: [] }), action: `paginate` \| `sort` \| `filter` | - |
+| onChange | 分页、排序、筛选变化时触发 | Function(pagination, filters, sorter, extra: { currentDataSource: [] }, action: `paginate` \| `sort` \| `filter`) | - |
 | onHeaderRow | 设置头部行属性 | Function(column, index) | - |
 | onRow | 设置行属性 | Function(record, index) | - |
 | getPopupContainer | 设置表格内各类浮层的渲染节点，如筛选菜单 | (triggerNode) => HTMLElement | `() => TableHtmlElement` |

--- a/components/table/interface.tsx
+++ b/components/table/interface.tsx
@@ -8,6 +8,8 @@ import { CheckboxProps } from '../checkbox';
 import { PaginationProps } from '../pagination';
 import { Breakpoint } from '../_util/responsiveObserve';
 import { INTERNAL_SELECTION_ITEM } from './hooks/useSelection';
+import { tuple } from '../_util/type';
+// import { TableAction } from './Table';
 
 export { GetRowKey, ExpandableConfig };
 
@@ -36,6 +38,9 @@ export interface TableLocale {
 }
 
 export type SortOrder = 'descend' | 'ascend' | null;
+
+const TableActions = tuple('paginate', 'sort', 'filter');
+export type TableAction = typeof TableActions[number];
 
 export type CompareFn<T> = (a: T, b: T, sortOrder?: SortOrder) => number;
 
@@ -154,6 +159,7 @@ export type TransformColumns<RecordType> = (
 
 export interface TableCurrentDataSource<RecordType> {
   currentDataSource: RecordType[];
+  action: TableAction;
 }
 
 export interface SorterResult<RecordType> {


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Perfermance optimization
- [x] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge

### 💡 Background and solution

When using the Table component every time we filter, sort or paginate the same callback onChange is called. Sometimes we need to know which action triggered the callback (Ex: return to first page when filtering data fetched from server-side), so a new param "action" added to the onChange event can be used avoid deep object comparisons to determine the triggered action.

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Table `onChange` add `action` in extra argument. |
| 🇨🇳 Chinese | Table `onChange`  添加 `action` 参数用于标示操作类型。 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

-----
[View rendered components/table/index.en-US.md](https://github.com/NetoBraghetto/ant-design/blob/add-action-indicator-on-table-change-event/components/table/index.en-US.md)
[View rendered components/table/index.zh-CN.md](https://github.com/NetoBraghetto/ant-design/blob/add-action-indicator-on-table-change-event/components/table/index.zh-CN.md)

-----
[View rendered components/table/index.en-US.md](https://github.com/NetoBraghetto/ant-design/blob/add-table-on-change-action-param/components/table/index.en-US.md)
[View rendered components/table/index.zh-CN.md](https://github.com/NetoBraghetto/ant-design/blob/add-table-on-change-action-param/components/table/index.zh-CN.md)