### PR TITLE
feat: 🆕 support Drawer closeIcon

### DIFF
--- a/components/drawer/__tests__/Drawer.test.js
+++ b/components/drawer/__tests__/Drawer.test.js
@@ -125,4 +125,13 @@ describe('Drawer', () => {
     );
     expect(wrapper2.find('button.forceRender').length).toBe(1);
   });
+
+  it('support closeIcon', () => {
+    const wrapper = render(
+      <Drawer visible closable closeIcon={<span>close</span>} width={400} getContainer={false}>
+        Here is content of Drawer
+      </Drawer>,
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
 });

--- a/components/drawer/__tests__/DrawerEvent.test.js
+++ b/components/drawer/__tests__/DrawerEvent.test.js
@@ -82,7 +82,7 @@ describe('Drawer', () => {
     expect(wrapper.instance().state.visible).toBe(true);
   });
 
-  it('destroyOnClose is true onClose', () => {
+  it('dom should be removed after close when destroyOnClose is true', () => {
     const wrapper = mount(<DrawerEventTester destroyOnClose />);
     wrapper.find('button.ant-btn').simulate('click');
     expect(wrapper.find('.ant-drawer-wrapper-body').exists()).toBe(true);
@@ -92,6 +92,18 @@ describe('Drawer', () => {
     });
     wrapper.find('.ant-drawer-wrapper-body').simulate('transitionend');
     expect(wrapper.find('.ant-drawer-wrapper-body').exists()).toBe(false);
+  });
+
+  it('dom should be existed after close when destroyOnClose is false', () => {
+    const wrapper = mount(<DrawerEventTester />);
+    wrapper.find('button.ant-btn').simulate('click');
+    expect(wrapper.find('.ant-drawer-wrapper-body').exists()).toBe(true);
+
+    wrapper.setState({
+      visible: false,
+    });
+    wrapper.find('.ant-drawer-wrapper-body').simulate('transitionend');
+    expect(wrapper.find('.ant-drawer-wrapper-body').exists()).toBe(true);
   });
 
   it('no mask and no closable', () => {

--- a/components/drawer/__tests__/__snapshots__/Drawer.test.js.snap
+++ b/components/drawer/__tests__/__snapshots__/Drawer.test.js.snap
@@ -558,3 +558,49 @@ exports[`Drawer style/drawerStyle/headerStyle/bodyStyle should work 1`] = `
   </div>
 </div>
 `;
+
+exports[`Drawer support closeIcon 1`] = `
+<div
+  class=""
+>
+  <div
+    class="ant-drawer ant-drawer-right"
+    tabindex="-1"
+  >
+    <div
+      class="ant-drawer-mask"
+    />
+    <div
+      class="ant-drawer-content-wrapper"
+      style="transform:translateX(100%);-ms-transform:translateX(100%);width:400px"
+    >
+      <div
+        class="ant-drawer-content"
+      >
+        <div
+          class="ant-drawer-wrapper-body"
+        >
+          <div
+            class="ant-drawer-header-no-title"
+          >
+            <button
+              aria-label="Close"
+              class="ant-drawer-close"
+              style="--scroll-bar:0px"
+            >
+              <span>
+                close
+              </span>
+            </button>
+          </div>
+          <div
+            class="ant-drawer-body"
+          >
+            Here is content of Drawer
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/components/drawer/index.en-US.md
+++ b/components/drawer/index.en-US.md
@@ -21,7 +21,7 @@ A Drawer is a panel that is typically overlaid on top of a page and slides in fr
 | Props | Description | Type | Default |
 | --- | --- | --- | --- |
 | closable | Whether a close (x) button is visible on top right of the Drawer dialog or not. | boolean | true |
-| closeIcon | custom close icon | ReactNode | - |
+| closeIcon | custom close icon | ReactNode | `<CloseOutlined />` |
 | destroyOnClose | Whether to unmount child components on closing drawer or not. | boolean | false |
 | forceRender | Prerender Drawer component forcely | boolean | false |
 | getContainer | Return the mounted node for Drawer. | HTMLElement \| `() => HTMLElement` \| Selectors \| false | 'body' |

--- a/components/drawer/index.en-US.md
+++ b/components/drawer/index.en-US.md
@@ -21,6 +21,7 @@ A Drawer is a panel that is typically overlaid on top of a page and slides in fr
 | Props | Description | Type | Default |
 | --- | --- | --- | --- |
 | closable | Whether a close (x) button is visible on top right of the Drawer dialog or not. | boolean | true |
+| closeIcon | custom close icon | ReactNode | - |
 | destroyOnClose | Whether to unmount child components on closing drawer or not. | boolean | false |
 | forceRender | Prerender Drawer component forcely | boolean | false |
 | getContainer | Return the mounted node for Drawer. | HTMLElement \| `() => HTMLElement` \| Selectors \| false | 'body' |

--- a/components/drawer/index.tsx
+++ b/components/drawer/index.tsx
@@ -21,6 +21,7 @@ const PlacementTypes = tuple('top', 'right', 'bottom', 'left');
 type placementType = typeof PlacementTypes[number];
 export interface DrawerProps {
   closable?: boolean;
+  closeIcon?: React.ReactNode;
   destroyOnClose?: boolean;
   forceRender?: boolean;
   getContainer?: string | HTMLElement | getContainerFunc | false;
@@ -195,7 +196,7 @@ class Drawer extends React.Component<DrawerProps & ConfigConsumerProps, IDrawerS
   }
 
   renderCloseIcon() {
-    const { closable, prefixCls, onClose } = this.props;
+    const { closable, closeIcon = <CloseOutlined />, prefixCls, onClose } = this.props;
     return (
       closable && (
         // eslint-disable-next-line react/button-has-type
@@ -209,7 +210,7 @@ class Drawer extends React.Component<DrawerProps & ConfigConsumerProps, IDrawerS
             } as any
           }
         >
-          <CloseOutlined />
+          {closeIcon}
         </button>
       )
     );
@@ -283,6 +284,7 @@ class Drawer extends React.Component<DrawerProps & ConfigConsumerProps, IDrawerS
                   'zIndex',
                   'style',
                   'closable',
+                  'closeIcon',
                   'destroyOnClose',
                   'drawerStyle',
                   'headerStyle',

--- a/components/drawer/index.zh-CN.md
+++ b/components/drawer/index.zh-CN.md
@@ -20,7 +20,7 @@ cover: https://gw.alipayobjects.com/zos/alicdn/7z8NJQhFb/Drawer.svg
 | 参数 | 说明 | 类型 | 默认值 |
 | --- | --- | --- | --- |
 | closable | 是否显示右上角的关闭按钮 | boolean | true |
-| closeIcon | 自定义关闭图标 | ReactNode | - |
+| closeIcon | 自定义关闭图标 | ReactNode | `<CloseOutlined />` |
 | destroyOnClose | 关闭时销毁 Drawer 里的子元素 | boolean | false |
 | forceRender | 预渲染 Drawer 内元素 | boolean | false |
 | getContainer | 指定 Drawer 挂载的 HTML 节点, false 为挂载在当前 dom | HTMLElement \| `() => HTMLElement` \| Selectors \| false | 'body' |

--- a/components/drawer/index.zh-CN.md
+++ b/components/drawer/index.zh-CN.md
@@ -20,6 +20,7 @@ cover: https://gw.alipayobjects.com/zos/alicdn/7z8NJQhFb/Drawer.svg
 | 参数 | 说明 | 类型 | 默认值 |
 | --- | --- | --- | --- |
 | closable | 是否显示右上角的关闭按钮 | boolean | true |
+| closeIcon | 自定义关闭图标 | ReactNode | - |
 | destroyOnClose | 关闭时销毁 Drawer 里的子元素 | boolean | false |
 | forceRender | 预渲染 Drawer 内元素 | boolean | false |
 | getContainer | 指定 Drawer 挂载的 HTML 节点, false 为挂载在当前 dom | HTMLElement \| `() => HTMLElement` \| Selectors \| false | 'body' |

--- a/components/modal/index.en-US.md
+++ b/components/modal/index.en-US.md
@@ -20,7 +20,7 @@ When requiring users to interact with the application, but without jumping to a 
 | cancelText | Text of the Cancel button | string\|ReactNode | `Cancel` |
 | centered | Centered Modal | Boolean | `false` |
 | closable | Whether a close (x) button is visible on top right of the modal dialog or not | boolean | true |
-| closeIcon | custom close icon | ReactNode | - |
+| closeIcon | custom close icon | ReactNode | `<CloseOutlined />` |
 | confirmLoading | Whether to apply loading visual effect for OK button or not | boolean | false |
 | destroyOnClose | Whether to unmount child components on onClose | boolean | false |
 | footer | Footer content, set as `footer={null}` when you don't need default buttons | string\|ReactNode | OK and Cancel buttons |

--- a/components/modal/index.zh-CN.md
+++ b/components/modal/index.zh-CN.md
@@ -23,7 +23,7 @@ cover: https://gw.alipayobjects.com/zos/alicdn/3StSdUlSH/Modal.svg
 | cancelText | 取消按钮文字 | string\|ReactNode | 取消 |
 | centered | 垂直居中展示 Modal | Boolean | `false` |
 | closable | 是否显示右上角的关闭按钮 | boolean | true |
-| closeIcon | 自定义关闭图标 | ReactNode | - |
+| closeIcon | 自定义关闭图标 | ReactNode | `<CloseOutlined />` |
 | confirmLoading | 确定按钮 loading | boolean | false |
 | destroyOnClose | 关闭时销毁 Modal 里的子元素 | boolean | false |
 | footer | 底部内容，当不需要默认底部按钮时，可以设为 `footer={null}` | string\|ReactNode | 确定取消按钮 |


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Perfermance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close #19283
close #19153

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Add `closeIcon` prop to Drawer. |
| 🇨🇳 Chinese | Drawer 新增 `closeIcon` 属性  |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/drawer/index.en-US.md](https://github.com/ant-design/ant-design/blob/feat-modal-drawer-close-icon/components/drawer/index.en-US.md)
[View rendered components/drawer/index.zh-CN.md](https://github.com/ant-design/ant-design/blob/feat-modal-drawer-close-icon/components/drawer/index.zh-CN.md)