### PR TITLE
fix: preserve warning in Form.Item

### DIFF
--- a/components/form/FormItem.tsx
+++ b/components/form/FormItem.tsx
@@ -210,6 +210,7 @@ function FormItem(props: FormItemProps): React.ReactElement {
           'labelAlign',
           'labelCol',
           'normalize',
+          'preserve',
           'required',
           'validateFirst',
           'validateStatus',

--- a/components/form/__tests__/index.test.js
+++ b/components/form/__tests__/index.test.js
@@ -563,10 +563,10 @@ describe('Form', () => {
     expect(wrapper.find('.ant-form-item').last().hasClass('ant-form-item-with-help')).toBeFalsy();
   });
 
-  it('no warning of initialValue & getValueProps', () => {
+  it('no warning of initialValue & getValueProps & preserve', () => {
     mount(
       <Form>
-        <Form.Item initialValue="bamboo" getValueProps={() => null}>
+        <Form.Item initialValue="bamboo" getValueProps={() => null} preserve={false}>
           <Input />
         </Form.Item>
       </Form>,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

fix #25514

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fix Form.Item warning for `preserve` as invalidate dom prop.     |
| 🇨🇳 Chinese |      修复 Form.Item 警告 `preserve` 是无效 dom 属性的问题。     |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
