### PR TITLE
style: hidden handler when inputnumber readonly

### DIFF
--- a/components/input-number/index.en-US.md
+++ b/components/input-number/index.en-US.md
@@ -18,6 +18,7 @@ When a numeric value needs to be provided.
 | autoFocus | If get focus when component mounted | boolean | false |
 | defaultValue | The initial value | number | - |
 | disabled | If disable the input | boolean | false |
+| readOnly | If readonly the input | boolean | false |
 | formatter | Specifies the format of the value presented | function(value: number \| string): string | - |
 | max | The max value | number | [Number.MAX_SAFE_INTEGER](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER) |
 | min | The min value | number | [Number.MIN_SAFE_INTEGER](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MIN_SAFE_INTEGER) |

--- a/components/input-number/index.tsx
+++ b/components/input-number/index.tsx
@@ -22,6 +22,7 @@ export interface InputNumberProps
   tabIndex?: number;
   onChange?: (value: number | string | undefined) => void;
   disabled?: boolean;
+  readOnly?: boolean;
   size?: SizeType;
   formatter?: (value: number | string | undefined) => string;
   parser?: (displayValue: string | undefined) => number | string;
@@ -37,7 +38,13 @@ export interface InputNumberProps
 
 const InputNumber = React.forwardRef<unknown, InputNumberProps>((props, ref) => {
   const renderInputNumber = ({ getPrefixCls, direction }: ConfigConsumerProps) => {
-    const { className, size: customizeSize, prefixCls: customizePrefixCls, ...others } = props;
+    const {
+      className,
+      size: customizeSize,
+      prefixCls: customizePrefixCls,
+      readOnly,
+      ...others
+    } = props;
     const prefixCls = getPrefixCls('input-number', customizePrefixCls);
     const upIcon = <UpOutlined className={`${prefixCls}-handler-up-inner`} />;
     const downIcon = <DownOutlined className={`${prefixCls}-handler-down-inner`} />;
@@ -51,6 +58,7 @@ const InputNumber = React.forwardRef<unknown, InputNumberProps>((props, ref) => 
               [`${prefixCls}-lg`]: mergeSize === 'large',
               [`${prefixCls}-sm`]: mergeSize === 'small',
               [`${prefixCls}-rtl`]: direction === 'rtl',
+              [`${prefixCls}-readonly`]: readOnly,
             },
             className,
           );
@@ -62,6 +70,7 @@ const InputNumber = React.forwardRef<unknown, InputNumberProps>((props, ref) => 
               upHandler={upIcon}
               downHandler={downIcon}
               prefixCls={prefixCls}
+              readOnly={readOnly}
               {...others}
             />
           );

--- a/components/input-number/index.zh-CN.md
+++ b/components/input-number/index.zh-CN.md
@@ -21,6 +21,7 @@ cover: https://gw.alipayobjects.com/zos/alicdn/XOS8qZ0kU/InputNumber.svg
 | autoFocus | 自动获取焦点 | boolean | false |
 | defaultValue | 初始值 | number | - |
 | disabled | 禁用 | boolean | false |
+| readOnly | 只读 | boolean | false |
 | formatter | 指定输入框展示值的格式 | function(value: number \| string): string | - |
 | max | 最大值 | number | [Number.MAX_SAFE_INTEGER](https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER) |
 | min | 最小值 | number | [Number.MIN_SAFE_INTEGER](https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Number/MIN_SAFE_INTEGER) |

--- a/components/input-number/style/index.less
+++ b/components/input-number/style/index.less
@@ -72,6 +72,12 @@
     }
   }
 
+  &-readonly {
+    .@{input-number-prefix-cls}-handler-wrap {
+      display: none;
+    }
+  }
+
   &-input {
     width: 100%;
     height: @input-height-base - 2px;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
close https://github.com/ant-design/ant-design/issues/25974
<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Adjust InputNunber handler bar to be hidden when `readOnly`.          |
| 🇨🇳 Chinese | 调整 InputNunber 操作栏在 `readOnly` 时为隐藏。          |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/input-number/index.en-US.md](https://github.com/ant-design/ant-design/blob/inputnumber-read/components/input-number/index.en-US.md)
[View rendered components/input-number/index.zh-CN.md](https://github.com/ant-design/ant-design/blob/inputnumber-read/components/input-number/index.zh-CN.md)