### PR TITLE
fix: RangePicker clear btn position

### DIFF
--- a/components/date-picker/style/index.less
+++ b/components/date-picker/style/index.less
@@ -61,6 +61,7 @@
   &-input {
     position: relative;
     display: inline-flex;
+    align-items: center;
     width: 100%;
 
     > input {
@@ -109,7 +110,12 @@
     align-self: center;
     margin-left: @padding-xs / 2;
     color: @disabled-color;
+    line-height: 1;
     pointer-events: none;
+
+    > * {
+      vertical-align: top;
+    }
   }
 
   &-clear {
@@ -117,11 +123,16 @@
     top: 50%;
     right: 0;
     color: @disabled-color;
+    line-height: 1;
     background: @component-background;
     transform: translateY(-50%);
     cursor: pointer;
     opacity: 0;
     transition: opacity @animation-duration-slow, color @animation-duration-slow;
+
+    > * {
+      vertical-align: top;
+    }
 
     &:hover {
       color: @text-color-secondary;
@@ -186,6 +197,12 @@
       align-items: center;
       padding: 0 @padding-xs;
       line-height: 1;
+    }
+
+    &.@{picker-prefix-cls}-small {
+      .@{picker-prefix-cls}-clear {
+        right: @input-padding-horizontal-sm;
+      }
     }
   }
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

resolve #25447

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Fix RangePicker clear icon position issue when `size=small`.       |
| 🇨🇳 Chinese |     修复 RangePicker 在 `size=small` 时清除按钮的位置问题。     |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
