### PR TITLE
fix: Collapse.Panel collapsible should be optional

### DIFF
--- a/components/collapse/CollapsePanel.tsx
+++ b/components/collapse/CollapsePanel.tsx
@@ -18,7 +18,7 @@ export interface CollapsePanelProps {
   forceRender?: boolean;
   id?: string;
   extra?: React.ReactNode;
-  collapsible: CollapsibleType;
+  collapsible?: CollapsibleType;
 }
 
 const CollapsePanel: React.FC<CollapsePanelProps> = props => {


### PR DESCRIPTION
It looks like this was broken in https://github.com/ant-design/ant-design/pull/27790. According to `rc-collapse`, the `collapsible` prop inside Collapse.Panel is optional, so it should be optional here as well if we're just forwarding props directly to the child component.

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

This was broken in https://github.com/ant-design/ant-design/pull/27790

### 💡 Background and solution

Upon using Collapse.Panel inside a TypeScript project and updating to the latest version of `antd`, Typescript now complains that `collapsible` is required in all usages of Collapse.Panel.

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed Typescript definitions for Collapse.Panel collapsible property. |
| 🇨🇳 Chinese | 修复了Collapse.Panel可折叠属性的Typescript定义。 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
