### PR TITLE
feat: Support rowSelection.dirty

### DIFF
--- a/components/table/__tests__/Table.rowSelection.test.js
+++ b/components/table/__tests__/Table.rowSelection.test.js
@@ -812,12 +812,12 @@ describe('Table.rowSelection', () => {
       expect(onChange).toHaveBeenCalledWith(['bamboo'], [{ name: 'bamboo' }]);
     });
 
-    it('cache with reserveKeys', () => {
+    it('cache with preserveKeys', () => {
       const onChange = jest.fn();
       const wrapper = mount(
         <Table
           dataSource={[{ name: 'light' }, { name: 'bamboo' }]}
-          rowSelection={{ onChange, reserveKeys: true }}
+          rowSelection={{ onChange, preserveKeys: true }}
           rowKey="name"
         />,
       );
@@ -833,7 +833,10 @@ describe('Table.rowSelection', () => {
         .find('tbody input')
         .first()
         .simulate('change', { target: { checked: true } });
-      expect(onChange).toHaveBeenCalledWith(['light', 'bamboo'], [undefined, { name: 'bamboo' }]);
+      expect(onChange).toHaveBeenCalledWith(
+        ['light', 'bamboo'],
+        [{ name: 'light' }, { name: 'bamboo' }],
+      );
     });
   });
 });

--- a/components/table/__tests__/Table.rowSelection.test.js
+++ b/components/table/__tests__/Table.rowSelection.test.js
@@ -812,12 +812,12 @@ describe('Table.rowSelection', () => {
       expect(onChange).toHaveBeenCalledWith(['bamboo'], [{ name: 'bamboo' }]);
     });
 
