### PR TITLE
fix: export CardInterface from Card resolves #24864

### DIFF
--- a/components/card/index.tsx
+++ b/components/card/index.tsx
@@ -57,7 +57,7 @@ export interface CardProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 't
   tabProps?: TabsProps;
 }
 
-interface CardInterface extends React.FC<CardProps> {
+export interface CardInterface extends React.FC<CardProps> {
   Grid: typeof Grid;
   Meta: typeof Meta;
 }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Perfermance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

https://github.com/ant-design/ant-design/issues/24864

### 💡 Background and solution

The `CardInterface` is not exported from the `Card` so Typescript cannot determine the shape of `CardInterface`.

This fix exports the `CardInterface`.

### 📝 Changelog

- Exports the `CardInterface` from `components/card/index.tsx`
