### PR TITLE
feat: add 'setSelectionRange' for the ref of Input and TextArea

### DIFF
--- a/components/input/Input.tsx
+++ b/components/input/Input.tsx
@@ -179,6 +179,10 @@ class Input extends React.Component<InputProps, InputState> {
     this.input.blur();
   }
 
+  setSelectionRange(start: number, end: number, direction?: 'forward' | 'backward' | 'none') {
+    this.input.setSelectionRange(start, end, direction);
+  }
+
   select() {
     this.input.select();
   }

--- a/components/input/TextArea.tsx
+++ b/components/input/TextArea.tsx
@@ -58,6 +58,10 @@ class TextArea extends React.Component<TextAreaProps, TextAreaState> {
     this.resizableTextArea.textArea.blur();
   }
 
+  setSelectionRange(start: number, end: number, direction?: 'forward' | 'backward' | 'none') {
+    this.resizableTextArea.textArea.setSelectionRange(start, end, direction);
+  }
+
   saveTextArea = (textarea: RcTextArea) => {
     this.resizableTextArea = textarea?.resizableTextArea;
   };

--- a/components/input/__tests__/index.test.js
+++ b/components/input/__tests__/index.test.js
@@ -74,6 +74,15 @@ describe('Input', () => {
       wrapper.unmount();
     });
   });
+
+  it('set mouse cursor position', () => {
+    const defaultValue = '11111';
+    const valLength = defaultValue.length;
+    const wrapper = mount(<Input autoFocus defaultValue={defaultValue} />);
+    wrapper.instance().setSelectionRange(valLength, valLength);
+    expect(wrapper.instance().input.selectionStart).toEqual(5);
+    expect(wrapper.instance().input.selectionEnd).toEqual(5);
+  });
 });
 
 describe('prefix and suffix', () => {

--- a/components/input/__tests__/textarea.test.js
+++ b/components/input/__tests__/textarea.test.js
@@ -161,6 +161,15 @@ describe('TextArea', () => {
     expect(wrapper.find('textarea').hasClass('ant-input-lg')).toBe(true);
     expect(wrapper.render()).toMatchSnapshot();
   });
+
+  it('set mouse cursor position', () => {
+    const defaultValue = '11111';
+    const valLength = defaultValue.length;
+    const wrapper = mount(<TextArea autoFocus defaultValue={defaultValue} />);
+    wrapper.instance().setSelectionRange(valLength, valLength);
+    expect(wrapper.instance().resizableTextArea.textArea.selectionStart).toEqual(5);
+    expect(wrapper.instance().resizableTextArea.textArea.selectionEnd).toEqual(5);
+  });
 });
 
 describe('TextArea allowClear', () => {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
<!--
1. Describe the source of requirement, like related issue link.
-->
close #27533

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | add setSelectionRange for the ref of Input and TextArea |
| 🇨🇳 Chinese | Input和TextArea组件的ref属性增加setSelectionRange方法 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
