### PR TITLE
docs: fix drag table not correct

### DIFF
--- a/components/table/demo/drag-sorting-handler.md
+++ b/components/table/demo/drag-sorting-handler.md
@@ -72,9 +72,6 @@ const data = [
 
 const SortableItem = sortableElement(props => <tr {...props} />);
 const SortableContainer = sortableContainer(props => <tbody {...props} />);
-const DragableBodyRow = ({ index, className, style, ...restProps }) => (
-  <SortableItem index={restProps['data-row-key']} {...restProps} />
-);
 
 class SortableTable extends React.Component {
   state = {
@@ -88,6 +85,13 @@ class SortableTable extends React.Component {
       console.log('Sorted items: ', newData);
       this.setState({ dataSource: newData });
     }
+  };
+
+  DragableBodyRow = ({ className, style, ...restProps }) => {
+    const { dataSource } = this.state;
+    // function findIndex base on Table rowKey props and should always be a right array index
+    const index = dataSource.findIndex(x => x.index === restProps['data-row-key']);
+    return <SortableItem index={index} {...restProps} />;
   };
 
   render() {
@@ -109,7 +113,7 @@ class SortableTable extends React.Component {
         components={{
           body: {
             wrapper: DraggableContainer,
-            row: DragableBodyRow,
+            row: this.DragableBodyRow,
           },
         }}
       />


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [x] 演示代码改进
- [ ] 组件样式改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

Resolve https://github.com/ant-design/ant-design/issues/25556
### 💡 需求背景和解决方案
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
![bug](https://user-images.githubusercontent.com/14831261/87110081-c2f6e780-c298-11ea-8a95-54775e0d8463.gif)
在拖拽的时候动画表现不正常，查了下[react-sortable-hoc](https://github.com/clauderic/react-sortable-hoc)引用库的几个 demo发现并没有这个问题，应该是实现拖拽项到另一列表上方时索引判断出错，导致应该向下移动的列表向上移动。

在解决中发现Table components 中body.row 里面的 prosp并没有返回当前 row 的index,不知道是不是查阅不仔细，所以目前的解决方案是将DragableBodyRow存在组件内，通过[].findIndex 去找 table 主键下对应的 index

```js

  DragableBodyRow = ({ className, style, ...restProps }) => {
    const { dataSource } = this.state;
    // function findIndex base on Table rowKey props and should always be a right array index
    const index = dataSource.findIndex(x => x.index === restProps['data-row-key']);
    return <SortableItem index={index} {...restProps} />;
  };
```
<!--
> 从用户角度描述具体变化，以及可能的 breaking change 和其他风险？
-->

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |   Fixed incorrect display of drag handle column demo code       |
| 🇨🇳 中文 |   修复拖拽手柄列演示代码显示不正确的问题       |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供


-----
[View rendered components/table/demo/drag-sorting-handler.md](https://github.com/Yunfly/ant-design/blob/fix/table-drag-demo/components/table/demo/drag-sorting-handler.md)