### PR TITLE
refactor: add className in BreadcrumbItemProps

### DIFF
--- a/components/breadcrumb/BreadcrumbItem.tsx
+++ b/components/breadcrumb/BreadcrumbItem.tsx
@@ -11,6 +11,7 @@ export interface BreadcrumbItemProps {
   overlay?: DropDownProps['overlay'];
   dropdownProps?: DropDownProps;
   onClick?: React.MouseEventHandler<HTMLAnchorElement | HTMLSpanElement>;
+  className?: string;
 }
 interface BreadcrumbItemInterface extends React.FC<BreadcrumbItemProps> {
   __ANT_BREADCRUMB_ITEM: boolean;

--- a/components/breadcrumb/index.en-US.md
+++ b/components/breadcrumb/index.en-US.md
@@ -32,6 +32,7 @@ A breadcrumb displays the current location within a hierarchy. It allows going b
 | href | Target of hyperlink | string | - |  |
 | overlay | The dropdown menu | [Menu](/components/menu) \| () => Menu | - |  |
 | onClick | Set the handler to handle click event | (e:MouseEvent) => void | - |  |
+| className | The additional css class | string | - |  |
 
 ### Breadcrumb.Separator
 

--- a/components/breadcrumb/index.zh-CN.md
+++ b/components/breadcrumb/index.zh-CN.md
@@ -33,6 +33,7 @@ cover: https://gw.alipayobjects.com/zos/alicdn/9Ltop8JwH/Breadcrumb.svg
 | href | 链接的目的地 | string | - |  |
 | overlay | 下拉菜单的内容 | [Menu](/components/menu) \| () => Menu | - |  |
 | onClick | 单击事件 | (e:MouseEvent) => void | - |  |
+| className | 自定义类名 | string | - |  |
 
 ### Breadcrumb.Separator
 


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [x] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)



### 💡 Background and solution
* 目前通过Breadcrumb.Item跳转只能通过 href 跟 onClick事件
   * 通过 href 跳转会刷新页面
   * 通过 onClick 事件使用 history.push进行页面跳转是一个比较不错的选择
      * onClick事件的欠缺是鼠标移到Breadcrumb.Item上 是一个 (cursor:text)
      * 目前的需求是 鼠标移到Breadcrumb.Item上 鼠标的样式跟 href一样( cursor:pointer)
* 最佳的方案是可以自己定制Breadcrumb.Item 的 hover事件，不过BreadcrumbItemProps上没有className
* 解决方案：BreadcrumbItemProps加上className

* 想过自己写一个组件放到 Breadcrumb里 不过现在的 Breadcrumb 接受 Breadcrumb.Item 跟 Breadcrumb.Separator


### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x ] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
