### PR TITLE
CarouselRef type

### DIFF
--- a/components/carousel/index.tsx
+++ b/components/carousel/index.tsx
@@ -22,7 +22,15 @@ export interface CarouselProps extends Omit<Settings, 'dots' | 'dotsClass'> {
       };
 }
 
-const Carousel = React.forwardRef<unknown, CarouselProps>(
+export interface CarouselRef {
+  goTo: (slide: number, dontAnimate: boolean) => void;
+  next: () => void;
+  prev: () => void;
+  autoPlay: boolean;
+  innerSlider: any;
+}
+
+const Carousel = React.forwardRef<CarouselRef, CarouselProps>(
   ({ dots = true, arrows = false, draggable = false, dotPosition = 'bottom', ...props }, ref) => {
     const { getPrefixCls, direction } = React.useContext(ConfigContext);
     const slickRef = React.useRef<any>();


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close https://github.com/ant-design/ant-design/issues/27932

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

After refactoring, Carousel ref definition has been typed as `unknown`, which lead to inconvenience in carousel reference usage in TypeScript projects.

These changes provides a separate `CarouselRef` type which can be used as follows:
```ts
const carouselRef = useRef<CarouselRef>(null);
const handleNext = () => carouselRef.current?.next();
```

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Provided a separate type definition for Carousel reference        |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
