### PR TITLE
fix: form customizing mixin

### DIFF
--- a/components/form/style/mixin.less
+++ b/components/form/style/mixin.less
@@ -10,6 +10,7 @@
   .@{ant-prefix}-input-affix-wrapper {
     &,
     &:hover {
+      background-color: @background-color;
       border-color: @border-color;
     }
 
@@ -19,16 +20,15 @@
     }
   }
 
-  .@{ant-prefix}-input {
-    &:not(&-disabled) {
-      background-color: @background-color;
-    }
+  .@{ant-prefix}-input-disabled {
+    background-color: @input-disabled-bg;
+    border-color: @input-border-color;
   }
 
-  .@{ant-prefix}-input-affix-wrapper {
-    &:not(&-disabled) {
-      background-color: @background-color;
-    }
+  .@{ant-prefix}-input-affix-wrapper-disabled {
+    background-color: @input-disabled-bg;
+    border-color: @input-border-color;
+
     input:focus {
       box-shadow: none !important;
     }

--- a/components/form/style/mixin.less
+++ b/components/form/style/mixin.less
@@ -9,6 +9,7 @@
   .@{ant-prefix}-input-affix-wrapper {
     &,
     &:hover {
+      background-color: @background-color;
       border-color: @border-color;
     }
 
@@ -18,16 +19,15 @@
     }
   }
 
-  .@{ant-prefix}-input {
-    &:not(&-disabled) {
-      background-color: @background-color;
-    }
+  .@{ant-prefix}-input-disabled {
+    background-color: @input-disabled-bg;
+    border-color: @input-border-color;
   }
 
-  .@{ant-prefix}-input-affix-wrapper {
-    &:not(&-disabled) {
-      background-color: @background-color;
-    }
+  .@{ant-prefix}-input-affix-wrapper-disabled {
+    background-color: @input-disabled-bg;
+    border-color: @input-border-color;
+
     input:focus {
       box-shadow: none !important;
     }

--- a/components/form/style/status.less
+++ b/components/form/style/status.less
@@ -125,6 +125,7 @@
     //select
     .@{ant-prefix}-select:not(.@{ant-prefix}-select-borderless) {
       .@{ant-prefix}-select-selector {
+        background-color: @form-warning-input-bg;
         border-color: @warning-color !important;
       }
       &.@{ant-prefix}-select-open .@{ant-prefix}-select-selector,
@@ -136,12 +137,14 @@
     //input-number, timepicker
     .@{ant-prefix}-input-number,
     .@{ant-prefix}-picker {
+      background-color: @form-warning-input-bg;
       border-color: @warning-color;
       &-focused,
       &:focus {
         .active(@warning-color);
       }
       &:not([disabled]):hover {
+        background-color: @form-warning-input-bg;
         border-color: @warning-color;
       }
     }
@@ -163,6 +166,7 @@
     //select
     .@{ant-prefix}-select:not(.@{ant-prefix}-select-borderless) {
       .@{ant-prefix}-select-selector {
+        background-color: @form-error-input-bg;
         border-color: @error-color !important;
       }
       &.@{ant-prefix}-select-open .@{ant-prefix}-select-selector,
@@ -188,12 +192,14 @@
     //input-number, timepicker
     .@{ant-prefix}-input-number,
     .@{ant-prefix}-picker {
+      background-color: @form-error-input-bg;
       border-color: @error-color;
       &-focused,
       &:focus {
         .active(@error-color);
       }
       &:not([disabled]):hover {
+        background-color: @form-error-input-bg;
         border-color: @error-color;
       }
     }
@@ -201,6 +207,7 @@
       .@{ant-prefix}-mention-editor {
         &,
         &:not([disabled]):hover {
+          background-color: @form-error-input-bg;
           border-color: @error-color;
         }
       }
@@ -211,6 +218,7 @@
     }
 
     .@{ant-prefix}-cascader-picker:focus .@{ant-prefix}-cascader-input {
+      background-color: @form-error-input-bg;
       .active(@error-color);
     }
 

--- a/components/form/style/status.less
+++ b/components/form/style/status.less
@@ -137,6 +137,7 @@
     //select
     .@{ant-prefix}-select:not(.@{ant-prefix}-select-borderless) {
       .@{ant-prefix}-select-selector {
+        background-color: @form-warning-input-bg;
         border-color: @warning-color !important;
       }
       &.@{ant-prefix}-select-open .@{ant-prefix}-select-selector,
@@ -148,12 +149,14 @@
     //input-number, timepicker
     .@{ant-prefix}-input-number,
     .@{ant-prefix}-picker {
+      background-color: @form-warning-input-bg;
       border-color: @warning-color;
       &-focused,
       &:focus {
         .active(@warning-color);
       }
       &:not([disabled]):hover {
+        background-color: @form-warning-input-bg;
         border-color: @warning-color;
       }
     }
@@ -175,6 +178,7 @@
     //select
     .@{ant-prefix}-select:not(.@{ant-prefix}-select-borderless) {
       .@{ant-prefix}-select-selector {
+        background-color: @form-error-input-bg;
         border-color: @error-color !important;
       }
       &.@{ant-prefix}-select-open .@{ant-prefix}-select-selector,
@@ -200,17 +204,34 @@
     //input-number, timepicker
     .@{ant-prefix}-input-number,
     .@{ant-prefix}-picker {
+      background-color: @form-error-input-bg;
       border-color: @error-color;
       &-focused,
       &:focus {
         .active(@error-color);
       }
       &:not([disabled]):hover {
+        background-color: @form-error-input-bg;
         border-color: @error-color;
       }
     }
 
+    .@{ant-prefix}-mention-wrapper {
+      .@{ant-prefix}-mention-editor {
+        &,
+        &:not([disabled]):hover {
+          background-color: @form-error-input-bg;
+          border-color: @error-color;
+        }
+      }
+      &.@{ant-prefix}-mention-active:not([disabled]) .@{ant-prefix}-mention-editor,
+      .@{ant-prefix}-mention-editor:not([disabled]):focus {
+        .active(@error-color);
+      }
+    }
+
     .@{ant-prefix}-cascader-picker:focus .@{ant-prefix}-cascader-input {
+      background-color: @form-error-input-bg;
       .active(@error-color);
     }
 


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

👻 ### What's the background?
I added property @background-color in .form-control-validation(), because now variables @form-error-input-bg and @form-warning-input-bg, which are thrown in this mixin - are not used anywhere. This property for customizing form input background-color if it needs. I hope this is correct

### 💡 Solution

### 📝 Changelog

No breaking changes and no any behavior changes
Just some variables for customizing

English Changelog:
added @background-color property for customizing form input, input-picker, input number and select in warning and error state
Chinese Changelog (optional):

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
