### PR TITLE
fix: TextArea wrapper with div when `!showCount`

### DIFF
--- a/components/auto-complete/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/auto-complete/__tests__/__snapshots__/demo.test.js.snap
@@ -147,23 +147,19 @@ exports[`renders ./components/auto-complete/demo/custom.md correctly 1`] = `
     <span
       class="ant-select-selection-search"
     >
-      <div
-        class="ant-input-textarea"
-      >
-        <textarea
-          aria-activedescendant="undefined_list_0"
-          aria-autocomplete="list"
-          aria-controls="undefined_list"
-          aria-haspopup="listbox"
-          aria-owns="undefined_list"
-          autocomplete="off"
-          class="ant-input ant-select-selection-search-input"
-          placeholder="input here"
-          role="combobox"
-          style="height:50px"
-          type="search"
-        />
-      </div>
+      <textarea
+        aria-activedescendant="undefined_list_0"
+        aria-autocomplete="list"
+        aria-controls="undefined_list"
+        aria-haspopup="listbox"
+        aria-owns="undefined_list"
+        autocomplete="off"
+        class="ant-input ant-select-selection-search-input"
+        placeholder="input here"
+        role="combobox"
+        style="height:50px"
+        type="search"
+      />
     </span>
     <span
       class="ant-select-selection-placeholder"

--- a/components/comment/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/comment/__tests__/__snapshots__/demo.test.js.snap
@@ -156,14 +156,10 @@ exports[`renders ./components/comment/demo/editor.md correctly 1`] = `
               <div
                 class="ant-form-item-control-input-content"
               >
-                <div
-                  class="ant-input-textarea"
-                >
-                  <textarea
-                    class="ant-input"
-                    rows="4"
-                  />
-                </div>
+                <textarea
+                  class="ant-input"
+                  rows="4"
+                />
               </div>
             </div>
           </div>

--- a/components/config-provider/__tests__/__snapshots__/components.test.js.snap
+++ b/components/config-provider/__tests__/__snapshots__/components.test.js.snap
@@ -14545,13 +14545,9 @@ exports[`ConfigProvider components Input configProvider 1`] = `
       </span>
     </span>
   </span>
-  <div
-    class="config-input-textarea"
-  >
-    <textarea
-      class="config-input"
-    />
-  </div>
+  <textarea
+    class="config-input"
+  />
 </div>
 `;
 
@@ -14646,13 +14642,9 @@ exports[`ConfigProvider components Input configProvider componentSize large 1`] 
       </span>
     </span>
   </span>
-  <div
-    class="config-input-textarea"
-  >
-    <textarea
-      class="config-input"
-    />
-  </div>
+  <textarea
+    class="config-input"
+  />
 </div>
 `;
 
@@ -14747,13 +14739,9 @@ exports[`ConfigProvider components Input configProvider componentSize middle 1`]
       </span>
     </span>
   </span>
-  <div
-    class="config-input-textarea"
-  >
-    <textarea
-      class="config-input"
-    />
-  </div>
+  <textarea
+    class="config-input"
+  />
 </div>
 `;
 
