### PR TITLE
fix: don't refresh page when use Typography.Link in router(#26624)

### DIFF
--- a/components/typography/Link.tsx
+++ b/components/typography/Link.tsx
@@ -6,10 +6,15 @@ export interface LinkProps
   extends BlockProps,
     Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, 'type'> {
   ellipsis?: boolean;
+  navigate?: Function;
+}
+
+function isModifiedEvent(event: React.MouseEvent<HTMLAnchorElement, MouseEvent>) {
+  return !!(event.metaKey || event.altKey || event.ctrlKey || event.shiftKey);
 }
 
 const Link: React.ForwardRefRenderFunction<HTMLElement, LinkProps> = (
-  { ellipsis, rel, ...restProps },
+  { ellipsis, rel, navigate, onClick, ...restProps },
   ref,
 ) => {
   devWarning(
@@ -22,9 +27,32 @@ const Link: React.ForwardRefRenderFunction<HTMLElement, LinkProps> = (
 
   React.useImperativeHandle(ref, () => baseRef.current?.contentRef.current!);
 
+  const { target } = restProps;
+
   const mergedProps = {
     ...restProps,
     rel: rel === undefined && restProps.target === '_blank' ? 'noopener noreferrer' : rel,
+    onClick: (event: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
+      try {
+        if (onClick) {
+          onClick(event);
+        }
+      } catch (ex) {
+        event.preventDefault();
+        throw ex;
+      }
+
+      if (
+        navigate && // react-router-dom Link
+        !event.defaultPrevented && // onClick prevented default
+        event.button === 0 && // ignore everything but left clicks
+        (!target || target === '_self') && // let browser handle "target=_blank" etc.
+        !isModifiedEvent(event) // ignore clicks with modifier keys
+      ) {
+        event.preventDefault();
+        navigate();
+      }
+    },
   };
 
   // https://github.com/ant-design/ant-design/issues/26622


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

新特性请提交至 feature 分支，其余可提交至 master 分支。
在一个维护者审核通过后合并。
请确保填写以下 pull request 的信息，谢谢！~

[[English Template / 英文模板](?expand=1)]
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 重构
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
close #26624
### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
解决的问题：`Typography.Link`组件被用在react-router-dom的Link组件上时，由于没有preventDefault，导致页面跳转时刷新。

解决方案：参考react-router-dom中Link组件的默认component（LinkAnchor）的实现，禁用点击事件的默认行为。
### 📝 更新日志怎么写？

<!--
> 从用户角度描述具体变化，以及可能的 breaking change 和其他风险？
-->

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |          |
| 🇨🇳 中文 |  修复了在react-router中使用Typography.Link组件时点击链接页面会自动刷新的bug        |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供