### PR TITLE
fix: avoid onFocus and onBlur triggering multiple times(#11249)

### DIFF
--- a/components/date-picker/__tests__/DatePicker.test.js
+++ b/components/date-picker/__tests__/DatePicker.test.js
@@ -5,6 +5,7 @@ import MockDate from 'mockdate';
 import DatePicker from '..';
 import { selectDate, openPanel, clearInput, nextYear, nextMonth, hasSelected } from './utils';
 import focusTest from '../../../tests/shared/focusTest';
+import { sleep } from '../../../tests/utils';
 
 describe('DatePicker', () => {
   const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
@@ -236,5 +237,23 @@ describe('DatePicker', () => {
         'Warning: [antd: DatePicker] `value` provides invalidate moment time. If you want to set empty value, use `null` instead.',
       );
     });
+  });
+
+  // Fix https://github.com/ant-design/ant-design/issues/11249
+  it('onFocus and onBlur should be only called once when focus and blur', async () => {
+    const onFocus = jest.fn();
+    const onBlur = jest.fn();
+    const wrapper = mount(<DatePicker onFocus={onFocus} onBlur={onBlur} />, {
+      attachTo: document.body,
+    });
+    openPanel(wrapper);
+    await sleep(100);
+    expect(onFocus).toBeCalledTimes(1);
+    expect(onBlur).toBeCalledTimes(0);
+    openPanel(wrapper);
+    await sleep(100);
+    expect(onFocus).toBeCalledTimes(1);
+    expect(onBlur).toBeCalledTimes(1);
+    wrapper.unmount();
   });
 });

--- a/components/date-picker/createPicker.tsx
+++ b/components/date-picker/createPicker.tsx
@@ -56,6 +56,11 @@ export default function createPicker(TheCalendar: React.ComponentClass): any {
 
     private prefixCls?: string;
 
+    // Avoid triggering multiple times on different inputs
+    private focused: boolean;
+
+    private triggerFocusOrBlur: boolean;
+
     constructor(props: any) {
       super(props);
       const value = props.value || props.defaultValue;
@@ -114,11 +119,45 @@ export default function createPicker(TheCalendar: React.ComponentClass): any {
       }
     };
 
+    handleFocus = (e: React.FocusEvent<HTMLInputElement>) => {
+      const {
+        props: { onFocus },
+        state: { open },
+        focused,
+        triggerFocusOrBlur,
+      } = this;
+      if ((!focused && open) || triggerFocusOrBlur) {
+        this.focused = true;
+        this.triggerFocusOrBlur = false;
+        if (onFocus) {
+          onFocus(e);
+        }
+      }
+    };
+
+    handleBlur = (e: React.FocusEvent<HTMLInputElement>) => {
+      const {
+        props: { onBlur },
+        state: { open },
+        focused,
+        triggerFocusOrBlur,
+      } = this;
+      if ((focused && !open) || triggerFocusOrBlur) {
+        this.focused = false;
+        this.triggerFocusOrBlur = false;
+        if (onBlur) {
+          onBlur(e);
+        }
+      }
+    };
+
     focus() {
+      this.triggerFocusOrBlur = true;
       this.input.focus();
     }
 
     blur() {
+      this.triggerFocusOrBlur = true;
       this.input.blur();
     }
 
@@ -246,8 +285,8 @@ export default function createPicker(TheCalendar: React.ComponentClass): any {
           id={props.id}
           className={classNames(props.className, props.pickerClass)}
           style={{ ...pickerStyle, ...props.style }}
-          onFocus={props.onFocus}
-          onBlur={props.onBlur}
+          onFocus={this.handleFocus}
+          onBlur={this.handleBlur}
           onMouseEnter={props.onMouseEnter}
           onMouseLeave={props.onMouseLeave}
         >


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Perfermance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close [#11249](https://github.com/ant-design/ant-design/issues/11249)

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix `onFocus` and `onBlur` callbacks of DatePicker triggering multiple times.(#11249)          |
| 🇨🇳 Chinese | 修复 DatePicker `onFocus`、 `onBlur` 回调触发多次问题。(#11249)         |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
