### PR TITLE
fix: Cascader options not open after press ESC and then search

### DIFF
--- a/components/cascader/__tests__/index.test.js
+++ b/components/cascader/__tests__/index.test.js
@@ -516,4 +516,12 @@ describe('Cascader', () => {
       .simulate('click');
     expect(onChange).toHaveBeenCalledWith(['zhejiang', 'hangzhou', 'xihu'], expect.anything());
   });
+
+  it('options should open after press esc and then search', () => {
+    const wrapper = mount(<Cascader options={options} showSearch />);
+    wrapper.find('input').simulate('change', { target: { value: 'jin' } });
+    wrapper.find('input').simulate('keydown', { keyCode: KeyCode.ESC });
+    wrapper.find('input').simulate('change', { target: { value: 'jin' } });
+    expect(wrapper.state('popupVisible')).toBe(true);
+  });
 });

--- a/components/cascader/index.tsx
+++ b/components/cascader/index.tsx
@@ -353,8 +353,9 @@ class Cascader extends React.Component<CascaderProps, CascaderState> {
   };
 
   handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { popupVisible } = this.state;
     const inputValue = e.target.value;
-    this.handlePopupVisibleChange(true);
+    if (!popupVisible) this.handlePopupVisibleChange(true);
     this.setState({ inputValue });
   };
 

--- a/components/cascader/index.tsx
+++ b/components/cascader/index.tsx
@@ -355,7 +355,9 @@ class Cascader extends React.Component<CascaderProps, CascaderState> {
   handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { popupVisible } = this.state;
     const inputValue = e.target.value;
-    if (!popupVisible) this.handlePopupVisibleChange(true);
+    if (!popupVisible) {
+      this.handlePopupVisibleChange(true);
+    }
     this.setState({ inputValue });
   };
 

--- a/components/cascader/index.tsx
+++ b/components/cascader/index.tsx
@@ -354,6 +354,7 @@ class Cascader extends React.Component<CascaderProps, CascaderState> {
 
   handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const inputValue = e.target.value;
+    this.handlePopupVisibleChange(true);
     this.setState({ inputValue });
   };
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
<!--
1. Describe the source of requirement, like related issue link.
-->
close #26266 

### 💡 Background and solution
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->
![image](https://user-images.githubusercontent.com/17452527/90515940-eebd9500-e195-11ea-990c-2068e81dd65e.png)
the options not open after press ESC and then input 'jin'
![image](https://user-images.githubusercontent.com/17452527/90515877-d77ea780-e195-11ea-9349-2bc3e6567b87.png)
### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Cascader options not open after press ESC and then search. |
| 🇨🇳 Chinese | 修复Cascader在按下ESC键，然后通过输入进行搜索时options不展开的问题。 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
