### PR TITLE
Exports CollapseInterface from Collapse

### DIFF
--- a/components/collapse/Collapse.tsx
+++ b/components/collapse/Collapse.tsx
@@ -37,7 +37,7 @@ interface PanelProps {
   extra?: React.ReactNode;
 }
 
-interface CollapseInterface extends React.FC<CollapseProps> {
+export interface CollapseInterface extends React.FC<CollapseProps> {
   Panel: typeof CollapsePanel;
 }
 


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

#26609

### 💡 Background and solution

CollapseInterface was not exported from the Collapse component

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Exports CollapseInterface from `components/collapse/Collapse.tsx`      |
| 🇨🇳 Chinese |           |
