### PR TITLE
fix: RangePicker border style when has same data

### DIFF
--- a/components/date-picker/style/panel.less
+++ b/components/date-picker/style/panel.less
@@ -239,6 +239,8 @@
     &-in-view&-range-hover-start:not(&-in-range):not(&-range-start):not(&-range-end),
     &-in-view&-range-hover-end:not(&-in-range):not(&-range-start):not(&-range-end),
     &-in-view&-range-hover-start&-range-start-single,
+    &-in-view&-range-hover-start&-range-start&-range-end&-range-end-near-hover,
+    &-in-view&-range-hover-end&-range-start&-range-end&-range-start-near-hover,
     &-in-view&-range-hover-end&-range-end-single,
     &-in-view&-range-hover:not(&-in-range) {
       &::after {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
fix https://github.com/ant-design/ant-design/issues/27425
<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the problem that the border style of RangePicker is abnormal when selecting again after selecting the same time.           |
| 🇨🇳 Chinese | 修复 RangePicker 选择同一时间后再次选择时边框样式异常的问题。           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
