### PR TITLE
fix: Table onShowSizeChange trigger twice

### DIFF
--- a/components/table/__tests__/Table.pagination.test.js
+++ b/components/table/__tests__/Table.pagination.test.js
@@ -285,7 +285,7 @@ describe('Table.pagination', () => {
     expect(wrapper.find('.ant-table-tbody tr.ant-table-row')).toHaveLength(data.length);
   });
 
-  it('select by checkbox to trigger stopPropagation', () => {
+  it('onShowSizeChange should trigger once', () => {
     jest.useFakeTimers();
     const onShowSizeChange = jest.fn();
     const onChange = jest.fn();
@@ -304,7 +304,8 @@ describe('Table.pagination', () => {
     const dropdownWrapper = mount(wrapper.find('Trigger').instance().getComponent());
     expect(wrapper.find('.ant-select-item-option').length).toBe(4);
     dropdownWrapper.find('.ant-select-item-option').at(3).simulate('click');
-    expect(onShowSizeChange).toHaveBeenCalled();
+    expect(onShowSizeChange).toHaveBeenCalledTimes(1);
+    expect(onShowSizeChange).toHaveBeenLastCalledWith(1, 100);
     expect(onChange).toHaveBeenCalled();
     jest.useRealTimers();
   });

--- a/components/table/hooks/usePagination.ts
+++ b/components/table/hooks/usePagination.ts
@@ -89,7 +89,6 @@ export default function usePagination(
     const paginationPageSize = mergedPagination?.pageSize;
     if (pageSize && pageSize !== paginationPageSize) {
       current = 1;
-      if (pagination && pagination.onShowSizeChange) pagination.onShowSizeChange(current, pageSize);
     }
     if (pagination && pagination.onChange) pagination.onChange(current, pageSize);
 


### PR DESCRIPTION


<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close #26100
close #27392

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Table `onShowSizeChange` trigger twice. |
| 🇨🇳 Chinese | 修复 Table 切换页长时 `onShowSizeChange` 触发两次的问题。 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
