### PR TITLE
fix: filters in column.children should render

### DIFF
--- a/components/table/__tests__/Table.filter.test.js
+++ b/components/table/__tests__/Table.filter.test.js
@@ -1262,6 +1262,7 @@ describe('Table.filter', () => {
     onChange.mockReset();
     wrapper.unmount();
   });
+
   it('filters in children should render', () => {
     const columns = [
       {

--- a/components/table/__tests__/Table.filter.test.js
+++ b/components/table/__tests__/Table.filter.test.js
@@ -1262,4 +1262,62 @@ describe('Table.filter', () => {
     onChange.mockReset();
     wrapper.unmount();
   });
+  it('filters in children should render', () => {
+    const columns = [
+      {
+        title: 'English Score',
+        dataIndex: 'english',
+        filters: [{ text: '1', value: 1 }],
+        onFilter: record => String(record.english1).includes(String(1)),
+        children: [
+          {
+            title: 'English Score1',
+            dataIndex: 'english1',
+            filters: [{ text: '2', value: 2 }],
+            onFilter: record => String(record.english2).includes(String(2)),
+          },
+          {
+            title: 'English Score2',
+            dataIndex: 'english2',
+            filters: [{ text: '2', value: 3 }],
+            onFilter: record => String(record.english2).includes(String(3)),
+          },
+        ],
+      },
+    ];
+    const dataSource = [
+      {
+        key: '1',
+        english: 71,
+        english1: 71,
+        english2: 72,
+      },
+      {
+        key: '2',
+        english: 89,
+        english1: 72,
+        english2: 72,
+      },
+      {
+        key: '3',
+        english: 70,
+        english1: 71,
+        english2: 73,
+      },
+      {
+        key: '4',
+        english: 89,
+        english1: 71,
+        english2: 72,
+      },
+    ];
+    const wrapper = mount(
+      createTable({
+        columns,
+        dataSource,
+      }),
+    );
+
+    expect(wrapper.find('.ant-table-filter-column')).toHaveLength(3);
+  });
 });

--- a/components/table/__tests__/__snapshots__/Table.rowSelection.test.js.snap
+++ b/components/table/__tests__/__snapshots__/Table.rowSelection.test.js.snap
@@ -76,7 +76,7 @@ exports[`Table.rowSelection fix expand on th left when selection column fixed on
                 <tr
                   aria-hidden="true"
                   class="ant-table-measure-row"
-                  style="height:0"
+                  style="height:0;font-size:0"
                 >
                   <td
                     style="padding:0;border:0;height:0"
@@ -427,7 +427,7 @@ exports[`Table.rowSelection fix selection column on the left 1`] = `
                 <tr
                   aria-hidden="true"
                   class="ant-table-measure-row"
-                  style="height:0"
+                  style="height:0;font-size:0"
                 >
                   <td
                     style="padding:0;border:0;height:0"
@@ -730,7 +730,7 @@ exports[`Table.rowSelection fix selection column on the left when any other colu
                 <tr
                   aria-hidden="true"
                   class="ant-table-measure-row"
-                  style="height:0"
+                  style="height:0;font-size:0"
                 >
                   <td
                     style="padding:0;border:0;height:0"

--- a/components/table/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/table/__tests__/__snapshots__/demo.test.js.snap
@@ -5697,7 +5697,7 @@ exports[`renders ./components/table/demo/fixed-columns.md correctly 1`] = `
                 <tr
                   aria-hidden="true"
                   class="ant-table-measure-row"
-                  style="height:0"
+                  style="height:0;font-size:0"
                 >
                   <td
                     style="padding:0;border:0;height:0"
@@ -6157,7 +6157,7 @@ exports[`renders ./components/table/demo/fixed-columns-header.md correctly 1`] =
                 <tr
                   aria-hidden="true"
                   class="ant-table-measure-row"
-                  style="height:0"
+                  style="height:0;font-size:0"
                 >
                   <td
                     style="padding:0;border:0;height:0"
@@ -7227,7 +7227,7 @@ exports[`renders ./components/table/demo/fixed-header.md correctly 1`] = `
                 <tr
                   aria-hidden="true"
                   class="ant-table-measure-row"
-                  style="height:0"
+                  style="height:0;font-size:0"
                 >
                   <td
                     style="padding:0;border:0;height:0"
@@ -8667,7 +8667,7 @@ exports[`renders ./components/table/demo/grouping-columns.md correctly 1`] = `
                 <tr
                   aria-hidden="true"
                   class="ant-table-measure-row"
-                  style="height:0"
+                  style="height:0;font-size:0"
                 >
                   <td
                     style="padding:0;border:0;height:0"
@@ -15555,7 +15555,7 @@ exports[`renders ./components/table/demo/sticky.md correctly 1`] = `
                 <tr
                   aria-hidden="true"
                   class="ant-table-measure-row"
-                  style="height:0"
+                  style="height:0;font-size:0"
                 >
                   <td
                     style="padding:0;border:0;height:0"
@@ -16790,7 +16790,7 @@ Array [
                   <tr
                     aria-hidden="true"
                     class="ant-table-measure-row"
-                    style="height:0"
+                    style="height:0;font-size:0"
                   >
                     <td
                       style="padding:0;border:0;height:0"

--- a/components/table/__tests__/__snapshots__/empty.test.js.snap
+++ b/components/table/__tests__/__snapshots__/empty.test.js.snap
@@ -341,7 +341,7 @@ exports[`Table renders empty table with fixed columns 1`] = `
                 <tr
                   aria-hidden="true"
                   class="ant-table-measure-row"
-                  style="height:0"
+                  style="height:0;font-size:0"
                 >
                   <td
                     style="padding:0;border:0;height:0"

--- a/components/table/hooks/useFilter/index.tsx
+++ b/components/table/hooks/useFilter/index.tsx
@@ -69,18 +69,20 @@ function injectFilter<RecordType>(
   return columns.map((column, index) => {
     const columnPos = getColumnPos(index, pos);
     const { filterMultiple = true } = column as ColumnType<RecordType>;
+    
+    let newColumn: ColumnsType<RecordType>[number] = column;
 
-    if (column.filters || column.filterDropdown) {
-      const columnKey = getColumnKey(column, columnPos);
+    if (newColumn.filters || newColumn.filterDropdown) {
+      const columnKey = getColumnKey(newColumn, columnPos);
       const filterState = filterStates.find(({ key }) => columnKey === key);
 
-      return {
-        ...column,
+      newColumn = {
+        ...newColumn,
         title: (renderProps: ColumnTitleProps<RecordType>) => (
           <FilterDropdown
             prefixCls={`${prefixCls}-filter`}
             dropdownPrefixCls={dropdownPrefixCls}
-            column={column}
+            column={newColumn}
             columnKey={columnKey}
             filterState={filterState}
             filterMultiple={filterMultiple}
@@ -94,13 +96,13 @@ function injectFilter<RecordType>(
       };
     }
 
-    if ('children' in column) {
-      return {
-        ...column,
+    if ('children' in newColumn) {
+      newColumn = {
+        ...newColumn,
         children: injectFilter(
           prefixCls,
           dropdownPrefixCls,
-          column.children,
+          newColumn.children,
           filterStates,
           triggerFilter,
           getPopupContainer,
@@ -110,7 +112,7 @@ function injectFilter<RecordType>(
       };
     }
 
-    return column;
+    return newColumn;
   });
 }
 


### PR DESCRIPTION
when a column has filter and it's children also have filters, all these filters in children can not render. this problem can not be found when use sorter.

<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fix Table filters didn't display in `column.children`.          |
| 🇨🇳 Chinese | 修复 Table `column.children` 内的筛选功能不展示的问题。 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
