### PR TITLE
style: add @badge-count-background

### DIFF
--- a/components/badge/style/index.less
+++ b/components/badge/style/index.less
@@ -23,7 +23,7 @@
     line-height: @badge-height;
     white-space: nowrap;
     text-align: center;
-    background: @badge-color;
+    background: @badge-count-background;
     border-radius: @badge-height / 2;
     box-shadow: 0 0 0 1px @shadow-color-inverse;
     a,

--- a/components/badge/style/index.less
+++ b/components/badge/style/index.less
@@ -23,7 +23,7 @@
     line-height: @badge-height;
     white-space: nowrap;
     text-align: center;
-    background: @highlight-color;
+    background: @badge-color;
     border-radius: @badge-height / 2;
     box-shadow: 0 0 0 1px @shadow-color-inverse;
     a,

--- a/components/style/themes/default.less
+++ b/components/style/themes/default.less
@@ -656,6 +656,7 @@
 @badge-font-weight: normal;
 @badge-status-size: 6px;
 @badge-text-color: @component-background;
+@badge-color: @highlight-color;
 
 // Rate
 // ---

--- a/components/style/themes/default.less
+++ b/components/style/themes/default.less
@@ -656,7 +656,7 @@
 @badge-font-weight: normal;
 @badge-status-size: 6px;
 @badge-text-color: @component-background;
-@badge-color: @highlight-color;
+@badge-count-background: @highlight-color;
 
 // Rate
 // ---


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->


### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

https://github.com/ant-design/ant-design/issues/26040

### 💡 Background and solution

Users are unable to change the badge color with out changing the `@highlight-color` for the entire theme.

### 📝 Changelog

Add @badge-count-background

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered .github/PULL_REQUEST_TEMPLATE.md](https://github.com/sorahn/ant-design/blob/badge-color/.github/PULL_REQUEST_TEMPLATE.md)
[View rendered .github/PULL_REQUEST_TEMPLATE/pr_cn.md](https://github.com/sorahn/ant-design/blob/badge-color/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)