### PR TITLE
fix: undefined in filterDropdown in Table should not render dropdown …

### DIFF
--- a/components/table/__tests__/Table.filter.test.js
+++ b/components/table/__tests__/Table.filter.test.js
@@ -69,6 +69,19 @@ describe('Table.filter', () => {
     expect(wrapper.find('.ant-table-filter-column')).toHaveLength(0);
   });
 
+  // https://github.com/ant-design/ant-design/issues/26988
+  it('not show filter icon when filter and filterDropdown is undefined', () => {
+    const noFilterColumn = { ...column, filters: undefined, filterDropdown: undefined };
+    delete noFilterColumn.onFilter;
+    const wrapper = mount(
+      createTable({
+        columns: [noFilterColumn],
+      }),
+    );
+
+    expect(wrapper.find('.ant-table-filter-column')).toHaveLength(0);
+  });
+
   it('renders filter correctly', () => {
     const wrapper = mount(createTable());
 

--- a/components/table/hooks/useFilter/index.tsx
+++ b/components/table/hooks/useFilter/index.tsx
@@ -70,7 +70,7 @@ function injectFilter<RecordType>(
     const columnPos = getColumnPos(index, pos);
     const { filterMultiple = true } = column as ColumnType<RecordType>;
 
-    if (column.filters || 'filterDropdown' in column) {
+    if (column.filters || column.filterDropdown) {
       const columnKey = getColumnKey(column, columnPos);
       const filterState = filterStates.find(({ key }) => columnKey === key);
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
1. #26988 

### 💡 Background and solution
When creating a Table with some columns, when the column `filterDropdown` is set to undefined, the dropdown is rendered with no content. [See example](https://codesandbox.io/s/strange-rgb-7c0kg?fontsize=14&hidenavigation=1&theme=dark)
![image](https://user-images.githubusercontent.com/6754603/94986741-bdf1bd80-0593-11eb-8350-fe6f5d26d3eb.png)

Although it makes sense to just not include `filterDropdown` to the column if no filter is needed, creating dynamic columns can be a challenge, and make code harder to read:
```
if (condition) {
  return {
      title: "Name",
      dataIndex: "name",
      filterDropdown: CustomDropdownComponnt
  };
} else {
  return {
      title: "Name",
      dataIndex: "name",
  };
}
```
compared to 
```
return {
    title: "Name",
    dataIndex: "name",
    filterDropdown: condition ? CustomDropdownComponent : undefined
};
```
The fix made is by checking to make sure that if  `dropdownFilter`is specified it must be truthy before rendering the dropdown.

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Table filter dropdown icon no longer appears if `filterDropdown` in column is set `undefined` or `null        |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
