### PR TITLE
feat: deprecate geekblue color in favor of deepblue

### DIFF
--- a/components/_util/colors.ts
+++ b/components/_util/colors.ts
@@ -11,7 +11,7 @@ export const PresetColorTypes = tuple(
   'green',
   'blue',
   'purple',
-  'geekblue',
+  'deepblue',
   'magenta',
   'volcano',
   'gold',

--- a/components/badge/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/badge/__tests__/__snapshots__/demo.test.js.snap
@@ -614,12 +614,12 @@ Array [
         class="ant-badge ant-badge-status ant-badge-not-a-wrapper"
       >
         <span
-          class="ant-badge-status-dot ant-badge-status-geekblue"
+          class="ant-badge-status-dot ant-badge-status-deepblue"
         />
         <span
           class="ant-badge-status-text"
         >
-          geekblue
+          deepblue
         </span>
       </span>
     </div>

--- a/components/badge/demo/colorful.md
+++ b/components/badge/demo/colorful.md
@@ -25,7 +25,7 @@ const colors = [
   'green',
   'blue',
   'purple',
-  'geekblue',
+  'deepblue',
   'magenta',
   'volcano',
   'gold',

--- a/components/style/color/colors.less
+++ b/components/style/color/colors.less
@@ -122,17 +122,17 @@
 @volcano-9: color(~`colorPalette('@{volcano-6}', 9) `);
 @volcano-10: color(~`colorPalette('@{volcano-6}', 10) `);
 
-@geekblue-base: #2f54eb;
-@geekblue-1: color(~`colorPalette('@{geekblue-6}', 1) `);
-@geekblue-2: color(~`colorPalette('@{geekblue-6}', 2) `);
-@geekblue-3: color(~`colorPalette('@{geekblue-6}', 3) `);
-@geekblue-4: color(~`colorPalette('@{geekblue-6}', 4) `);
-@geekblue-5: color(~`colorPalette('@{geekblue-6}', 5) `);
-@geekblue-6: @geekblue-base;
-@geekblue-7: color(~`colorPalette('@{geekblue-6}', 7) `);
-@geekblue-8: color(~`colorPalette('@{geekblue-6}', 8) `);
-@geekblue-9: color(~`colorPalette('@{geekblue-6}', 9) `);
-@geekblue-10: color(~`colorPalette('@{geekblue-6}', 10) `);
+@deepblue-base: #2f54eb;
+@deepblue-1: color(~`colorPalette('@{deepblue-6}', 1) `);
+@deepblue-2: color(~`colorPalette('@{deepblue-6}', 2) `);
+@deepblue-3: color(~`colorPalette('@{deepblue-6}', 3) `);
+@deepblue-4: color(~`colorPalette('@{deepblue-6}', 4) `);
+@deepblue-5: color(~`colorPalette('@{deepblue-6}', 5) `);
+@deepblue-6: @deepblue-base;
+@deepblue-7: color(~`colorPalette('@{deepblue-6}', 7) `);
+@deepblue-8: color(~`colorPalette('@{deepblue-6}', 8) `);
+@deepblue-9: color(~`colorPalette('@{deepblue-6}', 9) `);
+@deepblue-10: color(~`colorPalette('@{deepblue-6}', 10) `);
 
 @lime-base: #a0d911;
 @lime-1: color(~`colorPalette('@{lime-6}', 1) `);
@@ -158,5 +158,5 @@
 @gold-9: color(~`colorPalette('@{gold-6}', 9) `);
 @gold-10: color(~`colorPalette('@{gold-6}', 10) `);
 
-@preset-colors: pink, magenta, red, volcano, orange, yellow, gold, cyan, lime, green, blue, geekblue,
+@preset-colors: pink, magenta, red, volcano, orange, yellow, gold, cyan, lime, green, blue, deepblue,
   purple;

--- a/components/style/themes/dark.less
+++ b/components/style/themes/dark.less
@@ -112,16 +112,16 @@
 @volcano-9: mix(color(~`colorPalette('@{volcano-base}', 3) `), @component-background, 97%);
 @volcano-10: mix(color(~`colorPalette('@{volcano-base}', 2) `), @component-background, 98%);
 
-@geekblue-1: mix(color(~`colorPalette('@{geekblue-base}', 8) `), @component-background, 15%);
-@geekblue-2: mix(color(~`colorPalette('@{geekblue-base}', 7) `), @component-background, 25%);
-@geekblue-3: mix(@geekblue-base, @component-background, 30%);
-@geekblue-4: mix(@geekblue-base, @component-background, 45%);
-@geekblue-5: mix(@geekblue-base, @component-background, 65%);
-@geekblue-6: mix(@geekblue-base, @component-background, 85%);
-@geekblue-7: mix(color(~`colorPalette('@{geekblue-base}', 5) `), @component-background, 90%);
-@geekblue-8: mix(color(~`colorPalette('@{geekblue-base}', 4) `), @component-background, 95%);
-@geekblue-9: mix(color(~`colorPalette('@{geekblue-base}', 3) `), @component-background, 97%);
-@geekblue-10: mix(color(~`colorPalette('@{geekblue-base}', 2) `), @component-background, 98%);
+@deepblue-1: mix(color(~`colorPalette('@{deepblue-base}', 8) `), @component-background, 15%);
+@deepblue-2: mix(color(~`colorPalette('@{deepblue-base}', 7) `), @component-background, 25%);
+@deepblue-3: mix(@deepblue-base, @component-background, 30%);
+@deepblue-4: mix(@deepblue-base, @component-background, 45%);
+@deepblue-5: mix(@deepblue-base, @component-background, 65%);
+@deepblue-6: mix(@deepblue-base, @component-background, 85%);
+@deepblue-7: mix(color(~`colorPalette('@{deepblue-base}', 5) `), @component-background, 90%);
+@deepblue-8: mix(color(~`colorPalette('@{deepblue-base}', 4) `), @component-background, 95%);
+@deepblue-9: mix(color(~`colorPalette('@{deepblue-base}', 3) `), @component-background, 97%);
+@deepblue-10: mix(color(~`colorPalette('@{deepblue-base}', 2) `), @component-background, 98%);
 
 @lime-1: mix(color(~`colorPalette('@{lime-base}', 8) `), @component-background, 15%);
 @lime-2: mix(color(~`colorPalette('@{lime-base}', 7) `), @component-background, 25%);

--- a/components/table/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/table/__tests__/__snapshots__/demo.test.js.snap
@@ -302,7 +302,7 @@ exports[`renders ./components/table/demo/basic.md correctly 1`] = `
                       NICE
                     </span>
                     <span
-                      class="ant-tag ant-tag-geekblue"
+                      class="ant-tag ant-tag-deepblue"
                     >
                       DEVELOPER
                     </span>
@@ -415,7 +415,7 @@ exports[`renders ./components/table/demo/basic.md correctly 1`] = `
                       COOL
                     </span>
                     <span
-                      class="ant-tag ant-tag-geekblue"
+                      class="ant-tag ant-tag-deepblue"
                     >
                       TEACHER
                     </span>
@@ -11746,7 +11746,7 @@ exports[`renders ./components/table/demo/pagination.md correctly 1`] = `
                           NICE
                         </span>
                         <span
-                          class="ant-tag ant-tag-geekblue"
+                          class="ant-tag ant-tag-deepblue"
                         >
                           DEVELOPER
                         </span>
@@ -11863,7 +11863,7 @@ exports[`renders ./components/table/demo/pagination.md correctly 1`] = `
                           COOL
                         </span>
                         <span
-                          class="ant-tag ant-tag-geekblue"
+                          class="ant-tag ant-tag-deepblue"
                         >
                           TEACHER
                         </span>

--- a/components/table/demo/basic.md
+++ b/components/table/demo/basic.md
@@ -40,7 +40,7 @@ const columns = [
     render: tags => (
       <>
         {tags.map(tag => {
-          let color = tag.length > 5 ? 'geekblue' : 'green';
+          let color = tag.length > 5 ? 'deepblue' : 'green';
           if (tag === 'loser') {
             color = 'volcano';
           }

--- a/components/table/demo/pagination.md
+++ b/components/table/demo/pagination.md
@@ -54,7 +54,7 @@ const columns = [
     render: tags => (
       <span>
         {tags.map(tag => {
-          let color = tag.length > 5 ? 'geekblue' : 'green';
+          let color = tag.length > 5 ? 'deepblue' : 'green';
           if (tag === 'loser') {
             color = 'volcano';
           }

--- a/components/tag/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/tag/__tests__/__snapshots__/demo.test.js.snap
@@ -290,9 +290,9 @@ Array [
       blue
     </span>
     <span
-      class="ant-tag ant-tag-geekblue"
+      class="ant-tag ant-tag-deepblue"
     >
-      geekblue
+      deepblue
     </span>
     <span
       class="ant-tag ant-tag-purple"

--- a/components/tag/demo/colorful.md
+++ b/components/tag/demo/colorful.md
@@ -29,7 +29,7 @@ ReactDOM.render(
       <Tag color="green">green</Tag>
       <Tag color="cyan">cyan</Tag>
       <Tag color="blue">blue</Tag>
-      <Tag color="geekblue">geekblue</Tag>
+      <Tag color="deepblue">deepblue</Tag>
       <Tag color="purple">purple</Tag>
     </div>
     <Divider orientation="left">Custom</Divider>

--- a/components/tooltip/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/tooltip/__tests__/__snapshots__/demo.test.js.snap
@@ -133,7 +133,7 @@ Array [
       type="button"
     >
       <span>
-        geekblue
+        deepblue
       </span>
     </button>
     <button

--- a/components/tooltip/demo/colorful.md
+++ b/components/tooltip/demo/colorful.md
@@ -25,7 +25,7 @@ const colors = [
   'green',
   'blue',
   'purple',
-  'geekblue',
+  'deepblue',
   'magenta',
   'volcano',
   'gold',

--- a/docs/spec/illustration.en-US.md
+++ b/docs/spec/illustration.en-US.md
@@ -45,7 +45,7 @@ Sea Hare's color matching system is inspired by Ant Design's application of colo
 
 <img class="preview-img no-padding" align="right" src="https://gw.alipayobjects.com/mdn/rms_08e378/afts/img/A*0Dv9Rrp7GtMAAAAAAAAAAAAAARQnAQ" />
 
-Through research, we discovered blue and white accounts for a large proportion among enterprise products. We chose Geek Blue as our primary color for its technological, exploration and focused vibes.
+Through research, we discovered blue and white accounts for a large proportion among enterprise products. We chose Deep Blue as our primary color for its technological, exploration and focused vibes.
 
 <br />
 

--- a/site/theme/static/colors.less
+++ b/site/theme/static/colors.less
@@ -99,7 +99,7 @@
   .make-palette(gold);
   .make-palette(yellow);
   .make-palette(lime);
-  .make-palette(geekblue);
+  .make-palette(deepblue);
   .make-palette(gray);
 
   .palette-gray-11 {

--- a/site/theme/template/Color/ColorPalettes.jsx
+++ b/site/theme/template/Color/ColorPalettes.jsx
@@ -61,9 +61,9 @@ const ColorPalettes = props => {
       description: '包容、科技、普惠',
     },
     {
-      name: 'geekblue',
-      english: 'Geek Blue',
-      chinese: '极客蓝',
+      name: 'deepblue',
+      english: 'Deep Blue',
+      chinese: '深蓝',
       description: '探索、钻研',
     },
     {


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [x] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

* Deprecate color name `geekblue` in favor of `deepblue`

### 💡 Background and solution

* Geek is a derogatory word and is not a color description. Deep blue is descriptive and does not carry a derogatory meaning.  

### 📝 Changelog

* Remove `geekblue` color and replace it with `deepblue` in the color samples 

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Replace color `geekblue` with `deepblue` |
| 🇨🇳 Chinese | 用深蓝色代替极客蓝色 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/badge/demo/colorful.md](https://github.com/Kyle01/ant-design/blob/deprecate-geekblue-for-deepblue/components/badge/demo/colorful.md)
[View rendered components/table/demo/basic.md](https://github.com/Kyle01/ant-design/blob/deprecate-geekblue-for-deepblue/components/table/demo/basic.md)
[View rendered components/table/demo/pagination.md](https://github.com/Kyle01/ant-design/blob/deprecate-geekblue-for-deepblue/components/table/demo/pagination.md)
[View rendered components/tag/demo/colorful.md](https://github.com/Kyle01/ant-design/blob/deprecate-geekblue-for-deepblue/components/tag/demo/colorful.md)
[View rendered components/tooltip/demo/colorful.md](https://github.com/Kyle01/ant-design/blob/deprecate-geekblue-for-deepblue/components/tooltip/demo/colorful.md)
[View rendered docs/spec/illustration.en-US.md](https://github.com/Kyle01/ant-design/blob/deprecate-geekblue-for-deepblue/docs/spec/illustration.en-US.md)