### PR TITLE
fix: table filter

### DIFF
--- a/components/table/Table.tsx
+++ b/components/table/Table.tsx
@@ -49,7 +49,7 @@ interface ChangeEventInfo<RecordType> {
     pageSize?: number;
     total?: number;
   };
-  filters: Record<string, Key[] | null>;
+  filters: Record<string, (Key | boolean)[] | null>;
   sorter: SorterResult<RecordType> | SorterResult<RecordType>[];
 
   filterStates: FilterState<RecordType>[];
@@ -80,7 +80,7 @@ export interface TableProps<RecordType>
 
   onChange?: (
     pagination: TablePaginationConfig,
-    filters: Record<string, Key[] | null>,
+    filters: Record<string, (Key | boolean)[] | null>,
     sorter: SorterResult<RecordType> | SorterResult<RecordType>[],
     extra: TableCurrentDataSource<RecordType>,
   ) => void;
@@ -271,7 +271,7 @@ function Table<RecordType extends object = any>(props: TableProps<RecordType>) {
 
   // ============================ Filter ============================
   const onFilterChange = (
-    filters: Record<string, Key[]>,
+    filters: Record<string, (Key | boolean)[]>,
     filterStates: FilterState<RecordType>[],
   ) => {
     triggerOnChange(

--- a/components/table/__tests__/Table.filter.test.js
+++ b/components/table/__tests__/Table.filter.test.js
@@ -328,6 +328,41 @@ describe('Table.filter', () => {
     expect(wrapper.find('tbody tr').length).toBe(4);
   });
 
+  it('render checked of checkbox correctly controlled by filteredValue', () => {
+    ['Lucy', 23, false].forEach(val => {
+      const wrapper = mount(
+        createTable({
+          columns: [
+            {
+              ...column,
+              filters: [{ text: val, value: val }],
+              filteredValue: [val],
+            },
+          ],
+        }),
+      );
+
+      wrapper.find('.ant-dropdown-trigger').first().simulate('click');
+
+      expect(wrapper.find('FilterDropdown').find('Checkbox').at(0).props().checked).toEqual(true);
+    });
+
+    const wrapper = mount(
+      createTable({
+        columns: [
+          {
+            ...column,
+            filters: [{ text: 'ant', value: 'ant' }],
+            filteredValue: ['any-value-not-exists-in-filters'],
+          },
+        ],
+      }),
+    );
+    wrapper.find('.ant-dropdown-trigger').first().simulate('click');
+
+    expect(wrapper.find('FilterDropdown').find('Checkbox').at(0).props().checked).toEqual(false);
+  });
+
   it('can read defaults from defaultFilteredValue', () => {
     const wrapper = mount(
       createTable({

--- a/components/table/__tests__/Table.filter.test.js
+++ b/components/table/__tests__/Table.filter.test.js
@@ -501,6 +501,7 @@ describe('Table.filter', () => {
     ].forEach(([text, value]) => {
       it(`${typeof value} type`, () => {
         const onFilter = jest.fn();
+        const onChange = jest.fn();
         const filters = [{ text, value }];
         const wrapper = mount(
           createTable({
@@ -511,6 +512,7 @@ describe('Table.filter', () => {
                 onFilter,
               },
             ],
+            onChange,
           }),
         );
 
@@ -531,6 +533,10 @@ describe('Table.filter', () => {
 
         onFilter.mock.calls.forEach(([val]) => {
           expect(val).toBe(value);
+        });
+        onChange.mock.calls.forEach(([, currentFilters]) => {
+          const [, val] = Object.entries(currentFilters)[0];
+          expect(val).toEqual([value]);
         });
         // Another time of Filter show
         // https://github.com/ant-design/ant-design/issues/15593

--- a/components/table/hooks/useFilter/index.tsx
+++ b/components/table/hooks/useFilter/index.tsx
@@ -34,10 +34,11 @@ function collectFilterStates<RecordType>(
     } else if (column.filters || 'filterDropdown' in column || 'onFilter' in column) {
       if ('filteredValue' in column) {
         // Controlled
+        const filteredValues = (column.filteredValue || []).map(String);
         filterStates.push({
           column,
           key: getColumnKey(column, columnPos),
-          filteredKeys: column.filteredValue,
+          filteredKeys: filteredValues,
           forceFiltered: column.filtered,
         });
       } else {

--- a/components/table/hooks/useFilter/index.tsx
+++ b/components/table/hooks/useFilter/index.tsx
@@ -69,7 +69,7 @@ function injectFilter<RecordType>(
   return columns.map((column, index) => {
     const columnPos = getColumnPos(index, pos);
     const { filterMultiple = true } = column as ColumnType<RecordType>;
-    
+
     let newColumn: ColumnsType<RecordType>[number] = column;
 
     if (newColumn.filters || newColumn.filterDropdown) {
@@ -117,10 +117,21 @@ function injectFilter<RecordType>(
 }
 
 function generateFilterInfo<RecordType>(filterStates: FilterState<RecordType>[]) {
-  const currentFilters: Record<string, Key[] | null> = {};
+  const currentFilters: Record<string, (Key | boolean)[] | null> = {};
 
-  filterStates.forEach(({ key, filteredKeys }) => {
-    currentFilters[key] = filteredKeys || null;
+  filterStates.forEach(({ key, filteredKeys, column }) => {
+    const { filters } = column;
+    const originKeys: ColumnFilterItem['value'][] = [];
+    if (Array.isArray(filteredKeys)) {
+      filters?.forEach((filter: ColumnFilterItem) => {
+        if (filteredKeys.includes(String(filter.value))) {
+          originKeys.push(filter.value);
+        }
+      });
+      currentFilters[key] = originKeys;
+    } else {
+      currentFilters[key] = null;
+    }
   });
 
   return currentFilters;

--- a/components/table/hooks/useFilter/index.tsx
+++ b/components/table/hooks/useFilter/index.tsx
@@ -178,7 +178,7 @@ interface FilterConfig<RecordType> {
   mergedColumns: ColumnsType<RecordType>;
   locale: TableLocale;
   onFilterChange: (
-    filters: Record<string, Key[] | null>,
+    filters: Record<string, (Key | boolean)[] | null>,
     filterStates: FilterState<RecordType>[],
   ) => void;
   getPopupContainer?: GetPopupContainer;
@@ -194,7 +194,7 @@ function useFilter<RecordType>({
 }: FilterConfig<RecordType>): [
   TransformColumns<RecordType>,
   FilterState<RecordType>[],
-  () => Record<string, Key[] | null>,
+  () => Record<string, (Key | boolean)[] | null>,
 ] {
   const [filterStates, setFilterStates] = React.useState<FilterState<RecordType>[]>(
     collectFilterStates(mergedColumns, true),


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

resolve https://github.com/ant-design/ant-design/issues/28144

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

1. Table filters support `string`, `number`, `boolean`. But `onChange` event does not receive correct type, all filters value will be convert to string.This PR will return the origin value from filters to the `onChange` listener.

2. If we set prop `filteredValue` on Table, the related filters won't get checked, which I think they should.

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   fix that onChange event in table always get filters value of string type as parameter; <br />fix that related filters do not get checked if we set prop `filteredValue` on column    |
| 🇨🇳 Chinese |  修复表格 onChange 事件接收的 filters 参数值总是字符串的问题；<br />修复当设置列的 `filteredValue` 时 ，对应的过滤器没有被选中的问题        |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
