### PR TITLE
docs(input): add showCount version

### DIFF
--- a/components/input/index.en-US.md
+++ b/components/input/index.en-US.md
@@ -49,8 +49,8 @@ The rest of the props of Input are exactly the same as the original [input](http
 | allowClear | If allow to remove input content with clear icon | boolean | false |  |
 | onResize | The callback function that is triggered when resize | function({ width, height }) | - |  |
 | bordered | Whether has border style | boolean | true | 4.5.0 |
-| showCount | Whether show text count | boolean | false |  |
-| maxLength | The max length | number | - |  |
+| showCount | Whether show text count | boolean | false | 4.7.0 |
+| maxLength | The max length | number | - | 4.7.0 |
 
 The rest of the props of `Input.TextArea` are the same as the original [textarea](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea).
 

--- a/components/input/index.zh-CN.md
+++ b/components/input/index.zh-CN.md
@@ -50,8 +50,8 @@ Input 的其他属性和 React 自带的 [input](https://facebook.github.io/reac
 | allowClear | 可以点击清除图标删除内容 | boolean | false |  |
 | onResize | resize 回调 | function({ width, height }) | - |  |
 | bordered | 是否有边框 | boolean | true | 4.5.0 |
-| showCount | 是否展示字数 | boolean | false |  |
-| maxLength | 内容最大长度 | number | - |  |
+| showCount | 是否展示字数 | boolean | false | 4.7.0 |
+| maxLength | 内容最大长度 | number | - | 4.7.0 |
 
 `Input.TextArea` 的其他属性和浏览器自带的 [textarea](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea) 一致。
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed


-----
[View rendered components/input/index.en-US.md](https://github.com/ant-design/ant-design/blob/docs/components/input/index.en-US.md)
[View rendered components/input/index.zh-CN.md](https://github.com/ant-design/ant-design/blob/docs/components/input/index.zh-CN.md)