### PR TITLE
feat: cascader expandIcon

### DIFF
--- a/components/cascader/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/cascader/__tests__/__snapshots__/demo.test.js.snap
@@ -591,7 +591,7 @@ exports[`renders ./components/cascader/demo/size.md correctly 1`] = `
 `;
 
 exports[`renders ./components/cascader/demo/suffix.md correctly 1`] = `
-<div>
+Array [
   <span
     class="ant-cascader-picker"
     tabindex="0"
@@ -628,10 +628,11 @@ exports[`renders ./components/cascader/demo/suffix.md correctly 1`] = `
         />
       </svg>
     </span>
-  </span>
+  </span>,
+  <br />,
+  <br />,
   <span
     class="ant-cascader-picker"
-    style="margin-top:1rem"
     tabindex="0"
   >
     <span
@@ -651,6 +652,84 @@ exports[`renders ./components/cascader/demo/suffix.md correctly 1`] = `
     >
       ab
     </span>
-  </span>
-</div>
+  </span>,
+  <br />,
+  <br />,
+  <span
+    class="ant-cascader-picker"
+    tabindex="0"
+  >
+    <span
+      class="ant-cascader-picker-label"
+    />
+    <input
+      autocomplete="off"
+      class="ant-input ant-cascader-input "
+      placeholder="Please select"
+      readonly=""
+      tabindex="-1"
+      type="text"
+      value=""
+    />
+    <span
+      aria-label="down"
+      class="anticon anticon-down ant-cascader-picker-arrow"
+      role="img"
+    >
+      <svg
+        aria-hidden="true"
+        class=""
+        data-icon="down"
+        fill="currentColor"
+        focusable="false"
+        height="1em"
+        viewBox="64 64 896 896"
+        width="1em"
+      >
+        <path
+          d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+        />
+      </svg>
+    </span>
+  </span>,
+  <br />,
+  <br />,
+  <span
+    class="ant-cascader-picker"
+    tabindex="0"
+  >
+    <span
+      class="ant-cascader-picker-label"
+    />
+    <input
+      autocomplete="off"
+      class="ant-input ant-cascader-input "
+      placeholder="Please select"
+      readonly=""
+      tabindex="-1"
+      type="text"
+      value=""
+    />
+    <span
+      aria-label="down"
+      class="anticon anticon-down ant-cascader-picker-arrow"
+      role="img"
+    >
+      <svg
+        aria-hidden="true"
+        class=""
+        data-icon="down"
+        fill="currentColor"
+        focusable="false"
+        height="1em"
+        viewBox="64 64 896 896"
+        width="1em"
+      >
+        <path
+          d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+        />
+      </svg>
+    </span>
+  </span>,
+]
 `;

--- a/components/cascader/demo/suffix.md
+++ b/components/cascader/demo/suffix.md
@@ -1,18 +1,17 @@
 ---
 order: 11
-debug: true
 title:
-  zh-CN: 后缀图标
-  en-US: Suffix
+  zh-CN: 自定义图标
+  en-US: Custom Icons
 ---
 
 ## zh-CN
 
-省市区级联。
+通过 `suffixIcon` 自定义选择框后缀图标，通过 `expandIcon` 自定义次级菜单展开图标。
 
 ## en-US
 
-Cascade selection box for selecting province/city/district.
+Use `suffixIcon` to customize the selection box suffix icon, and use `expandIcon` to customize the current item expand icon.
 
 ```jsx
 import { Cascader } from 'antd';
@@ -58,21 +57,28 @@ function onChange(value) {
 }
 
 ReactDOM.render(
-  <div>
+  <>
     <Cascader
       suffixIcon={<SmileOutlined />}
       options={options}
       onChange={onChange}
       placeholder="Please select"
     />
+    <br />
+    <br />
+    <Cascader suffixIcon="ab" options={options} onChange={onChange} placeholder="Please select" />
+    <br />
+    <br />
     <Cascader
-      suffixIcon="ab"
-      style={{ marginTop: '1rem' }}
+      expandIcon={<SmileOutlined />}
       options={options}
       onChange={onChange}
       placeholder="Please select"
     />
-  </div>,
+    <br />
+    <br />
+    <Cascader expandIcon="ab" options={options} onChange={onChange} placeholder="Please select" />
+  </>,
   mountNode,
 );
 ```

