### PR TITLE
fix: not found content should be disabled

### DIFF
--- a/components/cascader/__tests__/__snapshots__/index.test.js.snap
+++ b/components/cascader/__tests__/__snapshots__/index.test.js.snap
@@ -592,9 +592,10 @@ exports[`Cascader have a notFoundContent that fit trigger input width 1`] = `
     <div>
       <ul
         class="ant-cascader-menu"
+        style="height: auto;"
       >
         <li
-          class="ant-cascader-menu-item"
+          class="ant-cascader-menu-item ant-cascader-menu-item-disabled"
           role="menuitem"
           title=""
         >
@@ -1177,9 +1178,10 @@ exports[`Cascader should show not found content when options.length is 0 1`] = `
     <div>
       <ul
         class="ant-cascader-menu"
+        style="height: auto; width: 0px;"
       >
         <li
-          class="ant-cascader-menu-item"
+          class="ant-cascader-menu-item ant-cascader-menu-item-disabled"
           role="menuitem"
           title=""
         >

--- a/components/cascader/__tests__/index.test.js
+++ b/components/cascader/__tests__/index.test.js
@@ -321,6 +321,12 @@ describe('Cascader', () => {
     expect(popupWrapper.render()).toMatchSnapshot();
   });
 
+  it('not found content shoule be disabled', () => {
+    const wrapper = mount(<Cascader options={[]} />);
+    wrapper.find('input').simulate('click');
+    expect(wrapper.find('.ant-cascader-menu-item-disabled').length).toBe(1);
+  });
+
   describe('limit filtered item count', () => {
     const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
 

--- a/components/cascader/index.tsx
+++ b/components/cascader/index.tsx
@@ -234,6 +234,19 @@ function warningValueNotExist(list: CascaderOptionType[], fieldNames: FieldNames
   });
 }
 
+function getEmptyNode(
+  renderEmpty: RenderEmptyHandler,
+  names: FilledFieldNamesType,
+  notFoundContent?: React.ReactNode,
+) {
+  return {
+    [names.value]: 'ANT_CASCADER_NOT_FOUND',
+    [names.label]: notFoundContent || renderEmpty('Cascader'),
+    disabled: true,
+    isEmptyNode: true,
+  };
+}
+
 class Cascader extends React.Component<CascaderProps, CascaderState> {
   static defaultProps = {
     transitionName: 'slide-up',
@@ -442,14 +455,7 @@ class Cascader extends React.Component<CascaderProps, CascaderState> {
         } as CascaderOptionType;
       });
     }
-    return [
-      {
-        [names.value]: 'ANT_CASCADER_NOT_FOUND',
-        [names.label]: notFoundContent || renderEmpty('Cascader'),
-        disabled: true,
-        isEmptyNode: true,
-      },
-    ];
+    return [getEmptyNode(renderEmpty, names, notFoundContent)];
   }
 
   focus() {
@@ -568,12 +574,7 @@ class Cascader extends React.Component<CascaderProps, CascaderState> {
             options = this.generateFilteredOptions(prefixCls, renderEmpty);
           }
         } else {
-          options = [
-            {
-              [names.label]: notFoundContent || renderEmpty('Cascader'),
-              [names.value]: 'ANT_CASCADER_NOT_FOUND',
-            },
-          ];
+          options = [getEmptyNode(renderEmpty, names, notFoundContent)];
         }
         // Dropdown menu should keep previous status until it is fully closed.
         if (!state.popupVisible) {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [X] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

[Cascader组件options为空数组时，暂无数据作为了下拉选项（可选项）](https://github.com/ant-design/ant-design/issues/27949)

close #27949
### 💡 Background and solution

Make `Not found content` disabled, just like it's done in filter nodes.

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Fix Cascader bug that empty data can be selected. |
| 🇨🇳 Chinese |  修复 Cascader 空数据可以被选择的问题。    |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [X] Doc is updated/provided or not needed
- [X] Demo is updated/provided or not needed
- [X] TypeScript definition is updated/provided or not needed
- [X] Changelog is provided or not needed
