### PR TITLE
docs: Update placeholder type for Rangepicker

### DIFF
--- a/components/time-picker/index.en-US.md
+++ b/components/time-picker/index.en-US.md
@@ -42,7 +42,7 @@ import moment from 'moment';
 | inputReadOnly | Set the `readonly` attribute of the input tag (avoids virtual keyboard on touch devices) | boolean | false |  |
 | minuteStep | interval between minutes in picker | number | 1 |  |
 | open | whether to popup panel | boolean | false |  |
-| placeholder | display when there's no value | string | "Select a time" |  |
+| placeholder | display when there's no value | string or [string, string] | "Select a time" |  |
 | popupClassName | className of panel | string | - |  |
 | popupStyle | style of panel | CSSProperties | - |  |
 | secondStep | interval between seconds in picker | number | 1 |  |

--- a/components/time-picker/index.en-US.md
+++ b/components/time-picker/index.en-US.md
@@ -42,7 +42,7 @@ import moment from 'moment';
 | inputReadOnly | Set the `readonly` attribute of the input tag (avoids virtual keyboard on touch devices) | boolean | false |  |
 | minuteStep | interval between minutes in picker | number | 1 |  |
 | open | whether to popup panel | boolean | false |  |
-| placeholder | display when there's no value | string or [string, string] | "Select a time" |  |
+| placeholder | display when there's no value | string \| [string, string] | "Select a time" |  |
 | popupClassName | className of panel | string | - |  |
 | popupStyle | style of panel | CSSProperties | - |  |
 | secondStep | interval between seconds in picker | number | 1 |  |


### PR DESCRIPTION
A rangepicker needs two placeholder fields instead of one. It is an array of two strings.

<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Perfermance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

https://ant.design/components/time-picker/#API

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

A rangepicker needs two placeholder fields instead of one. It is an array of two strings.

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

There is no potential this breaks anything.

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     none      |
| 🇨🇳 Chinese |        none   |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/time-picker/index.en-US.md](https://github.com/eenlars/ant-design/blob/patch-1/components/time-picker/index.en-US.md)