--- a/components/cascader/demo/suffix.md
+++ b/components/cascader/demo/suffix.md
@@ -1,5 +1,6 @@
 ---
 order: 11
+debug: true
 title:
   zh-CN: 自定义图标
   en-US: Custom Icons

--- a/components/cascader/index.en-US.md
+++ b/components/cascader/index.en-US.md
@@ -30,7 +30,7 @@ Cascade selection box.
 | disabled | whether disabled select | boolean | false |  |
 | displayRender | render function of displaying selected options | `(label, selectedOptions) => ReactNode` | `label => label.join(' / ')` |  |
 | expandTrigger | expand current item when click or hover, one of 'click' 'hover' | string | 'click' |  |
-| expandIcon | customize the current item expand icon | ReactNode | - | 4.3.4 |
+| expandIcon | customize the current item expand icon | ReactNode | - | 4.4.0 |
 | fieldNames | custom field name for label and value and children | object | `{ label: 'label', value: 'value', children: 'children' }` |  |
 | getPopupContainer | Parent Node which the selector should be rendered to. Default to `body`. When position issues happen, try to modify it into scrollable content and position it relative.[example](https://codepen.io/afc163/pen/zEjNOy?editors=0010) | Function(triggerNode) | () => document.body |  |
 | loadData | To load option lazily, and it cannot work with `showSearch` | `(selectedOptions) => void` | - |  |

--- a/components/cascader/index.en-US.md
+++ b/components/cascader/index.en-US.md
@@ -30,6 +30,7 @@ Cascade selection box.
 | disabled | whether disabled select | boolean | false |  |
 | displayRender | render function of displaying selected options | `(label, selectedOptions) => ReactNode` | `label => label.join(' / ')` |  |
 | expandTrigger | expand current item when click or hover, one of 'click' 'hover' | string | 'click' |  |
+| expandIcon | customize the current item expand icon | ReactNode | - | 4.3.4 |
 | fieldNames | custom field name for label and value and children | object | `{ label: 'label', value: 'value', children: 'children' }` |  |
 | getPopupContainer | Parent Node which the selector should be rendered to. Default to `body`. When position issues happen, try to modify it into scrollable content and position it relative.[example](https://codepen.io/afc163/pen/zEjNOy?editors=0010) | Function(triggerNode) | () => document.body |  |
 | loadData | To load option lazily, and it cannot work with `showSearch` | `(selectedOptions) => void` | - |  |

--- a/components/cascader/index.tsx
+++ b/components/cascader/index.tsx
@@ -97,6 +97,7 @@ export interface CascaderProps {
   loadData?: (selectedOptions?: CascaderOptionType[]) => void;
   /** 次级菜单的展开方式，可选 'click' 和 'hover' */
   expandTrigger?: CascaderExpandTrigger;
+  expandIcon?: React.ReactNode;
   /** 当此项为 true 时，点选每级菜单选项值都会发生变化 */
   changeOnSelect?: boolean;
   /** 浮层可见变化时回调 */
@@ -459,12 +460,14 @@ class Cascader extends React.Component<CascaderProps, CascaderState> {
           allowClear,
           showSearch = false,
           suffixIcon,
+          expandIcon,
           notFoundContent,
           popupClassName,
           bordered,
           dropdownRender,
           ...otherProps
         } = props;
+
         const mergedSize = customizeSize || size;
 
         const { value, inputFocused } = state;
@@ -594,9 +597,11 @@ class Cascader extends React.Component<CascaderProps, CascaderState> {
           </span>
         );
 
-        let expandIcon = <RightOutlined />;
-        if (isRtlLayout) {
-          expandIcon = <LeftOutlined />;
+        let expandIconNode;
+        if (expandIcon) {
+          expandIconNode = expandIcon;
+        } else {
+          expandIconNode = isRtlLayout ? <LeftOutlined /> : <RightOutlined />;
         }
 
         const loadingIcon = (
@@ -623,7 +628,7 @@ class Cascader extends React.Component<CascaderProps, CascaderState> {
             onPopupVisibleChange={this.handlePopupVisibleChange}
             onChange={this.handleChange}
             dropdownMenuColumnStyle={dropdownMenuColumnStyle}
-            expandIcon={expandIcon}
+            expandIcon={expandIconNode}
             loadingIcon={loadingIcon}
             popupClassName={rcCascaderPopupClassName}
             popupPlacement={this.getPopupPlacement(direction)}

--- a/components/cascader/index.zh-CN.md
+++ b/components/cascader/index.zh-CN.md
@@ -31,6 +31,7 @@ cover: https://gw.alipayobjects.com/zos/alicdn/UdS8y8xyZ/Cascader.svg
 | disabled | 禁用 | boolean | false |  |
 | displayRender | 选择后展示的渲染函数 | `(label, selectedOptions) => ReactNode` | `label => label.join(' / ')` |  |
 | expandTrigger | 次级菜单的展开方式，可选 'click' 和 'hover' | string | 'click' |  |
+| expandIcon | 自定义次级菜单展开图标 | ReactNode | - | 4.3.4 |
 | fieldNames | 自定义 options 中 label name children 的字段 | object | `{ label: 'label', value: 'value', children: 'children' }` |  |
 | getPopupContainer | 菜单渲染父节点。默认渲染到 body 上，如果你遇到菜单滚动定位问题，试试修改为滚动的区域，并相对其定位。[示例](https://codepen.io/afc163/pen/zEjNOy?editors=0010) | Function(triggerNode) | () => document.body |  |
 | loadData | 用于动态加载选项，无法与 `showSearch` 一起使用 | `(selectedOptions) => void` | - |  |

--- a/components/cascader/index.zh-CN.md
+++ b/components/cascader/index.zh-CN.md
@@ -31,7 +31,7 @@ cover: https://gw.alipayobjects.com/zos/alicdn/UdS8y8xyZ/Cascader.svg
 | disabled | 禁用 | boolean | false |  |
 | displayRender | 选择后展示的渲染函数 | `(label, selectedOptions) => ReactNode` | `label => label.join(' / ')` |  |
 | expandTrigger | 次级菜单的展开方式，可选 'click' 和 'hover' | string | 'click' |  |
-| expandIcon | 自定义次级菜单展开图标 | ReactNode | - | 4.3.4 |
+| expandIcon | 自定义次级菜单展开图标 | ReactNode | - | 4.4.0 |
 | fieldNames | 自定义 options 中 label name children 的字段 | object | `{ label: 'label', value: 'value', children: 'children' }` |  |
 | getPopupContainer | 菜单渲染父节点。默认渲染到 body 上，如果你遇到菜单滚动定位问题，试试修改为滚动的区域，并相对其定位。[示例](https://codepen.io/afc163/pen/zEjNOy?editors=0010) | Function(triggerNode) | () => document.body |  |
 | loadData | 用于动态加载选项，无法与 `showSearch` 一起使用 | `(selectedOptions) => void` | - |  |


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Perfermance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
close https://github.com/ant-design/ant-design/issues/24855
<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution
- 把原来的 Demo 放出来改了改
效果如下：

![2020-06-09 14 47 27](https://user-images.githubusercontent.com/29775873/84115234-4c2fba00-aa60-11ea-9ffd-0468c6ec8e27.gif)


<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Cascader add `expandIcon` to customize the current item expand icon.           |
| 🇨🇳 Chinese | Cascader 新增 `expandIcon` 来自定义次级菜单展开图标。            |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/cascader/demo/suffix.md](https://github.com/ant-design/ant-design/blob/feat-cascader/components/cascader/demo/suffix.md)
[View rendered components/cascader/index.en-US.md](https://github.com/ant-design/ant-design/blob/feat-cascader/components/cascader/index.en-US.md)
[View rendered components/cascader/index.zh-CN.md](https://github.com/ant-design/ant-design/blob/feat-cascader/components/cascader/index.zh-CN.md)