### PR TITLE
fix: Modal.confirm locale missing

### DIFF
--- a/components/config-provider/__tests__/__snapshots__/form.test.js.snap
+++ b/components/config-provider/__tests__/__snapshots__/form.test.js.snap
@@ -1,272 +1,44 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ConfigProvider.Form form requiredMark set requiredMark optional 1`] = `
-<ConfigProvider
-  form={
-    Object {
-      "requiredMark": "optional",
-    }
-  }
+<form
+  class="ant-form ant-form-horizontal"
 >
-  <LocaleReceiver
-    componentName="global"
+  <div
+    class="ant-row ant-form-item"
   >
-    <SizeContextProvider>
-      <LocaleProvider
-        _ANT_MARK__="internalMark"
-        locale={Object {}}
+    <div
+      class="ant-col ant-form-item-label"
+    >
+      <label
+        class="ant-form-item-required-mark-optional"
+        for="age"
+        title="年龄"
       >
-        <ForwardRef(InternalForm)
-          initialValues={
-            Object {
-              "age": 18,
-            }
-          }
+        年龄
+        <span
+          class="ant-form-item-optional"
         >
-          <SizeContextProvider>
-            <ForwardRef(Form)
-              className="ant-form ant-form-horizontal"
-              form={
-                Object {
-                  "__INTERNAL__": Object {
-                    "itemRef": [Function],
-                    "name": undefined,
-                  },
-                  "getFieldError": [Function],
-                  "getFieldInstance": [Function],
-                  "getFieldValue": [Function],
-                  "getFieldsError": [Function],
-                  "getFieldsValue": [Function],
-                  "getInternalHooks": [Function],
-                  "isFieldTouched": [Function],
-                  "isFieldValidating": [Function],
-                  "isFieldsTouched": [Function],
-                  "isFieldsValidating": [Function],
-                  "resetFields": [Function],
-                  "scrollToField": [Function],
-                  "setFields": [Function],
-                  "setFieldsValue": [Function],
-                  "submit": [Function],
-                  "validateFields": [Function],
-                }
-              }
-              initialValues={
-                Object {
-                  "age": 18,
-                }
-              }
-              onFinishFailed={[Function]}
-            >
-              <form
-                className="ant-form ant-form-horizontal"
-                onSubmit={[Function]}
-              >
-                <FormItem
-                  label="年龄"
-                  name="age"
-                  rules={
-                    Array [
-                      Object {
-                        "len": 17,
-                        "type": "number",
-                      },
-                    ]
-                  }
-                >
-                  <WrapperField
-                    label="年龄"
-                    messageVariables={
-                      Object {
-                        "label": "年龄",
-                      }
-                    }
-                    name="age"
-                    onReset={[Function]}
-                    rules={
-                      Array [
-                        Object {
-                          "len": 17,
-                          "type": "number",
-                        },
-                      ]
-                    }
-                    trigger="onChange"
-                    validateTrigger="onChange"
-                  >
-                    <Field
-                      fieldContext={
-                        Object {
-                          "__INTERNAL__": Object {
-                            "itemRef": [Function],
-                            "name": undefined,
-                          },
-                          "getFieldError": [Function],
-                          "getFieldInstance": [Function],
-                          "getFieldValue": [Function],
-                          "getFieldsError": [Function],
-                          "getFieldsValue": [Function],
-                          "getInternalHooks": [Function],
-                          "isFieldTouched": [Function],
-                          "isFieldValidating": [Function],
-                          "isFieldsTouched": [Function],
-                          "isFieldsValidating": [Function],
-                          "resetFields": [Function],
-                          "scrollToField": [Function],
-                          "setFields": [Function],
-                          "setFieldsValue": [Function],
-                          "submit": [Function],
-                          "validateFields": [Function],
-                          "validateTrigger": "onChange",
-                        }
-                      }
-                      key="_age"
-                      label="年龄"
-                      messageVariables={
-                        Object {
-                          "label": "年龄",
-                        }
-                      }
-                      name={
-                        Array [
-                          "age",
-                        ]
-                      }
-                      onReset={[Function]}
-                      rules={
-                        Array [
-                          Object {
-                            "len": 17,
-                            "type": "number",
-                          },
-                        ]
-                      }
-                      trigger="onChange"
-                      validateTrigger="onChange"
-                      valuePropName="value"
-                    >
-                      <Row
-                        className="ant-form-item"
-                        key="row"
-                      >
-                        <div
-                          className="ant-row ant-form-item"
-                          style={Object {}}
-                        >
-                          <FormItemLabel
-                            htmlFor="age"
-                            label="年龄"
-                            name="age"
-                            prefixCls="ant-form"
-                            required={false}
-                            requiredMark="optional"
-                            rules={
-                              Array [
-                                Object {
-                                  "len": 17,
-                                  "type": "number",
-                                },
-                              ]
-                            }
-                          >
-                            <Col
-                              className="ant-form-item-label"
-                            >
-                              <div
-                                className="ant-col ant-form-item-label"
-                                style={Object {}}
-                              >
-                                <label
-                                  className="ant-form-item-required-mark-optional"
-                                  htmlFor="age"
-                                  title="年龄"
-                                >
-                                  年龄
-                                  <span
-                                    className="ant-form-item-optional"
-                                  >
-                                    (optional)
-                                  </span>
-                                </label>
-                              </div>
-                            </Col>
-                          </FormItemLabel>
-                          <FormItemInput
-                            errors={Array []}
-                            label="年龄"
-                            name={
-                              Array [
-                                "age",
-                              ]
-                            }
-                            onDomErrorVisibleChange={[Function]}
-                            prefixCls="ant-form"
-                            rules={
-                              Array [
-                                Object {
-                                  "len": 17,
-                                  "type": "number",
-                                },
-                              ]
-                            }
-                            status=""
-                            touched={false}
-                            validateStatus=""
-                            validating={false}
-                          >
-                            <Col
-                              className="ant-form-item-control"
-                            >
-                              <div
-                                className="ant-col ant-form-item-control"
-                                style={Object {}}
-                              >
-                                <div
-                                  className="ant-form-item-control-input"
-                                >
-                                  <div
-                                    className="ant-form-item-control-input-content"
-                                  >
-                                    <Component
-                                      update={1}
-                                      value={18}
-                                    >
-                                      <input
-                                        id="age"
-                                        onChange={[Function]}
-                                        value={18}
-                                      />
-                                    </Component>
-                                  </div>
-                                </div>
-                                <ErrorList
-                                  errors={Array []}
-                                  onDomErrorVisibleChange={[Function]}
-                                >
-                                  <CSSMotion
-                                    motionAppear={true}
-                                    motionDeadline={500}
-                                    motionName="show-help"
-                                    onLeaveEnd={[Function]}
-                                    removeOnLeave={true}
-                                    visible={false}
-                                  >
-                                    <DomWrapper />
-                                  </CSSMotion>
-                                </ErrorList>
-                              </div>
-                            </Col>
-                          </FormItemInput>
-                        </div>
-                      </Row>
-                    </Field>
-                  </WrapperField>
-                </FormItem>
-              </form>
-            </ForwardRef(Form)>
-          </SizeContextProvider>
-        </ForwardRef(InternalForm)>
-      </LocaleProvider>
-    </SizeContextProvider>
-  </LocaleReceiver>
-</ConfigProvider>
+          (optional)
+        </span>
+      </label>
+    </div>
+    <div
+      class="ant-col ant-form-item-control"
+    >
+      <div
+        class="ant-form-item-control-input"
+      >
+        <div
+          class="ant-form-item-control-input-content"
+        >
+          <input
+            id="age"
+            value="18"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</form>
 `;

--- a/components/config-provider/__tests__/form.test.js
+++ b/components/config-provider/__tests__/form.test.js
@@ -88,7 +88,7 @@ describe('ConfigProvider.Form', () => {
         </ConfigProvider>,
       );
 
-      expect(wrapper).toMatchSnapshot();
+      expect(wrapper).toMatchRenderedSnapshot();
     });
   });
 });

--- a/components/config-provider/index.tsx
+++ b/components/config-provider/index.tsx
@@ -164,17 +164,18 @@ const ConfigProvider: React.FC<ConfigProviderProps> & {
       childNode = <RcFormProvider validateMessages={validateMessages}>{children}</RcFormProvider>;
     }
 
+    const childrenWithLocale =
+      locale === undefined ? (
+        childNode
+      ) : (
+        <LocaleProvider locale={locale || legacyLocale} _ANT_MARK__={ANT_MARK}>
+          {childNode}
+        </LocaleProvider>
+      );
+
     return (
       <SizeContextProvider size={componentSize}>
-        <ConfigContext.Provider value={config}>
-          {locale === undefined ? (
-            childNode
-          ) : (
-            <LocaleProvider locale={locale || legacyLocale} _ANT_MARK__={ANT_MARK}>
-              {childNode}
-            </LocaleProvider>
-          )}
-        </ConfigContext.Provider>
+        <ConfigContext.Provider value={config}>{childrenWithLocale}</ConfigContext.Provider>
       </SizeContextProvider>
     );
   };

--- a/components/config-provider/index.tsx
+++ b/components/config-provider/index.tsx
@@ -167,9 +167,13 @@ const ConfigProvider: React.FC<ConfigProviderProps> & {
     return (
       <SizeContextProvider size={componentSize}>
         <ConfigContext.Provider value={config}>
-          <LocaleProvider locale={locale || legacyLocale} _ANT_MARK__={ANT_MARK}>
-            {childNode}
-          </LocaleProvider>
+          {locale === undefined ? (
+            childNode
+          ) : (
+            <LocaleProvider locale={locale || legacyLocale} _ANT_MARK__={ANT_MARK}>
+              {childNode}
+            </LocaleProvider>
+          )}
         </ConfigContext.Provider>
       </SizeContextProvider>
     );


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close #27787
close #27597
close #27720
close #27662 
close #27578 

### 💡 Background and solution

https://github.com/ant-design/ant-design/pull/27376 里加了一层 ConfigProvider 把事情搞坏了。

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Modal.confirm locale missing after close it. |
| 🇨🇳 Chinese | 修复 Modal.confirm 关闭时国际化丢失的问题。 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
