### PR TITLE
feat: added `autoFocus` prop to Text, Paragraph and Title in Typography on editable input

### DIFF
--- a/components/typography/Base.tsx
+++ b/components/typography/Base.tsx
@@ -60,6 +60,7 @@ export interface BlockProps extends TypographyProps {
   delete?: boolean;
   strong?: boolean;
   keyboard?: boolean;
+  autoFocus?: boolean;
 }
 
 function wrapperDecorations(
@@ -156,7 +157,9 @@ class Base extends React.Component<InternalBlockProps, BaseState> {
   };
 
   componentDidMount() {
+    const { autoFocus, editable } = this.props;
     this.setState({ clientRendered: true });
+    if (autoFocus && editable) this.triggerEdit(true);
     this.resizeOnNextFrame();
   }
 

--- a/components/typography/__tests__/index.test.js
+++ b/components/typography/__tests__/index.test.js
@@ -303,6 +303,26 @@ describe('Typography', () => {
       });
     });
 
+    describe('auto focus', () => {
+      it('should auto focus when autoFocus prop is true on an editable', () => {
+        const wrapper = mount(
+          <Paragraph autoFocus editable>
+            Bamboo
+          </Paragraph>,
+        );
+        expect(wrapper.find('TextArea').at(0).prop('value')).toBe('Bamboo');
+      });
+
+      it('should not focus when autoFocus prop is true on non editable', () => {
+        const wrapper = mount(
+          <Paragraph autoFocus copyable>
+            Bamboo
+          </Paragraph>,
+        );
+        expect(wrapper.contains('TextArea')).toBe(false);
+      });
+    });
+
     it('should focus at the end of textarea', () => {
       const wrapper = mount(<Paragraph editable>content</Paragraph>);
       wrapper.find('.ant-typography-edit').first().simulate('click');

--- a/components/typography/index.en-US.md
+++ b/components/typography/index.en-US.md
@@ -31,7 +31,7 @@ Basic text writing, including headings, body text, lists, and more.
 | onChange | Trigger when user edits the content | function(string) | - |  |
 | strong | Bold style | boolean | false |  |
 | type | Content type | `secondary` \| `warning` \| `danger` | - |  |
-| autoFocus | Automatic focus on the TextArea (only works if `editable` is true) | boolean | false |  |
+| autoFocus | Automatic focus on the TextArea (only valid if `editable` is true) | boolean | false | 4.6.0 |
 
 ### Typography.Title
 
@@ -48,7 +48,7 @@ Basic text writing, including headings, body text, lists, and more.
 | underline | Underlined style | boolean | false |  |
 | onChange | Trigger when user edits the content | function(string) | - |  |
 | type | Content type | `secondary` \| `warning` \| `danger` | - |  |
-| autoFocus | Automatic focus on the TextArea (only works if `editable` is true) | boolean | false |  |
+| autoFocus | Automatic focus on the TextArea (only valid if `editable` is true) | boolean | false | 4.6.0 |
 
 ### Typography.Paragraph
 
@@ -65,7 +65,7 @@ Basic text writing, including headings, body text, lists, and more.
 | onChange | Trigger when user edits the content | function(string) | - |  |
 | strong | Bold style | boolean | false |  |
 | type | Content type | `secondary` \| `warning` \| `danger` | - |  |
-| autoFocus | Automatic focus on the TextArea (only works if `editable` is true) | boolean | false |  |
+| autoFocus | Automatic focus on the TextArea (only valid if `editable` is true) | boolean | false | 4.6.0 |
 
 ## FAQ
 

--- a/components/typography/index.en-US.md
+++ b/components/typography/index.en-US.md
@@ -31,6 +31,7 @@ Basic text writing, including headings, body text, lists, and more.
 | onChange | Trigger when user edits the content | function(string) | - |  |
 | strong | Bold style | boolean | false |  |
 | type | Content type | `secondary` \| `warning` \| `danger` | - |  |
+| autoFocus | Automatic focus on the TextArea (only works if `editable` is true) | boolean | false |  |
 
 ### Typography.Title
 
@@ -47,6 +48,7 @@ Basic text writing, including headings, body text, lists, and more.
 | underline | Underlined style | boolean | false |  |
 | onChange | Trigger when user edits the content | function(string) | - |  |
 | type | Content type | `secondary` \| `warning` \| `danger` | - |  |
+| autoFocus | Automatic focus on the TextArea (only works if `editable` is true) | boolean | false |  |
 
 ### Typography.Paragraph
 
@@ -63,6 +65,7 @@ Basic text writing, including headings, body text, lists, and more.
 | onChange | Trigger when user edits the content | function(string) | - |  |
 | strong | Bold style | boolean | false |  |
 | type | Content type | `secondary` \| `warning` \| `danger` | - |  |
+| autoFocus | Automatic focus on the TextArea (only works if `editable` is true) | boolean | false |  |
 
 ## FAQ
 

--- a/components/typography/index.zh-CN.md
+++ b/components/typography/index.zh-CN.md
@@ -31,7 +31,7 @@ cover: https://gw.alipayobjects.com/zos/alicdn/GOM1KQ24O/Typography.svg
 | underline | 添加下划线样式 | boolean | false |  |
 | strong | 是否加粗 | boolean | false |  |
 | type | 文本类型 | `secondary` \| `warning` \| `danger` | - |  |
-| autoFocus | 自动聚焦文本区域 (仅在 “可编辑” 为 true 时有效) | boolean | false |  |
+| autoFocus | 自动聚焦文本区域 (仅在 `editable` 为 true 时有效) | boolean | false | 4.6.0 |
 
 ### Typography.Title
 
@@ -48,7 +48,7 @@ cover: https://gw.alipayobjects.com/zos/alicdn/GOM1KQ24O/Typography.svg
 | underline | 添加下划线样式 | boolean | false |  |
 | onChange | 当用户提交编辑内容时触发 | function(string) | - |  |
 | type | 文本类型 | `secondary` \| `warning` \| `danger` | - |  |
-| autoFocus | 自动聚焦文本区域 (仅在 “可编辑” 为 true 时有效) | boolean | false |  |
+| autoFocus | 自动聚焦文本区域 (仅在 `editable` 为 true 时有效) | boolean | false | 4.6.0 |
 
 ### Typography.Paragraph
 
@@ -65,7 +65,7 @@ cover: https://gw.alipayobjects.com/zos/alicdn/GOM1KQ24O/Typography.svg
 | onChange | 当用户提交编辑内容时触发 | function(string) | - |  |
 | strong | 是否加粗 | boolean | false |  |
 | type | 文本类型 | `secondary` \| `warning` \| `danger` | - |  |
-| autoFocus | 自动聚焦文本区域 (仅在 “可编辑” 为 true 时有效) | boolean | false |  |
+| autoFocus | 自动聚焦文本区域 (仅在 `editable` 为 true 时有效) | boolean | false | 4.6.0 |
 
 ## FAQ
 

--- a/components/typography/index.zh-CN.md
+++ b/components/typography/index.zh-CN.md
@@ -31,6 +31,7 @@ cover: https://gw.alipayobjects.com/zos/alicdn/GOM1KQ24O/Typography.svg
 | underline | 添加下划线样式 | boolean | false |  |
 | strong | 是否加粗 | boolean | false |  |
 | type | 文本类型 | `secondary` \| `warning` \| `danger` | - |  |
+| autoFocus | 自动聚焦文本区域 (仅在 “可编辑” 为 true 时有效) | boolean | false |  |
 
 ### Typography.Title
 
@@ -47,6 +48,7 @@ cover: https://gw.alipayobjects.com/zos/alicdn/GOM1KQ24O/Typography.svg
 | underline | 添加下划线样式 | boolean | false |  |
 | onChange | 当用户提交编辑内容时触发 | function(string) | - |  |
 | type | 文本类型 | `secondary` \| `warning` \| `danger` | - |  |
+| autoFocus | 自动聚焦文本区域 (仅在 “可编辑” 为 true 时有效) | boolean | false |  |
 
 ### Typography.Paragraph
 
@@ -63,6 +65,7 @@ cover: https://gw.alipayobjects.com/zos/alicdn/GOM1KQ24O/Typography.svg
 | onChange | 当用户提交编辑内容时触发 | function(string) | - |  |
 | strong | 是否加粗 | boolean | false |  |
 | type | 文本类型 | `secondary` \| `warning` \| `danger` | - |  |
+| autoFocus | 自动聚焦文本区域 (仅在 “可编辑” 为 true 时有效) | boolean | false |  |
 
 ## FAQ
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->
https://github.com/ant-design/ant-design/issues/25811
### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/typography/index.en-US.md](https://github.com/OmriGM/ant-design/blob/OmriGM-typography/components/typography/index.en-US.md)
[View rendered components/typography/index.zh-CN.md](https://github.com/OmriGM/ant-design/blob/OmriGM-typography/components/typography/index.zh-CN.md)