### PR TITLE
fix: Space preserve empty dom when children is `null`

### DIFF
--- a/components/space/Item.tsx
+++ b/components/space/Item.tsx
@@ -1,0 +1,49 @@
+import * as React from 'react';
+import { LastIndexContext } from '.';
+import { SizeType } from '../config-provider/SizeContext';
+
+const spaceSize = {
+  small: 8,
+  middle: 16,
+  large: 24,
+};
+
+export interface ItemProps {
+  className: string;
+  children: React.ReactNode;
+  index: number;
+  direction?: 'horizontal' | 'vertical';
+  size?: SizeType | number;
+  marginDirection: 'marginLeft' | 'marginRight';
+}
+
+export default function Item({
+  className,
+  direction,
+  index,
+  size,
+  marginDirection,
+  children,
+}: ItemProps) {
+  const latestIndex = React.useContext(LastIndexContext);
+
+  if (children === null || children === undefined) {
+    return null;
+  }
+
+  return (
+    <div
+      className={className}
+      style={
+        index >= latestIndex
+          ? {}
+          : {
+              [direction === 'vertical' ? 'marginBottom' : marginDirection]:
+                typeof size === 'string' ? spaceSize[size] : size,
+            }
+      }
+    >
+      {children}
+    </div>
+  );
+}

--- a/components/space/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/space/__tests__/__snapshots__/demo.test.js.snap
@@ -397,12 +397,6 @@ exports[`renders ./components/space/demo/debug.md correctly 1`] = `
   </div>
   <div
     class="ant-space-item"
-  />
-  <div
-    class="ant-space-item"
-  />
-  <div
-    class="ant-space-item"
     style="margin-right:8px"
   >
     1

--- a/components/space/__tests__/index.test.js
+++ b/components/space/__tests__/index.test.js
@@ -43,8 +43,8 @@ describe('Space', () => {
       </Space>,
     );
 
-    expect(wrapper.find('.ant-space-item').at(0).prop('style').marginRight).toBe(10);
-    expect(wrapper.find('.ant-space-item').at(1).prop('style').marginRight).toBeUndefined();
+    expect(wrapper.find('div.ant-space-item').at(0).prop('style').marginRight).toBe(10);
+    expect(wrapper.find('div.ant-space-item').at(1).prop('style').marginRight).toBeUndefined();
   });
 
   it('should render vertical space width customize size', () => {
@@ -55,8 +55,8 @@ describe('Space', () => {
       </Space>,
     );
 
-    expect(wrapper.find('.ant-space-item').at(0).prop('style').marginBottom).toBe(10);
-    expect(wrapper.find('.ant-space-item').at(1).prop('style').marginBottom).toBeUndefined();
+    expect(wrapper.find('div.ant-space-item').at(0).prop('style').marginBottom).toBe(10);
+    expect(wrapper.find('div.ant-space-item').at(1).prop('style').marginBottom).toBeUndefined();
   });
 
   it('should render correct with children', () => {
@@ -78,7 +78,7 @@ describe('Space', () => {
       </Space>,
     );
 
-    expect(wrapper.find('.ant-space-item').length).toBe(3);
+    expect(wrapper.find('div.ant-space-item').length).toBe(3);
   });
 
   it('should be keep store', () => {

--- a/components/space/demo/debug.md
+++ b/components/space/demo/debug.md
@@ -32,6 +32,8 @@ ReactDOM.render(
     {false}
     {1}
     Button
+    {null}
+    {undefined}
   </Space>,
   mountNode,
 );

--- a/components/space/index.tsx
+++ b/components/space/index.tsx
@@ -2,6 +2,9 @@ import * as React from 'react';
 import classNames from 'classnames';
 import { ConfigConsumerProps, ConfigContext } from '../config-provider';
 import { SizeType } from '../config-provider/SizeContext';
+import Item from './Item';
+
+export const LastIndexContext = React.createContext(0);
 
 export interface SpaceProps {
   prefixCls?: string;
@@ -12,12 +15,6 @@ export interface SpaceProps {
   // No `stretch` since many components do not support that.
   align?: 'start' | 'end' | 'center' | 'baseline';
 }
-
-const spaceSize = {
-  small: 8,
-  middle: 16,
-  large: 24,
-};
 
 const Space: React.FC<SpaceProps> = props => {
   const { getPrefixCls, space, direction: directionConfig }: ConfigConsumerProps = React.useContext(
@@ -56,25 +53,32 @@ const Space: React.FC<SpaceProps> = props => {
 
   const marginDirection = directionConfig === 'rtl' ? 'marginLeft' : 'marginRight';
 
+  // Calculate latest one
+  let latestIndex = 0;
+  const nodes = React.Children.map(children, (child, i) => {
+    if (child !== null && child !== undefined) {
+      latestIndex = i;
+    }
+
+    /* eslint-disable react/no-array-index-key */
+    return (
+      <Item
+        className={itemClassName}
+        key={`${itemClassName}-${i}`}
+        direction={direction}
+        size={size}
+        index={i}
+        marginDirection={marginDirection}
+      >
+        {child}
+      </Item>
+    );
+    /* eslint-enable */
+  });
+
   return (
     <div className={cn} {...otherProps}>
-      {React.Children.map(children, (child, i) => (
-        <div
-          className={itemClassName}
-          // eslint-disable-next-line react/no-array-index-key
-          key={`${itemClassName}-${i}`}
-          style={
-            i === len - 1 || child === null || child === undefined
-              ? {}
-              : {
-                  [direction === 'vertical' ? 'marginBottom' : marginDirection]:
-                    typeof size === 'string' ? spaceSize[size] : size,
-                }
-          }
-        >
-          {child}
-        </div>
-      ))}
+      <LastIndexContext.Provider value={latestIndex}>{nodes}</LastIndexContext.Provider>
     </div>
   );
 };


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

fix #26386

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fix Space preserve empty dom node when `children` contains empty node.      |
| 🇨🇳 Chinese |     修复 Space 在 `children` 中包含空节点时会出现空 dom 的问题。      |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/space/demo/debug.md](https://github.com/ant-design/ant-design/blob/fix-space/components/space/demo/debug.md)