### PR TITLE
style: link-decoration

### DIFF
--- a/components/typography/style/index.less
+++ b/components/typography/style/index.less
@@ -93,6 +93,7 @@
   a&,
   a {
     .operation-unit();
+    text-decoration: @link-decoration;
 
     &:active,
     &:hover {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [x] Bug fix


### 🔗 Related issue link
Closes #26778 
https://github.com/ant-design/ant-design/issues/26778

### 💡 Background and solution

The text-decoration property of Link (a) was not linked by the default.less file. 
It was hard-coded in [operation-unit()](https://github.com/ant-design/ant-design/blob/master/components/style/mixins/operation-unit.less#L5) and needed to be override in [Link style](https://github.com/ant-design/ant-design/blob/master/components/typography/style/index.less#L94)

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ x] Doc is updated/provided or not needed
- [ x] Demo is updated/provided or not needed
- [ x] TypeScript definition is updated/provided or not needed
- [ x] Changelog is provided or not needed