@@ -14848,13 +14836,9 @@ exports[`ConfigProvider components Input configProvider virtual and dropdownMatc
       </span>
     </span>
   </span>
-  <div
-    class="ant-input-textarea"
-  >
-    <textarea
-      class="ant-input"
-    />
-  </div>
+  <textarea
+    class="ant-input"
+  />
 </div>
 `;
 
@@ -14949,13 +14933,9 @@ exports[`ConfigProvider components Input normal 1`] = `
       </span>
     </span>
   </span>
-  <div
-    class="ant-input-textarea"
-  >
-    <textarea
-      class="ant-input"
-    />
-  </div>
+  <textarea
+    class="ant-input"
+  />
 </div>
 `;
 
@@ -15050,13 +15030,9 @@ exports[`ConfigProvider components Input prefixCls 1`] = `
       </span>
     </span>
   </span>
-  <div
-    class="prefix-Input-textarea"
-  >
-    <textarea
-      class="prefix-Input"
-    />
-  </div>
+  <textarea
+    class="prefix-Input"
+  />
 </div>
 `;
 

--- a/components/form/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/form/__tests__/__snapshots__/demo.test.js.snap
@@ -2788,14 +2788,10 @@ exports[`renders ./components/form/demo/nest-messages.md correctly 1`] = `
         <div
           class="ant-form-item-control-input-content"
         >
-          <div
-            class="ant-input-textarea"
-          >
-            <textarea
-              class="ant-input"
-              id="nest-messages_user_introduction"
-            />
-          </div>
+          <textarea
+            class="ant-input"
+            id="nest-messages_user_introduction"
+          />
         </div>
       </div>
     </div>

--- a/components/input/TextArea.tsx
+++ b/components/input/TextArea.tsx
@@ -143,7 +143,7 @@ class TextArea extends React.Component<TextAreaProps, TextAreaState> {
             className,
           )}
           style={style}
-          {...(showCount ? { 'data-count': dataCount } : {})}
+          data-count={dataCount}
         >
           {textareaNode}
         </div>

--- a/components/input/TextArea.tsx
+++ b/components/input/TextArea.tsx
@@ -77,15 +77,16 @@ class TextArea extends React.Component<TextAreaProps, TextAreaState> {
   };
 
   renderTextArea = (prefixCls: string, bordered: boolean) => {
+    const { showCount, className, style } = this.props;
+
     return (
       <RcTextArea
         {...omit(this.props, ['allowClear', 'bordered', 'showCount'])}
-        className={classNames(
-          {
-            [`${prefixCls}-borderless`]: !bordered,
-          },
-          this.props.className,
-        )}
+        className={classNames({
+          [`${prefixCls}-borderless`]: !bordered,
+          [className!]: className && !showCount,
+        })}
+        style={showCount ? null : style}
         prefixCls={prefixCls}
         onChange={this.handleChange}
         ref={this.saveTextArea}
@@ -105,22 +106,15 @@ class TextArea extends React.Component<TextAreaProps, TextAreaState> {
     } = this.props;
 
     const prefixCls = getPrefixCls('input', customizePrefixCls);
-    const textareaProps = omit(this.props, ['className', 'style']);
 
     // Max length value
     const hasMaxLength = Number(maxLength) > 0;
     value = hasMaxLength ? value.slice(0, maxLength) : value;
 
-    // show count props
-    if (!showCount) {
-      textareaProps.className = className;
-      textareaProps.style = style;
-    }
-
     // TextArea
     let textareaNode = (
       <ClearableLabeledInput
-        {...textareaProps}
+        {...this.props}
         prefixCls={prefixCls}
         direction={direction}
         inputType="text"
@@ -140,11 +134,14 @@ class TextArea extends React.Component<TextAreaProps, TextAreaState> {
 
       textareaNode = (
         <div
-          className={classNames(`${prefixCls}-textarea`, {
-            [`${prefixCls}-textarea-show-count`]: showCount,
-            [`${prefixCls}-textarea-rtl`]: direction === 'rtl',
+          className={classNames(
+            `${prefixCls}-textarea`,
+            {
+              [`${prefixCls}-textarea-show-count`]: showCount,
+              [`${prefixCls}-textarea-rtl`]: direction === 'rtl',
+            },
             className,
-          })}
+          )}
           style={style}
           {...(showCount ? { 'data-count': dataCount } : {})}
         >

--- a/components/input/TextArea.tsx
+++ b/components/input/TextArea.tsx
@@ -137,9 +137,9 @@ class TextArea extends React.Component<TextAreaProps, TextAreaState> {
           className={classNames(
             `${prefixCls}-textarea`,
             {
-              [`${prefixCls}-textarea-show-count`]: showCount,
               [`${prefixCls}-textarea-rtl`]: direction === 'rtl',
             },
+            `${prefixCls}-textarea-show-count`,
             className,
           )}
           style={style}

--- a/components/input/TextArea.tsx
+++ b/components/input/TextArea.tsx
@@ -100,35 +100,57 @@ class TextArea extends React.Component<TextAreaProps, TextAreaState> {
       bordered = true,
       showCount = false,
       maxLength,
+      className,
+      style,
     } = this.props;
-    const prefixCls = getPrefixCls('input', customizePrefixCls);
-    const hasMaxLength = Number(maxLength) > 0;
-    value = hasMaxLength ? value.slice(0, maxLength) : value;
-    const valueLength = [...value].length;
-    const dataCount = `${valueLength}${hasMaxLength ? ` / ${maxLength}` : ''}`;
 
-    return (
-      <div
-        className={classNames(`${prefixCls}-textarea`, {
-          [`${prefixCls}-textarea-show-count`]: showCount,
-          [`${prefixCls}-textarea-rtl`]: direction === 'rtl',
-        })}
-        {...(showCount ? { 'data-count': dataCount } : {})}
-      >
-        <ClearableLabeledInput
-          {...this.props}
-          prefixCls={prefixCls}
-          direction={direction}
-          inputType="text"
-          value={value}
-          element={this.renderTextArea(prefixCls, bordered)}
-          handleReset={this.handleReset}
-          ref={this.saveClearableInput}
-          triggerFocus={this.focus}
-          bordered={bordered}
-        />
-      </div>
+    const prefixCls = getPrefixCls('input', customizePrefixCls);
+    const textareaProps = omit(this.props, ['className', 'style']);
+
+    if (!showCount) {
+      textareaProps.className = className;
+      textareaProps.style = style;
+    }
+
+    // TextArea
+    let textareaNode = (
+      <ClearableLabeledInput
+        {...textareaProps}
+        prefixCls={prefixCls}
+        direction={direction}
+        inputType="text"
+        value={value}
+        element={this.renderTextArea(prefixCls, bordered)}
+        handleReset={this.handleReset}
+        ref={this.saveClearableInput}
+        triggerFocus={this.focus}
+        bordered={bordered}
+      />
     );
+
+    // Only show text area wrapper when needed
+    if (showCount) {
+      const hasMaxLength = Number(maxLength) > 0;
+      value = hasMaxLength ? value.slice(0, maxLength) : value;
+      const valueLength = [...value].length;
+      const dataCount = `${valueLength}${hasMaxLength ? ` / ${maxLength}` : ''}`;
+
+      textareaNode = (
+        <div
+          className={classNames(`${prefixCls}-textarea`, {
+            [`${prefixCls}-textarea-show-count`]: showCount,
+            [`${prefixCls}-textarea-rtl`]: direction === 'rtl',
+            className,
+          })}
+          style={style}
+          {...(showCount ? { 'data-count': dataCount } : {})}
+        >
+          {textareaNode}
+        </div>
+      );
+    }
+
+    return textareaNode;
   };
 
   render() {

--- a/components/input/TextArea.tsx
+++ b/components/input/TextArea.tsx
@@ -107,6 +107,11 @@ class TextArea extends React.Component<TextAreaProps, TextAreaState> {
     const prefixCls = getPrefixCls('input', customizePrefixCls);
     const textareaProps = omit(this.props, ['className', 'style']);
 
+    // Max length value
+    const hasMaxLength = Number(maxLength) > 0;
+    value = hasMaxLength ? value.slice(0, maxLength) : value;
+
+    // show count props
     if (!showCount) {
       textareaProps.className = className;
       textareaProps.style = style;
@@ -130,8 +135,6 @@ class TextArea extends React.Component<TextAreaProps, TextAreaState> {
 
     // Only show text area wrapper when needed
     if (showCount) {
-      const hasMaxLength = Number(maxLength) > 0;
-      value = hasMaxLength ? value.slice(0, maxLength) : value;
       const valueLength = [...value].length;
       const dataCount = `${valueLength}${hasMaxLength ? ` / ${maxLength}` : ''}`;
 

--- a/components/input/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/input/__tests__/__snapshots__/demo.test.js.snap
@@ -260,15 +260,11 @@ Array [
       rows="1"
     />
   </div>,
-  <div
-    class="ant-input-textarea"
-  >
-    <textarea
-      class="ant-input"
-      rows="1"
-      style="width:100px"
-    />
-  </div>,
+  <textarea
+    class="ant-input"
+    rows="1"
+    style="width:100px"
+  />,
   <button
     class="ant-btn ant-btn-primary"
     type="button"
@@ -1008,74 +1004,58 @@ Array [
   </span>,
   <br />,
   <br />,
-  <div
-    class="ant-input-textarea"
+  <span
+    class="ant-input-affix-wrapper ant-input-affix-wrapper-textarea-with-clear-btn"
   >
+    <textarea
+      class="ant-input"
+      placeholder="textarea with clear icon"
+    />
     <span
-      class="ant-input-affix-wrapper ant-input-affix-wrapper-textarea-with-clear-btn"
+      aria-label="close-circle"
+      class="anticon anticon-close-circle ant-input-clear-icon-hidden ant-input-clear-icon"
+      role="button"
+      tabindex="-1"
     >
-      <textarea
-        class="ant-input"
-        placeholder="textarea with clear icon"
-      />
-      <span
-        aria-label="close-circle"
-        class="anticon anticon-close-circle ant-input-clear-icon-hidden ant-input-clear-icon"
-        role="button"
-        tabindex="-1"
+      <svg
+        aria-hidden="true"
+        class=""
+        data-icon="close-circle"
+        fill="currentColor"
+        focusable="false"
+        height="1em"
+        viewBox="64 64 896 896"
+        width="1em"
       >
-        <svg
-          aria-hidden="true"
-          class=""
-          data-icon="close-circle"
-          fill="currentColor"
-          focusable="false"
-          height="1em"
-          viewBox="64 64 896 896"
-          width="1em"
-        >
-          <path
-            d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm165.4 618.2l-66-.3L512 563.4l-99.3 118.4-66.1.3c-4.4 0-8-3.5-8-8 0-1.9.7-3.7 1.9-5.2l130.1-155L340.5 359a8.32 8.32 0 01-1.9-5.2c0-4.4 3.6-8 8-8l66.1.3L512 464.6l99.3-118.4 66-.3c4.4 0 8 3.5 8 8 0 1.9-.7 3.7-1.9 5.2L553.5 514l130 155c1.2 1.5 1.9 3.3 1.9 5.2 0 4.4-3.6 8-8 8z"
-          />
-        </svg>
-      </span>
+        <path
+          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm165.4 618.2l-66-.3L512 563.4l-99.3 118.4-66.1.3c-4.4 0-8-3.5-8-8 0-1.9.7-3.7 1.9-5.2l130.1-155L340.5 359a8.32 8.32 0 01-1.9-5.2c0-4.4 3.6-8 8-8l66.1.3L512 464.6l99.3-118.4 66-.3c4.4 0 8 3.5 8 8 0 1.9-.7 3.7-1.9 5.2L553.5 514l130 155c1.2 1.5 1.9 3.3 1.9 5.2 0 4.4-3.6 8-8 8z"
+        />
+      </svg>
     </span>
-  </div>,
+  </span>,
 ]
 `;
 
 exports[`renders ./components/input/demo/autosize-textarea.md correctly 1`] = `
 Array [
-  <div
-    class="ant-input-textarea"
-  >
-    <textarea
-      class="ant-input"
-      placeholder="Autosize height based on content lines"
-    />
-  </div>,
+  <textarea
+    class="ant-input"
+    placeholder="Autosize height based on content lines"
+  />,
   <div
     style="margin:24px 0"
   />,
-  <div
-    class="ant-input-textarea"
-  >
-    <textarea
-      class="ant-input"
-      placeholder="Autosize height with minimum and maximum number of lines"
-    />
-  </div>,
+  <textarea
+    class="ant-input"
+    placeholder="Autosize height with minimum and maximum number of lines"
+  />,
   <div
     style="margin:24px 0"
   />,
-  <div
-    class="ant-input-textarea"
-  >
-    <textarea
-      class="ant-input"
-      placeholder="Controlled autosize"
-    />
-  </div>,
+  <textarea
+    class="ant-input"
+    placeholder="Controlled autosize"
+  />,
 ]
 `;
 
@@ -1113,47 +1093,39 @@ exports[`renders ./components/input/demo/borderless-debug.md correctly 1`] = `
     type="text"
     value=""
   />
-  <div
-    class="ant-input-textarea"
+  <textarea
+    class="ant-input ant-input-borderless"
+    placeholder="Unbordered"
+  />
+  <span
+    class="ant-input-affix-wrapper ant-input-affix-wrapper-textarea-with-clear-btn ant-input-affix-wrapper-borderless"
   >
     <textarea
       class="ant-input ant-input-borderless"
       placeholder="Unbordered"
     />
-  </div>
-  <div
-    class="ant-input-textarea"
-  >
     <span
-      class="ant-input-affix-wrapper ant-input-affix-wrapper-textarea-with-clear-btn ant-input-affix-wrapper-borderless"
+      aria-label="close-circle"
+      class="anticon anticon-close-circle ant-input-clear-icon-hidden ant-input-clear-icon"
+      role="button"
+      tabindex="-1"
     >
-      <textarea
-        class="ant-input ant-input-borderless"
-        placeholder="Unbordered"
-      />
-      <span
-        aria-label="close-circle"
-        class="anticon anticon-close-circle ant-input-clear-icon-hidden ant-input-clear-icon"
-        role="button"
-        tabindex="-1"
+      <svg
+        aria-hidden="true"
+        class=""
+        data-icon="close-circle"
+        fill="currentColor"
+        focusable="false"
+        height="1em"
+        viewBox="64 64 896 896"
+        width="1em"
       >
-        <svg
-          aria-hidden="true"
-          class=""
-          data-icon="close-circle"
-          fill="currentColor"
-          focusable="false"
-          height="1em"
-          viewBox="64 64 896 896"
-          width="1em"
-        >
-          <path
-            d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm165.4 618.2l-66-.3L512 563.4l-99.3 118.4-66.1.3c-4.4 0-8-3.5-8-8 0-1.9.7-3.7 1.9-5.2l130.1-155L340.5 359a8.32 8.32 0 01-1.9-5.2c0-4.4 3.6-8 8-8l66.1.3L512 464.6l99.3-118.4 66-.3c4.4 0 8 3.5 8 8 0 1.9-.7 3.7-1.9 5.2L553.5 514l130 155c1.2 1.5 1.9 3.3 1.9 5.2 0 4.4-3.6 8-8 8z"
-          />
-        </svg>
-      </span>
+        <path
+          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm165.4 618.2l-66-.3L512 563.4l-99.3 118.4-66.1.3c-4.4 0-8-3.5-8-8 0-1.9.7-3.7 1.9-5.2l130.1-155L340.5 359a8.32 8.32 0 01-1.9-5.2c0-4.4 3.6-8 8-8l66.1.3L512 464.6l99.3-118.4 66-.3c4.4 0 8 3.5 8 8 0 1.9-.7 3.7-1.9 5.2L553.5 514l130 155c1.2 1.5 1.9 3.3 1.9 5.2 0 4.4-3.6 8-8 8z"
+        />
+      </svg>
     </span>
-  </div>
+  </span>
   <span
     class="ant-input-affix-wrapper ant-input-affix-wrapper-borderless"
   >
@@ -2764,14 +2736,10 @@ Array [
 `;
 
 exports[`renders ./components/input/demo/textarea.md correctly 1`] = `
-<div
-  class="ant-input-textarea"
->
-  <textarea
-    class="ant-input"
-    rows="4"
-  />
-</div>
+<textarea
+  class="ant-input"
+  rows="4"
+/>
 `;
 
 exports[`renders ./components/input/demo/textarea-resize.md correctly 1`] = `
@@ -2785,16 +2753,12 @@ Array [
       Auto Resize: false
     </span>
   </button>,
-  <div
-    class="ant-input-textarea"
+  <textarea
+    class="ant-input"
+    rows="4"
   >
-    <textarea
-      class="ant-input"
-      rows="4"
-    >
-      The autoSize property applies to textarea nodes, and only the height changes automatically. In addition, autoSize can be set to an object, specifying the minimum number of rows and the maximum number of rows. The autoSize property applies to textarea nodes, and only the height changes automatically. In addition, autoSize can be set to an object, specifying the minimum number of rows and the maximum number of rows.
-    </textarea>
-  </div>,
+    The autoSize property applies to textarea nodes, and only the height changes automatically. In addition, autoSize can be set to an object, specifying the minimum number of rows and the maximum number of rows. The autoSize property applies to textarea nodes, and only the height changes automatically. In addition, autoSize can be set to an object, specifying the minimum number of rows and the maximum number of rows.
+  </textarea>,
 ]
 `;
 

--- a/components/input/__tests__/__snapshots__/textarea.test.js.snap
+++ b/components/input/__tests__/__snapshots__/textarea.test.js.snap
@@ -1,305 +1,265 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`TextArea allowClear should change type when click 1`] = `
-<div
-  class="ant-input-textarea"
->
-  <span
-    class="ant-input-affix-wrapper ant-input-affix-wrapper-textarea-with-clear-btn"
-  >
-    <textarea
-      class="ant-input"
-    >
-      111
-    </textarea>
-    <span
-      aria-label="close-circle"
-      class="anticon anticon-close-circle ant-input-clear-icon"
-      role="button"
-      tabindex="-1"
-    >
-      <svg
-        aria-hidden="true"
-        class=""
-        data-icon="close-circle"
-        fill="currentColor"
-        focusable="false"
-        height="1em"
-        viewBox="64 64 896 896"
-        width="1em"
-      >
-        <path
-          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm165.4 618.2l-66-.3L512 563.4l-99.3 118.4-66.1.3c-4.4 0-8-3.5-8-8 0-1.9.7-3.7 1.9-5.2l130.1-155L340.5 359a8.32 8.32 0 01-1.9-5.2c0-4.4 3.6-8 8-8l66.1.3L512 464.6l99.3-118.4 66-.3c4.4 0 8 3.5 8 8 0 1.9-.7 3.7-1.9 5.2L553.5 514l130 155c1.2 1.5 1.9 3.3 1.9 5.2 0 4.4-3.6 8-8 8z"
-        />
-      </svg>
-    </span>
-  </span>
-</div>
-`;
-
-exports[`TextArea allowClear should change type when click 2`] = `
-<div
-  class="ant-input-textarea"
->
-  <span
-    class="ant-input-affix-wrapper ant-input-affix-wrapper-textarea-with-clear-btn"
-  >
-    <textarea
-      class="ant-input"
-    />
-    <span
-      aria-label="close-circle"
-      class="anticon anticon-close-circle ant-input-clear-icon-hidden ant-input-clear-icon"
-      role="button"
-      tabindex="-1"
-    >
-      <svg
-        aria-hidden="true"
-        class=""
-        data-icon="close-circle"
-        fill="currentColor"
-        focusable="false"
-        height="1em"
-        viewBox="64 64 896 896"
-        width="1em"
-      >
-        <path
-          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm165.4 618.2l-66-.3L512 563.4l-99.3 118.4-66.1.3c-4.4 0-8-3.5-8-8 0-1.9.7-3.7 1.9-5.2l130.1-155L340.5 359a8.32 8.32 0 01-1.9-5.2c0-4.4 3.6-8 8-8l66.1.3L512 464.6l99.3-118.4 66-.3c4.4 0 8 3.5 8 8 0 1.9-.7 3.7-1.9 5.2L553.5 514l130 155c1.2 1.5 1.9 3.3 1.9 5.2 0 4.4-3.6 8-8 8z"
-        />
-      </svg>
-    </span>
-  </span>
-</div>
-`;
-
-exports[`TextArea allowClear should not show icon if defaultValue is undefined, null or empty string 1`] = `
-<div
-  class="ant-input-textarea"
->
-  <span
-    class="ant-input-affix-wrapper ant-input-affix-wrapper-textarea-with-clear-btn"
-  >
-    <textarea
-      class="ant-input"
-    />
-    <span
-      aria-label="close-circle"
-      class="anticon anticon-close-circle ant-input-clear-icon-hidden ant-input-clear-icon"
-      role="button"
-      tabindex="-1"
-    >
-      <svg
-        aria-hidden="true"
-        class=""
-        data-icon="close-circle"
-        fill="currentColor"
-        focusable="false"
-        height="1em"
-        viewBox="64 64 896 896"
-        width="1em"
-      >
-        <path
-          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm165.4 618.2l-66-.3L512 563.4l-99.3 118.4-66.1.3c-4.4 0-8-3.5-8-8 0-1.9.7-3.7 1.9-5.2l130.1-155L340.5 359a8.32 8.32 0 01-1.9-5.2c0-4.4 3.6-8 8-8l66.1.3L512 464.6l99.3-118.4 66-.3c4.4 0 8 3.5 8 8 0 1.9-.7 3.7-1.9 5.2L553.5 514l130 155c1.2 1.5 1.9 3.3 1.9 5.2 0 4.4-3.6 8-8 8z"
-        />
-      </svg>
-    </span>
-  </span>
-</div>
-`;
-
-exports[`TextArea allowClear should not show icon if defaultValue is undefined, null or empty string 2`] = `
-<div
-  class="ant-input-textarea"
->
-  <span
-    class="ant-input-affix-wrapper ant-input-affix-wrapper-textarea-with-clear-btn"
-  >
-    <textarea
-      class="ant-input"
-    />
-    <span
-      aria-label="close-circle"
-      class="anticon anticon-close-circle ant-input-clear-icon-hidden ant-input-clear-icon"
-      role="button"
-      tabindex="-1"
-    >
-      <svg
-        aria-hidden="true"
-        class=""
-        data-icon="close-circle"
-        fill="currentColor"
-        focusable="false"
-        height="1em"
-        viewBox="64 64 896 896"
-        width="1em"
-      >
-        <path
-          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm165.4 618.2l-66-.3L512 563.4l-99.3 118.4-66.1.3c-4.4 0-8-3.5-8-8 0-1.9.7-3.7 1.9-5.2l130.1-155L340.5 359a8.32 8.32 0 01-1.9-5.2c0-4.4 3.6-8 8-8l66.1.3L512 464.6l99.3-118.4 66-.3c4.4 0 8 3.5 8 8 0 1.9-.7 3.7-1.9 5.2L553.5 514l130 155c1.2 1.5 1.9 3.3 1.9 5.2 0 4.4-3.6 8-8 8z"
-        />
-      </svg>
-    </span>
-  </span>
-</div>
-`;
-
-exports[`TextArea allowClear should not show icon if defaultValue is undefined, null or empty string 3`] = `
-<div
-  class="ant-input-textarea"
->
-  <span
-    class="ant-input-affix-wrapper ant-input-affix-wrapper-textarea-with-clear-btn"
-  >
-    <textarea
-      class="ant-input"
-    />
-    <span
-      aria-label="close-circle"
-      class="anticon anticon-close-circle ant-input-clear-icon-hidden ant-input-clear-icon"
-      role="button"
-      tabindex="-1"
-    >
-      <svg
-        aria-hidden="true"
-        class=""
-        data-icon="close-circle"
-        fill="currentColor"
-        focusable="false"
-        height="1em"
-        viewBox="64 64 896 896"
-        width="1em"
-      >
-        <path
-          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm165.4 618.2l-66-.3L512 563.4l-99.3 118.4-66.1.3c-4.4 0-8-3.5-8-8 0-1.9.7-3.7 1.9-5.2l130.1-155L340.5 359a8.32 8.32 0 01-1.9-5.2c0-4.4 3.6-8 8-8l66.1.3L512 464.6l99.3-118.4 66-.3c4.4 0 8 3.5 8 8 0 1.9-.7 3.7-1.9 5.2L553.5 514l130 155c1.2 1.5 1.9 3.3 1.9 5.2 0 4.4-3.6 8-8 8z"
-        />
-      </svg>
-    </span>
-  </span>
-</div>
-`;
-
-exports[`TextArea allowClear should not show icon if value is undefined, null or empty string 1`] = `
-<div
-  class="ant-input-textarea"
->
-  <span
-    class="ant-input-affix-wrapper ant-input-affix-wrapper-textarea-with-clear-btn"
-  >
-    <textarea
-      class="ant-input"
-    />
-    <span
-      aria-label="close-circle"
-      class="anticon anticon-close-circle ant-input-clear-icon-hidden ant-input-clear-icon"
-      role="button"
-      tabindex="-1"
-    >
-      <svg
-        aria-hidden="true"
-        class=""
-        data-icon="close-circle"
-        fill="currentColor"
-        focusable="false"
-        height="1em"
-        viewBox="64 64 896 896"
-        width="1em"
-      >
-        <path
-          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm165.4 618.2l-66-.3L512 563.4l-99.3 118.4-66.1.3c-4.4 0-8-3.5-8-8 0-1.9.7-3.7 1.9-5.2l130.1-155L340.5 359a8.32 8.32 0 01-1.9-5.2c0-4.4 3.6-8 8-8l66.1.3L512 464.6l99.3-118.4 66-.3c4.4 0 8 3.5 8 8 0 1.9-.7 3.7-1.9 5.2L553.5 514l130 155c1.2 1.5 1.9 3.3 1.9 5.2 0 4.4-3.6 8-8 8z"
-        />
-      </svg>
-    </span>
-  </span>
-</div>
-`;
-
-exports[`TextArea allowClear should not show icon if value is undefined, null or empty string 2`] = `
-<div
-  class="ant-input-textarea"
->
-  <span
-    class="ant-input-affix-wrapper ant-input-affix-wrapper-textarea-with-clear-btn"
-  >
-    <textarea
-      class="ant-input"
-    />
-    <span
-      aria-label="close-circle"
-      class="anticon anticon-close-circle ant-input-clear-icon-hidden ant-input-clear-icon"
-      role="button"
-      tabindex="-1"
-    >
-      <svg
-        aria-hidden="true"
-        class=""
-        data-icon="close-circle"
-        fill="currentColor"
-        focusable="false"
-        height="1em"
-        viewBox="64 64 896 896"
-        width="1em"
-      >
-        <path
-          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm165.4 618.2l-66-.3L512 563.4l-99.3 118.4-66.1.3c-4.4 0-8-3.5-8-8 0-1.9.7-3.7 1.9-5.2l130.1-155L340.5 359a8.32 8.32 0 01-1.9-5.2c0-4.4 3.6-8 8-8l66.1.3L512 464.6l99.3-118.4 66-.3c4.4 0 8 3.5 8 8 0 1.9-.7 3.7-1.9 5.2L553.5 514l130 155c1.2 1.5 1.9 3.3 1.9 5.2 0 4.4-3.6 8-8 8z"
-        />
-      </svg>
-    </span>
-  </span>
-</div>
-`;
-
-exports[`TextArea allowClear should not show icon if value is undefined, null or empty string 3`] = `
-<div
-  class="ant-input-textarea"
->
-  <span
-    class="ant-input-affix-wrapper ant-input-affix-wrapper-textarea-with-clear-btn"
-  >
-    <textarea
-      class="ant-input"
-    />
-    <span
-      aria-label="close-circle"
-      class="anticon anticon-close-circle ant-input-clear-icon-hidden ant-input-clear-icon"
-      role="button"
-      tabindex="-1"
-    >
-      <svg
-        aria-hidden="true"
-        class=""
-        data-icon="close-circle"
-        fill="currentColor"
-        focusable="false"
-        height="1em"
-        viewBox="64 64 896 896"
-        width="1em"
-      >
-        <path
-          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm165.4 618.2l-66-.3L512 563.4l-99.3 118.4-66.1.3c-4.4 0-8-3.5-8-8 0-1.9.7-3.7 1.9-5.2l130.1-155L340.5 359a8.32 8.32 0 01-1.9-5.2c0-4.4 3.6-8 8-8l66.1.3L512 464.6l99.3-118.4 66-.3c4.4 0 8 3.5 8 8 0 1.9-.7 3.7-1.9 5.2L553.5 514l130 155c1.2 1.5 1.9 3.3 1.9 5.2 0 4.4-3.6 8-8 8z"
-        />
-      </svg>
-    </span>
-  </span>
-</div>
-`;
-
-exports[`TextArea should support disabled 1`] = `
-<div
-  class="ant-input-textarea"
->
-  <textarea
-    class="ant-input ant-input-disabled"
-    disabled=""
-  />
-</div>
-`;
-
-exports[`TextArea should support maxLength 1`] = `
-<div
-  class="ant-input-textarea"
+<span
+  class="ant-input-affix-wrapper ant-input-affix-wrapper-textarea-with-clear-btn"
 >
   <textarea
     class="ant-input"
-    maxlength="10"
+  >
+    111
+  </textarea>
+  <span
+    aria-label="close-circle"
+    class="anticon anticon-close-circle ant-input-clear-icon"
+    role="button"
+    tabindex="-1"
+  >
+    <svg
+      aria-hidden="true"
+      class=""
+      data-icon="close-circle"
+      fill="currentColor"
+      focusable="false"
+      height="1em"
+      viewBox="64 64 896 896"
+      width="1em"
+    >
+      <path
+        d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm165.4 618.2l-66-.3L512 563.4l-99.3 118.4-66.1.3c-4.4 0-8-3.5-8-8 0-1.9.7-3.7 1.9-5.2l130.1-155L340.5 359a8.32 8.32 0 01-1.9-5.2c0-4.4 3.6-8 8-8l66.1.3L512 464.6l99.3-118.4 66-.3c4.4 0 8 3.5 8 8 0 1.9-.7 3.7-1.9 5.2L553.5 514l130 155c1.2 1.5 1.9 3.3 1.9 5.2 0 4.4-3.6 8-8 8z"
+      />
+    </svg>
+  </span>
+</span>
+`;
+
+exports[`TextArea allowClear should change type when click 2`] = `
+<span
+  class="ant-input-affix-wrapper ant-input-affix-wrapper-textarea-with-clear-btn"
+>
+  <textarea
+    class="ant-input"
   />
-</div>
+  <span
+    aria-label="close-circle"
+    class="anticon anticon-close-circle ant-input-clear-icon-hidden ant-input-clear-icon"
+    role="button"
+    tabindex="-1"
+  >
+    <svg
+      aria-hidden="true"
+      class=""
+      data-icon="close-circle"
+      fill="currentColor"
+      focusable="false"
+      height="1em"
+      viewBox="64 64 896 896"
+      width="1em"
+    >
+      <path
+        d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm165.4 618.2l-66-.3L512 563.4l-99.3 118.4-66.1.3c-4.4 0-8-3.5-8-8 0-1.9.7-3.7 1.9-5.2l130.1-155L340.5 359a8.32 8.32 0 01-1.9-5.2c0-4.4 3.6-8 8-8l66.1.3L512 464.6l99.3-118.4 66-.3c4.4 0 8 3.5 8 8 0 1.9-.7 3.7-1.9 5.2L553.5 514l130 155c1.2 1.5 1.9 3.3 1.9 5.2 0 4.4-3.6 8-8 8z"
+      />
+    </svg>
+  </span>
+</span>
+`;
+
+exports[`TextArea allowClear should not show icon if defaultValue is undefined, null or empty string 1`] = `
+<span
+  class="ant-input-affix-wrapper ant-input-affix-wrapper-textarea-with-clear-btn"
+>
+  <textarea
+    class="ant-input"
+  />
+  <span
+    aria-label="close-circle"
+    class="anticon anticon-close-circle ant-input-clear-icon-hidden ant-input-clear-icon"
+    role="button"
+    tabindex="-1"
+  >
+    <svg
+      aria-hidden="true"
+      class=""
+      data-icon="close-circle"
+      fill="currentColor"
+      focusable="false"
+      height="1em"
+      viewBox="64 64 896 896"
+      width="1em"
+    >
+      <path
+        d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm165.4 618.2l-66-.3L512 563.4l-99.3 118.4-66.1.3c-4.4 0-8-3.5-8-8 0-1.9.7-3.7 1.9-5.2l130.1-155L340.5 359a8.32 8.32 0 01-1.9-5.2c0-4.4 3.6-8 8-8l66.1.3L512 464.6l99.3-118.4 66-.3c4.4 0 8 3.5 8 8 0 1.9-.7 3.7-1.9 5.2L553.5 514l130 155c1.2 1.5 1.9 3.3 1.9 5.2 0 4.4-3.6 8-8 8z"
+      />
+    </svg>
+  </span>
+</span>
+`;
+
+exports[`TextArea allowClear should not show icon if defaultValue is undefined, null or empty string 2`] = `
+<span
+  class="ant-input-affix-wrapper ant-input-affix-wrapper-textarea-with-clear-btn"
+>
+  <textarea
+    class="ant-input"
+  />
+  <span
+    aria-label="close-circle"
+    class="anticon anticon-close-circle ant-input-clear-icon-hidden ant-input-clear-icon"
+    role="button"
+    tabindex="-1"
+  >
+    <svg
+      aria-hidden="true"
+      class=""
+      data-icon="close-circle"
+      fill="currentColor"
+      focusable="false"
+      height="1em"
+      viewBox="64 64 896 896"
+      width="1em"
+    >
+      <path
+        d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm165.4 618.2l-66-.3L512 563.4l-99.3 118.4-66.1.3c-4.4 0-8-3.5-8-8 0-1.9.7-3.7 1.9-5.2l130.1-155L340.5 359a8.32 8.32 0 01-1.9-5.2c0-4.4 3.6-8 8-8l66.1.3L512 464.6l99.3-118.4 66-.3c4.4 0 8 3.5 8 8 0 1.9-.7 3.7-1.9 5.2L553.5 514l130 155c1.2 1.5 1.9 3.3 1.9 5.2 0 4.4-3.6 8-8 8z"
+      />
+    </svg>
+  </span>
+</span>
+`;
+
+exports[`TextArea allowClear should not show icon if defaultValue is undefined, null or empty string 3`] = `
+<span
+  class="ant-input-affix-wrapper ant-input-affix-wrapper-textarea-with-clear-btn"
+>
+  <textarea
+    class="ant-input"
+  />
+  <span
+    aria-label="close-circle"
+    class="anticon anticon-close-circle ant-input-clear-icon-hidden ant-input-clear-icon"
+    role="button"
+    tabindex="-1"
+  >
+    <svg
+      aria-hidden="true"
+      class=""
+      data-icon="close-circle"
+      fill="currentColor"
+      focusable="false"
+      height="1em"
+      viewBox="64 64 896 896"
+      width="1em"
+    >
+      <path
+        d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm165.4 618.2l-66-.3L512 563.4l-99.3 118.4-66.1.3c-4.4 0-8-3.5-8-8 0-1.9.7-3.7 1.9-5.2l130.1-155L340.5 359a8.32 8.32 0 01-1.9-5.2c0-4.4 3.6-8 8-8l66.1.3L512 464.6l99.3-118.4 66-.3c4.4 0 8 3.5 8 8 0 1.9-.7 3.7-1.9 5.2L553.5 514l130 155c1.2 1.5 1.9 3.3 1.9 5.2 0 4.4-3.6 8-8 8z"
+      />
+    </svg>
+  </span>
+</span>
+`;
+
+exports[`TextArea allowClear should not show icon if value is undefined, null or empty string 1`] = `
+<span
+  class="ant-input-affix-wrapper ant-input-affix-wrapper-textarea-with-clear-btn"
+>
+  <textarea
+    class="ant-input"
+  />
+  <span
+    aria-label="close-circle"
+    class="anticon anticon-close-circle ant-input-clear-icon-hidden ant-input-clear-icon"
+    role="button"
+    tabindex="-1"
+  >
+    <svg
+      aria-hidden="true"
+      class=""
+      data-icon="close-circle"
+      fill="currentColor"
+      focusable="false"
+      height="1em"
+      viewBox="64 64 896 896"
+      width="1em"
+    >
+      <path
+        d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm165.4 618.2l-66-.3L512 563.4l-99.3 118.4-66.1.3c-4.4 0-8-3.5-8-8 0-1.9.7-3.7 1.9-5.2l130.1-155L340.5 359a8.32 8.32 0 01-1.9-5.2c0-4.4 3.6-8 8-8l66.1.3L512 464.6l99.3-118.4 66-.3c4.4 0 8 3.5 8 8 0 1.9-.7 3.7-1.9 5.2L553.5 514l130 155c1.2 1.5 1.9 3.3 1.9 5.2 0 4.4-3.6 8-8 8z"
+      />
+    </svg>
+  </span>
+</span>
+`;
+
+exports[`TextArea allowClear should not show icon if value is undefined, null or empty string 2`] = `
+<span
+  class="ant-input-affix-wrapper ant-input-affix-wrapper-textarea-with-clear-btn"
+>
+  <textarea
+    class="ant-input"
+  />
+  <span
+    aria-label="close-circle"
+    class="anticon anticon-close-circle ant-input-clear-icon-hidden ant-input-clear-icon"
+    role="button"
+    tabindex="-1"
+  >
+    <svg
+      aria-hidden="true"
+      class=""
+      data-icon="close-circle"
+      fill="currentColor"
+      focusable="false"
+      height="1em"
+      viewBox="64 64 896 896"
+      width="1em"
+    >
+      <path
+        d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm165.4 618.2l-66-.3L512 563.4l-99.3 118.4-66.1.3c-4.4 0-8-3.5-8-8 0-1.9.7-3.7 1.9-5.2l130.1-155L340.5 359a8.32 8.32 0 01-1.9-5.2c0-4.4 3.6-8 8-8l66.1.3L512 464.6l99.3-118.4 66-.3c4.4 0 8 3.5 8 8 0 1.9-.7 3.7-1.9 5.2L553.5 514l130 155c1.2 1.5 1.9 3.3 1.9 5.2 0 4.4-3.6 8-8 8z"
+      />
+    </svg>
+  </span>
+</span>
+`;
+
+exports[`TextArea allowClear should not show icon if value is undefined, null or empty string 3`] = `
+<span
+  class="ant-input-affix-wrapper ant-input-affix-wrapper-textarea-with-clear-btn"
+>
+  <textarea
+    class="ant-input"
+  />
+  <span
+    aria-label="close-circle"
+    class="anticon anticon-close-circle ant-input-clear-icon-hidden ant-input-clear-icon"
+    role="button"
+    tabindex="-1"
+  >
+    <svg
+      aria-hidden="true"
+      class=""
+      data-icon="close-circle"
+      fill="currentColor"
+      focusable="false"
+      height="1em"
+      viewBox="64 64 896 896"
+      width="1em"
+    >
+      <path
+        d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm165.4 618.2l-66-.3L512 563.4l-99.3 118.4-66.1.3c-4.4 0-8-3.5-8-8 0-1.9.7-3.7 1.9-5.2l130.1-155L340.5 359a8.32 8.32 0 01-1.9-5.2c0-4.4 3.6-8 8-8l66.1.3L512 464.6l99.3-118.4 66-.3c4.4 0 8 3.5 8 8 0 1.9-.7 3.7-1.9 5.2L553.5 514l130 155c1.2 1.5 1.9 3.3 1.9 5.2 0 4.4-3.6 8-8 8z"
+      />
+    </svg>
+  </span>
+</span>
+`;
+
+exports[`TextArea should support disabled 1`] = `
+<textarea
+  class="ant-input ant-input-disabled"
+  disabled=""
+/>
+`;
+
+exports[`TextArea should support maxLength 1`] = `
+<textarea
+  class="ant-input"
+  maxlength="10"
+/>
 `;

