### PR TITLE
Update index.less

### DIFF
--- a/components/layout/style/index.less
+++ b/components/layout/style/index.less
@@ -104,13 +104,13 @@
         font-size: @layout-zero-trigger-width / 2;
         line-height: @layout-zero-trigger-height;
         text-align: center;
-        background: @layout-sider-background;
+        background: @layout-trigger-background;
         border-radius: 0 @border-radius-base @border-radius-base 0;
         cursor: pointer;
         transition: background 0.3s ease;
 
         &:hover {
-          background: tint(@layout-sider-background, 10%);
+          background: tint(@layout-trigger-background, 10%);
         }
 
         &-right {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link [https://github.com/ant-design/ant-design/issues/26755](https://github.com/ant-design/ant-design/issues/26755)

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution
**Background:**
I want a sidebar with gradient background. But packup was failed with an error after I set the value of @layout-sider-color to 'linear-gradient(-154deg, rgb(64, 64, 64), rgb(0, 0, 0))' in webpack config. The error is like below:
我想实现一个渐变色的侧边栏，我尝试在webpack配置文件中设置@layout-sider-color的值为linear-gradient(-154deg, rgb(64, 64, 64), rgb(0, 0, 0))，但是重新打包时报错了，错误如下：

>       &:hover {
>           background: tint(@layout-sider-background, 10%);
>                     ^
>       Error evaluating function `tint`: Argument cannot be evaluated to a color

**Solution:**
After changing the background values of '&:hover' and '&-trigger' beneath '&-zero-width' from 'layout-sider-background' to 'layout-trigger-background' in my local file located in node_module folder, packup passed without any error. And I got my application sidebar with a gradient background finally.
当我把Layout的Less样式文件中 '&-zero-width'下的'&:hover' 和'&-trigger' 的background的值由'layout-sider-background' 改为 'layout-trigger-background' 后，可正常打包，访问应用可以看到已经有一个渐变色的侧边栏了

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |Layout component's style less file modified. background's value of &-trigger and &:hover beneath &-zero-width  changed from  @layout-sider-background to @layout-trigger-background    |
| 🇨🇳 Chinese |  Layout 组件Less样式文件修改。  &-zero-width 下   &-trigger 和 &:hover的background属性值由  @layout-sider-background 改为了 @layout-trigger-background     |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
