### PR TITLE
feat: add showCount.formatter for TextArea

### DIFF
--- a/components/input/TextArea.tsx
+++ b/components/input/TextArea.tsx
@@ -13,6 +13,7 @@ export interface TextAreaProps extends RcTextAreaProps {
   allowClear?: boolean;
   bordered?: boolean;
   showCount?: boolean;
+  countFormatter?: (count: number, maxLength?: number) => string;
   maxLength?: number;
   size?: SizeType;
 }
@@ -27,6 +28,7 @@ const TextArea = React.forwardRef<TextAreaRef, TextAreaProps>(
       prefixCls: customizePrefixCls,
       bordered = true,
       showCount = false,
+      countFormatter,
       maxLength,
       className,
       style,
@@ -117,7 +119,10 @@ const TextArea = React.forwardRef<TextAreaRef, TextAreaProps>(
     // Only show text area wrapper when needed
     if (showCount) {
       const valueLength = [...val].length;
-      const dataCount = `${valueLength}${hasMaxLength ? ` / ${maxLength}` : ''}`;
+
+      const dataCount = countFormatter
+        ? countFormatter(valueLength, maxLength)
+        : `${valueLength}${hasMaxLength ? ` / ${maxLength}` : ''}`;
 
       return (
         <div

--- a/components/input/TextArea.tsx
+++ b/components/input/TextArea.tsx
@@ -9,11 +9,14 @@ import { ConfigContext } from '../config-provider';
 import { fixControlledValue, resolveOnChange } from './Input';
 import SizeContext, { SizeType } from '../config-provider/SizeContext';
 
+interface ShowCountProps {
+  formatter: (args: { count: number; maxLength?: number }) => string;
+}
+
 export interface TextAreaProps extends RcTextAreaProps {
   allowClear?: boolean;
   bordered?: boolean;
-  showCount?: boolean;
-  countFormatter?: (count: number, maxLength?: number) => string;
+  showCount?: boolean | ShowCountProps;
   maxLength?: number;
   size?: SizeType;
 }
@@ -28,7 +31,6 @@ const TextArea = React.forwardRef<TextAreaRef, TextAreaProps>(
       prefixCls: customizePrefixCls,
       bordered = true,
       showCount = false,
-      countFormatter,
       maxLength,
       className,
       style,
@@ -120,9 +122,12 @@ const TextArea = React.forwardRef<TextAreaRef, TextAreaProps>(
     if (showCount) {
       const valueLength = [...val].length;
 
-      const dataCount = countFormatter
-        ? countFormatter(valueLength, maxLength)
-        : `${valueLength}${hasMaxLength ? ` / ${maxLength}` : ''}`;
+      let dataCount = '';
+      if (typeof showCount === 'object') {
+        dataCount = showCount.formatter({ count: valueLength, maxLength });
+      } else {
+        dataCount = `${valueLength}${hasMaxLength ? ` / ${maxLength}` : ''}`;
+      }
 
       return (
         <div

--- a/components/input/__tests__/textarea.test.js
+++ b/components/input/__tests__/textarea.test.js
@@ -166,12 +166,11 @@ describe('TextArea', () => {
       expect(wrapper.find('.ant-input').props().style.background).toBeFalsy();
     });
 
-    it('countFormatter', () => {
+    it('count formatter', () => {
       const wrapper = mount(
         <TextArea
           maxLength={5}
-          showCount
-          countFormatter={(count, maxLength) => `${count}, ${maxLength}`}
+          showCount={{ formatter: ({ count, maxLength }) => `${count}, ${maxLength}` }}
           value="12345678"
         />,
       );

--- a/components/input/__tests__/textarea.test.js
+++ b/components/input/__tests__/textarea.test.js
@@ -165,6 +165,20 @@ describe('TextArea', () => {
       expect(wrapper.find('.ant-input').hasClass('bamboo')).toBeFalsy();
       expect(wrapper.find('.ant-input').props().style.background).toBeFalsy();
     });
+
+    it('countFormatter', () => {
+      const wrapper = mount(
+        <TextArea
+          maxLength={5}
+          showCount
+          countFormatter={(count, maxLength) => `${count}, ${maxLength}`}
+          value="12345678"
+        />,
+      );
+      const textarea = wrapper.find('.ant-input-textarea');
+      expect(wrapper.find('textarea').prop('value')).toBe('12345');
+      expect(textarea.prop('data-count')).toBe('5, 5');
+    });
   });
 
   it('should support size', async () => {

--- a/components/input/index.en-US.md
+++ b/components/input/index.en-US.md
@@ -44,10 +44,10 @@ The rest of the props of Input are exactly the same as the original [input](http
 | --- | --- | --- | --- | --- |
 | allowClear | If allow to remove input content with clear icon | boolean | false |  |
 | autoSize | Height autosize feature, can be set to true \| false or an object { minRows: 2, maxRows: 6 } | boolean \| object | false |  |
-| bordered | Whether has border style | boolean \| { formatter: ({ count: number, maxLength?: number }) => string } | true | 4.5.0 (formatter: 4.10.0) |
+| bordered | Whether has border style | boolean | true | 4.5.0 |
 | defaultValue | The initial input content | string | - |  |
 | maxLength | The max length | number | - | 4.7.0 |
-| showCount | Whether show text count | boolean | false | 4.7.0 |
+| showCount | Whether show text count | boolean \| { formatter: ({ count: number, maxLength?: number }) => string } | false | 4.7.0 (formatter: 4.10.0) |
 | value | The input content value | string | - |  |
 | onPressEnter | The callback function that is triggered when Enter key is pressed | function(e) | - |  |
 | onResize | The callback function that is triggered when resize | function({ width, height }) | - |  |

--- a/components/input/index.en-US.md
+++ b/components/input/index.en-US.md
@@ -45,6 +45,7 @@ The rest of the props of Input are exactly the same as the original [input](http
 | allowClear | If allow to remove input content with clear icon | boolean | false |  |
 | autoSize | Height autosize feature, can be set to true \| false or an object { minRows: 2, maxRows: 6 } | boolean \| object | false |  |
 | bordered | Whether has border style | boolean | true | 4.5.0 |
+| countFormatter | Specifies the format of the count presented | (count: number, maxLength?: number) => string | - | 4.10.0 |
 | defaultValue | The initial input content | string | - |  |
 | maxLength | The max length | number | - | 4.7.0 |
 | showCount | Whether show text count | boolean | false | 4.7.0 |

--- a/components/input/index.en-US.md
+++ b/components/input/index.en-US.md
@@ -44,8 +44,7 @@ The rest of the props of Input are exactly the same as the original [input](http
 | --- | --- | --- | --- | --- |
 | allowClear | If allow to remove input content with clear icon | boolean | false |  |
 | autoSize | Height autosize feature, can be set to true \| false or an object { minRows: 2, maxRows: 6 } | boolean \| object | false |  |
-| bordered | Whether has border style | boolean | true | 4.5.0 |
-| countFormatter | Specifies the format of the count presented | (count: number, maxLength?: number) => string | - | 4.10.0 |
+| bordered | Whether has border style | boolean \| { formatter: ({ count: number, maxLength?: number }) => string } | true | 4.5.0 (formatter: 4.10.0) |
 | defaultValue | The initial input content | string | - |  |
 | maxLength | The max length | number | - | 4.7.0 |
 | showCount | Whether show text count | boolean | false | 4.7.0 |

--- a/components/input/index.zh-CN.md
+++ b/components/input/index.zh-CN.md
@@ -46,6 +46,7 @@ Input 的其他属性和 React 自带的 [input](https://facebook.github.io/reac
 | allowClear | 可以点击清除图标删除内容 | boolean | false |  |
 | autoSize | 自适应内容高度，可设置为 true \| false 或对象：{ minRows: 2, maxRows: 6 } | boolean \| object | false |  |
 | bordered | 是否有边框 | boolean | true | 4.5.0 |
+| countFormatter | 指定字数展示的格式 | (count: number, maxLength?: number) => string | - | 4.10.0 |
 | defaultValue | 输入框默认内容 | string | - |  |
 | maxLength | 内容最大长度 | number | - | 4.7.0 |
 | showCount | 是否展示字数 | boolean | false | 4.7.0 |

--- a/components/input/index.zh-CN.md
+++ b/components/input/index.zh-CN.md
@@ -49,7 +49,7 @@ Input 的其他属性和 React 自带的 [input](https://facebook.github.io/reac
 | countFormatter | 指定字数展示的格式 | (count: number, maxLength?: number) => string | - | 4.10.0 |
 | defaultValue | 输入框默认内容 | string | - |  |
 | maxLength | 内容最大长度 | number | - | 4.7.0 |
-| showCount | 是否展示字数 | boolean | false | 4.7.0 |
+| showCount | 是否展示字数 | boolean \| { formatter: ({ count: number, maxLength?: number }) => string } | false | 4.7.0 (formatter: 4.10.0) |
 | value | 输入框内容 | string | - |  |
 | onPressEnter | 按下回车的回调 | function(e) | - |  |
 | onResize | resize 回调 | function({ width, height }) | - |  |


### PR DESCRIPTION
### 🤔 This is a ...

- [X] New feature
- [ ] Bug fix
- [X] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [X] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

#28105 

### 💡 Background and solution

none

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Support custom count format by passing a function     |
| 🇨🇳 Chinese |    支持传入一个函数以自定义展示字数        |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [X] Doc is updated/provided or not needed
- [X] Demo is updated/provided or not needed
- [X] TypeScript definition is updated/provided or not needed
- [X] Changelog is provided or not needed


-----
[View rendered components/input/index.en-US.md](https://github.com/ant-design/ant-design/blob/feat/count-formatter/components/input/index.en-US.md)
[View rendered components/input/index.zh-CN.md](https://github.com/ant-design/ant-design/blob/feat/count-formatter/components/input/index.zh-CN.md)