### PR TITLE
fix: Radio.Button cannot use Tooltip

### DIFF
--- a/components/radio/radio.tsx
+++ b/components/radio/radio.tsx
@@ -7,7 +7,7 @@ import RadioGroupContext from './context';
 import { composeRef } from '../_util/ref';
 import devWarning from '../_util/devWarning';
 
-const InternalRadio: React.ForwardRefRenderFunction<unknown, RadioProps> = (props, ref) => {
+const InternalRadio: React.ForwardRefRenderFunction<HTMLElement, RadioProps> = (props, ref) => {
   const context = React.useContext(RadioGroupContext);
   const { getPrefixCls, direction } = React.useContext(ConfigContext);
   const innerRef = React.useRef<HTMLElement>();
@@ -37,8 +37,8 @@ const InternalRadio: React.ForwardRefRenderFunction<unknown, RadioProps> = (prop
     radioProps.disabled = props.disabled || context.disabled;
   }
   const wrapperClassString = classNames(
+    `${prefixCls}-wrapper`,
     {
-      [`${prefixCls}-wrapper`]: true,
       [`${prefixCls}-wrapper-checked`]: radioProps.checked,
       [`${prefixCls}-wrapper-disabled`]: radioProps.disabled,
       [`${prefixCls}-wrapper-rtl`]: direction === 'rtl',
@@ -54,13 +54,14 @@ const InternalRadio: React.ForwardRefRenderFunction<unknown, RadioProps> = (prop
       onMouseEnter={props.onMouseEnter}
       onMouseLeave={props.onMouseLeave}
     >
-      <RcCheckbox {...radioProps} prefixCls={prefixCls} ref={mergedRef as any} />
+      <RcCheckbox {...radioProps} prefixCls={prefixCls} ref={mergedRef} />
       {children !== undefined ? <span>{children}</span> : null}
     </label>
   );
 };
 
 const Radio = React.forwardRef<unknown, RadioProps>(InternalRadio);
+
 Radio.displayName = 'Radio';
 
 Radio.defaultProps = {

--- a/components/radio/style/index.less
+++ b/components/radio/style/index.less
@@ -185,6 +185,7 @@ span.@{radio-prefix-cls} + * {
     position: absolute;
     top: 0;
     left: 0;
+    z-index: -1;
     width: 100%;
     height: 100%;
   }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

resolve #26921
resolve #25222

close #26929

### 💡 Background and solution

之前的样式修复方案会导致 #26921 的问题，回滚并换了一种方式修复 #25222 。

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Radio.Button children cannot apply Tooltip. |
| 🇨🇳 Chinese | 修复 Radio.Button 内无法使用 Tooltip 的问题。  |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
