### PR TITLE
fix: Divider border style not work on text mode

### DIFF
--- a/components/divider/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/divider/__tests__/__snapshots__/demo.test.js.snap
@@ -13,6 +13,17 @@ Array [
     style="border-color:#7cb305"
   />,
   <div
+    class="ant-divider ant-divider-horizontal ant-divider-with-text ant-divider-with-text-center ant-divider-dashed"
+    role="separator"
+    style="border-color:#7cb305"
+  >
+    <span
+      class="ant-divider-inner-text"
+    >
+      Text
+    </span>
+  </div>,
+  <div
     class="ant-divider ant-divider-vertical"
     role="separator"
     style="height:60px;border-color:#7cb305"

--- a/components/divider/demo/customize-style.md
+++ b/components/divider/demo/customize-style.md
@@ -21,6 +21,9 @@ ReactDOM.render(
   <>
     <Divider style={{ borderWidth: 2, borderColor: '#7cb305' }} />
     <Divider style={{ borderColor: '#7cb305' }} dashed />
+    <Divider style={{ borderColor: '#7cb305' }} dashed>
+      Text
+    </Divider>
     <Divider type="vertical" style={{ height: 60, borderColor: '#7cb305' }} />
     <Divider type="vertical" style={{ height: 60, borderColor: '#7cb305' }} dashed />
   </>,

--- a/components/divider/style/index.less
+++ b/components/divider/style/index.less
@@ -35,13 +35,18 @@
     font-size: @font-size-lg;
     white-space: nowrap;
     text-align: center;
+    border-color: @divider-color;
     border-top: 0;
+
     &::before,
     &::after {
       position: relative;
       top: 50%;
       width: 50%;
-      border-top: 1px solid @divider-color;
+      border-top: 1px solid transparent;
+      // Chrome not accept `inherit` in `border-top`
+      border-top-color: inherit;
+      border-bottom: 0;
       transform: translateY(50%);
       content: '';
     }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

resolve #26846

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Fix Divider border style not work when text is provided.      |
| 🇨🇳 Chinese |   修复 Divider 在有文字时，设置边框颜色无效的问题。        |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/divider/demo/customize-style.md](https://github.com/ant-design/ant-design/blob/fix-dividier/components/divider/demo/customize-style.md)