### PR TITLE
docs: update modal version column

### DIFF
--- a/components/modal/index.en-US.md
+++ b/components/modal/index.en-US.md
@@ -13,36 +13,36 @@ When requiring users to interact with the application, but without jumping to a 
 
 ## API
 
-| Property | Description | Type | Default |
-| --- | --- | --- | --- |
-| afterClose | Specify a function that will be called when modal is closed completely | function | - |
-| bodyStyle | Body style for modal body element. Such as height, padding etc | CSSProperties | {} |
-| cancelText | Text of the Cancel button | ReactNode | `Cancel` |
-| cancelButtonProps | The cancel button props | [ButtonProps](/components/button/#API) | - |
-| centered | Centered Modal | boolean | false |
-| closable | Whether a close (x) button is visible on top right of the modal dialog or not | boolean | true |
-| closeIcon | Custom close icon | ReactNode | &lt;CloseOutlined /> |
-| confirmLoading | Whether to apply loading visual effect for OK button or not | boolean | false |
-| destroyOnClose | Whether to unmount child components on onClose | boolean | false |
-| footer | Footer content, set as `footer={null}` when you don't need default buttons | ReactNode | (OK and Cancel buttons) |
-| forceRender | Force render Modal | boolean | false |
-| getContainer | Return the mount node for Modal | HTMLElement \| () => HTMLElement \| Selectors \| false | document.body |
-| keyboard | Whether support press esc to close | boolean | true |
-| mask | Whether show mask or not | boolean | true |
-| maskClosable | Whether to close the modal dialog when the mask (area outside the modal) is clicked | boolean | true |
-| maskStyle | Style for modal's mask element | object | {} |
+| Property | Description | Type | Default | Version |
+| --- | --- | --- | --- | --- |
+| afterClose | Specify a function that will be called when modal is closed completely | function | - |  |
+| bodyStyle | Body style for modal body element. Such as height, padding etc | CSSProperties | {} |  |
+| cancelText | Text of the Cancel button | ReactNode | `Cancel` |  |
+| cancelButtonProps | The cancel button props | [ButtonProps](/components/button/#API) | - |  |
+| centered | Centered Modal | boolean | false |  |
+| closable | Whether a close (x) button is visible on top right of the modal dialog or not | boolean | true |  |
+| closeIcon | Custom close icon | ReactNode | &lt;CloseOutlined /> |  |
+| confirmLoading | Whether to apply loading visual effect for OK button or not | boolean | false |  |
+| destroyOnClose | Whether to unmount child components on onClose | boolean | false |  |
+| footer | Footer content, set as `footer={null}` when you don't need default buttons | ReactNode | (OK and Cancel buttons) |  |
+| forceRender | Force render Modal | boolean | false |  |
+| getContainer | Return the mount node for Modal | HTMLElement \| () => HTMLElement \| Selectors \| false | document.body |  |
+| keyboard | Whether support press esc to close | boolean | true |  |
+| mask | Whether show mask or not | boolean | true |  |
+| maskClosable | Whether to close the modal dialog when the mask (area outside the modal) is clicked | boolean | true |  |
+| maskStyle | Style for modal's mask element | object | {} |  |
 | modalRender | Custom modal content render | (node: ReactNode) => ReactNode | - | 4.7.0 |
-| okButtonProps | The ok button props | [ButtonProps](/components/button/#API) | - |
-| okText | Text of the OK button | ReactNode | `OK` |
-| okType | Button `type` of the OK button | string | `primary` |
-| onCancel | Specify a function that will be called when a user clicks mask, close button on top right or Cancel button | function(e) | - |
-| onOk | Specify a function that will be called when a user clicks the OK button | function(e) | - |
-| style | Style of floating layer, typically used at least for adjusting the position | CSSProperties | - |
-| title | The modal dialog's title | ReactNode | - |
-| visible | Whether the modal dialog is visible or not | boolean | false |
-| width | Width of the modal dialog | string \| number | 520 |
-| wrapClassName | The class name of the container of the modal dialog | string | - |
-| zIndex | The `z-index` of the Modal | number | 1000 |
+| okButtonProps | The ok button props | [ButtonProps](/components/button/#API) | - |  |
+| okText | Text of the OK button | ReactNode | `OK` |  |
+| okType | Button `type` of the OK button | string | `primary` |  |
+| onCancel | Specify a function that will be called when a user clicks mask, close button on top right or Cancel button | function(e) | - |  |
+| onOk | Specify a function that will be called when a user clicks the OK button | function(e) | - |  |
+| style | Style of floating layer, typically used at least for adjusting the position | CSSProperties | - |  |
+| title | The modal dialog's title | ReactNode | - |  |
+| visible | Whether the modal dialog is visible or not | boolean | false |  |
+| width | Width of the modal dialog | string \| number | 520 |  |
+| wrapClassName | The class name of the container of the modal dialog | string | - |  |
+| zIndex | The `z-index` of the Modal | number | 1000 |  |
 
 #### Note
 

--- a/components/modal/index.zh-CN.md
+++ b/components/modal/index.zh-CN.md
@@ -16,36 +16,36 @@ cover: https://gw.alipayobjects.com/zos/alicdn/3StSdUlSH/Modal.svg
 
 ## API
 
-| 参数 | 说明 | 类型 | 默认值 |
-| --- | --- | --- | --- |
-| afterClose | Modal 完全关闭后的回调 | function | - |
-| bodyStyle | Modal body 样式 | object | {} |
-| cancelButtonProps | cancel 按钮 props | [ButtonProps](/components/button/#API) | - |
-| cancelText | 取消按钮文字 | ReactNode | `取消` |
-| centered | 垂直居中展示 Modal | boolean | false |
-| closable | 是否显示右上角的关闭按钮 | boolean | true |
-| closeIcon | 自定义关闭图标 | ReactNode | &lt;CloseOutlined /> |
-| confirmLoading | 确定按钮 loading | boolean | false |
-| destroyOnClose | 关闭时销毁 Modal 里的子元素 | boolean | false |
-| footer | 底部内容，当不需要默认底部按钮时，可以设为 `footer={null}` | ReactNode | (确定取消按钮) |
-| forceRender | 强制渲染 Modal | boolean | false |
-| getContainer | 指定 Modal 挂载的 HTML 节点, false 为挂载在当前 dom | HTMLElement \| () => HTMLElement \| Selectors \| false | document.body |
-| keyboard | 是否支持键盘 esc 关闭 | boolean | true |
-| mask | 是否展示遮罩 | boolean | true |
-| maskClosable | 点击蒙层是否允许关闭 | boolean | true |
-| maskStyle | 遮罩样式 | object | {} |
+| 参数 | 说明 | 类型 | 默认值 | 版本 |
+| --- | --- | --- | --- | --- |
+| afterClose | Modal 完全关闭后的回调 | function | - |  |
+| bodyStyle | Modal body 样式 | object | {} |  |
+| cancelButtonProps | cancel 按钮 props | [ButtonProps](/components/button/#API) | - |  |
+| cancelText | 取消按钮文字 | ReactNode | `取消` |  |
+| centered | 垂直居中展示 Modal | boolean | false |  |
+| closable | 是否显示右上角的关闭按钮 | boolean | true |  |
+| closeIcon | 自定义关闭图标 | ReactNode | &lt;CloseOutlined /> |  |
+| confirmLoading | 确定按钮 loading | boolean | false |  |
+| destroyOnClose | 关闭时销毁 Modal 里的子元素 | boolean | false |  |
+| footer | 底部内容，当不需要默认底部按钮时，可以设为 `footer={null}` | ReactNode | (确定取消按钮) |  |
+| forceRender | 强制渲染 Modal | boolean | false |  |
+| getContainer | 指定 Modal 挂载的 HTML 节点, false 为挂载在当前 dom | HTMLElement \| () => HTMLElement \| Selectors \| false | document.body |  |
+| keyboard | 是否支持键盘 esc 关闭 | boolean | true |  |
+| mask | 是否展示遮罩 | boolean | true |  |
+| maskClosable | 点击蒙层是否允许关闭 | boolean | true |  |
+| maskStyle | 遮罩样式 | object | {} |  |
 | modalRender | 自定义渲染对话框 | (node: ReactNode) => ReactNode | - | 4.7.0 |
-| okButtonProps | ok 按钮 props | [ButtonProps](/components/button/#API) | - |
-| okText | 确认按钮文字 | ReactNode | `确定` |
-| okType | 确认按钮类型 | string | `primary` |
-| onCancel | 点击遮罩层或右上角叉或取消按钮的回调 | function(e) | - |
-| onOk | 点击确定回调 | function(e) | - |
-| style | 可用于设置浮层的样式，调整浮层位置等 | CSSProperties | - |
-| title | 标题 | ReactNode | - |
-| visible | 对话框是否可见 | boolean | - |
-| width | 宽度 | string \| number | 520 |
-| wrapClassName | 对话框外层容器的类名 | string | - |
-| zIndex | 设置 Modal 的 `z-index` | number | 1000 |
+| okButtonProps | ok 按钮 props | [ButtonProps](/components/button/#API) | - |  |
+| okText | 确认按钮文字 | ReactNode | `确定` |  |
+| okType | 确认按钮类型 | string | `primary` |  |
+| onCancel | 点击遮罩层或右上角叉或取消按钮的回调 | function(e) | - |  |
+| onOk | 点击确定回调 | function(e) | - |  |
+| style | 可用于设置浮层的样式，调整浮层位置等 | CSSProperties | - |  |
+| title | 标题 | ReactNode | - |  |
+| visible | 对话框是否可见 | boolean | - |  |
+| width | 宽度 | string \| number | 520 |  |
+| wrapClassName | 对话框外层容器的类名 | string | - |  |
+| zIndex | 设置 Modal 的 `z-index` | number | 1000 |  |
 
 #### 注意
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

version 列丢了
![image](https://user-images.githubusercontent.com/18572962/95698635-f882e680-0c74-11eb-9294-338bce7984a3.png)


<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | update modal docs |
| 🇨🇳 Chinese | 完善 modal 文档 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/modal/index.en-US.md](https://github.com/lich-yoo/ant-design/blob/docs/dialog/components/modal/index.en-US.md)
[View rendered components/modal/index.zh-CN.md](https://github.com/lich-yoo/ant-design/blob/docs/dialog/components/modal/index.zh-CN.md)