### PR TITLE
define UploadMethod type and export it

### DIFF
--- a/components/upload/interface.tsx
+++ b/components/upload/interface.tsx
@@ -71,6 +71,7 @@ export interface UploadLocale {
 export type UploadType = 'drag' | 'select';
 export type UploadListType = 'text' | 'picture' | 'picture-card';
 export type UploadListProgressProps = Omit<ProgressProps, 'percent' | 'type'>;
+export type UploadMethod = 'POST' | 'PUT' | 'PATCH' | 'post' | 'put' | 'patch';
 
 type PreviewFileHandler = (file: File | Blob) => PromiseLike<string>;
 type TransformFileHandler = (
@@ -85,7 +86,7 @@ export interface UploadProps<T = any> {
   action?: string | ((file: RcFile) => string) | ((file: RcFile) => PromiseLike<string>);
   directory?: boolean;
   data?: object | ((file: UploadFile<T>) => object);
-  method?: 'POST' | 'PUT' | 'PATCH' | 'post' | 'put' | 'patch';
+  method?: UploadMethod;
   headers?: HttpRequestHeader;
   showUploadList?: boolean | ShowUploadListInterface;
   multiple?: boolean;


### PR DESCRIPTION
### 🤔 This is a ...

TypeScript definition update

### 🔗 Related issue link

Currently, creating an Upload component with `method` in props will fail Typescript checks:

```tsx
const props = { method: "POST" }
<Upload {...props} />
```

error:

```plaintext
Types of property 'method' are incompatible.
    Type 'string' is not assignable to type '"PUT" | "POST" | "PATCH" | "post" | "put" | "patch"'
```

### 💡 Background and solution

This PR defines a `UploadMethod` type which allows it to be used:

```tsx
const postMethod: UploadMethod= "picture"
const props = { method: postMethod }
<Upload {...props} />
```

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     adds `UploadMethod` to `Upload` component interface to specify typed upload method.     |
| 🇨🇳 Chinese |    增加 `UploadMethod`型別到 `Upload`元件      |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
