### PR TITLE
fix: Collect FormItem errors should be sync with state

### DIFF
--- a/components/form/FormItem.tsx
+++ b/components/form/FormItem.tsx
@@ -144,17 +144,19 @@ function FormItem(props: FormItemProps): React.ReactElement {
     }
 
     // ======================== Errors ========================
+    // >>> collect sub errors
+    let subErrorList: string[] = [];
+    Object.keys(inlineErrors).forEach(subName => {
+      subErrorList = [...subErrorList, ...(inlineErrors[subName] || [])];
+    });
+
+    // >>> merged errors
     let mergedErrors: React.ReactNode[];
     if (help !== undefined && help !== null) {
       mergedErrors = toArray(help);
     } else {
       mergedErrors = meta ? meta.errors : [];
-      Object.keys(inlineErrors).forEach(subName => {
-        const subErrors = inlineErrors[subName] || [];
-        if (subErrors.length) {
-          mergedErrors = [...mergedErrors, ...subErrors];
-        }
-      });
+      mergedErrors = [...mergedErrors, ...subErrorList];
     }
 
     // ======================== Status ========================
@@ -163,7 +165,7 @@ function FormItem(props: FormItemProps): React.ReactElement {
       mergedValidateStatus = validateStatus;
     } else if (meta?.validating) {
       mergedValidateStatus = 'validating';
-    } else if (meta?.errors?.length) {
+    } else if (meta?.errors?.length || subErrorList.length) {
       mergedValidateStatus = 'error';
     } else if (meta?.touched) {
       mergedValidateStatus = 'success';

--- a/components/form/FormItem.tsx
+++ b/components/form/FormItem.tsx
@@ -122,12 +122,15 @@ function FormItem(props: FormItemProps): React.ReactElement {
   const updateChildItemErrors = noStyle
     ? updateItemErrors
     : (subName: string, subErrors: string[]) => {
-        if (!isEqual(inlineErrors[subName], subErrors)) {
-          setInlineErrors(prevInlineErrors => ({
-            ...prevInlineErrors,
-            [subName]: subErrors,
-          }));
-        }
+        setInlineErrors((prevInlineErrors = {}) => {
+          if (!isEqual(prevInlineErrors[subName], subErrors)) {
+            return {
+              ...prevInlineErrors,
+              [subName]: subErrors,
+            };
+          }
+          return prevInlineErrors;
+        });
       };
 
   // ===================== Children Ref =====================

--- a/components/form/__tests__/index.test.js
+++ b/components/form/__tests__/index.test.js
@@ -40,24 +40,78 @@ describe('Form', () => {
     scrollIntoView.mockRestore();
   });
 
-  it('noStyle Form.Item', async () => {
-    const onChange = jest.fn();
+  describe('noStyle Form.Item', () => {
+    it('work', async () => {
+      const onChange = jest.fn();
 
-    const wrapper = mount(
-      <Form>
-        <Form.Item>
-          <Form.Item name="test" rules={[{ required: true }]}>
-            <Input onChange={onChange} />
+      const wrapper = mount(
+        <Form>
+          <Form.Item>
+            <Form.Item name="test" rules={[{ required: true }]}>
+              <Input onChange={onChange} />
+            </Form.Item>
           </Form.Item>
-        </Form.Item>
-      </Form>,
-    );
+        </Form>,
+      );
 
-    await change(wrapper, 0, '');
-    expect(wrapper.find('.ant-form-item-explain').length).toBeTruthy();
-    expect(wrapper.find('.ant-form-item-has-error').length).toBeTruthy();
+      await change(wrapper, 0, '');
+      expect(wrapper.find('.ant-form-item-explain').length).toBeTruthy();
+      expect(wrapper.find('.ant-form-item-has-error').length).toBeTruthy();
 
-    expect(onChange).toHaveBeenCalled();
+      expect(onChange).toHaveBeenCalled();
+    });
+
+    it('should clean up', async () => {
+      const Demo = () => {
+        const [form] = Form.useForm();
+
+        return (
+          <Form form={form} initialValues={{ aaa: '2' }}>
+            <Form.Item name="aaa">
+              <Input
+                onChange={async () => {
+                  await sleep(0);
+                  try {
+                    await form.validateFields();
+                  } catch (e) {
+                    // do nothing
+                  }
+                }}
+              />
+            </Form.Item>
+            <Form.Item shouldUpdate noStyle>
+              {() => {
+                const aaa = form.getFieldValue('aaa');
+
+                if (aaa === '1') {
+                  return (
+                    <Form.Item name="bbb" rules={[{ required: true, message: 'aaa' }]}>
+                      <Input />
+                    </Form.Item>
+                  );
+                }
+
+                return (
+                  <Form.Item>
+                    <Form.Item name="ccc" rules={[{ required: true, message: 'ccc' }]} noStyle>
+                      <Input />
+                    </Form.Item>
+                  </Form.Item>
+                );
+              }}
+            </Form.Item>
+          </Form>
+        );
+      };
+
+      const wrapper = mount(<Demo />);
+      await change(wrapper, 0, '1');
+      expect(wrapper.find('.ant-form-item-explain').text()).toEqual('aaa');
+      await change(wrapper, 0, '2');
+      expect(wrapper.find('.ant-form-item-explain').text()).toEqual('ccc');
+      await change(wrapper, 0, '1');
+      expect(wrapper.find('.ant-form-item-explain').text()).toEqual('aaa');
+    });
   });
 
   it('`shouldUpdate` should work with render props', () => {

--- a/components/form/__tests__/index.test.js
+++ b/components/form/__tests__/index.test.js
@@ -54,7 +54,8 @@ describe('Form', () => {
     );
 
     await change(wrapper, 0, '');
-    expect(wrapper.find('.ant-form-item-explain').length).toBe(1);
+    expect(wrapper.find('.ant-form-item-explain').length).toBeTruthy();
+    expect(wrapper.find('.ant-form-item-has-error').length).toBeTruthy();
 
     expect(onChange).toHaveBeenCalled();
   });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

resolve #25705

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Fix FormItem sometime not clean up prev error message.       |
| 🇨🇳 Chinese |   修复 FormItem 有时候没有清理之前的错误信息的问题。       |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
