### PR TITLE
chore: `useContext` in Empty

### DIFF
--- a/components/empty/index.tsx
+++ b/components/empty/index.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import classNames from 'classnames';
-import { ConfigConsumer, ConfigConsumerProps } from '../config-provider';
+import { ConfigContext } from '../config-provider';
 import LocaleReceiver from '../locale-provider/LocaleReceiver';
 import DefaultEmptyImg from './empty';
 import SimpleEmptyImg from './simple';
@@ -30,59 +30,56 @@ interface EmptyType extends React.FC<EmptyProps> {
   PRESENTED_IMAGE_SIMPLE: React.ReactNode;
 }
 
-const Empty: EmptyType = (props: EmptyProps) => (
-  <ConfigConsumer>
-    {({ getPrefixCls, direction }: ConfigConsumerProps) => {
-      const {
-        className,
-        prefixCls: customizePrefixCls,
-        image = defaultEmptyImg,
-        description,
-        children,
-        imageStyle,
-        ...restProps
-      } = props;
+const Empty: EmptyType = (props: EmptyProps) => {
+  const { getPrefixCls, direction } = React.useContext(ConfigContext);
+  const {
+    className,
+    prefixCls: customizePrefixCls,
+    image = defaultEmptyImg,
+    description,
+    children,
+    imageStyle,
+    ...restProps
+  } = props;
 
-      return (
-        <LocaleReceiver componentName="Empty">
-          {(locale: TransferLocale) => {
-            const prefixCls = getPrefixCls('empty', customizePrefixCls);
-            const des = typeof description !== 'undefined' ? description : locale.description;
-            const alt = typeof des === 'string' ? des : 'empty';
+  return (
+    <LocaleReceiver componentName="Empty">
+      {(locale: TransferLocale) => {
+        const prefixCls = getPrefixCls('empty', customizePrefixCls);
+        const des = typeof description !== 'undefined' ? description : locale.description;
+        const alt = typeof des === 'string' ? des : 'empty';
 
-            let imageNode: React.ReactNode = null;
+        let imageNode: React.ReactNode = null;
 
-            if (typeof image === 'string') {
-              imageNode = <img alt={alt} src={image} />;
-            } else {
-              imageNode = image;
-            }
+        if (typeof image === 'string') {
+          imageNode = <img alt={alt} src={image} />;
+        } else {
+          imageNode = image;
+        }
 
-            return (
-              <div
-                className={classNames(
-                  prefixCls,
-                  {
-                    [`${prefixCls}-normal`]: image === simpleEmptyImg,
-                    [`${prefixCls}-rtl`]: direction === 'rtl',
-                  },
-                  className,
-                )}
-                {...restProps}
-              >
-                <div className={`${prefixCls}-image`} style={imageStyle}>
-                  {imageNode}
-                </div>
-                {des && <p className={`${prefixCls}-description`}>{des}</p>}
-                {children && <div className={`${prefixCls}-footer`}>{children}</div>}
-              </div>
-            );
-          }}
-        </LocaleReceiver>
-      );
-    }}
-  </ConfigConsumer>
-);
+        return (
+          <div
+            className={classNames(
+              prefixCls,
+              {
+                [`${prefixCls}-normal`]: image === simpleEmptyImg,
+                [`${prefixCls}-rtl`]: direction === 'rtl',
+              },
+              className,
+            )}
+            {...restProps}
+          >
+            <div className={`${prefixCls}-image`} style={imageStyle}>
+              {imageNode}
+            </div>
+            {des && <p className={`${prefixCls}-description`}>{des}</p>}
+            {children && <div className={`${prefixCls}-footer`}>{children}</div>}
+          </div>
+        );
+      }}
+    </LocaleReceiver>
+  );
+};
 
 Empty.PRESENTED_IMAGE_DEFAULT = defaultEmptyImg;
 Empty.PRESENTED_IMAGE_SIMPLE = simpleEmptyImg;

--- a/components/empty/index.tsx
+++ b/components/empty/index.tsx
@@ -30,17 +30,16 @@ interface EmptyType extends React.FC<EmptyProps> {
   PRESENTED_IMAGE_SIMPLE: React.ReactNode;
 }
 
-const Empty: EmptyType = (props: EmptyProps) => {
+const Empty: EmptyType = ({
+  className,
+  prefixCls: customizePrefixCls,
+  image = defaultEmptyImg,
+  description,
+  children,
+  imageStyle,
+  ...restProps
+}) => {
   const { getPrefixCls, direction } = React.useContext(ConfigContext);
-  const {
-    className,
-    prefixCls: customizePrefixCls,
-    image = defaultEmptyImg,
-    description,
-    children,
-    imageStyle,
-    ...restProps
-  } = props;
 
   return (
     <LocaleReceiver componentName="Empty">


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [x] Refactoring
- [x] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | use `useContext` instead of `ConfigConsumer` in Empty  |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