-    it('cache with preserveKeys', () => {
+    it('cache with preserveSelectedRowKeys', () => {
       const onChange = jest.fn();
       const wrapper = mount(
         <Table
           dataSource={[{ name: 'light' }, { name: 'bamboo' }]}
-          rowSelection={{ onChange, preserveKeys: true }}
+          rowSelection={{ onChange, preserveSelectedRowKeys: true }}
           rowKey="name"
         />,
       );

--- a/components/table/__tests__/Table.rowSelection.test.js
+++ b/components/table/__tests__/Table.rowSelection.test.js
@@ -787,27 +787,53 @@ describe('Table.rowSelection', () => {
     expect(onChange.mock.calls[0][1]).toEqual([expect.objectContaining({ name: 'bamboo' })]);
   });
 
-  it('do not cache selected keys', () => {
-    const onChange = jest.fn();
-    const wrapper = mount(
-      <Table
-        dataSource={[{ name: 'light' }, { name: 'bamboo' }]}
-        rowSelection={{ onChange }}
-        rowKey="name"
-      />,
-    );
+  describe('cache with selected keys', () => {
+    it('default not cache', () => {
+      const onChange = jest.fn();
+      const wrapper = mount(
+        <Table
+          dataSource={[{ name: 'light' }, { name: 'bamboo' }]}
+          rowSelection={{ onChange }}
+          rowKey="name"
+        />,
+      );
 
-    wrapper
-      .find('tbody input')
-      .first()
-      .simulate('change', { target: { checked: true } });
-    expect(onChange).toHaveBeenCalledWith(['light'], [{ name: 'light' }]);
+      wrapper
+        .find('tbody input')
+        .first()
+        .simulate('change', { target: { checked: true } });
+      expect(onChange).toHaveBeenCalledWith(['light'], [{ name: 'light' }]);
 
-    wrapper.setProps({ dataSource: [{ name: 'bamboo' }] });
-    wrapper
-      .find('tbody input')
-      .first()
-      .simulate('change', { target: { checked: true } });
-    expect(onChange).toHaveBeenCalledWith(['bamboo'], [{ name: 'bamboo' }]);
+      wrapper.setProps({ dataSource: [{ name: 'bamboo' }] });
+      wrapper
+        .find('tbody input')
+        .first()
+        .simulate('change', { target: { checked: true } });
+      expect(onChange).toHaveBeenCalledWith(['bamboo'], [{ name: 'bamboo' }]);
+    });
+
+    it('cache with dirty', () => {
+      const onChange = jest.fn();
+      const wrapper = mount(
+        <Table
+          dataSource={[{ name: 'light' }, { name: 'bamboo' }]}
+          rowSelection={{ onChange, dirty: true }}
+          rowKey="name"
+        />,
+      );
+
+      wrapper
+        .find('tbody input')
+        .first()
+        .simulate('change', { target: { checked: true } });
+      expect(onChange).toHaveBeenCalledWith(['light'], [{ name: 'light' }]);
+
+      wrapper.setProps({ dataSource: [{ name: 'bamboo' }] });
+      wrapper
+        .find('tbody input')
+        .first()
+        .simulate('change', { target: { checked: true } });
+      expect(onChange).toHaveBeenCalledWith(['light', 'bamboo'], [undefined, { name: 'bamboo' }]);
+    });
   });
 });

--- a/components/table/__tests__/Table.rowSelection.test.js
+++ b/components/table/__tests__/Table.rowSelection.test.js
@@ -812,12 +812,12 @@ describe('Table.rowSelection', () => {
       expect(onChange).toHaveBeenCalledWith(['bamboo'], [{ name: 'bamboo' }]);
     });
 
-    it('cache with dirty', () => {
+    it('cache with reserveKeys', () => {
       const onChange = jest.fn();
       const wrapper = mount(
         <Table
           dataSource={[{ name: 'light' }, { name: 'bamboo' }]}
-          rowSelection={{ onChange, dirty: true }}
+          rowSelection={{ onChange, reserveKeys: true }}
           rowKey="name"
         />,
       );

--- a/components/table/demo/ajax.md
+++ b/components/table/demo/ajax.md
@@ -11,7 +11,7 @@ title:
 
 另外，本例也展示了筛选排序功能如何交给服务端实现，列不需要指定具体的 `onFilter` 和 `sorter` 函数，而是在把筛选和排序的参数发到服务端来处理。
 
-当使用 `rowSelection` 时，请设置 `rowSelection.reserveKeys` 属性以保留 `key`。
+当使用 `rowSelection` 时，请设置 `rowSelection.preserveKeys` 属性以保留 `key`。
 
 **注意，此示例使用 [模拟接口](https://randomuser.me)，展示数据可能不准确，请打开网络面板查看请求。**
 
@@ -19,7 +19,7 @@ title:
 
 This example shows how to fetch and present data from a remote server, and how to implement filtering and sorting in server side by sending related parameters to server.
 
-Setting `rowSelection.reserveKeys` to keep the `key` when enable selection.
+Setting `rowSelection.preserveKeys` to keep the `key` when enable selection.
 
 **Note, this example use [Mock API](https://randomuser.me) that you can look up in Network Console.**
 

--- a/components/table/demo/ajax.md
+++ b/components/table/demo/ajax.md
@@ -11,7 +11,7 @@ title:
 
 另外，本例也展示了筛选排序功能如何交给服务端实现，列不需要指定具体的 `onFilter` 和 `sorter` 函数，而是在把筛选和排序的参数发到服务端来处理。
 
-当使用 `rowSelection` 时，请设置 `rowSelection.preserveKeys` 属性以保留 `key`。
+当使用 `rowSelection` 时，请设置 `rowSelection.preserveSelectedRowKeys` 属性以保留 `key`。
 
 **注意，此示例使用 [模拟接口](https://randomuser.me)，展示数据可能不准确，请打开网络面板查看请求。**
 
@@ -19,7 +19,7 @@ title:
 
 This example shows how to fetch and present data from a remote server, and how to implement filtering and sorting in server side by sending related parameters to server.
 
-Setting `rowSelection.preserveKeys` to keep the `key` when enable selection.
+Setting `rowSelection.preserveSelectedRowKeys` to keep the `key` when enable selection.
 
 **Note, this example use [Mock API](https://randomuser.me) that you can look up in Network Console.**
 

--- a/components/table/demo/ajax.md
+++ b/components/table/demo/ajax.md
@@ -11,11 +11,15 @@ title:
 
 另外，本例也展示了筛选排序功能如何交给服务端实现，列不需要指定具体的 `onFilter` 和 `sorter` 函数，而是在把筛选和排序的参数发到服务端来处理。
 
+当使用 `rowSelection` 时，请设置 `rowSelection.dirty` 属性以保留 `key`。
+
 **注意，此示例使用 [模拟接口](https://randomuser.me)，展示数据可能不准确，请打开网络面板查看请求。**
 
 ## en-US
 
 This example shows how to fetch and present data from a remote server, and how to implement filtering and sorting in server side by sending related parameters to server.
+
+Setting `rowSelection.dirty` to keep the `key` when enable selection.
 
 **Note, this example use [Mock API](https://randomuser.me) that you can look up in Network Console.**
 

--- a/components/table/demo/ajax.md
+++ b/components/table/demo/ajax.md
@@ -11,7 +11,7 @@ title:
 
 另外，本例也展示了筛选排序功能如何交给服务端实现，列不需要指定具体的 `onFilter` 和 `sorter` 函数，而是在把筛选和排序的参数发到服务端来处理。
 
-当使用 `rowSelection` 时，请设置 `rowSelection.dirty` 属性以保留 `key`。
+当使用 `rowSelection` 时，请设置 `rowSelection.reserveKeys` 属性以保留 `key`。
 
 **注意，此示例使用 [模拟接口](https://randomuser.me)，展示数据可能不准确，请打开网络面板查看请求。**
 
@@ -19,7 +19,7 @@ title:
 
 This example shows how to fetch and present data from a remote server, and how to implement filtering and sorting in server side by sending related parameters to server.
 
-Setting `rowSelection.dirty` to keep the `key` when enable selection.
+Setting `rowSelection.reserveKeys` to keep the `key` when enable selection.
 
 **Note, this example use [Mock API](https://randomuser.me) that you can look up in Network Console.**
 

--- a/components/table/hooks/useSelection.tsx
+++ b/components/table/hooks/useSelection.tsx
@@ -71,6 +71,7 @@ export default function useSelection<RecordType>(
   config: UseSelectionConfig<RecordType>,
 ): [TransformColumns<RecordType>, Set<Key>] {
   const {
+    dirty,
     selectedRowKeys,
     getCheckboxProps,
     onChange: onSelectionChange,
@@ -118,16 +119,25 @@ export default function useSelection<RecordType>(
 
   const setSelectedKeys = React.useCallback(
     (keys: Key[]) => {
-      const availableKeys: Key[] = [];
-      const records: RecordType[] = [];
+      let availableKeys: Key[];
+      let records: RecordType[];
 
-      keys.forEach(key => {
-        const record = getRecordByKey(key);
-        if (record !== undefined) {
-          availableKeys.push(key);
-          records.push(record);
-        }
-      });
+      // Keep key if mark as dirty
+      if (dirty) {
+        availableKeys = keys;
+        records = keys.map(key => getRecordByKey(key));
+      } else {
+        availableKeys = [];
+        records = [];
+
+        keys.forEach(key => {
+          const record = getRecordByKey(key);
+          if (record !== undefined) {
+            availableKeys.push(key);
+            records.push(record);
+          }
+        });
+      }
 
       setInnerSelectedKeys(availableKeys);
 
@@ -135,7 +145,7 @@ export default function useSelection<RecordType>(
         onSelectionChange(availableKeys, records);
       }
     },
-    [setInnerSelectedKeys, getRecordByKey, onSelectionChange],
+    [setInnerSelectedKeys, getRecordByKey, onSelectionChange, dirty],
   );
 
   // Trigger single `onSelect` event

--- a/components/table/hooks/useSelection.tsx
+++ b/components/table/hooks/useSelection.tsx
@@ -72,7 +72,7 @@ export default function useSelection<RecordType>(
   config: UseSelectionConfig<RecordType>,
 ): [TransformColumns<RecordType>, Set<Key>] {
   const {
-    preserveKeys,
+    preserveSelectedRowKeys,
     selectedRowKeys,
     getCheckboxProps,
     onChange: onSelectionChange,
@@ -127,8 +127,8 @@ export default function useSelection<RecordType>(
       let availableKeys: Key[];
       let records: RecordType[];
 
-      if (preserveKeys) {
-        // Keep key if mark as preserveKeys
+      if (preserveSelectedRowKeys) {
+        // Keep key if mark as preserveSelectedRowKeys
         const newCache = new Map<Key, RecordType>();
         availableKeys = keys;
         records = keys.map(key => {
@@ -165,7 +165,7 @@ export default function useSelection<RecordType>(
         onSelectionChange(availableKeys, records);
       }
     },
-    [setInnerSelectedKeys, getRecordByKey, onSelectionChange, preserveKeys],
+    [setInnerSelectedKeys, getRecordByKey, onSelectionChange, preserveSelectedRowKeys],
   );
 
   // ====================== Selections ======================

--- a/components/table/hooks/useSelection.tsx
+++ b/components/table/hooks/useSelection.tsx
@@ -71,7 +71,7 @@ export default function useSelection<RecordType>(
   config: UseSelectionConfig<RecordType>,
 ): [TransformColumns<RecordType>, Set<Key>] {
   const {
-    dirty,
+    reserveKeys,
     selectedRowKeys,
     getCheckboxProps,
     onChange: onSelectionChange,
@@ -122,8 +122,8 @@ export default function useSelection<RecordType>(
       let availableKeys: Key[];
       let records: RecordType[];
 
-      // Keep key if mark as dirty
-      if (dirty) {
+      // Keep key if mark as reserveKeys
+      if (reserveKeys) {
         availableKeys = keys;
         records = keys.map(key => getRecordByKey(key));
       } else {
@@ -145,7 +145,7 @@ export default function useSelection<RecordType>(
         onSelectionChange(availableKeys, records);
       }
     },
-    [setInnerSelectedKeys, getRecordByKey, onSelectionChange, dirty],
+    [setInnerSelectedKeys, getRecordByKey, onSelectionChange, reserveKeys],
   );
 
   // Trigger single `onSelect` event

--- a/components/table/index.en-US.md
+++ b/components/table/index.en-US.md
@@ -190,8 +190,8 @@ Properties for row selection.
 | fixed | Fixed selection column on the left | boolean | - |  |
 | getCheckboxProps | Get Checkbox or Radio props | Function(record) | - |  |
 | hideSelectAll | Hide the selectAll checkbox and custom selection | boolean | `false` | 4.3 |
+| preserveKeys | Keep selection `key` even when it removed from `dataSource` | boolean | - | 4.4 |
 | renderCell | Renderer of the table cell. Same as `render` in column | Function(checked, record, index, originNode) {} | - | 4.1 |
-| reserveKeys | Keep selection `key` even when it removed from `dataSource` | boolean | - | 4.4 |
 | selectedRowKeys | Controlled selected row keys | string\[]\|number[] | \[] |  |
 | selections | Custom selection [config](#rowSelection), only displays default selections when set to `true` | object\[]\|boolean | - |  |
 | type | `checkbox` or `radio` | `checkbox` \| `radio` | `checkbox` |  |

--- a/components/table/index.en-US.md
+++ b/components/table/index.en-US.md
@@ -185,19 +185,20 @@ Properties for row selection.
 
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
-| columnWidth | Set the width of the selection column | string\|number | `60px` | 4.0 |
-| columnTitle | Set the title of the selection column | string\|React.ReactNode | - | 4.0 |
-| fixed | Fixed selection column on the left | boolean | - | 4.0 |
-| getCheckboxProps | Get Checkbox or Radio props | Function(record) | - | 4.0 |
+| columnWidth | Set the width of the selection column | string\|number | `60px` |  |
+| columnTitle | Set the title of the selection column | string\|React.ReactNode | - |  |
+| dirty | Keep selection `key` even when it removed from `dataSource` | boolean | - | 4.4 |
+| fixed | Fixed selection column on the left | boolean | - |  |
+| getCheckboxProps | Get Checkbox or Radio props | Function(record) | - |  |
 | hideSelectAll | Hide the selectAll checkbox and custom selection | boolean | `false` | 4.3 |
 | renderCell | Renderer of the table cell. Same as `render` in column | Function(checked, record, index, originNode) {} | - | 4.1 |
-| selectedRowKeys | Controlled selected row keys | string\[]\|number[] | \[] | 4.0 |
-| selections | Custom selection [config](#rowSelection), only displays default selections when set to `true` | object\[]\|boolean | - | 4.0 |
-| type | `checkbox` or `radio` | `checkbox` \| `radio` | `checkbox` | 4.0 |
-| onChange | Callback executed when selected rows change | Function(selectedRowKeys, selectedRows) | - | 4.0 |
-| onSelect | Callback executed when select/deselect one row | Function(record, selected, selectedRows, nativeEvent) | - | 4.0 |
-| onSelectAll | Callback executed when select/deselect all rows | Function(selected, selectedRows, changeRows) | - | 4.0 |
-| onSelectInvert | Callback executed when row selection is inverted | Function(selectedRowKeys) | - | 4.0 |
+| selectedRowKeys | Controlled selected row keys | string\[]\|number[] | \[] |  |
+| selections | Custom selection [config](#rowSelection), only displays default selections when set to `true` | object\[]\|boolean | - |  |
+| type | `checkbox` or `radio` | `checkbox` \| `radio` | `checkbox` |  |
+| onChange | Callback executed when selected rows change | Function(selectedRowKeys, selectedRows) | - |  |
+| onSelect | Callback executed when select/deselect one row | Function(record, selected, selectedRows, nativeEvent) | - |  |
+| onSelectAll | Callback executed when select/deselect all rows | Function(selected, selectedRows, changeRows) | - |  |
+| onSelectInvert | Callback executed when row selection is inverted | Function(selectedRowKeys) | - |  |
 
 ### scroll
 

--- a/components/table/index.en-US.md
+++ b/components/table/index.en-US.md
@@ -190,7 +190,7 @@ Properties for row selection.
 | fixed | Fixed selection column on the left | boolean | - |  |
 | getCheckboxProps | Get Checkbox or Radio props | Function(record) | - |  |
 | hideSelectAll | Hide the selectAll checkbox and custom selection | boolean | `false` | 4.3 |
-| preserveKeys | Keep selection `key` even when it removed from `dataSource` | boolean | - | 4.4 |
+| preserveSelectedRowKeys | Keep selection `key` even when it removed from `dataSource` | boolean | - | 4.4 |
 | renderCell | Renderer of the table cell. Same as `render` in column | Function(checked, record, index, originNode) {} | - | 4.1 |
 | selectedRowKeys | Controlled selected row keys | string\[]\|number[] | \[] |  |
 | selections | Custom selection [config](#rowSelection), only displays default selections when set to `true` | object\[]\|boolean | - |  |

--- a/components/table/index.en-US.md
+++ b/components/table/index.en-US.md
@@ -187,11 +187,11 @@ Properties for row selection.
 | --- | --- | --- | --- | --- |
 | columnWidth | Set the width of the selection column | string\|number | `60px` |  |
 | columnTitle | Set the title of the selection column | string\|React.ReactNode | - |  |
-| dirty | Keep selection `key` even when it removed from `dataSource` | boolean | - | 4.4 |
 | fixed | Fixed selection column on the left | boolean | - |  |
 | getCheckboxProps | Get Checkbox or Radio props | Function(record) | - |  |
 | hideSelectAll | Hide the selectAll checkbox and custom selection | boolean | `false` | 4.3 |
 | renderCell | Renderer of the table cell. Same as `render` in column | Function(checked, record, index, originNode) {} | - | 4.1 |
+| reserveKeys | Keep selection `key` even when it removed from `dataSource` | boolean | - | 4.4 |
 | selectedRowKeys | Controlled selected row keys | string\[]\|number[] | \[] |  |
 | selections | Custom selection [config](#rowSelection), only displays default selections when set to `true` | object\[]\|boolean | - |  |
 | type | `checkbox` or `radio` | `checkbox` \| `radio` | `checkbox` |  |

--- a/components/table/index.zh-CN.md
+++ b/components/table/index.zh-CN.md
@@ -192,11 +192,11 @@ const columns = [
 | --- | --- | --- | --- | --- |
 | columnWidth | 自定义列表选择框宽度 | string\|number | `60px` |  |
 | columnTitle | 自定义列表选择框标题 | string\|React.ReactNode | - |  |
-| dirty | 当数据被删除时仍然保留选项的 `key` | boolean | - | 4.4 |
 | fixed | 把选择框列固定在左边 | boolean | - |  |
 | getCheckboxProps | 选择框的默认属性配置 | Function(record) | - |  |
 | hideSelectAll | 隐藏全选勾选框与自定义选择项 | boolean | false | 4.3 |
 | renderCell | 渲染勾选框，用法与 Column 的 `render` 相同 | Function(checked, record, index, originNode) {} | - | 4.1 |
+| reserveKeys | 当数据被删除时仍然保留选项的 `key` | boolean | - | 4.4 |
 | selectedRowKeys | 指定选中项的 key 数组，需要和 onChange 进行配合 | string\[]\|number[] | \[] |  |
 | selections | 自定义选择项 [配置项](#selection), 设为 `true` 时使用默认选择项 | object\[]\|boolean | true |  |
 | type | 多选/单选，`checkbox` or `radio` | string | `checkbox` |  |

--- a/components/table/index.zh-CN.md
+++ b/components/table/index.zh-CN.md
@@ -195,7 +195,7 @@ const columns = [
 | fixed | 把选择框列固定在左边 | boolean | - |  |
 | getCheckboxProps | 选择框的默认属性配置 | Function(record) | - |  |
 | hideSelectAll | 隐藏全选勾选框与自定义选择项 | boolean | false | 4.3 |
-| preserveKeys | 当数据被删除时仍然保留选项的 `key` | boolean | - | 4.4 |
+| preserveSelectedRowKeys | 当数据被删除时仍然保留选项的 `key` | boolean | - | 4.4 |
 | renderCell | 渲染勾选框，用法与 Column 的 `render` 相同 | Function(checked, record, index, originNode) {} | - | 4.1 |
 | selectedRowKeys | 指定选中项的 key 数组，需要和 onChange 进行配合 | string\[]\|number[] | \[] |  |
 | selections | 自定义选择项 [配置项](#selection), 设为 `true` 时使用默认选择项 | object\[]\|boolean | true |  |

--- a/components/table/index.zh-CN.md
+++ b/components/table/index.zh-CN.md
@@ -190,19 +190,20 @@ const columns = [
 
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
-| columnWidth | 自定义列表选择框宽度 | string\|number | `60px` | 4.0 |
-| columnTitle | 自定义列表选择框标题 | string\|React.ReactNode | - | 4.0 |
-| fixed | 把选择框列固定在左边 | boolean | - | 4.0 |
-| getCheckboxProps | 选择框的默认属性配置 | Function(record) | - | 4.0 |
+| columnWidth | 自定义列表选择框宽度 | string\|number | `60px` |  |
+| columnTitle | 自定义列表选择框标题 | string\|React.ReactNode | - |  |
+| dirty | 当数据被删除时仍然保留选项的 `key` | boolean | - | 4.4 |
+| fixed | 把选择框列固定在左边 | boolean | - |  |
+| getCheckboxProps | 选择框的默认属性配置 | Function(record) | - |  |
 | hideSelectAll | 隐藏全选勾选框与自定义选择项 | boolean | false | 4.3 |
 | renderCell | 渲染勾选框，用法与 Column 的 `render` 相同 | Function(checked, record, index, originNode) {} | - | 4.1 |
-| selectedRowKeys | 指定选中项的 key 数组，需要和 onChange 进行配合 | string\[]\|number[] | \[] | 4.0 |
-| selections | 自定义选择项 [配置项](#selection), 设为 `true` 时使用默认选择项 | object\[]\|boolean | true | 4.0 |
-| type | 多选/单选，`checkbox` or `radio` | string | `checkbox` | 4.0 |
-| onChange | 选中项发生变化时的回调 | Function(selectedRowKeys, selectedRows) | - | 4.0 |
-| onSelect | 用户手动选择/取消选择某行的回调 | Function(record, selected, selectedRows, nativeEvent) | - | 4.0 |
-| onSelectAll | 用户手动选择/取消选择所有行的回调 | Function(selected, selectedRows, changeRows) | - | 4.0 |
-| onSelectInvert | 用户手动选择反选的回调 | Function(selectedRowKeys) | - | 4.0 |
+| selectedRowKeys | 指定选中项的 key 数组，需要和 onChange 进行配合 | string\[]\|number[] | \[] |  |
+| selections | 自定义选择项 [配置项](#selection), 设为 `true` 时使用默认选择项 | object\[]\|boolean | true |  |
+| type | 多选/单选，`checkbox` or `radio` | string | `checkbox` |  |
+| onChange | 选中项发生变化时的回调 | Function(selectedRowKeys, selectedRows) | - |  |
+| onSelect | 用户手动选择/取消选择某行的回调 | Function(record, selected, selectedRows, nativeEvent) | - |  |
+| onSelectAll | 用户手动选择/取消选择所有行的回调 | Function(selected, selectedRows, changeRows) | - |  |
+| onSelectInvert | 用户手动选择反选的回调 | Function(selectedRowKeys) | - |  |
 
 ### scroll
 

--- a/components/table/index.zh-CN.md
+++ b/components/table/index.zh-CN.md
@@ -195,8 +195,8 @@ const columns = [
 | fixed | 把选择框列固定在左边 | boolean | - |  |
 | getCheckboxProps | 选择框的默认属性配置 | Function(record) | - |  |
 | hideSelectAll | 隐藏全选勾选框与自定义选择项 | boolean | false | 4.3 |
+| preserveKeys | 当数据被删除时仍然保留选项的 `key` | boolean | - | 4.4 |
 | renderCell | 渲染勾选框，用法与 Column 的 `render` 相同 | Function(checked, record, index, originNode) {} | - | 4.1 |
-| reserveKeys | 当数据被删除时仍然保留选项的 `key` | boolean | - | 4.4 |
 | selectedRowKeys | 指定选中项的 key 数组，需要和 onChange 进行配合 | string\[]\|number[] | \[] |  |
 | selections | 自定义选择项 [配置项](#selection), 设为 `true` 时使用默认选择项 | object\[]\|boolean | true |  |
 | type | 多选/单选，`checkbox` or `radio` | string | `checkbox` |  |

--- a/components/table/interface.tsx
+++ b/components/table/interface.tsx
@@ -126,7 +126,7 @@ export type SelectionSelectFn<T> = (
 
 export interface TableRowSelection<T> {
   /** Keep the selection keys in list even the key not exist in `dataSource` anymore */
-  reserveKeys?: boolean;
+  preserveKeys?: boolean;
   type?: RowSelectionType;
   selectedRowKeys?: Key[];
   onChange?: (selectedRowKeys: Key[], selectedRows: T[]) => void;

--- a/components/table/interface.tsx
+++ b/components/table/interface.tsx
@@ -126,7 +126,7 @@ export type SelectionSelectFn<T> = (
 
 export interface TableRowSelection<T> {
   /** Keep the selection keys in list even the key not exist in `dataSource` anymore */
-  preserveKeys?: boolean;
+  preserveSelectedRowKeys?: boolean;
   type?: RowSelectionType;
   selectedRowKeys?: Key[];
   onChange?: (selectedRowKeys: Key[], selectedRows: T[]) => void;

--- a/components/table/interface.tsx
+++ b/components/table/interface.tsx
@@ -126,7 +126,7 @@ export type SelectionSelectFn<T> = (
 
 export interface TableRowSelection<T> {
   /** Keep the selection keys in list even the key not exist in `dataSource` anymore */
-  dirty?: boolean;
+  reserveKeys?: boolean;
   type?: RowSelectionType;
   selectedRowKeys?: Key[];
   onChange?: (selectedRowKeys: Key[], selectedRows: T[]) => void;

--- a/components/table/interface.tsx
+++ b/components/table/interface.tsx
@@ -125,6 +125,8 @@ export type SelectionSelectFn<T> = (
 ) => void;
 
 export interface TableRowSelection<T> {
+  /** Keep the selection keys in list even the key not exist in `dataSource` anymore */
+  dirty?: boolean;
   type?: RowSelectionType;
   selectedRowKeys?: Key[];
   onChange?: (selectedRowKeys: Key[], selectedRows: T[]) => void;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Perfermance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

resolve #24640
resolve #24718

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Table support `rowSelection.dirty` to enable cache `key` with ajax.       |
| 🇨🇳 Chinese |     Table 添加 `rowSelection.dirty` 以支持异步数据下保留 `key`。     |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/table/demo/ajax.md](https://github.com/ant-design/ant-design/blob/table-dirty/components/table/demo/ajax.md)
[View rendered components/table/index.en-US.md](https://github.com/ant-design/ant-design/blob/table-dirty/components/table/index.en-US.md)
[View rendered components/table/index.zh-CN.md](https://github.com/ant-design/ant-design/blob/table-dirty/components/table/index.zh-CN.md)