### PR TITLE
fix: Tag component close icon display bug

### DIFF
--- a/components/tag/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/tag/__tests__/__snapshots__/demo.test.js.snap
@@ -482,17 +482,17 @@ Array [
     class="ant-tag"
   >
     Tag1
-    <div
+    <span
       class="ant-tag-close-icon"
     >
       关 闭
-    </div>
+    </span>
   </span>,
   <span
     class="ant-tag"
   >
     Tag2
-    <div
+    <span
       class="ant-tag-close-icon"
     >
       <span
@@ -518,7 +518,7 @@ Array [
           />
         </svg>
       </span>
-    </div>
+    </span>
   </span>,
 ]
 `;

--- a/components/tag/index.tsx
+++ b/components/tag/index.tsx
@@ -102,9 +102,9 @@ const InternalTag: React.ForwardRefRenderFunction<unknown, TagProps> = (
   const renderCloseIcon = () => {
     if (closable) {
       return closeIcon ? (
-        <div className={`${prefixCls}-close-icon`} onClick={handleCloseClick}>
+        <span className={`${prefixCls}-close-icon`} onClick={handleCloseClick}>
           {closeIcon}
-        </div>
+        </span>
       ) : (
         <CloseOutlined className={`${prefixCls}-close-icon`} onClick={handleCloseClick} />
       );


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->
[https://github.com/ant-design/ant-design/issues/27218](https://github.com/ant-design/ant-design/issues/27218)

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->
change the div tag to span tag

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |       tag component close icon display bug   |
| 🇨🇳 Chinese |      tag 标签自定义关闭 icon 换行 bug     |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
