### PR TITLE
Prevent Input.Search component to throw passing null as enterButton prop value

### DIFF
--- a/components/input/Search.tsx
+++ b/components/input/Search.tsx
@@ -56,7 +56,7 @@ const Search = React.forwardRef<Input, SearchProps>((props, ref) => {
     const btnClassName = `${prefixCls}-button`;
 
     let button: React.ReactNode;
-    const enterButtonAsElement = enterButton as React.ReactElement;
+    const enterButtonAsElement = (enterButton || {}) as React.ReactElement;
     const isAntdButton =
       enterButtonAsElement.type &&
       (enterButtonAsElement.type as typeof Button).__ANT_BUTTON === true;

--- a/components/input/__tests__/Search.test.js
+++ b/components/input/__tests__/Search.test.js
@@ -21,6 +21,12 @@ describe('Input.Search', () => {
     expect(wrapper.render()).toMatchSnapshot();
   });
 
+  it('should support enterButton null', () => {
+    expect(() => {
+      mount(<Search enterButton={null} />);
+    }).not.toThrow();
+  });
+
   it('should support ReactNode suffix without error', () => {
     const wrapper = mount(<Search suffix={<div>ok</div>} />);
     expect(wrapper.render()).toMatchSnapshot();


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

No open issue

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

The type of `enterButton` property is ReactNode, which accept the `null` value. In the code, it is performed a `enterButton.type` operation, resulting in a js error. With the default value, false, it is not an error because `false.type === undefined`.

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

It is possible to pass `null` as `enterButton` value without throw.

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |     x     |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
