### PR TITLE
fix: Upload don't support Popover

### DIFF
--- a/components/upload/__tests__/upload.test.js
+++ b/components/upload/__tests__/upload.test.js
@@ -528,4 +528,22 @@ describe('Upload', () => {
     const wrapper = mount(<Upload listType="picture-card" fileList={[file]} />);
     expect(wrapper.find('img').length).toBe(0);
   });
+
+  // https://github.com/ant-design/ant-design/issues/25077
+  it('should support events', () => {
+    const onClick = jest.fn();
+    const onMouseEnter = jest.fn();
+    const onMouseLeave = jest.fn();
+    const wrapper = mount(
+      <Upload onClick={onClick} onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
+        <button type="button">upload</button>
+      </Upload>,
+    );
+    wrapper.find('.ant-upload').at(1).simulate('click');
+    expect(onClick).toHaveBeenCalled();
+    wrapper.find('.ant-upload').at(1).simulate('mouseEnter');
+    expect(onMouseEnter).toHaveBeenCalled();
+    wrapper.find('.ant-upload').at(1).simulate('mouseLeave');
+    expect(onMouseLeave).toHaveBeenCalled();
+  });
 });

--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "rc-tree": "~3.3.0",
     "rc-tree-select": "~4.0.0",
     "rc-trigger": "~4.3.0",
-    "rc-upload": "~3.1.0",
+    "rc-upload": "~3.2.0",
     "rc-util": "^5.0.1",
     "scroll-into-view-if-needed": "^2.2.25",
     "warning": "^4.0.3"


### PR DESCRIPTION

<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Perfermance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->
close #25077

### 💡 Background and solution

fixed in https://github.com/react-component/upload/commit/472a3d68fbd1bafb6d9e4151d6a14744f63e87c4

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Upload don't support Popover. |
| 🇨🇳 Chinese | 修复 Upload 不支持包裹 Popover 的问题。  |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
