### PR TITLE
fix: Typography copyable tooltips

### DIFF
--- a/components/typography/Base.tsx
+++ b/components/typography/Base.tsx
@@ -391,14 +391,16 @@ class Base extends React.Component<InternalBlockProps, BaseState> {
     const prefixCls = this.getPrefixCls();
 
     const { tooltips } = copyable as CopyConfig;
-    const tooltipNodes = toArray(tooltips);
-    const title = copied ? tooltipNodes[1] || this.copiedStr : tooltipNodes[0] || this.copyStr;
-
+    let tooltipNodes = toArray(tooltips) as React.ReactNode[];
+    if (tooltips !== false && tooltipNodes.length === 0) {
+      tooltipNodes = [this.copyStr, this.copiedStr];
+    }
+    const title = copied ? tooltipNodes[1] : tooltipNodes[0];
     const ariaLabel = typeof title === 'string' ? title : '';
     const icons = toArray((copyable as CopyConfig).icon);
 
     return (
-      <Tooltip key="copy" title={tooltips === false ? '' : title}>
+      <Tooltip key="copy" title={title}>
         <TransButton
           className={classNames(`${prefixCls}-copy`, copied && `${prefixCls}-copy-success`)}
           onClick={this.onCopyClick}

--- a/components/typography/Base.tsx
+++ b/components/typography/Base.tsx
@@ -392,7 +392,7 @@ class Base extends React.Component<InternalBlockProps, BaseState> {
 
     const { tooltips } = copyable as CopyConfig;
     let tooltipNodes = toArray(tooltips) as React.ReactNode[];
-    if (tooltips !== false && tooltipNodes.length === 0) {
+    if (tooltipNodes.length === 0) {
       tooltipNodes = [this.copyStr, this.copiedStr];
     }
     const title = copied ? tooltipNodes[1] : tooltipNodes[0];
@@ -400,7 +400,7 @@ class Base extends React.Component<InternalBlockProps, BaseState> {
     const icons = toArray((copyable as CopyConfig).icon);
 
     return (
-      <Tooltip key="copy" title={title}>
+      <Tooltip key="copy" title={tooltips === false ? '' : title}>
         <TransButton
           className={classNames(`${prefixCls}-copy`, copied && `${prefixCls}-copy-success`)}
           onClick={this.onCopyClick}

--- a/components/typography/__tests__/index.test.js
+++ b/components/typography/__tests__/index.test.js
@@ -206,7 +206,7 @@ describe('Typography', () => {
 
     describe('copyable', () => {
       function copyTest(name, text, target, icon, tooltips) {
-        it(name, () => {
+        it(name, async () => {
           jest.useFakeTimers();
           const onCopy = jest.fn();
           const wrapper = mount(
@@ -229,13 +229,25 @@ describe('Typography', () => {
             expect(wrapper.find('.ant-tooltip-inner').text()).toBe('Copy');
           } else if (tooltips === false) {
             expect(wrapper.find('.ant-tooltip-inner').length).toBeFalsy();
+          } else if (tooltips[0] === '' && tooltips[1] === '') {
+            expect(wrapper.find('.ant-tooltip-inner').length).toBeFalsy();
+          } else if (tooltips[0] === '' && tooltips[1]) {
+            expect(wrapper.find('.ant-tooltip-inner').length).toBeFalsy();
+          } else if (tooltips[1] === '' && tooltips[0]) {
+            expect(wrapper.find('.ant-tooltip-inner').text()).toBe(tooltips[0]);
           } else {
             expect(wrapper.find('.ant-tooltip-inner').text()).toBe(tooltips[0]);
           }
 
           wrapper.find('.ant-typography-copy').first().simulate('click');
-          expect(copy.lastStr).toEqual(target);
+          jest.useRealTimers();
+          wrapper.find('.ant-typography-copy').first().simulate('mouseenter');
+          // tooltips 为 ['', 'xxx'] 时，切换时需要延时 mousenEnterDelay 的时长
+          if (tooltips && tooltips[0] === '' && tooltips[1]) {
+            await sleep(150);
+          }
 
+          expect(copy.lastStr).toEqual(target);
           wrapper.update();
           expect(onCopy).toHaveBeenCalled();
 
@@ -247,20 +259,29 @@ describe('Typography', () => {
           }
 
           expect(wrapper.find(copiedIcon).length).toBeTruthy();
+          wrapper.find('.ant-typography-copy').first().simulate('mouseenter');
 
           if (tooltips === undefined || tooltips === true) {
             expect(wrapper.find('.ant-tooltip-inner').text()).toBe('Copied');
           } else if (tooltips === false) {
             expect(wrapper.find('.ant-tooltip-inner').length).toBeFalsy();
+          } else if (tooltips[0] === '' && tooltips[1] === '') {
+            expect(wrapper.find('.ant-tooltip-inner').length).toBeFalsy();
+          } else if (tooltips[0] === '' && tooltips[1]) {
+            expect(wrapper.find('.ant-tooltip-inner').text()).toBe(tooltips[1]);
+          } else if (tooltips[1] === '' && tooltips[0]) {
+            expect(wrapper.find('.ant-tooltip-inner').text()).toBe('');
           } else {
             expect(wrapper.find('.ant-tooltip-inner').text()).toBe(tooltips[1]);
           }
 
+          jest.useFakeTimers();
           jest.runAllTimers();
           wrapper.update();
 
           // Will set back when 3 seconds pass
           expect(wrapper.find(copiedIcon).length).toBeFalsy();
+          wrapper.unmount();
           jest.useRealTimers();
         });
       }
@@ -280,6 +301,15 @@ describe('Typography', () => {
       copyTest('customize copy tooltips text', 'bamboo', 'bamboo', undefined, [
         'click here',
         'you clicked!!',
+      ]);
+      copyTest('tooltips contains two empty text', 'bamboo', 'bamboo', undefined, ['', '']);
+      copyTest('tooltips contains one empty text', 'bamboo', 'bamboo', undefined, [
+        '',
+        'you clicked!!',
+      ]);
+      copyTest('tooltips contains one empty text 2', 'bamboo', 'bamboo', undefined, [
+        'click here',
+        '',
       ]);
     });
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

https://github.com/ant-design/ant-design/pull/25953#issuecomment-674480396

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Typography `copyable.tooltips` cannot accept `['', '']`. |
| 🇨🇳 Chinese | 修复 Typography `copyable.tooltips` 属性不支持 `['', '']` 的问题。 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
