### PR TITLE
fix: missing autoFocus prop in Slider. Fixes #26982

### DIFF
--- a/components/slider/index.tsx
+++ b/components/slider/index.tsx
@@ -47,6 +47,7 @@ export interface SliderBaseProps {
   tooltipVisible?: boolean;
   tooltipPlacement?: TooltipPlacement;
   getTooltipPopupContainer?: (triggerNode: HTMLElement) => HTMLElement;
+  autoFocus?: boolean;
 }
 
 export interface SliderSingleProps extends SliderBaseProps {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->
1. #26982 - `autoFocus` prop missing in Slider.
### 💡 Background and solution
Based on the [Slider API documentation](https://ant.design/components/slider/#API), `autoFocus` prop is available to use. However, the type definition of `Slider` props is missing this. The underlying implementation `RcSlider` actually supports `autoFocus`. When using `Slider` as JSX, `autoFocus` prop works as expected. But on TSX, Typescript will show error `property 'autoFocus' does not exist on type 'IntrinsicAttributes & SliderRangeProps & RefAttributes<unknown>'`

The solution is to include `autoFocus` in `SliderBaseProps` as both range and single slider supports `autoFocus`

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |Added `autoFocus` prop to `Slider` as intended as per documentation. |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
