### PR TITLE
issue28420

### DIFF
--- a/components/transfer/index.tsx
+++ b/components/transfer/index.tsx
@@ -369,6 +369,7 @@ class Transfer<RecordType extends TransferItem = TransferItem> extends React.Com
           showSelectAll,
           oneWay,
           pagination,
+          onChange,
         } = this.props;
         const prefixCls = getPrefixCls('transfer', customizePrefixCls);
         const locale = this.getLocale(transferLocale, renderEmpty);
@@ -439,6 +440,7 @@ class Transfer<RecordType extends TransferItem = TransferItem> extends React.Com
               checkedKeys={targetSelectedKeys}
               handleFilter={this.handleRightFilter}
               handleClear={this.handleRightClear}
+              onChange={onChange}
               onItemSelect={this.onRightItemSelect}
               onItemSelectAll={this.onRightItemSelectAll}
               onItemRemove={this.onRightItemRemove}

--- a/components/transfer/list.tsx
+++ b/components/transfer/list.tsx
@@ -48,6 +48,7 @@ export interface TransferListProps<RecordType> extends TransferLocale {
   style?: React.CSSProperties;
   checkedKeys: string[];
   handleFilter: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onChange?: (targetKeys: string[], direction: TransferDirection, moveKeys: string[]) => void;
   onItemSelect: (key: string, check: boolean) => void;
   onItemSelectAll: (dataSource: string[], checkAll: boolean) => void;
   onItemRemove?: (keys: string[]) => void;


### PR DESCRIPTION
### This is a ...

- [x] New feature

### What's the background?
  
> 1. The Transfer component has two TransferList children components. However, they receive a limited set of props from the Transfer parent, and can’t directly edit the target keys. This can be useful when using custom ListBody that have more responsibilities than selecting items.
> 2. Solves the issue #28420 
  
### API Realization
  
> TransferList has a new optional prop, onChange, that is only used by custom ListBody.
  
### What's the affect?

> The user will be able to edit the Transfer targetKeys when declaring children components


### Self Check before Merge

- [ ] Doc is ready or not need
- [x] Demo is provided or not need
- [x] TypeScript definition is ready or not need
- [ ] Changelog provided

### Additional Plan?

None