### PR TITLE
chore: Update rc-tree deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
     "rc-tabs": "~11.5.0",
     "rc-textarea": "~0.3.0",
     "rc-tooltip": "~4.2.0",
-    "rc-tree": "~3.7.0",
+    "rc-tree": "~3.8.0",
     "rc-tree-select": "~4.0.2",
     "rc-trigger": "~4.3.0",
     "rc-upload": "~3.2.0",


### PR DESCRIPTION
`rc-tree@3.8.x` 没有任何更新，之前发布错回滚发了一个 patch 上去。可以放心合并。