### PR TITLE
refactor: cleanup <LoadingIcon /> and reduce bundle size on ~1.25kb

### DIFF
--- a/components/button/LoadingIcon.tsx
+++ b/components/button/LoadingIcon.tsx
@@ -1,5 +1,4 @@
-import * as React from 'react';
-import classNames from 'classnames';
+import React from 'react';
 import CSSMotion from 'rc-motion';
 import LoadingOutlined from '@ant-design/icons/LoadingOutlined';
 
@@ -8,7 +7,6 @@ export interface LoadingIconProps {
   existIcon: boolean;
   loading?: boolean | object;
 }
-
 const getCollapsedWidth = () => ({ width: 0, opacity: 0, transform: 'scale(0)' });
 const getRealWidth = (node: HTMLElement) => ({
   width: node.scrollWidth,
@@ -43,7 +41,7 @@ const LoadingIcon: React.FC<LoadingIconProps> = ({ prefixCls, loading, existIcon
       {({ className, style }: { className?: string; style?: React.CSSProperties }, ref: any) => {
         return (
           <span className={`${prefixCls}-loading-icon`} style={style} ref={ref}>
-            <LoadingOutlined className={classNames(className)} />
+            <LoadingOutlined className={className} />
           </span>
         );
       }}


### PR DESCRIPTION

<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [x] Bundle size optimization
- [x] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [x] Refactoring
- [x] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

NOTE:

if you go to https://babeljs.io/en/repl


if you paste there 'old' code, and measure the amount of characters, you will get ~3.1kb
if you paste there 'new' code, and measure the amount of characters, you will get ~1.8kb

presets:  es2015, es2016, react,  typescript,  stage-2

using this style you still have the same behavior, but you loose 1.5 kb from transpiled file size, which will help load websites a bit faster