### PR TITLE
fix: Sketch.Button default width

### DIFF
--- a/components/skeleton/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/skeleton/__tests__/__snapshots__/demo.test.js.snap
@@ -102,616 +102,377 @@ exports[`renders ./components/skeleton/demo/complex.md correctly 1`] = `
 `;
 
 exports[`renders ./components/skeleton/demo/element.md correctly 1`] = `
-<div>
-  <div>
-    <form
-      class="ant-form ant-form-inline"
-      style="margin-bottom:16px"
+Array [
+  <div
+    class="ant-space ant-space-horizontal ant-space-align-center"
+  >
+    <div
+      class="ant-space-item"
+      style="margin-right:8px"
     >
       <div
-        class="ant-row ant-form-item"
+        class="ant-skeleton ant-skeleton-element"
+      >
+        <span
+          class="ant-skeleton-button"
+        />
+      </div>
+    </div>
+    <div
+      class="ant-space-item"
+      style="margin-right:8px"
+    >
+      <div
+        class="ant-skeleton ant-skeleton-element"
+      >
+        <span
+          class="ant-skeleton-button"
+        />
+      </div>
+    </div>
+    <div
+      class="ant-space-item"
+      style="margin-right:8px"
+    >
+      <div
+        class="ant-skeleton ant-skeleton-element"
+      >
+        <span
+          class="ant-skeleton-avatar ant-skeleton-avatar-circle"
+        />
+      </div>
+    </div>
+    <div
+      class="ant-space-item"
+    >
+      <div
+        class="ant-skeleton ant-skeleton-element"
+      >
+        <span
+          class="ant-skeleton-input"
+          style="width:200px"
+        />
+      </div>
+    </div>
+  </div>,
+  <br />,
+  <br />,
+  <div
+    class="ant-skeleton ant-skeleton-element"
+  >
+    <div
+      class="ant-skeleton-image"
+    >
+      <svg
+        class="ant-skeleton-image-svg"
+        viewBox="0 0 1098 1024"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          class="ant-skeleton-image-path"
+          d="M365.714286 329.142857q0 45.714286-32.036571 77.677714t-77.677714 32.036571-77.677714-32.036571-32.036571-77.677714 32.036571-77.677714 77.677714-32.036571 77.677714 32.036571 32.036571 77.677714zM950.857143 548.571429l0 256-804.571429 0 0-109.714286 182.857143-182.857143 91.428571 91.428571 292.571429-292.571429zM1005.714286 146.285714l-914.285714 0q-7.460571 0-12.873143 5.412571t-5.412571 12.873143l0 694.857143q0 7.460571 5.412571 12.873143t12.873143 5.412571l914.285714 0q7.460571 0 12.873143-5.412571t5.412571-12.873143l0-694.857143q0-7.460571-5.412571-12.873143t-12.873143-5.412571zM1097.142857 164.571429l0 694.857143q0 37.741714-26.843429 64.585143t-64.585143 26.843429l-914.285714 0q-37.741714 0-64.585143-26.843429t-26.843429-64.585143l0-694.857143q0-37.741714 26.843429-64.585143t64.585143-26.843429l914.285714 0q37.741714 0 64.585143 26.843429t26.843429 64.585143z"
+        />
+      </svg>
+    </div>
+  </div>,
+  <div
+    class="ant-divider ant-divider-horizontal"
+    role="separator"
+  />,
+  <form
+    class="ant-form ant-form-inline"
+    style="margin:16px 0"
+  >
+    <div
+      class="ant-row ant-form-item"
+    >
+      <div
+        class="ant-col ant-form-item-label"
+      >
+        <label
+          class=""
+          title="Active"
+        >
+          Active
+        </label>
+      </div>
+      <div
+        class="ant-col ant-form-item-control"
       >
         <div
-          class="ant-col ant-form-item-label"
-        >
-          <label
-            class=""
-            title="ButtonActive"
-          >
-            ButtonActive
-          </label>
-        </div>
-        <div
-          class="ant-col ant-form-item-control"
+          class="ant-form-item-control-input"
         >
           <div
-            class="ant-form-item-control-input"
+            class="ant-form-item-control-input-content"
+          >
+            <button
+              aria-checked="false"
+              class="ant-switch"
+              role="switch"
+              type="button"
+            >
+              <div
+                class="ant-switch-handle"
+              />
+              <span
+                class="ant-switch-inner"
+              />
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="ant-row ant-form-item"
+    >
+      <div
+        class="ant-col ant-form-item-label"
+      >
+        <label
+          class=""
+          title="Size"
+        >
+          Size
+        </label>
+      </div>
+      <div
+        class="ant-col ant-form-item-control"
+      >
+        <div
+          class="ant-form-item-control-input"
+        >
+          <div
+            class="ant-form-item-control-input-content"
           >
             <div
-              class="ant-form-item-control-input-content"
+              class="ant-radio-group ant-radio-group-outline"
             >
-              <button
-                aria-checked="false"
-                class="ant-switch"
-                role="switch"
-                type="button"
+              <label
+                class="ant-radio-button-wrapper ant-radio-button-wrapper-checked"
               >
-                <div
-                  class="ant-switch-handle"
-                />
                 <span
-                  class="ant-switch-inner"
-                />
-              </button>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div
-        class="ant-row ant-form-item"
-      >
-        <div
-          class="ant-col ant-form-item-label"
-        >
-          <label
-            class=""
-            title="ButtonSize"
-          >
-            ButtonSize
-          </label>
-        </div>
-        <div
-          class="ant-col ant-form-item-control"
-        >
-          <div
-            class="ant-form-item-control-input"
-          >
-            <div
-              class="ant-form-item-control-input-content"
-            >
-              <div
-                class="ant-radio-group ant-radio-group-outline"
+                  class="ant-radio-button ant-radio-button-checked"
+                >
+                  <input
+                    checked=""
+                    class="ant-radio-button-input"
+                    type="radio"
+                    value="default"
+                  />
+                  <span
+                    class="ant-radio-button-inner"
+                  />
+                </span>
+                <span>
+                  Default
+                </span>
+              </label>
+              <label
+                class="ant-radio-button-wrapper"
               >
-                <label
-                  class="ant-radio-button-wrapper ant-radio-button-wrapper-checked"
-                >
-                  <span
-                    class="ant-radio-button ant-radio-button-checked"
-                  >
-                    <input
-                      checked=""
-                      class="ant-radio-button-input"
-                      type="radio"
-                      value="default"
-                    />
-                    <span
-                      class="ant-radio-button-inner"
-                    />
-                  </span>
-                  <span>
-                    Default
-                  </span>
-                </label>
-                <label
-                  class="ant-radio-button-wrapper"
-                >
-                  <span
-                    class="ant-radio-button"
-                  >
-                    <input
-                      class="ant-radio-button-input"
-                      type="radio"
-                      value="large"
-                    />
-                    <span
-                      class="ant-radio-button-inner"
-                    />
-                  </span>
-                  <span>
-                    Large
-                  </span>
-                </label>
-                <label
-                  class="ant-radio-button-wrapper"
-                >
-                  <span
-                    class="ant-radio-button"
-                  >
-                    <input
-                      class="ant-radio-button-input"
-                      type="radio"
-                      value="small"
-                    />
-                    <span
-                      class="ant-radio-button-inner"
-                    />
-                  </span>
-                  <span>
-                    Small
-                  </span>
-                </label>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div
-        class="ant-row ant-form-item"
-      >
-        <div
-          class="ant-col ant-form-item-label"
-        >
-          <label
-            class=""
-            title="ButtonShape"
-          >
-            ButtonShape
-          </label>
-        </div>
-        <div
-          class="ant-col ant-form-item-control"
-        >
-          <div
-            class="ant-form-item-control-input"
-          >
-            <div
-              class="ant-form-item-control-input-content"
-            >
-              <div
-                class="ant-radio-group ant-radio-group-outline"
-              >
-                <label
-                  class="ant-radio-button-wrapper ant-radio-button-wrapper-checked"
-                >
-                  <span
-                    class="ant-radio-button ant-radio-button-checked"
-                  >
-                    <input
-                      checked=""
-                      class="ant-radio-button-input"
-                      type="radio"
-                      value="default"
-                    />
-                    <span
-                      class="ant-radio-button-inner"
-                    />
-                  </span>
-                  <span>
-                    Default
-                  </span>
-                </label>
-                <label
-                  class="ant-radio-button-wrapper"
-                >
-                  <span
-                    class="ant-radio-button"
-                  >
-                    <input
-                      class="ant-radio-button-input"
-                      type="radio"
-                      value="round"
-                    />
-                    <span
-                      class="ant-radio-button-inner"
-                    />
-                  </span>
-                  <span>
-                    Round
-                  </span>
-                </label>
-                <label
-                  class="ant-radio-button-wrapper"
-                >
-                  <span
-                    class="ant-radio-button"
-                  >
-                    <input
-                      class="ant-radio-button-input"
-                      type="radio"
-                      value="circle"
-                    />
-                    <span
-                      class="ant-radio-button-inner"
-                    />
-                  </span>
-                  <span>
-                    Circle
-                  </span>
-                </label>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </form>
-    <div
-      class="ant-skeleton ant-skeleton-element"
-    >
-      <span
-        class="ant-skeleton-button"
-      />
-    </div>
-  </div>
-  <br />
-  <div>
-    <form
-      class="ant-form ant-form-inline"
-      style="margin-bottom:16px"
-    >
-      <div
-        class="ant-row ant-form-item"
-      >
-        <div
-          class="ant-col ant-form-item-label"
-        >
-          <label
-            class=""
-            title="AvatarActive"
-          >
-            AvatarActive
-          </label>
-        </div>
-        <div
-          class="ant-col ant-form-item-control"
-        >
-          <div
-            class="ant-form-item-control-input"
-          >
-            <div
-              class="ant-form-item-control-input-content"
-            >
-              <button
-                aria-checked="false"
-                class="ant-switch"
-                role="switch"
-                type="button"
-              >
-                <div
-                  class="ant-switch-handle"
-                />
                 <span
-                  class="ant-switch-inner"
-                />
-              </button>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div
-        class="ant-row ant-form-item"
-      >
-        <div
-          class="ant-col ant-form-item-label"
-        >
-          <label
-            class=""
-            title="AvatarSize"
-          >
-            AvatarSize
-          </label>
-        </div>
-        <div
-          class="ant-col ant-form-item-control"
-        >
-          <div
-            class="ant-form-item-control-input"
-          >
-            <div
-              class="ant-form-item-control-input-content"
-            >
-              <div
-                class="ant-radio-group ant-radio-group-outline"
+                  class="ant-radio-button"
+                >
+                  <input
+                    class="ant-radio-button-input"
+                    type="radio"
+                    value="large"
+                  />
+                  <span
+                    class="ant-radio-button-inner"
+                  />
+                </span>
+                <span>
+                  Large
+                </span>
+              </label>
+              <label
+                class="ant-radio-button-wrapper"
               >
-                <label
-                  class="ant-radio-button-wrapper ant-radio-button-wrapper-checked"
-                >
-                  <span
-                    class="ant-radio-button ant-radio-button-checked"
-                  >
-                    <input
-                      checked=""
-                      class="ant-radio-button-input"
-                      type="radio"
-                      value="default"
-                    />
-                    <span
-                      class="ant-radio-button-inner"
-                    />
-                  </span>
-                  <span>
-                    Default
-                  </span>
-                </label>
-                <label
-                  class="ant-radio-button-wrapper"
-                >
-                  <span
-                    class="ant-radio-button"
-                  >
-                    <input
-                      class="ant-radio-button-input"
-                      type="radio"
-                      value="large"
-                    />
-                    <span
-                      class="ant-radio-button-inner"
-                    />
-                  </span>
-                  <span>
-                    Large
-                  </span>
-                </label>
-                <label
-                  class="ant-radio-button-wrapper"
-                >
-                  <span
-                    class="ant-radio-button"
-                  >
-                    <input
-                      class="ant-radio-button-input"
-                      type="radio"
-                      value="small"
-                    />
-                    <span
-                      class="ant-radio-button-inner"
-                    />
-                  </span>
-                  <span>
-                    Small
-                  </span>
-                </label>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div
-        class="ant-row ant-form-item"
-      >
-        <div
-          class="ant-col ant-form-item-label"
-        >
-          <label
-            class=""
-            title="AvatarShape"
-          >
-            AvatarShape
-          </label>
-        </div>
-        <div
-          class="ant-col ant-form-item-control"
-        >
-          <div
-            class="ant-form-item-control-input"
-          >
-            <div
-              class="ant-form-item-control-input-content"
-            >
-              <div
-                class="ant-radio-group ant-radio-group-outline"
-              >
-                <label
-                  class="ant-radio-button-wrapper"
-                >
-                  <span
-                    class="ant-radio-button"
-                  >
-                    <input
-                      class="ant-radio-button-input"
-                      type="radio"
-                      value="square"
-                    />
-                    <span
-                      class="ant-radio-button-inner"
-                    />
-                  </span>
-                  <span>
-                    Square
-                  </span>
-                </label>
-                <label
-                  class="ant-radio-button-wrapper ant-radio-button-wrapper-checked"
-                >
-                  <span
-                    class="ant-radio-button ant-radio-button-checked"
-                  >
-                    <input
-                      checked=""
-                      class="ant-radio-button-input"
-                      type="radio"
-                      value="circle"
-                    />
-                    <span
-                      class="ant-radio-button-inner"
-                    />
-                  </span>
-                  <span>
-                    Circle
-                  </span>
-                </label>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </form>
-    <div
-      class="ant-skeleton ant-skeleton-element"
-    >
-      <span
-        class="ant-skeleton-avatar ant-skeleton-avatar-circle"
-      />
-    </div>
-  </div>
-  <br />
-  <div>
-    <form
-      class="ant-form ant-form-inline"
-      style="margin-bottom:16px"
-    >
-      <div
-        class="ant-row ant-form-item"
-      >
-        <div
-          class="ant-col ant-form-item-label"
-        >
-          <label
-            class=""
-            title="InputActive"
-          >
-            InputActive
-          </label>
-        </div>
-        <div
-          class="ant-col ant-form-item-control"
-        >
-          <div
-            class="ant-form-item-control-input"
-          >
-            <div
-              class="ant-form-item-control-input-content"
-            >
-              <button
-                aria-checked="false"
-                class="ant-switch"
-                role="switch"
-                type="button"
-              >
-                <div
-                  class="ant-switch-handle"
-                />
                 <span
-                  class="ant-switch-inner"
-                />
-              </button>
+                  class="ant-radio-button"
+                >
+                  <input
+                    class="ant-radio-button-input"
+                    type="radio"
+                    value="small"
+                  />
+                  <span
+                    class="ant-radio-button-inner"
+                  />
+                </span>
+                <span>
+                  Small
+                </span>
+              </label>
             </div>
           </div>
         </div>
       </div>
+    </div>
+    <div
+      class="ant-row ant-form-item"
+    >
       <div
-        class="ant-row ant-form-item"
+        class="ant-col ant-form-item-label"
+      >
+        <label
+          class=""
+          title="Button Shape"
+        >
+          Button Shape
+        </label>
+      </div>
+      <div
+        class="ant-col ant-form-item-control"
       >
         <div
-          class="ant-col ant-form-item-label"
-        >
-          <label
-            class=""
-            title="InputSize"
-          >
-            InputSize
-          </label>
-        </div>
-        <div
-          class="ant-col ant-form-item-control"
+          class="ant-form-item-control-input"
         >
           <div
-            class="ant-form-item-control-input"
+            class="ant-form-item-control-input-content"
           >
             <div
-              class="ant-form-item-control-input-content"
+              class="ant-radio-group ant-radio-group-outline"
             >
-              <div
-                class="ant-radio-group ant-radio-group-outline"
+              <label
+                class="ant-radio-button-wrapper ant-radio-button-wrapper-checked"
               >
-                <label
-                  class="ant-radio-button-wrapper ant-radio-button-wrapper-checked"
+                <span
+                  class="ant-radio-button ant-radio-button-checked"
                 >
+                  <input
+                    checked=""
+                    class="ant-radio-button-input"
+                    type="radio"
+                    value="default"
+                  />
                   <span
-                    class="ant-radio-button ant-radio-button-checked"
-                  >
-                    <input
-                      checked=""
-                      class="ant-radio-button-input"
-                      type="radio"
-                      value="default"
-                    />
-                    <span
-                      class="ant-radio-button-inner"
-                    />
-                  </span>
-                  <span>
-                    Default
-                  </span>
-                </label>
-                <label
-                  class="ant-radio-button-wrapper"
+                    class="ant-radio-button-inner"
+                  />
+                </span>
+                <span>
+                  Default
+                </span>
+              </label>
+              <label
+                class="ant-radio-button-wrapper"
+              >
+                <span
+                  class="ant-radio-button"
                 >
+                  <input
+                    class="ant-radio-button-input"
+                    type="radio"
+                    value="round"
+                  />
                   <span
-                    class="ant-radio-button"
-                  >
-                    <input
-                      class="ant-radio-button-input"
-                      type="radio"
-                      value="large"
-                    />
-                    <span
-                      class="ant-radio-button-inner"
-                    />
-                  </span>
-                  <span>
-                    Large
-                  </span>
-                </label>
-                <label
-                  class="ant-radio-button-wrapper"
+                    class="ant-radio-button-inner"
+                  />
+                </span>
+                <span>
+                  Round
+                </span>
+              </label>
+              <label
+                class="ant-radio-button-wrapper"
+              >
+                <span
+                  class="ant-radio-button"
                 >
+                  <input
+                    class="ant-radio-button-input"
+                    type="radio"
+                    value="circle"
+                  />
                   <span
-                    class="ant-radio-button"
-                  >
-                    <input
-                      class="ant-radio-button-input"
-                      type="radio"
-                      value="small"
-                    />
-                    <span
-                      class="ant-radio-button-inner"
-                    />
-                  </span>
-                  <span>
-                    Small
-                  </span>
-                </label>
-              </div>
+                    class="ant-radio-button-inner"
+                  />
+                </span>
+                <span>
+                  Circle
+                </span>
+              </label>
             </div>
           </div>
         </div>
       </div>
-    </form>
-    <div
-      class="ant-skeleton ant-skeleton-element"
-    >
-      <span
-        class="ant-skeleton-input"
-        style="width:300px"
-      />
     </div>
-  </div>
-  <br />
-  <div>
     <div
-      class="ant-skeleton ant-skeleton-element"
+      class="ant-row ant-form-item"
     >
       <div
-        class="ant-skeleton-image"
+        class="ant-col ant-form-item-label"
       >
-        <svg
-          class="ant-skeleton-image-svg"
-          viewBox="0 0 1098 1024"
-          xmlns="http://www.w3.org/2000/svg"
+        <label
+          class=""
+          title="Avatar Shape"
         >
-          <path
-            class="ant-skeleton-image-path"
-            d="M365.714286 329.142857q0 45.714286-32.036571 77.677714t-77.677714 32.036571-77.677714-32.036571-32.036571-77.677714 32.036571-77.677714 77.677714-32.036571 77.677714 32.036571 32.036571 77.677714zM950.857143 548.571429l0 256-804.571429 0 0-109.714286 182.857143-182.857143 91.428571 91.428571 292.571429-292.571429zM1005.714286 146.285714l-914.285714 0q-7.460571 0-12.873143 5.412571t-5.412571 12.873143l0 694.857143q0 7.460571 5.412571 12.873143t12.873143 5.412571l914.285714 0q7.460571 0 12.873143-5.412571t5.412571-12.873143l0-694.857143q0-7.460571-5.412571-12.873143t-12.873143-5.412571zM1097.142857 164.571429l0 694.857143q0 37.741714-26.843429 64.585143t-64.585143 26.843429l-914.285714 0q-37.741714 0-64.585143-26.843429t-26.843429-64.585143l0-694.857143q0-37.741714 26.843429-64.585143t64.585143-26.843429l914.285714 0q37.741714 0 64.585143 26.843429t26.843429 64.585143z"
-          />
-        </svg>
+          Avatar Shape
+        </label>
+      </div>
+      <div
+        class="ant-col ant-form-item-control"
+      >
+        <div
+          class="ant-form-item-control-input"
+        >
+          <div
+            class="ant-form-item-control-input-content"
+          >
+            <div
+              class="ant-radio-group ant-radio-group-outline"
+            >
+              <label
+                class="ant-radio-button-wrapper"
+              >
+                <span
+                  class="ant-radio-button"
+                >
+                  <input
+                    class="ant-radio-button-input"
+                    type="radio"
+                    value="square"
+                  />
+                  <span
+                    class="ant-radio-button-inner"
+                  />
+                </span>
+                <span>
+                  Square
+                </span>
+              </label>
+              <label
+                class="ant-radio-button-wrapper ant-radio-button-wrapper-checked"
+              >
+                <span
+                  class="ant-radio-button ant-radio-button-checked"
+                >
+                  <input
+                    checked=""
+                    class="ant-radio-button-input"
+                    type="radio"
+                    value="circle"
+                  />
+                  <span
+                    class="ant-radio-button-inner"
+                  />
+                </span>
+                <span>
+                  Circle
+                </span>
+              </label>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
-  </div>
-</div>
+  </form>,
+]
 `;
 
 exports[`renders ./components/skeleton/demo/list.md correctly 1`] = `
-<div>
+Array [
   <button
     aria-checked="false"
     class="ant-switch"
@@ -724,7 +485,7 @@ exports[`renders ./components/skeleton/demo/list.md correctly 1`] = `
     <span
       class="ant-switch-inner"
     />
