### PR TITLE
fix: Set site h tag style in dark mode

### DIFF
--- a/components/empty/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/empty/__tests__/__snapshots__/demo.test.js.snap
@@ -99,9 +99,9 @@ exports[`renders ./components/empty/demo/config-provider.md correctly 1`] = `
   <div
     class="config-provider"
   >
-    <h3>
+    <h4>
       Select
-    </h3>
+    </h4>
     <div
       class="ant-select ant-select-single ant-select-show-arrow"
       style="width:200px"
@@ -159,9 +159,9 @@ exports[`renders ./components/empty/demo/config-provider.md correctly 1`] = `
         </span>
       </span>
     </div>
-    <h3>
+    <h4>
       TreeSelect
-    </h3>
+    </h4>
     <div
       class="ant-select ant-tree-select ant-select-single ant-select-show-arrow"
       style="width:200px"
@@ -219,9 +219,9 @@ exports[`renders ./components/empty/demo/config-provider.md correctly 1`] = `
         </span>
       </span>
     </div>
-    <h3>
+    <h4>
       Cascader
-    </h3>
+    </h4>
     <span
       class="ant-cascader-picker ant-cascader-picker-show-search"
       style="width:200px"
@@ -259,9 +259,9 @@ exports[`renders ./components/empty/demo/config-provider.md correctly 1`] = `
         </svg>
       </span>
     </span>
-    <h3>
+    <h4>
       Transfer
-    </h3>
+    </h4>
     <div
       class="ant-transfer"
     >
@@ -532,9 +532,9 @@ exports[`renders ./components/empty/demo/config-provider.md correctly 1`] = `
         </div>
       </div>
     </div>
-    <h3>
+    <h4>
       Table
-    </h3>
+    </h4>
     <div
       class="ant-table-wrapper"
       style="margin-top:8px"
@@ -640,9 +640,9 @@ exports[`renders ./components/empty/demo/config-provider.md correctly 1`] = `
         </div>
       </div>
     </div>
-    <h3>
+    <h4>
       List
-    </h3>
+    </h4>
     <div
       class="ant-list ant-list-split"
     >

--- a/components/empty/demo/config-provider.md
+++ b/components/empty/demo/config-provider.md
@@ -58,19 +58,19 @@ class Demo extends React.Component {
 
         <ConfigProvider renderEmpty={customize && customizeRenderEmpty}>
           <div className="config-provider">
-            <h3>Select</h3>
+            <h4>Select</h4>
             <Select style={style} />
 
-            <h3>TreeSelect</h3>
+            <h4>TreeSelect</h4>
             <TreeSelect style={style} treeData={[]} />
 
-            <h3>Cascader</h3>
+            <h4>Cascader</h4>
             <Cascader style={style} options={[]} showSearch />
 
-            <h3>Transfer</h3>
+            <h4>Transfer</h4>
             <Transfer />
 
-            <h3>Table</h3>
+            <h4>Table</h4>
             <Table
               style={{ marginTop: 8 }}
               columns={[
@@ -87,7 +87,7 @@ class Demo extends React.Component {
               ]}
             />
 
-            <h3>List</h3>
+            <h4>List</h4>
             <List />
           </div>
         </ConfigProvider>
@@ -100,7 +100,7 @@ ReactDOM.render(<Demo />, mountNode);
 ```
 
 <style>
-.code-box-demo .config-provider h3 {
+.code-box-demo .config-provider h4 {
   font-size: inherit;
   margin: 16px 0 8px 0;
 }

--- a/components/style/themes/default.less
+++ b/components/style/themes/default.less
@@ -55,8 +55,7 @@
 @text-color-inverse: @white;
 @icon-color: inherit;
 @icon-color-hover: fade(@black, 75%);
-@heading-color: fade(#000, 85%);
-@heading-color-dark: fade(@white, 100%);
+@heading-color: fade(@black, 85%);
 @text-color-dark: fade(@white, 85%);
 @text-color-secondary-dark: fade(@white, 65%);
 @text-selection-bg: @primary-color;

--- a/site/theme/static/dark.less
+++ b/site/theme/static/dark.less
@@ -93,6 +93,15 @@
     }
   }
 
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    color: @heading-color;
+  }
+
   .markdown {
     code,
     pre,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [x] Site / documentation update
- [x] Demo update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

Site h tag color is black in dark mode, see:
https://ant.design/components/slider-cn/#components-slider-demo-mark
https://ant.design/components/empty-cn/#components-empty-demo-config-provider
https://ant.design/components/tag-cn/#components-tag-demo-status
https://ant.design/components/table-cn/#components-table-demo-size
https://ant.design/components/skeleton-cn/#components-skeleton-demo-children

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Site h tag has no style |
| 🇨🇳 Chinese | 官网 h 标签没有设置颜色 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed


-----
[View rendered components/empty/demo/config-provider.md](https://github.com/llwslc/ant-design/blob/site-dark-h-tag/components/empty/demo/config-provider.md)