### PR TITLE
fix: Layout overflow style for table sticky

### DIFF
--- a/components/layout/style/index.less
+++ b/components/layout/style/index.less
@@ -18,6 +18,12 @@
 
   &&-has-sider {
     flex-direction: row;
+    
+    
+    > .@{layout-prefix-cls},
+    > .@{layout-prefix-cls}-content {
+      width: 0; // https://segmentfault.com/a/1190000019498300
+    }
   }
 
   &-header,

--- a/components/layout/style/index.less
+++ b/components/layout/style/index.less
@@ -18,10 +18,6 @@
 
   &&-has-sider {
     flex-direction: row;
-    > .@{layout-prefix-cls},
-    > .@{layout-prefix-cls}-content {
-      overflow-x: hidden;
-    }
   }
 
   &-header,

--- a/components/layout/style/index.less
+++ b/components/layout/style/index.less
@@ -19,7 +19,6 @@
   &&-has-sider {
     flex-direction: row;
     
-    
     > .@{layout-prefix-cls},
     > .@{layout-prefix-cls}-content {
       width: 0; // https://segmentfault.com/a/1190000019498300


### PR DESCRIPTION
close #28154

<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close #28154

### 💡 Background and solution

回滚 https://github.com/ant-design/ant-design/commit/500b2225567f03397d9faec5f4e60a8f35fc4d28 ，现在已经不清楚是为了啥加的，删后没看出明显的问题。

改成 width: 0 的解决方案避免内容溢出：https://segmentfault.com/a/1190000019498300

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fix Layout overflow style for Table `sticky`. |
| 🇨🇳 Chinese | 修复 Layout 内部使用 Table `sticky` 属性失效的问题。  |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
