### PR TITLE
feat: textArea -  add word count ( same as antd mobile)  example: 20/500

### DIFF
--- a/components/auto-complete/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/auto-complete/__tests__/__snapshots__/demo.test.js.snap
@@ -137,18 +137,23 @@ exports[`renders ./components/auto-complete/demo/custom.md correctly 1`] = `
     <span
       class="ant-select-selection-search"
     >
-      <textarea
-        aria-activedescendant="undefined_list_0"
-        aria-autocomplete="list"
-        aria-controls="undefined_list"
-        aria-haspopup="listbox"
-        aria-owns="undefined_list"
-        autocomplete="off"
-        class="ant-input ant-select-selection-search-input"
-        placeholder="input here"
-        role="combobox"
-        style="height:50px"
-      />
+      <div
+        class="ant-input-control"
+        value=""
+      >
+        <textarea
+          aria-activedescendant="undefined_list_0"
+          aria-autocomplete="list"
+          aria-controls="undefined_list"
+          aria-haspopup="listbox"
+          aria-owns="undefined_list"
+          autocomplete="off"
+          class="ant-input ant-select-selection-search-input"
+          placeholder="input here"
+          role="combobox"
+          style="height:50px"
+        />
+      </div>
     </span>
     <span
       class="ant-select-selection-placeholder"

--- a/components/comment/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/comment/__tests__/__snapshots__/demo.test.js.snap
@@ -156,10 +156,15 @@ exports[`renders ./components/comment/demo/editor.md correctly 1`] = `
               <div
                 class="ant-form-item-control-input-content"
               >
-                <textarea
-                  class="ant-input"
-                  rows="4"
-                />
+                <div
+                  class="ant-input-control"
+                  value=""
+                >
+                  <textarea
+                    class="ant-input"
+                    rows="4"
+                  />
+                </div>
               </div>
             </div>
           </div>

--- a/components/config-provider/__tests__/__snapshots__/components.test.js.snap
+++ b/components/config-provider/__tests__/__snapshots__/components.test.js.snap
@@ -14489,9 +14489,14 @@ exports[`ConfigProvider components Input configProvider 1`] = `
       </span>
     </span>
   </span>
-  <textarea
-    class="config-input"
-  />
+  <div
+    class="config-input-control"
+    value=""
+  >
+    <textarea
+      class="config-input"
+    />
+  </div>
 </div>
 `;
 
@@ -14578,9 +14583,14 @@ exports[`ConfigProvider components Input configProvider componentSize large 1`] 
       </span>
     </span>
   </span>
-  <textarea
-    class="config-input"
-  />
+  <div
+    class="config-input-control"
+    value=""
+  >
+    <textarea
+      class="config-input"
+    />
+  </div>
 </div>
 `;
 
@@ -14667,9 +14677,14 @@ exports[`ConfigProvider components Input configProvider componentSize middle 1`]
       </span>
     </span>
   </span>
-  <textarea
-    class="config-input"
-  />
+  <div
+    class="config-input-control"
+    value=""
+  >
+    <textarea
+      class="config-input"
+    />
+  </div>
 </div>
 `;
 
