### PR TITLE
fix: RangePicker align active-bar with small size

### DIFF
--- a/components/date-picker/style/index.less
+++ b/components/date-picker/style/index.less
@@ -209,6 +209,10 @@
       .@{picker-prefix-cls}-clear {
         right: @input-padding-horizontal-sm;
       }
+      
+      .@{picker-prefix-cls}-active-bar {
+        margin-left: @input-padding-horizontal-sm;
+      }
     }
   }
 

--- a/components/date-picker/style/rtl.less
+++ b/components/date-picker/style/rtl.less
@@ -60,6 +60,14 @@
         margin-left: 0;
       }
     }
+
+    &.@{picker-prefix-cls}-small {
+      .@{picker-prefix-cls}-active-bar {
+        .@{picker-prefix-cls}-rtl& {
+          margin-right: @input-padding-horizontal-sm;
+        }
+      }
+    }
   }
 
   // ======================== Ranges ========================


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close #27671
<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution
RangePicker的active-bar在small size下没对齐
![image](https://user-images.githubusercontent.com/15973973/98630135-6e9e6a00-2355-11eb-9cad-9a48d3c3bc9f.png)
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix small size RangePicker active bar align issue. |
| 🇨🇳 Chinese | 修复 RangePicker `size="small"` 时高亮线没有对齐的问题。 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
