### PR TITLE
fix: Table filters string key removed

### DIFF
--- a/components/table/hooks/useFilter/FilterDropdown.tsx
+++ b/components/table/hooks/useFilter/FilterDropdown.tsx
@@ -54,7 +54,7 @@ function renderFilterItems({
   }
   return filters.map((filter, index) => {
     let key = filter.value;
-    if (typeof key !== 'string' || typeof key !== 'number') {
+    if (typeof key !== 'string' && typeof key !== 'number') {
       key = String(key);
     }
 

--- a/components/table/hooks/useFilter/FilterDropdown.tsx
+++ b/components/table/hooks/useFilter/FilterDropdown.tsx
@@ -53,7 +53,7 @@ function renderFilterItems({
     );
   }
   return filters.map((filter, index) => {
-    const key = String(filter.value);
+    const key = filter.value;
 
     if (filter.children) {
       return (

--- a/components/table/hooks/useFilter/FilterDropdown.tsx
+++ b/components/table/hooks/useFilter/FilterDropdown.tsx
@@ -53,7 +53,10 @@ function renderFilterItems({
     );
   }
   return filters.map((filter, index) => {
-    const key = filter.value;
+    let key = filter.value;
+    if (typeof key !== 'string' || typeof key !== 'number') {
+      key = String(key);
+    }
 
     if (filter.children) {
       return (


### PR DESCRIPTION
[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

#28144 

### 💡 Background and solution

Background: Table filters was returning key in the form of string even if we pass key as an integer. 
Solution: Removed explicit String conversion from filter hook. 

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Removed explicit String conversion from filter hook.   |
| 🇨🇳 Chinese |    从过滤器挂钩中移除了显式字符串转换。       |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
