### PR TITLE
fix: btn loading 2 twice

### DIFF
--- a/components/button/__tests__/type.test.tsx
+++ b/components/button/__tests__/type.test.tsx
@@ -170,6 +170,8 @@ describe('Button', () => {
     jest.useFakeTimers();
     const wrapper = mount(<Button loading={{ delay: 1000 }} />);
     wrapper.update();
+    wrapper.setProps({ loading: { delay: 2000 } });
+    wrapper.update();
     wrapper.setProps({ loading: false });
 
     act(() => {

--- a/components/button/button.tsx
+++ b/components/button/button.tsx
@@ -121,6 +121,8 @@ interface CompoundedComponent
   __ANT_BUTTON: boolean;
 }
 
+type Loading = number | boolean;
+
 const InternalButton: React.ForwardRefRenderFunction<unknown, ButtonProps> = (props, ref) => {
   const {
     loading,
@@ -138,7 +140,7 @@ const InternalButton: React.ForwardRefRenderFunction<unknown, ButtonProps> = (pr
   } = props;
 
   const size = React.useContext(SizeContext);
-  const [innerLoading, setLoading] = React.useState(loading);
+  const [innerLoading, setLoading] = React.useState<Loading>(!!loading);
   const [hasTwoCNChar, setHasTwoCNChar] = React.useState(false);
   const { getPrefixCls, autoInsertSpaceInButton, direction } = React.useContext(ConfigContext);
   const buttonRef = (ref as any) || React.createRef<HTMLElement>();
@@ -163,16 +165,24 @@ const InternalButton: React.ForwardRefRenderFunction<unknown, ButtonProps> = (pr
     }
   };
 
+  // =============== Update Loading ===============
+  let loadingOrDelay: Loading;
+  if (typeof loading === 'object' && loading.delay) {
+    loadingOrDelay = loading.delay || true;
+  } else {
+    loadingOrDelay = !!loading;
+  }
+
   React.useEffect(() => {
-    if (typeof loading === 'object' && loading.delay) {
+    clearTimeout(delayTimeoutRef.current);
+    if (typeof loadingOrDelay === 'number') {
       delayTimeoutRef.current = window.setTimeout(() => {
-        setLoading(loading);
-      }, loading.delay);
+        setLoading(loadingOrDelay);
+      }, loadingOrDelay);
     } else {
-      clearTimeout(delayTimeoutRef.current);
-      setLoading(loading);
+      setLoading(loadingOrDelay);
     }
-  }, [loading]);
+  }, [loadingOrDelay]);
 
   React.useEffect(() => {
     fixTwoCNChar();
@@ -230,7 +240,7 @@ const InternalButton: React.ForwardRefRenderFunction<unknown, ButtonProps> = (pr
     icon && !innerLoading ? (
       icon
     ) : (
-      <LoadingIcon existIcon={!!icon} prefixCls={prefixCls} loading={innerLoading} />
+      <LoadingIcon existIcon={!!icon} prefixCls={prefixCls} loading={!!innerLoading} />
     );
 
   const kids =


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Perfermance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

resolve #24708

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Fix Button `loading.delay` repeat trigger when parent re-render.        |
| 🇨🇳 Chinese |   修复 Button 在父阶段重新渲染时 `loading.delay` 会重复触发的问题。       |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
