### PR TITLE
Button loading timeout cleanup

### DIFF
--- a/components/button/button.tsx
+++ b/components/button/button.tsx
@@ -144,11 +144,10 @@ const InternalButton: React.ForwardRefRenderFunction<unknown, ButtonProps> = (pr
   } = props;
 
   const size = React.useContext(SizeContext);
-  const [innerLoading, setLoading] = React.useState<Loading>(!!loading);
+  const [innerLoading, setLoading] = React.useState<boolean>(!!loading);
   const [hasTwoCNChar, setHasTwoCNChar] = React.useState(false);
   const { getPrefixCls, autoInsertSpaceInButton, direction } = React.useContext(ConfigContext);
   const buttonRef = (ref as any) || React.createRef<HTMLElement>();
-  const delayTimeoutRef = React.useRef<number>();
 
   const isNeedInserted = () => {
     return React.Children.count(children) === 1 && !icon && !isUnborderedButtonType(type);
@@ -178,14 +177,13 @@ const InternalButton: React.ForwardRefRenderFunction<unknown, ButtonProps> = (pr
   }
 
   React.useEffect(() => {
-    clearTimeout(delayTimeoutRef.current);
     if (typeof loadingOrDelay === 'number') {
-      delayTimeoutRef.current = window.setTimeout(() => {
-        setLoading(loadingOrDelay);
+      const delayTimeout = window.setTimeout(() => {
+        setLoading(true);
       }, loadingOrDelay);
-    } else {
-      setLoading(loadingOrDelay);
+      return () => clearTimeout(delayTimeout);
     }
+    setLoading(!!loadingOrDelay);
   }, [loadingOrDelay]);
 
   React.useEffect(fixTwoCNChar, [buttonRef]);


### PR DESCRIPTION
Avoid warning: "Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in a useEffect cleanup function."

<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

If a Button is unmounted before the loader being displayed, React logs this warning: "Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in a useEffect cleanup function."

### 💡 Background and solution

Use useEffect cleanup.

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
