### PR TITLE
feat: upgrade rc-input-number to support <InputNumber onStep />

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "rc-dropdown": "~3.1.2",
     "rc-field-form": "~1.10.0",
     "rc-image": "~3.0.6",
-    "rc-input-number": "~6.0.0",
+    "rc-input-number": "~6.1.0",
     "rc-mentions": "~1.4.0",
     "rc-menu": "~8.6.1",
     "rc-motion": "^2.0.0",


### PR DESCRIPTION
[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [x] New feature

### 🔗 Related issue link

https://github.com/react-component/input-number/pull/269/files

### 💡 Background and solution

Enable `onStep` support for InputNumber to be able to differentiate value change by input or value change by stepping with arrow up/down.

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  InputNumber triggers onStep when value steps up or down  |
| 🇨🇳 Chinese | InputNumber 增加 onStep 事件，在用户步进变量时触发 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