@@ -14756,9 +14771,14 @@ exports[`ConfigProvider components Input configProvider virtual and dropdownMatc
       </span>
     </span>
   </span>
-  <textarea
-    class="ant-input"
-  />
+  <div
+    class="ant-input-control"
+    value=""
+  >
+    <textarea
+      class="ant-input"
+    />
+  </div>
 </div>
 `;
 
@@ -14845,9 +14865,14 @@ exports[`ConfigProvider components Input normal 1`] = `
       </span>
     </span>
   </span>
-  <textarea
-    class="ant-input"
-  />
+  <div
+    class="ant-input-control"
+    value=""
+  >
+    <textarea
+      class="ant-input"
+    />
+  </div>
 </div>
 `;
 
@@ -14934,9 +14959,14 @@ exports[`ConfigProvider components Input prefixCls 1`] = `
       </span>
     </span>
   </span>
-  <textarea
-    class="prefix-Input"
-  />
+  <div
+    class="prefix-Input-control"
+    value=""
+  >
+    <textarea
+      class="prefix-Input"
+    />
+  </div>
 </div>
 `;
 

--- a/components/form/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/form/__tests__/__snapshots__/demo.test.js.snap
@@ -933,6 +933,81 @@ exports[`renders ./components/form/demo/customized-form-controls.md correctly 1`
 </form>
 `;
 
+exports[`renders ./components/form/demo/dep-debug.md correctly 1`] = `
+<form
+  class="ant-form ant-form-horizontal"
+  id="debug"
+>
+  0
+  <div
+    class="ant-row ant-form-item"
+  >
+    <div
+      class="ant-col ant-form-item-label"
+    >
+      <label
+        class=""
+        for="debug_debug1"
+        title="debug1"
+      >
+        debug1
+      </label>
+    </div>
+    <div
+      class="ant-col ant-form-item-control"
+    >
+      <div
+        class="ant-form-item-control-input"
+      >
+        <div
+          class="ant-form-item-control-input-content"
+        >
+          <input
+            class="ant-input"
+            id="debug_debug1"
+            type="text"
+            value="debug1"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-row ant-form-item"
+  >
+    <div
+      class="ant-col ant-form-item-label"
+    >
+      <label
+        class=""
+        for="debug_debug2"
+        title="debug2"
+      >
+        debug2
+      </label>
+    </div>
+    <div
+      class="ant-col ant-form-item-control"
+    >
+      <div
+        class="ant-form-item-control-input"
+      >
+        <div
+          class="ant-form-item-control-input-content"
+        >
+          <input
+            class="ant-input"
+            id="debug_debug2"
+            type="text"
+            value="debug2"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</form>
+`;
+
 exports[`renders ./components/form/demo/disabled-input-debug.md correctly 1`] = `
 <form
   class="ant-form ant-form-horizontal"
@@ -1443,81 +1518,6 @@ exports[`renders ./components/form/demo/disabled-input-debug.md correctly 1`] = 
       >
         <div>
           Buggy!
-        </div>
-      </div>
-    </div>
-  </div>
-</form>
-`;
-
-exports[`renders ./components/form/demo/dep-debug.md correctly 1`] = `
-<form
-  class="ant-form ant-form-horizontal"
-  id="debug"
->
-  0
-  <div
-    class="ant-row ant-form-item"
-  >
-    <div
-      class="ant-col ant-form-item-label"
-    >
-      <label
-        class=""
-        for="debug_debug1"
-        title="debug1"
-      >
-        debug1
-      </label>
-    </div>
-    <div
-      class="ant-col ant-form-item-control"
-    >
-      <div
-        class="ant-form-item-control-input"
-      >
-        <div
-          class="ant-form-item-control-input-content"
-        >
-          <input
-            class="ant-input"
-            id="debug_debug1"
-            type="text"
-            value="debug1"
-          />
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    class="ant-row ant-form-item"
-  >
-    <div
-      class="ant-col ant-form-item-label"
-    >
-      <label
-        class=""
-        for="debug_debug2"
-        title="debug2"
-      >
-        debug2
-      </label>
-    </div>
-    <div
-      class="ant-col ant-form-item-control"
-    >
-      <div
-        class="ant-form-item-control-input"
-      >
-        <div
-          class="ant-form-item-control-input-content"
-        >
-          <input
-            class="ant-input"
-            id="debug_debug2"
-            type="text"
-            value="debug2"
-          />
         </div>
       </div>
     </div>
@@ -2570,10 +2570,15 @@ exports[`renders ./components/form/demo/nest-messages.md correctly 1`] = `
         <div
           class="ant-form-item-control-input-content"
         >
-          <textarea
-            class="ant-input"
-            id="nest-messages_user_introduction"
-          />
+          <div
+            class="ant-input-control"
+            value=""
+          >
+            <textarea
+              class="ant-input"
+              id="nest-messages_user_introduction"
+            />
+          </div>
         </div>
       </div>
     </div>

--- a/components/input/TextArea.tsx
+++ b/components/input/TextArea.tsx
@@ -115,7 +115,7 @@ class TextArea extends React.Component<TextAreaProps, TextAreaState> {
       prefixCls: customizePrefixCls,
       bordered = true,
       showCount = false,
-      maxLength = showCount ? 500 : undefined,
+      maxLength = showCount ? 200 : undefined,
     } = this.props;
     const prefixCls = getPrefixCls('input', customizePrefixCls);
     return (

--- a/components/input/TextArea.tsx
+++ b/components/input/TextArea.tsx
@@ -9,7 +9,7 @@ import { fixControlledValue, resolveOnChange } from './Input';
 export interface TextAreaProps extends RcTextAreaProps {
   allowClear?: boolean;
   bordered?: boolean;
-  hasCount?: boolean;
+  showCount?: boolean;
 }
 
 export interface TextAreaState {
@@ -17,13 +17,14 @@ export interface TextAreaState {
 }
 
 function countSymbols(text = ''): number {
-  if (text == null || text == undefined) return 0;
+  if (text == null) return 0;
   const regexAstralSymbols = /[\uD800-\uDBFF][\uDC00-\uDFFF]|\n/g;
   return text.toString().replace(regexAstralSymbols, '_').length;
 }
 
 class TextArea extends React.Component<TextAreaProps, TextAreaState> {
   resizableTextArea: ResizableTextArea;
+
   clearableInput: ClearableLabeledInput;
 
   constructor(props: TextAreaProps) {
@@ -80,12 +81,12 @@ class TextArea extends React.Component<TextAreaProps, TextAreaState> {
   renderTextArea = (
     prefixCls: string,
     bordered: boolean,
-    hasCount: boolean,
+    showCount: boolean,
     value: string,
     maxLength: number | undefined,
   ) => {
     const characterLength = countSymbols(value);
-    const maxLen = hasCount ? maxLength : undefined;
+    const maxLen = showCount ? maxLength : undefined;
 
     return (
       <div className={`${prefixCls}-control`}>
@@ -99,7 +100,7 @@ class TextArea extends React.Component<TextAreaProps, TextAreaState> {
           onChange={this.handleChange}
           ref={this.saveTextArea}
         />
-        {hasCount && (
+        {showCount && (
           <span className={`${prefixCls}-control-count`}>
             <span>{characterLength}</span>/{maxLength}
           </span>
@@ -113,8 +114,8 @@ class TextArea extends React.Component<TextAreaProps, TextAreaState> {
     const {
       prefixCls: customizePrefixCls,
       bordered = true,
-      hasCount = false,
-      maxLength = hasCount ? 500 : undefined,
+      showCount = false,
+      maxLength = showCount ? 500 : undefined,
     } = this.props;
     const prefixCls = getPrefixCls('input', customizePrefixCls);
     return (
@@ -124,7 +125,7 @@ class TextArea extends React.Component<TextAreaProps, TextAreaState> {
         direction={direction}
         inputType="text"
         value={fixControlledValue(value)}
-        element={this.renderTextArea(prefixCls, bordered, hasCount, value, maxLength)}
+        element={this.renderTextArea(prefixCls, bordered, showCount, value, maxLength)}
         handleReset={this.handleReset}
         ref={this.saveClearableInput}
         triggerFocus={this.focus}

--- a/components/input/TextArea.tsx
+++ b/components/input/TextArea.tsx
@@ -16,14 +16,14 @@ export interface TextAreaState {
   value: any;
 }
 
-function countSymbols(text = '') {
+function countSymbols(text = ''): number {
+  if (text == null || text == undefined) return 0;
   const regexAstralSymbols = /[\uD800-\uDBFF][\uDC00-\uDFFF]|\n/g;
-  return text.replace(regexAstralSymbols, '_').length;
+  return text.toString().replace(regexAstralSymbols, '_').length;
 }
 
 class TextArea extends React.Component<TextAreaProps, TextAreaState> {
   resizableTextArea: ResizableTextArea;
-
   clearableInput: ClearableLabeledInput;
 
   constructor(props: TextAreaProps) {
@@ -85,7 +85,7 @@ class TextArea extends React.Component<TextAreaProps, TextAreaState> {
     maxLength: number | undefined,
   ) => {
     const characterLength = countSymbols(value);
-    const maxLen = hasCount ? maxLength : false;
+    const maxLen = hasCount ? maxLength : undefined;
 
     return (
       <div className={`${prefixCls}-control`}>
@@ -109,7 +109,7 @@ class TextArea extends React.Component<TextAreaProps, TextAreaState> {
   };
 
   renderComponent = ({ getPrefixCls, direction }: ConfigConsumerProps) => {
-    const { value } = this.state;
+    const { value = '' } = this.state;
     const {
       prefixCls: customizePrefixCls,
       bordered = true,

--- a/components/input/TextArea.tsx
+++ b/components/input/TextArea.tsx
@@ -9,10 +9,16 @@ import { fixControlledValue, resolveOnChange } from './Input';
 export interface TextAreaProps extends RcTextAreaProps {
   allowClear?: boolean;
   bordered?: boolean;
+  hasCount?:boolean;
 }
 
 export interface TextAreaState {
   value: any;
+}
+
+function countSymbols(text = '') {
+  const regexAstralSymbols = /[\uD800-\uDBFF][\uDC00-\uDFFF]|\n/g;
+  return text.replace(regexAstralSymbols, '_').length;
 }
 
 class TextArea extends React.Component<TextAreaProps, TextAreaState> {
@@ -71,23 +77,34 @@ class TextArea extends React.Component<TextAreaProps, TextAreaState> {
     resolveOnChange(this.resizableTextArea.textArea, e, this.props.onChange);
   };
 
-  renderTextArea = (prefixCls: string, bordered: boolean) => {
+  renderTextArea = (prefixCls: string, bordered: boolean,hasCount:boolean,value:string,maxLength:number) => {
+    let characterLength = countSymbols(value);
+    let maxLen = hasCount?maxLength:false;
+   
     return (
+      <div className={`${prefixCls}-control`}>
       <RcTextArea
         {...omit(this.props, ['allowClear', 'bordered'])}
         className={classNames(this.props.className, {
           [`${prefixCls}-borderless`]: !bordered,
         })}
+        maxLength={maxLen}
         prefixCls={prefixCls}
         onChange={this.handleChange}
         ref={this.saveTextArea}
       />
+        {hasCount && (
+          <span className={`${prefixCls}-control-count`}>
+            <span>{characterLength}</span>/{maxLength}
+          </span>
+        )}
+      </div>
     );
   };
 
   renderComponent = ({ getPrefixCls, direction }: ConfigConsumerProps) => {
     const { value } = this.state;
-    const { prefixCls: customizePrefixCls, bordered = true } = this.props;
+    const { prefixCls: customizePrefixCls, bordered = true ,hasCount=true ,maxLength=hasCount?500:undefined} = this.props;
     const prefixCls = getPrefixCls('input', customizePrefixCls);
     return (
       <ClearableLabeledInput
@@ -96,11 +113,12 @@ class TextArea extends React.Component<TextAreaProps, TextAreaState> {
         direction={direction}
         inputType="text"
         value={fixControlledValue(value)}
-        element={this.renderTextArea(prefixCls, bordered)}
+        element={this.renderTextArea(prefixCls,bordered,hasCount,value,maxLength)}
         handleReset={this.handleReset}
         ref={this.saveClearableInput}
         triggerFocus={this.focus}
         bordered={bordered}
+       
       />
     );
   };

--- a/components/input/TextArea.tsx
+++ b/components/input/TextArea.tsx
@@ -9,7 +9,7 @@ import { fixControlledValue, resolveOnChange } from './Input';
 export interface TextAreaProps extends RcTextAreaProps {
   allowClear?: boolean;
   bordered?: boolean;
-  hasCount?:boolean;
+  hasCount?: boolean;
 }
 
 export interface TextAreaState {
@@ -77,22 +77,28 @@ class TextArea extends React.Component<TextAreaProps, TextAreaState> {
     resolveOnChange(this.resizableTextArea.textArea, e, this.props.onChange);
   };
 
-  renderTextArea = (prefixCls: string, bordered: boolean,hasCount:boolean,value:string,maxLength:number) => {
-    let characterLength = countSymbols(value);
-    let maxLen = hasCount?maxLength:false;
-   
+  renderTextArea = (
+    prefixCls: string,
+    bordered: boolean,
+    hasCount: boolean,
+    value: string,
+    maxLength: number|undefined,
+  ) => {
+    const characterLength = countSymbols(value);
+    const maxLen = hasCount ? maxLength : false;
+
     return (
       <div className={`${prefixCls}-control`}>
-      <RcTextArea
-        {...omit(this.props, ['allowClear', 'bordered'])}
-        className={classNames(this.props.className, {
-          [`${prefixCls}-borderless`]: !bordered,
-        })}
-        maxLength={maxLen}
-        prefixCls={prefixCls}
-        onChange={this.handleChange}
-        ref={this.saveTextArea}
-      />
+        <RcTextArea
+          {...omit(this.props, ['allowClear', 'bordered'])}
+          className={classNames(this.props.className, {
+            [`${prefixCls}-borderless`]: !bordered,
+          })}
+          maxLength={maxLen}
+          prefixCls={prefixCls}
+          onChange={this.handleChange}
+          ref={this.saveTextArea}
+        />
         {hasCount && (
           <span className={`${prefixCls}-control-count`}>
             <span>{characterLength}</span>/{maxLength}
@@ -104,7 +110,12 @@ class TextArea extends React.Component<TextAreaProps, TextAreaState> {
 
   renderComponent = ({ getPrefixCls, direction }: ConfigConsumerProps) => {
     const { value } = this.state;
-    const { prefixCls: customizePrefixCls, bordered = true ,hasCount=true ,maxLength=hasCount?500:undefined} = this.props;
+    const {
+      prefixCls: customizePrefixCls,
+      bordered = true,
+      hasCount = false,
+      maxLength = hasCount ? 500 : undefined,
+    } = this.props;
     const prefixCls = getPrefixCls('input', customizePrefixCls);
     return (
       <ClearableLabeledInput
@@ -113,12 +124,11 @@ class TextArea extends React.Component<TextAreaProps, TextAreaState> {
         direction={direction}
         inputType="text"
         value={fixControlledValue(value)}
-        element={this.renderTextArea(prefixCls,bordered,hasCount,value,maxLength)}
+        element={this.renderTextArea(prefixCls, bordered, hasCount, value, maxLength)}
         handleReset={this.handleReset}
         ref={this.saveClearableInput}
         triggerFocus={this.focus}
         bordered={bordered}
-       
       />
     );
   };

--- a/components/input/TextArea.tsx
+++ b/components/input/TextArea.tsx
@@ -82,7 +82,7 @@ class TextArea extends React.Component<TextAreaProps, TextAreaState> {
     bordered: boolean,
     hasCount: boolean,
     value: string,
-    maxLength: number|undefined,
+    maxLength: number | undefined,
   ) => {
     const characterLength = countSymbols(value);
     const maxLen = hasCount ? maxLength : false;

--- a/components/input/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/input/__tests__/__snapshots__/demo.test.js.snap
@@ -258,11 +258,16 @@ Array [
       rows="1"
     />
   </div>,
-  <textarea
-    class="ant-input"
-    rows="1"
-    style="width:100px"
-  />,
+  <div
+    class="ant-input-control"
+    value=""
+  >
+    <textarea
+      class="ant-input"
+      rows="1"
+      style="width:100px"
+    />
+  </div>,
   <button
     class="ant-btn ant-btn-primary"
     type="button"
@@ -1002,10 +1007,15 @@ Array [
   <span
     class="ant-input-affix-wrapper ant-input-affix-wrapper-textarea-with-clear-btn"
   >
-    <textarea
-      class="ant-input"
-      placeholder="textarea with clear icon"
-    />
+    <div
+      class="ant-input-control"
+      value=""
+    >
+      <textarea
+        class="ant-input"
+        placeholder="textarea with clear icon"
+      />
+    </div>
     <span
       aria-label="close-circle"
       class="anticon anticon-close-circle ant-input-textarea-clear-icon ant-input-textarea-clear-icon-hidden"
@@ -1033,24 +1043,39 @@ Array [
 
 exports[`renders ./components/input/demo/autosize-textarea.md correctly 1`] = `
 Array [
-  <textarea
-    class="ant-input"
-    placeholder="Autosize height based on content lines"
-  />,
+  <div
+    class="ant-input-control"
+    value=""
+  >
+    <textarea
+      class="ant-input"
+      placeholder="Autosize height based on content lines"
+    />
+  </div>,
   <div
     style="margin:24px 0"
   />,
-  <textarea
-    class="ant-input"
-    placeholder="Autosize height with minimum and maximum number of lines"
-  />,
+  <div
+    class="ant-input-control"
+    value=""
+  >
+    <textarea
+      class="ant-input"
+      placeholder="Autosize height with minimum and maximum number of lines"
+    />
+  </div>,
   <div
     style="margin:24px 0"
   />,
-  <textarea
-    class="ant-input"
-    placeholder="Controlled autosize"
-  />,
+  <div
+    class="ant-input-control"
+    value=""
+  >
+    <textarea
+      class="ant-input"
+      placeholder="Controlled autosize"
+    />
+  </div>,
 ]
 `;
 
@@ -1088,17 +1113,27 @@ exports[`renders ./components/input/demo/borderless-debug.md correctly 1`] = `
     type="text"
     value=""
   />
-  <textarea
-    class="ant-input ant-input-borderless"
-    placeholder="Unbordered"
-  />
-  <span
-    class="ant-input-affix-wrapper ant-input-affix-wrapper-textarea-with-clear-btn ant-input-affix-wrapper-borderless"
+  <div
+    class="ant-input-control"
+    value=""
   >
     <textarea
       class="ant-input ant-input-borderless"
       placeholder="Unbordered"
     />
+  </div>
+  <span
+    class="ant-input-affix-wrapper ant-input-affix-wrapper-textarea-with-clear-btn ant-input-affix-wrapper-borderless"
+  >
+    <div
+      class="ant-input-control"
+      value=""
+    >
+      <textarea
+        class="ant-input ant-input-borderless"
+        placeholder="Unbordered"
+      />
+    </div>
     <span
       aria-label="close-circle"
       class="anticon anticon-close-circle ant-input-textarea-clear-icon ant-input-textarea-clear-icon-hidden"
@@ -2638,10 +2673,15 @@ Array [
 `;
 
 exports[`renders ./components/input/demo/textarea.md correctly 1`] = `
-<textarea
-  class="ant-input"
-  rows="4"
-/>
+<div
+  class="ant-input-control"
+  value=""
+>
+  <textarea
+    class="ant-input"
+    rows="4"
+  />
+</div>
 `;
 
 exports[`renders ./components/input/demo/textarea-resize.md correctly 1`] = `
@@ -2655,12 +2695,17 @@ Array [
       Auto Resize: false
     </span>
   </button>,
-  <textarea
-    class="ant-input"
-    rows="4"
+  <div
+    class="ant-input-control"
+    value="The autoSize property applies to textarea nodes, and only the height changes automatically. In addition, autoSize can be set to an object, specifying the minimum number of rows and the maximum number of rows. The autoSize property applies to textarea nodes, and only the height changes automatically. In addition, autoSize can be set to an object, specifying the minimum number of rows and the maximum number of rows."
   >
-    The autoSize property applies to textarea nodes, and only the height changes automatically. In addition, autoSize can be set to an object, specifying the minimum number of rows and the maximum number of rows. The autoSize property applies to textarea nodes, and only the height changes automatically. In addition, autoSize can be set to an object, specifying the minimum number of rows and the maximum number of rows.
-  </textarea>,
+    <textarea
+      class="ant-input"
+      rows="4"
+    >
+      The autoSize property applies to textarea nodes, and only the height changes automatically. In addition, autoSize can be set to an object, specifying the minimum number of rows and the maximum number of rows. The autoSize property applies to textarea nodes, and only the height changes automatically. In addition, autoSize can be set to an object, specifying the minimum number of rows and the maximum number of rows.
+    </textarea>
+  </div>,
 ]
 `;
 

--- a/components/input/__tests__/__snapshots__/textarea.test.js.snap
+++ b/components/input/__tests__/__snapshots__/textarea.test.js.snap
@@ -4,11 +4,16 @@ exports[`TextArea allowClear should change type when click 1`] = `
 <span
   class="ant-input-affix-wrapper ant-input-affix-wrapper-textarea-with-clear-btn"
 >
-  <textarea
-    class="ant-input"
+  <div
+    class="ant-input-control"
+    value="111"
   >
-    111
-  </textarea>
+    <textarea
+      class="ant-input"
+    >
+      111
+    </textarea>
+  </div>
   <span
     aria-label="close-circle"
     class="anticon anticon-close-circle ant-input-textarea-clear-icon"
@@ -37,9 +42,16 @@ exports[`TextArea allowClear should change type when click 2`] = `
 <span
   class="ant-input-affix-wrapper ant-input-affix-wrapper-textarea-with-clear-btn"
 >
-  <textarea
-    class="ant-input"
-  />
+  <div
+    class="ant-input-control"
+    value=""
+  >
+    <textarea
+      class="ant-input"
+    >
+      111
+    </textarea>
+  </div>
   <span
     aria-label="close-circle"
     class="anticon anticon-close-circle ant-input-textarea-clear-icon ant-input-textarea-clear-icon-hidden"
@@ -251,15 +263,24 @@ exports[`TextArea allowClear should not show icon if value is undefined, null or
 `;
 
 exports[`TextArea should support disabled 1`] = `
-<textarea
-  class="ant-input ant-input-disabled"
-  disabled=""
-/>
+<div
+  class="ant-input-control"
+  value=""
+>
+  <textarea
+    class="ant-input ant-input-disabled"
+    disabled=""
+  />
+</div>
 `;
 
 exports[`TextArea should support maxLength 1`] = `
-<textarea
-  class="ant-input"
-  maxlength="10"
-/>
+<div
+  class="ant-input-control"
+  value=""
+>
+  <textarea
+    class="ant-input"
+  />
+</div>
 `;

--- a/components/input/__tests__/textarea.test.js
+++ b/components/input/__tests__/textarea.test.js
@@ -243,9 +243,9 @@ describe('TextArea allowClear', () => {
   });
 });
 
-describe('TextArea hasCount',()=>{
+describe('TextArea showCount', () => {
   it('should count words correctly', async () => {
-    const wrapper = mount(<Input.TextArea hasCount autoSize />, { attachTo: document.body });
+    const wrapper = mount(<Input.TextArea showCount autoSize />, { attachTo: document.body });
     const countNum = wrapper.find('.ant-input-control-count>span');
     wrapper.find('textarea').simulate('change', {
       target: {
@@ -256,7 +256,7 @@ describe('TextArea hasCount',()=>{
     wrapper.unmount();
   });
 
-  it('should not contain any counting number without "hasCount"', async () => {
+  it('should not contain any counting number without "showCount"', async () => {
     const wrapper = mount(<Input.TextArea autoSize />, { attachTo: document.body });
     const countNum = wrapper.find('.ant-input-control-count>span');
     wrapper.find('textarea').simulate('change', {
@@ -267,4 +267,4 @@ describe('TextArea hasCount',()=>{
     expect(countNum).toEqual({});
     wrapper.unmount();
   });
-})
+});

--- a/components/input/__tests__/textarea.test.js
+++ b/components/input/__tests__/textarea.test.js
@@ -241,7 +241,9 @@ describe('TextArea allowClear', () => {
     expect(setSelectionRangeFn).toHaveBeenCalled();
     wrapper.unmount();
   });
+});
 
+describe('TextArea hasCount',()=>{
   it('should count words correctly', async () => {
     const wrapper = mount(<Input.TextArea hasCount autoSize />, { attachTo: document.body });
     const countNum = wrapper.find('.ant-input-control-count>span');
@@ -265,4 +267,4 @@ describe('TextArea allowClear', () => {
     expect(countNum).toEqual({});
     wrapper.unmount();
   });
-});
+})

--- a/components/input/__tests__/textarea.test.js
+++ b/components/input/__tests__/textarea.test.js
@@ -241,4 +241,28 @@ describe('TextArea allowClear', () => {
     expect(setSelectionRangeFn).toHaveBeenCalled();
     wrapper.unmount();
   });
+
+  it('should count words correctly', async () => {
+    const wrapper = mount(<Input.TextArea hasCount autoSize />, { attachTo: document.body });
+    const countNum = wrapper.find('.ant-input-control-count>span');
+    wrapper.find('textarea').simulate('change', {
+      target: {
+        value: 'You are Welcome',
+      },
+    });
+    expect(countNum.text()).toBe('15');
+    wrapper.unmount();
+  });
+
+  it('should not contain any counting number without "hasCount"', async () => {
+    const wrapper = mount(<Input.TextArea autoSize />, { attachTo: document.body });
+    const countNum = wrapper.find('.ant-input-control-count>span');
+    wrapper.find('textarea').simulate('change', {
+      target: {
+        value: 'You are Welcome',
+      },
+    });
+    expect(countNum).toEqual({});
+    wrapper.unmount();
+  });
 });

--- a/components/input/index.en-US.md
+++ b/components/input/index.en-US.md
@@ -50,7 +50,7 @@ The rest of the props of Input are exactly the same as the original [input](http
 | onResize | The callback function that is triggered when resize | function({ width, height }) | - |  |
 | bordered | Whether has border style | boolean | true | 4.5.0 |
 | showCount | Whether has word count | boolean | false | 4.5.0 |
-| maxLength | The max length | number | - | 4.5.0 |
+| maxLength | The max length | number | 500 | 4.5.0 |
 
 The rest of the props of `Input.TextArea` are the same as the original [textarea](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea).
 

--- a/components/input/index.en-US.md
+++ b/components/input/index.en-US.md
@@ -50,7 +50,7 @@ The rest of the props of Input are exactly the same as the original [input](http
 | onResize | The callback function that is triggered when resize | function({ width, height }) | - |  |
 | bordered | Whether has border style | boolean | true | 4.5.0 |
 | showCount | Whether has word count | boolean | false | 4.5.0 |
-| maxLength | The max length | number | 500 | 4.5.0 |
+| maxLength | The max length | number | 200 | 4.5.0 |
 
 The rest of the props of `Input.TextArea` are the same as the original [textarea](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea).
 

--- a/components/input/index.en-US.md
+++ b/components/input/index.en-US.md
@@ -49,7 +49,8 @@ The rest of the props of Input are exactly the same as the original [input](http
 | allowClear | If allow to remove input content with clear icon | boolean | false |  |
 | onResize | The callback function that is triggered when resize | function({ width, height }) | - |  |
 | bordered | Whether has border style | boolean | true | 4.5.0 |
-| hasCount | Whether has word count | boolean | false | 4.5.0 |
+| showCount | Whether has word count | boolean | false | 4.5.0 |
+| maxLength | The max length | number | - | 4.5.0 |
 
 The rest of the props of `Input.TextArea` are the same as the original [textarea](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea).
 

--- a/components/input/index.en-US.md
+++ b/components/input/index.en-US.md
@@ -49,7 +49,7 @@ The rest of the props of Input are exactly the same as the original [input](http
 | allowClear | If allow to remove input content with clear icon | boolean | false |  |
 | onResize | The callback function that is triggered when resize | function({ width, height }) | - |  |
 | bordered | Whether has border style | boolean | true | 4.5.0 |
-| hasCount | Whether has word count | boolean | false |  |
+| hasCount | Whether has word count | boolean | false | 4.5.0 |
 
 
 The rest of the props of `Input.TextArea` are the same as the original [textarea](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea).

--- a/components/input/index.en-US.md
+++ b/components/input/index.en-US.md
@@ -51,7 +51,6 @@ The rest of the props of Input are exactly the same as the original [input](http
 | bordered | Whether has border style | boolean | true | 4.5.0 |
 | hasCount | Whether has word count | boolean | false | 4.5.0 |
 
-
 The rest of the props of `Input.TextArea` are the same as the original [textarea](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea).
 
 #### Input.Search

--- a/components/input/index.en-US.md
+++ b/components/input/index.en-US.md
@@ -49,6 +49,8 @@ The rest of the props of Input are exactly the same as the original [input](http
 | allowClear | If allow to remove input content with clear icon | boolean | false |  |
 | onResize | The callback function that is triggered when resize | function({ width, height }) | - |  |
 | bordered | Whether has border style | boolean | true | 4.5.0 |
+| hasCount | Whether has word count | boolean | false |  |
+
 
 The rest of the props of `Input.TextArea` are the same as the original [textarea](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea).
 

--- a/components/input/index.zh-CN.md
+++ b/components/input/index.zh-CN.md
@@ -51,7 +51,7 @@ Input 的其他属性和 React 自带的 [input](https://facebook.github.io/reac
 | onResize | resize 回调 | function({ width, height }) | - |  |
 | bordered | 是否有边框 | boolean | true | 4.5.0 |
 | showCount | 是否显示字数统计 | boolean | false | 4.5.0 |
-| maxLength | 最大长度 | number | 500 | 4.5.0 |
+| maxLength | 最大长度 | number | 200 | 4.5.0 |
 
 `Input.TextArea` 的其他属性和浏览器自带的 [textarea](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea) 一致。
 

--- a/components/input/index.zh-CN.md
+++ b/components/input/index.zh-CN.md
@@ -50,7 +50,8 @@ Input 的其他属性和 React 自带的 [input](https://facebook.github.io/reac
 | allowClear | 可以点击清除图标删除内容 | boolean | false |  |
 | onResize | resize 回调 | function({ width, height }) | - |  |
 | bordered | 是否有边框 | boolean | true | 4.5.0 |
-| hasCount | 是否显示字数统计 | boolean | false | 4.5.0 |
+| showCount | 是否显示字数统计 | boolean | false | 4.5.0 |
+| maxLength | 最大长度 | number | - | 4.5.0 |
 
 `Input.TextArea` 的其他属性和浏览器自带的 [textarea](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea) 一致。
 

--- a/components/input/index.zh-CN.md
+++ b/components/input/index.zh-CN.md
@@ -51,7 +51,7 @@ Input 的其他属性和 React 自带的 [input](https://facebook.github.io/reac
 | onResize | resize 回调 | function({ width, height }) | - |  |
 | bordered | 是否有边框 | boolean | true | 4.5.0 |
 | showCount | 是否显示字数统计 | boolean | false | 4.5.0 |
-| maxLength | 最大长度 | number | - | 4.5.0 |
+| maxLength | 最大长度 | number | 500 | 4.5.0 |
 
 `Input.TextArea` 的其他属性和浏览器自带的 [textarea](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea) 一致。
 

--- a/components/input/index.zh-CN.md
+++ b/components/input/index.zh-CN.md
@@ -50,7 +50,7 @@ Input 的其他属性和 React 自带的 [input](https://facebook.github.io/reac
 | allowClear | 可以点击清除图标删除内容 | boolean | false |  |
 | onResize | resize 回调 | function({ width, height }) | - |  |
 | bordered | 是否有边框 | boolean | true | 4.5.0 |
-| hasCount | 是否显示字数统计 | boolean | false |  |
+| hasCount | 是否显示字数统计 | boolean | false | 4.5.0 |
 
 `Input.TextArea` 的其他属性和浏览器自带的 [textarea](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea) 一致。
 

--- a/components/input/index.zh-CN.md
+++ b/components/input/index.zh-CN.md
@@ -50,6 +50,7 @@ Input 的其他属性和 React 自带的 [input](https://facebook.github.io/reac
 | allowClear | 可以点击清除图标删除内容 | boolean | false |  |
 | onResize | resize 回调 | function({ width, height }) | - |  |
 | bordered | 是否有边框 | boolean | true | 4.5.0 |
+| hasCount | 是否显示字数统计 | boolean | false |  |
 
 `Input.TextArea` 的其他属性和浏览器自带的 [textarea](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea) 一致。
 

--- a/components/input/style/index.less
+++ b/components/input/style/index.less
@@ -20,6 +20,14 @@
       vertical-align: top; // https://github.com/ant-design/ant-design/issues/6403
     }
   }
+// style for textarea control
+  &-control{
+    position: relative;
+    &-count{
+      float: right;
+      color: @text-color-secondary;
+    }
+  }
 
   &-password-icon {
     color: @text-color-secondary;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->
在业务开发中，经常需要使用到textArea 的计数功能（如：20/100），之前发现antd-mobile有count字数功能，而antd-design没有，就考虑加上一个。
### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

<img width="614" alt="截屏2020-07-19 上午11 54 18" src="https://user-images.githubusercontent.com/13415767/87866617-96d51800-c9b6-11ea-816f-93282346dc99.png">

close #24940


### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed


-----
[View rendered components/input/index.en-US.md](https://github.com/komagic/ant-design/blob/feature/components/input/index.en-US.md)
[View rendered components/input/index.zh-CN.md](https://github.com/komagic/ant-design/blob/feature/components/input/index.zh-CN.md)