### PR TITLE
fix: avoid colorPalette error when the saturation/value === 1

### DIFF
--- a/components/style/color/colorPalette.less
+++ b/components/style/color/colorPalette.less
@@ -9,10 +9,10 @@
 .colorPaletteMixin() {
 @functions: ~`(function() {
   var hueStep = 2;
-  var saturationStep = 16;
-  var saturationStep2 = 5;
-  var brightnessStep1 = 5;
-  var brightnessStep2 = 15;
+  var saturationStep = 0.16;
+  var saturationStep2 = 0.05;
+  var brightnessStep1 = 0.05;
+  var brightnessStep2 = 0.15;
   var lightColorCount = 5;
   var darkColorCount = 4;
 
@@ -33,28 +33,34 @@
   var getSaturation = function(hsv, i, isLight) {
     var saturation;
     if (isLight) {
-      saturation = Math.round(hsv.s * 100) - saturationStep * i;
+      saturation = hsv.s - saturationStep * i;
     } else if (i === darkColorCount) {
-      saturation = Math.round(hsv.s * 100) + saturationStep;
+      saturation = hsv.s + saturationStep;
     } else {
-      saturation = Math.round(hsv.s * 100) + saturationStep2 * i;
+      saturation = hsv.s + saturationStep2 * i;
     }
-    if (saturation > 100) {
-      saturation = 100;
+    if (saturation > 1) {
+      saturation = 1;
     }
-    if (isLight && i === lightColorCount && saturation > 10) {
-      saturation = 10;
+    if (isLight && i === lightColorCount && saturation > 0.1) {
+      saturation = 0.1;
     }
-    if (saturation < 6) {
-      saturation = 6;
+    if (saturation < 0.06) {
+      saturation = 0.06;
     }
-    return Math.round(saturation);
+    return Number(saturation.toFixed(2));
   };
   var getValue = function(hsv, i, isLight) {
+    var value;
     if (isLight) {
-      return Math.round(hsv.v * 100) + brightnessStep1 * i;
+      value = hsv.v + brightnessStep1 * i;
+    }else{
+      value = hsv.v - brightnessStep2 * i
     }
-    return Math.round(hsv.v * 100) - brightnessStep2 * i;
+    if (value > 1) {
+      value = 1;
+    }
+    return Number(value.toFixed(2))
   };
 
   this.colorPalette = function(color, index) {


### PR DESCRIPTION

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Perfermance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

there is a colorPalette error when the saturation/value === 1, caused by tinycolor.js convert them to percentage value.

![image](https://user-images.githubusercontent.com/11362195/84891786-0497d680-b0cf-11ea-9e0a-331eb000938c.png)


### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |avoid colorPalette error when the saturation/value === 1 |
| 🇨🇳 Chinese |修复当saturation/value === 1时的调色盘错误|

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
