### PR TITLE
style: notification text add word-wrap

### DIFF
--- a/components/notification/style/index.less
+++ b/components/notification/style/index.less
@@ -39,6 +39,7 @@
     margin-bottom: @notification-margin-bottom;
     margin-left: auto;
     overflow: hidden;
+    word-wrap: break-word;
     background: @notification-bg;
     border-radius: @border-radius-base;
     box-shadow: @shadow-2;
@@ -60,7 +61,6 @@
     line-height: @line-height-base;
 
     &-message {
-      display: inline-block;
       margin-bottom: 8px;
       color: @heading-color;
       font-size: @font-size-lg;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

before
![ex1](https://user-images.githubusercontent.com/26539665/96828450-4912f480-146a-11eb-977d-01fab587f124.png)
after
![ex2](https://user-images.githubusercontent.com/26539665/96828457-4ca67b80-146a-11eb-8dde-93ca4d5318d3.png)



<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Notification wrap long words     |
| 🇨🇳 Chinese | 长单词自动换行，使其不溢出弹框          |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
