### PR TITLE
feat: support for upload with aggregated progress

### DIFF
--- a/components/upload/Upload.tsx
+++ b/components/upload/Upload.tsx
@@ -120,7 +120,7 @@ class Upload extends React.Component<UploadProps, UploadState> {
     });
   };
 
-  onProgress = (e: { percent: number }, file: UploadFile) => {
+  onProgress = (e: { percent: number; loaded: number; total: number }, file: UploadFile) => {
     const { fileList } = this.state;
     const targetItem = getFileItem(file, fileList);
     // removed
@@ -128,6 +128,8 @@ class Upload extends React.Component<UploadProps, UploadState> {
       return;
     }
     targetItem.percent = e.percent;
+    targetItem.payloadLoaded = e.loaded;
+    targetItem.payloadSize = e.total;
     this.onChange({
       event: e,
       file: { ...targetItem },

--- a/components/upload/interface.tsx
+++ b/components/upload/interface.tsx
@@ -14,7 +14,7 @@ export interface RcFile extends File {
 }
 
 export interface RcCustomRequestOptions {
-  onProgress: (event: { percent: number }, file: File) => void;
+  onProgress: (event: { percent: number; loaded: number; total: number }, file: File) => void;
   onError: (error: Error) => void;
   onSuccess: (response: object, file: File) => void;
   data: object;
@@ -43,6 +43,8 @@ export interface UploadFile<T = any> {
   type: string;
   xhr?: T;
   preview?: string;
+  payloadLoaded?: number;
+  payloadSize?: number;
 }
 
 export interface UploadChangeParam<T extends object = UploadFile> {


### PR DESCRIPTION
### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

I could not find any.

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->
The `<Upload>` component offers an easy way to control the upload progress via the `percentage` property in the `UploadFile`. This covers the use case when the user wants to show the individual progress for each file but it does not support for show the aggregated progress for multiple file uploads. We can solve the problem in user land with the following approach:
```javascript
const onChange = ({ file, fileList, event }) => {
    /*
     Hack to include the data we need to calculate the progress. Unfortunately
     Ant only give us the percentage of each item and not what was currently loaded.
     */
    if (event) {
      const current = fileList.filter(item => item.uid === file.uid)[0];
      current.loaded = event.loaded;
      current.size = event.total;
      // This example is not complete, it is missing to handle the states 'error' and 'removed'
    }
   // Do calculation for total/loaded size
};
```
With the code above we persist the progress between `onChange` calls. An alternative would be to have full control of the file list.

This can be supported by ant with minimal change by including these two infos in the `UploadFile`.
Important: It includes the `payloadSize` because we can have discrepancies between `file.size` and `event.total`.

### 📝 Changelog

Changes: Add two new properties to `UploadFile`, `payloadLoaded` and `payloadSize`.
Risks: Conflicts if users are mutating the `UploadFile` in user land.

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
