### PR TITLE
fix: Slider step prop not accepting null value

### DIFF
--- a/components/slider/__tests__/index.test.js
+++ b/components/slider/__tests__/index.test.js
@@ -40,6 +40,20 @@ describe('Slider', () => {
     expect(wrapper.find('.ant-tooltip-content').length).toBe(0);
   });
 
+  it('when step is null, thumb can only be slided to the specific mark', () => {
+    const intentionallyWrongValue = 40;
+    const marks = {
+      0: '0',
+      48: '48',
+      100: '100',
+    };
+
+    const wrapper = mount(
+      <Slider marks={marks} defaultValue={intentionallyWrongValue} step={null} tooltipVisible />,
+    );
+    expect(wrapper.find('.ant-slider-handle').get(0).props).toHaveProperty('value', 48);
+  });
+
   it('should render in RTL direction', () => {
     const wrapper = mount(
       <ConfigProvider direction="rtl">

--- a/components/slider/__tests__/index.test.js
+++ b/components/slider/__tests__/index.test.js
@@ -108,4 +108,9 @@ describe('Slider', () => {
       mount(<Slider value={value} tooltipVisible />);
     });
   });
+  it('step should not crash with undefined value', () => {
+    [undefined, null].forEach(value => {
+      mount(<Slider step={value} tooltipVisible />);
+    });
+  });
 });

--- a/components/slider/__tests__/index.test.js
+++ b/components/slider/__tests__/index.test.js
@@ -54,6 +54,30 @@ describe('Slider', () => {
     expect(wrapper.find('.ant-slider-handle').get(0).props).toHaveProperty('value', 48);
   });
 
+  it('when step is not null, thumb can be slided to the multiples of step', () => {
+    const marks = {
+      0: '0',
+      48: '48',
+      100: '100',
+    };
+
+    const wrapper = mount(<Slider marks={marks} defaultValue={49} step={1} tooltipVisible />);
+    expect(wrapper.find('.ant-slider-handle').get(0).props).toHaveProperty('value', 49);
+  });
+
+  it('when step is undefined, thumb can be slided to the multiples of step', () => {
+    const marks = {
+      0: '0',
+      48: '48',
+      100: '100',
+    };
+
+    const wrapper = mount(
+      <Slider marks={marks} defaultValue={49} step={undefined} tooltipVisible />,
+    );
+    expect(wrapper.find('.ant-slider-handle').get(0).props).toHaveProperty('value', 49);
+  });
+
   it('should render in RTL direction', () => {
     const wrapper = mount(
       <ConfigProvider direction="rtl">

--- a/components/slider/__tests__/type.test.tsx
+++ b/components/slider/__tests__/type.test.tsx
@@ -29,4 +29,21 @@ describe('Slider.typescript', () => {
     );
     expect(result).toBeTruthy();
   });
+
+  it('step can be null value', () => {
+    const value = 0;
+    function onChange(v: number) {
+      return v;
+    }
+    const result = (
+      <Slider
+        defaultValue={value}
+        value={value}
+        onChange={onChange}
+        onAfterChange={onChange}
+        step={null}
+      />
+    );
+    expect(result).toBeTruthy();
+  });
 });

--- a/components/slider/index.tsx
+++ b/components/slider/index.tsx
@@ -143,6 +143,7 @@ const Slider = React.forwardRef<unknown, SliderSingleProps | SliderRangeProps>(
       return (
         <RcRange
           {...(restProps as SliderRangeProps)}
+          step={restProps.step!}
           className={cls}
           ref={ref}
           handle={(info: HandleGeneratorInfo) =>
@@ -159,6 +160,7 @@ const Slider = React.forwardRef<unknown, SliderSingleProps | SliderRangeProps>(
     return (
       <RcSlider
         {...(restProps as SliderSingleProps)}
+        step={restProps.step!}
         className={cls}
         ref={ref}
         handle={(info: HandleGeneratorInfo) =>

--- a/components/slider/index.tsx
+++ b/components/slider/index.tsx
@@ -32,7 +32,7 @@ export interface SliderBaseProps {
   reverse?: boolean;
   min?: number;
   max?: number;
-  step?: number;
+  step?: null | number;
   marks?: SliderMarks;
   dots?: boolean;
   included?: boolean;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

1. [#26976](https://github.com/ant-design/ant-design/issues/26976)

### 💡 Background and solution

The `step` prop for `Slider` will trigger typescript error: `Type null is not assignable to type 'number | undefined' `.  This is because the type definition does not allow `null` value, eventhough in the [documents it allowed as mentioned](https://ant.design/components/slider/):

```
the granularity the slider can step through values. Must greater than 0, and be divided by (max - min) . When marks no null, step can be null
```

This can be fixed by changing the definition of `step` to allow `null` value. 
Since underlying component used in `Slider` is `react-component/slider` its `step` props do not allow `null`, although in their documentation [it is allowed.](https://github.com/react-component/slider).
A quick fix will force the value `null!` within the library, while client apps will still be able to pass in `step={null}` without typescript errors. Until the underlying prop interface is resolved, this should a sufficient enough fix.

Updated typescript test to catch this error, and also added tests to ensure slider behaves as expected when null is passed. 
### 📝 Changelog

No breaking changes

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |Fixed `step` prop in `Slider` to accept null as a valid value in accordance to the documentation.|
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
