### PR TITLE
fix: Tree showLine mutiple line title breaks

### DIFF
--- a/components/transfer/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/transfer/__tests__/__snapshots__/demo.test.js.snap
@@ -4406,7 +4406,7 @@ exports[`renders ./components/transfer/demo/tree-transfer.md correctly 1`] = `
                       class="ant-tree-indent"
                     >
                       <span
-                        class="ant-tree-indent-unit ant-tree-indent-unit-start"
+                        class="ant-tree-indent-unit"
                       />
                     </span>
                     <span
@@ -4438,7 +4438,7 @@ exports[`renders ./components/transfer/demo/tree-transfer.md correctly 1`] = `
                       class="ant-tree-indent"
                     >
                       <span
-                        class="ant-tree-indent-unit ant-tree-indent-unit-end"
+                        class="ant-tree-indent-unit"
                       />
                     </span>
                     <span

--- a/components/tree/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/tree/__tests__/__snapshots__/demo.test.js.snap
@@ -78,7 +78,7 @@ exports[`renders ./components/tree/demo/basic.md correctly 1`] = `
               class="ant-tree-indent"
             >
               <span
-                class="ant-tree-indent-unit ant-tree-indent-unit-start ant-tree-indent-unit-end-first-level"
+                class="ant-tree-indent-unit ant-tree-indent-unit-start ant-tree-indent-unit-end"
               />
             </span>
             <span
@@ -131,7 +131,7 @@ exports[`renders ./components/tree/demo/basic.md correctly 1`] = `
               class="ant-tree-indent"
             >
               <span
-                class="ant-tree-indent-unit ant-tree-indent-unit-start ant-tree-indent-unit-end-first-level"
+                class="ant-tree-indent-unit ant-tree-indent-unit-start ant-tree-indent-unit-end"
               />
               <span
                 class="ant-tree-indent-unit ant-tree-indent-unit-start"
@@ -166,10 +166,10 @@ exports[`renders ./components/tree/demo/basic.md correctly 1`] = `
               class="ant-tree-indent"
             >
               <span
-                class="ant-tree-indent-unit ant-tree-indent-unit-start ant-tree-indent-unit-end-first-level"
+                class="ant-tree-indent-unit ant-tree-indent-unit-start ant-tree-indent-unit-end"
               />
               <span
-                class="ant-tree-indent-unit ant-tree-indent-unit-end"
+                class="ant-tree-indent-unit ant-tree-indent-unit-start"
               />
             </span>
             <span
@@ -201,7 +201,7 @@ exports[`renders ./components/tree/demo/basic.md correctly 1`] = `
               class="ant-tree-indent"
             >
               <span
-                class="ant-tree-indent-unit ant-tree-indent-unit-end ant-tree-indent-unit-end-first-level"
+                class="ant-tree-indent-unit ant-tree-indent-unit-start ant-tree-indent-unit-end"
               />
             </span>
             <span
@@ -254,10 +254,10 @@ exports[`renders ./components/tree/demo/basic.md correctly 1`] = `
               class="ant-tree-indent"
             >
               <span
-                class="ant-tree-indent-unit ant-tree-indent-unit-end ant-tree-indent-unit-end-first-level"
+                class="ant-tree-indent-unit ant-tree-indent-unit-start ant-tree-indent-unit-end"
               />
               <span
-                class="ant-tree-indent-unit ant-tree-indent-unit-start ant-tree-indent-unit-end"
+                class="ant-tree-indent-unit ant-tree-indent-unit-end"
               />
             </span>
             <span
@@ -461,7 +461,7 @@ exports[`renders ./components/tree/demo/basic-controlled.md correctly 1`] = `
                 class="ant-tree-indent-unit ant-tree-indent-unit-start"
               />
               <span
-                class="ant-tree-indent-unit"
+                class="ant-tree-indent-unit ant-tree-indent-unit-start"
               />
             </span>
             <span
@@ -496,7 +496,7 @@ exports[`renders ./components/tree/demo/basic-controlled.md correctly 1`] = `
                 class="ant-tree-indent-unit ant-tree-indent-unit-start"
               />
               <span
-                class="ant-tree-indent-unit ant-tree-indent-unit-end"
+                class="ant-tree-indent-unit ant-tree-indent-unit-start"
               />
             </span>
             <span
@@ -528,7 +528,7 @@ exports[`renders ./components/tree/demo/basic-controlled.md correctly 1`] = `
               class="ant-tree-indent"
             >
               <span
-                class="ant-tree-indent-unit"
+                class="ant-tree-indent-unit ant-tree-indent-unit-start"
               />
             </span>
             <span
