### PR TITLE
Fix: deprecated children prop in rc-tree

### DIFF
--- a/components/tree/DirectoryTree.tsx
+++ b/components/tree/DirectoryTree.tsx
@@ -35,6 +35,10 @@ function getTreeData({ treeData, children }: DirectoryTreeProps) {
   return treeData || convertTreeToData(children);
 }
 
+function getPropsWithoutChildren({ children: _, ...props }: DirectoryTreeProps) {
+  return props;
+}
+
 const DirectoryTree: React.FC<DirectoryTreeProps> = ({
   defaultExpandAll,
   defaultExpandParent,
@@ -222,7 +226,8 @@ const DirectoryTree: React.FC<DirectoryTreeProps> = ({
       icon={getIcon}
       ref={ref}
       blockNode
-      {...otherProps}
+      treeData={getTreeData(props)}
+      {...getPropsWithoutChildren(otherProps)}
       prefixCls={prefixCls}
       className={connectClassName}
       expandedKeys={expandedKeys}


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [x] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
nothing.
<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution
I thought children is passed to rc-tree, but children prop is deprecated T_T.
I found the solution that omit the children prop and inject treeData. 
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog
children prop will not passed to rc-tree.
<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | children prop will not passed to rc-tree.          |
| 🇨🇳 Chinese | 兒童支柱不會傳遞到rc-tree.          |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
