### PR TITLE
fix: List.Item.Meta width overflow

### DIFF
--- a/components/list/style/index.less
+++ b/components/list/style/index.less
@@ -55,22 +55,21 @@
     align-items: center;
     justify-content: space-between;
     padding: @list-item-padding;
-
-    &-content {
-      color: @text-color;
-    }
+    color: @text-color;
 
     &-meta {
       display: flex;
       flex: 1;
       align-items: flex-start;
-      font-size: 0;
+      max-width: 100%;
 
       &-avatar {
         margin-right: @list-item-meta-avatar-margin-right;
       }
       &-content {
         flex: 1 0;
+        overflow: hidden;
+        color: @text-color;
       }
       &-title {
         margin-bottom: 4px;

--- a/components/list/style/index.less
+++ b/components/list/style/index.less
@@ -68,7 +68,7 @@
       }
       &-content {
         flex: 1 0;
-        overflow: hidden;
+        width: 0;
         color: @text-color;
       }
       &-title {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Perfermance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

fix #24969


### 💡 Background and solution
Set max-width on wrapper & overflow hidden on flex-item

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Fix List.Item.Meta content width may overflow sometimes.   |
| 🇨🇳 Chinese |  修正了 List.Item.Meta 内容宽度有时会溢出的问题。 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
