### PR TITLE
fix: devWarning valid mistake for successPercent (progress.tsx)

### DIFF
--- a/components/progress/progress.tsx
+++ b/components/progress/progress.tsx
@@ -124,7 +124,7 @@ export default class Progress extends React.Component<ProgressProps> {
     const progressInfo = this.renderProcessInfo(prefixCls, progressStatus);
 
     devWarning(
-      'successPercent' in props,
+      !('successPercent' in props),
       'Progress',
       '`successPercent` is deprecated. Please use `success` instead.',
     );


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

1. Describe the problem and the scenario.
We are website in prod using antd, and we see a warning when using the Progress component about successPercent depreciation, but this props is not being used.
2. GIF or snapshot should be provided if includes UI/interactive modification.

3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
It's just little mistake on devWarning()


### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
