### PR TITLE
fix: #26126 use mergedData instead of pageData to decide whether to render bottom pagination or not

### DIFF
--- a/components/table/Table.tsx
+++ b/components/table/Table.tsx
@@ -495,7 +495,7 @@ function Table<RecordType extends object = any>(props: TableProps<RecordType>) {
           internalRefs={internalRefs as any}
           transformColumns={transformColumns}
         />
-        {pageData && pageData.length > 0 && bottomPaginationNode}
+        {mergedData && mergedData.length > 0 && bottomPaginationNode}
       </Spin>
     </div>
   );

--- a/components/table/__tests__/Table.pagination.test.js
+++ b/components/table/__tests__/Table.pagination.test.js
@@ -349,7 +349,7 @@ describe('Table.pagination', () => {
     const dropdownWrapper = mount(wrapper.find('Trigger').instance().getComponent());
     dropdownWrapper.find('.ant-select-item-option').at(2).simulate('click');
 
-    expect(onChange).toBeCalledTimes(1)
+    expect(onChange).toBeCalledTimes(1);
   });
 
   it('dynamic warning', () => {
@@ -376,5 +376,41 @@ describe('Table.pagination', () => {
     expect(errorSpy).toHaveBeenCalledWith(
       'Warning: [antd: Table] `dataSource` length is less than `pagination.total` but large than `pagination.pageSize`. Please make sure your config correct data with async mode.',
     );
+  });
+
+  it('should render pagination after last item on last page being removed with async mode', () => {
+    const lastPageNum = data.length;
+    const wrapper = mount(
+      createTable({ pagination: { pageSize: 1, total: data.length, current: lastPageNum } }),
+    );
+
+    const newCol = [
+      {
+        title: 'Name',
+        dataIndex: 'name',
+      },
+      {
+        title: 'Action',
+        dataIndex: 'name',
+        render(_, record) {
+          const deleteRow = () => {
+            const newData = data.filter(d => d.key !== record.key);
+            wrapper.setProps({
+              dataSource: newData,
+              pagination: { pageSize: 1, total: newData.length, current: lastPageNum },
+            });
+          };
+          return (
+            <span className="btn-delete" onClick={deleteRow}>
+              Delete
+            </span>
+          );
+        },
+      },
+    ];
+
+    wrapper.setProps({ columns: newCol });
+    wrapper.find('.btn-delete').simulate('click');
+    expect(wrapper.find('.ant-pagination')).toHaveLength(1);
   });
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close #26126

### 💡 Background and solution
Currently,  when using backend pagination (meaning manually managing property pagination.total),  if the last record on the last page is deleted,  and pagination becomes invisible(which should not happen), since length of  records is not 0.

Use mergeData.length to decide whether to render bottom pagination should fix the problem.

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
