### PR TITLE
fix: Divider color with text

### DIFF
--- a/components/divider/style/index.less
+++ b/components/divider/style/index.less
@@ -6,7 +6,7 @@
 .@{divider-prefix-cls} {
   .reset-component;
 
-  border-top: 1px solid @divider-color;
+  border-top: @border-width-base solid @divider-color;
 
   &-vertical {
     position: relative;
@@ -16,7 +16,7 @@
     margin: 0 8px;
     vertical-align: middle;
     border-top: 0;
-    border-left: 1px solid @divider-color;
+    border-left: @border-width-base solid @divider-color;
   }
 
   &-horizontal {
@@ -43,7 +43,7 @@
       position: relative;
       top: 50%;
       width: 50%;
-      border-top: 1px solid transparent;
+      border-top: @border-width-base solid transparent;
       // Chrome not accept `inherit` in `border-top`
       border-top-color: inherit;
       border-bottom: 0;
@@ -83,7 +83,7 @@
     background: none;
     border-color: @divider-color;
     border-style: dashed;
-    border-width: 1px 0 0;
+    border-width: @border-width-base 0 0;
   }
 
   &-horizontal&-with-text&-dashed {
@@ -95,7 +95,7 @@
   }
 
   &-vertical&-dashed {
-    border-width: 0 0 0 1px;
+    border-width: 0 0 0 @border-width-base;
   }
 
   &-plain&-with-text {

--- a/components/divider/style/index.less
+++ b/components/divider/style/index.less
@@ -35,8 +35,8 @@
     font-size: @font-size-lg;
     white-space: nowrap;
     text-align: center;
-    border-color: @divider-color;
     border-top: 0;
+    border-top-color: @divider-color;
 
     &::before,
     &::after {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

close #27132 

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

Broken in #26863 

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Divider color when contains text.  |
| 🇨🇳 Chinese |  修复 Divider 带标题时的分割线颜色。  |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