-  </button>
+  </button>,
   <div
     class="ant-list ant-list-vertical ant-list-lg ant-list-split"
   >
@@ -827,6 +588,6 @@ exports[`renders ./components/skeleton/demo/list.md correctly 1`] = `
         </ul>
       </div>
     </div>
-  </div>
-</div>
+  </div>,
+]
 `;

--- a/components/skeleton/demo/element.md
+++ b/components/skeleton/demo/element.md
@@ -1,8 +1,8 @@
 ---
-order: 2
+order: 2.1
 title:
-  zh-CN: 骨架按钮、头像、输入框和图像。
-  en-US: Skeleton button, avatar, input and Image.
+  zh-CN: 按钮/头像/输入框/图像
+  en-US: Button/Avatar/Input/Image
 ---
 
 ## zh-CN
@@ -11,29 +11,25 @@ title:
 
 ## en-US
 
-Skeleton button, avatar, input and Image.
+Skeleton Button, Avatar, Input and Image.
 
 ```jsx
-import { Skeleton, Switch, Form, Radio } from 'antd';
+import { Skeleton, Space, Divider, Switch, Form, Radio } from 'antd';
 
 class Demo extends React.Component {
   state = {
-    buttonActive: false,
-    avatarActive: false,
-    inputActive: false,
-    buttonSize: 'default',
-    avatarSize: 'default',
-    inputSize: 'default',
+    active: false,
+    size: 'default',
     buttonShape: 'default',
     avatarShape: 'circle',
   };
 
-  handleActiveChange = prop => checked => {
-    this.setState({ [prop]: checked });
+  handleActiveChange = checked => {
+    this.setState({ active: checked });
   };
 
-  handleSizeChange = prop => e => {
-    this.setState({ [prop]: e.target.value });
+  handleSizeChange = e => {
+    this.setState({ size: e.target.value });
   };
 
   handleShapeChange = prop => e => {
@@ -41,83 +37,45 @@ class Demo extends React.Component {
   };
 
   render() {
-    const {
-      buttonActive,
-      avatarActive,
-      inputActive,
-      buttonSize,
-      avatarSize,
-      inputSize,
-      buttonShape,
-      avatarShape,
-    } = this.state;
+    const { active, size, buttonShape, avatarShape } = this.state;
     return (
-      <div>
-        <div>
-          <Form layout="inline" style={{ marginBottom: 16 }}>
-            <Form.Item label="ButtonActive">
-              <Switch checked={buttonActive} onChange={this.handleActiveChange('buttonActive')} />
-            </Form.Item>
-            <Form.Item label="ButtonSize">
-              <Radio.Group value={buttonSize} onChange={this.handleSizeChange('buttonSize')}>
-                <Radio.Button value="default">Default</Radio.Button>
-                <Radio.Button value="large">Large</Radio.Button>
-                <Radio.Button value="small">Small</Radio.Button>
-              </Radio.Group>
-            </Form.Item>
-            <Form.Item label="ButtonShape">
-              <Radio.Group value={buttonShape} onChange={this.handleShapeChange('buttonShape')}>
-                <Radio.Button value="default">Default</Radio.Button>
-                <Radio.Button value="round">Round</Radio.Button>
-                <Radio.Button value="circle">Circle</Radio.Button>
-              </Radio.Group>
-            </Form.Item>
-          </Form>
-          <Skeleton.Button active={buttonActive} size={buttonSize} shape={buttonShape} />
-        </div>
+      <>
+        <Space>
+          <Skeleton.Button active={active} size={size} shape={buttonShape} />
+          <Skeleton.Button active={active} size={size} shape={buttonShape} />
+          <Skeleton.Avatar active={active} size={size} shape={avatarShape} />
+          <Skeleton.Input style={{ width: 200 }} active={active} size={size} />
+        </Space>
         <br />
-        <div>
-          <Form layout="inline" style={{ marginBottom: 16 }}>
-            <Form.Item label="AvatarActive">
-              <Switch checked={avatarActive} onChange={this.handleActiveChange('avatarActive')} />
-            </Form.Item>
-            <Form.Item label="AvatarSize">
-              <Radio.Group value={avatarSize} onChange={this.handleSizeChange('avatarSize')}>
-                <Radio.Button value="default">Default</Radio.Button>
-                <Radio.Button value="large">Large</Radio.Button>
-                <Radio.Button value="small">Small</Radio.Button>
-              </Radio.Group>
-            </Form.Item>
-            <Form.Item label="AvatarShape">
-              <Radio.Group value={avatarShape} onChange={this.handleShapeChange('avatarShape')}>
-                <Radio.Button value="square">Square</Radio.Button>
-                <Radio.Button value="circle">Circle</Radio.Button>
-              </Radio.Group>
-            </Form.Item>
-          </Form>
-          <Skeleton.Avatar active={avatarActive} size={avatarSize} shape={avatarShape} />
-        </div>
         <br />
-        <div>
-          <Form layout="inline" style={{ marginBottom: 16 }}>
-            <Form.Item label="InputActive">
-              <Switch checked={inputActive} onChange={this.handleActiveChange('inputActive')} />
-            </Form.Item>
-            <Form.Item label="InputSize">
-              <Radio.Group value={inputSize} onChange={this.handleSizeChange('inputSize')}>
-                <Radio.Button value="default">Default</Radio.Button>
-                <Radio.Button value="large">Large</Radio.Button>
-                <Radio.Button value="small">Small</Radio.Button>
-              </Radio.Group>
-            </Form.Item>
-          </Form>
-          <Skeleton.Input style={{ width: '300px' }} active={inputActive} size={inputSize} />
-        </div>
-        <br />
-        <div>
-          <Skeleton.Image />
-        </div>
-      </div>
+        <Skeleton.Image />
+        <Divider />
+        <Form layout="inline" style={{ margin: '16px 0' }}>
+          <Form.Item label="Active">
+            <Switch checked={active} onChange={this.handleActiveChange} />
+          </Form.Item>
+          <Form.Item label="Size">
+            <Radio.Group value={size} onChange={this.handleSizeChange}>
+              <Radio.Button value="default">Default</Radio.Button>
+              <Radio.Button value="large">Large</Radio.Button>
+              <Radio.Button value="small">Small</Radio.Button>
+            </Radio.Group>
+          </Form.Item>
+          <Form.Item label="Button Shape">
+            <Radio.Group value={buttonShape} onChange={this.handleShapeChange('buttonShape')}>
+              <Radio.Button value="default">Default</Radio.Button>
+              <Radio.Button value="round">Round</Radio.Button>
+              <Radio.Button value="circle">Circle</Radio.Button>
+            </Radio.Group>
+          </Form.Item>
+          <Form.Item label="Avatar Shape">
+            <Radio.Group value={avatarShape} onChange={this.handleShapeChange('avatarShape')}>
+              <Radio.Button value="square">Square</Radio.Button>
+              <Radio.Button value="circle">Circle</Radio.Button>
+            </Radio.Group>
+          </Form.Item>
+        </Form>
+      </>
     );
   }
 }

--- a/components/skeleton/demo/list.md
+++ b/components/skeleton/demo/list.md
@@ -50,7 +50,7 @@ class App extends React.Component {
     const { loading } = this.state;
 
     return (
-      <div>
+      <>
         <Switch checked={!loading} onChange={this.onChange} />
 
         <List
@@ -88,7 +88,7 @@ class App extends React.Component {
             </List.Item>
           )}
         />
-      </div>
+      </>
     );
   }
 }

--- a/components/skeleton/style/index.less
+++ b/components/skeleton/style/index.less
@@ -109,6 +109,8 @@
   // Skeleton element
   &-element {
     display: inline-block;
+    width: auto;
+
     .@{skeleton-button-prefix-cls} {
       .skeleton-element-button();
     }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Perfermance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

https://codesandbox.io/s/mutable-voice-5ovbg

<img width="654" alt="image" src="https://user-images.githubusercontent.com/507615/86083237-3f850b80-bacc-11ea-96fc-7984d16d3763.png">

should be `inline-block`.

<img width="423" alt="image" src="https://user-images.githubusercontent.com/507615/86082847-570fc480-bacb-11ea-976a-b990c02eb218.png">

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Skeleton Button/Avatar/Input/Image default width to auto. |
| 🇨🇳 Chinese | 修复 Skeleton Button/Avatar/Input/Image 默认宽度为 auto。 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/skeleton/demo/element.md](https://github.com/ant-design/ant-design/blob/skeleton-demo/components/skeleton/demo/element.md)
[View rendered components/skeleton/demo/list.md](https://github.com/ant-design/ant-design/blob/skeleton-demo/components/skeleton/demo/list.md)