### PR TITLE
Fix Modal missing modalRender prop

### DIFF
--- a/components/modal/ConfirmDialog.tsx
+++ b/components/modal/ConfirmDialog.tsx
@@ -31,6 +31,7 @@ const ConfirmDialog = (props: ConfirmDialogProps) => {
     direction,
     prefixCls,
     rootPrefixCls,
+    modalRender,
   } = props;
 
   devWarning(
@@ -93,6 +94,7 @@ const ConfirmDialog = (props: ConfirmDialogProps) => {
       keyboard={keyboard}
       centered={centered}
       getContainer={getContainer}
+      modalRender={modalRender}
     >
       <div className={`${contentPrefixCls}-body-wrapper`}>
         <div className={`${contentPrefixCls}-body`}>

--- a/components/modal/Modal.tsx
+++ b/components/modal/Modal.tsx
@@ -80,6 +80,7 @@ export interface ModalProps {
   wrapProps?: any;
   prefixCls?: string;
   closeIcon?: React.ReactNode;
+  modalRender?: (node: ReactNode) => ReactNode;
 }
 
 type getContainerFunc = () => HTMLElement;

--- a/components/modal/Modal.tsx
+++ b/components/modal/Modal.tsx
@@ -115,6 +115,7 @@ export interface ModalFuncProps {
   transitionName?: string;
   maskTransitionName?: string;
   direction?: string;
+  modalRender?: (node: ReactNode) => ReactNode;
 }
 
 export interface ModalLocale {


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [x] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 重构
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
https://github.com/ant-design/ant-design/issues/27174

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
支持Modal拖拽

### 📝 更新日志怎么写？

<!--
> 从用户角度描述具体变化，以及可能的 breaking change 和其他风险？
-->

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | Fix Modal missing modalRender prop |
| 🇨🇳 中文 | 修复 Modal modalRender 属性定义 |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
