### PR TITLE
style: 💄 update Menu.Item horizontal style

### DIFF
--- a/components/menu/style/index.less
+++ b/components/menu/style/index.less
@@ -346,6 +346,7 @@
       padding-left: 0;
       vertical-align: bottom;
       border-bottom: 2px solid transparent;
+
       &:hover,
       &-active,
       &-open,

--- a/components/menu/style/index.less
+++ b/components/menu/style/index.less
@@ -341,7 +341,9 @@
       margin: @menu-item-padding;
       margin-top: 0;
       margin-bottom: 0;
-      padding: 0;
+      padding: @menu-item-padding;
+      padding-right: 0;
+      padding-left: 0;
       vertical-align: bottom;
       border-bottom: 2px solid transparent;
       &:hover,

--- a/components/menu/style/index.less
+++ b/components/menu/style/index.less
@@ -338,9 +338,12 @@
       position: relative;
       top: 1px;
       display: inline-block;
+      margin: @menu-item-padding;
+      margin-top: 0;
+      margin-bottom: 0;
+      padding: 0;
       vertical-align: bottom;
       border-bottom: 2px solid transparent;
-
       &:hover,
       &-active,
       &-open,
@@ -348,6 +351,10 @@
         color: @menu-highlight-color;
         border-bottom: 2px solid @menu-highlight-color;
       }
+    }
+
+    > .@{menu-prefix-cls}-submenu > .@{menu-prefix-cls}-submenu-title {
+      padding: 0;
     }
 
     > .@{menu-prefix-cls}-item {

--- a/site/theme/template/Layout/Header/Navigation.less
+++ b/site/theme/template/Layout/Header/Navigation.less
@@ -15,6 +15,8 @@
     & > .ant-menu-submenu {
       min-width: 72px;
       height: @header-height;
+      margin-right: 0;
+      margin-left: 0;
       line-height: @header-height - @menu-item-border - 2px;
       border-top: @menu-item-border solid transparent;
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
![image](https://user-images.githubusercontent.com/18677354/87508249-87498c80-c6a1-11ea-81eb-a752db8a637d.png)
![image](https://user-images.githubusercontent.com/18677354/87508269-92042180-c6a1-11ea-8878-95bb32ece343.png)

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

Make active border and dropdown width the same as item content.

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | （加粗他们）**Menu.Item's blue indicator line and dropdown width are the same as its content's width in `horizontal` mode.**  |
| 🇨🇳 Chinese |  （加粗他们） **Menu.Item 水平模式的蓝色指示线和下拉菜单宽度现在和其文字内容宽度一致。**     |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
