### PR TITLE
fix: update the slice rule when the TextArea component limits maxLength

### DIFF
--- a/components/input/TextArea.tsx
+++ b/components/input/TextArea.tsx
@@ -113,7 +113,8 @@ class TextArea extends React.Component<TextAreaProps, TextAreaState> {
 
     // Max length value
     const hasMaxLength = Number(maxLength) > 0;
-    value = hasMaxLength ? value.slice(0, maxLength) : value;
+    // fix #27612 将value转为数组进行截取，解决 '😂'.length === 2 等emoji表情导致的截取乱码的问题
+    value = hasMaxLength ? [...value].slice(0, maxLength).join('') : value;
 
     // TextArea
     const textareaNode = (size?: SizeType) => (

--- a/components/input/__tests__/textarea.test.js
+++ b/components/input/__tests__/textarea.test.js
@@ -141,6 +141,14 @@ describe('TextArea', () => {
       expect(textarea.prop('data-count')).toBe('5 / 5');
     });
 
+    // 修改TextArea value截取规则后新增单测
+    it('slice emoji', () => {
+      const wrapper = mount(<TextArea maxLength={5} showCount value="1234😂" />);
+      const textarea = wrapper.find('.ant-input-textarea');
+      expect(wrapper.find('textarea').prop('value')).toBe('1234😂');
+      expect(textarea.prop('data-count')).toBe('5 / 5');
+    });
+
     it('className & style patch to outer', () => {
       const wrapper = mount(
         <TextArea className="bamboo" style={{ background: 'red' }} showCount />,


### PR DESCRIPTION
[[English Template / 英文模板](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE.md)]

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [x] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

fix #27612 

close #27626

### 💡 需求背景和解决方案

- 老代码
```javascript
// 输出是乱码
'😂'.slice(0, 1);
```

- 新代码
```javascript
// 输出是正确的
[...'😂'].slice(0, 1).join('');
```

- 测试用例
在`textarea.test.js`文件中补充了一个测试用例用于测试2个长度的emoji表情处于边界裁切时的输出情况。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |   Fix TextArea emoji cut when enable `maxLength`.    |
| 🇨🇳 中文 |    修复 TextArea 使用 emoji 时被裁切的问题。      |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供