### PR TITLE
fix: changed sorting and validation labels to proper English

### DIFF
--- a/components/locale/default.tsx
+++ b/components/locale/default.tsx
@@ -28,9 +28,9 @@ const localeValues: Locale = {
     sortTitle: 'Sort',
     expand: 'Expand row',
     collapse: 'Collapse row',
-    triggerDesc: 'Click sort by descend',
-    triggerAsc: 'Click sort by ascend',
-    cancelSort: 'Click to cancel sort',
+    triggerDesc: 'Click to sort descending',
+    triggerAsc: 'Click to sort ascending',
+    cancelSort: 'Click to cancel sorting',
   },
   Modal: {
     okText: 'OK',
@@ -78,7 +78,7 @@ const localeValues: Locale = {
   Form: {
     optional: '(optional)',
     defaultValidateMessages: {
-      default: 'Field validation error ${label}',
+      default: 'Field validation error for ${label}',
       required: 'Please enter ${label}',
       enum: '${label} must be one of [${enum}]',
       whitespace: '${label} cannot be a blank character',
@@ -104,14 +104,14 @@ const localeValues: Locale = {
       },
       string: {
         len: '${label} must be ${len} characters',
-        min: '${label} at least ${min} characters',
-        max: '${label} up to ${max} characters',
+        min: '${label} must be at least ${min} characters',
+        max: '${label} must be up to ${max} characters',
         range: '${label} must be between ${min}-${max} characters',
       },
       number: {
         len: '${label} must be equal to ${len}',
-        min: '${label} minimum value is ${min}',
-        max: '${label} maximum value is ${max}',
+        min: '${label} must be minimum ${min}',
+        max: '${label} must be maximum ${max}',
         range: '${label} must be between ${min}-${max}',
       },
       array: {

--- a/components/locale/en_GB.tsx
+++ b/components/locale/en_GB.tsx
@@ -46,7 +46,7 @@ const localeValues: Locale = {
   },
   Form: {
     defaultValidateMessages: {
-      default: 'Field validation error ${label}',
+      default: 'Field validation error for ${label}',
       required: 'Please enter ${label}',
       enum: '${label} must be one of [${enum}]',
       whitespace: '${label} cannot be a blank character',
@@ -72,14 +72,14 @@ const localeValues: Locale = {
       },
       string: {
         len: '${label} must be ${len} characters',
-        min: '${label} at least ${min} characters',
-        max: '${label} up to ${max} characters',
+        min: '${label} must be at least ${min} characters',
+        max: '${label} must be up to ${max} characters',
         range: '${label} must be between ${min}-${max} characters',
       },
       number: {
         len: '${label} must be equal to ${len}',
-        min: '${label} minimum value is ${min}',
-        max: '${label} maximum value is ${max}',
+        min: '${label} must be minimum ${min}',
+        max: '${label} must be maximum ${max}',
         range: '${label} must be between ${min}-${max}',
       },
       array: {

--- a/components/locale/ga_IE.tsx
+++ b/components/locale/ga_IE.tsx
@@ -26,9 +26,9 @@ const localeValues: Locale = {
     sortTitle: 'Sort',
     expand: 'Expand row',
     collapse: 'Collapse row',
-    triggerDesc: 'Click sort by descend',
-    triggerAsc: 'Click sort by ascend',
-    cancelSort: 'Click to cancel sort',
+    triggerDesc: 'Click to sort descending',
+    triggerAsc: 'Click to sort ascending',
+    cancelSort: 'Click to cancel sorting',
   },
   Modal: {
     okText: 'OK',
@@ -101,14 +101,14 @@ const localeValues: Locale = {
       },
       string: {
         len: '${label} must be ${len} characters',
-        min: '${label} at least ${min} characters',
-        max: '${label} up to ${max} characters',
+        min: '${label} must be at least ${min} characters',
+        max: '${label} must be up to ${max} characters',
         range: '${label} must be between ${min}-${max} characters',
       },
       number: {
         len: '${label} must be equal to ${len}',
-        min: '${label} minimum value is ${min}',
-        max: '${label} maximum value is ${max}',
+        min: '${label} must be minimum ${min}',
+        max: '${label} must be maximum ${max}',
         range: '${label} must be between ${min}-${max}',
       },
       array: {

--- a/components/locale/ga_IE.tsx
+++ b/components/locale/ga_IE.tsx
@@ -75,7 +75,7 @@ const localeValues: Locale = {
   },
   Form: {
     defaultValidateMessages: {
-      default: 'Field validation error ${label}',
+      default: 'Field validation error for ${label}',
       required: 'Please enter ${label}',
       enum: '${label} must be one of [${enum}]',
       whitespace: '${label} cannot be a blank character',


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [x] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

No related issues. 

### 💡 Background and solution

Some labels for ga_IE, en_GB and default locales were poorly translated and required custom labels/messages to make them correct in English. I aimed to remedy that.

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Changed for ga_IE, en_GB and default locales:<br><br>"Click sort by descend" -> "Click to sort descending"<br>"Click sort by ascend" -> "Click to sort ascending"<br>"Click to cancel sort" -> "Click to cancel sorting"<br>"Field validation error ${label}" -> "Field validation error for ${label}" <br> "${label} at least ${min} characters" -> "${label} must be at least ${min} characters"<br>"${label} up to ${max} characters" -> "${label} must be up to ${max} characters"<br>"${label} minimum value is ${min}" -> "${label} must be minimum ${min}" <br>"${label} maximum value is ${max}" -> "${label} must be maximum ${max}"  |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
