### PR TITLE
feat: support triggerSubMenuAction for <Menu />

### DIFF
--- a/components/menu/__tests__/index.test.js
+++ b/components/menu/__tests__/index.test.js
@@ -332,7 +332,7 @@ describe('Menu', () => {
       );
     });
 
-    it('vertical', () => {
+    it('vertical with hover(default)', () => {
       const wrapper = mount(
         <Menu mode="vertical">
           <SubMenu key="1" title="submenu1">
@@ -354,7 +354,29 @@ describe('Menu', () => {
       );
     });
 
-    it('horizontal', () => {
+    it('vertical with click', () => {
+      const wrapper = mount(
+        <Menu mode="vertical" triggerSubMenuAction="click">
+          <SubMenu key="1" title="submenu1">
+            <Menu.Item key="submenu1">Option 1</Menu.Item>
+            <Menu.Item key="submenu2">Option 2</Menu.Item>
+          </SubMenu>
+          <Menu.Item key="2">menu2</Menu.Item>
+        </Menu>,
+      );
+      expect(wrapper.find('.ant-menu-sub').length).toBe(0);
+      toggleMenu(wrapper, 0, 'click');
+      expect(wrapper.find('.ant-menu-sub').hostNodes().length).toBe(1);
+      expect(wrapper.find('.ant-menu-sub').hostNodes().at(0).hasClass('ant-menu-hidden')).not.toBe(
+        true,
+      );
+      toggleMenu(wrapper, 0, 'click');
+      expect(wrapper.find('.ant-menu-sub').hostNodes().at(0).hasClass('ant-menu-hidden')).toBe(
+        true,
+      );
+    });
+
+    it('horizontal with hover(default)', () => {
       jest.useFakeTimers();
       const wrapper = mount(
         <Menu mode="horizontal">
@@ -372,6 +394,29 @@ describe('Menu', () => {
         true,
       );
       toggleMenu(wrapper, 0, 'mouseleave');
+      expect(wrapper.find('.ant-menu-sub').hostNodes().at(0).hasClass('ant-menu-hidden')).toBe(
+        true,
+      );
+    });
+
+    it('horizontal with click', () => {
+      jest.useFakeTimers();
+      const wrapper = mount(
+        <Menu mode="horizontal" triggerSubMenuAction="click">
+          <SubMenu key="1" title="submenu1">
+            <Menu.Item key="submenu1">Option 1</Menu.Item>
+            <Menu.Item key="submenu2">Option 2</Menu.Item>
+          </SubMenu>
+          <Menu.Item key="2">menu2</Menu.Item>
+        </Menu>,
+      );
+      expect(wrapper.find('.ant-menu-sub').length).toBe(0);
+      toggleMenu(wrapper, 0, 'click');
+      expect(wrapper.find('.ant-menu-sub').hostNodes().length).toBe(1);
+      expect(wrapper.find('.ant-menu-sub').hostNodes().at(0).hasClass('ant-menu-hidden')).not.toBe(
+        true,
+      );
+      toggleMenu(wrapper, 0, 'click');
       expect(wrapper.find('.ant-menu-sub').hostNodes().at(0).hasClass('ant-menu-hidden')).toBe(
         true,
       );

--- a/components/menu/index.en-US.md
+++ b/components/menu/index.en-US.md
@@ -45,6 +45,7 @@ More layouts with navigation: [Layout](/components/layout).
 | theme | Color theme of the menu | `light` \| `dark` | `light` |  |
 | onClick | Called when a menu item is clicked | function({ item, key, keyPath, domEvent }) | - |  |
 | onDeselect | Called when a menu item is deselected (multiple mode only) | function({ item, key, keyPath, selectedKeys, domEvent }) | - |  |
+| triggerSubMenuAction | Which action can trigger submenu open/close | `hover` \| `click` | `hover` |  |
 | onOpenChange | Called when sub-menus are opened or closed | function(openKeys: string\[]) | noop |  |
 | onSelect | Called when a menu item is selected | function({ item, key, keyPath, selectedKeys, domEvent }) | none |  |
 | overflowedIndicator | Customized icon when menu is collapsed | ReactNode | - |  |

--- a/components/menu/index.tsx
+++ b/components/menu/index.tsx
@@ -42,6 +42,7 @@ export interface MenuProps {
   onOpenChange?: (openKeys: string[]) => void;
   onSelect?: (param: SelectParam) => void;
   onDeselect?: (param: SelectParam) => void;
+  triggerSubMenuAction?: 'hover' | 'click';
   onClick?: (param: ClickParam) => void;
   style?: React.CSSProperties;
   openAnimation?: string;

--- a/components/menu/index.zh-CN.md
+++ b/components/menu/index.zh-CN.md
@@ -46,6 +46,7 @@ cover: https://gw.alipayobjects.com/zos/alicdn/3XZcjGpvK/Menu.svg
 | theme | 主题颜色 | `light` \| `dark` | `light` |  |
 | onClick | 点击 MenuItem 调用此函数 | function({ item, key, keyPath, domEvent }) | - |  |
 | onDeselect | 取消选中时调用，仅在 multiple 生效 | function({ item, key, keyPath, selectedKeys, domEvent }) | - |  |
+| triggerSubMenuAction | SubMenu 展开/关闭的触发行为 | `hover` \| `click` | `hover` |  |
 | onOpenChange | SubMenu 展开/关闭的回调 | function(openKeys: string\[]) | noop |  |
 | onSelect | 被选中时调用 | function({ item, key, keyPath, selectedKeys, domEvent }) | -   |  |
 | overflowedIndicator | 自定义 Menu 折叠时的图标 | ReactNode | - |  |


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Perfermance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

refs: https://github.com/ant-design/ant-design/issues/24984

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->
The Menu in vertical/horizontal mode used to only support open/close SubMenu by 'hover'.
As re-menu has already supported triggerSubMenuAction with hover/click, just add it in Menu and provide test cases.
[![Image from Gyazo](https://i.gyazo.com/afe62cdfa1391bfca8697d4873a46183.gif)](https://gyazo.com/afe62cdfa1391bfca8697d4873a46183)

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Menu support `triggerSubMenuAction` (hover or click). |
| 🇨🇳 Chinese | Menu 增加 `triggerSubMenuAction` 属性以支持配置菜单弹出的交互方式。 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/menu/index.en-US.md](https://github.com/hydRAnger/ant-design/blob/feat/trigger_submenu_action/components/menu/index.en-US.md)
[View rendered components/menu/index.zh-CN.md](https://github.com/hydRAnger/ant-design/blob/feat/trigger_submenu_action/components/menu/index.zh-CN.md)