### PR TITLE
feat: drawer support getPopupContainer and getPrefixCls by ConfigProvider

### DIFF
--- a/components/config-provider/__tests__/container.test.js
+++ b/components/config-provider/__tests__/container.test.js
@@ -3,6 +3,7 @@ import { mount } from 'enzyme';
 import ConfigProvider from '..';
 import DatePicker from '../../date-picker';
 import Slider from '../../slider';
+import Drawer from '../../drawer';
 
 describe('ConfigProvider.GetPopupContainer', () => {
   it('Datepicker', () => {
@@ -23,6 +24,17 @@ describe('ConfigProvider.GetPopupContainer', () => {
       </ConfigProvider>,
     );
     wrapper.find('.ant-slider-handle').first().simulate('mouseenter');
+    expect(getPopupContainer).toHaveBeenCalled();
+  });
+
+  it('drawer', () => {
+    const getPopupContainer = jest.fn(node => node.parentNode);
+    const Demo = ({ visible }) => (
+      <ConfigProvider getPopupContainer={getPopupContainer}>
+        <Drawer visible={visible} />
+      </ConfigProvider>
+    );
+    mount(<Demo visible />);
     expect(getPopupContainer).toHaveBeenCalled();
   });
 });

--- a/components/drawer/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/drawer/__tests__/__snapshots__/demo.test.js.snap
@@ -11,6 +11,21 @@ exports[`renders ./components/drawer/demo/basic-right.md correctly 1`] = `
 </button>
 `;
 
+exports[`renders ./components/drawer/demo/config-provider.md correctly 1`] = `
+<div
+  class="site-drawer-render-in-current-wrapper"
+>
+  <button
+    class="ant-btn ant-btn-primary"
+    type="button"
+  >
+    <span>
+      Open
+    </span>
+  </button>
+</div>
+`;
+
 exports[`renders ./components/drawer/demo/form-in-drawer.md correctly 1`] = `
 <button
   class="ant-btn ant-btn-primary"

--- a/components/drawer/demo/config-provider.md
+++ b/components/drawer/demo/config-provider.md
@@ -1,0 +1,57 @@
+---
+order: 99
+title:
+  zh-CN: ConfigProvider
+  en-US: ConfigProvider
+debug: true
+---
+
+## zh-CN
+
+支持 ConfigProvider 配置。
+
+## en-US
+
+config by ConfigProvider.
+
+```tsx
+import React, { useState, useRef } from 'react';
+import { Drawer, ConfigProvider, Button } from 'antd';
+
+const App: React.FC = () => {
+  const domRef = useRef();
+  const [visible, setVisible] = useState(false);
+  const showDrawer = () => {
+    setVisible(true);
+  };
+  const onClose = () => {
+    setVisible(false);
+  };
+  return (
+    <ConfigProvider
+      getPopupContainer={() => {
+        return domRef.current;
+      }}
+    >
+      <div ref={domRef} className="site-drawer-render-in-current-wrapper">
+        <Button type="primary" onClick={showDrawer}>
+          Open
+        </Button>
+        <Drawer
+          style={{ position: 'absolute' }}
+          title="ConfigProvider"
+          placement="right"
+          onClose={onClose}
+          visible={visible}
+        >
+          <p>Some contents...</p>
+          <p>Some contents...</p>
+          <p>Some contents...</p>
+        </Drawer>
+      </div>
+    </ConfigProvider>
+  );
+};
+
+ReactDOM.render(<App />, mountNode);
+```

--- a/components/drawer/index.tsx
+++ b/components/drawer/index.tsx
@@ -306,7 +306,9 @@ class Drawer extends React.Component<DrawerProps & ConfigConsumerProps, IDrawerS
                 ])}
                 getContainer={
                   // 有可能为 false，所以不能直接判断
-                  rest.getContainer === undefined ? getPopupContainer : rest.getContainer
+                  rest.getContainer === undefined
+                    ? () => (getPopupContainer ? getPopupContainer(document.body) : undefined)
+                    : rest.getContainer
                 }
                 {...offsetStyle}
                 prefixCls={prefixCls}

--- a/components/drawer/index.tsx
+++ b/components/drawer/index.tsx
@@ -6,7 +6,7 @@ import classNames from 'classnames';
 import omit from 'omit.js';
 
 import { ConfigConsumerProps } from '../config-provider';
-import { withConfigConsumer } from '../config-provider/context';
+import { withConfigConsumer, ConfigConsumer } from '../config-provider/context';
 import { tuple } from '../_util/type';
 
 const DrawerContext = React.createContext<Drawer | null>(null);
@@ -253,54 +253,75 @@ class Drawer extends React.Component<DrawerProps & ConfigConsumerProps, IDrawerS
 
   // render Provider for Multi-level drawer
   renderProvider = (value: Drawer) => {
-    const { prefixCls, placement, className, mask, direction, visible, ...rest } = this.props;
     this.parentDrawer = value;
-    const drawerClassName = classNames(className, {
-      'no-mask': !mask,
-      [`${prefixCls}-rtl`]: direction === 'rtl',
-    });
-    const offsetStyle = mask ? this.getOffsetStyle() : {};
 
     return (
-      <DrawerContext.Provider value={this}>
-        <RcDrawer
-          handler={false}
-          {...omit(rest, [
-            'zIndex',
-            'style',
-            'closable',
-            'destroyOnClose',
-            'drawerStyle',
-            'headerStyle',
-            'bodyStyle',
-            'footerStyle',
-            'footer',
-            'locale',
-            'title',
-            'push',
-            'visible',
-            'getPopupContainer',
-            'rootPrefixCls',
-            'getPrefixCls',
-            'renderEmpty',
-            'csp',
-            'pageHeader',
-            'autoInsertSpaceInButton',
-            'width',
-            'height',
-            'dropdownMatchSelectWidth',
-          ])}
-          {...offsetStyle}
-          prefixCls={prefixCls}
-          open={visible}
-          showMask={mask}
-          placement={placement}
-          style={this.getRcDrawerStyle()}
-          className={drawerClassName}
-        >
-          {this.renderBody()}
-        </RcDrawer>
-      </DrawerContext.Provider>
+      <ConfigConsumer>
+        {({ getPopupContainer, getPrefixCls }) => {
+          const {
+            prefixCls: customizePrefixCls,
+            placement,
+            className,
+            mask,
+            direction,
+            visible,
+            ...rest
+          } = this.props;
+
+          const prefixCls = getPrefixCls('select', customizePrefixCls);
+          const drawerClassName = classNames(className, {
+            'no-mask': !mask,
+            [`${prefixCls}-rtl`]: direction === 'rtl',
+          });
+          const offsetStyle = mask ? this.getOffsetStyle() : {};
+
+          return (
+            <DrawerContext.Provider value={this}>
+              <RcDrawer
+                handler={false}
+                {...omit(rest, [
+                  'zIndex',
+                  'style',
+                  'closable',
+                  'destroyOnClose',
+                  'drawerStyle',
+                  'headerStyle',
+                  'bodyStyle',
+                  'footerStyle',
+                  'footer',
+                  'locale',
+                  'title',
+                  'push',
+                  'visible',
+                  'getPopupContainer',
+                  'rootPrefixCls',
+                  'getPrefixCls',
+                  'renderEmpty',
+                  'csp',
+                  'pageHeader',
+                  'autoInsertSpaceInButton',
+                  'width',
+                  'height',
+                  'dropdownMatchSelectWidth',
+                ])}
+                getContainer={
+                  // 有可能为 false，所以不能直接判断
+                  rest.getContainer === undefined ? getPopupContainer : rest.getContainer
+                }
+                {...offsetStyle}
+                prefixCls={prefixCls}
+                open={visible}
+                showMask={mask}
+                placement={placement}
+                style={this.getRcDrawerStyle()}
+                className={drawerClassName}
+              >
+                {this.renderBody()}
+              </RcDrawer>
+            </DrawerContext.Provider>
+          );
+        }}
+      </ConfigConsumer>
     );
   };
 


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

新特性请提交至 feature 分支，其余可提交至 master 分支。
在一个维护者审核通过后合并。
请确保填写以下 pull request 的信息，谢谢！~

[[English Template / 英文模板](?expand=1)]
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

通过 ConfigProvider 设置 getPopupContainer 之后，因为 modal 支持 getPopupContainer，但是 
drawer 不支持。导致 drawer 中的 model 显示异常

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志怎么写？

<!--
> 从用户角度描述具体变化，以及可能的 breaking change 和其他风险？
-->

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |      Drawer support  set `getPopupContainer and`  `getPrefixCls` by ConfigProvider   |
| 🇨🇳 中文 |    Drawer 支持通过 ConfigProvider 来全局设置 `getPrefixCls` 和 `getPopupContainer`   |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供


-----
[View rendered components/drawer/demo/config-provider.md](https://github.com/ant-design/ant-design/blob/config-provider/components/drawer/demo/config-provider.md)