### PR TITLE
fix: Table Expand Icon 在设置@font-size-base后错位

### DIFF
--- a/components/table/style/index.less
+++ b/components/table/style/index.less
@@ -413,12 +413,15 @@
     float: left;
     box-sizing: border-box;
 
-    width: ceil(@font-size-sm * 1.4);
-    height: ceil(@font-size-sm * 1.4);
+    // https://github.com/ant-design/ant-design/issues/24719
+    @expand-icon-height: ceil((@font-size-sm * 1.4 - @border-width-base * 3) / 2) * 2 + @border-width-base * 3;
+
+    width: @expand-icon-height;
+    height: @expand-icon-height;
     padding: 0;
     color: inherit;
-    line-height: @font-size-sm;
-    vertical-align: floor((@font-size-base - ceil(@font-size-sm * 1.4)) / 2);
+    line-height: @expand-icon-height;
+    // vertical-align: floor((@font-size-base - ceil(@font-size-sm * 1.4)) / 2);
     background: @table-expand-icon-bg;
     border: @border-width-base @border-style-base @border-color-split;
     border-radius: @border-radius-base;
@@ -441,7 +444,7 @@
     }
 
     &::before {
-      top: 7px;
+      top: (@expand-icon-height - @border-width-base * 3) / 2;
       right: 3px;
       left: 3px;
       height: @border-width-base;
@@ -450,7 +453,7 @@
     &::after {
       top: 3px;
       bottom: 3px;
-      left: 7px;
+      left: (@expand-icon-height - @border-width-base * 3) / 2;
       width: @border-width-base;
       transform: rotate(90deg);
     }
@@ -474,7 +477,7 @@
     }
 
     .@{table-prefix-cls}-row-indent + & {
-      margin-top: (@font-size-base * @line-height-base - ceil(@font-size-sm * 1.4)) / 2;
+      margin-top: (@font-size-base * @line-height-base - @expand-icon-height) / 2;
       margin-right: @padding-xs;
     }
   }

--- a/components/table/style/index.less
+++ b/components/table/style/index.less
@@ -413,14 +413,12 @@
     float: left;
     box-sizing: border-box;
 
-    // https://github.com/ant-design/ant-design/issues/24719
-    @expand-icon-height: ceil((@font-size-sm * 1.4 - @border-width-base * 3) / 2) * 2 + @border-width-base * 3;
-
-    width: @expand-icon-height;
-    height: @expand-icon-height;
+    width: ceil((@font-size-sm * 1.4 - @border-width-base * 3) / 2) * 2 + @border-width-base * 3;
+    height: ceil((@font-size-sm * 1.4 - @border-width-base * 3) / 2) * 2 + @border-width-base * 3;
     padding: 0;
     color: inherit;
-    line-height: @expand-icon-height;
+    line-height: ceil((@font-size-sm * 1.4 - @border-width-base * 3) / 2) * 2 + @border-width-base *
+      3;
     // vertical-align: floor((@font-size-base - ceil(@font-size-sm * 1.4)) / 2);
     background: @table-expand-icon-bg;
     border: @border-width-base @border-style-base @border-color-split;
@@ -444,7 +442,7 @@
     }
 
     &::before {
-      top: (@expand-icon-height - @border-width-base * 3) / 2;
+      top: ceil((@font-size-sm * 1.4 - @border-width-base * 3) / 2);
       right: 3px;
       left: 3px;
       height: @border-width-base;
@@ -453,7 +451,7 @@
     &::after {
       top: 3px;
       bottom: 3px;
-      left: (@expand-icon-height - @border-width-base * 3) / 2;
+      left: ceil((@font-size-sm * 1.4 - @border-width-base * 3) / 2);
       width: @border-width-base;
       transform: rotate(90deg);
     }
@@ -477,7 +475,8 @@
     }
 
     .@{table-prefix-cls}-row-indent + & {
-      margin-top: (@font-size-base * @line-height-base - @expand-icon-height) / 2;
+      margin-top: (@font-size-base * @line-height-base - @border-width-base * 3) / 2 -
+        ceil((@font-size-sm * 1.4 - @border-width-base * 3) / 2);
       margin-right: @padding-xs;
     }
   }


### PR DESCRIPTION
Expand Icon

<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Perfermance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

fix #24719

### 💡 Background and solution

1. Calculate expand-icon-height
2. Calculate top & left of before/after pseudo elements

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |  修复当font-size-base不等于14px时，Table组件的Expand Icon错位的问题  |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
