### PR TITLE
fix: fixed transfer components titles type error

### DIFF
--- a/components/transfer/index.tsx
+++ b/components/transfer/index.tsx
@@ -46,7 +46,7 @@ export type SelectAllLabel =
   | ((info: { selectedCount: number; totalCount: number }) => React.ReactNode);
 
 export interface TransferLocale {
-  titles: string[];
+  titles: RenderResult[];
   notFoundContent?: React.ReactNode;
   searchPlaceholder: string;
   itemUnit: string;
@@ -72,7 +72,7 @@ export interface TransferProps<RecordType> {
   style?: React.CSSProperties;
   listStyle: ((style: ListStyle) => React.CSSProperties) | React.CSSProperties;
   operationStyle?: React.CSSProperties;
-  titles?: string[];
+  titles?: RenderResult[];
   operations?: string[];
   showSearch?: boolean;
   filterOption?: (inputValue: string, item: RecordType) => boolean;

--- a/components/transfer/index.tsx
+++ b/components/transfer/index.tsx
@@ -164,7 +164,7 @@ class Transfer<RecordType extends TransferItem = TransferItem> extends React.Com
     }
   };
 
-  getTitles(transferLocale: TransferLocale): string[] {
+  getTitles(transferLocale: TransferLocale): RenderResult[] {
     const { titles } = this.props;
     if (titles) {
       return titles;


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

新特性请提交至 feature 分支，其余可提交至 master 分支。
在维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

[[English Template / 英文模板](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE.md)]

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [x] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
[https://github.com/ant-design/ant-design/issues/28289](url)

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

问题：transfer组件说明文档上写的是ReactNode[]类型但是代码上却是string[]
解决方案：替换TransferLocale接口和TransferProps接口的titles类型为RenderResult[]与render返回类型一致
效果：现在可以正常使用ReactNode[]赋值到titles

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |     fixed transfer components titles type error     |
| 🇨🇳 中文 |    修复transfer组件的titles接收类型异常      |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
