### PR TITLE
fix: Checkbox.Group forward child element ref

### DIFF
--- a/components/checkbox/Group.tsx
+++ b/components/checkbox/Group.tsx
@@ -38,119 +38,124 @@ export interface CheckboxGroupContext {
 
 export const GroupContext = React.createContext<CheckboxGroupContext | null>(null);
 
-const CheckboxGroup: React.FC<CheckboxGroupProps> = ({
-  defaultValue,
-  children,
-  options = [],
-  prefixCls: customizePrefixCls,
-  className,
-  style,
-  onChange,
-  ...restProps
-}) => {
-  const { getPrefixCls, direction } = React.useContext(ConfigContext);
-
-  const [value, setValue] = React.useState<CheckboxValueType[]>(
-    restProps.value || defaultValue || [],
-  );
-  const [registeredValues, setRegisteredValues] = React.useState<CheckboxValueType[]>([]);
-
-  React.useEffect(() => {
-    if ('value' in restProps) {
-      setValue(restProps.value || []);
-    }
-  }, [restProps.value]);
-
-  const getOptions = () => {
-    return options.map(option => {
-      if (typeof option === 'string') {
-        return {
-          label: option,
-          value: option,
-        };
-      }
-      return option;
-    });
-  };
-
-  const cancelValue = (val: string) => {
-    setRegisteredValues(prevValues => prevValues.filter(v => v !== val));
-  };
-
-  const registerValue = (val: string) => {
-    setRegisteredValues(prevValues => [...prevValues, val]);
-  };
-
-  const toggleOption = (option: CheckboxOptionType) => {
-    const optionIndex = value.indexOf(option.value);
-    const newValue = [...value];
-    if (optionIndex === -1) {
-      newValue.push(option.value);
-    } else {
-      newValue.splice(optionIndex, 1);
-    }
-    if (!('value' in restProps)) {
-      setValue(newValue);
-    }
-    if (onChange) {
-      const opts = getOptions();
-      onChange(
-        newValue
-          .filter(val => registeredValues.indexOf(val) !== -1)
-          .sort((a, b) => {
-            const indexA = opts.findIndex(opt => opt.value === a);
-            const indexB = opts.findIndex(opt => opt.value === b);
-            return indexA - indexB;
-          }),
-      );
-    }
-  };
-
-  const prefixCls = getPrefixCls('checkbox', customizePrefixCls);
-  const groupPrefixCls = `${prefixCls}-group`;
-
-  const domProps = omit(restProps, ['value', 'disabled']);
-
-  if (options && options.length > 0) {
-    children = getOptions().map(option => (
-      <Checkbox
-        prefixCls={prefixCls}
-        key={option.value.toString()}
-        disabled={'disabled' in option ? option.disabled : restProps.disabled}
-        value={option.value}
-        checked={value.indexOf(option.value) !== -1}
-        onChange={option.onChange}
-        className={`${groupPrefixCls}-item`}
-        style={option.style}
-      >
-        {option.label}
-      </Checkbox>
-    ));
-  }
-
-  const context = {
-    toggleOption,
-    value,
-    disabled: restProps.disabled,
-    name: restProps.name,
-
-    // https://github.com/ant-design/ant-design/issues/16376
-    registerValue,
-    cancelValue,
-  };
-
-  const classString = classNames(
-    groupPrefixCls,
+const CheckboxGroup = React.forwardRef<HTMLDivElement, CheckboxGroupProps>(
+  (
     {
-      [`${groupPrefixCls}-rtl`]: direction === 'rtl',
+      defaultValue,
+      children,
+      options = [],
+      prefixCls: customizePrefixCls,
+      className,
+      style,
+      onChange,
+      ...restProps
     },
-    className,
-  );
-  return (
-    <div className={classString} style={style} {...domProps}>
-      <GroupContext.Provider value={context}>{children}</GroupContext.Provider>
-    </div>
-  );
-};
+    ref,
+  ) => {
+    const { getPrefixCls, direction } = React.useContext(ConfigContext);
+
+    const [value, setValue] = React.useState<CheckboxValueType[]>(
+      restProps.value || defaultValue || [],
+    );
+    const [registeredValues, setRegisteredValues] = React.useState<CheckboxValueType[]>([]);
+
+    React.useEffect(() => {
+      if ('value' in restProps) {
+        setValue(restProps.value || []);
+      }
+    }, [restProps.value]);
+
+    const getOptions = () => {
+      return options.map(option => {
+        if (typeof option === 'string') {
+          return {
+            label: option,
+            value: option,
+          };
+        }
+        return option;
+      });
+    };
+
+    const cancelValue = (val: string) => {
+      setRegisteredValues(prevValues => prevValues.filter(v => v !== val));
+    };
+
+    const registerValue = (val: string) => {
+      setRegisteredValues(prevValues => [...prevValues, val]);
+    };
+
+    const toggleOption = (option: CheckboxOptionType) => {
+      const optionIndex = value.indexOf(option.value);
+      const newValue = [...value];
+      if (optionIndex === -1) {
+        newValue.push(option.value);
+      } else {
+        newValue.splice(optionIndex, 1);
+      }
+      if (!('value' in restProps)) {
+        setValue(newValue);
+      }
+      if (onChange) {
+        const opts = getOptions();
+        onChange(
+          newValue
+            .filter(val => registeredValues.indexOf(val) !== -1)
+            .sort((a, b) => {
+              const indexA = opts.findIndex(opt => opt.value === a);
+              const indexB = opts.findIndex(opt => opt.value === b);
+              return indexA - indexB;
+            }),
+        );
+      }
+    };
+
+    const prefixCls = getPrefixCls('checkbox', customizePrefixCls);
+    const groupPrefixCls = `${prefixCls}-group`;
+
+    const domProps = omit(restProps, ['value', 'disabled']);
+
+    if (options && options.length > 0) {
+      children = getOptions().map(option => (
+        <Checkbox
+          prefixCls={prefixCls}
+          key={option.value.toString()}
+          disabled={'disabled' in option ? option.disabled : restProps.disabled}
+          value={option.value}
+          checked={value.indexOf(option.value) !== -1}
+          onChange={option.onChange}
+          className={`${groupPrefixCls}-item`}
+          style={option.style}
+        >
+          {option.label}
+        </Checkbox>
+      ));
+    }
+
+    const context = {
+      toggleOption,
+      value,
+      disabled: restProps.disabled,
+      name: restProps.name,
+
+      // https://github.com/ant-design/ant-design/issues/16376
+      registerValue,
+      cancelValue,
+    };
+
+    const classString = classNames(
+      groupPrefixCls,
+      {
+        [`${groupPrefixCls}-rtl`]: direction === 'rtl',
+      },
+      className,
+    );
+    return (
+      <div className={classString} style={style} {...domProps} ref={ref}>
+        <GroupContext.Provider value={context}>{children}</GroupContext.Provider>
+      </div>
+    );
+  },
+);
 
 export default React.memo(CheckboxGroup);

--- a/components/checkbox/__tests__/group.test.js
+++ b/components/checkbox/__tests__/group.test.js
@@ -174,4 +174,19 @@ describe('CheckboxGroup', () => {
     wrapper.find('.ant-checkbox-input').at(0).simulate('change');
     expect(wrapper.find('.ant-checkbox-checked').length).toBe(0);
   });
+
+  it('should forward ref', () => {
+    let checkboxGroupRef;
+    const wrapper = mount(
+      <Checkbox.Group
+        ref={ref => {
+          checkboxGroupRef = ref;
+        }}
+      >
+        <Checkbox key={1} value={1} />
+      </Checkbox.Group>,
+    );
+
+    expect(checkboxGroupRef).toBe(wrapper.children().getDOMNode());
+  });
 });


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

新特性请提交至 feature 分支，其余可提交至 master 分支。
在维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

[[English Template / 英文模板](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE.md)]

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
1. 修复在 legacy Form 中，使用 `Checkbox.Group` 的表单项丢失数据的问题
2. 因为 legacy Form 需要表单项控件提供 `ref`，这里改为转发子元素的 `ref`

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | Fix Checkbox.Group not working properly, when is used in legacy Form. |
| 🇨🇳 中文 | 修复 Checkbox.Group 在 legacy Form 中，不能正常工作的问题 |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
