### PR TITLE
fix: Fix DirectoryTree  miss ref.scrollTo function

### DIFF
--- a/components/tree/DirectoryTree.tsx
+++ b/components/tree/DirectoryTree.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import classNames from 'classnames';
+import RcTree from 'rc-tree';
 import debounce from 'lodash/debounce';
 import { conductExpandParent } from 'rc-tree/lib/util';
 import { EventDataNode, DataNode, Key } from 'rc-tree/lib/interface';
@@ -35,18 +36,18 @@ function getTreeData({ treeData, children }: DirectoryTreeProps) {
   return treeData || convertTreeToData(children);
 }
 
-const DirectoryTree: React.FC<DirectoryTreeProps> = ({
-  defaultExpandAll,
-  defaultExpandParent,
-  defaultExpandedKeys,
-  ...props
-}) => {
+const DirectoryTree: React.ForwardRefRenderFunction<RcTree, DirectoryTreeProps> = (
+  { defaultExpandAll, defaultExpandParent, defaultExpandedKeys, ...props },
+  ref,
+) => {
   // Shift click usage
   const lastSelectedKey = React.useRef<Key>();
 
   const cachedSelectedKeys = React.useRef<Key[]>();
 
-  const ref = React.createRef<any>();
+  const treeRef = React.createRef<RcTree>();
+
+  React.useImperativeHandle(ref, () => treeRef.current!);
 
   const getInitExpandedKeys = () => {
     const { keyEntities } = convertDataToEntities(getTreeData(props));
@@ -93,7 +94,7 @@ const DirectoryTree: React.FC<DirectoryTreeProps> = ({
 
     // Call internal rc-tree expand function
     // https://github.com/ant-design/ant-design/issues/12567
-    ref.current.onNodeExpand(event, node);
+    treeRef.current!.onNodeExpand(event as any, node);
   };
 
   const onDebounceExpand = debounce(expandFolderNode, 200, {
@@ -220,7 +221,7 @@ const DirectoryTree: React.FC<DirectoryTreeProps> = ({
   return (
     <Tree
       icon={getIcon}
-      ref={ref}
+      ref={treeRef}
       blockNode
       {...otherProps}
       prefixCls={prefixCls}
@@ -235,9 +236,12 @@ const DirectoryTree: React.FC<DirectoryTreeProps> = ({
   );
 };
 
-DirectoryTree.defaultProps = {
+const ForwardDirectoryTree = React.forwardRef(DirectoryTree);
+ForwardDirectoryTree.displayName = 'DirectoryTree';
+
+ForwardDirectoryTree.defaultProps = {
   showIcon: true,
   expandAction: 'click' as DirectoryTreeProps['expandAction'],
 };
 
-export default DirectoryTree;
+export default ForwardDirectoryTree;

--- a/components/tree/__tests__/directory.test.js
+++ b/components/tree/__tests__/directory.test.js
@@ -250,4 +250,11 @@ describe('Directory Tree', () => {
       expect.objectContaining({ event: 'select', nativeEvent: expect.anything() }),
     );
   });
+
+  it('ref support', () => {
+    const treeRef = React.createRef();
+    mount(createTree({ ref: treeRef }));
+
+    expect('scrollTo' in treeRef.current).toBeTruthy();
+  });
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fix DirectoryTree can not use `scrollTo` with ref.      |
| 🇨🇳 Chinese |     修复 DirectoryTree 不能通过 `ref` 调用 `scrollTo` 的问题。     |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
