### PR TITLE
fix: slider default tooltipplacement in rtl

### DIFF
--- a/components/slider/index.tsx
+++ b/components/slider/index.tsx
@@ -78,6 +78,16 @@ const Slider = React.forwardRef<unknown, SliderSingleProps | SliderRangeProps>((
     setVisibles(temp);
   };
 
+  const getTooltipPlacement = (tooltipPlacement?: TooltipPlacement, vertical?: boolean) => {
+    if (tooltipPlacement) {
+      return tooltipPlacement;
+    }
+    if (!vertical) {
+      return 'top';
+    }
+    return direction === 'rtl' ? 'left' : 'right';
+  };
+
   const handleWithTooltip: HandleGeneratorFn = ({
     tooltipPrefixCls,
     prefixCls,
@@ -97,7 +107,7 @@ const Slider = React.forwardRef<unknown, SliderSingleProps | SliderRangeProps>((
         prefixCls={tooltipPrefixCls}
         title={tipFormatter ? tipFormatter(value) : ''}
         visible={visible}
-        placement={tooltipPlacement || (vertical ? 'right' : 'top')}
+        placement={getTooltipPlacement(tooltipPlacement, vertical)}
         transitionName="zoom-down"
         key={index}
         overlayClassName={`${prefixCls}-tooltip`}


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed the default `tooltipPlacement` for vertical Slider in RTL mode.   |
| 🇨🇳 Chinese | 修复垂直方向 Slider 在 RTL 模式下默认的 `tooltipPlacement`。         |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
