### PR TITLE
Fix/table onchange

### DIFF
--- a/components/table/__tests__/Table.pagination.test.js
+++ b/components/table/__tests__/Table.pagination.test.js
@@ -100,7 +100,7 @@ describe('Table.pagination', () => {
 
     wrapper.find('.ant-select-selector').simulate('mousedown');
     wrapper.find('.ant-select-item').last().simulate('click');
-    expect(scrollTo).toHaveBeenCalledTimes(3);
+    expect(scrollTo).toHaveBeenCalledTimes(2);
   });
 
   it('fires change event', () => {
@@ -181,13 +181,13 @@ describe('Table.pagination', () => {
   });
 
   // https://github.com/ant-design/ant-design/issues/24913
-  it('should onChange called when pageSize change', () => {
+  it('should pagination onChange called when pageSize change', () => {
     const onChange = jest.fn();
     const onShowSizeChange = jest.fn();
     const wrapper = mount(
       createTable({
         pagination: {
-          current: 1,
+          current: 2,
           pageSize: 10,
           total: 200,
           onChange,
@@ -198,7 +198,59 @@ describe('Table.pagination', () => {
     wrapper.find('.ant-select-selector').simulate('mousedown');
     expect(wrapper.find('.ant-select-item-option').length).toBe(4);
     wrapper.find('.ant-select-item-option').at(1).simulate('click');
+    expect(onChange).toHaveBeenCalledTimes(1);
     expect(onChange).toHaveBeenCalledWith(1, 20);
+  });
+
+  it('should pagination onShowSizeChange called when pageSize change', () => {
+    const onShowSizeChange = jest.fn();
+    const wrapper = mount(
+      createTable({
+        pagination: {
+          current: 2,
+          pageSize: 10,
+          total: 200,
+          onShowSizeChange,
+        },
+      }),
+    );
+    wrapper.find('.ant-select-selector').simulate('mousedown');
+    expect(wrapper.find('.ant-select-item-option').length).toBe(4);
+    wrapper.find('.ant-select-item-option').at(1).simulate('click');
+    expect(onShowSizeChange).toHaveBeenCalledTimes(1);
+    expect(onShowSizeChange).toHaveBeenCalledWith(1, 20);
+  });
+
+  it('should table onChange called when pageSize change', () => {
+    const onChange = jest.fn();
+    const wrapper = mount(
+      createTable({
+        onChange,
+        pagination: {
+          current: 2,
+          pageSize: 10,
+          total: 200,
+        },
+      }),
+    );
+    wrapper.find('.ant-select-selector').simulate('mousedown');
+    expect(wrapper.find('.ant-select-item-option').length).toBe(4);
+    wrapper.find('.ant-select-item-option').at(1).simulate('click');
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith(
+      { current: 1, pageSize: 20, total: 200 },
+      {},
+      {},
+      {
+        currentDataSource: [
+          { key: 0, name: 'Jack' },
+          { key: 1, name: 'Lucy' },
+          { key: 2, name: 'Tom' },
+          { key: 3, name: 'Jerry' },
+        ],
+        action: 'paginate',
+      },
+    );
   });
 
   it('should not change page when pagination current is specified', () => {

--- a/components/table/hooks/usePagination.ts
+++ b/components/table/hooks/usePagination.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useRef } from 'react';
 import { PaginationProps } from '../../pagination';
 import { TablePaginationConfig } from '../interface';
 
@@ -82,11 +82,19 @@ export default function usePagination(
     });
   };
 
+  const paginationCurrentRef = useRef<number>();
+
+  const paginationPageSizeRef = useRef<number>();
+
   const onInternalChange: PaginationProps['onChange'] = (...args) => {
     const [current] = args;
+    const pageSize = args[1] || mergedPagination.pageSize!;
     refreshPagination(current);
-
-    onChange(current, args[1] || mergedPagination.pageSize!);
+    if (!(paginationCurrentRef.current === current && paginationPageSizeRef.current === pageSize)) {
+      paginationCurrentRef.current = current;
+      paginationPageSizeRef.current = pageSize;
+      onChange(current, pageSize);
+    }
 
     if (pagination && pagination.onChange) {
       pagination.onChange(...args);
@@ -94,14 +102,18 @@ export default function usePagination(
   };
 
   const onInternalShowSizeChange: PaginationProps['onShowSizeChange'] = (...args) => {
-    const [, pageSize] = args;
+    const [current, pageSize] = args;
     setInnerPagination({
       ...mergedPagination,
       current: 1,
       pageSize,
     });
 
-    onChange(1, pageSize);
+    if (!(paginationCurrentRef.current === current && paginationPageSizeRef.current === pageSize)) {
+      paginationCurrentRef.current = current;
+      paginationPageSizeRef.current = pageSize;
+      onChange(1, pageSize);
+    }
 
     if (pagination && pagination.onShowSizeChange) {
       pagination.onShowSizeChange(...args);

--- a/components/table/hooks/usePagination.ts
+++ b/components/table/hooks/usePagination.ts
@@ -82,17 +82,23 @@ export default function usePagination(
     });
   };
 
-  const paginationCurrentRef = useRef<number>();
-
-  const paginationPageSizeRef = useRef<number>();
+  const paginationRefs = {
+    pageCurrent: useRef<number>(),
+    pageSize: useRef<number>(),
+  };
 
   const onInternalChange: PaginationProps['onChange'] = (...args) => {
     const [current] = args;
     const pageSize = args[1] || mergedPagination.pageSize!;
     refreshPagination(current);
-    if (!(paginationCurrentRef.current === current && paginationPageSizeRef.current === pageSize)) {
-      paginationCurrentRef.current = current;
-      paginationPageSizeRef.current = pageSize;
+    if (
+      !(
+        paginationRefs.pageCurrent.current === current &&
+        paginationRefs.pageSize.current === pageSize
+      )
+    ) {
+      paginationRefs.pageCurrent.current = current;
+      paginationRefs.pageSize.current = pageSize;
       onChange(current, pageSize);
     }
 
@@ -109,14 +115,19 @@ export default function usePagination(
       pageSize,
     });
 
-    if (!(paginationCurrentRef.current === current && paginationPageSizeRef.current === pageSize)) {
-      paginationCurrentRef.current = current;
-      paginationPageSizeRef.current = pageSize;
+    if (
+      !(
+        paginationRefs.pageCurrent.current === current &&
+        paginationRefs.pageSize.current === pageSize
+      )
+    ) {
+      paginationRefs.pageCurrent.current = current;
+      paginationRefs.pageSize.current = pageSize;
       onChange(1, pageSize);
     }
 
     if (pagination && pagination.onShowSizeChange) {
-      pagination.onShowSizeChange(...args);
+      pagination.onShowSizeChange(1, pageSize);
     }
   };
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
https://github.com/ant-design/ant-design/issues/25434

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

原因在于：
1、之前 https://github.com/react-component/pagination/pull/272 给 pagination 自己的 onSizeChange 支持了 onChange，对 pagination 来说是没问题的，但 table 对于 分页的 onInternalChange 和 onInternalShowSizeChange 都会响应，导致table onChange 重复。
2、rc-pagination 先触发自己的 onChange，再触发 onSizeChange，合理的逻辑应该反过来。
3、table 的 onInternalShowSizeChange 时会（也应该）把current 重置为 1， 但 onInternalChange 并不会，导致 table的onchange不光重复响应，响应的参数也不对。
所以在 table 层面，应该根据 onChange， onSizeChange 谁先触发，而把他们聚合成一个，保证 table 的 onchange ，table中pagination 的 onchange，onshowsizechange 保持一致。

rc-pagination 的 修复pr https://github.com/react-component/pagination/pull/285 。否则 test case 无法跑通。

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->
| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    fix `onChange` of `Table` fired twice when `pageSize` changed      |
| 🇨🇳 Chinese |  修复切换 `pageSize` 时 `Table` 的 `onChange` 事件被触发两次且参数错误       |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
