### PR TITLE
fix: cascader value overwritten when filtering  (#26554)

### DIFF
--- a/components/cascader/__tests__/index.test.js
+++ b/components/cascader/__tests__/index.test.js
@@ -524,4 +524,25 @@ describe('Cascader', () => {
     wrapper.find('input').simulate('change', { target: { value: 'jin' } });
     expect(wrapper.state('popupVisible')).toBe(true);
   });
+
+  it('onChange works correctly when the label of fieldNames is the same as value', () => {
+    const onChange = jest.fn();
+    const sameNames = { label: 'label', value: 'label', children: 'children' };
+    const wrapper = mount(
+      <Cascader options={options} onChange={onChange} showSearch fieldNames={sameNames} />,
+    );
+    wrapper.find('input').simulate('click');
+    wrapper.find('input').simulate('change', { target: { value: 'nan' } });
+    const popupWrapper = mount(wrapper.find('Cascader').find('Trigger').instance().getComponent());
+    popupWrapper
+      .find('.ant-cascader-menu')
+      .at(0)
+      .find('.ant-cascader-menu-item')
+      .at(0)
+      .simulate('click');
+    expect(onChange).toHaveBeenCalledWith(
+      ['Jiangsu', 'Nanjing', 'Zhong Hua men'],
+      expect.anything(),
+    );
+  });
 });

--- a/components/cascader/__tests__/index.test.js
+++ b/components/cascader/__tests__/index.test.js
@@ -532,7 +532,7 @@ describe('Cascader', () => {
       <Cascader options={options} onChange={onChange} showSearch fieldNames={sameNames} />,
     );
     wrapper.find('input').simulate('click');
-    wrapper.find('input').simulate('change', { target: { value: 'nan' } });
+    wrapper.find('input').simulate('change', { target: { value: 'est' } });
     const popupWrapper = mount(wrapper.find('Cascader').find('Trigger').instance().getComponent());
     popupWrapper
       .find('.ant-cascader-menu')
@@ -540,9 +540,6 @@ describe('Cascader', () => {
       .find('.ant-cascader-menu-item')
       .at(0)
       .simulate('click');
-    expect(onChange).toHaveBeenCalledWith(
-      ['Jiangsu', 'Nanjing', 'Zhong Hua men'],
-      expect.anything(),
-    );
+    expect(onChange).toHaveBeenCalledWith(['Zhejiang', 'Hangzhou', 'West Lake'], expect.anything());
   });
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
close [#26554](https://github.com/ant-design/ant-design/issues/26554)

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution
问题原因在于 fieldNames 中 label 与 value 相同， value 被覆盖丢失，onChange 返回自定义 label 导致。
由于搜索时，动态改变 fieldNames 不合适，且在 rc-cascader 中没有找到可以兼容 value 的地方。
所以使用新增字段保留 value 的方式，需要 Contributor 看下此方式是否可以？

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix cascader value overwritten when filtering |
| 🇨🇳 Chinese | 修复 cascader 搜索时 value 被覆盖的情况 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
