### PR TITLE
fix: slider typescript definition gets type warning in onChange

### DIFF
--- a/components/slider/__tests__/type.test.tsx
+++ b/components/slider/__tests__/type.test.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import Slider from '..';
+
+describe('Slider.typescript', () => {
+  it('single value', () => {
+    const value = 0;
+    function onChange(v: number) {
+      return v;
+    }
+    const result = (
+      <Slider defaultValue={value} value={value} onChange={onChange} onAfterChange={onChange} />
+    );
+    expect(result).toBeTruthy();
+  });
+
+  it('range value', () => {
+    const value: [number, number] = [0, 1];
+    function onChange(v: [number, number]) {
+      return v;
+    }
+    const result = (
+      <Slider
+        range
+        defaultValue={value}
+        value={value}
+        onChange={onChange}
+        onAfterChange={onChange}
+      />
+    );
+    expect(result).toBeTruthy();
+  });
+});

--- a/components/slider/index.tsx
+++ b/components/slider/index.tsx
@@ -16,8 +16,6 @@ export interface SliderMarks {
       };
 }
 
-export type SliderValue = number | [number, number];
-
 interface HandleGeneratorInfo {
   value?: number;
   dragging: boolean;
@@ -31,23 +29,18 @@ export type HandleGeneratorFn = (config: {
   info: HandleGeneratorInfo;
 }) => React.ReactNode;
 
-export interface SliderProps {
+export interface SliderBaseProps {
   prefixCls?: string;
   tooltipPrefixCls?: string;
-  range?: boolean;
   reverse?: boolean;
   min?: number;
   max?: number;
   step?: number | null;
   marks?: SliderMarks;
   dots?: boolean;
-  value?: SliderValue;
-  defaultValue?: SliderValue;
   included?: boolean;
   disabled?: boolean;
   vertical?: boolean;
-  onChange?: (value: SliderValue) => void;
-  onAfterChange?: (value: SliderValue) => void;
   tipFormatter?: null | ((value?: number) => React.ReactNode);
   className?: string;
   id?: string;
@@ -57,9 +50,25 @@ export interface SliderProps {
   getTooltipPopupContainer?: (triggerNode: HTMLElement) => HTMLElement;
 }
 
+export interface SliderSingleProps extends SliderBaseProps {
+  range?: false;
+  value?: number;
+  defaultValue?: number;
+  onChange?: (value: number) => void;
+  onAfterChange?: (value: number) => void;
+}
+
+export interface SliderRangeProps extends SliderBaseProps {
+  range: true;
+  value?: [number, number];
+  defaultValue?: [number, number];
+  onChange?: (value: [number, number]) => void;
+  onAfterChange?: (value: [number, number]) => void;
+}
+
 export type Visibles = { [index: number]: boolean };
 
-const Slider = React.forwardRef<unknown, SliderProps>((props, ref) => {
+const Slider = React.forwardRef<unknown, SliderSingleProps | SliderRangeProps>((props, ref) => {
   const { getPrefixCls, direction, getPopupContainer } = React.useContext(ConfigContext);
   const [visibles, setVisibles] = React.useState<Visibles>({});
 


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

新特性请提交至 feature 分支，其余可提交至 master 分支。
在一个维护者审核通过后合并。
请确保填写以下 pull request 的信息，谢谢！~

[[English Template / 英文模板](?expand=1)]
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式改进
- [x] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

Slider 由于类型可能是 number 或者 [number,number] 导致在 TS 中会报错。

[Issue 链接](https://github.com/ant-design/ant-design/issues/25326)

### 💡 需求背景和解决方案

新增了两个类型 `SliderSingleProps` 和 `SliderSingleProps` 继承原来的 `Props`，并用 `range`属性 作为区分帮助 TS 进行类型推断。

如果有别的好的解决方案也请指教一下 😂

### 📝 更新日志怎么写？


| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | Fix Slider `value` TypeScript error.         |
| 🇨🇳 中文 | 修复 Slider `value` 的 TS 定义报错的问题。 |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
