### PR TITLE
revert: remove ref support with Radio.Group

### DIFF
--- a/components/radio/group.tsx
+++ b/components/radio/group.tsx
@@ -7,7 +7,7 @@ import { ConfigContext } from '../config-provider';
 import SizeContext from '../config-provider/SizeContext';
 import { RadioGroupContextProvider } from './context';
 
-const RadioGroup = React.forwardRef<unknown, RadioGroupProps>((props, ref) => {
+const RadioGroup: React.FC<RadioGroupProps> = props => {
   const { getPrefixCls, direction } = React.useContext(ConfigContext);
   const size = React.useContext(SizeContext);
 
@@ -53,7 +53,6 @@ const RadioGroup = React.forwardRef<unknown, RadioGroupProps>((props, ref) => {
           // 此处类型自动推导为 string
           return (
             <Radio
-              ref={ref}
               key={option}
               prefixCls={optionsPrefixCls}
               disabled={disabled}
@@ -67,7 +66,6 @@ const RadioGroup = React.forwardRef<unknown, RadioGroupProps>((props, ref) => {
         // 此处类型自动推导为 { label: string value: string }
         return (
           <Radio
-            ref={ref}
             key={`radio-group-value-options-${option.value}`}
             prefixCls={optionsPrefixCls}
             disabled={option.disabled || disabled}
@@ -116,7 +114,7 @@ const RadioGroup = React.forwardRef<unknown, RadioGroupProps>((props, ref) => {
       {renderGroup()}
     </RadioGroupContextProvider>
   );
-});
+};
 
 RadioGroup.defaultProps = {
   buttonStyle: 'outline' as RadioGroupButtonStyle,


### PR DESCRIPTION
底层 `rc-util` 已经修复了，这个 fix 不需要了。

Reverts ant-design/ant-design#25328

ref https://github.com/ant-design/compatible/issues/70