### PR TITLE
fix: Search crash in AutoComplete

### DIFF
--- a/components/input/Search.tsx
+++ b/components/input/Search.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import classNames from 'classnames';
+import { composeRef } from 'rc-util/lib/ref';
 import SearchOutlined from '@ant-design/icons/SearchOutlined';
 import LoadingOutlined from '@ant-design/icons/LoadingOutlined';
 import Input, { InputProps } from './Input';
@@ -21,8 +22,8 @@ export interface SearchProps extends InputProps {
   loading?: boolean;
 }
 
-const Search = React.forwardRef<unknown, SearchProps>((props, ref) => {
-  const inputRef = (ref as any) || React.createRef<Input>();
+const Search = React.forwardRef<Input, SearchProps>((props, ref) => {
+  const inputRef = React.useRef<Input>(null);
 
   const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { onChange: customOnChange, onSearch: customOnSearch } = props;
@@ -35,7 +36,7 @@ const Search = React.forwardRef<unknown, SearchProps>((props, ref) => {
   };
 
   const onMouseDown: React.MouseEventHandler<HTMLElement> = e => {
-    if (document.activeElement === inputRef.current.input) {
+    if (document.activeElement === inputRef.current?.input) {
       e.preventDefault();
     }
   };
@@ -46,7 +47,7 @@ const Search = React.forwardRef<unknown, SearchProps>((props, ref) => {
       return;
     }
     if (customOnSearch) {
-      customOnSearch(inputRef.current.input.value, e);
+      customOnSearch(inputRef.current?.input.value!, e);
     }
   };
 
@@ -183,7 +184,7 @@ const Search = React.forwardRef<unknown, SearchProps>((props, ref) => {
       <SizeContext.Consumer>
         {size => (
           <Input
-            ref={inputRef}
+            ref={composeRef<Input>(inputRef, ref)}
             onPressEnter={onSearch}
             {...restProps}
             size={customizeSize || size}

--- a/components/input/__tests__/Search.test.js
+++ b/components/input/__tests__/Search.test.js
@@ -201,4 +201,12 @@ describe('Input.Search', () => {
     expect(prevented).toBeTruthy();
     expect(document.activeElement).toBe(wrapper.find('input').at(0).getDOMNode());
   });
+
+  it('not crash when use function ref', () => {
+    const ref = jest.fn();
+    const wrapper = mount(<Search ref={ref} enterButton />);
+    expect(() => {
+      wrapper.find('button').simulate('mousedown');
+    }).not.toThrow();
+  });
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Perfermance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

fix #25031

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Fix Input.Search as AutoComplete customize component crash issue.        |
| 🇨🇳 Chinese |   修复 Input.Search 作为 AutoComplete 自定义组件会崩溃的问题。      |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
