### PR TITLE
fix: TextArea value works differently as Input

### DIFF
--- a/components/input/TextArea.tsx
+++ b/components/input/TextArea.tsx
@@ -13,6 +13,8 @@ export interface TextAreaProps extends RcTextAreaProps {
 
 export interface TextAreaState {
   value: any;
+  /** `value` from prev props */
+  prevValue: any;
 }
 
 class TextArea extends React.Component<TextAreaProps, TextAreaState> {
@@ -25,16 +27,17 @@ class TextArea extends React.Component<TextAreaProps, TextAreaState> {
     const value = typeof props.value === 'undefined' ? props.defaultValue : props.value;
     this.state = {
       value,
+      // eslint-disable-next-line react/no-unused-state
+      prevValue: props.value,
     };
   }
 
-  static getDerivedStateFromProps(nextProps: TextAreaProps) {
-    if (nextProps.value !== undefined) {
-      return {
-        value: nextProps.value,
-      };
+  static getDerivedStateFromProps(nextProps: TextAreaProps, { prevValue }: TextAreaState) {
+    const newState: Partial<TextAreaState> = { prevValue: nextProps.value };
+    if (nextProps.value !== undefined || prevValue !== nextProps.value) {
+      newState.value = nextProps.value;
     }
-    return null;
+    return newState;
   }
 
   setValue(value: string, callback?: () => void) {

--- a/components/input/__tests__/textarea.test.js
+++ b/components/input/__tests__/textarea.test.js
@@ -124,6 +124,14 @@ describe('TextArea', () => {
       }),
     );
   });
+
+  it('should works same as Input', async () => {
+    const input = mount(<Input value="111" />);
+    const textarea = mount(<TextArea value="111" />);
+    input.setProps({ value: undefined });
+    textarea.setProps({ value: undefined });
+    expect(textarea.getDOMNode().value).toBe(input.getDOMNode().value);
+  });
 });
 
 describe('TextArea allowClear', () => {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

broken in #26327

### 💡 Background and solution

重现链接：https://codesandbox.io/s/brave-chandrasekhar-yq0pe?file=/index.js

TextArea 应该和 Input 的行为完全一致。

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix TextArea different behavior with Input when set `value` to `undefined`. |
| 🇨🇳 Chinese | 修复 TextArea 设置 `value` 为 `undefined` 时和 Input 行为不一致的问题。  |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
