### PR TITLE
fix: useModal missing prefix

### DIFF
--- a/components/config-provider/context.tsx
+++ b/components/config-provider/context.tsx
@@ -11,7 +11,7 @@ export interface ConfigConsumerProps {
   getTargetContainer?: () => HTMLElement;
   getPopupContainer?: (triggerNode: HTMLElement) => HTMLElement;
   rootPrefixCls?: string;
-  getPrefixCls: (suffixCls: string, customizePrefixCls?: string) => string;
+  getPrefixCls: (suffixCls?: string, customizePrefixCls?: string) => string;
   renderEmpty: RenderEmptyHandler;
   csp?: CSPConfig;
   autoInsertSpaceInButton?: boolean;
@@ -32,7 +32,7 @@ export interface ConfigConsumerProps {
 
 export const ConfigContext = React.createContext<ConfigConsumerProps>({
   // We provide a default function for Context without provider
-  getPrefixCls: (suffixCls: string, customizePrefixCls?: string) => {
+  getPrefixCls: (suffixCls?: string, customizePrefixCls?: string) => {
     if (customizePrefixCls) return customizePrefixCls;
 
     return suffixCls ? `ant-${suffixCls}` : 'ant';

--- a/components/modal/__tests__/hook.test.js
+++ b/components/modal/__tests__/hook.test.js
@@ -35,6 +35,8 @@ describe('Modal.hook', () => {
     wrapper.find('button').simulate('click');
 
     expect(wrapper.find('.test-hook').text()).toEqual('bamboo');
+    expect(wrapper.find('.ant-btn').length).toBeTruthy();
+    expect(wrapper.find('.ant-modal-body').length).toBeTruthy();
 
     // Update instance
     instance.update({

--- a/components/modal/useModal/HookModal.tsx
+++ b/components/modal/useModal/HookModal.tsx
@@ -27,7 +27,10 @@ const HookModal: React.ForwardRefRenderFunction<HookModalRef, HookModalProps> = 
 ) => {
   const [visible, setVisible] = React.useState(true);
   const [innerConfig, setInnerConfig] = React.useState(config);
-  const { direction } = React.useContext(ConfigContext);
+  const { direction, getPrefixCls } = React.useContext(ConfigContext);
+
+  const prefixCls = getPrefixCls('modal');
+  const rootPrefixCls = getPrefixCls();
 
   function close() {
     setVisible(false);
@@ -47,6 +50,8 @@ const HookModal: React.ForwardRefRenderFunction<HookModalRef, HookModalProps> = 
     <LocaleReceiver componentName="Modal" defaultLocale={defaultLocale.Modal}>
       {(modalLocale: ModalLocale) => (
         <ConfirmDialog
+          prefixCls={prefixCls}
+          rootPrefixCls={rootPrefixCls}
           {...innerConfig}
           close={close}
           visible={visible}


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

resolve #25895

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fix Modal `useModal` missing style issue.     |
| 🇨🇳 Chinese |     修复 Modal `useModal` 丢失样式问题。       |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
