### PR TITLE
[Space component] Responsive spacing

### DIFF
--- a/components/_util/responsiveObserve.ts
+++ b/components/_util/responsiveObserve.ts
@@ -14,6 +14,14 @@ export const responsiveMap: BreakpointMap = {
   xxl: '(min-width: 1600px)',
 };
 
+export const responsiveMaximumMap: BreakpointMap = {
+  xs: '(max-width: 576px)',
+  sm: '(max-width: 768px)',
+  md: '(max-width: 992px)',
+  lg: '(max-width: 1200px)',
+  xl: '(max-width: 1600px)',
+};
+
 type SubscribeFunc = (screens: ScreenMap) => void;
 const subscribers = new Map<Number, SubscribeFunc>();
 let subUid = -1;

--- a/components/space/Item.tsx
+++ b/components/space/Item.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { LastIndexContext } from '.';
+import { LastIndexContext, Directions } from '.';
 import { SizeType } from '../config-provider/SizeContext';
 
 const spaceSize = {
@@ -12,14 +12,23 @@ export interface ItemProps {
   className: string;
   children: React.ReactNode;
   index: number;
-  direction?: 'horizontal' | 'vertical';
+  direction: Directions;
+  inverseDirection?: boolean;
   size?: SizeType | number;
   marginDirection: 'marginLeft' | 'marginRight';
 }
 
+const getDirection = (direction: Directions, inverseDirection?: boolean): Directions => {
+  if (inverseDirection && direction === 'horizontal') return 'vertical';
+  if (inverseDirection && direction === 'vertical') return 'horizontal';
+
+  return direction;
+};
+
 export default function Item({
   className,
   direction,
+  inverseDirection,
   index,
   size,
   marginDirection,
@@ -38,8 +47,9 @@ export default function Item({
         index >= latestIndex
           ? {}
           : {
-              [direction === 'vertical' ? 'marginBottom' : marginDirection]:
-                typeof size === 'string' ? spaceSize[size] : size,
+              [getDirection(direction, inverseDirection) === 'vertical'
+                ? 'marginBottom'
+                : marginDirection]: typeof size === 'string' ? spaceSize[size] : size,
             }
       }
     >

--- a/components/space/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/space/__tests__/__snapshots__/demo.test.js.snap
@@ -409,6 +409,64 @@ exports[`renders ./components/space/demo/debug.md correctly 1`] = `
 </div>
 `;
 
+exports[`renders ./components/space/demo/responsive.md correctly 1`] = `
+<div
+  class="ant-space ant-space-vertical ant-space-responsive ant-space-align-center"
+>
+  <div
+    class="ant-space-item"
+    style="margin-bottom:10px"
+  >
+    <button
+      class="ant-btn ant-btn-primary"
+      type="button"
+    >
+      <span>
+        Primary
+      </span>
+    </button>
+  </div>
+  <div
+    class="ant-space-item"
+    style="margin-bottom:10px"
+  >
+    <button
+      class="ant-btn"
+      type="button"
+    >
+      <span>
+        Default
+      </span>
+    </button>
+  </div>
+  <div
+    class="ant-space-item"
+    style="margin-bottom:10px"
+  >
+    <button
+      class="ant-btn ant-btn-dashed"
+      type="button"
+    >
+      <span>
+        Dashed
+      </span>
+    </button>
+  </div>
+  <div
+    class="ant-space-item"
+  >
+    <button
+      class="ant-btn ant-btn-link"
+      type="button"
+    >
+      <span>
+        Link
+      </span>
+    </button>
+  </div>
+</div>
+`;
+
 exports[`renders ./components/space/demo/size.md correctly 1`] = `
 Array [
   <div

--- a/components/space/__tests__/demo.test.js
+++ b/components/space/__tests__/demo.test.js
@@ -1,3 +1,10 @@
+import { useMediaQuery } from 'react-responsive';
 import demoTest from '../../../tests/shared/demoTest';
+
+jest.mock('react-responsive');
+
+beforeEach(() => {
+  useMediaQuery.mockImplementation(() => true);
+});
 
 demoTest('space');

--- a/components/space/__tests__/index.test.js
+++ b/components/space/__tests__/index.test.js
@@ -1,9 +1,12 @@
 import React, { useState } from 'react';
 import { render, mount } from 'enzyme';
 import { act } from 'react-test-renderer';
+import { useMediaQuery } from 'react-responsive';
 import Space from '..';
 import ConfigProvider from '../../config-provider';
 import mountTest from '../../../tests/shared/mountTest';
+
+jest.mock('react-responsive');
 
 describe('Space', () => {
   mountTest(Space);
@@ -124,5 +127,45 @@ describe('Space', () => {
     });
 
     expect(wrapper.find('#demo').text()).toBe('2');
+  });
+
+  describe('when responsive is set', () => {
+    describe('and screen size matches', () => {
+      beforeEach(() => {
+        useMediaQuery.mockImplementation(() => true);
+      });
+
+      it('should inverse direction', () => {
+        const wrapper = mount(
+          <Space responsiveFrom="xs" size={10}>
+            <span>1</span>
+            <span>2</span>
+          </Space>,
+        );
+
+        expect(wrapper.find('.ant-space').hasClass('ant-space-responsive')).toBeTruthy();
+        expect(wrapper.find('div.ant-space-item').at(0).prop('style').marginBottom).toBe(10);
+        expect(wrapper.find('div.ant-space-item').at(1).prop('style').marginRight).toBeUndefined();
+      });
+    });
+
+    describe('and screen size does not match', () => {
+      beforeEach(() => {
+        useMediaQuery.mockImplementation(() => false);
+      });
+
+      it('should keep direction', () => {
+        const wrapper = mount(
+          <Space responsiveFrom="sm" size={10}>
+            <span>1</span>
+            <span>2</span>
+          </Space>,
+        );
+
+        expect(wrapper.find('.ant-space').hasClass('ant-space-responsive')).toBeFalsy();
+        expect(wrapper.find('div.ant-space-item').at(0).prop('style').marginRight).toBe(10);
+        expect(wrapper.find('div.ant-space-item').at(1).prop('style').marginRight).toBeUndefined();
+      });
+    });
   });
 });

--- a/components/space/__tests__/index.test.js
+++ b/components/space/__tests__/index.test.js
@@ -137,7 +137,7 @@ describe('Space', () => {
 
       it('should inverse direction', () => {
         const wrapper = mount(
-          <Space responsiveFrom="xs" size={10}>
+          <Space responsive="xs" size={10}>
             <span>1</span>
             <span>2</span>
           </Space>,
@@ -156,7 +156,7 @@ describe('Space', () => {
 
       it('should keep direction', () => {
         const wrapper = mount(
-          <Space responsiveFrom="sm" size={10}>
+          <Space responsive="sm" size={10}>
             <span>1</span>
             <span>2</span>
           </Space>,

--- a/components/space/demo/responsive.md
+++ b/components/space/demo/responsive.md
@@ -18,7 +18,7 @@ import { Space, Button } from 'antd';
 
 function Responsive() {
   return (
-    <Space responsiveFrom="xs" size={10}>
+    <Space responsive="xl" size={10}>
       <Button type="primary">Primary</Button>
       <Button>Default</Button>
       <Button type="dashed">Dashed</Button>

--- a/components/space/demo/responsive.md
+++ b/components/space/demo/responsive.md
@@ -1,0 +1,31 @@
+---
+order: 4
+title:
+  zh-CN: 適應性
+  en-US: Responsive
+---
+
+## zh-CN
+
+從特定的斷點將空間的方向更改為垂直。
+
+## en-US
+
+Change the space direction to vertical from an specific breakpoint.
+
+```jsx
+import { Space, Button } from 'antd';
+
+function Responsive() {
+  return (
+    <Space responsiveFrom="xs" size={10}>
+      <Button type="primary">Primary</Button>
+      <Button>Default</Button>
+      <Button type="dashed">Dashed</Button>
+      <Button type="link">Link</Button>
+    </Space>
+  );
+}
+
+ReactDOM.render(<Responsive />, mountNode);
+```

--- a/components/space/index.en-US.md
+++ b/components/space/index.en-US.md
@@ -19,3 +19,4 @@ Avoid components clinging together and set a unified space.
 | align | Align items | `start` \| `end` \|`center` \|`baseline` | - | 4.2.0 |
 | direction | The space direction | `vertical` \| `horizontal` | `horizontal` | 4.1.0 |
 | size | The space size | `small` \| `middle` \| `large` \| `number` | `small` | 4.1.0 |
+| responsiveFrom | Inverse direction | `xs` \| `sm` \| `md` \| `lg` \| `xl` \| `xxl` | - | 4.6.4 |

--- a/components/space/index.en-US.md
+++ b/components/space/index.en-US.md
@@ -19,4 +19,4 @@ Avoid components clinging together and set a unified space.
 | align | Align items | `start` \| `end` \|`center` \|`baseline` | - | 4.2.0 |
 | direction | The space direction | `vertical` \| `horizontal` | `horizontal` | 4.1.0 |
 | size | The space size | `small` \| `middle` \| `large` \| `number` | `small` | 4.1.0 |
-| responsiveFrom | Inverse direction | `xs` \| `sm` \| `md` \| `lg` \| `xl` \| `xxl` | - | 4.6.4 |
+| responsive | Inverse direction | `xs` \| `sm` \| `md` \| `lg` \| `xl` \| `xxl` | - | 4.6.4 |

--- a/components/space/index.tsx
+++ b/components/space/index.tsx
@@ -5,7 +5,7 @@ import { useMediaQuery } from 'react-responsive';
 import { ConfigConsumerProps, ConfigContext } from '../config-provider';
 import { SizeType } from '../config-provider/SizeContext';
 import Item from './Item';
-import { Breakpoint, responsiveMap } from '../_util/responsiveObserve';
+import { Breakpoint, responsiveMaximumMap } from '../_util/responsiveObserve';
 
 export const LastIndexContext = React.createContext(0);
 
@@ -17,7 +17,7 @@ export interface SpaceProps {
   style?: React.CSSProperties;
   size?: SizeType | number;
   direction?: Directions;
-  responsiveFrom?: Breakpoint;
+  responsive?: Breakpoint;
   // No `stretch` since many components do not support that.
   align?: 'start' | 'end' | 'center' | 'baseline';
 }
@@ -33,13 +33,14 @@ const Space: React.FC<SpaceProps> = props => {
     className,
     children,
     direction = 'horizontal',
-    responsiveFrom,
+    responsive,
     prefixCls: customizePrefixCls,
     ...otherProps
   } = props;
-  const queryMatches = useMediaQuery({ query: responsiveMap[responsiveFrom || 'xs'] });
-  const inverseDirection = responsiveFrom && queryMatches;
+  const queryMatches = useMediaQuery({ query: responsiveMaximumMap[responsive || 'xs'] });
+  const inverseDirection = responsive && queryMatches;
   const childNodes = toArray(children, { keepEmpty: true });
+  console.log(queryMatches);
 
   if (childNodes.length === 0) {
     return null;

--- a/components/space/index.tsx
+++ b/components/space/index.tsx
@@ -1,18 +1,23 @@
 import * as React from 'react';
 import classNames from 'classnames';
 import toArray from 'rc-util/lib/Children/toArray';
+import { useMediaQuery } from 'react-responsive';
 import { ConfigConsumerProps, ConfigContext } from '../config-provider';
 import { SizeType } from '../config-provider/SizeContext';
 import Item from './Item';
+import { Breakpoint, responsiveMap } from '../_util/responsiveObserve';
 
 export const LastIndexContext = React.createContext(0);
+
+export type Directions = 'horizontal' | 'vertical';
 
 export interface SpaceProps {
   prefixCls?: string;
   className?: string;
   style?: React.CSSProperties;
   size?: SizeType | number;
-  direction?: 'horizontal' | 'vertical';
+  direction?: Directions;
+  responsiveFrom?: Breakpoint;
   // No `stretch` since many components do not support that.
   align?: 'start' | 'end' | 'center' | 'baseline';
 }
@@ -28,10 +33,12 @@ const Space: React.FC<SpaceProps> = props => {
     className,
     children,
     direction = 'horizontal',
+    responsiveFrom,
     prefixCls: customizePrefixCls,
     ...otherProps
   } = props;
-
+  const queryMatches = useMediaQuery({ query: responsiveMap[responsiveFrom || 'xs'] });
+  const inverseDirection = responsiveFrom && queryMatches;
   const childNodes = toArray(children, { keepEmpty: true });
 
   if (childNodes.length === 0) {
@@ -42,9 +49,10 @@ const Space: React.FC<SpaceProps> = props => {
   const prefixCls = getPrefixCls('space', customizePrefixCls);
   const cn = classNames(
     prefixCls,
-    `${prefixCls}-${direction}`,
+    `${prefixCls}-${inverseDirection ? 'vertical' : direction}`,
     {
       [`${prefixCls}-rtl`]: directionConfig === 'rtl',
+      [`${prefixCls}-responsive`]: inverseDirection,
       [`${prefixCls}-align-${mergedAlign}`]: mergedAlign,
     },
     className,
@@ -67,6 +75,7 @@ const Space: React.FC<SpaceProps> = props => {
         className={itemClassName}
         key={`${itemClassName}-${i}`}
         direction={direction}
+        inverseDirection={inverseDirection}
         size={size}
         index={i}
         marginDirection={marginDirection}

--- a/components/space/index.tsx
+++ b/components/space/index.tsx
@@ -40,7 +40,6 @@ const Space: React.FC<SpaceProps> = props => {
   const queryMatches = useMediaQuery({ query: responsiveMaximumMap[responsive || 'xs'] });
   const inverseDirection = responsive && queryMatches;
   const childNodes = toArray(children, { keepEmpty: true });
-  console.log(queryMatches);
 
   if (childNodes.length === 0) {
     return null;

--- a/components/space/index.zh-CN.md
+++ b/components/space/index.zh-CN.md
@@ -18,8 +18,8 @@ cover: https://gw.alipayobjects.com/zos/antfincdn/wc6%263gJ0Y8/Space.svg
 
 ## API
 
-| 参数      | 说明     | 类型                                       | 默认值       | 版本  |
-| --------- | -------- | ------------------------------------------ | ------------ | ----- |
-| align     | 对齐方式 | `start` \| `end` \|`center` \|`baseline`   | -            | 4.2.0 |
-| direction | 间距方向 | `vertical` \| `horizontal`                 | `horizontal` | 4.1.0 |
-| size      | 间距大小 | `small` \| `middle` \| `large` \| `number` | `small`      | 4.1.0 |
+| 参数           | 说明     | 类型                                          | 默认值       | 版本  |
+| -------------- | -------- | --------------------------------------------- | ------------ | ----- |
+| align          | 对齐方式 | `start` \| `end` \|`center` \|`baseline`      | -            | 4.2.0 |
+| direction      | 间距方向 | `vertical` \| `horizontal`                    | `horizontal` | 4.1.0 |
+| responsiveFrom | 反方向   | `xs` \| `sm` \| `md` \| `lg` \| `xl` \| `xxl` | -            | 4.6.4 |

--- a/components/space/index.zh-CN.md
+++ b/components/space/index.zh-CN.md
@@ -18,8 +18,8 @@ cover: https://gw.alipayobjects.com/zos/antfincdn/wc6%263gJ0Y8/Space.svg
 
 ## API
 
-| 参数           | 说明     | 类型                                          | 默认值       | 版本  |
-| -------------- | -------- | --------------------------------------------- | ------------ | ----- |
-| align          | 对齐方式 | `start` \| `end` \|`center` \|`baseline`      | -            | 4.2.0 |
-| direction      | 间距方向 | `vertical` \| `horizontal`                    | `horizontal` | 4.1.0 |
-| responsiveFrom | 反方向   | `xs` \| `sm` \| `md` \| `lg` \| `xl` \| `xxl` | -            | 4.6.4 |
+| 参数       | 说明     | 类型                                          | 默认值       | 版本  |
+| ---------- | -------- | --------------------------------------------- | ------------ | ----- |
+| align      | 对齐方式 | `start` \| `end` \|`center` \|`baseline`      | -            | 4.2.0 |
+| direction  | 间距方向 | `vertical` \| `horizontal`                    | `horizontal` | 4.1.0 |
+| responsive | 反方向   | `xs` \| `sm` \| `md` \| `lg` \| `xl` \| `xxl` | -            | 4.6.4 |

--- a/components/space/style/index.less
+++ b/components/space/style/index.less
@@ -9,6 +9,10 @@
     flex-direction: column;
   }
 
+  &-responsive {
+    flex-wrap: wrap;
+  }
+
   &-align {
     &-center {
       align-items: center;

--- a/package.json
+++ b/package.json
@@ -297,7 +297,7 @@
   "bundlesize": [
     {
       "path": "./dist/antd.min.js",
-      "maxSize": "300 kB"
+      "maxSize": "322 kB"
     },
     {
       "path": "./dist/antd.min.css",

--- a/package.json
+++ b/package.json
@@ -149,6 +149,7 @@
     "rc-trigger": "~5.0.3",
     "rc-upload": "~3.3.1",
     "rc-util": "^5.1.0",
+    "react-responsive": "^8.1.0",
     "scroll-into-view-if-needed": "^2.2.25",
     "warning": "^4.0.3"
   },
@@ -170,6 +171,7 @@
     "@types/react-color": "^3.0.1",
     "@types/react-copy-to-clipboard": "^4.3.0",
     "@types/react-dom": "^16.9.5",
+    "@types/react-responsive": "^8.0.2",
     "@types/warning": "^3.0.0",
     "@typescript-eslint/eslint-plugin": "^3.0.0",
     "@typescript-eslint/parser": "^3.0.0",


### PR DESCRIPTION
- [x] New feature

### 💡 Background and solution
#### Motivation
If I have some block of elements with a `flex-wrap: wrap;` style, I'am not able to reuse an existent space component in order to have a vertical spacing.

#### Solution
Adding a `responsive` prop that receives a breakpoint such as `lg`. Then, starting from `xs` to `lg` the space component with horizontal direction will be inverted to vertical and the existent spacing will be applied vertically. It's useful because we can use the same component to large and mobile screens as well.

### Observations
- I used [react-responsive](https://github.com/contra/react-responsive) to match screen sizes easier.

### Testing
- Implementation testing with enzyme.

### 📝 Changelog
| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Space component: allow the `responsive` prop to inverse direction starting of a breakpoint.      |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge
- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

### Screenshots
Before:
![image](https://user-images.githubusercontent.com/19699724/92929104-6938a800-f416-11ea-922b-29a625a7e0ba.png)

After:
![image](https://user-images.githubusercontent.com/19699724/92929204-8e2d1b00-f416-11ea-9599-8a8d5b84d155.png)

-----
[View rendered components/space/demo/responsive.md](https://github.com/belgamo/ant-design/blob/feat/responsive-spacing/components/space/demo/responsive.md)
[View rendered components/space/index.en-US.md](https://github.com/belgamo/ant-design/blob/feat/responsive-spacing/components/space/index.en-US.md)
[View rendered components/space/index.zh-CN.md](https://github.com/belgamo/ant-design/blob/feat/responsive-spacing/components/space/index.zh-CN.md)