### PR TITLE
fix: shoundn't keep table filterDropdown inner status in controlled mode

### DIFF
--- a/components/table/__tests__/Table.filter.test.js
+++ b/components/table/__tests__/Table.filter.test.js
@@ -1150,7 +1150,6 @@ describe('Table.filter', () => {
   });
 
   it(`shouldn't keep status when controlled filteredValue isn't change`, () => {
-    jest.useFakeTimers();
     const filterControlledColumn = {
       title: 'Name',
       dataIndex: 'name',

--- a/components/table/__tests__/Table.filter.test.js
+++ b/components/table/__tests__/Table.filter.test.js
@@ -1148,4 +1148,33 @@ describe('Table.filter', () => {
     expect(wrapper.find('tbody tr')).toHaveLength(1);
     expect(wrapper.find('tbody tr td').text()).toEqual('Jack');
   });
+
+  it(`shouldn't keep status when controlled filteredValue isn't change`, () => {
+    jest.useFakeTimers();
+    const filterControlledColumn = {
+      title: 'Name',
+      dataIndex: 'name',
+      filteredValue: null,
+      filters: [
+        { text: 'Boy', value: 'boy' },
+        { text: 'Girl', value: 'girl' },
+      ],
+      onFilter: filterFn,
+    };
+    const wrapper = mount(createTable({ columns: [filterControlledColumn] }));
+    wrapper.find('.ant-dropdown-trigger').first().simulate('click');
+    wrapper.find('FilterDropdown').find('MenuItem').first().simulate('click');
+    wrapper // close drodown
+      .find('FilterDropdown')
+      .find('.ant-table-filter-dropdown-btns .ant-btn-primary')
+      .simulate('click');
+    wrapper.find('.ant-dropdown-trigger').first().simulate('click'); // reopen
+    const checkbox = wrapper
+      .find('FilterDropdown')
+      .find('MenuItem')
+      .first()
+      .find('Checkbox')
+      .first();
+    expect(checkbox.props().checked).toEqual(false);
+  });
 });

--- a/components/table/hooks/useFilter/FilterDropdown.tsx
+++ b/components/table/hooks/useFilter/FilterDropdown.tsx
@@ -154,6 +154,11 @@ function FilterDropdown<RecordType>(props: FilterDropdownProps<RecordType>) {
   };
 
   const onVisibleChange = (newVisible: boolean) => {
+    if (newVisible && propFilteredKeys !== undefined) {
+      // Sync filteredKeys on appear in controlled mode (propFilteredKeys !== undefiend)
+      setFilteredKeysSync(propFilteredKeys || []);
+    }
+
     triggerVisible(newVisible);
 
     // Default will filter when closed


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Perfermance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution
Table filter dropdown's value doesn't follow controlled filtered value.
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the problem that Table's filter dropdown's display value doesn't sync with controlled `filteredValue`.  |
| 🇨🇳 Chinese |  修正了受控状态下 Table 列的过滤菜单显示的值和 `filteredValue` 不同步的问题。   |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
