### PR TITLE
fix(textarea): display defaultValue when value is undefined

### DIFF
--- a/components/input/TextArea.tsx
+++ b/components/input/TextArea.tsx
@@ -29,7 +29,7 @@ class TextArea extends React.Component<TextAreaProps, TextAreaState> {
   }
 
   static getDerivedStateFromProps(nextProps: TextAreaProps) {
-    if ('value' in nextProps) {
+    if (nextProps.value !== undefined) {
       return {
         value: nextProps.value,
       };
@@ -38,7 +38,7 @@ class TextArea extends React.Component<TextAreaProps, TextAreaState> {
   }
 
   setValue(value: string, callback?: () => void) {
-    if (!('value' in this.props)) {
+    if (this.props.value === undefined) {
       this.setState({ value }, callback);
     }
   }

--- a/components/input/__tests__/textarea.test.js
+++ b/components/input/__tests__/textarea.test.js
@@ -242,4 +242,10 @@ describe('TextArea allowClear', () => {
     expect(setSelectionRangeFn).toHaveBeenCalled();
     wrapper.unmount();
   });
+
+  // https://github.com/ant-design/ant-design/issues/26308
+  it('should display defaultValue when value is undefined', () => {
+    const wrapper = mount(<Input.TextArea defaultValue="Light" value={undefined} />);
+    expect(wrapper.find('textarea').at(0).getDOMNode().value).toBe('Light');
+  });
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close [#26308](https://github.com/ant-design/ant-design/issues/26308)

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Textarea don't display `defaultValue` when `value` is `undefined`. |
| 🇨🇳 Chinese | 修复 Textarea 当 `value` 为 `undefined` 时未显示 `defaultValue` 问题。|

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
