### PR TITLE
fix(radio): build site failed in webpack@4.44.0

### DIFF
--- a/components/radio/index.tsx
+++ b/components/radio/index.tsx
@@ -3,7 +3,15 @@ import Group from './group';
 import Button from './radioButton';
 import { RadioProps } from './interface';
 
-export * from './interface';
+export {
+  RadioGroupButtonStyle,
+  RadioGroupOptionType,
+  RadioGroupProps,
+  RadioGroupContextProps,
+  RadioProps,
+  RadioChangeEventTarget,
+  RadioChangeEvent,
+} from './interface';
 interface CompoundedComponent
   extends React.ForwardRefExoticComponent<RadioProps & React.RefAttributes<HTMLElement>> {
   Group: typeof Group;

--- a/package.json
+++ b/package.json
@@ -278,7 +278,6 @@
     "theme-switcher": "^1.0.2",
     "typescript": "~3.9.2",
     "webpack-bundle-analyzer": "^3.6.0",
-    "webpack": "~4.43.0",
     "xhr-mock": "^2.4.1",
     "xhr2": "^0.2.0",
     "yaml-front-matter": "^4.0.0"


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

fix `Radio` build site failed in `webpack@4.40.0`

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Radio cannot render in `webpack@4.44.0`. |
| 🇨🇳 Chinese | 修复 Radio 在 `webpack@4.44.0` 下无法使用的问题。 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
