### PR TITLE
Improve warning in <Affix>

### DIFF
--- a/components/affix/index.tsx
+++ b/components/affix/index.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import classNames from 'classnames';
 import omit from 'omit.js';
 import ResizeObserver from 'rc-resize-observer';
+import warning from 'rc-util/lib/warning';
 import { ConfigContext, ConfigConsumerProps } from '../config-provider';
 import { throttleByAnimationFrameDecorator } from '../_util/throttleByAnimationFrame';
 
@@ -274,6 +275,12 @@ class Affix extends React.Component<AffixProps, AffixState> {
     // Omit this since `onTestUpdatePosition` only works on test.
     if (process.env.NODE_ENV === 'test') {
       props = omit(props, ['onTestUpdatePosition']);
+    }
+    if (children.length > 1) {
+      warning(
+        false,
+        'Affix component received more than one child node with `children`. ResizeObserver will only observe first one.',
+      );
     }
 
     return (


### PR DESCRIPTION
Affix uses ResizeObserver. If multiple children are used the ResizeObserver will print a warning, but it is impossible to know which Ant component needs attention.

<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [x] Other (about what?)

### 🔗 Related issue link
Resize observer prints a warning, but no way to know which Ant component needs attention!

https://github.com/react-component/resize-observer/blob/master/src/index.tsx
<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution
No solution. Just improved logging.
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog
Improved logging for Affix
<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
