### PR TITLE
fix: Add missing properties to ShowUploadListInterface

### DIFF
--- a/components/upload/Upload.tsx
+++ b/components/upload/Upload.tsx
@@ -5,6 +5,7 @@ import Dragger from './Dragger';
 import UploadList from './UploadList';
 import {
   RcFile,
+  ShowUploadListInterface,
   UploadProps,
   UploadFile,
   UploadLocale,
@@ -247,7 +248,7 @@ const InternalUpload: React.ForwardRefRenderFunction<unknown, UploadProps> = (pr
       <LocaleReceiver componentName="Upload" defaultLocale={defaultLocale.Upload}>
         {(locale: UploadLocale) => {
           const { showRemoveIcon, showPreviewIcon, showDownloadIcon, removeIcon, downloadIcon } =
-            typeof showUploadList === 'boolean' ? ({} as any) : showUploadList;
+            typeof showUploadList === 'boolean' ? ({} as ShowUploadListInterface) : showUploadList;
           return (
             <UploadList
               listType={listType}
@@ -270,7 +271,9 @@ const InternalUpload: React.ForwardRefRenderFunction<unknown, UploadProps> = (pr
           );
         }}
       </LocaleReceiver>
-    ) : button;
+    ) : (
+      button
+    );
 
   if (type === 'drag') {
     const dragCls = classNames(

--- a/components/upload/__tests__/type.test.tsx
+++ b/components/upload/__tests__/type.test.tsx
@@ -10,4 +10,21 @@ describe('Upload.typescript', () => {
     );
     expect(upload).toBeTruthy();
   });
+
+  it('showUploadList', () => {
+    const upload = (
+      <Upload
+        showUploadList={{
+          showPreviewIcon: true,
+          showRemoveIcon: true,
+          showDownloadIcon: true,
+          removeIcon: 'Remove',
+          downloadIcon: 'Download',
+        }}
+      >
+        <span>click to upload</span>
+      </Upload>
+    );
+    expect(upload).toBeTruthy();
+  });
 });

--- a/components/upload/interface.tsx
+++ b/components/upload/interface.tsx
@@ -56,6 +56,8 @@ export interface ShowUploadListInterface {
   showRemoveIcon?: boolean;
   showPreviewIcon?: boolean;
   showDownloadIcon?: boolean;
+  removeIcon?: React.ReactNode;
+  downloadIcon?: React.ReactNode;
 }
 
 export interface UploadLocale {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [X] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
close #26405
<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution
With the addition of `downloadIcon` and `removeIcon` to the `Upload` component's `showUploadList` prop, we need to update the relevant TS interface `ShowUploadListInterface`. Adding these two as optional properties solves the issue.
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Extend `ShowUploadListInterface` of Upload with `removeIcon` and `downloadIcon` properties.        |
| 🇨🇳 Chinese |   Upload 组件 `ShowUploadListInterface` 类型添加 `removeIcon` 和 `downloadIcon` 属性声明。        |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [X] Doc is updated/provided or not needed
- [X] Demo is updated/provided or not needed
- [X] TypeScript definition is updated/provided or not needed
- [X] Changelog is provided or not needed
