### PR TITLE
fix: restrict nested table styles to only apply to direct children of td

### DIFF
--- a/components/table/style/index.less
+++ b/components/table/style/index.less
@@ -106,6 +106,23 @@
       > td {
         border-bottom: @border-width-base @border-style-base @border-color-split;
         transition: background 0.3s;
+
+        // ========================= Nest Table ===========================
+        > .@{table-prefix-cls}-wrapper:only-child {
+          .@{table-prefix-cls} {
+            margin: -@table-padding-vertical -@table-padding-horizontal -@table-padding-vertical (@table-padding-horizontal +
+                  ceil(@font-size-sm * 1.4));
+
+            &-tbody > tr:last-child > td {
+              border-bottom: 0;
+
+              &:first-child,
+              &:last-child {
+                border-radius: 0;
+              }
+            }
+          }
+        }
       }
 
       &.@{table-prefix-cls}-row:hover {
@@ -123,23 +140,6 @@
         &:hover {
           > td {
             background: @table-selected-row-hover-bg;
-          }
-        }
-      }
-
-      // ========================= Nest Table ===========================
-      .@{table-prefix-cls}-wrapper:only-child {
-        .@{table-prefix-cls} {
-          margin: -@table-padding-vertical -@table-padding-horizontal -@table-padding-vertical (@table-padding-horizontal +
-                ceil(@font-size-sm * 1.4));
-
-          &-tbody > tr:last-child > td {
-            border-bottom: 0;
-
-            &:first-child,
-            &:last-child {
-              border-radius: 0;
-            }
           }
         }
       }


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

新特性请提交至 feature 分支，其余可提交至 master 分支。
在一个维护者审核通过后合并。
请确保填写以下 pull request 的信息，谢谢！~

[[English Template / 英文模板](?expand=1)]
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 重构
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
1.  `.ant-table-tbody > tr .ant-table-wrapper:only-child` 会匹配 `tr` 下所有的层级，导致会意外匹配单独被包裹的表格，如：
```html
<tr>
  <td>
    <div>some content</div>
    <div>
      <div class="ant-table-wrapper">
        ...
      </div>
    </div>
  </td>
</tr>
```
2. 改为限定为匹配 `td` 的直接子元素

### 📝 更新日志怎么写？

<!--
> 从用户角度描述具体变化，以及可能的 breaking change 和其他风险？
-->

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | Fix Table nested table styles affects all sub-level tables. |
| 🇨🇳 中文 | 修复 Table 嵌套表格样式会影响所有子层级表格的问题。 |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
