### PR TITLE
fix: titles of TransferProps type to ReactNode

### DIFF
--- a/components/transfer/index.tsx
+++ b/components/transfer/index.tsx
@@ -46,7 +46,7 @@ export type SelectAllLabel =
   | ((info: { selectedCount: number; totalCount: number }) => React.ReactNode);
 
 export interface TransferLocale {
-  titles: string[];
+  titles: React.ReactNode[];
   notFoundContent?: React.ReactNode;
   searchPlaceholder: string;
   itemUnit: string;
@@ -72,7 +72,7 @@ export interface TransferProps<RecordType> {
   style?: React.CSSProperties;
   listStyle: ((style: ListStyle) => React.CSSProperties) | React.CSSProperties;
   operationStyle?: React.CSSProperties;
-  titles?: string[];
+  titles?: React.ReactNode[];
   operations?: string[];
   showSearch?: boolean;
   filterOption?: (inputValue: string, item: RecordType) => boolean;
@@ -164,7 +164,7 @@ class Transfer<RecordType extends TransferItem = TransferItem> extends React.Com
     }
   };
 
-  getTitles(transferLocale: TransferLocale): string[] {
+  getTitles(transferLocale: TransferLocale): React.ReactNode[] {
     const { titles } = this.props;
     if (titles) {
       return titles;

--- a/components/transfer/list.tsx
+++ b/components/transfer/list.tsx
@@ -42,7 +42,7 @@ type RenderListFunction<T> = (props: TransferListBodyProps<T>) => React.ReactNod
 
 export interface TransferListProps<RecordType> extends TransferLocale {
   prefixCls: string;
-  titleText: string;
+  titleText: React.ReactNode;
   dataSource: RecordType[];
   filterOption?: (filterText: string, item: RecordType) => boolean;
   style?: React.CSSProperties;


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close https://github.com/ant-design/ant-design/issues/28289

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fixed titles of TransferProps type to ReactNode         |
| 🇨🇳 Chinese |  修正 TransferProps 的 titles 型別為  ReactNode      |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
