### PR TITLE
docs: Corrected "onFilter" definition for Table Column in docs (English)

### DIFF
--- a/components/table/index.en-US.md
+++ b/components/table/index.en-US.md
@@ -140,7 +140,7 @@ One of the Table `columns` prop for describing the table's columns, Column has t
 | title | Title of this column | ReactNode \| ({ sortOrder, sortColumn, filters }) => ReactNode | - |  |
 | width | Width of this column ([width not working?](https://github.com/ant-design/ant-design/issues/13825#issuecomment-449889241)) | string \| number | - |  |
 | onCell | Set props on per cell | function(record, rowIndex) | - |  |
-| onFilter | Callback executed when the confirm filter button is clicked | function | - |  |
+| onFilter | Function that determines if the row is displayed when filtered | function(value, record) => boolean  | - |  |
 | onFilterDropdownVisibleChange | Callback executed when `filterDropdownVisible` is changed | function(visible) {} | - |  |
 | onHeaderCell | Set props on per header cell | function(column) | - |  |
 | showSorterTooltip | If header show next sorter direction tooltip, override `showSorterTooltip` in table | boolean | true |  |


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 💡 Background and solution

Previously onFilter description for Table Column stated: "Callback executed when the confirm filter button is clicked".
This may be misleading, as one could think that this is an empty callback done only when the filter list changes, while this is a function that determines if the row should be displayed or not based on the boolean result of its execution.

I've done the best I can to clarify that.

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Changed the "onFilter" description in the "Column" section of "Table" component for React.          |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [] Doc is updated/provided or not needed
- [] Demo is updated/provided or not needed
- [] TypeScript definition is updated/provided or not needed
- [] Changelog is provided or not needed


-----
[View rendered components/table/index.en-US.md](https://github.com/yasikovsky/ant-design/blob/patch-1/components/table/index.en-US.md)