### PR TITLE
fix: Fixed code that increased package size if tree shaking is disabled

### DIFF
--- a/components/transfer/ListItem.tsx
+++ b/components/transfer/ListItem.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import classNames from 'classnames';
-import { DeleteOutlined } from '@ant-design/icons';
+import DeleteOutlined from '@ant-design/icons/DeleteOutlined';
 import { TransferItem, TransferLocale } from '.';
 import defaultLocale from '../locale/default';
 import Checkbox from '../checkbox';


### PR DESCRIPTION
With the merged pull request https://github.com/ant-design/ant-design/pull/21752 bundle size was decreased even if tree shaking was disabled. The pull request https://github.com/ant-design/ant-design/pull/24041 destroyed these feature. 

With this pull request this is fixed again.

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [x] Bundle size optimization
- [ ] Perfermance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

https://github.com/ant-design/ant-design/pull/21752
and
 https://github.com/ant-design/ant-design/pull/24041

### 💡 Background and solution

This enables only the import of required icons instead of whole icon library even if tree shaking is disabled.

### 📝 Changelog

No change on user site.

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
