### PR TITLE
fix: Desc label with flex node

### DIFF
--- a/components/descriptions/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/descriptions/__tests__/__snapshots__/demo.test.js.snap
@@ -861,7 +861,11 @@ exports[`renders ./components/descriptions/demo/text.md correctly 1`] = `
               <span
                 class="ant-descriptions-item-label"
               >
-                Billing Mode
+                <div
+                  style="display:flex"
+                >
+                  Billing Mode
+                </div>
               </span>
               <span
                 class="ant-descriptions-item-content"

--- a/components/descriptions/demo/text.md
+++ b/components/descriptions/demo/text.md
@@ -52,7 +52,9 @@ const columns = [
 ReactDOM.render(
   <Descriptions title="User Info" column={2}>
     <Descriptions.Item label="Product">Cloud Database</Descriptions.Item>
-    <Descriptions.Item label="Billing Mode">Prepaid</Descriptions.Item>
+    <Descriptions.Item label={<div style={{ display: 'flex' }}>Billing Mode</div>}>
+      Prepaid
+    </Descriptions.Item>
     <Descriptions.Item label="Automatic Renewal">YES</Descriptions.Item>
     <Descriptions.Item label="Order time">2018-04-24 18:00:00</Descriptions.Item>
     <Descriptions.Item label="Usage Time" span={2}>

--- a/components/descriptions/style/index.less
+++ b/components/descriptions/style/index.less
@@ -103,7 +103,6 @@
 
       .@{descriptions-prefix-cls}-item-label {
         display: inline-flex;
-        flex-wrap: nowrap;
       }
     }
   }

--- a/components/descriptions/style/index.less
+++ b/components/descriptions/style/index.less
@@ -101,8 +101,10 @@
     &-container {
       display: flex;
 
-      .@{descriptions-prefix-cls}-item-label {
+      .@{descriptions-prefix-cls}-item-label,
+      .@{descriptions-prefix-cls}-item-content {
         display: inline-flex;
+        align-items: baseline;
       }
     }
   }

--- a/components/descriptions/style/index.less
+++ b/components/descriptions/style/index.less
@@ -93,10 +93,6 @@
   &-item {
     padding-bottom: 0;
     vertical-align: top;
-    > span {
-      display: inline-flex;
-      align-items: baseline;
-    }
 
     &-container {
       display: flex;

--- a/components/descriptions/style/index.less
+++ b/components/descriptions/style/index.less
@@ -100,6 +100,11 @@
 
     &-container {
       display: flex;
+
+      .@{descriptions-prefix-cls}-item-label {
+        display: inline-flex;
+        flex-wrap: nowrap;
+      }
     }
   }
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

https://github.com/ant-design/ant-design/pull/25903#discussion_r511800517

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Fix Description style when `label` use block element.      |
| 🇨🇳 Chinese |     修复 Description 在 `label` 自定义为块状元素时的样式问题。     |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/descriptions/demo/text.md](https://github.com/ant-design/ant-design/blob/fix-desc/components/descriptions/demo/text.md)