### PR TITLE
feat: add de_DE localisation for defaultValidateMessages for Form Component

### DIFF
--- a/components/locale/de_DE.tsx
+++ b/components/locale/de_DE.tsx
@@ -1,8 +1,11 @@
+/* eslint-disable no-template-curly-in-string */
 import Pagination from 'rc-pagination/lib/locale/de_DE';
 import DatePicker from '../date-picker/locale/de_DE';
 import TimePicker from '../time-picker/locale/de_DE';
 import Calendar from '../calendar/locale/de_DE';
 import { Locale } from '../locale-provider';
+
+const typeTemplate = '${label} ist nicht gültig. ${type} erwartet';
 
 const localeValues: Locale = {
   locale: 'de',
@@ -23,9 +26,9 @@ const localeValues: Locale = {
     sortTitle: 'Sortieren',
     expand: 'Zeile erweitern',
     collapse: 'Zeile reduzieren',
-    triggerDesc: '﻿Klicken zur absteigenden  Sortierung',
-    triggerAsc: '﻿Klicken zur aufsteigenden Sortierung',
-    cancelSort: '﻿Klicken zum Abbrechen der Sortierung',
+    triggerDesc: 'Klicken zur absteigenden  Sortierung',
+    triggerAsc: 'Klicken zur aufsteigenden Sortierung',
+    cancelSort: 'Klicken zum Abbrechen der Sortierung',
   },
   Modal: {
     okText: 'OK',
@@ -59,6 +62,55 @@ const localeValues: Locale = {
   },
   PageHeader: {
     back: 'Zurück',
+  },
+  Form: {
+    defaultValidateMessages: {
+      default: 'Feld-Validierungsfehler: ${label}',
+      required: 'Bitte geben Sie ${label} an',
+      enum: '${label} muss eines der folgenden sein [${enum}]',
+      whitespace: '${label} darf kein Leerzeichen sein',
+      date: {
+        format: '${label} ist ein ungültiges Datumsformat',
+        parse: '${label} kann nicht in ein Datum umgewandelt werden',
+        invalid: '${label} ist ein ungültiges Datum',
+      },
+      types: {
+        string: typeTemplate,
+        method: typeTemplate,
+        array: typeTemplate,
+        object: typeTemplate,
+        number: typeTemplate,
+        date: typeTemplate,
+        boolean: typeTemplate,
+        integer: typeTemplate,
+        float: typeTemplate,
+        regexp: typeTemplate,
+        email: typeTemplate,
+        url: typeTemplate,
+        hex: typeTemplate,
+      },
+      string: {
+        len: '${label} muss genau ${len} Zeichen lang sein',
+        min: '${label} muss mindestens ${min} Zeichen lang sein',
+        max: '${label} darf höchstens ${max} Zeichen lang sein',
+        range: '${label} muss zwischen ${min} und ${max} Zeichen lang sein',
+      },
+      number: {
+        len: '${label} muss gleich ${len} sein',
+        min: '${label} muss mindestens ${min} sein',
+        max: '${label} darf maximal ${max} sein',
+        range: '${label} muss zwischen ${min} und ${max} liegen',
+      },
+      array: {
+        len: 'Es müssen ${len} ${label} sein',
+        min: 'Es müssen mindestens ${min} ${label} sein',
+        max: 'Es dürfen maximal ${max} ${label} sein',
+        range: 'Die Anzahl an ${label} muss zwischen ${min} und ${max} liegen',
+      },
+      pattern: {
+        mismatch: '${label} enspricht nicht dem ${pattern} Muster',
+      },
+    },
   },
 };
 


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [x] Other (about what?)

### 🔗 Related issue link
#23369 
<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution
Adds default form validation messages in german (deDE) to the form component 

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    added german translations for default form validation messages    |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
