### PR TITLE
fix: Avatar falling back to children on image error

### DIFF
--- a/components/avatar/__tests__/Avatar.test.js
+++ b/components/avatar/__tests__/Avatar.test.js
@@ -100,6 +100,8 @@ describe('Avatar Render', () => {
 
     expect(wrapper).toMatchSnapshot();
     expect(wrapper.find('.ant-avatar-string').length).toBe(1);
+    // children should show, when image load error without onError return false
+    expect(wrapper.find('.ant-avatar-string').prop('style')).not.toHaveProperty('opacity', 0);
 
     // simulate successful src url
     wrapper.setProps({ src: LOAD_SUCCESS_SRC });

--- a/components/avatar/__tests__/__snapshots__/Avatar.test.js.snap
+++ b/components/avatar/__tests__/__snapshots__/Avatar.test.js.snap
@@ -91,7 +91,9 @@ exports[`Avatar Render should show image on success after a failure state 1`] = 
       className="ant-avatar-string"
       style={
         Object {
-          "opacity": 0,
+          "WebkitTransform": "scale(0.72) translateX(-50%)",
+          "msTransform": "scale(0.72) translateX(-50%)",
+          "transform": "scale(0.72) translateX(-50%)",
         }
       }
     >

--- a/components/avatar/index.en-US.md
+++ b/components/avatar/index.en-US.md
@@ -19,3 +19,5 @@ Avatars can be used to represent people or objects. It supports images, `Icon`s,
 | alt | This attribute defines the alternative text describing the image | string | - |  |
 | onError | handler when img load error, return false to prevent default fallback behavior | () => boolean | - |  |
 | gap | Letter type unit distance between left and right sides | number | 4 | 4.3.0 |
+
+> Tip: You can set `icon` or `children` as the fallback for image load error, with the priority of `icon` > `children`

--- a/components/avatar/index.tsx
+++ b/components/avatar/index.tsx
@@ -79,6 +79,12 @@ const Avatar: React.FC<AvatarProps> = props => {
     setScaleParam();
   }, [props.children, props.gap]);
 
+  React.useEffect(() => {
+    if (props.children) {
+      setScaleParam();
+    }
+  }, [isImgExist]);
+
   const handleImgLoadError = () => {
     const { onError } = props;
     const errorFlag = onError ? onError() : undefined;

--- a/components/avatar/index.zh-CN.md
+++ b/components/avatar/index.zh-CN.md
@@ -24,3 +24,5 @@ cover: https://gw.alipayobjects.com/zos/antfincdn/aBcnbw68hP/Avatar.svg
 | alt | 图像无法显示时的替代文本 | string | - |  |
 | onError | 图片加载失败的事件，返回 false 会关闭组件默认的 fallback 行为 | () => boolean | - |  |
 | gap | 字符类型距离左右两侧边界单位像素 | number | 4 | 4.3.0 |
+
+> Tip：你可以设置 `icon` 或 `children` 作为图片加载失败的默认 fallback 行为，优先级为 `icon` > `children`


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Perfermance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
https://github.com/ant-design/ant-design/issues/24897
<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution
当image加载失败时，如果有children，则fall back到children
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fix Avatar fallback to children when loading image with error.      |
| 🇨🇳 Chinese |    修复 Avatar 图片加载错误的显示问题。      |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/avatar/index.en-US.md](https://github.com/sosohime/ant-design/blob/master/components/avatar/index.en-US.md)
[View rendered components/avatar/index.zh-CN.md](https://github.com/sosohime/ant-design/blob/master/components/avatar/index.zh-CN.md)