### PR TITLE
fix: zeroWidth trigger sider not collapsible

### DIFF
--- a/components/layout/Sider.tsx
+++ b/components/layout/Sider.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { useContext, useRef, useState, useEffect } from 'react';
 import classNames from 'classnames';
 import omit from 'omit.js';
 import BarsOutlined from '@ant-design/icons/BarsOutlined';
@@ -76,14 +77,14 @@ const Sider: React.FC<SiderProps> = ({
   onBreakpoint,
   ...props
 }) => {
-  const { siderHook } = React.useContext(LayoutContext);
+  const { siderHook } = useContext(LayoutContext);
 
-  const [collapsed, setCollapsed] = React.useState(
+  const [collapsed, setCollapsed] = useState(
     'collapsed' in props ? props.collapsed : defaultCollapsed,
   );
-  const [below, setBelow] = React.useState(false);
+  const [below, setBelow] = useState(false);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if ('collapsed' in props) {
       setCollapsed(props.collapsed);
     }
@@ -98,16 +99,23 @@ const Sider: React.FC<SiderProps> = ({
     }
   };
 
-  React.useEffect(() => {
-    const responsiveHandler = (mql: MediaQueryListEvent | MediaQueryList) => {
-      setBelow(mql.matches);
-      if (onBreakpoint) {
-        onBreakpoint(mql.matches);
-      }
-      if (collapsed !== mql.matches) {
-        handleSetCollapsed(mql.matches, 'responsive');
-      }
-    };
+  // ========================= Responsive =========================
+  const responsiveHandlerRef = useRef<(mql: MediaQueryListEvent | MediaQueryList) => void>();
+  responsiveHandlerRef.current = (mql: MediaQueryListEvent | MediaQueryList) => {
+    setBelow(mql.matches);
+    if (onBreakpoint) {
+      onBreakpoint(mql.matches);
+    }
+
+    if (collapsed !== mql.matches) {
+      handleSetCollapsed(mql.matches, 'responsive');
+    }
+  };
+
+  useEffect(() => {
+    function responsiveHandler(mql: MediaQueryListEvent | MediaQueryList) {
+      return responsiveHandlerRef.current!(mql);
+    }
 
     let mql: MediaQueryList;
     if (typeof window !== 'undefined') {
@@ -129,9 +137,9 @@ const Sider: React.FC<SiderProps> = ({
         mql?.removeListener(responsiveHandler);
       }
     };
-  }, [onBreakpoint, collapsed]);
+  }, []);
 
-  React.useEffect(() => {
+  useEffect(() => {
     const uniqueId = generateId('ant-sider-');
     siderHook.addSider(uniqueId);
     return () => siderHook.removeSider(uniqueId);
@@ -141,7 +149,7 @@ const Sider: React.FC<SiderProps> = ({
     handleSetCollapsed(!collapsed, 'clickTrigger');
   };
 
-  const { getPrefixCls } = React.useContext(ConfigContext);
+  const { getPrefixCls } = useContext(ConfigContext);
 
   const renderSider = () => {
     const prefixCls = getPrefixCls('layout-sider', customizePrefixCls);

--- a/components/layout/__tests__/index.test.js
+++ b/components/layout/__tests__/index.test.js
@@ -98,7 +98,7 @@ describe('Layout', () => {
     expect(wrapper.find('.ant-layout-sider').at(0).prop('style').flex).toBe('0 0 50%');
   });
 
-  describe.only('zeroWidth', () => {
+  describe('zeroWidth', () => {
     it('detect ant-layout-sider-zero-width class in sider when its width is 0%', async () => {
       const wrapper = mount(
         <Layout>
@@ -111,20 +111,51 @@ describe('Layout', () => {
       expect(wrapper.find('.ant-layout-sider').hasClass('ant-layout-sider-zero-width')).toBe(true);
     });
 
-    it.only('should collapsible', () => {
-      const onCollapse = jest.fn();
+    describe('should collapsible', () => {
+      it('uncontrolled', () => {
+        const onCollapse = jest.fn();
 
-      const wrapper = mount(
-        <Layout>
-          <Sider collapsible breakpoint="lg" collapsedWidth="0" onCollapse={onCollapse}>
-            Sider
-          </Sider>
-          <Content>Content</Content>
-        </Layout>,
-      );
+        const wrapper = mount(
+          <Layout>
+            <Sider collapsible breakpoint="lg" collapsedWidth="0" onCollapse={onCollapse}>
+              Sider
+            </Sider>
+            <Content>Content</Content>
+          </Layout>,
+        );
 
-      wrapper.find('.ant-layout-sider-zero-width-trigger').simulate('click');
-      expect(onCollapse).toHaveBeenCalledTimes(1);
+        onCollapse.mockReset();
+
+        wrapper.find('.ant-layout-sider-zero-width-trigger').simulate('click');
+        expect(onCollapse).toHaveBeenCalledTimes(1);
+      });
+
+      it('controlled', () => {
+        const Demo = () => {
+          const [collapsed, setCollapsed] = React.useState(true);
+
+          return (
+            <Layout>
+              <Sider
+                collapsed={collapsed}
+                collapsible
+                breakpoint="lg"
+                collapsedWidth="0"
+                onCollapse={setCollapsed}
+              >
+                Sider
+              </Sider>
+              <Content>Content</Content>
+            </Layout>
+          );
+        };
+
+        const wrapper = mount(<Demo />);
+        expect(wrapper.find(Sider).prop('collapsed')).toBeTruthy();
+
+        wrapper.find('.ant-layout-sider-zero-width-trigger').simulate('click');
+        expect(wrapper.find(Sider).prop('collapsed')).toBeFalsy();
+      });
     });
   });
 

--- a/components/layout/__tests__/index.test.js
+++ b/components/layout/__tests__/index.test.js
@@ -98,16 +98,34 @@ describe('Layout', () => {
     expect(wrapper.find('.ant-layout-sider').at(0).prop('style').flex).toBe('0 0 50%');
   });
 
-  it('detect ant-layout-sider-zero-width class in sider when its width is 0%', async () => {
-    const wrapper = mount(
-      <Layout>
-        <div>
-          <Sider width="0%">Sider</Sider>
-        </div>
-        <Content>Content</Content>
-      </Layout>,
-    );
-    expect(wrapper.find('.ant-layout-sider').hasClass('ant-layout-sider-zero-width')).toBe(true);
+  describe.only('zeroWidth', () => {
+    it('detect ant-layout-sider-zero-width class in sider when its width is 0%', async () => {
+      const wrapper = mount(
+        <Layout>
+          <div>
+            <Sider width="0%">Sider</Sider>
+          </div>
+          <Content>Content</Content>
+        </Layout>,
+      );
+      expect(wrapper.find('.ant-layout-sider').hasClass('ant-layout-sider-zero-width')).toBe(true);
+    });
+
+    it.only('should collapsible', () => {
+      const onCollapse = jest.fn();
+
+      const wrapper = mount(
+        <Layout>
+          <Sider collapsible breakpoint="lg" collapsedWidth="0" onCollapse={onCollapse}>
+            Sider
+          </Sider>
+          <Content>Content</Content>
+        </Layout>,
+      );
+
+      wrapper.find('.ant-layout-sider-zero-width-trigger').simulate('click');
+      expect(onCollapse).toHaveBeenCalledTimes(1);
+    });
   });
 
   it('detect ant-layout-sider-dark as default theme', async () => {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

resolve #27975

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fix Layout.Sider can not collapse when `width='0'`.      |
| 🇨🇳 Chinese |    修复 Layout.Sider 在 `width='0'` 时不能展开的问题。      |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
