### PR TITLE
fix: Arabic locale

### DIFF
--- a/components/locale/ar_EG.tsx
+++ b/components/locale/ar_EG.tsx
@@ -5,7 +5,7 @@ import TimePicker from '../time-picker/locale/ar_EG';
 import Calendar from '../calendar/locale/ar_EG';
 import { Locale } from '../locale-provider';
 
-const typeTemplate = 'صالحًا ${type} من نوع ${label} ليس';
+const typeTemplate = 'ليس ${label} من نوع ${type} صالحًا';
 
 const localeValues: Locale = {
   locale: 'ar',
@@ -68,14 +68,14 @@ const localeValues: Locale = {
   },
   Form: {
     defaultValidateMessages: {
-      default: '${label} خطأ في حقل الإدخال',
-      required: '${label} يرجى إدخال',
-      enum: '[${enum}] يجب أن يكون واحدا من ${label}',
-      whitespace: 'لا يمكن أن يكون حرفًا فارغًا ${label}',
+      "default": 'خطأ في حقل الإدخال ${label}',
+      required: 'يرجى إدخال ${label}',
+      "enum": '${label} يجب أن يكون واحدا من [${enum}]',
+      whitespace: '${label} لا يمكن أن يكون حرفًا فارغًا',
       date: {
-        format: 'تنسيق التاريخ غير صحيح ${label}',
-        parse: 'لا يمكن تحويلها إلى تاريخ ${label}',
-        invalid: 'غير صحيح ${label} تاريخ',
+        format: '${label} تنسيق التاريخ غير صحيح',
+        parse: '${label} لا يمكن تحويلها إلى تاريخ',
+        invalid: 'تاريخ ${label} غير صحيح',
       },
       types: {
         string: typeTemplate,
@@ -93,10 +93,10 @@ const localeValues: Locale = {
         hex: typeTemplate,
       },
       string: {
-        len: 'أحرف ${len} ان يكون ${label} يجب',
-        min: 'أحرف ${min} على الأقل ${label}',
-        max: 'أحرف ${max} يصل إلى ${label}',
-        range: 'أحرف ${max}-${min} ان يكون مابين ${label} يجب',
+        len: 'يجب ${label} ان يكون ${len} أحرف',
+        min: '${label} على الأقل ${min} أحرف',
+        max: '${label} يصل إلى ${max} أحرف',
+        range: 'يجب ${label} ان يكون مابين ${min}-${max} أحرف',
       },
       number: {
         len: '${len} ان يساوي ${label} يجب',
@@ -105,13 +105,13 @@ const localeValues: Locale = {
         range: '${max}-${min} ان يكون مابين ${label} يجب',
       },
       array: {
-        len: '${len} طوله ${label} يجب أن يكون',
-        min: '${min} طوله الأدنى ${label} يجب أن يكون',
-        max: '${max} طوله الأقصى ${label} يجب أن يكون',
-        range: '${max}-${min} طوله مابين ${label} يجب أن يكون',
+        len: 'يجب أن يكون ${label} طوله ${len}',
+        min: 'يجب أن يكون ${label} طوله الأدنى ${min}',
+        max: 'يجب أن يكون ${label} طوله الأقصى ${max}',
+        range: 'يجب أن يكون ${label} طوله مابين ${min}-${max}',
       },
       pattern: {
-        mismatch: '${pattern} مع ${label} لا يتطابق',
+        mismatch: 'لا يتطابق ${label} مع ${pattern}',
       },
     },
   },


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

All Arabic strings in this file flipped the order of the words in the sentence, for example, if 
${label} = كلمة السر
The old message will be
كلمة السر يرجى إدخال
But the correct message is
يرجى إدخال كلمة السر

![image](https://user-images.githubusercontent.com/1688821/89706375-a7513080-d96d-11ea-87dc-07944fdac0ce.png)

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
