### PR TITLE
feat: add a focusTriggerAfterClose prop to Modal for passing down to rc-dialog

### DIFF
--- a/components/modal/ConfirmDialog.tsx
+++ b/components/modal/ConfirmDialog.tsx
@@ -36,6 +36,7 @@ const ConfirmDialog = (props: ConfirmDialogProps) => {
     closable = false,
     closeIcon,
     modalRender,
+    focusTriggerAfterClose,
   } = props;
 
   devWarning(
@@ -101,6 +102,7 @@ const ConfirmDialog = (props: ConfirmDialogProps) => {
       closable={closable}
       closeIcon={closeIcon}
       modalRender={modalRender}
+      focusTriggerAfterClose={focusTriggerAfterClose}
     >
       <div className={`${contentPrefixCls}-body-wrapper`}>
         <ConfigProvider prefixCls={rootPrefixCls}>

--- a/components/modal/Modal.tsx
+++ b/components/modal/Modal.tsx
@@ -81,6 +81,7 @@ export interface ModalProps {
   prefixCls?: string;
   closeIcon?: React.ReactNode;
   modalRender?: (node: React.ReactNode) => React.ReactNode;
+  focusTriggerAfterClose?: boolean;
 }
 
 type getContainerFunc = () => HTMLElement;
@@ -119,6 +120,7 @@ export interface ModalFuncProps {
   bodyStyle?: React.CSSProperties;
   closeIcon?: React.ReactNode;
   modalRender?: (node: React.ReactNode) => React.ReactNode;
+  focusTriggerAfterClose?: boolean;
 }
 
 export interface ModalLocale {
@@ -177,6 +179,7 @@ const Modal: ModalInterface = props => {
     centered,
     getContainer,
     closeIcon,
+    focusTriggerAfterClose = true,
     ...restProps
   } = props;
 
@@ -208,6 +211,7 @@ const Modal: ModalInterface = props => {
       mousePosition={mousePosition}
       onClose={handleCancel}
       closeIcon={closeIconToRender}
+      focusTriggerAfterClose={focusTriggerAfterClose}
     />
   );
 };

--- a/components/modal/index.en-US.md
+++ b/components/modal/index.en-US.md
@@ -26,7 +26,7 @@ When requiring users to interact with the application, but without jumping to a 
 | destroyOnClose | Whether to unmount child components on onClose | boolean | false |  |
 | footer | Footer content, set as `footer={null}` when you don't need default buttons | ReactNode | (OK and Cancel buttons) |  |
 | forceRender | Force render Modal | boolean | false |  |
-| focusTriggerAfterClose | Whether need to focus trigger element after dialog is closed | boolean | true |  |
+| focusTriggerAfterClose | Whether need to focus trigger element after dialog is closed | boolean | true | 4.9.0 |
 | getContainer | Return the mount node for Modal | HTMLElement \| () => HTMLElement \| Selectors \| false | document.body |  |
 | keyboard | Whether support press esc to close | boolean | true |  |
 | mask | Whether show mask or not | boolean | true |  |

--- a/components/modal/index.en-US.md
+++ b/components/modal/index.en-US.md
@@ -26,6 +26,7 @@ When requiring users to interact with the application, but without jumping to a 
 | destroyOnClose | Whether to unmount child components on onClose | boolean | false |  |
 | footer | Footer content, set as `footer={null}` when you don't need default buttons | ReactNode | (OK and Cancel buttons) |  |
 | forceRender | Force render Modal | boolean | false |  |
+| focusTriggerAfterClose | Whether need to focus trigger element after dialog is closed | boolean | true |  |
 | getContainer | Return the mount node for Modal | HTMLElement \| () => HTMLElement \| Selectors \| false | document.body |  |
 | keyboard | Whether support press esc to close | boolean | true |  |
 | mask | Whether show mask or not | boolean | true |  |

--- a/components/modal/index.zh-CN.md
+++ b/components/modal/index.zh-CN.md
@@ -29,7 +29,7 @@ cover: https://gw.alipayobjects.com/zos/alicdn/3StSdUlSH/Modal.svg
 | destroyOnClose | 关闭时销毁 Modal 里的子元素 | boolean | false |  |
 | footer | 底部内容，当不需要默认底部按钮时，可以设为 `footer={null}` | ReactNode | (确定取消按钮) |  |
 | forceRender | 强制渲染 Modal | boolean | false |  |
-| focusTriggerAfterClose | 对话框关闭后是否需要聚焦触发元素 | boolean | true |  |
+| focusTriggerAfterClose | 对话框关闭后是否需要聚焦触发元素 | boolean | true | 4.9.0 |
 | getContainer | 指定 Modal 挂载的 HTML 节点, false 为挂载在当前 dom | HTMLElement \| () => HTMLElement \| Selectors \| false | document.body |  |
 | keyboard | 是否支持键盘 esc 关闭 | boolean | true |  |
 | mask | 是否展示遮罩 | boolean | true |  |

--- a/components/modal/index.zh-CN.md
+++ b/components/modal/index.zh-CN.md
@@ -29,6 +29,7 @@ cover: https://gw.alipayobjects.com/zos/alicdn/3StSdUlSH/Modal.svg
 | destroyOnClose | 关闭时销毁 Modal 里的子元素 | boolean | false |  |
 | footer | 底部内容，当不需要默认底部按钮时，可以设为 `footer={null}` | ReactNode | (确定取消按钮) |  |
 | forceRender | 强制渲染 Modal | boolean | false |  |
+| focusTriggerAfterClose | 对话框关闭后是否需要聚焦触发元素 | boolean | true |  |
 | getContainer | 指定 Modal 挂载的 HTML 节点, false 为挂载在当前 dom | HTMLElement \| () => HTMLElement \| Selectors \| false | document.body |  |
 | keyboard | 是否支持键盘 esc 关闭 | boolean | true |  |
 | mask | 是否展示遮罩 | boolean | true |  |


### PR DESCRIPTION
Also:
- set default value to true, similarly to rc-dialog
- add comments to the Modal docs. CN is google-translated though.

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 💡 Background and solution

I've faced an issue when after selecting something in a Modal I need to close it and to update a global state and then an input is supposed to reflect to redux action and being focused. But the antd's Modal focuses back the modal activating button after hide animation ends.
That's why this props would help. Actually, this prop can be set right now but without TS support though.

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | `focusTriggerAfterClose` prop is added to Modal props type definitions |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/modal/index.en-US.md](https://github.com/molokovev/ant-design/blob/pr/add_missing_modal_focusTriggerAfterClose_prop_type/components/modal/index.en-US.md)
[View rendered components/modal/index.zh-CN.md](https://github.com/molokovev/ant-design/blob/pr/add_missing_modal_focusTriggerAfterClose_prop_type/components/modal/index.zh-CN.md)