@@ -581,10 +581,10 @@ exports[`renders ./components/tree/demo/basic-controlled.md correctly 1`] = `
               class="ant-tree-indent"
             >
               <span
-                class="ant-tree-indent-unit"
+                class="ant-tree-indent-unit ant-tree-indent-unit-start"
               />
               <span
-                class="ant-tree-indent-unit ant-tree-indent-unit-start"
+                class="ant-tree-indent-unit"
               />
             </span>
             <span
@@ -616,7 +616,7 @@ exports[`renders ./components/tree/demo/basic-controlled.md correctly 1`] = `
               class="ant-tree-indent"
             >
               <span
-                class="ant-tree-indent-unit"
+                class="ant-tree-indent-unit ant-tree-indent-unit-start"
               />
               <span
                 class="ant-tree-indent-unit"
@@ -651,10 +651,10 @@ exports[`renders ./components/tree/demo/basic-controlled.md correctly 1`] = `
               class="ant-tree-indent"
             >
               <span
-                class="ant-tree-indent-unit"
+                class="ant-tree-indent-unit ant-tree-indent-unit-start"
               />
               <span
-                class="ant-tree-indent-unit ant-tree-indent-unit-end"
+                class="ant-tree-indent-unit"
               />
             </span>
             <span
@@ -686,7 +686,7 @@ exports[`renders ./components/tree/demo/basic-controlled.md correctly 1`] = `
               class="ant-tree-indent"
             >
               <span
-                class="ant-tree-indent-unit ant-tree-indent-unit-end"
+                class="ant-tree-indent-unit ant-tree-indent-unit-start"
               />
             </span>
             <span
@@ -881,7 +881,7 @@ exports[`renders ./components/tree/demo/customized-icon.md correctly 1`] = `
               class="ant-tree-indent"
             >
               <span
-                class="ant-tree-indent-unit ant-tree-indent-unit-start ant-tree-indent-unit-end-first-level"
+                class="ant-tree-indent-unit ant-tree-indent-unit-start ant-tree-indent-unit-end"
               />
             </span>
             <span
@@ -930,7 +930,7 @@ exports[`renders ./components/tree/demo/customized-icon.md correctly 1`] = `
               class="ant-tree-indent"
             >
               <span
-                class="ant-tree-indent-unit ant-tree-indent-unit-end ant-tree-indent-unit-end-first-level"
+                class="ant-tree-indent-unit ant-tree-indent-unit-start ant-tree-indent-unit-end"
               />
             </span>
             <span
@@ -1122,7 +1122,7 @@ exports[`renders ./components/tree/demo/directory.md correctly 1`] = `
               class="ant-tree-indent"
             >
               <span
-                class="ant-tree-indent-unit ant-tree-indent-unit-end"
+                class="ant-tree-indent-unit ant-tree-indent-unit-start"
               />
             </span>
             <span
@@ -1233,7 +1233,7 @@ exports[`renders ./components/tree/demo/directory.md correctly 1`] = `
               class="ant-tree-indent"
             >
               <span
-                class="ant-tree-indent-unit ant-tree-indent-unit-start ant-tree-indent-unit-end-first-level"
+                class="ant-tree-indent-unit ant-tree-indent-unit-end"
               />
             </span>
             <span
@@ -1282,7 +1282,7 @@ exports[`renders ./components/tree/demo/directory.md correctly 1`] = `
               class="ant-tree-indent"
             >
               <span
-                class="ant-tree-indent-unit ant-tree-indent-unit-end ant-tree-indent-unit-end-first-level"
+                class="ant-tree-indent-unit ant-tree-indent-unit-end"
               />
             </span>
             <span
@@ -1484,7 +1484,7 @@ exports[`renders ./components/tree/demo/draggable.md correctly 1`] = `
                 class="ant-tree-indent-unit ant-tree-indent-unit-start"
               />
               <span
-                class="ant-tree-indent-unit"
+                class="ant-tree-indent-unit ant-tree-indent-unit-start"
               />
             </span>
             <span
@@ -1514,7 +1514,7 @@ exports[`renders ./components/tree/demo/draggable.md correctly 1`] = `
                 class="ant-tree-indent-unit ant-tree-indent-unit-start"
               />
               <span
-                class="ant-tree-indent-unit ant-tree-indent-unit-end"
+                class="ant-tree-indent-unit ant-tree-indent-unit-start"
               />
             </span>
             <span
@@ -1541,7 +1541,7 @@ exports[`renders ./components/tree/demo/draggable.md correctly 1`] = `
               class="ant-tree-indent"
             >
               <span
-                class="ant-tree-indent-unit"
+                class="ant-tree-indent-unit ant-tree-indent-unit-start"
               />
             </span>
             <span
