### PR TITLE
fix: vertical Tabs long active title style

### DIFF
--- a/components/tabs/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/tabs/__tests__/__snapshots__/demo.test.js.snap
@@ -2597,84 +2597,105 @@ exports[`renders ./components/tabs/demo/nest.md correctly 1`] = `
 `;
 
 exports[`renders ./components/tabs/demo/position.md correctly 1`] = `
-<div>
+Array [
   <div
     class="ant-space ant-space-horizontal ant-space-align-center"
-    style="margin-bottom:16px"
+    style="margin-bottom:24px"
   >
     <div
       class="ant-space-item"
       style="margin-right:8px"
     >
-      Tab position：
+      Tab position:
     </div>
     <div
       class="ant-space-item"
     >
       <div
-        class="ant-select ant-select-single ant-select-show-arrow"
+        class="ant-radio-group ant-radio-group-outline"
       >
-        <div
-          class="ant-select-selector"
+        <label
+          class="ant-radio-button-wrapper"
         >
           <span
-            class="ant-select-selection-search"
+            class="ant-radio-button"
           >
             <input
-              aria-activedescendant="undefined_list_0"
-              aria-autocomplete="list"
-              aria-controls="undefined_list"
-              aria-haspopup="listbox"
-              aria-owns="undefined_list"
-              autocomplete="off"
-              class="ant-select-selection-search-input"
-              readonly=""
-              role="combobox"
-              style="opacity:0"
-              type="search"
-              unselectable="on"
-              value=""
+              class="ant-radio-button-input"
+              type="radio"
+              value="top"
+            />
+            <span
+              class="ant-radio-button-inner"
             />
           </span>
-          <span
-            class="ant-select-selection-item"
-            title="top"
-          >
+          <span>
             top
           </span>
-        </div>
-        <span
-          aria-hidden="true"
-          class="ant-select-arrow"
-          style="user-select:none;-webkit-user-select:none"
-          unselectable="on"
+        </label>
+        <label
+          class="ant-radio-button-wrapper"
         >
           <span
-            aria-label="down"
-            class="anticon anticon-down ant-select-suffix"
-            role="img"
+            class="ant-radio-button"
           >
-            <svg
-              aria-hidden="true"
-              class=""
-              data-icon="down"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
-              />
-            </svg>
+            <input
+              class="ant-radio-button-input"
+              type="radio"
+              value="bottom"
+            />
+            <span
+              class="ant-radio-button-inner"
+            />
           </span>
-        </span>
+          <span>
+            bottom
+          </span>
+        </label>
+        <label
+          class="ant-radio-button-wrapper ant-radio-button-wrapper-checked"
+        >
+          <span
+            class="ant-radio-button ant-radio-button-checked"
+          >
+            <input
+              checked=""
+              class="ant-radio-button-input"
+              type="radio"
+              value="left"
+            />
+            <span
+              class="ant-radio-button-inner"
+            />
+          </span>
+          <span>
+            left
+          </span>
+        </label>
+        <label
+          class="ant-radio-button-wrapper"
+        >
+          <span
+            class="ant-radio-button"
+          >
+            <input
+              class="ant-radio-button-input"
+              type="radio"
+              value="right"
+            />
+            <span
+              class="ant-radio-button-inner"
+            />
+          </span>
+          <span>
+            right
+          </span>
+        </label>
       </div>
     </div>
-  </div>
+  </div>,
   <div
-    class="ant-tabs ant-tabs-top"
+    class="ant-tabs ant-tabs-left"
   >
     <div
       class="ant-tabs-nav"
@@ -2769,7 +2790,7 @@ exports[`renders ./components/tabs/demo/position.md correctly 1`] = `
       class="ant-tabs-content-holder"
     >
       <div
-        class="ant-tabs-content ant-tabs-content-top"
+        class="ant-tabs-content ant-tabs-content-left"
       >
         <div
           aria-hidden="false"
@@ -2795,8 +2816,8 @@ exports[`renders ./components/tabs/demo/position.md correctly 1`] = `
         />
       </div>
     </div>
-  </div>
-</div>
+  </div>,
+]
 `;
 
 exports[`renders ./components/tabs/demo/size.md correctly 1`] = `

--- a/components/tabs/demo/position.md
+++ b/components/tabs/demo/position.md
@@ -14,37 +14,33 @@ title:
 Tab's position: left, right, top or bottom. Will auto switch to `top` in mobile.
 
 ```jsx
-import { Tabs, Select, Space } from 'antd';
+import { Tabs, Radio, Space } from 'antd';
 
 const { TabPane } = Tabs;
-const { Option } = Select;
 
 class Demo extends React.Component {
   state = {
-    tabPosition: 'top',
+    tabPosition: 'left',
   };
 
-  changeTabPosition = tabPosition => {
-    this.setState({ tabPosition });
+  changeTabPosition = e => {
+    this.setState({ tabPosition: e.target.value });
   };
 
   render() {
+    const { tabPosition } = this.state;
     return (
-      <div>
-        <Space style={{ marginBottom: 16 }}>
-          Tab position：
-          <Select
-            value={this.state.tabPosition}
-            onChange={this.changeTabPosition}
-            dropdownMatchSelectWidth={false}
-          >
-            <Option value="top">top</Option>
-            <Option value="bottom">bottom</Option>
-            <Option value="left">left</Option>
-            <Option value="right">right</Option>
-          </Select>
+      <>
+        <Space style={{ marginBottom: 24 }}>
+          Tab position:
+          <Radio.Group value={tabPosition} onChange={this.changeTabPosition}>
+            <Radio.Button value="top">top</Radio.Button>
+            <Radio.Button value="bottom">bottom</Radio.Button>
+            <Radio.Button value="left">left</Radio.Button>
+            <Radio.Button value="right">right</Radio.Button>
+          </Radio.Group>
         </Space>
-        <Tabs tabPosition={this.state.tabPosition}>
+        <Tabs tabPosition={tabPosition}>
           <TabPane tab="Tab 1" key="1">
             Content of Tab 1
           </TabPane>
@@ -55,7 +51,7 @@ class Demo extends React.Component {
             Content of Tab 3
           </TabPane>
         </Tabs>
-      </div>
+      </>
     );
   }
 }

--- a/components/tabs/style/index.less
+++ b/components/tabs/style/index.less
@@ -150,6 +150,7 @@
 
     &-btn {
       outline: none;
+      transition: all 0.3s;
     }
 
     &-remove {

--- a/components/tabs/style/position.less
+++ b/components/tabs/style/position.less
@@ -106,6 +106,11 @@
         &:last-of-type {
           margin-bottom: 0;
         }
+
+        &-active .@{tab-prefix-cls}-tab-btn {
+          font-weight: normal;
+          text-shadow: 0 0 0.25px @tabs-active-color;
+        }
       }
 
       // >>>>>>>>>>> Nav


### PR DESCRIPTION


<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close #27557

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix vertical Tabs long title cause tab width changes. |
| 🇨🇳 Chinese | 修复垂直 Tabs 标题文字很长时导致页签宽度跳动的问题。  |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/tabs/demo/position.md](https://github.com/ant-design/ant-design/blob/fix-tabs-title/components/tabs/demo/position.md)