### PR TITLE
fix: shouldn't set input-bg inside a error form item

### DIFF
--- a/components/form/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/form/__tests__/__snapshots__/demo.test.js.snap
@@ -932,6 +932,523 @@ exports[`renders ./components/form/demo/customized-form-controls.md correctly 1`
 </form>
 `;
 
+exports[`renders ./components/form/demo/disabled-input-debug.md correctly 1`] = `
+<form
+  class="ant-form ant-form-horizontal"
+>
+  <div
+    class="ant-row ant-form-item"
+  >
+    <div
+      class="ant-col ant-form-item-label"
+    >
+      <label
+        class=""
+        title="Normal0"
+      >
+        Normal0
+      </label>
+    </div>
+    <div
+      class="ant-col ant-form-item-control"
+    >
+      <div
+        class="ant-form-item-control-input"
+      >
+        <div
+          class="ant-form-item-control-input-content"
+        >
+          <input
+            class="ant-input"
+            placeholder="unavailable choice"
+            type="text"
+            value="Buggy!"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-error"
+  >
+    <div
+      class="ant-col ant-form-item-label"
+    >
+      <label
+        class=""
+        title="Fail0"
+      >
+        Fail0
+      </label>
+    </div>
+    <div
+      class="ant-col ant-form-item-control"
+    >
+      <div
+        class="ant-form-item-control-input"
+      >
+        <div
+          class="ant-form-item-control-input-content"
+        >
+          <input
+            class="ant-input"
+            placeholder="unavailable choice"
+            type="text"
+            value="Buggy!"
+          />
+        </div>
+      </div>
+      <div
+        class="ant-form-item-explain"
+      >
+        <div>
+          Buggy!
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-error"
+  >
+    <div
+      class="ant-col ant-form-item-label"
+    >
+      <label
+        class=""
+        title="FailDisabled0"
+      >
+        FailDisabled0
+      </label>
+    </div>
+    <div
+      class="ant-col ant-form-item-control"
+    >
+      <div
+        class="ant-form-item-control-input"
+      >
+        <div
+          class="ant-form-item-control-input-content"
+        >
+          <input
+            class="ant-input ant-input-disabled"
+            disabled=""
+            placeholder="unavailable choice"
+            type="text"
+            value="Buggy!"
+          />
+        </div>
+      </div>
+      <div
+        class="ant-form-item-explain"
+      >
+        <div>
+          Buggy!
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-row ant-form-item"
+  >
+    <div
+      class="ant-col ant-form-item-label"
+    >
+      <label
+        class=""
+        title="Normal1"
+      >
+        Normal1
+      </label>
+    </div>
+    <div
+      class="ant-col ant-form-item-control"
+    >
+      <div
+        class="ant-form-item-control-input"
+      >
+        <div
+          class="ant-form-item-control-input-content"
+        >
+          <input
+            class="ant-input"
+            placeholder="unavailable choice"
+            type="text"
+            value="Buggy!"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-error"
+  >
+    <div
+      class="ant-col ant-form-item-label"
+    >
+      <label
+        class=""
+        title="Fail1"
+      >
+        Fail1
+      </label>
+    </div>
+    <div
+      class="ant-col ant-form-item-control"
+    >
+      <div
+        class="ant-form-item-control-input"
+      >
+        <div
+          class="ant-form-item-control-input-content"
+        >
+          <input
+            class="ant-input"
+            placeholder="unavailable choice"
+            type="text"
+            value="Buggy!"
+          />
+        </div>
+      </div>
+      <div
+        class="ant-form-item-explain"
+      >
+        <div>
+          Buggy!
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-error"
+  >
+    <div
+      class="ant-col ant-form-item-label"
+    >
+      <label
+        class=""
+        title="FailDisabled1"
+      >
+        FailDisabled1
+      </label>
+    </div>
+    <div
+      class="ant-col ant-form-item-control"
+    >
+      <div
+        class="ant-form-item-control-input"
+      >
+        <div
+          class="ant-form-item-control-input-content"
+        >
+          <input
+            class="ant-input ant-input-disabled"
+            disabled=""
+            placeholder="unavailable choice"
+            type="text"
+            value="Buggy!"
+          />
+        </div>
+      </div>
+      <div
+        class="ant-form-item-explain"
+      >
+        <div>
+          Buggy!
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-row ant-form-item"
+  >
+    <div
+      class="ant-col ant-form-item-label"
+    >
+      <label
+        class=""
+        title="Normal2"
+      >
+        Normal2
+      </label>
+    </div>
+    <div
+      class="ant-col ant-form-item-control"
+    >
+      <div
+        class="ant-form-item-control-input"
+      >
+        <div
+          class="ant-form-item-control-input-content"
+        >
+          <span
+            class="ant-input-group-wrapper"
+          >
+            <span
+              class="ant-input-wrapper ant-input-group"
+            >
+              <span
+                class="ant-input-group-addon"
+              >
+                Buggy!
+              </span>
+              <input
+                class="ant-input"
+                placeholder="unavailable choice"
+                type="text"
+                value=""
+              />
+            </span>
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-error"
+  >
+    <div
+      class="ant-col ant-form-item-label"
+    >
+      <label
+        class=""
+        title="Fail2"
+      >
+        Fail2
+      </label>
+    </div>
+    <div
+      class="ant-col ant-form-item-control"
+    >
+      <div
+        class="ant-form-item-control-input"
+      >
+        <div
+          class="ant-form-item-control-input-content"
+        >
+          <span
+            class="ant-input-group-wrapper"
+          >
+            <span
+              class="ant-input-wrapper ant-input-group"
+            >
+              <span
+                class="ant-input-group-addon"
+              >
+                Buggy!
+              </span>
+              <input
+                class="ant-input"
+                placeholder="unavailable choice"
+                type="text"
+                value=""
+              />
+            </span>
+          </span>
+        </div>
+      </div>
+      <div
+        class="ant-form-item-explain"
+      >
+        <div>
+          Buggy!
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-error"
+  >
+    <div
+      class="ant-col ant-form-item-label"
+    >
+      <label
+        class=""
+        title="FailDisabled2"
+      >
+        FailDisabled2
+      </label>
+    </div>
+    <div
+      class="ant-col ant-form-item-control"
+    >
+      <div
+        class="ant-form-item-control-input"
+      >
+        <div
+          class="ant-form-item-control-input-content"
+        >
+          <span
+            class="ant-input-group-wrapper"
+          >
+            <span
+              class="ant-input-wrapper ant-input-group"
+            >
+              <span
+                class="ant-input-group-addon"
+              >
+                Buggy!
+              </span>
+              <input
+                class="ant-input ant-input-disabled"
+                disabled=""
+                placeholder="unavailable choice"
+                type="text"
+                value=""
+              />
+            </span>
+          </span>
+        </div>
+      </div>
+      <div
+        class="ant-form-item-explain"
+      >
+        <div>
+          Buggy!
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-row ant-form-item"
+  >
+    <div
+      class="ant-col ant-form-item-label"
+    >
+      <label
+        class=""
+        title="Normal3"
+      >
+        Normal3
+      </label>
+    </div>
+    <div
+      class="ant-col ant-form-item-control"
+    >
+      <div
+        class="ant-form-item-control-input"
+      >
+        <div
+          class="ant-form-item-control-input-content"
+        >
+          <span
+            class="ant-input-affix-wrapper"
+          >
+            <span
+              class="ant-input-prefix"
+            >
+              人民币
+            </span>
+            <input
+              class="ant-input"
+              placeholder="unavailable choice"
+              type="text"
+              value="50"
+            />
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-error"
+  >
+    <div
+      class="ant-col ant-form-item-label"
+    >
+      <label
+        class=""
+        title="Fail3"
+      >
+        Fail3
+      </label>
+    </div>
+    <div
+      class="ant-col ant-form-item-control"
+    >
+      <div
+        class="ant-form-item-control-input"
+      >
+        <div
+          class="ant-form-item-control-input-content"
+        >
+          <span
+            class="ant-input-affix-wrapper"
+          >
+            <span
+              class="ant-input-prefix"
+            >
+              人民币
+            </span>
+            <input
+              class="ant-input"
+              placeholder="unavailable choice"
+              type="text"
+              value="50"
+            />
+          </span>
+        </div>
+      </div>
+      <div
+        class="ant-form-item-explain"
+      >
+        <div>
+          Buggy!
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-error"
+  >
+    <div
+      class="ant-col ant-form-item-label"
+    >
+      <label
+        class=""
+        title="FailDisabled3"
+      >
+        FailDisabled3
+      </label>
+    </div>
+    <div
+      class="ant-col ant-form-item-control"
+    >
+      <div
+        class="ant-form-item-control-input"
+      >
+        <div
+          class="ant-form-item-control-input-content"
+        >
+          <span
+            class="ant-input-affix-wrapper ant-input-affix-wrapper-disabled"
+          >
+            <span
+              class="ant-input-prefix"
+            >
+              人民币
+            </span>
+            <input
+              class="ant-input ant-input-disabled"
+              disabled=""
+              placeholder="unavailable choice"
+              type="text"
+              value="50"
+            />
+          </span>
+        </div>
+      </div>
+      <div
+        class="ant-form-item-explain"
+      >
+        <div>
+          Buggy!
+        </div>
+      </div>
+    </div>
+  </div>
+</form>
+`;
+
 exports[`renders ./components/form/demo/dynamic-form-item.md correctly 1`] = `
 <form
   class="ant-form ant-form-horizontal"

--- a/components/form/demo/disabled-input-debug.md
+++ b/components/form/demo/disabled-input-debug.md
@@ -1,0 +1,61 @@
+---
+order: 30
+title:
+  zh-CN: Disabled Input Debug
+  en-US: Disabled Input Debug
+---
+
+## zh-CN
+
+Buggy!
+
+## en-US
+
+Buggy!
+
+```tsx
+import { SmileOutlined } from '@ant-design/icons';
+import { Form, Input } from 'antd';
+
+ReactDOM.render(
+  <Form>
+    <Form.Item label="Normal0">
+      <Input placeholder="unavailable choice" value="Buggy!" />
+    </Form.Item>
+    <Form.Item label="Fail0" validateStatus="error" help="Buggy!">
+      <Input placeholder="unavailable choice" value="Buggy!" />
+    </Form.Item>
+    <Form.Item label="FailDisabled0" validateStatus="error" help="Buggy!">
+      <Input placeholder="unavailable choice" disabled value="Buggy!" />
+    </Form.Item>
+    <Form.Item label="Normal1">
+      <Input placeholder="unavailable choice" value="Buggy!" />
+    </Form.Item>
+    <Form.Item label="Fail1" validateStatus="error" help="Buggy!">
+      <Input placeholder="unavailable choice" value="Buggy!" />
+    </Form.Item>
+    <Form.Item label="FailDisabled1" validateStatus="error" help="Buggy!">
+      <Input placeholder="unavailable choice" disabled value="Buggy!" />
+    </Form.Item>
+    <Form.Item label="Normal2">
+      <Input placeholder="unavailable choice" addonBefore="Buggy!" />
+    </Form.Item>
+    <Form.Item label="Fail2" validateStatus="error" help="Buggy!">
+      <Input placeholder="unavailable choice" addonBefore="Buggy!" />
+    </Form.Item>
+    <Form.Item label="FailDisabled2" validateStatus="error" help="Buggy!">
+      <Input placeholder="unavailable choice" disabled addonBefore="Buggy!" />
+    </Form.Item>
+    <Form.Item label="Normal3">
+      <Input placeholder="unavailable choice" prefix="人民币" value="50" />
+    </Form.Item>
+    <Form.Item label="Fail3" validateStatus="error" help="Buggy!">
+      <Input placeholder="unavailable choice" prefix="人民币" value="50" />
+    </Form.Item>
+    <Form.Item label="FailDisabled3" validateStatus="error" help="Buggy!">
+      <Input placeholder="unavailable choice" disabled prefix="人民币" value="50" />
+    </Form.Item>
+  </Form>,
+  mountNode,
+);
+```

--- a/components/form/demo/disabled-input-debug.md
+++ b/components/form/demo/disabled-input-debug.md
@@ -7,11 +7,11 @@ title:
 
 ## zh-CN
 
-Buggy!
+Test disabled Input with validate state
 
 ## en-US
 
-Buggy!
+Test disabled Input with validate state
 
 ```tsx
 import { Form, Input } from 'antd';

--- a/components/form/demo/disabled-input-debug.md
+++ b/components/form/demo/disabled-input-debug.md
@@ -14,7 +14,6 @@ Buggy!
 Buggy!
 
 ```tsx
-import { SmileOutlined } from '@ant-design/icons';
 import { Form, Input } from 'antd';
 
 ReactDOM.render(

--- a/components/form/style/mixin.less
+++ b/components/form/style/mixin.less
@@ -10,7 +10,6 @@
   .@{ant-prefix}-input-affix-wrapper {
     &,
     &:hover {
-      background-color: @background-color;
       border-color: @border-color;
     }
 
@@ -18,13 +17,18 @@
     &-focused {
       .active(@border-color);
     }
+  }
 
-    &:not([disabled]):hover {
-      border-color: @border-color;
+  .@{ant-prefix}-input {
+    &:not(&-disabled) {
+      background-color: @background-color;
     }
   }
 
   .@{ant-prefix}-input-affix-wrapper {
+    &:not(&-disabled) {
+      background-color: @background-color;
+    }
     input:focus {
       box-shadow: none !important;
     }
@@ -40,7 +44,6 @@
 
   .@{ant-prefix}-input-group-addon {
     color: @text-color;
-    background-color: @background-color;
     border-color: @border-color;
   }
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
fix https://github.com/ant-design/ant-design/issues/25376 
<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Fix Input disabled `backgroundColor` is override when inside a `error` or `warning` FormItem.   |
| 🇨🇳 Chinese |   修正 Input 在禁用状态下背景颜色被 `error`  或 `warning` 的 FormItem 覆盖的问题。   |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
