### PR TITLE
fix(pageHeader): if title is null,no render title view

### DIFF
--- a/components/page-header/__tests__/index.test.js
+++ b/components/page-header/__tests__/index.test.js
@@ -50,6 +50,18 @@ describe('PageHeader', () => {
     expect(wrapper.find('.ant-page-header-back')).toHaveLength(0);
   });
 
+  it('pageHeader do not has title', () => {
+    const routes = [
+      {
+        path: 'index',
+        breadcrumbName: 'First-level Menu',
+      },
+    ];
+    const wrapper = mount(<PageHeader breadcrumb={{ routes }}>test</PageHeader>);
+    expect(wrapper.find('.ant-page-header-heading-lef').exists()).toBeFalsy();
+    expect(wrapper.find('.ant-page-header-heading').exists()).toBeFalsy();
+  });
+
   it('pageHeader should no contain back', () => {
     const wrapper = mount(<PageHeader title="Page Title" backIcon={false} />);
     expect(wrapper.find('.ant-page-header-back')).toHaveLength(0);

--- a/components/page-header/index.tsx
+++ b/components/page-header/index.tsx
@@ -69,13 +69,14 @@ const getBackIcon = (props: PageHeaderProps, direction: string = 'ltr') => {
 const renderTitle = (prefixCls: string, props: PageHeaderProps, direction: string = 'ltr') => {
   const { title, avatar, subTitle, tags, extra, onBack } = props;
   const headingPrefixCls = `${prefixCls}-heading`;
-  // 如果 什么都没有，直接返回一个 空
-  if (!title && !subTitle && !tags && !extra) {
+  const hasHeading = title || subTitle || tags || extra;
+  // 如果 什么都没有，直接返回一个 null
+  if (!hasHeading) {
     return null;
   }
   const backIcon = getBackIcon(props, direction);
   const backIconDom = renderBack(prefixCls, backIcon, onBack);
-  const hasTitle = backIconDom || avatar || title || subTitle || tags || extra;
+  const hasTitle = backIconDom || avatar || hasHeading;
   return (
     <div className={headingPrefixCls}>
       {hasTitle && (

--- a/components/page-header/index.tsx
+++ b/components/page-header/index.tsx
@@ -72,31 +72,36 @@ const renderTitle = (prefixCls: string, props: PageHeaderProps, direction: strin
   if (title || subTitle || tags || extra) {
     const backIcon = getBackIcon(props, direction);
     const backIconDom = renderBack(prefixCls, backIcon, onBack);
+    const hasTitle = backIconDom || avatar || title || subTitle || tags || extra;
     return (
-      <div className={headingPrefixCls}>
-        <div className={`${headingPrefixCls}-left`}>
-          {backIconDom}
-          {avatar && <Avatar {...avatar} />}
-          {title && (
-            <span
-              className={`${headingPrefixCls}-title`}
-              title={typeof title === 'string' ? title : undefined}
-            >
-              {title}
-            </span>
+      hasTitle && (
+        <div className={headingPrefixCls}>
+          {hasTitle && (
+            <div className={`${headingPrefixCls}-left`}>
+              {backIconDom}
+              {avatar && <Avatar {...avatar} />}
+              {title && (
+                <span
+                  className={`${headingPrefixCls}-title`}
+                  title={typeof title === 'string' ? title : undefined}
+                >
+                  {title}
+                </span>
+              )}
+              {subTitle && (
+                <span
+                  className={`${headingPrefixCls}-sub-title`}
+                  title={typeof subTitle === 'string' ? subTitle : undefined}
+                >
+                  {subTitle}
+                </span>
+              )}
+              {tags && <span className={`${headingPrefixCls}-tags`}>{tags}</span>}
+            </div>
           )}
-          {subTitle && (
-            <span
-              className={`${headingPrefixCls}-sub-title`}
-              title={typeof subTitle === 'string' ? subTitle : undefined}
-            >
-              {subTitle}
-            </span>
-          )}
-          {tags && <span className={`${headingPrefixCls}-tags`}>{tags}</span>}
+          {extra && <span className={`${headingPrefixCls}-extra`}>{extra}</span>}
         </div>
-        {extra && <span className={`${headingPrefixCls}-extra`}>{extra}</span>}
-      </div>
+      )
     );
   }
   return null;

--- a/components/page-header/index.tsx
+++ b/components/page-header/index.tsx
@@ -69,42 +69,41 @@ const getBackIcon = (props: PageHeaderProps, direction: string = 'ltr') => {
 const renderTitle = (prefixCls: string, props: PageHeaderProps, direction: string = 'ltr') => {
   const { title, avatar, subTitle, tags, extra, onBack } = props;
   const headingPrefixCls = `${prefixCls}-heading`;
-  if (title || subTitle || tags || extra) {
-    const backIcon = getBackIcon(props, direction);
-    const backIconDom = renderBack(prefixCls, backIcon, onBack);
-    const hasTitle = backIconDom || avatar || title || subTitle || tags || extra;
-    return (
-      hasTitle && (
-        <div className={headingPrefixCls}>
-          {hasTitle && (
-            <div className={`${headingPrefixCls}-left`}>
-              {backIconDom}
-              {avatar && <Avatar {...avatar} />}
-              {title && (
-                <span
-                  className={`${headingPrefixCls}-title`}
-                  title={typeof title === 'string' ? title : undefined}
-                >
-                  {title}
-                </span>
-              )}
-              {subTitle && (
-                <span
-                  className={`${headingPrefixCls}-sub-title`}
-                  title={typeof subTitle === 'string' ? subTitle : undefined}
-                >
-                  {subTitle}
-                </span>
-              )}
-              {tags && <span className={`${headingPrefixCls}-tags`}>{tags}</span>}
-            </div>
-          )}
-          {extra && <span className={`${headingPrefixCls}-extra`}>{extra}</span>}
-        </div>
-      )
-    );
+  // 如果 什么都没有，直接返回一个 空
+  if (!title && !subTitle && !tags && !extra) {
+    return null;
   }
-  return null;
+  const backIcon = getBackIcon(props, direction);
+  const backIconDom = renderBack(prefixCls, backIcon, onBack);
+  const hasTitle = backIconDom || avatar || title || subTitle || tags || extra;
+  return (
+    <div className={headingPrefixCls}>
+      {hasTitle && (
+        <div className={`${headingPrefixCls}-left`}>
+          {backIconDom}
+          {avatar && <Avatar {...avatar} />}
+          {title && (
+            <span
+              className={`${headingPrefixCls}-title`}
+              title={typeof title === 'string' ? title : undefined}
+            >
+              {title}
+            </span>
+          )}
+          {subTitle && (
+            <span
+              className={`${headingPrefixCls}-sub-title`}
+              title={typeof subTitle === 'string' ? subTitle : undefined}
+            >
+              {subTitle}
+            </span>
+          )}
+          {tags && <span className={`${headingPrefixCls}-tags`}>{tags}</span>}
+        </div>
+      )}
+      {extra && <span className={`${headingPrefixCls}-extra`}>{extra}</span>}
+    </div>
+  );
 };
 
 const renderFooter = (prefixCls: string, footer: React.ReactNode) => {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

新特性请提交至 feature 分支，其余可提交至 master 分支。
在维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

[[English Template / 英文模板](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE.md)]

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

close https://github.com/ant-design/pro-components/issues/552

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |  Fix the problem that empty dom will be displayed when title is empty   |
| 🇨🇳 中文 |   修复 title 为空时，会展示空 dom 的问题      |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
