### PR TITLE
feat: components used in confirm title and content support prefixCls

### DIFF
--- a/components/modal/ConfirmDialog.tsx
+++ b/components/modal/ConfirmDialog.tsx
@@ -3,6 +3,7 @@ import classNames from 'classnames';
 import Dialog, { ModalFuncProps } from './Modal';
 import ActionButton from './ActionButton';
 import devWarning from '../_util/devWarning';
+import ConfigProvider from '../config-provider';
 
 interface ConfirmDialogProps extends ModalFuncProps {
   afterClose?: () => void;
@@ -96,13 +97,15 @@ const ConfirmDialog = (props: ConfirmDialogProps) => {
       getContainer={getContainer}
     >
       <div className={`${contentPrefixCls}-body-wrapper`}>
-        <div className={`${contentPrefixCls}-body`} style={bodyStyle}>
-          {icon}
-          {props.title === undefined ? null : (
-            <span className={`${contentPrefixCls}-title`}>{props.title}</span>
-          )}
-          <div className={`${contentPrefixCls}-content`}>{props.content}</div>
-        </div>
+        <ConfigProvider prefixCls={rootPrefixCls}>
+          <div className={`${contentPrefixCls}-body`} style={bodyStyle}>
+            {icon}
+            {props.title === undefined ? null : (
+              <span className={`${contentPrefixCls}-title`}>{props.title}</span>
+            )}
+            <div className={`${contentPrefixCls}-content`}>{props.content}</div>
+          </div>
+        </ConfigProvider>
         <div className={`${contentPrefixCls}-btns`}>
           {cancelButton}
           <ActionButton


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

Background：

`Modal.config` 中 设置的 `rootPrefixCls`， 只会作用于`Modal.confirm` 中的 `Modal`组件部分，而不会作用于`Modal`接收的antd子组件，如`title`和`content`。因为`title`和`content`的类型是`ReactNode`，可以接收antd组件，在全局设置`prefixCls`后，会导致这部分组件样式丢失，目前解决方式只能在每个使用的地方都加上`prefixCls`。

Solution:

`Modal.confirm` 内部形成一个 `context`，复用`ConfigProvider`，将`Modal.config` 中 设置的 `rootPrefixCls`传给内部`ConfigProvider`。

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | `rootPrefixCls` set in `Modal.config` can be effective for the antd components used in `title` and `content` |
| 🇨🇳 Chinese | `Modal.config` 中设置的 `rootPrefixCls` 可以对`title`和`content`下使用的antd组件生效 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
