### PR TITLE
feat: improved uk_UA translations 

### DIFF
--- a/components/locale/uk_UA.tsx
+++ b/components/locale/uk_UA.tsx
@@ -28,8 +28,8 @@ const localeValues: Locale = {
   },
   Transfer: {
     searchPlaceholder: 'Введіть текст для пошуку',
-    itemUnit: 'item',
-    itemsUnit: 'items',
+    itemUnit: 'елем.',
+    itemsUnit: 'елем.',
   },
   Upload: {
     uploading: 'Завантаження ...',

--- a/components/table/__tests__/__snapshots__/Table.rowSelection.test.js.snap
+++ b/components/table/__tests__/__snapshots__/Table.rowSelection.test.js.snap
@@ -18,7 +18,7 @@ exports[`Table.rowSelection fix expand on th left when selection column fixed on
         >
           <div
             class="ant-table-content"
-            style="overflow-x:scroll;overflow-y:hidden"
+            style="overflow-x:auto;overflow-y:hidden"
           >
             <table
               style="width:903px;min-width:100%;table-layout:fixed"
@@ -356,7 +356,7 @@ exports[`Table.rowSelection fix selection column on the left 1`] = `
         >
           <div
             class="ant-table-content"
-            style="overflow-x:scroll;overflow-y:hidden"
+            style="overflow-x:auto;overflow-y:hidden"
           >
             <table
               style="width:903px;min-width:100%;table-layout:fixed"
@@ -644,7 +644,7 @@ exports[`Table.rowSelection fix selection column on the left when any other colu
         >
           <div
             class="ant-table-content"
-            style="overflow-x:scroll;overflow-y:hidden"
+            style="overflow-x:auto;overflow-y:hidden"
           >
             <table
               style="width:903px;min-width:100%;table-layout:fixed"

--- a/components/table/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/table/__tests__/__snapshots__/demo.test.js.snap
@@ -5776,7 +5776,7 @@ exports[`renders ./components/table/demo/fixed-columns.md correctly 1`] = `
         >
           <div
             class="ant-table-content"
-            style="overflow-x:scroll;overflow-y:hidden"
+            style="overflow-x:auto;overflow-y:hidden"
           >
             <table
               style="width:1300px;min-width:100%;table-layout:fixed"
@@ -6218,7 +6218,7 @@ exports[`renders ./components/table/demo/fixed-columns-header.md correctly 1`] =
           </div>
           <div
             class="ant-table-body"
-            style="overflow-x:scroll;overflow-y:scroll;max-height:300px"
+            style="overflow-x:auto;overflow-y:scroll;max-height:300px"
           >
             <table
               style="width:1500px;min-width:100%;table-layout:fixed"
@@ -8633,7 +8633,7 @@ exports[`renders ./components/table/demo/grouping-columns.md correctly 1`] = `
           </div>
           <div
             class="ant-table-body"
-            style="overflow-x:scroll;overflow-y:scroll;max-height:240px"
+            style="overflow-x:auto;overflow-y:scroll;max-height:240px"
           >
             <table
               style="width:calc(700px + 50%);min-width:100%;table-layout:fixed"
@@ -15479,7 +15479,7 @@ Array [
           >
             <div
               class="ant-table-content"
-              style="overflow-x:scroll;overflow-y:hidden"
+              style="overflow-x:auto;overflow-y:hidden"
             >
               <table
                 style="width:2000px;min-width:100%;table-layout:fixed"

--- a/components/table/__tests__/__snapshots__/empty.test.js.snap
+++ b/components/table/__tests__/__snapshots__/empty.test.js.snap
@@ -247,7 +247,7 @@ exports[`Table renders empty table with fixed columns 1`] = `
         >
           <div
             class="ant-table-content"
-            style="overflow-x:scroll;overflow-y:hidden"
+            style="overflow-x:auto;overflow-y:hidden"
           >
             <table
               style="width:1px;min-width:100%;table-layout:fixed"


### PR DESCRIPTION
Changed english 'item' and 'items' to uk_UA 'елем.' (елемент) and 'елем.' (елемента/елементів)

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [+ ] Other: improved localization

### 🔗 Related issue link

None

### 💡 Background and solution

None

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     translate a few words to uk_UA      |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [+] Doc is updated/provided or not needed
- [+] Demo is updated/provided or not needed
- [+] TypeScript definition is updated/provided or not needed
- [+ ] Changelog is provided or not needed
