### PR TITLE
feat: FormItem support _internalItemRender

### DIFF
--- a/components/button/LoadingIcon.tsx
+++ b/components/button/LoadingIcon.tsx
@@ -40,7 +40,7 @@ const LoadingIcon: React.FC<LoadingIconProps> = ({ prefixCls, loading, existIcon
       onLeaveStart={getRealWidth}
       onLeaveActive={getCollapsedWidth}
     >
-      {({ className, style }: { className: string; style: React.CSSProperties }, ref: any) => {
+      {({ className, style }: { className?: string; style?: React.CSSProperties }, ref: any) => {
         return (
           <span className={`${prefixCls}-loading-icon`} style={style} ref={ref}>
             <LoadingOutlined className={classNames(className)} />
@@ -49,6 +49,6 @@ const LoadingIcon: React.FC<LoadingIconProps> = ({ prefixCls, loading, existIcon
       }}
     </CSSMotion>
   );
-}
+};
 
 export default LoadingIcon;

--- a/components/form/ErrorList.tsx
+++ b/components/form/ErrorList.tsx
@@ -69,7 +69,7 @@ export default function ErrorList({
       motionAppear
       removeOnLeave
     >
-      {({ className: motionClassName }: { className: string }) => {
+      {({ className: motionClassName }: { className?: string }) => {
         return (
           <div
             className={classNames(

--- a/components/form/FormItemInput.tsx
+++ b/components/form/FormItemInput.tsx
@@ -102,7 +102,7 @@ const FormItemInput: React.FC<FormItemInputProps & FormItemInputMiscProps> = pro
     </FormItemPrefixContext.Provider>
   );
 
-  // && 如果 extra=0，就会出问题
+  // If extra = 0, && will goes wrong
   // 0&&error -> 0
   const extraDom = extra ? <div className={`${baseClassName}-extra`}>{extra}</div> : null;
 

--- a/components/form/FormItemInput.tsx
+++ b/components/form/FormItemInput.tsx
@@ -18,8 +18,7 @@ interface FormItemInputMiscProps {
   validateStatus?: ValidateStatus;
   onDomErrorVisibleChange: (visible: boolean) => void;
   /**
-   * @name 自定义 FormItem 的 dom 结构
-   * @private no use
+   * @private Internal usage, do not use in any of your production.
    */
   _internalItemRender?: {
     mark: string;

--- a/components/form/FormItemInput.tsx
+++ b/components/form/FormItemInput.tsx
@@ -21,14 +21,17 @@ interface FormItemInputMiscProps {
    * @name 自定义 FormItem 的 dom 结构
    * @private no use
    */
-  _internalItemRender?: (
-    props: FormItemInputProps & FormItemInputMiscProps,
-    domList: {
-      input: JSX.Element;
-      errorList: JSX.Element;
-      extra: JSX.Element | null;
-    },
-  ) => React.ReactNode;
+  _internalItemRender?: {
+    mark: string;
+    render: (
+      props: FormItemInputProps & FormItemInputMiscProps,
+      domList: {
+        input: JSX.Element;
+        errorList: JSX.Element;
+        extra: JSX.Element | null;
+      },
+    ) => React.ReactNode;
+  };
 }
 
 export interface FormItemInputProps {
@@ -104,15 +107,16 @@ const FormItemInput: React.FC<FormItemInputProps & FormItemInputMiscProps> = pro
   // 0&&error -> 0
   const extraDom = extra ? <div className={`${baseClassName}-extra`}>{extra}</div> : null;
 
-  const dom = formItemRender ? (
-    formItemRender(props, { input: inputDom, errorList: errorListDom, extra: extraDom })
-  ) : (
-    <>
-      {inputDom}
-      {errorListDom}
-      {extraDom}
-    </>
-  );
+  const dom =
+    formItemRender && formItemRender.mark === 'pro_table_render' && formItemRender.render ? (
+      formItemRender.render(props, { input: inputDom, errorList: errorListDom, extra: extraDom })
+    ) : (
+      <>
+        {inputDom}
+        {errorListDom}
+        {extraDom}
+      </>
+    );
   return (
     <FormContext.Provider value={subFormContext}>
       <Col {...mergedWrapperCol} className={className}>

--- a/components/form/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/form/__tests__/__snapshots__/demo.test.js.snap
@@ -2341,7 +2341,6 @@ exports[`renders ./components/form/demo/inline-login.md correctly 1`] = `
         >
           <button
             class="ant-btn ant-btn-primary"
-            disabled=""
             type="submit"
           >
             <span>

--- a/components/form/__tests__/index.test.js
+++ b/components/form/__tests__/index.test.js
@@ -777,14 +777,17 @@ describe('Form', () => {
       <Form>
         <Form.Item
           name="light"
-          _internalItemRender={(_, doms) => {
-            return (
-              <div id="test">
-                {doms.input}
-                {doms.errorList}
-                {doms.extra}
-              </div>
-            );
+          _internalItemRender={{
+            mark: 'pro_table_render',
+            render: (_, doms) => {
+              return (
+                <div id="test">
+                  {doms.input}
+                  {doms.errorList}
+                  {doms.extra}
+                </div>
+              );
+            },
           }}
         >
           <input defaultValue="should warning" />

--- a/components/form/__tests__/index.test.js
+++ b/components/form/__tests__/index.test.js
@@ -772,6 +772,28 @@ describe('Form', () => {
     expect(wrapper.find('form').hasClass('ant-form-hide-required-mark')).toBeTruthy();
   });
 
+  it('_internalItemRender api test', () => {
+    const wrapper = mount(
+      <Form>
+        <Form.Item
+          name="light"
+          _internalItemRender={(_, doms) => {
+            return (
+              <div id="test">
+                {doms.input}
+                {doms.errorList}
+                {doms.extra}
+              </div>
+            );
+          }}
+        >
+          <input defaultValue="should warning" />
+        </Form.Item>
+      </Form>,
+    );
+    expect(wrapper.find('#test').exists()).toBeTruthy();
+  });
+
   describe('tooltip', () => {
     it('ReactNode', () => {
       const wrapper = mount(

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "rc-dialog": "~8.4.0",
     "rc-drawer": "~4.1.0",
     "rc-dropdown": "~3.2.0",
-    "rc-field-form": "~1.15.0",
+    "rc-field-form": "~1.17.0",
     "rc-image": "~4.0.0",
     "rc-input-number": "~6.1.0",
     "rc-mentions": "~1.5.0",


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

新特性请提交至 feature 分支，其余可提交至 master 分支。
在维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

[[English Template / 英文模板](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE.md)]

### 🤔 这个变动的性质是？

- [x] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

为了支持可编辑表格


### 💡 需求背景和解决方案

让用户可以自定义 FormItem 的 dom 结构，这样可以将错误信息藏起来，或者修改为 hover 的方式

### 📝 更新日志

不希望用户使用

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
