### PR TITLE
fix: submenu scroll issue

### DIFF
--- a/components/menu/style/index.less
+++ b/components/menu/style/index.less
@@ -213,11 +213,6 @@
 
       // https://github.com/ant-design/ant-design/issues/13955
       &::before {
-        position: absolute;
-        top: -7px;
-        right: 0;
-        bottom: 0;
-        left: 0;
         width: 100%;
         height: 100%;
         opacity: 0.0001;


### PR DESCRIPTION
### 🤔 This is a ...
- [X] Bug fix

### 🔗 Related issue link
Fixes #24064

Broken scroll on [submenus](https://github.com/ant-design/ant-design/issues/24064)

### 💡 Background and solution
Seems the `position: absolute;` was breaking the scroll.  I don't see it break any of the other examples, but I'm new here so ¯\\_(ツ)_/¯ could be wrong. . .  Also removed top, left, right, and bottom properties as they will no longer do any good.

### 📝 Changelog
Fix:  broken scroll on SubMenu component

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      X     |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [X] Doc is updated/provided or not needed
- [X] Demo is updated/provided or not needed
- [X] TypeScript definition is updated/provided or not needed
- [X] Changelog is provided or not needed
