### PR TITLE
fix: Transfer filterOption not trigger by spaces

### DIFF
--- a/components/transfer/__tests__/search.test.js
+++ b/components/transfer/__tests__/search.test.js
@@ -6,6 +6,24 @@ import Transfer from '../index';
 describe('Transfer.Search', () => {
   const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
 
+  const dataSource = [
+    {
+      key: 'a',
+      title: 'a',
+      description: 'a',
+    },
+    {
+      key: 'b',
+      title: 'b',
+      description: 'b',
+    },
+    {
+      key: 'c',
+      title: 'c',
+      description: 'c',
+    },
+  ];
+
   afterEach(() => {
     errorSpy.mockReset();
   });
@@ -16,33 +34,13 @@ describe('Transfer.Search', () => {
 
   it('should show cross icon when input value exists', () => {
     const wrapper = mount(<Search value="" />);
-
     expect(wrapper).toMatchSnapshot();
-
     wrapper.setProps({ value: 'a' });
-
     expect(wrapper).toMatchSnapshot();
   });
 
   it('onSearch', () => {
     jest.useFakeTimers();
-    const dataSource = [
-      {
-        key: 'a',
-        title: 'a',
-        description: 'a',
-      },
-      {
-        key: 'b',
-        title: 'b',
-        description: 'b',
-      },
-      {
-        key: 'c',
-        title: 'c',
-        description: 'c',
-      },
-    ];
 
     const onSearch = jest.fn();
     const wrapper = mount(
@@ -55,36 +53,40 @@ describe('Transfer.Search', () => {
         showSearch
       />,
     );
-
     wrapper
       .find('.ant-input')
       .at(0)
       .simulate('change', { target: { value: 'a' } });
     expect(onSearch).toHaveBeenCalledWith('left', 'a');
-
     onSearch.mockReset();
-
-    wrapper
-      .find('.ant-transfer-list-search-action')
-      .at(0)
-      .simulate('click');
+    wrapper.find('.ant-transfer-list-search-action').at(0).simulate('click');
     expect(onSearch).toHaveBeenCalledWith('left', '');
     jest.useRealTimers();
   });
 
   it('legacy props#onSearchChange doesnot work anymore', () => {
     const onSearchChange = jest.fn();
-
     const wrapper = mount(
       <Transfer render={item => item.title} onSearchChange={onSearchChange} showSearch />,
     );
-
     wrapper
       .find('.ant-input')
       .at(0)
       .simulate('change', { target: { value: 'a' } });
-
     expect(errorSpy.mock.calls.length).toBe(0);
     expect(onSearchChange).not.toHaveBeenCalled();
+  });
+
+  // https://github.com/ant-design/ant-design/issues/26208
+  it('typing space should trigger filterOption', () => {
+    const filterOption = jest.fn();
+    const wrapper = mount(
+      <Transfer filterOption={filterOption} dataSource={dataSource} showSearch />,
+    );
+    wrapper
+      .find('.ant-input')
+      .at(0)
+      .simulate('change', { target: { value: ' ' } });
+    expect(filterOption).toHaveBeenCalledTimes(dataSource.length);
   });
 });

--- a/components/transfer/list.tsx
+++ b/components/transfer/list.tsx
@@ -125,7 +125,7 @@ export default class TransferList extends React.PureComponent<
       const { renderedText } = renderedItem;
 
       // Filter skip
-      if (filterValue && filterValue.trim() && !this.matchFilter(renderedText, item)) {
+      if (filterValue && !this.matchFilter(renderedText, item)) {
         return null;
       }
 


### PR DESCRIPTION


<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->
close #26208

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Transfer `filterOption` not trigger when search spaces. |
| 🇨🇳 Chinese | 修复 Transfer 搜索空格时 `filterOption` 没有触发的问题。 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
