### PR TITLE
fix: Add type of initialValue prop to Form.List

### DIFF
--- a/components/form/FormList.tsx
+++ b/components/form/FormList.tsx
@@ -21,6 +21,7 @@ export interface FormListProps {
   prefixCls?: string;
   name: string | number | (string | number)[];
   rules?: ValidatorRule[];
+  initialValue?: any[];
   children: (
     fields: FormListFieldData[],
     operation: FormListOperation,

--- a/components/form/index.en-US.md
+++ b/components/form/index.en-US.md
@@ -169,7 +169,7 @@ Provides array management for fields.
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
 | children | Render function | (fields: Field\[], operation: { add, remove, move }, meta: { errors }) => React.ReactNode | - |  |
-| initialValue | Config sub default value. Form `initialValues` get higher priority when conflict | string | - | 4.9.0 |
+| initialValue | Config sub default value. Form `initialValues` get higher priority when conflict | any[] | - | 4.9.0 |
 | name | Field name, support array | [NamePath](#NamePath) | - |  |
 | rules | Validate rules, only support customize validator. Should work with [ErrorList](#Form.ErrorList) | { validator, message }\[] | - | 4.7.0 |
 

--- a/components/form/index.zh-CN.md
+++ b/components/form/index.zh-CN.md
@@ -170,7 +170,7 @@ Form 通过增量更新方式，只更新被修改的字段相关组件以达到
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
 | children | 渲染函数 | (fields: Field\[], operation: { add, remove, move }, meta: { errors }) => React.ReactNode | - |  |
-| initialValue | 设置子元素默认值，如果与 Form 的 `initialValues` 冲突则以 Form 为准 | string | - | 4.9.0 |
+| initialValue | 设置子元素默认值，如果与 Form 的 `initialValues` 冲突则以 Form 为准 | any[] | - | 4.9.0 |
 | name | 字段名，支持数组 | [NamePath](#NamePath) | - |  |
 | rules | 校验规则，仅支持自定义规则。需要配合 [ErrorList](#Form.ErrorList) 一同使用。 | { validator, message }\[] | - | 4.7.0 |
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution
Follow rc-from https://github.com/react-component/field-form/blob/master/src/List.tsx#L24
and https://github.com/ant-design/ant-design/pull/27872, ant-design lost the `initialValue` prop type.
Also updated the doc

So just add it!
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |Form.List `initialValue` types are supported|
| 🇨🇳 Chinese |Form.List `initialValue` 增加类型支持|

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
