### PR TITLE
feat: Form scrollToFirstError support ScrollLogicalPosition

### DIFF
--- a/components/form/Form.tsx
+++ b/components/form/Form.tsx
@@ -24,7 +24,7 @@ export interface FormProps<Values = any> extends Omit<RcFormProps<Values>, 'form
   wrapperCol?: ColProps;
   form?: FormInstance<Values>;
   size?: SizeType;
-  scrollToFirstError?: boolean;
+  scrollToFirstError?: { block?: ScrollLogicalPosition };
   requiredMark?: RequiredMark;
   /** @deprecated Will warning in future branch. Pls use `requiredMark` instead. */
   hideRequiredMark?: boolean;
@@ -107,7 +107,7 @@ const InternalForm: React.ForwardRefRenderFunction<unknown, FormProps> = (props,
     }
 
     if (scrollToFirstError && errorInfo.errorFields.length) {
-      wrapForm.scrollToField(errorInfo.errorFields[0].name);
+      wrapForm.scrollToField(errorInfo.errorFields[0].name, { ...scrollToFirstError });
     }
   };
 

--- a/components/form/Form.tsx
+++ b/components/form/Form.tsx
@@ -24,7 +24,7 @@ export interface FormProps<Values = any> extends Omit<RcFormProps<Values>, 'form
   wrapperCol?: ColProps;
   form?: FormInstance<Values>;
   size?: SizeType;
-  scrollToFirstError?: { block?: ScrollLogicalPosition };
+  scrollToFirstError?: boolean | { block?: ScrollLogicalPosition };
   requiredMark?: RequiredMark;
   /** @deprecated Will warning in future branch. Pls use `requiredMark` instead. */
   hideRequiredMark?: boolean;
@@ -106,8 +106,13 @@ const InternalForm: React.ForwardRefRenderFunction<unknown, FormProps> = (props,
       onFinishFailed(errorInfo);
     }
 
+    let defaultScrollToFirstError: { block?: ScrollLogicalPosition } = { block: 'nearest' };
+
     if (scrollToFirstError && errorInfo.errorFields.length) {
-      wrapForm.scrollToField(errorInfo.errorFields[0].name, { ...scrollToFirstError });
+      if (typeof scrollToFirstError === 'object') {
+        defaultScrollToFirstError = scrollToFirstError;
+      }
+      wrapForm.scrollToField(errorInfo.errorFields[0].name, defaultScrollToFirstError);
     }
   };
 

