### PR TITLE
fix(select): fix tags mode white space wrapping issue 

### DIFF
--- a/components/select/style/multiple.less
+++ b/components/select/style/multiple.less
@@ -78,7 +78,7 @@
         display: inline-block;
         margin-right: @padding-xs / 2;
         overflow: hidden;
-        white-space: nowrap;
+        white-space: pre; // fix whitespace wrapping. custom tags display all whitespace within.
         text-overflow: ellipsis;
       }
 
@@ -123,7 +123,7 @@
         top: 0;
         left: 0;
         z-index: 999;
-        white-space: nowrap;
+        white-space: pre; // fix whitespace wrapping caused width calculation bug
         visibility: hidden;
       }
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

fix #27683

### 💡 Background and solution
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

Using `<Select>` component with `tags` mode will cause the space within tag's text wrapped both in "edit" and "view" status.
- "edit" status
![image](https://user-images.githubusercontent.com/2825625/98933395-858eb900-251b-11eb-87f9-9d48c82786d6.png)
- "view" status
![image](https://user-images.githubusercontent.com/2825625/98933457-9fc89700-251b-11eb-8ba4-faa13f86dc18.png)

This is cause by using `white-space: nowrap` in class `ant-select-selection-item-content` & `ant-selection-search-mirror`.

[white-space value explaination on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/white-space)
![image](https://user-images.githubusercontent.com/2825625/98933740-0483f180-251c-11eb-9cb8-570a77c24e06.png)

The `nowrap` value in both class will cause span width calculation logic faill to get the right width, which is the cause of the behavior as follow gif:
![image](https://s23.aconvert.com/convert/p3r68-cdx67/58yk5-448n7.gif)

Instead of `white-space: nowrap`, using `white-space: pre` for the two class mentioned above will keep spaces in both head and tail display properly within the text, and the `span` width calculation logic works well.

> Or there maybe better solution using `javascript`.

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fix Select `tags` mode cannot input whitespace normally. |
| 🇨🇳 Chinese |  修复 Select `tags` 模式下无法输入空格的问题。   |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