--- a/components/input/__tests__/textarea.test.js
+++ b/components/input/__tests__/textarea.test.js
@@ -133,11 +133,27 @@ describe('TextArea', () => {
     expect(textarea.find('textarea').prop('value')).toBe(input.getDOMNode().value);
   });
 
-  it('should support showCount', async () => {
-    const wrapper = mount(<TextArea maxLength={5} showCount value="12345678" />);
-    const textarea = wrapper.find('.ant-input-textarea');
-    expect(wrapper.find('textarea').prop('value')).toBe('12345');
-    expect(textarea.prop('data-count')).toBe('5 / 5');
+  describe('should support showCount', () => {
+    it('maxLength', () => {
+      const wrapper = mount(<TextArea maxLength={5} showCount value="12345678" />);
+      const textarea = wrapper.find('.ant-input-textarea');
+      expect(wrapper.find('textarea').prop('value')).toBe('12345');
+      expect(textarea.prop('data-count')).toBe('5 / 5');
+    });
+
+    it('className & style patch to outer', () => {
+      const wrapper = mount(
+        <TextArea className="bamboo" style={{ background: 'red' }} showCount />,
+      );
+
+      // Outer
+      expect(wrapper.find('div').first().hasClass('bamboo')).toBeTruthy();
+      expect(wrapper.find('div').first().props().style.background).toEqual('red');
+
+      // Inner
+      expect(wrapper.find('.ant-input').hasClass('bamboo')).toBeFalsy();
+      expect(wrapper.find('.ant-input').props().style.background).toBeFalsy();
+    });
   });
 });
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fix TextArea wrapped with additional div when `showCount` is `false`. And pass `className` & `style` to wrapper when `showCount` is `true`.          |
| 🇨🇳 Chinese |   修复 TextArea 没有设置 `showCount` 时仍然会包裹 div 的问题，同时解决 `showCount` 下 `className` 和 `style` 没有传递给最外层节点的问题。       |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
