### PR TITLE
fix: fix no shadow in the style of the Select focus.

### DIFF
--- a/components/select/style/index.less
+++ b/components/select/style/index.less
@@ -28,7 +28,7 @@
     }
   }
 
-  .@{select-prefix-cls}-focused&:not(.@{select-prefix-cls}-disabled&) {
+  .@{select-prefix-cls}-focused:not(.@{select-prefix-cls}-disabled)& {
     .active();
   }
 


### PR DESCRIPTION
Fix #26255 style error.

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link


### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |Fix no shadow in the style of the Select focus.|
| 🇨🇳 Chinese |修复 Select 组件 focus 状态样式无阴影|

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