--- a/components/form/__tests__/index.test.js
+++ b/components/form/__tests__/index.test.js
@@ -227,7 +227,7 @@ describe('Form', () => {
     const onFinishFailed = jest.fn();
 
     const wrapper = mount(
-      <Form scrollToFirstError onFinishFailed={onFinishFailed}>
+      <Form scrollToFirstError={{ block: 'center' }} onFinishFailed={onFinishFailed}>
         <Form.Item name="test" rules={[{ required: true }]}>
           <input />
         </Form.Item>
@@ -238,7 +238,11 @@ describe('Form', () => {
     expect(scrollIntoView).not.toHaveBeenCalled();
     wrapper.find('form').simulate('submit');
     await sleep(50);
-    expect(scrollIntoView).toHaveBeenCalled();
+    const inputNode = document.getElementById('test');
+    expect(scrollIntoView).toHaveBeenCalledWith(inputNode, {
+      block: 'center',
+      scrollMode: 'if-needed',
+    });
     expect(onFinishFailed).toHaveBeenCalled();
 
     wrapper.unmount();

--- a/components/form/index.en-US.md
+++ b/components/form/index.en-US.md
@@ -30,7 +30,7 @@ High performance Form component with data scope management. Including data colle
 | name | Form name. Will be the prefix of Field `id` | string | - |  |
 | preserve | Keep field value even when field removed | boolean | true | 4.4.0 |
 | requiredMark | Required mark style. Can use required mark or optional mark. You can not config to single Form.Item since this is a Form level config | boolean \| `optional` | true | 4.6.0 |
-| scrollToFirstError | Auto scroll to first failed field when submit | boolean | false |  |
+| scrollToFirstError | Auto scroll to first failed field when submit | boolean \| { block:`center` \| `end` \| `nearest`\| `start` } | false |  |
 | size | Set field component size (antd components only) | `small` \| `middle` \| `large` | - |  |
 | validateMessages | Validation prompt template, description [see below](#validateMessages) | [ValidateMessages](https://github.com/react-component/field-form/blob/master/src/utils/messages.ts) | - |  |
 | validateTrigger | Config field validate trigger | string \| string\[] | `onChange` | 4.3.0 |

--- a/components/form/index.en-US.md
+++ b/components/form/index.en-US.md
@@ -30,7 +30,7 @@ High performance Form component with data scope management. Including data colle
 | name | Form name. Will be the prefix of Field `id` | string | - |  |
 | preserve | Keep field value even when field removed | boolean | true | 4.4.0 |
 | requiredMark | Required mark style. Can use required mark or optional mark. You can not config to single Form.Item since this is a Form level config | boolean \| `optional` | true | 4.6.0 |
-| scrollToFirstError | Auto scroll to first failed field when submit | boolean \| { block:`center` \| `end` \| `nearest`\| `start` } | false |  |
+| scrollToFirstError | Auto scroll to first failed field when submit | boolean \| { block: `center` \| `end` \| `nearest`\| `start` } | false |  |
 | size | Set field component size (antd components only) | `small` \| `middle` \| `large` | - |  |
 | validateMessages | Validation prompt template, description [see below](#validateMessages) | [ValidateMessages](https://github.com/react-component/field-form/blob/master/src/utils/messages.ts) | - |  |
 | validateTrigger | Config field validate trigger | string \| string\[] | `onChange` | 4.3.0 |

--- a/components/form/index.zh-CN.md
+++ b/components/form/index.zh-CN.md
@@ -31,7 +31,7 @@ cover: https://gw.alipayobjects.com/zos/alicdn/ORmcdeaoO/Form.svg
 | name | 表单名称，会作为表单字段 `id` 前缀使用 | string | - |  |
 | preserve | 当字段被删除时保留字段值 | boolean | true | 4.4.0 |
 | requiredMark | 必选样式，可以切换为必选或者可选展示样式。此为 Form 配置，Form.Item 无法单独配置 | boolean \| `optional` | true | 4.6.0 |
-| scrollToFirstError | 提交失败自动滚动到第一个错误字段 | boolean \| { block:`center` \| `end` \| `nearest`\| `start` } | false |  |
+| scrollToFirstError | 提交失败自动滚动到第一个错误字段 | boolean \| { block: `center` \| `end` \| `nearest`\| `start` } | false |  |
 | size | 设置字段组件的尺寸（仅限 antd 组件） | `small` \| `middle` \| `large` | - |  |
 | validateMessages | 验证提示模板，说明[见下](#validateMessages) | [ValidateMessages](https://github.com/react-component/field-form/blob/master/src/utils/messages.ts) | - |  |
 | validateTrigger | 统一设置字段校验规则 | string \| string\[] | `onChange` | 4.3.0 |

--- a/components/form/index.zh-CN.md
+++ b/components/form/index.zh-CN.md
@@ -31,7 +31,7 @@ cover: https://gw.alipayobjects.com/zos/alicdn/ORmcdeaoO/Form.svg
 | name | 表单名称，会作为表单字段 `id` 前缀使用 | string | - |  |
 | preserve | 当字段被删除时保留字段值 | boolean | true | 4.4.0 |
 | requiredMark | 必选样式，可以切换为必选或者可选展示样式。此为 Form 配置，Form.Item 无法单独配置 | boolean \| `optional` | true | 4.6.0 |
-| scrollToFirstError | 提交失败自动滚动到第一个错误字段 | boolean | false |  |
+| scrollToFirstError | 提交失败自动滚动到第一个错误字段 | boolean \| { block:`center` \| `end` \| `nearest`\| `start` } | false |  |
 | size | 设置字段组件的尺寸（仅限 antd 组件） | `small` \| `middle` \| `large` | - |  |
 | validateMessages | 验证提示模板，说明[见下](#validateMessages) | [ValidateMessages](https://github.com/react-component/field-form/blob/master/src/utils/messages.ts) | - |  |
 | validateTrigger | 统一设置字段校验规则 | string \| string\[] | `onChange` | 4.3.0 |


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close https://github.com/ant-design/ant-design/issues/27877

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->
control first error field scroll into view 
控制滚动到第一个错误提示的视图位置
for example:
``` js
<Form
  scrollToFirstError={{
    block: 'center'
  }}
>
</Form>
```
{ block:`center` \| `end` \| `nearest`\| `start` }

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Form scrollToFirstError support ScrollLogicalPosition        |
| 🇨🇳 Chinese |    表格组件的scrollToFirstError属性支持 ScrollLogicalPosition 滚动位置参数       |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


[components/transfer/index.zh-CN.md](https://github.com/vouis/ant-design/blob/%2327877-feature/components/form/index.zh-CN.md)
[components/transfer/index.en-US.md](https://github.com/vouis/ant-design/blob/%2327877-feature/components/form/index.en-US.md)


-----
[View rendered components/form/index.en-US.md](https://github.com/vouis/ant-design/blob/#27877-feature/components/form/index.en-US.md)
[View rendered components/form/index.zh-CN.md](https://github.com/vouis/ant-design/blob/#27877-feature/components/form/index.zh-CN.md)