### PR TITLE
fix: `Button` as component for react-router `Link`

### DIFF
--- a/components/button/button.tsx
+++ b/components/button/button.tsx
@@ -262,7 +262,7 @@ const InternalButton: React.ForwardRefRenderFunction<unknown, ButtonProps> = (pr
       ? spaceChildren(children, isNeedInserted() && autoInsertSpace)
       : null;
 
-  const linkButtonRestProps = omit(rest as AnchorButtonProps, ['htmlType', 'loading']);
+  const linkButtonRestProps = omit(rest as AnchorButtonProps, ['htmlType', 'loading', 'navigate']);
   if (linkButtonRestProps.href !== undefined) {
     return (
       <a {...linkButtonRestProps} className={classes} onClick={handleClick} ref={buttonRef}>


### PR DESCRIPTION
[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [X] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

#26622 (except that this is for Button, not for Typography.Link)

### 💡 Background and solution

React router passes `navigate` as prop to component in <Link to={to}
component={Component}>. This is already fixed for Typography.Link.
(#26623) This fixes `<Link to={to} component={Button}` />
### 📝 Changelog


| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Fix Button warning Invalid value for prop navigate when using with react-router.        |
| 🇨🇳 Chinese | 修复 Button 和 react-router 一起使用时抛出 Invalid value for prop navigate 的问题。 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
