### PR TITLE
fix: Select with multiple type has no room for icons

### DIFF
--- a/components/select/style/multiple.less
+++ b/components/select/style/multiple.less
@@ -44,6 +44,10 @@
       }
     }
 
+    &.@{select-prefix-cls}-show-arrow .@{select-prefix-cls}-selector {
+      padding-right: @font-size-base * 1.5;
+    }
+
     &.@{select-prefix-cls}-allow-clear .@{select-prefix-cls}-selector {
       padding-right: @font-size-sm + @control-padding-horizontal;
     }

--- a/components/select/style/rtl.less
+++ b/components/select/style/rtl.less
@@ -61,6 +61,14 @@
       padding-left: @font-size-sm + @control-padding-horizontal;
     }
   }
+
+  &.@{select-prefix-cls}-show-arrow .@{select-prefix-cls}-selector {
+    .@{select-prefix-cls}-rtl& {
+      padding-right: @input-padding-vertical-base;
+      padding-left: @font-size-base * 1.5;
+    }
+  }
+
   // ======================== Selections ========================
   .@{select-prefix-cls}-selection-item {
     .@{select-prefix-cls}-rtl& {


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close #26147 

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     fix Select with multiple type has no room for icons      |
| 🇨🇳 Chinese |   修复多选模式的 Select  在 showArrow 时没有给 icon 留出空间         |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
