### PR TITLE
refactor: refine some typos

### DIFF
--- a/components/input/__tests__/Password.test.js
+++ b/components/input/__tests__/Password.test.js
@@ -109,7 +109,7 @@ describe('Input.Password', () => {
   });
 
   // https://github.com/ant-design/ant-design/pull/20544#issuecomment-569861679
-  it('should not contain value attribute in input element with defautValue', async () => {
+  it('should not contain value attribute in input element with defaultValue', async () => {
     const wrapper = mount(<Input.Password defaultValue="value" />);
     await sleep();
     expect(wrapper.find('input').at('0').getDOMNode().getAttribute('value')).toBeFalsy();

--- a/components/input/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/input/__tests__/__snapshots__/demo.test.js.snap
@@ -2299,7 +2299,7 @@ Array [
   >
     <input
       class="ant-input"
-      placeholder="input search loading deault"
+      placeholder="input search loading default"
       type="text"
       value=""
     />

--- a/components/input/demo/autosize-textarea.md
+++ b/components/input/demo/autosize-textarea.md
@@ -11,7 +11,7 @@ title:
 
 ## en-US
 
-`autoSize` prop for a `textarea` type of `Input` makes the height to automatically adjust based on the content. An options object can be provided to `autoSize` to specify the minimum and maximum number of lines the textarea will automatically adjust.
+`autoSize` prop for a `textarea` type of `Input` makes the height to automatically adjust based on the content. An option object can be provided to `autoSize` to specify the minimum and maximum number of lines the textarea will automatically adjust.
 
 ```jsx
 import { Input } from 'antd';

--- a/components/input/demo/group.md
+++ b/components/input/demo/group.md
@@ -13,7 +13,7 @@ title:
 
 ## en-US
 
-Input.Group example
+Input.Group example.
 
 Note: You don't need `Col` to control the width in the `compact` mode.
 

--- a/components/input/demo/presuffix.md
+++ b/components/input/demo/presuffix.md
@@ -11,7 +11,7 @@ title:
 
 ## en-US
 
-Add prefix or suffix icons inside input.
+Add a prefix or suffix icons inside input.
 
 ```jsx
 import { Input, Tooltip } from 'antd';

--- a/components/input/demo/search-input-loading.md
+++ b/components/input/demo/search-input-loading.md
@@ -20,7 +20,7 @@ const { Search } = Input;
 
 ReactDOM.render(
   <>
-    <Search placeholder="input search loading deault" loading />
+    <Search placeholder="input search loading default" loading />
     <br />
     <br />
     <Search placeholder="input search loading with enterButton" loading enterButton />


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Perfermance optimization
- [x] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->
None

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->
Refine some typos.
### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     refine some typos      |
| 🇨🇳 Chinese |     修复一些拼写错误      |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/input/demo/autosize-textarea.md](https://github.com/Rustin-Liu/ant-design/blob/rustin-patch-input/components/input/demo/autosize-textarea.md)
[View rendered components/input/demo/group.md](https://github.com/Rustin-Liu/ant-design/blob/rustin-patch-input/components/input/demo/group.md)
[View rendered components/input/demo/presuffix.md](https://github.com/Rustin-Liu/ant-design/blob/rustin-patch-input/components/input/demo/presuffix.md)
[View rendered components/input/demo/search-input-loading.md](https://github.com/Rustin-Liu/ant-design/blob/rustin-patch-input/components/input/demo/search-input-loading.md)