### PR TITLE
style: fix Radio.Button validation error highlight

### DIFF
--- a/components/form/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/form/__tests__/__snapshots__/demo.test.js.snap
@@ -5566,7 +5566,7 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
       class="ant-col ant-col-6 ant-form-item-label"
     >
       <label
-        class=""
+        class="ant-form-item-required"
         for="validate_other_radio-button"
         title="Radio.Button"
       >

--- a/components/form/demo/validate-other.md
+++ b/components/form/demo/validate-other.md
@@ -120,7 +120,11 @@ const Demo = () => {
         </Radio.Group>
       </Form.Item>
 
-      <Form.Item name="radio-button" label="Radio.Button">
+      <Form.Item
+        name="radio-button"
+        label="Radio.Button"
+        rules={[{ required: true, message: 'Please pick an item!' }]}
+      >
         <Radio.Group>
           <Radio.Button value="a">item 1</Radio.Button>
           <Radio.Button value="b">item 2</Radio.Button>

--- a/components/form/style/status.less
+++ b/components/form/style/status.less
@@ -232,6 +232,17 @@
         }
       }
     }
+
+    // RadioGroup
+    .@{ant-prefix}-radio-button-wrapper {
+      border-color: @error-color !important;
+
+      &:not(:first-child) {
+        &::before {
+          background-color: @error-color;
+        }
+      }
+    }
   }
 
   // Patch to keep error explain color


### PR DESCRIPTION
[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

This partially covers https://github.com/ant-design/ant-design/issues/24590

### 💡 Background and solution

Form.Item validateStatus has no effect on the contained Radio.Button styling. Error color should be used for borders to match other form controls (input, select, etc).

### 📝 Changelog


| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix Radio.Button validation error highlight |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/form/demo/validate-other.md](https://github.com/dhorelik/ant-design/blob/radio-button-validation-error/components/form/demo/validate-other.md)