### PR TITLE
feat: customize Typography.Paragraph copyable and editable

### DIFF
--- a/components/typography/Base.tsx
+++ b/components/typography/Base.tsx
@@ -384,7 +384,7 @@ class Base extends React.Component<InternalBlockProps, BaseState> {
     const prefixCls = this.getPrefixCls();
 
     const { tooltips } = copyable as CopyConfig;
-    let title: string | React.ReactNode = '';
+    let title: React.ReactNode = '';
     if (tooltips !== false) {
       const tooltipNodes = toArray(tooltips);
       title = copied ? tooltipNodes[1] || this.copiedStr : tooltipNodes[0] || this.copyStr;

--- a/components/typography/Base.tsx
+++ b/components/typography/Base.tsx
@@ -28,8 +28,8 @@ const isTextOverflowSupport = isStyleSupport('textOverflow');
 interface CopyConfig {
   text?: string;
   onCopy?: () => void;
-  icon?: React.ReactNode | Array<React.ReactNode>;
-  tooltips?: boolean | Array<React.ReactNode>;
+  icon?: React.ReactNode;
+  tooltips?: boolean | React.ReactNode;
 }
 
 interface EditConfig {
@@ -384,25 +384,18 @@ class Base extends React.Component<InternalBlockProps, BaseState> {
     const prefixCls = this.getPrefixCls();
 
     const { tooltips } = copyable as CopyConfig;
-
     let title: string | React.ReactNode = '';
     if (Array.isArray(tooltips)) {
-      title = copied
-        ? (tooltips as Array<React.ReactNode>)[1] || this.copiedStr
-        : (tooltips as Array<React.ReactNode>)[0] || this.copyStr;
-    } else if (typeof tooltips === 'undefined' || tooltips) {
+      const tooltipsNode = toArray(tooltips);
+      title = copied ? tooltipsNode[1] || this.copiedStr : tooltipsNode[0] || this.copyStr;
+    } else if (tooltips === undefined || tooltips) {
       title = copied ? this.copiedStr : this.copyStr;
     } else {
       title = '';
     }
 
     const ariaLabel = typeof title === 'string' ? title : '';
-
-    const icons = Array.isArray((copyable as CopyConfig).icon)
-      ? (copyable as CopyConfig).icon
-      : [(copyable as CopyConfig).icon];
-    const copyIcon = (icons as Array<React.ReactNode>)[0] || <CopyOutlined />;
-    const copiedIcon = (icons as Array<React.ReactNode>)[1] || <CheckOutlined />;
+    const icons = toArray((copyable as CopyConfig).icon);
 
     return (
       <Tooltip key="copy" title={title}>
@@ -411,7 +404,7 @@ class Base extends React.Component<InternalBlockProps, BaseState> {
           onClick={this.onCopyClick}
           aria-label={ariaLabel}
         >
-          {copied ? copiedIcon : copyIcon}
+          {copied ? icons[1] || <CheckOutlined /> : icons[0] || <CopyOutlined />}
         </TransButton>
       </Tooltip>
     );

--- a/components/typography/Base.tsx
+++ b/components/typography/Base.tsx
@@ -390,8 +390,6 @@ class Base extends React.Component<InternalBlockProps, BaseState> {
       title = copied ? tooltipsNode[1] || this.copiedStr : tooltipsNode[0] || this.copyStr;
     } else if (tooltips === undefined || tooltips) {
       title = copied ? this.copiedStr : this.copyStr;
-    } else {
-      title = '';
     }
 
     const ariaLabel = typeof title === 'string' ? title : '';

--- a/components/typography/Base.tsx
+++ b/components/typography/Base.tsx
@@ -385,11 +385,9 @@ class Base extends React.Component<InternalBlockProps, BaseState> {
 
     const { tooltips } = copyable as CopyConfig;
     let title: string | React.ReactNode = '';
-    if (Array.isArray(tooltips)) {
-      const tooltipsNode = toArray(tooltips);
-      title = copied ? tooltipsNode[1] || this.copiedStr : tooltipsNode[0] || this.copyStr;
-    } else if (tooltips === undefined || tooltips) {
-      title = copied ? this.copiedStr : this.copyStr;
+    if (tooltips !== false) {
+      const tooltipNodes = toArray(tooltips);
+      title = copied ? tooltipNodes[1] || this.copiedStr : tooltipNodes[0] || this.copyStr;
     }
 
     const ariaLabel = typeof title === 'string' ? title : '';

--- a/components/typography/Base.tsx
+++ b/components/typography/Base.tsx
@@ -34,6 +34,8 @@ interface CopyConfig {
 
 interface EditConfig {
   editing?: boolean;
+  icon?: React.ReactNode;
+  tooltip?: boolean | React.ReactNode;
   onStart?: () => void;
   onChange?: (value: string) => void;
   maxLength?: number;
@@ -362,15 +364,20 @@ class Base extends React.Component<InternalBlockProps, BaseState> {
     const { editable } = this.props;
     if (!editable) return;
 
+    const { icon, tooltip } = editable as EditConfig;
+
+    const title = toArray(tooltip)[0] || this.editStr;
+    const ariaLabel = typeof title === 'string' ? title : '';
+
     return (
-      <Tooltip key="edit" title={this.editStr}>
+      <Tooltip key="edit" title={tooltip === false ? '' : title}>
         <TransButton
           ref={this.setEditRef}
           className={`${this.getPrefixCls()}-edit`}
           onClick={this.onEditClick}
-          aria-label={this.editStr}
+          aria-label={ariaLabel}
         >
-          <EditOutlined role="button" />
+          {icon || <EditOutlined role="button" />}
         </TransButton>
       </Tooltip>
     );
@@ -384,17 +391,14 @@ class Base extends React.Component<InternalBlockProps, BaseState> {
     const prefixCls = this.getPrefixCls();
 
     const { tooltips } = copyable as CopyConfig;
-    let title: React.ReactNode = '';
-    if (tooltips !== false) {
-      const tooltipNodes = toArray(tooltips);
-      title = copied ? tooltipNodes[1] || this.copiedStr : tooltipNodes[0] || this.copyStr;
-    }
+    const tooltipNodes = toArray(tooltips);
+    const title = copied ? tooltipNodes[1] || this.copiedStr : tooltipNodes[0] || this.copyStr;
 
     const ariaLabel = typeof title === 'string' ? title : '';
     const icons = toArray((copyable as CopyConfig).icon);
 
     return (
-      <Tooltip key="copy" title={title}>
+      <Tooltip key="copy" title={tooltips === false ? '' : title}>
         <TransButton
           className={classNames(`${prefixCls}-copy`, copied && `${prefixCls}-copy-success`)}
           onClick={this.onCopyClick}

--- a/components/typography/Base.tsx
+++ b/components/typography/Base.tsx
@@ -28,8 +28,8 @@ const isTextOverflowSupport = isStyleSupport('textOverflow');
 interface CopyConfig {
   text?: string;
   onCopy?: () => void;
-  icon?: React.ReactNode;
-  tooltips?: [React.ReactNode, React.ReactNode];
+  icon?: React.ReactNode | Array<React.ReactNode>;
+  tooltips?: boolean | Array<React.ReactNode>;
 }
 
 interface EditConfig {
@@ -383,11 +383,26 @@ class Base extends React.Component<InternalBlockProps, BaseState> {
 
     const prefixCls = this.getPrefixCls();
 
-    const title = copied
-      ? (copyable as CopyConfig).tooltips?.[1] || this.copiedStr
-      : (copyable as CopyConfig).tooltips?.[0] || this.copyStr;
+    const { tooltips } = copyable as CopyConfig;
+
+    let title: string | React.ReactNode = '';
+    if (Array.isArray(tooltips)) {
+      title = copied
+        ? (tooltips as Array<React.ReactNode>)[1] || this.copiedStr
+        : (tooltips as Array<React.ReactNode>)[0] || this.copyStr;
+    } else if (typeof tooltips === 'undefined' || tooltips) {
+      title = copied ? this.copiedStr : this.copyStr;
+    } else {
+      title = '';
+    }
 
     const ariaLabel = typeof title === 'string' ? title : '';
+
+    const icons = Array.isArray((copyable as CopyConfig).icon)
+      ? (copyable as CopyConfig).icon
+      : [(copyable as CopyConfig).icon];
+    const copyIcon = (icons as Array<React.ReactNode>)[0] || <CopyOutlined />;
+    const copiedIcon = (icons as Array<React.ReactNode>)[1] || <CheckOutlined />;
 
     return (
       <Tooltip key="copy" title={title}>
@@ -396,7 +411,7 @@ class Base extends React.Component<InternalBlockProps, BaseState> {
           onClick={this.onCopyClick}
           aria-label={ariaLabel}
         >
-          {copied ? <CheckOutlined /> : (copyable as CopyConfig).icon || <CopyOutlined />}
+          {copied ? copiedIcon : copyIcon}
         </TransButton>
       </Tooltip>
     );

--- a/components/typography/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/typography/__tests__/__snapshots__/demo.test.js.snap
@@ -362,6 +362,73 @@ Array [
   <div
     class="ant-typography"
   >
+    Custom Edit icon and replace tooltip text.
+    <div
+      aria-label="click to edit text"
+      class="ant-typography-edit"
+      role="button"
+      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-block"
+      tabindex="0"
+    >
+      <span
+        aria-label="highlight"
+        class="anticon anticon-highlight"
+        role="img"
+      >
+        <svg
+          aria-hidden="true"
+          class=""
+          data-icon="highlight"
+          fill="currentColor"
+          focusable="false"
+          height="1em"
+          viewBox="64 64 896 896"
+          width="1em"
+        >
+          <path
+            d="M957.6 507.4L603.2 158.2a7.9 7.9 0 00-11.2 0L353.3 393.4a8.03 8.03 0 00-.1 11.3l.1.1 40 39.4-117.2 115.3a8.03 8.03 0 00-.1 11.3l.1.1 39.5 38.9-189.1 187H72.1c-4.4 0-8.1 3.6-8.1 8V860c0 4.4 3.6 8 8 8h344.9c2.1 0 4.1-.8 5.6-2.3l76.1-75.6 40.4 39.8a7.9 7.9 0 0011.2 0l117.1-115.6 40.1 39.5a7.9 7.9 0 0011.2 0l238.7-235.2c3.4-3 3.4-8 .3-11.2zM389.8 796.2H229.6l134.4-133 80.1 78.9-54.3 54.1zm154.8-62.1L373.2 565.2l68.6-67.6 171.4 168.9-68.6 67.6zM713.1 658L450.3 399.1 597.6 254l262.8 259-147.3 145z"
+          />
+        </svg>
+      </span>
+    </div>
+  </span>,
+  <br />,
+  <span
+    class="ant-typography"
+  >
+    Hide Edit tooltip.
+    <div
+      aria-label="Edit"
+      class="ant-typography-edit"
+      role="button"
+      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-block"
+      tabindex="0"
+    >
+      <span
+        aria-label="edit"
+        class="anticon anticon-edit"
+        role="button"
+      >
+        <svg
+          aria-hidden="true"
+          class=""
+          data-icon="edit"
+          fill="currentColor"
+          focusable="false"
+          height="1em"
+          viewBox="64 64 896 896"
+          width="1em"
+        >
+          <path
+            d="M257.7 752c2 0 4-.2 6-.5L431.9 722c2-.4 3.9-1.3 5.3-2.8l423.9-423.9a9.96 9.96 0 000-14.1L694.9 114.9c-1.9-1.9-4.4-2.9-7.1-2.9s-5.2 1-7.1 2.9L256.8 538.8c-1.5 1.5-2.4 3.3-2.8 5.3l-29.5 168.2a33.5 33.5 0 009.4 29.8c6.6 6.4 14.9 9.9 23.8 9.9zm67.4-174.4L687.8 215l73.3 73.3-362.7 362.6-88.9 15.7 15.6-89zM880 836H144c-17.7 0-32 14.3-32 32v36c0 4.4 3.6 8 8 8h784c4.4 0 8-3.6 8-8v-36c0-17.7-14.3-32-32-32z"
+          />
+        </svg>
+      </span>
+    </div>
+  </div>,
+  <div
+    class="ant-typography"
+  >
     This is an editable text with limited length.
     <div
       aria-label="Edit"
@@ -457,13 +524,14 @@ Array [
         </svg>
       </span>
     </div>
-  </div>,
-  <div
+  </span>,
+  <br />,
+  <span
     class="ant-typography"
   >
-    Custom icon.
+    Custom Copy icon and replace tooltips text.
     <div
-      aria-label="Copy"
+      aria-label="click here"
       class="ant-typography-copy"
       role="button"
       style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-block"
@@ -492,46 +560,12 @@ Array [
     </div>
   </span>,
   <br />,
-  <span
-    class="ant-typography"
-  >
-    Replace tooltips text.
-    <div
-      aria-label="click here"
-      class="ant-typography-copy"
-      role="button"
-      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-block"
-      tabindex="0"
-    >
-      <span
-        aria-label="copy"
-        class="anticon anticon-copy"
-        role="img"
-      >
-        <svg
-          aria-hidden="true"
-          class=""
-          data-icon="copy"
-          fill="currentColor"
-          focusable="false"
-          height="1em"
-          viewBox="64 64 896 896"
-          width="1em"
-        >
-          <path
-            d="M832 64H296c-4.4 0-8 3.6-8 8v56c0 4.4 3.6 8 8 8h496v688c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8V96c0-17.7-14.3-32-32-32zM704 192H192c-17.7 0-32 14.3-32 32v530.7c0 8.5 3.4 16.6 9.4 22.6l173.3 173.3c2.2 2.2 4.7 4 7.4 5.5v1.9h4.2c3.5 1.3 7.2 2 11 2H704c17.7 0 32-14.3 32-32V224c0-17.7-14.3-32-32-32zM350 856.2L263.9 770H350v86.2zM664 888H414V746c0-22.1-17.9-40-40-40H232V264h432v624z"
-          />
-        </svg>
-      </span>
-    </div>
-  </span>,
-  <br />,
   <div
     class="ant-typography"
   >
-    Hide tooltips.
+    Hide Copy tooltips.
     <div
-      aria-label=""
+      aria-label="Copy"
       class="ant-typography-copy"
       role="button"
       style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-block"

--- a/components/typography/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/typography/__tests__/__snapshots__/demo.test.js.snap
@@ -391,9 +391,8 @@ Array [
         </svg>
       </span>
     </div>
-  </span>,
-  <br />,
-  <span
+  </div>,
+  <div
     class="ant-typography"
   >
     Hide Edit tooltip.
@@ -524,9 +523,8 @@ Array [
         </svg>
       </span>
     </div>
-  </span>,
-  <br />,
-  <span
+  </div>,
+  <div
     class="ant-typography"
   >
     Custom Copy icon and replace tooltips text.
@@ -558,8 +556,7 @@ Array [
         </svg>
       </span>
     </div>
-  </span>,
-  <br />,
+  </div>,
   <div
     class="ant-typography"
   >

--- a/components/typography/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/typography/__tests__/__snapshots__/demo.test.js.snap
@@ -43,7 +43,7 @@ exports[`renders ./components/typography/demo/basic.md correctly 1`] = `
         Sketch
       </code>
     </span>
-     and
+     and 
     <span
       class="ant-typography"
     >
@@ -83,7 +83,7 @@ exports[`renders ./components/typography/demo/basic.md correctly 1`] = `
   <div
     class="ant-typography"
   >
-    Press
+    Press 
     <span
       class="ant-typography"
     >
@@ -298,7 +298,7 @@ Array [
   <div
     class="ant-typography ant-typography-ellipsis"
   >
-    Ant Design, a design language for background applications, is refined by Ant UED Team. This is a nest sample
+    Ant Design, a design language for background applications, is refined by Ant UED Team. This is a nest sample 
     <span
       class="ant-typography"
     >
@@ -634,7 +634,7 @@ Array [
         Sketch
       </code>
     </span>
-     and
+     and 
     <span
       class="ant-typography"
     >

--- a/components/typography/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/typography/__tests__/__snapshots__/demo.test.js.snap
@@ -43,7 +43,7 @@ exports[`renders ./components/typography/demo/basic.md correctly 1`] = `
         Sketch
       </code>
     </span>
-     and 
+     and
     <span
       class="ant-typography"
     >
@@ -83,7 +83,7 @@ exports[`renders ./components/typography/demo/basic.md correctly 1`] = `
   <div
     class="ant-typography"
   >
-    Press 
+    Press
     <span
       class="ant-typography"
     >
@@ -298,7 +298,7 @@ Array [
   <div
     class="ant-typography ant-typography-ellipsis"
   >
-    Ant Design, a design language for background applications, is refined by Ant UED Team. This is a nest sample 
+    Ant Design, a design language for background applications, is refined by Ant UED Team. This is a nest sample
     <span
       class="ant-typography"
     >
@@ -490,13 +490,48 @@ Array [
         </svg>
       </span>
     </div>
-  </div>,
-  <div
+  </span>,
+  <br />,
+  <span
     class="ant-typography"
   >
     Replace tooltips text.
     <div
       aria-label="click here"
+      class="ant-typography-copy"
+      role="button"
+      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-block"
+      tabindex="0"
+    >
+      <span
+        aria-label="copy"
+        class="anticon anticon-copy"
+        role="img"
+      >
+        <svg
+          aria-hidden="true"
+          class=""
+          data-icon="copy"
+          fill="currentColor"
+          focusable="false"
+          height="1em"
+          viewBox="64 64 896 896"
+          width="1em"
+        >
+          <path
+            d="M832 64H296c-4.4 0-8 3.6-8 8v56c0 4.4 3.6 8 8 8h496v688c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8V96c0-17.7-14.3-32-32-32zM704 192H192c-17.7 0-32 14.3-32 32v530.7c0 8.5 3.4 16.6 9.4 22.6l173.3 173.3c2.2 2.2 4.7 4 7.4 5.5v1.9h4.2c3.5 1.3 7.2 2 11 2H704c17.7 0 32-14.3 32-32V224c0-17.7-14.3-32-32-32zM350 856.2L263.9 770H350v86.2zM664 888H414V746c0-22.1-17.9-40-40-40H232V264h432v624z"
+          />
+        </svg>
+      </span>
+    </div>
+  </span>,
+  <br />,
+  <div
+    class="ant-typography"
+  >
+    Hide tooltips.
+    <div
+      aria-label=""
       class="ant-typography-copy"
       role="button"
       style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-block"
@@ -568,7 +603,7 @@ Array [
         Sketch
       </code>
     </span>
-     and 
+     and
     <span
       class="ant-typography"
     >

--- a/components/typography/__tests__/index.test.js
+++ b/components/typography/__tests__/index.test.js
@@ -221,7 +221,7 @@ describe('Typography', () => {
             expect(wrapper.find('.anticon-copy').length).toBeTruthy();
           }
 
-          if (tooltips === undefined) {
+          if (tooltips === undefined || tooltips === true) {
             expect(wrapper.find('.ant-typography-copy').first().props()['aria-label']).toBe('Copy');
           } else if (tooltips === false) {
             expect(wrapper.find('.ant-typography-copy').first().props()['aria-label']).toBe('');
@@ -246,7 +246,7 @@ describe('Typography', () => {
 
           expect(wrapper.find(copiedIcon).length).toBeTruthy();
 
-          if (tooltips === undefined) {
+          if (tooltips === undefined || tooltips === true) {
             expect(wrapper.find('.ant-typography-copy').first().props()['aria-label']).toBe(
               'Copied',
             );
@@ -275,6 +275,7 @@ describe('Typography', () => {
         <SmileOutlined key="copy-icon" />,
         <LikeOutlined key="copied-icon" />,
       ]);
+      copyTest('customize copy', 'bamboo', 'bamboo', undefined, true);
       copyTest('customize copy', 'bamboo', 'bamboo', undefined, false);
       copyTest('customize copy', 'bamboo', 'bamboo', undefined, ['click here', 'you clicked!!']);
     });

--- a/components/typography/__tests__/index.test.js
+++ b/components/typography/__tests__/index.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { mount } from 'enzyme';
+import { SmileOutlined, LikeOutlined } from '@ant-design/icons';
 import KeyCode from 'rc-util/lib/KeyCode';
 import copy from 'copy-to-clipboard';
 import Title from '../Title';
@@ -204,15 +205,31 @@ describe('Typography', () => {
     });
 
     describe('copyable', () => {
-      function copyTest(name, text, target) {
+      function copyTest(name, text, target, icon, tooltips) {
         it(name, () => {
           jest.useFakeTimers();
           const onCopy = jest.fn();
           const wrapper = mount(
-            <Base component="p" copyable={{ text, onCopy }}>
+            <Base component="p" copyable={{ text, onCopy, icon, tooltips }}>
               test copy
             </Base>,
           );
+
+          if (icon) {
+            expect(wrapper.find('.anticon-smile').length).toBeTruthy();
+          } else {
+            expect(wrapper.find('.anticon-copy').length).toBeTruthy();
+          }
+
+          if (tooltips === undefined) {
+            expect(wrapper.find('.ant-typography-copy').first().props()['aria-label']).toBe('Copy');
+          } else if (tooltips === false) {
+            expect(wrapper.find('.ant-typography-copy').first().props()['aria-label']).toBe('');
+          } else {
+            expect(wrapper.find('.ant-typography-copy').first().props()['aria-label']).toBe(
+              tooltips[0],
+            );
+          }
 
           wrapper.find('.ant-typography-copy').first().simulate('click');
           expect(copy.lastStr).toEqual(target);
@@ -220,19 +237,46 @@ describe('Typography', () => {
           wrapper.update();
           expect(onCopy).toHaveBeenCalled();
 
-          expect(wrapper.find('.anticon-check').length).toBeTruthy();
+          let copiedIcon = '.anticon-check';
+          if (icon && icon.length > 1) {
+            copiedIcon = '.anticon-like';
+          } else {
+            copiedIcon = '.anticon-check';
+          }
+
+          expect(wrapper.find(copiedIcon).length).toBeTruthy();
+
+          if (tooltips === undefined) {
+            expect(wrapper.find('.ant-typography-copy').first().props()['aria-label']).toBe(
+              'Copied',
+            );
+          } else if (tooltips === false) {
+            expect(wrapper.find('.ant-typography-copy').first().props()['aria-label']).toBe('');
+          } else {
+            expect(wrapper.find('.ant-typography-copy').first().props()['aria-label']).toBe(
+              tooltips[1],
+            );
+          }
 
           jest.runAllTimers();
           wrapper.update();
 
           // Will set back when 3 seconds pass
-          expect(wrapper.find('.anticon-check').length).toBeFalsy();
+          expect(wrapper.find(copiedIcon).length).toBeFalsy();
           jest.useRealTimers();
         });
       }
 
       copyTest('basic copy', undefined, 'test copy');
       copyTest('customize copy', 'bamboo', 'bamboo');
+      copyTest('customize copy', 'bamboo', 'bamboo', <SmileOutlined />);
+      copyTest('customize copy', 'bamboo', 'bamboo', [<SmileOutlined key="copy-icon" />]);
+      copyTest('customize copy', 'bamboo', 'bamboo', [
+        <SmileOutlined key="copy-icon" />,
+        <LikeOutlined key="copied-icon" />,
+      ]);
+      copyTest('customize copy', 'bamboo', 'bamboo', undefined, false);
+      copyTest('customize copy', 'bamboo', 'bamboo', undefined, ['click here', 'you clicked!!']);
     });
 
     describe('editable', () => {

--- a/components/typography/demo/interactive.md
+++ b/components/typography/demo/interactive.md
@@ -57,13 +57,11 @@ class Demo extends React.Component {
           }}
         >
           {this.state.customIconStr}
-        </Text>
-        <br />
-        <Text editable={{ tooltip: false, onChange: this.onHideTooltipStrChange }}>
+        </Paragraph>
+        <Paragraph editable={{ tooltip: false, onChange: this.onHideTooltipStrChange }}>
           {this.state.hideTooltipStr}
-        </Text>
-        <br />
-        <Text
+        </Paragraph>
+        <Paragraph
           editable={{
             onChange: this.onLengthLimitedStrChange,
             maxLength: 50,
@@ -71,21 +69,17 @@ class Demo extends React.Component {
           }}
         >
           {this.state.lengthLimitedStr}
-        </Text>
-        <br />
-        <Text copyable>This is a copyable text.</Text>
-        <br />
-        <Text copyable={{ text: 'Hello, Ant Design!' }}>Replace copy text.</Text>
-        <br />
-        <Text
+        </Paragraph>
+        <Paragraph copyable>This is a copyable text.</Paragraph>
+        <Paragraph copyable={{ text: 'Hello, Ant Design!' }}>Replace copy text.</Paragraph>
+        <Paragraph
           copyable={{
             icon: [<SmileOutlined key="copy-icon" />, <SmileFilled key="copied-icon" />],
             tooltips: ['click here', 'you clicked!!'],
           }}
         >
           Custom Copy icon and replace tooltips text.
-        </Text>
-        <br />
+        </Paragraph>
         <Paragraph copyable={{ tooltips: false }}>Hide Copy tooltips.</Paragraph>
       </>
     );

--- a/components/typography/demo/interactive.md
+++ b/components/typography/demo/interactive.md
@@ -15,19 +15,29 @@ Provide additional interactive capacity of editable and copyable.
 
 ```jsx
 import { Typography } from 'antd';
-import { SmileOutlined, SmileFilled } from '@ant-design/icons';
+import { HighlightOutlined, SmileOutlined, SmileFilled } from '@ant-design/icons';
 
 const { Paragraph } = Typography;
 
 class Demo extends React.Component {
   state = {
     str: 'This is an editable text.',
+    customIconStr: 'Custom Edit icon and replace tooltip text.',
+    hideTooltipStr: 'Hide Edit tooltip.',
     lengthLimitedStr: 'This is an editable text with limited length.',
   };
 
   onChange = str => {
     console.log('Content change:', str);
     this.setState({ str });
+  };
+
+  onCustomIconStrChange = customIconStr => {
+    this.setState({ customIconStr });
+  };
+
+  onHideTooltipStrChange = hideTooltipStr => {
+    this.setState({ hideTooltipStr });
   };
 
   onLengthLimitedStrChange = lengthLimitedStr => {
@@ -40,6 +50,20 @@ class Demo extends React.Component {
       <>
         <Paragraph editable={{ onChange: this.onChange }}>{this.state.str}</Paragraph>
         <Paragraph
+          editable={{
+            icon: <HighlightOutlined />,
+            tooltip: ['click to edit text'],
+            onChange: this.onCustomIconStrChange,
+          }}
+        >
+          {this.state.customIconStr}
+        </Text>
+        <br />
+        <Text editable={{ tooltip: false, onChange: this.onHideTooltipStrChange }}>
+          {this.state.hideTooltipStr}
+        </Text>
+        <br />
+        <Text
           editable={{
             onChange: this.onLengthLimitedStrChange,
             maxLength: 50,
@@ -56,14 +80,13 @@ class Demo extends React.Component {
         <Text
           copyable={{
             icon: [<SmileOutlined key="copy-icon" />, <SmileFilled key="copied-icon" />],
+            tooltips: ['click here', 'you clicked!!'],
           }}
         >
-          Custom icon.
+          Custom Copy icon and replace tooltips text.
         </Text>
         <br />
-        <Text copyable={{ tooltips: ['click here', 'you clicked!!'] }}>Replace tooltips text.</Text>
-        <br />
-        <Paragraph copyable={{ tooltips: false }}>Hide tooltips.</Paragraph>
+        <Paragraph copyable={{ tooltips: false }}>Hide Copy tooltips.</Paragraph>
       </>
     );
   }

--- a/components/typography/demo/interactive.md
+++ b/components/typography/demo/interactive.md
@@ -45,7 +45,6 @@ class Demo extends React.Component {
   };
 
   render() {
-    const { lengthLimitedStr } = this.state;
     return (
       <>
         <Paragraph editable={{ onChange: this.onChange }}>{this.state.str}</Paragraph>

--- a/components/typography/demo/interactive.md
+++ b/components/typography/demo/interactive.md
@@ -14,76 +14,58 @@ title:
 Provide additional interactive capacity of editable and copyable.
 
 ```jsx
+import React, { useState } from 'react';
 import { Typography } from 'antd';
 import { HighlightOutlined, SmileOutlined, SmileFilled } from '@ant-design/icons';
 
 const { Paragraph } = Typography;
 
-class Demo extends React.Component {
-  state = {
-    str: 'This is an editable text.',
-    customIconStr: 'Custom Edit icon and replace tooltip text.',
-    hideTooltipStr: 'Hide Edit tooltip.',
-    lengthLimitedStr: 'This is an editable text with limited length.',
-  };
+const Demo: React.FC = () => {
+  const [editableStr, setEditableStr] = useState('This is an editable text.');
+  const [customIconStr, setCustomIconStr] = useState('Custom Edit icon and replace tooltip text.');
+  const [hideTooltipStr, setHideTooltipStr] = useState('Hide Edit tooltip.');
+  const [lengthLimitedStr, setLengthLimitedStr] = useState(
+    'This is an editable text with limited length.',
+  );
 
-  onChange = str => {
-    console.log('Content change:', str);
-    this.setState({ str });
-  };
-
-  onCustomIconStrChange = customIconStr => {
-    this.setState({ customIconStr });
-  };
-
-  onHideTooltipStrChange = hideTooltipStr => {
-    this.setState({ hideTooltipStr });
-  };
-
-  onLengthLimitedStrChange = lengthLimitedStr => {
-    this.setState({ lengthLimitedStr });
-  };
-
-  render() {
-    return (
-      <>
-        <Paragraph editable={{ onChange: this.onChange }}>{this.state.str}</Paragraph>
-        <Paragraph
-          editable={{
-            icon: <HighlightOutlined />,
-            tooltip: ['click to edit text'],
-            onChange: this.onCustomIconStrChange,
-          }}
-        >
-          {this.state.customIconStr}
-        </Paragraph>
-        <Paragraph editable={{ tooltip: false, onChange: this.onHideTooltipStrChange }}>
-          {this.state.hideTooltipStr}
-        </Paragraph>
-        <Paragraph
-          editable={{
-            onChange: this.onLengthLimitedStrChange,
-            maxLength: 50,
-            autoSize: { maxRows: 5, minRows: 3 },
-          }}
-        >
-          {this.state.lengthLimitedStr}
-        </Paragraph>
-        <Paragraph copyable>This is a copyable text.</Paragraph>
-        <Paragraph copyable={{ text: 'Hello, Ant Design!' }}>Replace copy text.</Paragraph>
-        <Paragraph
-          copyable={{
-            icon: [<SmileOutlined key="copy-icon" />, <SmileFilled key="copied-icon" />],
-            tooltips: ['click here', 'you clicked!!'],
-          }}
-        >
-          Custom Copy icon and replace tooltips text.
-        </Paragraph>
-        <Paragraph copyable={{ tooltips: false }}>Hide Copy tooltips.</Paragraph>
-      </>
-    );
-  }
-}
+  return (
+    <>
+      <Paragraph editable={{ onChange: setEditableStr }}>{editableStr}</Paragraph>
+      <Paragraph
+        editable={{
+          icon: <HighlightOutlined />,
+          tooltip: ['click to edit text'],
+          onChange: setCustomIconStr,
+        }}
+      >
+        {customIconStr}
+      </Paragraph>
+      <Paragraph editable={{ tooltip: false, onChange: setHideTooltipStr }}>
+        {hideTooltipStr}
+      </Paragraph>
+      <Paragraph
+        editable={{
+          onChange: setLengthLimitedStr,
+          maxLength: 50,
+          autoSize: { maxRows: 5, minRows: 3 },
+        }}
+      >
+        {lengthLimitedStr}
+      </Paragraph>
+      <Paragraph copyable>This is a copyable text.</Paragraph>
+      <Paragraph copyable={{ text: 'Hello, Ant Design!' }}>Replace copy text.</Paragraph>
+      <Paragraph
+        copyable={{
+          icon: [<SmileOutlined key="copy-icon" />, <SmileFilled key="copied-icon" />],
+          tooltips: ['click here', 'you clicked!!'],
+        }}
+      >
+        Custom Copy icon and replace tooltips text.
+      </Paragraph>
+      <Paragraph copyable={{ tooltips: false }}>Hide Copy tooltips.</Paragraph>
+    </>
+  );
+};
 
 ReactDOM.render(<Demo />, mountNode);
 ```

--- a/components/typography/demo/interactive.md
+++ b/components/typography/demo/interactive.md
@@ -15,7 +15,7 @@ Provide additional interactive capacity of editable and copyable.
 
 ```jsx
 import { Typography } from 'antd';
-import { SmileOutlined } from '@ant-design/icons';
+import { SmileOutlined, SmileFilled } from '@ant-design/icons';
 
 const { Paragraph } = Typography;
 
@@ -46,14 +46,24 @@ class Demo extends React.Component {
             autoSize: { maxRows: 5, minRows: 3 },
           }}
         >
-          {lengthLimitedStr}
-        </Paragraph>
-        <Paragraph copyable>This is a copyable text.</Paragraph>
-        <Paragraph copyable={{ text: 'Hello, Ant Design!' }}>Replace copy text.</Paragraph>
-        <Paragraph copyable={{ icon: <SmileOutlined /> }}>Custom icon.</Paragraph>
-        <Paragraph copyable={{ tooltips: ['click here', 'you clicked!!'] }}>
-          Replace tooltips text.
-        </Paragraph>
+          {this.state.lengthLimitedStr}
+        </Text>
+        <br />
+        <Text copyable>This is a copyable text.</Text>
+        <br />
+        <Text copyable={{ text: 'Hello, Ant Design!' }}>Replace copy text.</Text>
+        <br />
+        <Text
+          copyable={{
+            icon: [<SmileOutlined key="copy-icon" />, <SmileFilled key="copied-icon" />],
+          }}
+        >
+          Custom icon.
+        </Text>
+        <br />
+        <Text copyable={{ tooltips: ['click here', 'you clicked!!'] }}>Replace tooltips text.</Text>
+        <br />
+        <Paragraph copyable={{ tooltips: false }}>Hide tooltips.</Paragraph>
       </>
     );
   }

--- a/components/typography/demo/interactive.md
+++ b/components/typography/demo/interactive.md
@@ -34,7 +34,7 @@ const Demo: React.FC = () => {
       <Paragraph
         editable={{
           icon: <HighlightOutlined />,
-          tooltip: ['click to edit text'],
+          tooltip: 'click to edit text',
           onChange: setCustomIconStr,
         }}
       >

--- a/components/typography/index.en-US.md
+++ b/components/typography/index.en-US.md
@@ -20,7 +20,7 @@ Basic text writing, including headings, body text, lists, and more.
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
 | code | Code style | boolean | false |  |
-| copyable | Whether to be copyable, customize it via setting an object | boolean \| { text: string, onCopy: function, icon: ReactNode \| \[ReactNode, ReactNode\], tooltips: boolean \| \[ReactNode, ReactNode\] } | false | icon and tooltips: 4.4.0 |
+| copyable | Whether to be copyable, customize it via setting an object | boolean \| { text: string, onCopy: function, icon: ReactNode, tooltips: boolean \| ReactNode } | false | icon and tooltips: 4.4.0 |
 | delete | Deleted line style | boolean | false |  |
 | disabled | Disabled content | boolean | false |  |
 | editable | If editable. Can control edit state when is object | boolean \| { editing: boolean, maxLength: number, autoSize: true \| false \| { minRows: number, maxRows: number }, onStart: function, onChange: function(string) } | false | maxLength and autoSize: 4.6.0 |
@@ -37,7 +37,7 @@ Basic text writing, including headings, body text, lists, and more.
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
 | code | Code style | boolean | false |  |
-| copyable | Whether to be copyable, customize it via setting an object | boolean \| { text: string, onCopy: function, icon: ReactNode \| \[ReactNode, ReactNode\], tooltips: boolean \| \[ReactNode, ReactNode\] } | false | icon and tooltips: 4.4.0 |
+| copyable | Whether to be copyable, customize it via setting an object | boolean \| { text: string, onCopy: function, icon: ReactNode, tooltips: boolean \| ReactNode } | false | icon and tooltips: 4.4.0 |
 | delete | Deleted line style | boolean | false |  |
 | disabled | Disabled content | boolean | false |  |
 | editable | If editable. Can control edit state when is object | boolean \| { editing: boolean, maxLength: number, autoSize: true \| false \| { minRows: number, maxRows: number }, onStart: function, onChange: function(string) } | false | maxLength and autoSize: 4.6.0 |
@@ -53,7 +53,7 @@ Basic text writing, including headings, body text, lists, and more.
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
 | code | Code style | boolean | false |  |
-| copyable | Whether to be copyable, customize it via setting an object | boolean \| { text: string, onCopy: function, icon: ReactNode \| \[ReactNode, ReactNode\], tooltips: boolean \| \[ReactNode, ReactNode\] } | false | icon and tooltips: 4.4.0 |
+| copyable | Whether to be copyable, customize it via setting an object | boolean \| { text: string, onCopy: function, icon: ReactNode, tooltips: boolean \| ReactNode } | false | icon and tooltips: 4.4.0 |
 | delete | Deleted line style | boolean | false |  |
 | disabled | Disabled content | boolean | false |  |
 | editable | If editable. Can control edit state when is object | boolean \| { editing: boolean, maxLength: number, autoSize: true \| false \| { minRows: number, maxRows: number }, onStart: function, onChange: function(string) } | false | maxLength and autoSize: 4.6.0 |

--- a/components/typography/index.en-US.md
+++ b/components/typography/index.en-US.md
@@ -20,7 +20,7 @@ Basic text writing, including headings, body text, lists, and more.
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
 | code | Code style | boolean | false |  |
-| copyable | Whether to be copyable, customize it via setting an object | boolean \| { text: string, onCopy: function, icon: ReactNode, tooltips: \[ReactNode, ReactNode\] } | false | icon and tooltips: 4.4.0 |
+| copyable | Whether to be copyable, customize it via setting an object | boolean \| { text: string, onCopy: function, icon: ReactNode \| \[ReactNode, ReactNode\], tooltips: boolean \| \[ReactNode, ReactNode\] } | false | icon and tooltips: 4.4.0 |
 | delete | Deleted line style | boolean | false |  |
 | disabled | Disabled content | boolean | false |  |
 | editable | If editable. Can control edit state when is object | boolean \| { editing: boolean, maxLength: number, autoSize: true \| false \| { minRows: number, maxRows: number }, onStart: function, onChange: function(string) } | false | maxLength and autoSize: 4.6.0 |
@@ -37,7 +37,7 @@ Basic text writing, including headings, body text, lists, and more.
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
 | code | Code style | boolean | false |  |
-| copyable | Whether to be copyable, customize it via setting an object | boolean \| { text: string, onCopy: function, icon: ReactNode, tooltips: \[ReactNode, ReactNode\] } | false | icon and tooltips: 4.4.0 |
+| copyable | Whether to be copyable, customize it via setting an object | boolean \| { text: string, onCopy: function, icon: ReactNode \| \[ReactNode, ReactNode\], tooltips: boolean \| \[ReactNode, ReactNode\] } | false | icon and tooltips: 4.4.0 |
 | delete | Deleted line style | boolean | false |  |
 | disabled | Disabled content | boolean | false |  |
 | editable | If editable. Can control edit state when is object | boolean \| { editing: boolean, maxLength: number, autoSize: true \| false \| { minRows: number, maxRows: number }, onStart: function, onChange: function(string) } | false | maxLength and autoSize: 4.6.0 |
@@ -53,7 +53,7 @@ Basic text writing, including headings, body text, lists, and more.
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
 | code | Code style | boolean | false |  |
-| copyable | Whether to be copyable, customize it via setting an object | boolean \| { text: string, onCopy: function, icon: ReactNode, tooltips: \[ReactNode, ReactNode\] } | false | icon and tooltips: 4.4.0 |
+| copyable | Whether to be copyable, customize it via setting an object | boolean \| { text: string, onCopy: function, icon: ReactNode \| \[ReactNode, ReactNode\], tooltips: boolean \| \[ReactNode, ReactNode\] } | false | icon and tooltips: 4.4.0 |
 | delete | Deleted line style | boolean | false |  |
 | disabled | Disabled content | boolean | false |  |
 | editable | If editable. Can control edit state when is object | boolean \| { editing: boolean, maxLength: number, autoSize: true \| false \| { minRows: number, maxRows: number }, onStart: function, onChange: function(string) } | false | maxLength and autoSize: 4.6.0 |

--- a/components/typography/index.en-US.md
+++ b/components/typography/index.en-US.md
@@ -20,10 +20,10 @@ Basic text writing, including headings, body text, lists, and more.
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
 | code | Code style | boolean | false |  |
-| copyable | Whether to be copyable, customize it via setting an object | boolean \| { text: string, onCopy: function, icon: ReactNode, tooltips: boolean \| ReactNode } | false | `icon` and `tooltips`: 4.4.0 `icon: ReactNode[]` and `tooltips: false`: 4.?.0 |
+| copyable | Whether to be copyable, customize it via setting an object | boolean \| { text: string, onCopy: function, icon: ReactNode, tooltips: boolean \| ReactNode } | false | `icon` and `tooltips`: 4.4.0 `icon: ReactNode[]` and `tooltips: false`: 4.6.0 |
 | delete | Deleted line style | boolean | false |  |
 | disabled | Disabled content | boolean | false |  |
-| editable | If editable. Can control edit state when is object | boolean \| { editing: boolean, maxLength: number, autoSize: true \| false \| { minRows: number, maxRows: number }, onStart: function, onChange: function(string), icon: ReactNode, tooltip: boolean \| ReactNode } | false | `maxLength` and `autoSize`: 4.6.0 `icon` and `tooltip`: 4.?.0 |
+| editable | If editable. Can control edit state when is object | boolean \| { editing: boolean, maxLength: number, autoSize: true \| false \| { minRows: number, maxRows: number }, onStart: function, onChange: function(string), icon: ReactNode, tooltip: boolean \| ReactNode } | false | `maxLength` and `autoSize`: 4.6.0 `icon` and `tooltip`: 4.6.0 |
 | ellipsis | Display ellipsis when text overflows. Should set width when ellipsis needed | boolean | false |  |
 | mark | Marked style | boolean | false |  |
 | keyboard | Keyboard style | boolean | false | 4.3.0 |
@@ -37,10 +37,10 @@ Basic text writing, including headings, body text, lists, and more.
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
 | code | Code style | boolean | false |  |
-| copyable | Whether to be copyable, customize it via setting an object | boolean \| { text: string, onCopy: function, icon: ReactNode, tooltips: boolean \| ReactNode } | false | `icon` and `tooltips`: 4.4.0 `icon: ReactNode[]` and `tooltips: false`: 4.?.0 |
+| copyable | Whether to be copyable, customize it via setting an object | boolean \| { text: string, onCopy: function, icon: ReactNode, tooltips: boolean \| ReactNode } | false | `icon` and `tooltips`: 4.4.0 `icon: ReactNode[]` and `tooltips: false`: 4.6.0 |
 | delete | Deleted line style | boolean | false |  |
 | disabled | Disabled content | boolean | false |  |
-| editable | If editable. Can control edit state when is object | boolean \| { editing: boolean, maxLength: number, autoSize: true \| false \| { minRows: number, maxRows: number }, onStart: function, onChange: function(string), icon: ReactNode, tooltip: boolean \| ReactNode } | false | `maxLength` and `autoSize`: 4.6.0 `icon` and `tooltip`: 4.?.0 |
+| editable | If editable. Can control edit state when is object | boolean \| { editing: boolean, maxLength: number, autoSize: true \| false \| { minRows: number, maxRows: number }, onStart: function, onChange: function(string), icon: ReactNode, tooltip: boolean \| ReactNode } | false | `maxLength` and `autoSize`: 4.6.0 `icon` and `tooltip`: 4.6.0 |
 | ellipsis | Display ellipsis when text overflows. Can configure rows and expandable by using object | boolean \| { rows: number, expandable: boolean, onExpand: function(event), onEllipsis: function(ellipsis) } | false | `onEllipsis`: 4.2.0 |
 | level | Set content importance. Match with `h1`, `h2`, `h3`, `h4`, `h5` | number: 1, 2, 3, 4, 5 | 1 | 5: 4.6.0 |
 | mark | Marked style | boolean | false |  |
@@ -53,10 +53,10 @@ Basic text writing, including headings, body text, lists, and more.
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
 | code | Code style | boolean | false |  |
-| copyable | Whether to be copyable, customize it via setting an object | boolean \| { text: string, onCopy: function, icon: ReactNode, tooltips: boolean \| ReactNode } | false | `icon` and `tooltips`: 4.4.0 `icon: ReactNode[]` and `tooltips: false`: 4.?.0 |
+| copyable | Whether to be copyable, customize it via setting an object | boolean \| { text: string, onCopy: function, icon: ReactNode, tooltips: boolean \| ReactNode } | false | `icon` and `tooltips`: 4.4.0 `icon: ReactNode[]` and `tooltips: false`: 4.6.0 |
 | delete | Deleted line style | boolean | false |  |
 | disabled | Disabled content | boolean | false |  |
-| editable | If editable. Can control edit state when is object | boolean \| { editing: boolean, maxLength: number, autoSize: true \| false \| { minRows: number, maxRows: number }, onStart: function, onChange: function(string), icon: ReactNode, tooltip: boolean \| ReactNode } | false | `maxLength` and `autoSize`: 4.6.0 `icon` and `tooltip`: 4.?.0 |
+| editable | If editable. Can control edit state when is object | boolean \| { editing: boolean, maxLength: number, autoSize: true \| false \| { minRows: number, maxRows: number }, onStart: function, onChange: function(string), icon: ReactNode, tooltip: boolean \| ReactNode } | false | `maxLength` and `autoSize`: 4.6.0 `icon` and `tooltip`: 4.6.0 |
 | ellipsis | Display ellipsis when text overflows. Can configure rows expandable and suffix by using object | boolean \| { rows: number, expandable: boolean, suffix: string, symbol: React.ReactNode, onExpand: function(event), onEllipsis: function(ellipsis) } | false | `onEllipsis`: 4.2.0 |
 | mark | Marked style | boolean | false |  |
 | underline | Underlined style | boolean | false |  |

--- a/components/typography/index.en-US.md
+++ b/components/typography/index.en-US.md
@@ -20,10 +20,10 @@ Basic text writing, including headings, body text, lists, and more.
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
 | code | Code style | boolean | false |  |
-| copyable | Whether to be copyable, customize it via setting an object. See [below](#copyable) | boolean \| { text: string, onCopy: function, icon: ReactNode, tooltips: boolean \| ReactNode } | false | icon and tooltips: 4.4.0 |
+| copyable | Whether to be copyable, customize it via setting an object | boolean \| { text: string, onCopy: function, icon: ReactNode, tooltips: boolean \| ReactNode } | false | See [below](#copyable) |
 | delete | Deleted line style | boolean | false |  |
 | disabled | Disabled content | boolean | false |  |
-| editable | If editable. Can control edit state when is object | boolean \| { editing: boolean, maxLength: number, autoSize: true \| false \| { minRows: number, maxRows: number }, onStart: function, onChange: function(string), icon: ReactNode, tooltip: boolean \| ReactNode } | false | maxLength, autoSize, icon and tooltip: 4.6.0 |
+| editable | If editable. Can control edit state when is object | boolean \| { editing: boolean, maxLength: number, autoSize: true \| false \| { minRows: number, maxRows: number }, onStart: function, onChange: function(string), icon: ReactNode, tooltip: boolean \| ReactNode } | false | See [below](#editable) |
 | ellipsis | Display ellipsis when text overflows. Should set width when ellipsis needed | boolean | false |  |
 | mark | Marked style | boolean | false |  |
 | keyboard | Keyboard style | boolean | false | 4.3.0 |
@@ -37,10 +37,10 @@ Basic text writing, including headings, body text, lists, and more.
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
 | code | Code style | boolean | false |  |
-| copyable | Whether to be copyable, customize it via setting an object. See [below](#copyable) | boolean \| { text: string, onCopy: function, icon: ReactNode, tooltips: boolean \| ReactNode } | false | icon and tooltips: 4.4.0 |
+| copyable | Whether to be copyable, customize it via setting an object | boolean \| { text: string, onCopy: function, icon: ReactNode, tooltips: boolean \| ReactNode } | false | See [below](#copyable) |
 | delete | Deleted line style | boolean | false |  |
 | disabled | Disabled content | boolean | false |  |
-| editable | If editable. Can control edit state when is object | boolean \| { editing: boolean, maxLength: number, autoSize: true \| false \| { minRows: number, maxRows: number }, onStart: function, onChange: function(string), icon: ReactNode, tooltip: boolean \| ReactNode } | false | maxLength, autoSize, icon and tooltip: 4.6.0 |
+| editable | If editable. Can control edit state when is object | boolean \| { editing: boolean, maxLength: number, autoSize: true \| false \| { minRows: number, maxRows: number }, onStart: function, onChange: function(string), icon: ReactNode, tooltip: boolean \| ReactNode } | false | See [below](#editable) |
 | ellipsis | Display ellipsis when text overflows. Can configure rows and expandable by using object | boolean \| { rows: number, expandable: boolean, onExpand: function(event), onEllipsis: function(ellipsis) } | false | onEllipsis: 4.2.0 |
 | level | Set content importance. Match with `h1`, `h2`, `h3`, `h4`, `h5` | number: 1, 2, 3, 4, 5 | 1 | 5: 4.6.0 |
 | mark | Marked style | boolean | false |  |
@@ -53,10 +53,10 @@ Basic text writing, including headings, body text, lists, and more.
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
 | code | Code style | boolean | false |  |
-| copyable | Whether to be copyable, customize it via setting an object. See [below](#copyable) | boolean \| { text: string, onCopy: function, icon: ReactNode, tooltips: boolean \| ReactNode } | false | icon and tooltips: 4.4.0 |
+| copyable | Whether to be copyable, customize it via setting an object | boolean \| { text: string, onCopy: function, icon: ReactNode, tooltips: boolean \| ReactNode } | false | See [below](#copyable) |
 | delete | Deleted line style | boolean | false |  |
 | disabled | Disabled content | boolean | false |  |
-| editable | If editable. Can control edit state when is object | boolean \| { editing: boolean, maxLength: number, autoSize: true \| false \| { minRows: number, maxRows: number }, onStart: function, onChange: function(string), icon: ReactNode, tooltip: boolean \| ReactNode } | false | maxLength, autoSize, icon and tooltip: 4.6.0 |
+| editable | If editable. Can control edit state when is object | boolean \| { editing: boolean, maxLength: number, autoSize: true \| false \| { minRows: number, maxRows: number }, onStart: function, onChange: function(string), icon: ReactNode, tooltip: boolean \| ReactNode } | false | See [below](#editable) |
 | ellipsis | Display ellipsis when text overflows. Can configure rows expandable and suffix by using object | boolean \| { rows: number, expandable: boolean, suffix: string, symbol: React.ReactNode, onExpand: function(event), onEllipsis: function(ellipsis) } | false | onEllipsis: 4.2.0 |
 | mark | Marked style | boolean | false |  |
 | underline | Underlined style | boolean | false |  |
@@ -73,6 +73,16 @@ Basic text writing, including headings, body text, lists, and more.
 `copyable` supports `{ icon: [<SmileOutlined key="copy-icon" />, <SmileFilled key="copied-icon" />] }` to customize copy and copied icon since `4.6.0`.
 
 `copyable` supports `{ tooltips: false }` to hide tooltips since `4.6.0`.
+
+### editable
+
+`editable` supports `{ maxLength: 50 }` to config TextArea `maxLength` props since `4.6.0`.
+
+`editable` supports `{ autoSize: { maxRows: 5, minRows: 3 } }` to config TextArea `autoSize` props since `4.6.0`.
+
+`editable` supports `{ icon: <HighlightOutlined /> }` to customize edit icon since `4.6.0`.
+
+`editable` supports `{ tooltips: 'click to edit text' }` to replace tooltip text since `4.6.0`.
 
 ## FAQ
 

--- a/components/typography/index.en-US.md
+++ b/components/typography/index.en-US.md
@@ -20,10 +20,10 @@ Basic text writing, including headings, body text, lists, and more.
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
 | code | Code style | boolean | false |  |
-| copyable | Whether to be copyable, customize it via setting an object | boolean \| { text: string, onCopy: function, icon: ReactNode, tooltips: boolean \| ReactNode } | false | icon and tooltips: 4.4.0 |
+| copyable | Whether to be copyable, customize it via setting an object | boolean \| { text: string, onCopy: function, icon: ReactNode, tooltips: boolean \| ReactNode } | false | `icon` and `tooltips`: 4.4.0 `icon: ReactNode[]` and `tooltips: false`: 4.?.0 |
 | delete | Deleted line style | boolean | false |  |
 | disabled | Disabled content | boolean | false |  |
-| editable | If editable. Can control edit state when is object | boolean \| { editing: boolean, maxLength: number, autoSize: true \| false \| { minRows: number, maxRows: number }, onStart: function, onChange: function(string) } | false | maxLength and autoSize: 4.6.0 |
+| editable | If editable. Can control edit state when is object | boolean \| { editing: boolean, maxLength: number, autoSize: true \| false \| { minRows: number, maxRows: number }, onStart: function, onChange: function(string), icon: ReactNode, tooltip: boolean \| ReactNode } | false | `maxLength` and `autoSize`: 4.6.0 `icon` and `tooltip`: 4.?.0 |
 | ellipsis | Display ellipsis when text overflows. Should set width when ellipsis needed | boolean | false |  |
 | mark | Marked style | boolean | false |  |
 | keyboard | Keyboard style | boolean | false | 4.3.0 |
@@ -37,11 +37,11 @@ Basic text writing, including headings, body text, lists, and more.
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
 | code | Code style | boolean | false |  |
-| copyable | Whether to be copyable, customize it via setting an object | boolean \| { text: string, onCopy: function, icon: ReactNode, tooltips: boolean \| ReactNode } | false | icon and tooltips: 4.4.0 |
+| copyable | Whether to be copyable, customize it via setting an object | boolean \| { text: string, onCopy: function, icon: ReactNode, tooltips: boolean \| ReactNode } | false | `icon` and `tooltips`: 4.4.0 `icon: ReactNode[]` and `tooltips: false`: 4.?.0 |
 | delete | Deleted line style | boolean | false |  |
 | disabled | Disabled content | boolean | false |  |
-| editable | If editable. Can control edit state when is object | boolean \| { editing: boolean, maxLength: number, autoSize: true \| false \| { minRows: number, maxRows: number }, onStart: function, onChange: function(string) } | false | maxLength and autoSize: 4.6.0 |
-| ellipsis | Display ellipsis when text overflows. Can configure rows and expandable by using object | boolean \| { rows: number, expandable: boolean, onExpand: function(event), onEllipsis: function(ellipsis) } | false | onEllipsis: 4.2.0 |
+| editable | If editable. Can control edit state when is object | boolean \| { editing: boolean, maxLength: number, autoSize: true \| false \| { minRows: number, maxRows: number }, onStart: function, onChange: function(string), icon: ReactNode, tooltip: boolean \| ReactNode } | false | `maxLength` and `autoSize`: 4.6.0 `icon` and `tooltip`: 4.?.0 |
+| ellipsis | Display ellipsis when text overflows. Can configure rows and expandable by using object | boolean \| { rows: number, expandable: boolean, onExpand: function(event), onEllipsis: function(ellipsis) } | false | `onEllipsis`: 4.2.0 |
 | level | Set content importance. Match with `h1`, `h2`, `h3`, `h4`, `h5` | number: 1, 2, 3, 4, 5 | 1 | 5: 4.6.0 |
 | mark | Marked style | boolean | false |  |
 | underline | Underlined style | boolean | false |  |
@@ -53,11 +53,11 @@ Basic text writing, including headings, body text, lists, and more.
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
 | code | Code style | boolean | false |  |
-| copyable | Whether to be copyable, customize it via setting an object | boolean \| { text: string, onCopy: function, icon: ReactNode, tooltips: boolean \| ReactNode } | false | icon and tooltips: 4.4.0 |
+| copyable | Whether to be copyable, customize it via setting an object | boolean \| { text: string, onCopy: function, icon: ReactNode, tooltips: boolean \| ReactNode } | false | `icon` and `tooltips`: 4.4.0 `icon: ReactNode[]` and `tooltips: false`: 4.?.0 |
 | delete | Deleted line style | boolean | false |  |
 | disabled | Disabled content | boolean | false |  |
-| editable | If editable. Can control edit state when is object | boolean \| { editing: boolean, maxLength: number, autoSize: true \| false \| { minRows: number, maxRows: number }, onStart: function, onChange: function(string) } | false | maxLength and autoSize: 4.6.0 |
-| ellipsis | Display ellipsis when text overflows. Can configure rows expandable and suffix by using object | boolean \| { rows: number, expandable: boolean, suffix: string, symbol: React.ReactNode, onExpand: function(event), onEllipsis: function(ellipsis) } | false | onEllipsis: 4.2.0 |
+| editable | If editable. Can control edit state when is object | boolean \| { editing: boolean, maxLength: number, autoSize: true \| false \| { minRows: number, maxRows: number }, onStart: function, onChange: function(string), icon: ReactNode, tooltip: boolean \| ReactNode } | false | `maxLength` and `autoSize`: 4.6.0 `icon` and `tooltip`: 4.?.0 |
+| ellipsis | Display ellipsis when text overflows. Can configure rows expandable and suffix by using object | boolean \| { rows: number, expandable: boolean, suffix: string, symbol: React.ReactNode, onExpand: function(event), onEllipsis: function(ellipsis) } | false | `onEllipsis`: 4.2.0 |
 | mark | Marked style | boolean | false |  |
 | underline | Underlined style | boolean | false |  |
 | onChange | Trigger when user edits the content | function(string) | - |  |

--- a/components/typography/index.en-US.md
+++ b/components/typography/index.en-US.md
@@ -20,10 +20,10 @@ Basic text writing, including headings, body text, lists, and more.
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
 | code | Code style | boolean | false |  |
-| copyable | Whether to be copyable, customize it via setting an object | boolean \| { text: string, onCopy: function, icon: ReactNode, tooltips: boolean \| ReactNode } | false | `icon` and `tooltips`: 4.4.0 `icon: ReactNode[]` and `tooltips: false`: 4.6.0 |
+| copyable | Whether to be copyable, customize it via setting an object | boolean \| { text: string, onCopy: function, icon: ReactNode, tooltips: boolean \| ReactNode } | false | icon and tooltips: 4.4.0 |
 | delete | Deleted line style | boolean | false |  |
 | disabled | Disabled content | boolean | false |  |
-| editable | If editable. Can control edit state when is object | boolean \| { editing: boolean, maxLength: number, autoSize: true \| false \| { minRows: number, maxRows: number }, onStart: function, onChange: function(string), icon: ReactNode, tooltip: boolean \| ReactNode } | false | `maxLength`, `autoSize`, `icon` and `tooltip`: 4.6.0 |
+| editable | If editable. Can control edit state when is object | boolean \| { editing: boolean, maxLength: number, autoSize: true \| false \| { minRows: number, maxRows: number }, onStart: function, onChange: function(string), icon: ReactNode, tooltip: boolean \| ReactNode } | false | maxLength, autoSize, icon and tooltip: 4.6.0 |
 | ellipsis | Display ellipsis when text overflows. Should set width when ellipsis needed | boolean | false |  |
 | mark | Marked style | boolean | false |  |
 | keyboard | Keyboard style | boolean | false | 4.3.0 |
@@ -37,11 +37,11 @@ Basic text writing, including headings, body text, lists, and more.
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
 | code | Code style | boolean | false |  |
-| copyable | Whether to be copyable, customize it via setting an object | boolean \| { text: string, onCopy: function, icon: ReactNode, tooltips: boolean \| ReactNode } | false | `icon` and `tooltips`: 4.4.0 `icon: ReactNode[]` and `tooltips: false`: 4.6.0 |
+| copyable | Whether to be copyable, customize it via setting an object | boolean \| { text: string, onCopy: function, icon: ReactNode, tooltips: boolean \| ReactNode } | false | icon and tooltips: 4.4.0 |
 | delete | Deleted line style | boolean | false |  |
 | disabled | Disabled content | boolean | false |  |
-| editable | If editable. Can control edit state when is object | boolean \| { editing: boolean, maxLength: number, autoSize: true \| false \| { minRows: number, maxRows: number }, onStart: function, onChange: function(string), icon: ReactNode, tooltip: boolean \| ReactNode } | false | `maxLength`, `autoSize`, `icon` and `tooltip`: 4.6.0 |
-| ellipsis | Display ellipsis when text overflows. Can configure rows and expandable by using object | boolean \| { rows: number, expandable: boolean, onExpand: function(event), onEllipsis: function(ellipsis) } | false | `onEllipsis`: 4.2.0 |
+| editable | If editable. Can control edit state when is object | boolean \| { editing: boolean, maxLength: number, autoSize: true \| false \| { minRows: number, maxRows: number }, onStart: function, onChange: function(string), icon: ReactNode, tooltip: boolean \| ReactNode } | false | maxLength, autoSize, icon and tooltip: 4.6.0 |
+| ellipsis | Display ellipsis when text overflows. Can configure rows and expandable by using object | boolean \| { rows: number, expandable: boolean, onExpand: function(event), onEllipsis: function(ellipsis) } | false | onEllipsis: 4.2.0 |
 | level | Set content importance. Match with `h1`, `h2`, `h3`, `h4`, `h5` | number: 1, 2, 3, 4, 5 | 1 | 5: 4.6.0 |
 | mark | Marked style | boolean | false |  |
 | underline | Underlined style | boolean | false |  |
@@ -53,11 +53,11 @@ Basic text writing, including headings, body text, lists, and more.
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
 | code | Code style | boolean | false |  |
-| copyable | Whether to be copyable, customize it via setting an object | boolean \| { text: string, onCopy: function, icon: ReactNode, tooltips: boolean \| ReactNode } | false | `icon` and `tooltips`: 4.4.0 `icon: ReactNode[]` and `tooltips: false`: 4.6.0 |
+| copyable | Whether to be copyable, customize it via setting an object | boolean \| { text: string, onCopy: function, icon: ReactNode, tooltips: boolean \| ReactNode } | false | icon and tooltips: 4.4.0 |
 | delete | Deleted line style | boolean | false |  |
 | disabled | Disabled content | boolean | false |  |
-| editable | If editable. Can control edit state when is object | boolean \| { editing: boolean, maxLength: number, autoSize: true \| false \| { minRows: number, maxRows: number }, onStart: function, onChange: function(string), icon: ReactNode, tooltip: boolean \| ReactNode } | false | `maxLength`, `autoSize`, `icon` and `tooltip`: 4.6.0 |
-| ellipsis | Display ellipsis when text overflows. Can configure rows expandable and suffix by using object | boolean \| { rows: number, expandable: boolean, suffix: string, symbol: React.ReactNode, onExpand: function(event), onEllipsis: function(ellipsis) } | false | `onEllipsis`: 4.2.0 |
+| editable | If editable. Can control edit state when is object | boolean \| { editing: boolean, maxLength: number, autoSize: true \| false \| { minRows: number, maxRows: number }, onStart: function, onChange: function(string), icon: ReactNode, tooltip: boolean \| ReactNode } | false | maxLength, autoSize, icon and tooltip: 4.6.0 |
+| ellipsis | Display ellipsis when text overflows. Can configure rows expandable and suffix by using object | boolean \| { rows: number, expandable: boolean, suffix: string, symbol: React.ReactNode, onExpand: function(event), onEllipsis: function(ellipsis) } | false | onEllipsis: 4.2.0 |
 | mark | Marked style | boolean | false |  |
 | underline | Underlined style | boolean | false |  |
 | onChange | Trigger when user edits the content | function(string) | - |  |

--- a/components/typography/index.en-US.md
+++ b/components/typography/index.en-US.md
@@ -23,7 +23,7 @@ Basic text writing, including headings, body text, lists, and more.
 | copyable | Whether to be copyable, customize it via setting an object | boolean \| { text: string, onCopy: function, icon: ReactNode, tooltips: boolean \| ReactNode } | false | `icon` and `tooltips`: 4.4.0 `icon: ReactNode[]` and `tooltips: false`: 4.6.0 |
 | delete | Deleted line style | boolean | false |  |
 | disabled | Disabled content | boolean | false |  |
-| editable | If editable. Can control edit state when is object | boolean \| { editing: boolean, maxLength: number, autoSize: true \| false \| { minRows: number, maxRows: number }, onStart: function, onChange: function(string), icon: ReactNode, tooltip: boolean \| ReactNode } | false | `maxLength` and `autoSize`: 4.6.0 `icon` and `tooltip`: 4.6.0 |
+| editable | If editable. Can control edit state when is object | boolean \| { editing: boolean, maxLength: number, autoSize: true \| false \| { minRows: number, maxRows: number }, onStart: function, onChange: function(string), icon: ReactNode, tooltip: boolean \| ReactNode } | false | `maxLength`, `autoSize`, `icon` and `tooltip`: 4.6.0 |
 | ellipsis | Display ellipsis when text overflows. Should set width when ellipsis needed | boolean | false |  |
 | mark | Marked style | boolean | false |  |
 | keyboard | Keyboard style | boolean | false | 4.3.0 |
@@ -40,7 +40,7 @@ Basic text writing, including headings, body text, lists, and more.
 | copyable | Whether to be copyable, customize it via setting an object | boolean \| { text: string, onCopy: function, icon: ReactNode, tooltips: boolean \| ReactNode } | false | `icon` and `tooltips`: 4.4.0 `icon: ReactNode[]` and `tooltips: false`: 4.6.0 |
 | delete | Deleted line style | boolean | false |  |
 | disabled | Disabled content | boolean | false |  |
-| editable | If editable. Can control edit state when is object | boolean \| { editing: boolean, maxLength: number, autoSize: true \| false \| { minRows: number, maxRows: number }, onStart: function, onChange: function(string), icon: ReactNode, tooltip: boolean \| ReactNode } | false | `maxLength` and `autoSize`: 4.6.0 `icon` and `tooltip`: 4.6.0 |
+| editable | If editable. Can control edit state when is object | boolean \| { editing: boolean, maxLength: number, autoSize: true \| false \| { minRows: number, maxRows: number }, onStart: function, onChange: function(string), icon: ReactNode, tooltip: boolean \| ReactNode } | false | `maxLength`, `autoSize`, `icon` and `tooltip`: 4.6.0 |
 | ellipsis | Display ellipsis when text overflows. Can configure rows and expandable by using object | boolean \| { rows: number, expandable: boolean, onExpand: function(event), onEllipsis: function(ellipsis) } | false | `onEllipsis`: 4.2.0 |
 | level | Set content importance. Match with `h1`, `h2`, `h3`, `h4`, `h5` | number: 1, 2, 3, 4, 5 | 1 | 5: 4.6.0 |
 | mark | Marked style | boolean | false |  |
@@ -56,7 +56,7 @@ Basic text writing, including headings, body text, lists, and more.
 | copyable | Whether to be copyable, customize it via setting an object | boolean \| { text: string, onCopy: function, icon: ReactNode, tooltips: boolean \| ReactNode } | false | `icon` and `tooltips`: 4.4.0 `icon: ReactNode[]` and `tooltips: false`: 4.6.0 |
 | delete | Deleted line style | boolean | false |  |
 | disabled | Disabled content | boolean | false |  |
-| editable | If editable. Can control edit state when is object | boolean \| { editing: boolean, maxLength: number, autoSize: true \| false \| { minRows: number, maxRows: number }, onStart: function, onChange: function(string), icon: ReactNode, tooltip: boolean \| ReactNode } | false | `maxLength` and `autoSize`: 4.6.0 `icon` and `tooltip`: 4.6.0 |
+| editable | If editable. Can control edit state when is object | boolean \| { editing: boolean, maxLength: number, autoSize: true \| false \| { minRows: number, maxRows: number }, onStart: function, onChange: function(string), icon: ReactNode, tooltip: boolean \| ReactNode } | false | `maxLength`, `autoSize`, `icon` and `tooltip`: 4.6.0 |
 | ellipsis | Display ellipsis when text overflows. Can configure rows expandable and suffix by using object | boolean \| { rows: number, expandable: boolean, suffix: string, symbol: React.ReactNode, onExpand: function(event), onEllipsis: function(ellipsis) } | false | `onEllipsis`: 4.2.0 |
 | mark | Marked style | boolean | false |  |
 | underline | Underlined style | boolean | false |  |

--- a/components/typography/index.en-US.md
+++ b/components/typography/index.en-US.md
@@ -20,7 +20,7 @@ Basic text writing, including headings, body text, lists, and more.
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
 | code | Code style | boolean | false |  |
-| copyable | Whether to be copyable, customize it via setting an object | boolean \| { text: string, onCopy: function, icon: ReactNode, tooltips: boolean \| ReactNode } | false | icon and tooltips: 4.4.0 |
+| copyable | Whether to be copyable, customize it via setting an object. See [below](#copyable) | boolean \| { text: string, onCopy: function, icon: ReactNode, tooltips: boolean \| ReactNode } | false | icon and tooltips: 4.4.0 |
 | delete | Deleted line style | boolean | false |  |
 | disabled | Disabled content | boolean | false |  |
 | editable | If editable. Can control edit state when is object | boolean \| { editing: boolean, maxLength: number, autoSize: true \| false \| { minRows: number, maxRows: number }, onStart: function, onChange: function(string), icon: ReactNode, tooltip: boolean \| ReactNode } | false | maxLength, autoSize, icon and tooltip: 4.6.0 |
@@ -37,7 +37,7 @@ Basic text writing, including headings, body text, lists, and more.
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
 | code | Code style | boolean | false |  |
-| copyable | Whether to be copyable, customize it via setting an object | boolean \| { text: string, onCopy: function, icon: ReactNode, tooltips: boolean \| ReactNode } | false | icon and tooltips: 4.4.0 |
+| copyable | Whether to be copyable, customize it via setting an object. See [below](#copyable) | boolean \| { text: string, onCopy: function, icon: ReactNode, tooltips: boolean \| ReactNode } | false | icon and tooltips: 4.4.0 |
 | delete | Deleted line style | boolean | false |  |
 | disabled | Disabled content | boolean | false |  |
 | editable | If editable. Can control edit state when is object | boolean \| { editing: boolean, maxLength: number, autoSize: true \| false \| { minRows: number, maxRows: number }, onStart: function, onChange: function(string), icon: ReactNode, tooltip: boolean \| ReactNode } | false | maxLength, autoSize, icon and tooltip: 4.6.0 |
@@ -53,7 +53,7 @@ Basic text writing, including headings, body text, lists, and more.
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
 | code | Code style | boolean | false |  |
-| copyable | Whether to be copyable, customize it via setting an object | boolean \| { text: string, onCopy: function, icon: ReactNode, tooltips: boolean \| ReactNode } | false | icon and tooltips: 4.4.0 |
+| copyable | Whether to be copyable, customize it via setting an object. See [below](#copyable) | boolean \| { text: string, onCopy: function, icon: ReactNode, tooltips: boolean \| ReactNode } | false | icon and tooltips: 4.4.0 |
 | delete | Deleted line style | boolean | false |  |
 | disabled | Disabled content | boolean | false |  |
 | editable | If editable. Can control edit state when is object | boolean \| { editing: boolean, maxLength: number, autoSize: true \| false \| { minRows: number, maxRows: number }, onStart: function, onChange: function(string), icon: ReactNode, tooltip: boolean \| ReactNode } | false | maxLength, autoSize, icon and tooltip: 4.6.0 |
@@ -63,6 +63,16 @@ Basic text writing, including headings, body text, lists, and more.
 | onChange | Trigger when user edits the content | function(string) | - |  |
 | strong | Bold style | boolean | false |  |
 | type | Content type | `secondary` \| `warning` \| `danger` | - |  |
+
+### copyable
+
+`copyable` supports `{ icon: <SmileOutlined /> }` to customize copy icon since `4.4.0`.
+
+`copyable` supports `{ tooltips: ['click here', 'you clicked!!'] }` to replace tooltips text since `4.4.0`.
+
+`copyable` supports `{ icon: [<SmileOutlined key="copy-icon" />, <SmileFilled key="copied-icon" />] }` to customize copy and copied icon since `4.6.0`.
+
+`copyable` supports `{ tooltips: false }` to hide tooltips since `4.6.0`.
 
 ## FAQ
 

--- a/components/typography/index.zh-CN.md
+++ b/components/typography/index.zh-CN.md
@@ -21,10 +21,10 @@ cover: https://gw.alipayobjects.com/zos/alicdn/GOM1KQ24O/Typography.svg
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
 | code | 添加代码样式 | boolean | false |  |
-| copyable | 是否可拷贝，为对象时可进行各种自定义 | boolean \| { text: string, onCopy: function, icon: ReactNode, tooltips: boolean \| ReactNode } | false | `icon` and `tooltips`: 4.4.0 `icon: ReactNode[]` and `tooltips: false`: 4.?.0 |
+| copyable | 是否可拷贝，为对象时可进行各种自定义 | boolean \| { text: string, onCopy: function, icon: ReactNode, tooltips: boolean \| ReactNode } | false | `icon` and `tooltips`: 4.4.0 `icon: ReactNode[]` and `tooltips: false`: 4.6.0 |
 | delete | 添加删除线样式 | boolean | false |  |
 | disabled | 禁用文本 | boolean | false |  |
-| editable | 是否可编辑，为对象时可对编辑进行控制 | boolean \| { editing: boolean, maxLength: number, autoSize: true \| false \| { minRows: number, maxRows: number }, onStart: function, onChange: function(string), icon: ReactNode, tooltip: boolean \| ReactNode } | false | `maxLength` and `autoSize`: 4.6.0 `icon` and `tooltip`: 4.?.0 |
+| editable | 是否可编辑，为对象时可对编辑进行控制 | boolean \| { editing: boolean, maxLength: number, autoSize: true \| false \| { minRows: number, maxRows: number }, onStart: function, onChange: function(string), icon: ReactNode, tooltip: boolean \| ReactNode } | false | `maxLength` and `autoSize`: 4.6.0 `icon` and `tooltip`: 4.6.0 |
 | ellipsis | 设置自动溢出省略，需要设置元素宽度 | boolean | false |  |
 | mark | 添加标记样式 | boolean | false |  |
 | keyboard | 添加键盘样式 | boolean | false | 4.3.0 |
@@ -37,10 +37,10 @@ cover: https://gw.alipayobjects.com/zos/alicdn/GOM1KQ24O/Typography.svg
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
 | code | 添加代码样式 | boolean | false |  |
-| copyable | 是否可拷贝，为对象时可进行各种自定义 | boolean \| { text: string, onCopy: function, icon: ReactNode, tooltips: boolean \| ReactNode } | false | `icon` and `tooltips`: 4.4.0 `icon: ReactNode[]` and `tooltips: false`: 4.?.0 |
+| copyable | 是否可拷贝，为对象时可进行各种自定义 | boolean \| { text: string, onCopy: function, icon: ReactNode, tooltips: boolean \| ReactNode } | false | `icon` and `tooltips`: 4.4.0 `icon: ReactNode[]` and `tooltips: false`: 4.6.0 |
 | delete | 添加删除线样式 | boolean | false |  |
 | disabled | 禁用文本 | boolean | false |  |
-| editable | 是否可编辑，为对象时可对编辑进行控制 | boolean \| { editing: boolean, maxLength: number, autoSize: true \| false \| { minRows: number, maxRows: number }, onStart: function, onChange: function(string), icon: ReactNode, tooltip: boolean \| ReactNode } | false | `maxLength` and `autoSize`: 4.6.0 `icon` and `tooltip`: 4.?.0 |
+| editable | 是否可编辑，为对象时可对编辑进行控制 | boolean \| { editing: boolean, maxLength: number, autoSize: true \| false \| { minRows: number, maxRows: number }, onStart: function, onChange: function(string), icon: ReactNode, tooltip: boolean \| ReactNode } | false | `maxLength` and `autoSize`: 4.6.0 `icon` and `tooltip`: 4.6.0 |
 | ellipsis | 自动溢出省略，为对象时可设置省略行数与是否可展开等 | boolean \| { rows: number, expandable: boolean, onExpand: function(event), onEllipsis: function(ellipsis) } | false | `onEllipsis`: 4.2.0 |
 | level | 重要程度，相当于 `h1`、`h2`、`h3`、`h4`、`h5` | number: 1, 2, 3, 4, 5 | 1 | 5: 4.6.0 |
 | mark | 添加标记样式 | boolean | false |  |
@@ -53,10 +53,10 @@ cover: https://gw.alipayobjects.com/zos/alicdn/GOM1KQ24O/Typography.svg
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
 | code | 添加代码样式 | boolean | false |  |
-| copyable | 是否可拷贝，为对象时可进行各种自定义 | boolean \| { text: string, onCopy: function, icon: ReactNode, tooltips: boolean \| ReactNode } | false | `icon` and `tooltips`: 4.4.0 `icon: ReactNode[]` and `tooltips: false`: 4.?.0 |
+| copyable | 是否可拷贝，为对象时可进行各种自定义 | boolean \| { text: string, onCopy: function, icon: ReactNode, tooltips: boolean \| ReactNode } | false | `icon` and `tooltips`: 4.4.0 `icon: ReactNode[]` and `tooltips: false`: 4.6.0 |
 | delete | 添加删除线样式 | boolean | false |  |
 | disabled | 禁用文本 | boolean | false |  |
-| editable | 是否可编辑，为对象时可对编辑进行控制 | boolean \| { editing: boolean, maxLength: number, autoSize: true \| false \| { minRows: number, maxRows: number }, onStart: function, onChange: function(string), icon: ReactNode, tooltip: boolean \| ReactNode } | false | `maxLength` and `autoSize`: 4.6.0 `icon` and `tooltip`: 4.?.0 |
+| editable | 是否可编辑，为对象时可对编辑进行控制 | boolean \| { editing: boolean, maxLength: number, autoSize: true \| false \| { minRows: number, maxRows: number }, onStart: function, onChange: function(string), icon: ReactNode, tooltip: boolean \| ReactNode } | false | `maxLength` and `autoSize`: 4.6.0 `icon` and `tooltip`: 4.6.0 |
 | ellipsis | 自动溢出省略，为对象时可设置省略行数、是否可展开、添加后缀等 | boolean \| { rows: number, expandable: boolean, suffix: string, symbol: React.ReactNode, onExpand: function(event), onEllipsis: function(ellipsis) } | false | `onEllipsis`: 4.2.0 |
 | mark | 添加标记样式 | boolean | false |  |
 | underline | 添加下划线样式 | boolean | false |  |

--- a/components/typography/index.zh-CN.md
+++ b/components/typography/index.zh-CN.md
@@ -21,10 +21,10 @@ cover: https://gw.alipayobjects.com/zos/alicdn/GOM1KQ24O/Typography.svg
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
 | code | 添加代码样式 | boolean | false |  |
-| copyable | 是否可拷贝，为对象时可进行各种自定义 | boolean \| { text: string, onCopy: function, icon: ReactNode, tooltips: boolean \| ReactNode } | false | `icon` and `tooltips`: 4.4.0 `icon: ReactNode[]` and `tooltips: false`: 4.6.0 |
+| copyable | 是否可拷贝，为对象时可进行各种自定义 | boolean \| { text: string, onCopy: function, icon: ReactNode, tooltips: boolean \| ReactNode } | false | icon and tooltips: 4.4.0 |
 | delete | 添加删除线样式 | boolean | false |  |
 | disabled | 禁用文本 | boolean | false |  |
-| editable | 是否可编辑，为对象时可对编辑进行控制 | boolean \| { editing: boolean, maxLength: number, autoSize: true \| false \| { minRows: number, maxRows: number }, onStart: function, onChange: function(string), icon: ReactNode, tooltip: boolean \| ReactNode } | false | `maxLength`, `autoSize`, `icon` and `tooltip`: 4.6.0 |
+| editable | 是否可编辑，为对象时可对编辑进行控制 | boolean \| { editing: boolean, maxLength: number, autoSize: true \| false \| { minRows: number, maxRows: number }, onStart: function, onChange: function(string), icon: ReactNode, tooltip: boolean \| ReactNode } | false | maxLength, autoSize, icon and tooltip: 4.6.0 |
 | ellipsis | 设置自动溢出省略，需要设置元素宽度 | boolean | false |  |
 | mark | 添加标记样式 | boolean | false |  |
 | keyboard | 添加键盘样式 | boolean | false | 4.3.0 |
@@ -37,11 +37,11 @@ cover: https://gw.alipayobjects.com/zos/alicdn/GOM1KQ24O/Typography.svg
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
 | code | 添加代码样式 | boolean | false |  |
-| copyable | 是否可拷贝，为对象时可进行各种自定义 | boolean \| { text: string, onCopy: function, icon: ReactNode, tooltips: boolean \| ReactNode } | false | `icon` and `tooltips`: 4.4.0 `icon: ReactNode[]` and `tooltips: false`: 4.6.0 |
+| copyable | 是否可拷贝，为对象时可进行各种自定义 | boolean \| { text: string, onCopy: function, icon: ReactNode, tooltips: boolean \| ReactNode } | false | icon and tooltips: 4.4.0 |
 | delete | 添加删除线样式 | boolean | false |  |
 | disabled | 禁用文本 | boolean | false |  |
-| editable | 是否可编辑，为对象时可对编辑进行控制 | boolean \| { editing: boolean, maxLength: number, autoSize: true \| false \| { minRows: number, maxRows: number }, onStart: function, onChange: function(string), icon: ReactNode, tooltip: boolean \| ReactNode } | false | `maxLength`, `autoSize`, `icon` and `tooltip`: 4.6.0 |
-| ellipsis | 自动溢出省略，为对象时可设置省略行数与是否可展开等 | boolean \| { rows: number, expandable: boolean, onExpand: function(event), onEllipsis: function(ellipsis) } | false | `onEllipsis`: 4.2.0 |
+| editable | 是否可编辑，为对象时可对编辑进行控制 | boolean \| { editing: boolean, maxLength: number, autoSize: true \| false \| { minRows: number, maxRows: number }, onStart: function, onChange: function(string), icon: ReactNode, tooltip: boolean \| ReactNode } | false | maxLength, autoSize, icon and tooltip: 4.6.0 |
+| ellipsis | 自动溢出省略，为对象时可设置省略行数与是否可展开等 | boolean \| { rows: number, expandable: boolean, onExpand: function(event), onEllipsis: function(ellipsis) } | false | onEllipsis: 4.2.0 |
 | level | 重要程度，相当于 `h1`、`h2`、`h3`、`h4`、`h5` | number: 1, 2, 3, 4, 5 | 1 | 5: 4.6.0 |
 | mark | 添加标记样式 | boolean | false |  |
 | underline | 添加下划线样式 | boolean | false |  |
@@ -53,11 +53,11 @@ cover: https://gw.alipayobjects.com/zos/alicdn/GOM1KQ24O/Typography.svg
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
 | code | 添加代码样式 | boolean | false |  |
-| copyable | 是否可拷贝，为对象时可进行各种自定义 | boolean \| { text: string, onCopy: function, icon: ReactNode, tooltips: boolean \| ReactNode } | false | `icon` and `tooltips`: 4.4.0 `icon: ReactNode[]` and `tooltips: false`: 4.6.0 |
+| copyable | 是否可拷贝，为对象时可进行各种自定义 | boolean \| { text: string, onCopy: function, icon: ReactNode, tooltips: boolean \| ReactNode } | false | icon and tooltips: 4.4.0 |
 | delete | 添加删除线样式 | boolean | false |  |
 | disabled | 禁用文本 | boolean | false |  |
-| editable | 是否可编辑，为对象时可对编辑进行控制 | boolean \| { editing: boolean, maxLength: number, autoSize: true \| false \| { minRows: number, maxRows: number }, onStart: function, onChange: function(string), icon: ReactNode, tooltip: boolean \| ReactNode } | false | `maxLength`, `autoSize`, `icon` and `tooltip`: 4.6.0 |
-| ellipsis | 自动溢出省略，为对象时可设置省略行数、是否可展开、添加后缀等 | boolean \| { rows: number, expandable: boolean, suffix: string, symbol: React.ReactNode, onExpand: function(event), onEllipsis: function(ellipsis) } | false | `onEllipsis`: 4.2.0 |
+| editable | 是否可编辑，为对象时可对编辑进行控制 | boolean \| { editing: boolean, maxLength: number, autoSize: true \| false \| { minRows: number, maxRows: number }, onStart: function, onChange: function(string), icon: ReactNode, tooltip: boolean \| ReactNode } | false | maxLength, autoSize, icon and tooltip: 4.6.0 |
+| ellipsis | 自动溢出省略，为对象时可设置省略行数、是否可展开、添加后缀等 | boolean \| { rows: number, expandable: boolean, suffix: string, symbol: React.ReactNode, onExpand: function(event), onEllipsis: function(ellipsis) } | false | onEllipsis: 4.2.0 |
 | mark | 添加标记样式 | boolean | false |  |
 | underline | 添加下划线样式 | boolean | false |  |
 | onChange | 当用户提交编辑内容时触发 | function(string) | - |  |

--- a/components/typography/index.zh-CN.md
+++ b/components/typography/index.zh-CN.md
@@ -21,7 +21,7 @@ cover: https://gw.alipayobjects.com/zos/alicdn/GOM1KQ24O/Typography.svg
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
 | code | 添加代码样式 | boolean | false |  |
-| copyable | 是否可拷贝，为对象时可进行各种自定义 | boolean \| { text: string, onCopy: function, icon: ReactNode, tooltips: boolean \| ReactNode } | false | icon and tooltips: 4.4.0 |
+| copyable | 是否可拷贝，为对象时可进行各种自定义，说明[见下](#copyable) | boolean \| { text: string, onCopy: function, icon: ReactNode, tooltips: boolean \| ReactNode } | false | icon and tooltips: 4.4.0 |
 | delete | 添加删除线样式 | boolean | false |  |
 | disabled | 禁用文本 | boolean | false |  |
 | editable | 是否可编辑，为对象时可对编辑进行控制 | boolean \| { editing: boolean, maxLength: number, autoSize: true \| false \| { minRows: number, maxRows: number }, onStart: function, onChange: function(string), icon: ReactNode, tooltip: boolean \| ReactNode } | false | maxLength, autoSize, icon and tooltip: 4.6.0 |
@@ -37,7 +37,7 @@ cover: https://gw.alipayobjects.com/zos/alicdn/GOM1KQ24O/Typography.svg
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
 | code | 添加代码样式 | boolean | false |  |
-| copyable | 是否可拷贝，为对象时可进行各种自定义 | boolean \| { text: string, onCopy: function, icon: ReactNode, tooltips: boolean \| ReactNode } | false | icon and tooltips: 4.4.0 |
+| copyable | 是否可拷贝，为对象时可进行各种自定义，说明[见下](#copyable) | boolean \| { text: string, onCopy: function, icon: ReactNode, tooltips: boolean \| ReactNode } | false | icon and tooltips: 4.4.0 |
 | delete | 添加删除线样式 | boolean | false |  |
 | disabled | 禁用文本 | boolean | false |  |
 | editable | 是否可编辑，为对象时可对编辑进行控制 | boolean \| { editing: boolean, maxLength: number, autoSize: true \| false \| { minRows: number, maxRows: number }, onStart: function, onChange: function(string), icon: ReactNode, tooltip: boolean \| ReactNode } | false | maxLength, autoSize, icon and tooltip: 4.6.0 |
@@ -53,7 +53,7 @@ cover: https://gw.alipayobjects.com/zos/alicdn/GOM1KQ24O/Typography.svg
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
 | code | 添加代码样式 | boolean | false |  |
-| copyable | 是否可拷贝，为对象时可进行各种自定义 | boolean \| { text: string, onCopy: function, icon: ReactNode, tooltips: boolean \| ReactNode } | false | icon and tooltips: 4.4.0 |
+| copyable | 是否可拷贝，为对象时可进行各种自定义，说明[见下](#copyable) | boolean \| { text: string, onCopy: function, icon: ReactNode, tooltips: boolean \| ReactNode } | false | icon and tooltips: 4.4.0 |
 | delete | 添加删除线样式 | boolean | false |  |
 | disabled | 禁用文本 | boolean | false |  |
 | editable | 是否可编辑，为对象时可对编辑进行控制 | boolean \| { editing: boolean, maxLength: number, autoSize: true \| false \| { minRows: number, maxRows: number }, onStart: function, onChange: function(string), icon: ReactNode, tooltip: boolean \| ReactNode } | false | maxLength, autoSize, icon and tooltip: 4.6.0 |
@@ -63,6 +63,16 @@ cover: https://gw.alipayobjects.com/zos/alicdn/GOM1KQ24O/Typography.svg
 | onChange | 当用户提交编辑内容时触发 | function(string) | - |  |
 | strong | 是否加粗 | boolean | false |  |
 | type | 文本类型 | `secondary` \| `warning` \| `danger` | - |  |
+
+### copyable
+
+从 `4.4.0` 版本开始，`copyable` 支持使用 `{ icon: <SmileOutlined /> }` 设置 copy 图标。
+
+从 `4.4.0` 版本开始，`copyable` 支持使用 `{ tooltips: ['click here', 'you clicked!!'] }` 设置 tooltips 文本。
+
+从 `4.6.0` 版本开始，`copyable` 支持使用 `{ icon: [<SmileOutlined key="copy-icon" />, <SmileFilled key="copied-icon" />] }` 设置 copy 和 copied 图标。
+
+从 `4.6.0` 版本开始，`copyable` 支持使用 `{ tooltips: false }` 设置隐藏 tooltips。
 
 ## FAQ
 

--- a/components/typography/index.zh-CN.md
+++ b/components/typography/index.zh-CN.md
@@ -21,7 +21,7 @@ cover: https://gw.alipayobjects.com/zos/alicdn/GOM1KQ24O/Typography.svg
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
 | code | 添加代码样式 | boolean | false |  |
-| copyable | 是否可拷贝，为对象时可进行各种自定义 | boolean \| { text: string, onCopy: function, icon: ReactNode, tooltips: \[ReactNode, ReactNode\] } | false | `icon` 和 `tooltips` 在 `4.4.0` 支持 |
+| copyable | 是否可拷贝，为对象时可进行各种自定义 | boolean \| { text: string, onCopy: function, icon: ReactNode \| \[ReactNode, ReactNode\], tooltips: boolean \| \[ReactNode, ReactNode\] } | false | `icon` 和 `tooltips` 在 `4.4.0` 支持 |
 | delete | 添加删除线样式 | boolean | false |  |
 | disabled | 禁用文本 | boolean | false |  |
 | editable | 是否可编辑，为对象时可对编辑进行控制 | boolean \| { editing: boolean, maxLength: number, autoSize: true \| false \| { minRows: number, maxRows: number }, onStart: function, onChange: function(string) } | false | maxLength and autoSize: 4.6.0 |
@@ -37,7 +37,7 @@ cover: https://gw.alipayobjects.com/zos/alicdn/GOM1KQ24O/Typography.svg
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
 | code | 添加代码样式 | boolean | false |  |
-| copyable | 是否可拷贝，为对象时可进行各种自定义 | boolean \| { text: string, onCopy: function, icon: ReactNode, tooltips: \[ReactNode, ReactNode\] } | false | `icon` 和 `tooltips` 在 `4.4.0` 支持 |
+| copyable | 是否可拷贝，为对象时可进行各种自定义 | boolean \| { text: string, onCopy: function, icon: ReactNode \| \[ReactNode, ReactNode\], tooltips: boolean \| \[ReactNode, ReactNode\] } | false | `icon` 和 `tooltips` 在 `4.4.0` 支持 |
 | delete | 添加删除线样式 | boolean | false |  |
 | disabled | 禁用文本 | boolean | false |  |
 | editable | 是否可编辑，为对象时可对编辑进行控制 | boolean \| { editing: boolean, maxLength: number, autoSize: true \| false \| { minRows: number, maxRows: number }, onStart: function, onChange: function(string) } | false | maxLength and autoSize: 4.6.0 |
@@ -53,7 +53,7 @@ cover: https://gw.alipayobjects.com/zos/alicdn/GOM1KQ24O/Typography.svg
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
 | code | 添加代码样式 | boolean | false |  |
-| copyable | 是否可拷贝，为对象时可进行各种自定义 | boolean \| { text: string, onCopy: function, icon: ReactNode, tooltips: \[ReactNode, ReactNode\] } | false | `icon` 和 `tooltips` 在 `4.4.0` 支持 |
+| copyable | 是否可拷贝，为对象时可进行各种自定义 | boolean \| { text: string, onCopy: function, icon: ReactNode \| \[ReactNode, ReactNode\], tooltips: boolean \| \[ReactNode, ReactNode\] } | false | `icon` 和 `tooltips` 在 `4.4.0` 支持 |
 | delete | 添加删除线样式 | boolean | false |  |
 | disabled | 禁用文本 | boolean | false |  |
 | editable | 是否可编辑，为对象时可对编辑进行控制 | boolean \| { editing: boolean, maxLength: number, autoSize: true \| false \| { minRows: number, maxRows: number }, onStart: function, onChange: function(string) } | false | maxLength and autoSize: 4.6.0 |

--- a/components/typography/index.zh-CN.md
+++ b/components/typography/index.zh-CN.md
@@ -21,7 +21,7 @@ cover: https://gw.alipayobjects.com/zos/alicdn/GOM1KQ24O/Typography.svg
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
 | code | 添加代码样式 | boolean | false |  |
-| copyable | 是否可拷贝，为对象时可进行各种自定义 | boolean \| { text: string, onCopy: function, icon: ReactNode \| \[ReactNode, ReactNode\], tooltips: boolean \| \[ReactNode, ReactNode\] } | false | `icon` 和 `tooltips` 在 `4.4.0` 支持 |
+| copyable | 是否可拷贝，为对象时可进行各种自定义 | boolean \| { text: string, onCopy: function, icon: ReactNode, tooltips: boolean \| ReactNode } | false | `icon` 和 `tooltips` 在 `4.4.0` 支持 |
 | delete | 添加删除线样式 | boolean | false |  |
 | disabled | 禁用文本 | boolean | false |  |
 | editable | 是否可编辑，为对象时可对编辑进行控制 | boolean \| { editing: boolean, maxLength: number, autoSize: true \| false \| { minRows: number, maxRows: number }, onStart: function, onChange: function(string) } | false | maxLength and autoSize: 4.6.0 |
@@ -37,7 +37,7 @@ cover: https://gw.alipayobjects.com/zos/alicdn/GOM1KQ24O/Typography.svg
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
 | code | 添加代码样式 | boolean | false |  |
-| copyable | 是否可拷贝，为对象时可进行各种自定义 | boolean \| { text: string, onCopy: function, icon: ReactNode \| \[ReactNode, ReactNode\], tooltips: boolean \| \[ReactNode, ReactNode\] } | false | `icon` 和 `tooltips` 在 `4.4.0` 支持 |
+| copyable | 是否可拷贝，为对象时可进行各种自定义 | boolean \| { text: string, onCopy: function, icon: ReactNode, tooltips: boolean \| ReactNode } | false | `icon` 和 `tooltips` 在 `4.4.0` 支持 |
 | delete | 添加删除线样式 | boolean | false |  |
 | disabled | 禁用文本 | boolean | false |  |
 | editable | 是否可编辑，为对象时可对编辑进行控制 | boolean \| { editing: boolean, maxLength: number, autoSize: true \| false \| { minRows: number, maxRows: number }, onStart: function, onChange: function(string) } | false | maxLength and autoSize: 4.6.0 |
@@ -53,7 +53,7 @@ cover: https://gw.alipayobjects.com/zos/alicdn/GOM1KQ24O/Typography.svg
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
 | code | 添加代码样式 | boolean | false |  |
-| copyable | 是否可拷贝，为对象时可进行各种自定义 | boolean \| { text: string, onCopy: function, icon: ReactNode \| \[ReactNode, ReactNode\], tooltips: boolean \| \[ReactNode, ReactNode\] } | false | `icon` 和 `tooltips` 在 `4.4.0` 支持 |
+| copyable | 是否可拷贝，为对象时可进行各种自定义 | boolean \| { text: string, onCopy: function, icon: ReactNode, tooltips: boolean \| ReactNode } | false | `icon` 和 `tooltips` 在 `4.4.0` 支持 |
 | delete | 添加删除线样式 | boolean | false |  |
 | disabled | 禁用文本 | boolean | false |  |
 | editable | 是否可编辑，为对象时可对编辑进行控制 | boolean \| { editing: boolean, maxLength: number, autoSize: true \| false \| { minRows: number, maxRows: number }, onStart: function, onChange: function(string) } | false | maxLength and autoSize: 4.6.0 |

--- a/components/typography/index.zh-CN.md
+++ b/components/typography/index.zh-CN.md
@@ -21,10 +21,10 @@ cover: https://gw.alipayobjects.com/zos/alicdn/GOM1KQ24O/Typography.svg
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
 | code | 添加代码样式 | boolean | false |  |
-| copyable | 是否可拷贝，为对象时可进行各种自定义 | boolean \| { text: string, onCopy: function, icon: ReactNode, tooltips: boolean \| ReactNode } | false | `icon` 和 `tooltips` 在 `4.4.0` 支持 |
+| copyable | 是否可拷贝，为对象时可进行各种自定义 | boolean \| { text: string, onCopy: function, icon: ReactNode, tooltips: boolean \| ReactNode } | false | `icon` and `tooltips`: 4.4.0 `icon: ReactNode[]` and `tooltips: false`: 4.?.0 |
 | delete | 添加删除线样式 | boolean | false |  |
 | disabled | 禁用文本 | boolean | false |  |
-| editable | 是否可编辑，为对象时可对编辑进行控制 | boolean \| { editing: boolean, maxLength: number, autoSize: true \| false \| { minRows: number, maxRows: number }, onStart: function, onChange: function(string) } | false | maxLength and autoSize: 4.6.0 |
+| editable | 是否可编辑，为对象时可对编辑进行控制 | boolean \| { editing: boolean, maxLength: number, autoSize: true \| false \| { minRows: number, maxRows: number }, onStart: function, onChange: function(string), icon: ReactNode, tooltip: boolean \| ReactNode } | false | `maxLength` and `autoSize`: 4.6.0 `icon` and `tooltip`: 4.?.0 |
 | ellipsis | 设置自动溢出省略，需要设置元素宽度 | boolean | false |  |
 | mark | 添加标记样式 | boolean | false |  |
 | keyboard | 添加键盘样式 | boolean | false | 4.3.0 |
@@ -37,11 +37,11 @@ cover: https://gw.alipayobjects.com/zos/alicdn/GOM1KQ24O/Typography.svg
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
 | code | 添加代码样式 | boolean | false |  |
-| copyable | 是否可拷贝，为对象时可进行各种自定义 | boolean \| { text: string, onCopy: function, icon: ReactNode, tooltips: boolean \| ReactNode } | false | `icon` 和 `tooltips` 在 `4.4.0` 支持 |
+| copyable | 是否可拷贝，为对象时可进行各种自定义 | boolean \| { text: string, onCopy: function, icon: ReactNode, tooltips: boolean \| ReactNode } | false | `icon` and `tooltips`: 4.4.0 `icon: ReactNode[]` and `tooltips: false`: 4.?.0 |
 | delete | 添加删除线样式 | boolean | false |  |
 | disabled | 禁用文本 | boolean | false |  |
-| editable | 是否可编辑，为对象时可对编辑进行控制 | boolean \| { editing: boolean, maxLength: number, autoSize: true \| false \| { minRows: number, maxRows: number }, onStart: function, onChange: function(string) } | false | maxLength and autoSize: 4.6.0 |
-| ellipsis | 自动溢出省略，为对象时可设置省略行数与是否可展开等 | boolean \| { rows: number, expandable: boolean, onExpand: function(event), onEllipsis: function(ellipsis) } | false | onEllipsis: 4.2.0 |
+| editable | 是否可编辑，为对象时可对编辑进行控制 | boolean \| { editing: boolean, maxLength: number, autoSize: true \| false \| { minRows: number, maxRows: number }, onStart: function, onChange: function(string), icon: ReactNode, tooltip: boolean \| ReactNode } | false | `maxLength` and `autoSize`: 4.6.0 `icon` and `tooltip`: 4.?.0 |
+| ellipsis | 自动溢出省略，为对象时可设置省略行数与是否可展开等 | boolean \| { rows: number, expandable: boolean, onExpand: function(event), onEllipsis: function(ellipsis) } | false | `onEllipsis`: 4.2.0 |
 | level | 重要程度，相当于 `h1`、`h2`、`h3`、`h4`、`h5` | number: 1, 2, 3, 4, 5 | 1 | 5: 4.6.0 |
 | mark | 添加标记样式 | boolean | false |  |
 | underline | 添加下划线样式 | boolean | false |  |
@@ -53,11 +53,11 @@ cover: https://gw.alipayobjects.com/zos/alicdn/GOM1KQ24O/Typography.svg
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
 | code | 添加代码样式 | boolean | false |  |
-| copyable | 是否可拷贝，为对象时可进行各种自定义 | boolean \| { text: string, onCopy: function, icon: ReactNode, tooltips: boolean \| ReactNode } | false | `icon` 和 `tooltips` 在 `4.4.0` 支持 |
+| copyable | 是否可拷贝，为对象时可进行各种自定义 | boolean \| { text: string, onCopy: function, icon: ReactNode, tooltips: boolean \| ReactNode } | false | `icon` and `tooltips`: 4.4.0 `icon: ReactNode[]` and `tooltips: false`: 4.?.0 |
 | delete | 添加删除线样式 | boolean | false |  |
 | disabled | 禁用文本 | boolean | false |  |
-| editable | 是否可编辑，为对象时可对编辑进行控制 | boolean \| { editing: boolean, maxLength: number, autoSize: true \| false \| { minRows: number, maxRows: number }, onStart: function, onChange: function(string) } | false | maxLength and autoSize: 4.6.0 |
-| ellipsis | 自动溢出省略，为对象时可设置省略行数、是否可展开、添加后缀等 | boolean \| { rows: number, expandable: boolean, suffix: string, symbol: React.ReactNode, onExpand: function(event), onEllipsis: function(ellipsis) } | false | onEllipsis: 4.2.0 |
+| editable | 是否可编辑，为对象时可对编辑进行控制 | boolean \| { editing: boolean, maxLength: number, autoSize: true \| false \| { minRows: number, maxRows: number }, onStart: function, onChange: function(string), icon: ReactNode, tooltip: boolean \| ReactNode } | false | `maxLength` and `autoSize`: 4.6.0 `icon` and `tooltip`: 4.?.0 |
+| ellipsis | 自动溢出省略，为对象时可设置省略行数、是否可展开、添加后缀等 | boolean \| { rows: number, expandable: boolean, suffix: string, symbol: React.ReactNode, onExpand: function(event), onEllipsis: function(ellipsis) } | false | `onEllipsis`: 4.2.0 |
 | mark | 添加标记样式 | boolean | false |  |
 | underline | 添加下划线样式 | boolean | false |  |
 | onChange | 当用户提交编辑内容时触发 | function(string) | - |  |

--- a/components/typography/index.zh-CN.md
+++ b/components/typography/index.zh-CN.md
@@ -24,7 +24,7 @@ cover: https://gw.alipayobjects.com/zos/alicdn/GOM1KQ24O/Typography.svg
 | copyable | 是否可拷贝，为对象时可进行各种自定义 | boolean \| { text: string, onCopy: function, icon: ReactNode, tooltips: boolean \| ReactNode } | false | `icon` and `tooltips`: 4.4.0 `icon: ReactNode[]` and `tooltips: false`: 4.6.0 |
 | delete | 添加删除线样式 | boolean | false |  |
 | disabled | 禁用文本 | boolean | false |  |
-| editable | 是否可编辑，为对象时可对编辑进行控制 | boolean \| { editing: boolean, maxLength: number, autoSize: true \| false \| { minRows: number, maxRows: number }, onStart: function, onChange: function(string), icon: ReactNode, tooltip: boolean \| ReactNode } | false | `maxLength` and `autoSize`: 4.6.0 `icon` and `tooltip`: 4.6.0 |
+| editable | 是否可编辑，为对象时可对编辑进行控制 | boolean \| { editing: boolean, maxLength: number, autoSize: true \| false \| { minRows: number, maxRows: number }, onStart: function, onChange: function(string), icon: ReactNode, tooltip: boolean \| ReactNode } | false | `maxLength`, `autoSize`, `icon` and `tooltip`: 4.6.0 |
 | ellipsis | 设置自动溢出省略，需要设置元素宽度 | boolean | false |  |
 | mark | 添加标记样式 | boolean | false |  |
 | keyboard | 添加键盘样式 | boolean | false | 4.3.0 |
@@ -40,7 +40,7 @@ cover: https://gw.alipayobjects.com/zos/alicdn/GOM1KQ24O/Typography.svg
 | copyable | 是否可拷贝，为对象时可进行各种自定义 | boolean \| { text: string, onCopy: function, icon: ReactNode, tooltips: boolean \| ReactNode } | false | `icon` and `tooltips`: 4.4.0 `icon: ReactNode[]` and `tooltips: false`: 4.6.0 |
 | delete | 添加删除线样式 | boolean | false |  |
 | disabled | 禁用文本 | boolean | false |  |
-| editable | 是否可编辑，为对象时可对编辑进行控制 | boolean \| { editing: boolean, maxLength: number, autoSize: true \| false \| { minRows: number, maxRows: number }, onStart: function, onChange: function(string), icon: ReactNode, tooltip: boolean \| ReactNode } | false | `maxLength` and `autoSize`: 4.6.0 `icon` and `tooltip`: 4.6.0 |
+| editable | 是否可编辑，为对象时可对编辑进行控制 | boolean \| { editing: boolean, maxLength: number, autoSize: true \| false \| { minRows: number, maxRows: number }, onStart: function, onChange: function(string), icon: ReactNode, tooltip: boolean \| ReactNode } | false | `maxLength`, `autoSize`, `icon` and `tooltip`: 4.6.0 |
 | ellipsis | 自动溢出省略，为对象时可设置省略行数与是否可展开等 | boolean \| { rows: number, expandable: boolean, onExpand: function(event), onEllipsis: function(ellipsis) } | false | `onEllipsis`: 4.2.0 |
 | level | 重要程度，相当于 `h1`、`h2`、`h3`、`h4`、`h5` | number: 1, 2, 3, 4, 5 | 1 | 5: 4.6.0 |
 | mark | 添加标记样式 | boolean | false |  |
@@ -56,7 +56,7 @@ cover: https://gw.alipayobjects.com/zos/alicdn/GOM1KQ24O/Typography.svg
 | copyable | 是否可拷贝，为对象时可进行各种自定义 | boolean \| { text: string, onCopy: function, icon: ReactNode, tooltips: boolean \| ReactNode } | false | `icon` and `tooltips`: 4.4.0 `icon: ReactNode[]` and `tooltips: false`: 4.6.0 |
 | delete | 添加删除线样式 | boolean | false |  |
 | disabled | 禁用文本 | boolean | false |  |
-| editable | 是否可编辑，为对象时可对编辑进行控制 | boolean \| { editing: boolean, maxLength: number, autoSize: true \| false \| { minRows: number, maxRows: number }, onStart: function, onChange: function(string), icon: ReactNode, tooltip: boolean \| ReactNode } | false | `maxLength` and `autoSize`: 4.6.0 `icon` and `tooltip`: 4.6.0 |
+| editable | 是否可编辑，为对象时可对编辑进行控制 | boolean \| { editing: boolean, maxLength: number, autoSize: true \| false \| { minRows: number, maxRows: number }, onStart: function, onChange: function(string), icon: ReactNode, tooltip: boolean \| ReactNode } | false | `maxLength`, `autoSize`, `icon` and `tooltip`: 4.6.0 |
 | ellipsis | 自动溢出省略，为对象时可设置省略行数、是否可展开、添加后缀等 | boolean \| { rows: number, expandable: boolean, suffix: string, symbol: React.ReactNode, onExpand: function(event), onEllipsis: function(ellipsis) } | false | `onEllipsis`: 4.2.0 |
 | mark | 添加标记样式 | boolean | false |  |
 | underline | 添加下划线样式 | boolean | false |  |

--- a/components/typography/index.zh-CN.md
+++ b/components/typography/index.zh-CN.md
@@ -21,10 +21,10 @@ cover: https://gw.alipayobjects.com/zos/alicdn/GOM1KQ24O/Typography.svg
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
 | code | 添加代码样式 | boolean | false |  |
-| copyable | 是否可拷贝，为对象时可进行各种自定义，说明[见下](#copyable) | boolean \| { text: string, onCopy: function, icon: ReactNode, tooltips: boolean \| ReactNode } | false | icon and tooltips: 4.4.0 |
+| copyable | 是否可拷贝，为对象时可进行各种自定义 | boolean \| { text: string, onCopy: function, icon: ReactNode, tooltips: boolean \| ReactNode } | false | 说明[见下](#copyable) |
 | delete | 添加删除线样式 | boolean | false |  |
 | disabled | 禁用文本 | boolean | false |  |
-| editable | 是否可编辑，为对象时可对编辑进行控制 | boolean \| { editing: boolean, maxLength: number, autoSize: true \| false \| { minRows: number, maxRows: number }, onStart: function, onChange: function(string), icon: ReactNode, tooltip: boolean \| ReactNode } | false | maxLength, autoSize, icon and tooltip: 4.6.0 |
+| editable | 是否可编辑，为对象时可对编辑进行控制 | boolean \| { editing: boolean, maxLength: number, autoSize: true \| false \| { minRows: number, maxRows: number }, onStart: function, onChange: function(string), icon: ReactNode, tooltip: boolean \| ReactNode } | false | 说明[见下](#editable) |
 | ellipsis | 设置自动溢出省略，需要设置元素宽度 | boolean | false |  |
 | mark | 添加标记样式 | boolean | false |  |
 | keyboard | 添加键盘样式 | boolean | false | 4.3.0 |
@@ -37,10 +37,10 @@ cover: https://gw.alipayobjects.com/zos/alicdn/GOM1KQ24O/Typography.svg
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
 | code | 添加代码样式 | boolean | false |  |
-| copyable | 是否可拷贝，为对象时可进行各种自定义，说明[见下](#copyable) | boolean \| { text: string, onCopy: function, icon: ReactNode, tooltips: boolean \| ReactNode } | false | icon and tooltips: 4.4.0 |
+| copyable | 是否可拷贝，为对象时可进行各种自定义 | boolean \| { text: string, onCopy: function, icon: ReactNode, tooltips: boolean \| ReactNode } | false | 说明[见下](#copyable) |
 | delete | 添加删除线样式 | boolean | false |  |
 | disabled | 禁用文本 | boolean | false |  |
-| editable | 是否可编辑，为对象时可对编辑进行控制 | boolean \| { editing: boolean, maxLength: number, autoSize: true \| false \| { minRows: number, maxRows: number }, onStart: function, onChange: function(string), icon: ReactNode, tooltip: boolean \| ReactNode } | false | maxLength, autoSize, icon and tooltip: 4.6.0 |
+| editable | 是否可编辑，为对象时可对编辑进行控制 | boolean \| { editing: boolean, maxLength: number, autoSize: true \| false \| { minRows: number, maxRows: number }, onStart: function, onChange: function(string), icon: ReactNode, tooltip: boolean \| ReactNode } | false | 说明[见下](#editable) |
 | ellipsis | 自动溢出省略，为对象时可设置省略行数与是否可展开等 | boolean \| { rows: number, expandable: boolean, onExpand: function(event), onEllipsis: function(ellipsis) } | false | onEllipsis: 4.2.0 |
 | level | 重要程度，相当于 `h1`、`h2`、`h3`、`h4`、`h5` | number: 1, 2, 3, 4, 5 | 1 | 5: 4.6.0 |
 | mark | 添加标记样式 | boolean | false |  |
@@ -53,10 +53,10 @@ cover: https://gw.alipayobjects.com/zos/alicdn/GOM1KQ24O/Typography.svg
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
 | code | 添加代码样式 | boolean | false |  |
-| copyable | 是否可拷贝，为对象时可进行各种自定义，说明[见下](#copyable) | boolean \| { text: string, onCopy: function, icon: ReactNode, tooltips: boolean \| ReactNode } | false | icon and tooltips: 4.4.0 |
+| copyable | 是否可拷贝，为对象时可进行各种自定义 | boolean \| { text: string, onCopy: function, icon: ReactNode, tooltips: boolean \| ReactNode } | false | 说明[见下](#copyable) |
 | delete | 添加删除线样式 | boolean | false |  |
 | disabled | 禁用文本 | boolean | false |  |
-| editable | 是否可编辑，为对象时可对编辑进行控制 | boolean \| { editing: boolean, maxLength: number, autoSize: true \| false \| { minRows: number, maxRows: number }, onStart: function, onChange: function(string), icon: ReactNode, tooltip: boolean \| ReactNode } | false | maxLength, autoSize, icon and tooltip: 4.6.0 |
+| editable | 是否可编辑，为对象时可对编辑进行控制 | boolean \| { editing: boolean, maxLength: number, autoSize: true \| false \| { minRows: number, maxRows: number }, onStart: function, onChange: function(string), icon: ReactNode, tooltip: boolean \| ReactNode } | false | 说明[见下](#editable) |
 | ellipsis | 自动溢出省略，为对象时可设置省略行数、是否可展开、添加后缀等 | boolean \| { rows: number, expandable: boolean, suffix: string, symbol: React.ReactNode, onExpand: function(event), onEllipsis: function(ellipsis) } | false | onEllipsis: 4.2.0 |
 | mark | 添加标记样式 | boolean | false |  |
 | underline | 添加下划线样式 | boolean | false |  |
@@ -73,6 +73,16 @@ cover: https://gw.alipayobjects.com/zos/alicdn/GOM1KQ24O/Typography.svg
 从 `4.6.0` 版本开始，`copyable` 支持使用 `{ icon: [<SmileOutlined key="copy-icon" />, <SmileFilled key="copied-icon" />] }` 设置 copy 和 copied 图标。
 
 从 `4.6.0` 版本开始，`copyable` 支持使用 `{ tooltips: false }` 设置隐藏 tooltips。
+
+### editable
+
+从 `4.4.0` 版本开始，`editable` 支持使用 `{ maxLength: 50 }` 设置 TextArea 的 `maxLength` 属性。
+
+从 `4.4.0` 版本开始，`editable` 支持使用 `{ autoSize: { maxRows: 5, minRows: 3 } }` 设置 TextArea 的 `autoSize` 属性。
+
+从 `4.6.0` 版本开始，`editable` 支持使用 `{ icon: <HighlightOutlined /> }` 设置 edit 图标。
+
+从 `4.6.0` 版本开始，`editable` 支持使用 `{ tooltips: 'click to edit text' }` 设置 tooltip 文本。
 
 ## FAQ
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

resolve https://github.com/ant-design/ant-design/issues/25947
resolve https://github.com/ant-design/ant-design/issues/25994
resolve https://github.com/ant-design/ant-design/issues/19562

### 💡 Background and solution

- copyable
  - add `icon` prop
  - add `tooltips` prop
- editable
  - add `icon` prop
  - add `tooltip` prop

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Typography emhance`copyable` and `editable` props. |
| 🇨🇳 Chinese |  Typography 增强 `copyable` 和 `editable` 属性。  |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed


-----
[View rendered components/typography/demo/interactive.md](https://github.com/llwslc/ant-design/blob/customize-copyable/components/typography/demo/interactive.md)
[View rendered components/typography/index.en-US.md](https://github.com/llwslc/ant-design/blob/customize-copyable/components/typography/index.en-US.md)
[View rendered components/typography/index.zh-CN.md](https://github.com/llwslc/ant-design/blob/customize-copyable/components/typography/index.zh-CN.md)