### PR TITLE
fix: Tooltip custom color typescript type definition

### DIFF
--- a/components/tooltip/index.tsx
+++ b/components/tooltip/index.tsx
@@ -7,6 +7,7 @@ import getPlacements, { AdjustOverflow, PlacementsConfig } from './placements';
 import { cloneElement, isValidElement } from '../_util/reactNode';
 import { ConfigContext } from '../config-provider';
 import { PresetColorType, PresetColorTypes } from '../_util/colors';
+import { LiteralUnion } from '../_util/type';
 
 export { AdjustOverflow, PlacementsConfig };
 
@@ -39,7 +40,7 @@ export interface TooltipAlignConfig {
 export interface AbstractTooltipProps extends Partial<RcTooltipProps> {
   style?: React.CSSProperties;
   className?: string;
-  color?: PresetColorType;
+  color?: LiteralUnion<PresetColorType, string>;
   placement?: TooltipPlacement;
   builtinPlacements?: BuildInPlacements;
   openClassName?: string;


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式改进
- [x] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
在TypeScript版本中使用Tooltip 自定义color属性（如#099999），代码检查报错

[Issue 链接](https://github.com/ant-design/ant-design/issues/25015)

close #25015

### 💡 需求背景和解决方案

将 Tooltip 中 color 定义由

```typescript
color?: PresetColorType;
```

变为

```typescript
color?: LiteralUnion<PresetColorType, string>;
```

### 📝 更新日志怎么写？

<!--
> 从用户角度描述具体变化，以及可能的 breaking change 和其他风险？
-->

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | fix Tooltip custom color typescript type definition |
| 🇨🇳 中文 | 修复 Tooltip 自定义颜色 Typescript 定义错误 |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供

首次尝试提交 PR :)