### PR TITLE
style: optimize comment actions style

### DIFF
--- a/components/comment/style/index.less
+++ b/components/comment/style/index.less
@@ -79,7 +79,7 @@
       display: inline-block;
       color: @comment-action-color;
       > span {
-        padding-right: 10px;
+        margin-right: 10px;
         color: @comment-action-color;
         font-size: @comment-font-size-sm;
         cursor: pointer;

--- a/components/comment/style/rtl.less
+++ b/components/comment/style/rtl.less
@@ -34,8 +34,8 @@
     > li {
       > span {
         .@{comment-prefix-cls}-rtl & {
-          padding-right: 0;
-          padding-left: 10px;
+          margin-right: 0;
+          margin-left: 10px;
         }
       }
     }


### PR DESCRIPTION
### 🤔 This is a ...

- [x] Component style update

### 💡 Background and solution
For A11Y, when we add `tabIndex` to the comment actions `span`, it has some extra space while pressing "Tab" into this element.
```jsx
<Comment
  actions={[
    <span
      role="button"
      tabIndex={0}
      key="comment-reply"
      onKeyDown={handleClickReply}
      onClick={handleClickReply}
    >
      回复
    </span>,
  ]}
  //  ...other props
/>
```

![image](https://user-images.githubusercontent.com/9879279/84122592-83b14e80-a9ed-11ea-8da6-601a644e53c3.png)

After the fix, the tab outline area is corrected:
![image](https://user-images.githubusercontent.com/9879279/84122452-4c42a200-a9ed-11ea-8ee6-21e8be555c17.png)


### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Optimize Comment actions style. |
| 🇨🇳 Chinese | 优化 Comment 操作栏样式。 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is ~~updated/provided or~~ not needed
- [x] Demo is ~~updated/provided or~~ not needed
- [x] TypeScript definition is ~~updated/provided or~~ not needed
- [x] Changelog is provided ~~or not needed~~
