### PR TITLE
fix: <Table/> sticky z-index calculation.

### DIFF
--- a/components/table/style/index.less
+++ b/components/table/style/index.less
@@ -9,7 +9,7 @@
 @table-header-icon-color: #bfbfbf;
 @table-header-icon-color-hover: darken(@table-header-icon-color, 10%);
 @table-header-sort-active-filter-bg: lighten(@table-header-sort-active-bg, 2%);
-@table-sticky-zindex: @zindex-table-fixed + 1;
+@table-sticky-zindex: calc(@zindex-table-fixed + 1);
 @table-sticky-scroll-bar-active-bg: fade(@table-sticky-scroll-bar-bg, 80%);
 
 .@{table-prefix-cls}-wrapper {


### PR DESCRIPTION
### 🤔 This is a ...

- [x] Bug fix

### 🔗 Related issue link

I couldn't find any related issue.
During our development a build failed and therefore I decided to directly contribute a fix.

### 💡 Background and solution

During development of our frontend the build failed with the following exception:
```
@table-sticky-zindex: @zindex-table-fixed + 1;
^
Operation on an invalid type
```

### 📝 Changelog

With the implemented fix the build passes without error.
There shouldn't be any breaking changes since it is a css native functionality that is being added.

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
