### PR TITLE
fix: Radio.Group forward child element ref

### DIFF
--- a/components/radio/__tests__/group.test.js
+++ b/components/radio/__tests__/group.test.js
@@ -153,6 +153,19 @@ describe('Radio Group', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
+  it('should forward ref', () => {
+    let radioGroupRef;
+    const wrapper = mount(
+      createRadioGroupByOption({
+        ref: ref => {
+          radioGroupRef = ref;
+        },
+      }),
+    );
+
+    expect(radioGroupRef).toBe(wrapper.children().getDOMNode());
+  });
+
   describe('value is null or undefined', () => {
     it('use `defaultValue` when `value` is undefined', () => {
       const options = [{ label: 'Bamboo', value: 'bamboo' }];

--- a/components/radio/group.tsx
+++ b/components/radio/group.tsx
@@ -7,7 +7,7 @@ import { ConfigContext } from '../config-provider';
 import SizeContext from '../config-provider/SizeContext';
 import { RadioGroupContextProvider } from './context';
 
-const RadioGroup: React.FC<RadioGroupProps> = props => {
+const RadioGroup = React.forwardRef<HTMLDivElement, RadioGroupProps>((props, ref) => {
   const { getPrefixCls, direction } = React.useContext(ConfigContext);
   const size = React.useContext(SizeContext);
 
@@ -96,6 +96,7 @@ const RadioGroup: React.FC<RadioGroupProps> = props => {
         onMouseEnter={onMouseEnter}
         onMouseLeave={onMouseLeave}
         id={id}
+        ref={ref}
       >
         {childrenToRender}
       </div>
@@ -114,7 +115,7 @@ const RadioGroup: React.FC<RadioGroupProps> = props => {
       {renderGroup()}
     </RadioGroupContextProvider>
   );
-};
+});
 
 RadioGroup.defaultProps = {
   buttonStyle: 'outline' as RadioGroupButtonStyle,


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

新特性请提交至 feature 分支，其余可提交至 master 分支。
在一个维护者审核通过后合并。
请确保填写以下 pull request 的信息，谢谢！~

[[English Template / 英文模板](?expand=1)]
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 重构
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
1. 修复在 legacy Form 中，使用 `Radio.Group` 的表单项丢失数据的问题
2. 因为 legacy Form 需要表单项控件提供 `ref`，这里改为转发子元素的 `ref`

### 📝 更新日志怎么写？

<!--
> 从用户角度描述具体变化，以及可能的 breaking change 和其他风险？
-->

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | Fix Radio.Group not working properly, when is used in legacy Form. |
| 🇨🇳 中文 | 修复 Radio.Group 在 legacy Form 中，不能正常工作的问题 |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
