### PR TITLE
feat: modal.update() supports functional updating (#27162)

### DIFF
--- a/components/modal/__tests__/confirm.test.js
+++ b/components/modal/__tests__/confirm.test.js
@@ -244,7 +244,7 @@ describe('Modal.confirm triggers callbacks correctly', () => {
     jest.useRealTimers();
   });
 
-  it('could be update', () => {
+  it('could be update by new config', () => {
     jest.useFakeTimers();
     ['info', 'success', 'warning', 'error'].forEach(type => {
       const instance = Modal[type]({
@@ -267,6 +267,49 @@ describe('Modal.confirm triggers callbacks correctly', () => {
       expect($$(`.ant-modal-confirm-${type}`)).toHaveLength(1);
       expect($$('.ant-modal-confirm-title')[0].innerHTML).toBe('new title');
       expect($$('.ant-modal-confirm-content')[0].innerHTML).toBe('new content');
+      instance.destroy();
+      jest.runAllTimers();
+    });
+    jest.useRealTimers();
+  });
+
+  it('could be update by call function', () => {
+    jest.useFakeTimers();
+    ['info', 'success', 'warning', 'error'].forEach(type => {
+      const instance = Modal[type]({
+        title: 'title',
+        okButtonProps: {
+          loading: true,
+          style: {
+            color: 'red',
+          },
+        },
+      });
+      act(() => {
+        jest.runAllTimers();
+      });
+      expect($$(`.ant-modal-confirm-${type}`)).toHaveLength(1);
+      expect($$('.ant-modal-confirm-title')[0].innerHTML).toBe('title');
+      expect($$('.ant-modal-confirm-btns .ant-btn-primary')[0].classList).toContain(
+        'ant-btn-loading',
+      );
+      expect($$('.ant-modal-confirm-btns .ant-btn-primary')[0].style.color).toBe('red');
+      instance.update(prevConfig => ({
+        ...prevConfig,
+        okButtonProps: {
+          ...prevConfig.okButtonProps,
+          loading: false,
+        },
+      }));
+      act(() => {
+        jest.runAllTimers();
+      });
+      expect($$(`.ant-modal-confirm-${type}`)).toHaveLength(1);
+      expect($$('.ant-modal-confirm-title')[0].innerHTML).toBe('title');
+      expect($$('.ant-modal-confirm-btns .ant-btn-primary')[0].classList).not.toContain(
+        'ant-btn-loading',
+      );
+      expect($$('.ant-modal-confirm-btns .ant-btn-primary')[0].style.color).toBe('red');
       instance.destroy();
       jest.runAllTimers();
     });

--- a/components/modal/confirm.tsx
+++ b/components/modal/confirm.tsx
@@ -14,11 +14,13 @@ function getRootPrefixCls() {
   return defaultRootPrefixCls;
 }
 
+type ConfigUpdate = ModalFuncProps | ((prevConfig: ModalFuncProps) => ModalFuncProps);
+
 export type ModalFunc = (
   props: ModalFuncProps,
 ) => {
   destroy: () => void;
-  update: (newConfig: ModalFuncProps) => void;
+  update: (configUpdate: ConfigUpdate) => void;
 };
 
 export interface ModalStaticFunctions {
@@ -84,11 +86,15 @@ export default function confirm(config: ModalFuncProps) {
     render(currentConfig);
   }
 
-  function update(newConfig: ModalFuncProps) {
-    currentConfig = {
-      ...currentConfig,
-      ...newConfig,
-    };
+  function update(configUpdate: ConfigUpdate) {
+    if (typeof configUpdate === 'function') {
+      currentConfig = configUpdate(currentConfig);
+    } else {
+      currentConfig = {
+        ...currentConfig,
+        ...configUpdate,
+      };
+    }
     render(currentConfig);
   }
 

--- a/components/modal/index.en-US.md
+++ b/components/modal/index.en-US.md
@@ -96,6 +96,11 @@ modal.update({
   content: 'Updated content',
 });
 
+modal.update(prevConfig => ({
+  ...prevConfig,
+  title: `${prevConfig.title} (New)`,
+}));
+
 modal.destroy();
 ```
 

--- a/components/modal/index.en-US.md
+++ b/components/modal/index.en-US.md
@@ -96,6 +96,7 @@ modal.update({
   content: 'Updated content',
 });
 
+// on 4.8.0 or above, you can pass a function to update modal
 modal.update(prevConfig => ({
   ...prevConfig,
   title: `${prevConfig.title} (New)`,

--- a/components/modal/index.zh-CN.md
+++ b/components/modal/index.zh-CN.md
@@ -99,6 +99,7 @@ modal.update({
   content: '修改的内容',
 });
 
+// 在 4.8.0 或更高版本中，可以通过传入函数的方式更新弹窗
 modal.update(prevConfig => ({
   ...prevConfig,
   title: `${prevConfig.title}（新）`,

--- a/components/modal/index.zh-CN.md
+++ b/components/modal/index.zh-CN.md
@@ -99,6 +99,11 @@ modal.update({
   content: '修改的内容',
 });
 
+modal.update(prevConfig => ({
+  ...prevConfig,
+  title: `${prevConfig.title}（新）`,
+}));
+
 modal.destroy();
 ```
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->
Related issue: #27162 

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

Story: [CodeSandbox](https://codesandbox.io/s/friendly-breeze-mkthf?file=/src/App.tsx)

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | `modal.update()` supports functional updating |
| 🇨🇳 Chinese |`modal.update()` 支持函数式更新 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/modal/index.en-US.md](https://github.com/Mongkii/ant-design/blob/feature/components/modal/index.en-US.md)
[View rendered components/modal/index.zh-CN.md](https://github.com/Mongkii/ant-design/blob/feature/components/modal/index.zh-CN.md)