### PR TITLE
fix: Form.Item with `help` should display error style when validate failed

### DIFF
--- a/components/form/FormItem.tsx
+++ b/components/form/FormItem.tsx
@@ -159,10 +159,15 @@ function FormItem(props: FormItemProps): React.ReactElement {
 
     // ======================== Status ========================
     let mergedValidateStatus: ValidateStatus = '';
-    if (validateStatus !== undefined) mergedValidateStatus = validateStatus;
-    else if (meta?.validating) mergedValidateStatus = 'validating';
-    else if (meta?.errors?.length) mergedValidateStatus = 'error';
-    else if (meta?.touched) mergedValidateStatus = 'success';
+    if (validateStatus !== undefined) {
+      mergedValidateStatus = validateStatus;
+    } else if (meta?.validating) {
+      mergedValidateStatus = 'validating';
+    } else if (meta?.errors?.length) {
+      mergedValidateStatus = 'error';
+    } else if (meta?.touched) {
+      mergedValidateStatus = 'success';
+    }
 
     if (domErrorVisible && help) {
       prevValidateStatusRef.current = mergedValidateStatus;

--- a/components/form/FormItem.tsx
+++ b/components/form/FormItem.tsx
@@ -145,29 +145,18 @@ function FormItem(props: FormItemProps): React.ReactElement {
 
     // ======================== Errors ========================
     let mergedErrors: React.ReactNode[];
-    if (help !== undefined && help !== null) {
-      mergedErrors = toArray(help);
-    } else {
-      mergedErrors = meta ? meta.errors : [];
-      Object.keys(inlineErrors).forEach(subName => {
-        const subErrors = inlineErrors[subName] || [];
-        if (subErrors.length) {
-          mergedErrors = [...mergedErrors, ...subErrors];
-        }
-      });
-    }
+    mergedErrors = meta ? meta.errors : [];
+    Object.keys(inlineErrors).forEach(subName => {
+      const subErrors = inlineErrors[subName] || [];
+      if (subErrors.length) mergedErrors = [...mergedErrors, ...subErrors];
+    });
 
     // ======================== Status ========================
     let mergedValidateStatus: ValidateStatus = '';
-    if (validateStatus !== undefined) {
-      mergedValidateStatus = validateStatus;
-    } else if (meta && meta.validating) {
-      mergedValidateStatus = 'validating';
-    } else if (!help && mergedErrors.length) {
-      mergedValidateStatus = 'error';
-    } else if (meta && meta.touched) {
-      mergedValidateStatus = 'success';
-    }
+    if (validateStatus !== undefined) mergedValidateStatus = validateStatus;
+    else if (meta?.validating) mergedValidateStatus = 'validating';
+    else if (mergedErrors.length) mergedValidateStatus = 'error';
+    else if (meta?.touched) mergedValidateStatus = 'success';
 
     if (domErrorVisible && help) {
       prevValidateStatusRef.current = mergedValidateStatus;

--- a/components/form/FormItem.tsx
+++ b/components/form/FormItem.tsx
@@ -145,17 +145,23 @@ function FormItem(props: FormItemProps): React.ReactElement {
 
     // ======================== Errors ========================
     let mergedErrors: React.ReactNode[];
-    mergedErrors = meta ? meta.errors : [];
-    Object.keys(inlineErrors).forEach(subName => {
-      const subErrors = inlineErrors[subName] || [];
-      if (subErrors.length) mergedErrors = [...mergedErrors, ...subErrors];
-    });
+    if (help !== undefined && help !== null) {
+      mergedErrors = toArray(help);
+    } else {
+      mergedErrors = meta ? meta.errors : [];
+      Object.keys(inlineErrors).forEach(subName => {
+        const subErrors = inlineErrors[subName] || [];
+        if (subErrors.length) {
+          mergedErrors = [...mergedErrors, ...subErrors];
+        }
+      });
+    }
 
     // ======================== Status ========================
     let mergedValidateStatus: ValidateStatus = '';
     if (validateStatus !== undefined) mergedValidateStatus = validateStatus;
     else if (meta?.validating) mergedValidateStatus = 'validating';
-    else if (mergedErrors.length) mergedValidateStatus = 'error';
+    else if (meta?.errors?.length) mergedValidateStatus = 'error';
     else if (meta?.touched) mergedValidateStatus = 'success';
 
     if (domErrorVisible && help) {

--- a/components/form/FormItemInput.tsx
+++ b/components/form/FormItemInput.tsx
@@ -55,7 +55,7 @@ const FormItemInput: React.FC<FormItemInputProps & FormItemInputMiscProps> = ({
 
   const className = classNames(`${baseClassName}-control`, mergedWrapperCol.className);
 
-  const [visible, cacheErrors] = useCacheErrors(
+  const [errorVisible, cacheErrors] = useCacheErrors(
     errors,
     changedVisible => {
       if (changedVisible) {
@@ -82,7 +82,7 @@ const FormItemInput: React.FC<FormItemInputProps & FormItemInputMiscProps> = ({
 
   const memoErrors = useMemo(
     () => cacheErrors,
-    visible,
+    errorVisible,
     (_, nextVisible) => nextVisible,
   );
 
@@ -109,7 +109,7 @@ const FormItemInput: React.FC<FormItemInputProps & FormItemInputMiscProps> = ({
         </div>
         <CSSMotion
           motionDeadline={500}
-          visible={visible}
+          visible={errorVisible || (help !== undefined && help !== null)}
           motionName="show-help"
           onLeaveEnd={() => {
             onDomErrorVisibleChange(false);
@@ -120,10 +120,14 @@ const FormItemInput: React.FC<FormItemInputProps & FormItemInputMiscProps> = ({
           {({ className: motionClassName }: { className: string }) => {
             return (
               <div className={classNames(`${baseClassName}-explain`, motionClassName)} key="help">
-                {memoErrors.map((error, index) => (
-                  // eslint-disable-next-line react/no-array-index-key
-                  <div key={index}>{error}</div>
-                ))}
+                {errorVisible ? (
+                  memoErrors.map((error, index) => (
+                    // eslint-disable-next-line react/no-array-index-key
+                    <div key={index}>{error}</div>
+                  ))
+                ) : (
+                  <div>{help}</div>
+                )}
               </div>
             );
           }}

--- a/components/form/FormItemInput.tsx
+++ b/components/form/FormItemInput.tsx
@@ -55,7 +55,7 @@ const FormItemInput: React.FC<FormItemInputProps & FormItemInputMiscProps> = ({
 
   const className = classNames(`${baseClassName}-control`, mergedWrapperCol.className);
 
-  const [errorVisible, cacheErrors] = useCacheErrors(
+  const [visible, cacheErrors] = useCacheErrors(
     errors,
     changedVisible => {
       if (changedVisible) {
@@ -82,7 +82,7 @@ const FormItemInput: React.FC<FormItemInputProps & FormItemInputMiscProps> = ({
 
   const memoErrors = useMemo(
     () => cacheErrors,
-    errorVisible,
+    visible,
     (_, nextVisible) => nextVisible,
   );
 
@@ -109,7 +109,7 @@ const FormItemInput: React.FC<FormItemInputProps & FormItemInputMiscProps> = ({
         </div>
         <CSSMotion
           motionDeadline={500}
-          visible={errorVisible || (help !== undefined && help !== null)}
+          visible={visible}
           motionName="show-help"
           onLeaveEnd={() => {
             onDomErrorVisibleChange(false);
@@ -120,14 +120,10 @@ const FormItemInput: React.FC<FormItemInputProps & FormItemInputMiscProps> = ({
           {({ className: motionClassName }: { className: string }) => {
             return (
               <div className={classNames(`${baseClassName}-explain`, motionClassName)} key="help">
-                {errorVisible ? (
-                  memoErrors.map((error, index) => (
-                    // eslint-disable-next-line react/no-array-index-key
-                    <div key={index}>{error}</div>
-                  ))
-                ) : (
-                  <div>{help}</div>
-                )}
+                {memoErrors.map((error, index) => (
+                  // eslint-disable-next-line react/no-array-index-key
+                  <div key={index}>{error}</div>
+                ))}
               </div>
             );
           }}

--- a/components/form/__tests__/index.test.js
+++ b/components/form/__tests__/index.test.js
@@ -354,6 +354,19 @@ describe('Form', () => {
     expect(wrapper.find('.ant-form-item-explain').length).toBeTruthy();
   });
 
+  it('Form.Item should display validation message when set help', async () => {
+    const wrapper = mount(
+      <Form>
+        <Form.Item name="test" help="" rules={[{ required: true, message: 'message' }]}>
+          <Input />
+        </Form.Item>
+      </Form>,
+    );
+
+    await change(wrapper, 0, '');
+    expect(wrapper.find('.ant-form-item-explain').first().text()).toEqual('message');
+  });
+
   // https://github.com/ant-design/ant-design/issues/21167
   it('`require` without `name`', () => {
     const wrapper = mount(

--- a/components/form/__tests__/index.test.js
+++ b/components/form/__tests__/index.test.js
@@ -354,17 +354,18 @@ describe('Form', () => {
     expect(wrapper.find('.ant-form-item-explain').length).toBeTruthy();
   });
 
-  it('Form.Item should display validation message when set help', async () => {
+  it('Form.Item with `help` should display error style when validate failed', async () => {
     const wrapper = mount(
       <Form>
-        <Form.Item name="test" help="" rules={[{ required: true, message: 'message' }]}>
+        <Form.Item name="test" help="help" rules={[{ required: true, message: 'message' }]}>
           <Input />
         </Form.Item>
       </Form>,
     );
 
     await change(wrapper, 0, '');
-    expect(wrapper.find('.ant-form-item-explain').first().text()).toEqual('message');
+    expect(wrapper.find('.ant-form-item').first().hasClass('ant-form-item-has-error')).toBeTruthy();
+    expect(wrapper.find('.ant-form-item-explain').text()).toEqual('help');
   });
 
   // https://github.com/ant-design/ant-design/issues/21167


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close #25560 

### 💡 Background and solution


### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fix Form.Item `help` style when verification fails  |
| 🇨🇳 Chinese |   修复 Form.Item  `help`  在校验失败时的样式    |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
