### PR TITLE
fix: AutoComplete warning when using placeholder and allowClear

### DIFF
--- a/components/auto-complete/__tests__/index.test.js
+++ b/components/auto-complete/__tests__/index.test.js
@@ -69,4 +69,13 @@ describe('AutoComplete', () => {
     wrapper.find('input').simulate('change', { target: { value: '1' } });
     expect(wrapper.find('.ant-select-item-option').length).toBe(2);
   });
+
+  it('should not warning when getInputElement is null', () => {
+    jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    mount(<AutoComplete placeholder="input here" allowClear />);
+    // eslint-disable-next-line no-console
+    expect(console.warn).not.toBeCalled();
+    // eslint-disable-next-line no-console
+    console.warn.mockRestore();
+  });
 });

--- a/components/auto-complete/index.tsx
+++ b/components/auto-complete/index.tsx
@@ -46,7 +46,7 @@ const AutoComplete: React.ForwardRefRenderFunction<Select, AutoCompleteProps> = 
   React.useImperativeHandle<Select, Select>(ref, () => selectRef.current!);
 
   // ============================= Input =============================
-  let customizeInput: React.ReactElement;
+  let customizeInput: React.ReactElement | undefined;
 
   if (
     childNodes.length === 1 &&
@@ -56,7 +56,7 @@ const AutoComplete: React.ForwardRefRenderFunction<Select, AutoCompleteProps> = 
     [customizeInput] = childNodes;
   }
 
-  const getInputElement = (): React.ReactElement => customizeInput;
+  const getInputElement = customizeInput ? (): React.ReactElement => customizeInput! : undefined;
 
   // ============================ Options ============================
   let optionChildren: React.ReactNode;


### PR DESCRIPTION


<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close #26760

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix AutoComplete warning when using `placeholder` and `allowClear`. |
| 🇨🇳 Chinese | 修复 AutoComplete 使用 `placeholder` 和 `allowClear` 时抛出警告的问题。 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
