### PR TITLE
style: updated justify content css property to work with flex

### DIFF
--- a/components/table/style/index.less
+++ b/components/table/style/index.less
@@ -165,7 +165,7 @@
     display: flex;
 
     &-left {
-      justify-content: start;
+      justify-content: flex-start;
     }
 
     &-center {
@@ -173,7 +173,7 @@
     }
 
     &-right {
-      justify-content: end;
+      justify-content: flex-end;
     }
   }
 

--- a/components/table/style/rtl.less
+++ b/components/table/style/rtl.less
@@ -55,13 +55,13 @@
   &-pagination {
     &-left {
       .@{table-wrapepr-cls}.@{table-wrapepr-rtl-cls} & {
-        justify-content: end;
+        justify-content: flex-end;
       }
     }
 
     &-right {
       .@{table-wrapepr-cls}.@{table-wrapepr-rtl-cls} & {
-        justify-content: start;
+        justify-content: flex-start;
       }
     }
   }


### PR DESCRIPTION

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link


### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

Changed the Table pagination css position property `justify-content` values to work with the flex layout.

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Changed the Table pagination css position property `justify-content` values to work with the flex layout.       |
| 🇨🇳 Chinese |  更改了表分页css的位置属性“ justify-content”值以与flex布局一起使用。|

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