@@ -1589,7 +1589,7 @@ exports[`renders ./components/tree/demo/draggable.md correctly 1`] = `
               class="ant-tree-indent"
             >
               <span
-                class="ant-tree-indent-unit ant-tree-indent-unit-end"
+                class="ant-tree-indent-unit ant-tree-indent-unit-start"
               />
             </span>
             <span
@@ -2025,7 +2025,7 @@ exports[`renders ./components/tree/demo/line.md correctly 1`] = `
                   class="ant-tree-indent-unit ant-tree-indent-unit-start"
                 />
                 <span
-                  class="ant-tree-indent-unit"
+                  class="ant-tree-indent-unit ant-tree-indent-unit-start"
                 />
               </span>
               <span
@@ -2054,12 +2054,17 @@ exports[`renders ./components/tree/demo/line.md correctly 1`] = `
               </span>
               <span
                 class="ant-tree-node-content-wrapper ant-tree-node-content-wrapper-normal"
-                title="leaf"
+                title=""
               >
                 <span
                   class="ant-tree-title"
                 >
-                  leaf
+                  <div>
+                    multiple line title
+                  </div>
+                  <div>
+                    multiple line title
+                  </div>
                 </span>
               </span>
             </div>
@@ -2074,7 +2079,7 @@ exports[`renders ./components/tree/demo/line.md correctly 1`] = `
                   class="ant-tree-indent-unit ant-tree-indent-unit-start"
                 />
                 <span
-                  class="ant-tree-indent-unit ant-tree-indent-unit-end"
+                  class="ant-tree-indent-unit ant-tree-indent-unit-start"
                 />
               </span>
               <span
@@ -2120,7 +2125,7 @@ exports[`renders ./components/tree/demo/line.md correctly 1`] = `
                 class="ant-tree-indent"
               >
                 <span
-                  class="ant-tree-indent-unit"
+                  class="ant-tree-indent-unit ant-tree-indent-unit-start"
                 />
               </span>
               <span
@@ -2169,7 +2174,7 @@ exports[`renders ./components/tree/demo/line.md correctly 1`] = `
                 class="ant-tree-indent"
               >
                 <span
-                  class="ant-tree-indent-unit ant-tree-indent-unit-end"
+                  class="ant-tree-indent-unit ant-tree-indent-unit-start"
                 />
               </span>
               <span
@@ -2516,7 +2521,7 @@ exports[`renders ./components/tree/demo/switcher-icon.md correctly 1`] = `
               class="ant-tree-indent"
             >
               <span
-                class="ant-tree-indent-unit ant-tree-indent-unit-start ant-tree-indent-unit-end-first-level"
+                class="ant-tree-indent-unit ant-tree-indent-unit-start ant-tree-indent-unit-end"
               />
             </span>
             <span
@@ -2562,7 +2567,7 @@ exports[`renders ./components/tree/demo/switcher-icon.md correctly 1`] = `
               class="ant-tree-indent"
             >
               <span
-                class="ant-tree-indent-unit ant-tree-indent-unit-start ant-tree-indent-unit-end-first-level"
+                class="ant-tree-indent-unit ant-tree-indent-unit-start ant-tree-indent-unit-end"
               />
               <span
                 class="ant-tree-indent-unit ant-tree-indent-unit-start"
@@ -2611,10 +2616,10 @@ exports[`renders ./components/tree/demo/switcher-icon.md correctly 1`] = `
               class="ant-tree-indent"
             >
               <span
-                class="ant-tree-indent-unit ant-tree-indent-unit-start ant-tree-indent-unit-end-first-level"
+                class="ant-tree-indent-unit ant-tree-indent-unit-start ant-tree-indent-unit-end"
               />
               <span
-                class="ant-tree-indent-unit"
+                class="ant-tree-indent-unit ant-tree-indent-unit-start"
               />
             </span>
             <span
@@ -2660,10 +2665,10 @@ exports[`renders ./components/tree/demo/switcher-icon.md correctly 1`] = `
               class="ant-tree-indent"
             >
               <span
-                class="ant-tree-indent-unit ant-tree-indent-unit-start ant-tree-indent-unit-end-first-level"
+                class="ant-tree-indent-unit ant-tree-indent-unit-start ant-tree-indent-unit-end"
               />
               <span
-                class="ant-tree-indent-unit ant-tree-indent-unit-end"
+                class="ant-tree-indent-unit ant-tree-indent-unit-start"
               />
             </span>
             <span
@@ -2709,7 +2714,7 @@ exports[`renders ./components/tree/demo/switcher-icon.md correctly 1`] = `
               class="ant-tree-indent"
             >
               <span
-                class="ant-tree-indent-unit ant-tree-indent-unit-end-first-level"
+                class="ant-tree-indent-unit ant-tree-indent-unit-start ant-tree-indent-unit-end"
               />
             </span>
             <span
@@ -2755,7 +2760,7 @@ exports[`renders ./components/tree/demo/switcher-icon.md correctly 1`] = `
               class="ant-tree-indent"
             >
               <span
