### PR TITLE
fix: PageHeader tabs broken style since 4.3.0

### DIFF
--- a/components/page-header/style/index.less
+++ b/components/page-header/style/index.less
@@ -102,14 +102,14 @@
 
   &-footer {
     margin-top: @margin-md;
-    .@{ant-prefix}-tabs-bar {
-      margin-bottom: 1px;
-      border-bottom: 0;
-      .@{ant-prefix}-tabs-nav {
-        .@{ant-prefix}-tabs-tab {
-          padding: @tabs-horizontal-padding-sm;
-          font-size: @page-header-tabs-tab-font-size;
-        }
+    .@{ant-prefix}-tabs-nav {
+      &::before {
+        border: none;
+      }
+
+      .@{ant-prefix}-tabs-tab {
+        padding: @tabs-horizontal-padding-sm;
+        font-size: @page-header-tabs-tab-font-size;
       }
     }
   }


### PR DESCRIPTION


<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Perfermance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close #24989

### 💡 Background and solution

| version  | screenshot |
| ---------- | --------- |
| 4.3.4 ❌ | <img width="617" alt="image" src="https://user-images.githubusercontent.com/507615/84615020-5c311900-aefa-11ea-8738-ec0f2c73328f.png"> |
| 4.2.x ✅ | <img width="628" alt="image" src="https://user-images.githubusercontent.com/507615/84615030-63582700-aefa-11ea-8283-fb7f166c022b.png">  |

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix PageHeader tabs broken style since `4.3.0`. |
| 🇨🇳 Chinese | 修复 PageHeader 从 `4.3.0` 后的 `tabs` 样式错误。  |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
