### PR TITLE
修复transfer titles 类型错误

### DIFF
--- a/components/transfer/index.tsx
+++ b/components/transfer/index.tsx
@@ -46,7 +46,7 @@ export type SelectAllLabel =
   | ((info: { selectedCount: number; totalCount: number }) => React.ReactNode);
 
 export interface TransferLocale {
-  titles: string[];
+  titles: RenderResult[];
   notFoundContent?: React.ReactNode;
   searchPlaceholder: string;
   itemUnit: string;
@@ -72,7 +72,7 @@ export interface TransferProps<RecordType> {
   style?: React.CSSProperties;
   listStyle: ((style: ListStyle) => React.CSSProperties) | React.CSSProperties;
   operationStyle?: React.CSSProperties;
-  titles?: string[];
+  titles?: RenderResult[];
   operations?: string[];
   showSearch?: boolean;
   filterOption?: (inputValue: string, item: RecordType) => boolean;


### PR DESCRIPTION
### 🤔 这个变动的性质是？

-  TypeScript 定义更新

### 🔗 相关 Issue

[https://github.com/ant-design/ant-design/issues/28289](url)

### 💡 需求背景和解决方案

问题：transfer组件说明文档上写的是ReactNode[]类型但是代码上却是string[]
解决方案：替换TransferLocale接口和TransferProps接口的titles类型为RenderResult[]与render返回类型一致
效果：现在可以正常使用ReactNode[]赋值到titles

### 📝 更新日志

现在可以正常使用ReactNode[]赋值到titles

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |     fixed transfer components titles type error     |
| 🇨🇳 中文 |    修复transfer组件的titles接收类型异常      |

### ☑️ 请求合并前的自查清单

- ☑️文档已补充或无须补充
- ☑️ 代码演示已提供或无须提供
- ☑️ TypeScript 定义已补充或无须补充
- ☑️ Changelog 已提供或无须提供