### PR TITLE
fix: Menu not support React.Fragment

### DIFF
--- a/components/menu/__tests__/index.test.js
+++ b/components/menu/__tests__/index.test.js
@@ -24,6 +24,26 @@ describe('Menu', () => {
     </Menu>
   ));
 
+  mountTest(() => (
+    <Menu>
+      <Menu.Item />
+      <>
+        <Menu.ItemGroup />
+        <Menu.SubMenu />
+        {null}
+      </>
+      <>
+        <Menu.Item />
+      </>
+      {undefined}
+      <>
+        <>
+          <Menu.Item />
+        </>
+      </>
+    </Menu>
+  ));
+
   rtlTest(() => (
     <Menu>
       <Menu.Item />

--- a/components/menu/demo/horizontal.md
+++ b/components/menu/demo/horizontal.md
@@ -39,7 +39,7 @@ class App extends React.Component {
         <Menu.Item key="app" disabled icon={<AppstoreOutlined />}>
           Navigation Two
         </Menu.Item>
-        <SubMenu icon={<SettingOutlined />} title="Navigation Three - Submenu">
+        <SubMenu key="SubMenu" icon={<SettingOutlined />} title="Navigation Three - Submenu">
           <Menu.ItemGroup title="Item 1">
             <Menu.Item key="setting:1">Option 1</Menu.Item>
             <Menu.Item key="setting:2">Option 2</Menu.Item>

--- a/components/table/hooks/useFilter/FilterDropdown.tsx
+++ b/components/table/hooks/useFilter/FilterDropdown.tsx
@@ -34,21 +34,22 @@ function renderFilterItems({
   locale: TableLocale;
 }) {
   if (filters.length === 0) {
-    // wrapped with <></> to avoid react warning
+    // wrapped with <div /> to avoid react warning
     // https://github.com/ant-design/ant-design/issues/25979
     return (
-      <>
+      <div
+        style={{
+          margin: '16px 0',
+        }}
+      >
         <Empty
           image={Empty.PRESENTED_IMAGE_SIMPLE}
           description={locale.filterEmptyText}
-          style={{
-            margin: '16px 0',
-          }}
           imageStyle={{
             height: 24,
           }}
         />
-      </>
+      </div>
     );
   }
   return filters.map((filter, index) => {

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "rc-image": "~3.0.6",
     "rc-input-number": "~6.0.0",
     "rc-mentions": "~1.4.0",
-    "rc-menu": "~8.5.2",
+    "rc-menu": "~8.6.0",
     "rc-motion": "^2.0.0",
     "rc-notification": "~4.4.0",
     "rc-pagination": "~3.0.3",

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "rc-image": "~3.0.6",
     "rc-input-number": "~6.0.0",
     "rc-mentions": "~1.4.0",
-    "rc-menu": "~8.6.0",
+    "rc-menu": "~8.6.1",
     "rc-motion": "^2.0.0",
     "rc-notification": "~4.4.0",
     "rc-pagination": "~3.0.3",


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close #18022 
close #19463 
close #22097 
close #10688 
close #15724 
close #16962 

ref #4853 

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Menu not support React.Fragment inside. |
| 🇨🇳 Chinese | 修复 Menu 不支持 React.Fragment 的问题。  |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/menu/demo/horizontal.md](https://github.com/ant-design/ant-design/blob/menu-fragment/components/menu/demo/horizontal.md)