### PR TITLE
feat: custom getInputElement

### DIFF
--- a/components/auto-complete/index.tsx
+++ b/components/auto-complete/index.tsx
@@ -38,7 +38,13 @@ function isSelectOptionOrSelectOptGroup(child: any): Boolean {
 }
 
 const AutoComplete: React.ForwardRefRenderFunction<Select, AutoCompleteProps> = (props, ref) => {
-  const { prefixCls: customizePrefixCls, className, children, dataSource } = props;
+  const {
+    prefixCls: customizePrefixCls,
+    className,
+    children,
+    dataSource,
+    getInputElement: rcGetInputElement,
+  } = props;
   const childNodes: React.ReactElement[] = toArray(children);
 
   const selectRef = React.useRef<Select>();
@@ -48,7 +54,9 @@ const AutoComplete: React.ForwardRefRenderFunction<Select, AutoCompleteProps> = 
   // ============================= Input =============================
   let customizeInput: React.ReactElement;
 
-  if (
+  if (rcGetInputElement) {
+    customizeInput = rcGetInputElement();
+  } else if (
     childNodes.length === 1 &&
     isValidElement(childNodes[0]) &&
     !isSelectOptionOrSelectOptGroup(childNodes[0])


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
https://github.com/ant-design/ant-design/issues/23941

### 💡 Background and solution

in the Autocomplete component, developers can either provide a custom input, or a custom option item for the option list, but not both. This should allow developers to do both

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    AutoComplete now accepts custom `getInputElement` prop    |
| 🇨🇳 Chinese |     AutoComplete 接受自定义 `getInputElement` 属性     |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