-                class="ant-tree-indent-unit ant-tree-indent-unit-end ant-tree-indent-unit-end-first-level"
+                class="ant-tree-indent-unit ant-tree-indent-unit-start ant-tree-indent-unit-end"
               />
             </span>
             <span

--- a/components/tree/__tests__/__snapshots__/directory.test.js.snap
+++ b/components/tree/__tests__/__snapshots__/directory.test.js.snap
@@ -95,7 +95,7 @@ exports[`Directory Tree DirectoryTree should expend all when use treeData and de
               class="ant-tree-indent"
             >
               <span
-                class="ant-tree-indent-unit ant-tree-indent-unit-start ant-tree-indent-unit-end ant-tree-indent-unit-end-first-level"
+                class="ant-tree-indent-unit ant-tree-indent-unit-start ant-tree-indent-unit-end"
               />
             </span>
             <span
@@ -165,7 +165,7 @@ exports[`Directory Tree DirectoryTree should expend all when use treeData and de
               class="ant-tree-indent"
             >
               <span
-                class="ant-tree-indent-unit ant-tree-indent-unit-start ant-tree-indent-unit-end ant-tree-indent-unit-end-first-level"
+                class="ant-tree-indent-unit ant-tree-indent-unit-start ant-tree-indent-unit-end"
               />
               <span
                 class="ant-tree-indent-unit ant-tree-indent-unit-start ant-tree-indent-unit-end"
@@ -360,7 +360,7 @@ exports[`Directory Tree defaultExpandAll 1`] = `
               class="ant-tree-indent"
             >
               <span
-                class="ant-tree-indent-unit ant-tree-indent-unit-end"
+                class="ant-tree-indent-unit ant-tree-indent-unit-start"
               />
             </span>
             <span
@@ -471,7 +471,7 @@ exports[`Directory Tree defaultExpandAll 1`] = `
               class="ant-tree-indent"
             >
               <span
-                class="ant-tree-indent-unit ant-tree-indent-unit-start ant-tree-indent-unit-end-first-level"
+                class="ant-tree-indent-unit ant-tree-indent-unit-end"
               />
             </span>
             <span
@@ -520,7 +520,7 @@ exports[`Directory Tree defaultExpandAll 1`] = `
               class="ant-tree-indent"
             >
               <span
-                class="ant-tree-indent-unit ant-tree-indent-unit-end ant-tree-indent-unit-end-first-level"
+                class="ant-tree-indent-unit ant-tree-indent-unit-end"
               />
             </span>
             <span
@@ -872,7 +872,7 @@ exports[`Directory Tree expand click 1`] = `
                 class="ant-tree-indent"
               >
                 <span
-                  class="ant-tree-indent-unit ant-tree-indent-unit-end"
+                  class="ant-tree-indent-unit ant-tree-indent-unit-start"
                 />
               </span>
               <span
@@ -1291,7 +1291,7 @@ exports[`Directory Tree expand double click 1`] = `
                 class="ant-tree-indent"
               >
                 <span
-                  class="ant-tree-indent-unit ant-tree-indent-unit-end"
+                  class="ant-tree-indent-unit ant-tree-indent-unit-start"
                 />
               </span>
               <span
@@ -1661,7 +1661,7 @@ exports[`Directory Tree expand with state control click 1`] = `
                 class="ant-tree-indent"
               >
                 <span
-                  class="ant-tree-indent-unit ant-tree-indent-unit-start ant-tree-indent-unit-end ant-tree-indent-unit-end-first-level"
+                  class="ant-tree-indent-unit ant-tree-indent-unit-start ant-tree-indent-unit-end"
                 />
               </span>
               <span
@@ -1809,7 +1809,7 @@ exports[`Directory Tree expand with state control doubleClick 1`] = `
                 class="ant-tree-indent"
               >
                 <span
-                  class="ant-tree-indent-unit ant-tree-indent-unit-start ant-tree-indent-unit-end ant-tree-indent-unit-end-first-level"
+                  class="ant-tree-indent-unit ant-tree-indent-unit-start ant-tree-indent-unit-end"
                 />
               </span>
               <span
@@ -2019,7 +2019,7 @@ exports[`Directory Tree expandedKeys update 1`] = `
                 class="ant-tree-indent"
               >
                 <span
-                  class="ant-tree-indent-unit ant-tree-indent-unit-start ant-tree-indent-unit-end-first-level"
+                  class="ant-tree-indent-unit ant-tree-indent-unit-end"
                 />
               </span>
               <span
@@ -2068,7 +2068,7 @@ exports[`Directory Tree expandedKeys update 1`] = `
                 class="ant-tree-indent"
               >
                 <span
-                  class="ant-tree-indent-unit ant-tree-indent-unit-end ant-tree-indent-unit-end-first-level"
+                  class="ant-tree-indent-unit ant-tree-indent-unit-end"
                 />
               </span>
               <span
@@ -2261,7 +2261,7 @@ exports[`Directory Tree group select 1`] = `
               class="ant-tree-indent"
             >
               <span
-                class="ant-tree-indent-unit ant-tree-indent-unit-end"
+                class="ant-tree-indent-unit ant-tree-indent-unit-start"
               />
             </span>
             <span
@@ -2372,7 +2372,7 @@ exports[`Directory Tree group select 1`] = `
               class="ant-tree-indent"
             >
               <span
-                class="ant-tree-indent-unit ant-tree-indent-unit-start ant-tree-indent-unit-end-first-level"
+                class="ant-tree-indent-unit ant-tree-indent-unit-end"
               />
             </span>
             <span
@@ -2421,7 +2421,7 @@ exports[`Directory Tree group select 1`] = `
               class="ant-tree-indent"
             >
               <span
-                class="ant-tree-indent-unit ant-tree-indent-unit-end ant-tree-indent-unit-end-first-level"
+                class="ant-tree-indent-unit ant-tree-indent-unit-end"
               />
             </span>
             <span
@@ -2613,7 +2613,7 @@ exports[`Directory Tree group select 2`] = `
               class="ant-tree-indent"
             >
               <span
-                class="ant-tree-indent-unit ant-tree-indent-unit-end"
+                class="ant-tree-indent-unit ant-tree-indent-unit-start"
               />
             </span>
             <span
@@ -2724,7 +2724,7 @@ exports[`Directory Tree group select 2`] = `
               class="ant-tree-indent"
             >
               <span
-                class="ant-tree-indent-unit ant-tree-indent-unit-start ant-tree-indent-unit-end-first-level"
+                class="ant-tree-indent-unit ant-tree-indent-unit-end"
               />
             </span>
             <span
@@ -2773,7 +2773,7 @@ exports[`Directory Tree group select 2`] = `
               class="ant-tree-indent"
             >
               <span
-                class="ant-tree-indent-unit ant-tree-indent-unit-end ant-tree-indent-unit-end-first-level"
+                class="ant-tree-indent-unit ant-tree-indent-unit-end"
               />
             </span>
             <span
@@ -3027,7 +3027,7 @@ exports[`Directory Tree selectedKeys update 1`] = `
               class="ant-tree-indent"
             >
               <span
-                class="ant-tree-indent-unit ant-tree-indent-unit-end"
+                class="ant-tree-indent-unit ant-tree-indent-unit-start"
               />
             </span>
             <span
@@ -3138,7 +3138,7 @@ exports[`Directory Tree selectedKeys update 1`] = `
               class="ant-tree-indent"
             >
               <span
-                class="ant-tree-indent-unit ant-tree-indent-unit-start ant-tree-indent-unit-end-first-level"
+                class="ant-tree-indent-unit ant-tree-indent-unit-end"
               />
             </span>
             <span
@@ -3187,7 +3187,7 @@ exports[`Directory Tree selectedKeys update 1`] = `
               class="ant-tree-indent"
             >
               <span
-                class="ant-tree-indent-unit ant-tree-indent-unit-end ant-tree-indent-unit-end-first-level"
+                class="ant-tree-indent-unit ant-tree-indent-unit-end"
               />
             </span>
             <span

--- a/components/tree/__tests__/__snapshots__/index.test.js.snap
+++ b/components/tree/__tests__/__snapshots__/index.test.js.snap
@@ -196,7 +196,7 @@ exports[`Tree showLine is object type should render correctly 1`] = `
               class="ant-tree-indent"
             >
               <span
-                class="ant-tree-indent-unit ant-tree-indent-unit-start ant-tree-indent-unit-end-first-level"
+                class="ant-tree-indent-unit ant-tree-indent-unit-start ant-tree-indent-unit-end"
               />
             </span>
             <span
@@ -245,7 +245,7 @@ exports[`Tree showLine is object type should render correctly 1`] = `
               class="ant-tree-indent"
             >
               <span
-                class="ant-tree-indent-unit ant-tree-indent-unit-start ant-tree-indent-unit-end-first-level"
+                class="ant-tree-indent-unit ant-tree-indent-unit-start ant-tree-indent-unit-end"
               />
               <span
                 class="ant-tree-indent-unit ant-tree-indent-unit-start"
@@ -277,10 +277,10 @@ exports[`Tree showLine is object type should render correctly 1`] = `
               class="ant-tree-indent"
             >
               <span
-                class="ant-tree-indent-unit ant-tree-indent-unit-start ant-tree-indent-unit-end-first-level"
+                class="ant-tree-indent-unit ant-tree-indent-unit-start ant-tree-indent-unit-end"
               />
               <span
-                class="ant-tree-indent-unit"
+                class="ant-tree-indent-unit ant-tree-indent-unit-start"
               />
             </span>
             <span
@@ -309,10 +309,10 @@ exports[`Tree showLine is object type should render correctly 1`] = `
               class="ant-tree-indent"
             >
               <span
-                class="ant-tree-indent-unit ant-tree-indent-unit-start ant-tree-indent-unit-end-first-level"
+                class="ant-tree-indent-unit ant-tree-indent-unit-start ant-tree-indent-unit-end"
               />
               <span
-                class="ant-tree-indent-unit ant-tree-indent-unit-end"
+                class="ant-tree-indent-unit ant-tree-indent-unit-start"
               />
             </span>
             <span
@@ -341,7 +341,7 @@ exports[`Tree showLine is object type should render correctly 1`] = `
               class="ant-tree-indent"
             >
               <span
-                class="ant-tree-indent-unit ant-tree-indent-unit-end-first-level"
+                class="ant-tree-indent-unit ant-tree-indent-unit-start ant-tree-indent-unit-end"
               />
             </span>
             <span
@@ -390,7 +390,7 @@ exports[`Tree showLine is object type should render correctly 1`] = `
               class="ant-tree-indent"
             >
               <span
-                class="ant-tree-indent-unit ant-tree-indent-unit-end ant-tree-indent-unit-end-first-level"
+                class="ant-tree-indent-unit ant-tree-indent-unit-start ant-tree-indent-unit-end"
               />
             </span>
             <span
@@ -490,7 +490,7 @@ exports[`Tree switcherIcon in Tree could be string 1`] = `
               class="ant-tree-indent"
             >
               <span
-                class="ant-tree-indent-unit ant-tree-indent-unit-start ant-tree-indent-unit-end-first-level"
+                class="ant-tree-indent-unit ant-tree-indent-unit-start ant-tree-indent-unit-end"
               />
             </span>
             <span
@@ -515,7 +515,7 @@ exports[`Tree switcherIcon in Tree could be string 1`] = `
               class="ant-tree-indent"
             >
               <span
-                class="ant-tree-indent-unit ant-tree-indent-unit-end ant-tree-indent-unit-end-first-level"
+                class="ant-tree-indent-unit ant-tree-indent-unit-start ant-tree-indent-unit-end"
               />
             </span>
             <span
@@ -591,7 +591,7 @@ exports[`Tree switcherIcon should be loading icon when loadData 1`] = `
               class="ant-tree-indent"
             >
               <span
-                class="ant-tree-indent-unit ant-tree-indent-unit-start ant-tree-indent-unit-end-first-level"
+                class="ant-tree-indent-unit ant-tree-indent-unit-start ant-tree-indent-unit-end"
               />
             </span>
             <span
@@ -640,7 +640,7 @@ exports[`Tree switcherIcon should be loading icon when loadData 1`] = `
               class="ant-tree-indent"
             >
               <span
-                class="ant-tree-indent-unit ant-tree-indent-unit-end ant-tree-indent-unit-end-first-level"
+                class="ant-tree-indent-unit ant-tree-indent-unit-start ant-tree-indent-unit-end"
               />
             </span>
             <span

--- a/components/tree/demo/line.md
+++ b/components/tree/demo/line.md
@@ -30,7 +30,16 @@ const treeData = [
         icon: <CarryOutOutlined />,
         children: [
           { title: 'leaf', key: '0-0-0-0', icon: <CarryOutOutlined /> },
-          { title: 'leaf', key: '0-0-0-1', icon: <CarryOutOutlined /> },
+          {
+            title: (
+              <>
+                <div>multiple line title</div>
+                <div>multiple line title</div>
+              </>
+            ),
+            key: '0-0-0-1',
+            icon: <CarryOutOutlined />,
+          },
           { title: 'leaf', key: '0-0-0-2', icon: <CarryOutOutlined /> },
         ],
       },

--- a/components/tree/style/mixin.less
+++ b/components/tree/style/mixin.less
@@ -96,11 +96,11 @@
   // >>> Switcher
   & &-switcher {
     .antTreeSwitcherIcon();
+    position: relative;
     flex: none;
+    align-self: stretch;
 
     width: @tree-title-height;
-    align-self: stretch;
-    position: relative;
     margin: 0;
     line-height: @tree-title-height;
     text-align: center;
@@ -222,11 +222,11 @@
 
         &::before {
           position: absolute;
-          content: '';
           top: 0;
-          bottom: -@tree-node-padding;
           right: @tree-title-height / 2;
+          bottom: -@tree-node-padding;
           border-right: 1px solid @border-color-base;
+          content: '';
         }
 
         &-end {
@@ -249,9 +249,9 @@
   .@{tree-prefix-cls}-switcher {
     &-leaf-line {
       &::before {
-        height: @tree-title-height - 10px !important;
         top: auto !important;
         bottom: auto !important;
+        height: @tree-title-height - 10px !important;
       }
     }
   }

--- a/components/tree/style/mixin.less
+++ b/components/tree/style/mixin.less
@@ -120,27 +120,27 @@
       color: @primary-color;
     }
 
-    &-leaf-line {
-      z-index: 1;
-      display: inline-block;
-      width: 100%;
-      height: 100%;
-      &::before {
-        position: absolute;
-        height: @tree-title-height;
-        margin-left: -1px;
-        border-left: 1px solid @normal-color;
-        content: ' ';
-      }
-      &::after {
-        position: absolute;
-        width: @tree-title-height - 14px;
-        height: @tree-title-height - 10px;
-        margin-left: -1px;
-        border-bottom: 1px solid @normal-color;
-        content: ' ';
-      }
-    }
+    // &-leaf-line {
+    //   z-index: 1;
+    //   display: inline-block;
+    //   width: 100%;
+    //   height: 100%;
+    //   &::before {
+    //     position: absolute;
+    //     height: @tree-title-height;
+    //     margin-left: -1px;
+    //     border-left: 1px solid @normal-color;
+    //     content: ' ';
+    //   }
+    //   &::after {
+    //     position: absolute;
+    //     width: @tree-title-height - 14px;
+    //     height: @tree-title-height - 10px;
+    //     margin-left: -1px;
+    //     border-bottom: 1px solid @normal-color;
+    //     content: ' ';
+    //   }
+    // }
   }
 
   // >>> Checkbox
@@ -217,40 +217,55 @@
         position: relative;
         height: 100%;
 
-        &:first-child::after {
-          position: absolute;
-          top: calc(100% - @tree-title-height - 4px);
-          right: @tree-title-height / 2;
-          bottom: -4px;
-          border-right: 1px solid @border-color-base;
-          content: '';
-        }
-
         &::before {
           position: absolute;
-          top: calc(100% - 4px);
-          right: -@tree-title-height / 2;
-          bottom: -@tree-title-height - 4px;
-          border-right: 1px solid @border-color-base;
           content: '';
+          top: 0;
+          bottom: -@padding-xs / 2;
+          right: @tree-title-height / 2;
+          border-right: 1px solid @border-color-base;
         }
 
-        &-end::before,
-        &-end-first-level::after {
-          display: none;
+        &-end {
+          &::before {
+            display: none;
+          }
         }
+
+        // &:first-child::after {
+        //   position: absolute;
+        //   top: calc(100% - @tree-title-height - 4px);
+        //   right: @tree-title-height / 2;
+        //   bottom: -4px;
+        //   border-right: 1px solid @border-color-base;
+        //   content: '';
+        // }
+
+        // &::before {
+        //   position: absolute;
+        //   top: calc(100% - 4px);
+        //   right: -@tree-title-height / 2;
+        //   bottom: -@tree-title-height - 4px;
+        //   border-right: 1px solid @border-color-base;
+        //   content: '';
+        // }
+
+        // &-end::before,
+        // &-end-first-level::after {
+        //   display: none;
+        // }
       }
     }
 
     /* Motion should hide line of measure */
