### PR TITLE
fix: colorPalette is not defined

### DIFF
--- a/components/tree-select/style/index.less
+++ b/components/tree-select/style/index.less
@@ -35,12 +35,10 @@
   }
 }
 
-// ========================== Tree ==========================
-.antTreeFn(@select-tree-prefix-cls);
-
-// change switcher icon rotation in rtl direction
 .@{select-tree-prefix-cls} {
-  // >>> Switcher
+  .antTreeFn(@select-tree-prefix-cls);
+
+  // change switcher icon rotation in rtl direction
   & &-switcher {
     &_close {
       .@{select-tree-prefix-cls}-switcher-icon {

--- a/components/tree/style/index.less
+++ b/components/tree/style/index.less
@@ -9,6 +9,8 @@
 
 .antCheckboxFn(@checkbox-prefix-cls: ~'@{ant-prefix}-tree-checkbox');
 
-.antTreeFn(@tree-prefix-cls);
+.@{tree-prefix-cls} {
+  .antTreeFn(@tree-prefix-cls);
+}
 
 @import './rtl';

--- a/components/tree/style/mixin.less
+++ b/components/tree/style/mixin.less
@@ -31,233 +31,231 @@
 
 .antTreeFn(@custom-tree-prefix-cls) {
   @custom-tree-node-prefix-cls: ~'@{custom-tree-prefix-cls}-treenode';
-  .@{custom-tree-prefix-cls} {
-    .reset-component;
-    background: @tree-bg;
+  .reset-component;
+  background: @tree-bg;
+  border-radius: @border-radius-base;
+  transition: background-color 0.3s;
+
+  &-focused:not(:hover):not(&-active-focused) {
+    background: @primary-1;
+  }
+
+  // =================== Virtual List ===================
+  &-list-holder-inner {
+    align-items: flex-start;
+  }
+
+  &.@{custom-tree-prefix-cls}-block-node {
+    .@{custom-tree-prefix-cls}-list-holder-inner {
+      align-items: stretch;
+
+      // >>> Title
+      .@{custom-tree-prefix-cls}-node-content-wrapper {
+        flex: auto;
+      }
+    }
+  }
+
+  // ===================== TreeNode =====================
+  .@{custom-tree-node-prefix-cls} {
+    display: flex;
+    align-items: flex-start;
+    padding: 0 0 (@padding-xs / 2) 0;
+    outline: none;
+    // Disabled
+    &-disabled {
+      // >>> Title
+      .@{custom-tree-prefix-cls}-node-content-wrapper {
+        color: @disabled-color;
+        cursor: not-allowed;
+
+        &:hover {
+          background: transparent;
+        }
+      }
+    }
+
+    &-active .@{custom-tree-prefix-cls}-node-content-wrapper {
+      background: @tree-node-hover-bg;
+    }
+  }
+
+  // >>> Indent
+  &-indent {
+    align-self: stretch;
+    white-space: nowrap;
+    user-select: none;
+
+    &-unit {
+      display: inline-block;
+      width: @tree-title-height;
+    }
+  }
+
+  // >>> Switcher
+  & &-switcher {
+    .antTreeSwitcherIcon();
+    flex: none;
+
+    width: @tree-title-height;
+    height: @tree-title-height;
+    margin: 0;
+    line-height: @tree-title-height;
+    text-align: center;
+    cursor: pointer;
+
+    &-noop {
+      cursor: default;
+    }
+
+    &_close {
+      .@{custom-tree-prefix-cls}-switcher-icon {
+        svg {
+          transform: rotate(-90deg);
+        }
+      }
+    }
+
+    &-loading-icon {
+      color: @primary-color;
+    }
+
+    &-leaf-line {
+      z-index: 1;
+      display: inline-block;
+      width: 100%;
+      height: 100%;
+      &::before {
+        position: absolute;
+        height: @tree-title-height;
+        margin-left: -1px;
+        border-left: 1px solid @normal-color;
+        content: ' ';
+      }
+      &::after {
+        position: absolute;
+        width: @tree-title-height - 14px;
+        height: @tree-title-height - 10px;
+        margin-left: -1px;
+        border-bottom: 1px solid @normal-color;
+        content: ' ';
+      }
+    }
+  }
+
+  // >>> Checkbox
+  & &-checkbox {
+    top: initial;
+    margin: ((@tree-title-height - @checkbox-size) / 2) 8px 0 0;
+  }
+
+  // >>> Title
+  & &-node-content-wrapper {
+    min-height: @tree-title-height;
+    margin: 0;
+    padding: 0 4px;
+    color: inherit;
+    line-height: @tree-title-height;
+    background: transparent;
     border-radius: @border-radius-base;
-    transition: background-color 0.3s;
+    cursor: pointer;
+    transition: all 0.3s, border 0s, line-height 0s;
 
-    &-focused:not(:hover):not(&-active-focused) {
-      background: @primary-1;
+    &:hover {
+      background-color: @tree-node-hover-bg;
     }
 
-    // =================== Virtual List ===================
-    &-list-holder-inner {
-      align-items: flex-start;
+    &.@{custom-tree-prefix-cls}-node-selected {
+      background-color: @tree-node-selected-bg;
     }
 
-    &.@{custom-tree-prefix-cls}-block-node {
-      .@{custom-tree-prefix-cls}-list-holder-inner {
-        align-items: stretch;
-
-        // >>> Title
-        .@{custom-tree-prefix-cls}-node-content-wrapper {
-          flex: auto;
-        }
-      }
-    }
-
-    // ===================== TreeNode =====================
-    .@{custom-tree-node-prefix-cls} {
-      display: flex;
-      align-items: flex-start;
-      padding: 0 0 (@padding-xs / 2) 0;
-      outline: none;
-      // Disabled
-      &-disabled {
-        // >>> Title
-        .@{custom-tree-prefix-cls}-node-content-wrapper {
-          color: @disabled-color;
-          cursor: not-allowed;
-
-          &:hover {
-            background: transparent;
-          }
-        }
-      }
-
-      &-active .@{custom-tree-prefix-cls}-node-content-wrapper {
-        background: @tree-node-hover-bg;
-      }
-    }
-
-    // >>> Indent
-    &-indent {
-      align-self: stretch;
-      white-space: nowrap;
-      user-select: none;
-
-      &-unit {
-        display: inline-block;
-        width: @tree-title-height;
-      }
-    }
-
-    // >>> Switcher
-    & &-switcher {
-      .antTreeSwitcherIcon();
-      flex: none;
-
+    // Icon
+    .@{custom-tree-prefix-cls}-iconEle {
+      display: inline-block;
       width: @tree-title-height;
       height: @tree-title-height;
-      margin: 0;
       line-height: @tree-title-height;
       text-align: center;
-      cursor: pointer;
-
-      &-noop {
-        cursor: default;
+      vertical-align: top;
+      &:empty {
+        display: none;
       }
+    }
+  }
 
-      &_close {
-        .@{custom-tree-prefix-cls}-switcher-icon {
-          svg {
-            transform: rotate(-90deg);
-          }
-        }
-      }
+  // ==================== Draggable =====================
+  &-node-content-wrapper[draggable='true'] {
+    line-height: @tree-title-height - 4px;
+    border-top: 2px transparent solid;
+    border-bottom: 2px transparent solid;
+    user-select: none;
+  }
 
-      &-loading-icon {
-        color: @primary-color;
-      }
+  .@{custom-tree-node-prefix-cls}.drag-over {
+    > [draggable] {
+      color: white;
+      background-color: @primary-color;
+      opacity: 0.8;
+    }
+  }
+  .@{custom-tree-node-prefix-cls}.drag-over-gap-top {
+    > [draggable] {
+      border-top-color: @primary-color;
+    }
+  }
+  .@{custom-tree-node-prefix-cls}.drag-over-gap-bottom {
+    > [draggable] {
+      border-bottom-color: @primary-color;
+    }
+  }
 
-      &-leaf-line {
-        z-index: 1;
-        display: inline-block;
-        width: 100%;
+  // ==================== Show Line =====================
+  &-show-line {
+    // ================ Indent lines ================
+    .@{custom-tree-prefix-cls}-indent {
+      &-unit {
+        position: relative;
         height: 100%;
+
+        &:first-child::after {
+          position: absolute;
+          top: calc(100% - @tree-title-height - 4px);
+          right: @tree-title-height / 2;
+          bottom: -4px;
+          border-right: 1px solid @border-color-base;
+          content: '';
+        }
+
         &::before {
           position: absolute;
-          height: @tree-title-height;
-          margin-left: -1px;
-          border-left: 1px solid @normal-color;
-          content: ' ';
+          top: calc(100% - 4px);
+          right: -@tree-title-height / 2;
+          bottom: -@tree-title-height - 4px;
+          border-right: 1px solid @border-color-base;
+          content: '';
         }
-        &::after {
-          position: absolute;
-          width: @tree-title-height - 14px;
-          height: @tree-title-height - 10px;
-          margin-left: -1px;
-          border-bottom: 1px solid @normal-color;
-          content: ' ';
-        }
-      }
-    }
 
-    // >>> Checkbox
-    & &-checkbox {
-      top: initial;
-      margin: ((@tree-title-height - @checkbox-size) / 2) 8px 0 0;
-    }
-
-    // >>> Title
-    & &-node-content-wrapper {
-      min-height: @tree-title-height;
-      margin: 0;
-      padding: 0 4px;
-      color: inherit;
-      line-height: @tree-title-height;
-      background: transparent;
-      border-radius: @border-radius-base;
-      cursor: pointer;
-      transition: all 0.3s, border 0s, line-height 0s;
-
-      &:hover {
-        background-color: @tree-node-hover-bg;
-      }
-
-      &.@{custom-tree-prefix-cls}-node-selected {
-        background-color: @tree-node-selected-bg;
-      }
-
-      // Icon
-      .@{custom-tree-prefix-cls}-iconEle {
-        display: inline-block;
-        width: @tree-title-height;
-        height: @tree-title-height;
-        line-height: @tree-title-height;
-        text-align: center;
-        vertical-align: top;
-        &:empty {
+        &-end::before,
+        &-end-first-level::after {
           display: none;
         }
       }
     }
 
-    // ==================== Draggable =====================
-    &-node-content-wrapper[draggable='true'] {
-      line-height: @tree-title-height - 4px;
-      border-top: 2px transparent solid;
-      border-bottom: 2px transparent solid;
-      user-select: none;
-    }
-
-    .@{custom-tree-node-prefix-cls}.drag-over {
-      > [draggable] {
-        color: white;
-        background-color: @primary-color;
-        opacity: 0.8;
-      }
-    }
-    .@{custom-tree-node-prefix-cls}.drag-over-gap-top {
-      > [draggable] {
-        border-top-color: @primary-color;
-      }
-    }
-    .@{custom-tree-node-prefix-cls}.drag-over-gap-bottom {
-      > [draggable] {
-        border-bottom-color: @primary-color;
-      }
-    }
-
-    // ==================== Show Line =====================
-    &-show-line {
-      // ================ Indent lines ================
-      .@{custom-tree-prefix-cls}-indent {
-        &-unit {
-          position: relative;
-          height: 100%;
-
-          &:first-child::after {
-            position: absolute;
-            top: calc(100% - @tree-title-height - 4px);
-            right: @tree-title-height / 2;
-            bottom: -4px;
-            border-right: 1px solid @border-color-base;
-            content: '';
-          }
-
-          &::before {
-            position: absolute;
-            top: calc(100% - 4px);
-            right: -@tree-title-height / 2;
-            bottom: -@tree-title-height - 4px;
-            border-right: 1px solid @border-color-base;
-            content: '';
-          }
-
-          &-end::before,
-          &-end-first-level::after {
-            display: none;
-          }
+    /* Motion should hide line of measure */
+    .@{custom-tree-node-prefix-cls}-motion:not(.@{tree-motion}-leave):not(.@{tree-motion}-appear-active) {
+      .@{custom-tree-prefix-cls}-indent-unit {
+        &::after,
+        &::before {
+          display: none;
         }
       }
+    }
 
-      /* Motion should hide line of measure */
-      .@{custom-tree-node-prefix-cls}-motion:not(.@{tree-motion}-leave):not(.@{tree-motion}-appear-active) {
-        .@{custom-tree-prefix-cls}-indent-unit {
-          &::after,
-          &::before {
-            display: none;
-          }
-        }
-      }
-
-      // ============== Cover Background ==============
-      .@{custom-tree-prefix-cls}-switcher {
-        z-index: 1;
-        background: @component-background;
-      }
+    // ============== Cover Background ==============
+    .@{custom-tree-prefix-cls}-switcher {
+      z-index: 1;
+      background: @component-background;
     }
   }
 }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close #26290
close #23480 
close #23412 

### 💡 Background and solution

参考 #26290 里的重现（用法来自[定制主题](https://ant.design/docs/react/customize-theme-cn#%E4%BD%BF%E7%94%A8%E6%9A%97%E9%BB%91%E4%B8%BB%E9%A2%98%E5%92%8C%E7%B4%A7%E5%87%91%E4%B8%BB%E9%A2%98) 里的方式三），当使用 `@import "~antd/dist/antd.less"` 引入样式时，在 lessOptions 的 `modifyVars` 里添加 hack 字段如下。

```js
modifyVars: {
  hack: `true;@import "require.resolve('antd/lib/style/color/colorPalette.less')";`;
}
```

此时启动项目时会报 `ReferenceError: colorPalette is not defined'` 的错误：

```
Failed to compile.

./src/App.less (./node_modules/css-loader/dist/cjs.js??ref--6-oneOf-8-1!./node_modules/postcss-loader/src??postcss!./node_modules/resolve-url-loader??ref--6-oneOf-8-3!./node_modules/less-loader/dist/cjs.js??ref--6-oneOf-8-4!./src/App.less)

.antTreeFn(@tree-prefix-cls);
^
Error evaluating function color: JavaScript evaluation error: 'ReferenceError: colorPalette is not defined'
Error in /Users/yango/react/grow-fe/node_modules/antd/lib/tree/style/index.less (line 12, column 0)
```

移除 hack 字段，错误消失。这段 hack 代码来自于：https://unpkg.com/antd/dist/theme.js

但是这段代码不能移除，当使用 babel-plugin-import 引入样式时（而不是 `@import "~antd/dist/antd.less"`），如果没有这段 hack，同样会报 `ReferenceError: colorPalette is not defined`。

继续排查发现是下面两段代码会导致问题，移除这两个 mixin 调用后错误消失。

https://github.com/ant-design/ant-design/blob/875e190ac7aa41227863bf1b0d02b9c799479b50/components/tree/style/index.less#L12

https://github.com/ant-design/ant-design/blob/875e190ac7aa41227863bf1b0d02b9c799479b50/components/tree-select/style/index.less#L39

进一步排查，发现只要在 mixin 中应用了 `@primary-1` 这样会使用 colorPalette 做色彩计算的变量，就会导致问题。

```less
.antTreeFn() {
  div {
   color: @primary-1; // 使用了 colorPalette 计算的变量
  }
}

.antTreeFn(); // 报错!!!
```

寻找解决方案的过程中试验出，如果 mixin 的调用不在顶层，而在一个 selector 里面时，错误也会消失。

```diff
.antTreeFn() {
  div {
   color: @primary-1; // 使用了 colorPalette 计算的变量
  }
}

+ div {
  .antTreeFn(); // 错误解决
+ }
```

看上去和 less 解析 mixin 的顺序有关系，具体原因没有排查。

解决方式就是将 `.antTreeFn()` 里的一层包裹拿到调用的外面。

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix `colorPalette is not defined` when customize theme in some situation. |
| 🇨🇳 Chinese | 修复使用主题有时会报 `colorPalette is not defined` 的问题。  |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