-    .@{custom-tree-node-prefix-cls}-motion:not(.@{tree-motion}-leave):not(.@{tree-motion}-appear-active) {
-      .@{custom-tree-prefix-cls}-indent-unit {
-        &::after,
-        &::before {
-          display: none;
-        }
-      }
-    }
+    // .@{custom-tree-node-prefix-cls}-motion:not(.@{tree-motion}-leave):not(.@{tree-motion}-appear-active) {
+    //   .@{custom-tree-prefix-cls}-indent-unit {
+    //     &::after,
+    //     &::before {
+    //       display: none;
+    //     }
+    //   }
+    // }
 
     // ============== Cover Background ==============
     .@{custom-tree-prefix-cls}-switcher {
@@ -262,10 +277,10 @@
 
 .@{tree-node-prefix-cls}-leaf-last {
   .@{tree-prefix-cls}-switcher {
-    &-leaf-line {
-      &::before {
-        height: @tree-title-height - 10px !important;
-      }
-    }
+    // &-leaf-line {
+    //   &::before {
+    //     height: @tree-title-height - 10px !important;
+    //   }
+    // }
   }
 }

--- a/components/tree/style/mixin.less
+++ b/components/tree/style/mixin.less
@@ -4,6 +4,7 @@
 @tree-node-prefix-cls: ~'@{tree-prefix-cls}-treenode';
 @select-tree-prefix-cls: ~'@{ant-prefix}-select-tree';
 @tree-motion: ~'@{ant-prefix}-motion-collapse';
+@tree-node-padding: @padding-xs / 2;
 
 .antTreeSwitcherIcon(@type: 'tree-default-open-icon') {
   .@{tree-prefix-cls}-switcher-icon,
@@ -60,7 +61,7 @@
   .@{custom-tree-node-prefix-cls} {
     display: flex;
     align-items: flex-start;
-    padding: 0 0 (@padding-xs / 2) 0;
+    padding: 0 0 @tree-node-padding 0;
     outline: none;
     // Disabled
     &-disabled {
@@ -98,7 +99,8 @@
     flex: none;
 
     width: @tree-title-height;
-    height: @tree-title-height;
+    align-self: stretch;
+    position: relative;
     margin: 0;
     line-height: @tree-title-height;
     text-align: center;
@@ -120,27 +122,28 @@
       color: @primary-color;
     }
 
-    // &-leaf-line {
-    //   z-index: 1;
-    //   display: inline-block;
-    //   width: 100%;
-    //   height: 100%;
-    //   &::before {
-    //     position: absolute;
-    //     height: @tree-title-height;
-    //     margin-left: -1px;
-    //     border-left: 1px solid @normal-color;
-    //     content: ' ';
-    //   }
-    //   &::after {
-    //     position: absolute;
-    //     width: @tree-title-height - 14px;
-    //     height: @tree-title-height - 10px;
-    //     margin-left: -1px;
-    //     border-bottom: 1px solid @normal-color;
-    //     content: ' ';
-    //   }
-    // }
+    &-leaf-line {
+      z-index: 1;
+      display: inline-block;
+      width: 100%;
+      height: 100%;
+      &::before {
+        position: absolute;
+        top: 0;
+        bottom: -@tree-node-padding;
+        margin-left: -1px;
+        border-left: 1px solid @normal-color;
+        content: ' ';
+      }
+      &::after {
+        position: absolute;
+        width: @tree-title-height - 14px;
+        height: @tree-title-height - 10px;
+        margin-left: -1px;
+        border-bottom: 1px solid @normal-color;
+        content: ' ';
+      }
+    }
   }
 
   // >>> Checkbox
@@ -221,7 +224,7 @@
           position: absolute;
           content: '';
           top: 0;
-          bottom: -@padding-xs / 2;
+          bottom: -@tree-node-padding;
           right: @tree-title-height / 2;
           border-right: 1px solid @border-color-base;
         }
@@ -231,41 +234,8 @@
             display: none;
           }
         }
-
-        // &:first-child::after {
-        //   position: absolute;
-        //   top: calc(100% - @tree-title-height - 4px);
-        //   right: @tree-title-height / 2;
-        //   bottom: -4px;
-        //   border-right: 1px solid @border-color-base;
-        //   content: '';
-        // }
-
-        // &::before {
-        //   position: absolute;
-        //   top: calc(100% - 4px);
-        //   right: -@tree-title-height / 2;
-        //   bottom: -@tree-title-height - 4px;
-        //   border-right: 1px solid @border-color-base;
-        //   content: '';
-        // }
-
-        // &-end::before,
-        // &-end-first-level::after {
-        //   display: none;
-        // }
       }
     }
-
-    /* Motion should hide line of measure */
-    // .@{custom-tree-node-prefix-cls}-motion:not(.@{tree-motion}-leave):not(.@{tree-motion}-appear-active) {
-    //   .@{custom-tree-prefix-cls}-indent-unit {
-    //     &::after,
-    //     &::before {
-    //       display: none;
-    //     }
-    //   }
-    // }
 
     // ============== Cover Background ==============
     .@{custom-tree-prefix-cls}-switcher {
@@ -277,10 +247,12 @@
 
 .@{tree-node-prefix-cls}-leaf-last {
   .@{tree-prefix-cls}-switcher {
-    // &-leaf-line {
-    //   &::before {
-    //     height: @tree-title-height - 10px !important;
-    //   }
-    // }
+    &-leaf-line {
+      &::before {
+        height: @tree-title-height - 10px !important;
+        top: auto !important;
+        bottom: auto !important;
+      }
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
     "rc-tabs": "~11.7.0",
     "rc-textarea": "~0.3.0",
     "rc-tooltip": "~5.0.0",
-    "rc-tree": "~3.10.0",
+    "rc-tree": "~3.11.0",
     "rc-tree-select": "~4.1.1",
     "rc-trigger": "~5.0.3",
     "rc-upload": "~3.3.1",


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

resolve #27364

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fix Tree with `showLine` not connect line when `title` break line.      |
| 🇨🇳 Chinese |    修复 Tree 配置 `showLine` 下 `title` 多行的时候，线会截断的问题。       |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/tree/demo/line.md](https://github.com/ant-design/ant-design/blob/fix-lines/components/tree/demo/line.md)