### PR TITLE
feat: bumped version of `rc-image` 4.3.1 -> 4.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "rc-drawer": "~4.1.0",
     "rc-dropdown": "~3.2.0",
     "rc-field-form": "~1.17.3",
-    "rc-image": "~4.3.1",
+    "rc-image": "~4.4.0",
     "rc-input-number": "~6.1.0",
     "rc-mentions": "~1.5.0",
     "rc-menu": "~8.10.0",


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [X] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

Fixes https://github.com/ant-design/ant-design/issues/28415

### 💡 Background and solution

I added zoom in/out using the mouse wheel in `react-components/image` (https://github.com/react-component/image/pull/52), it was merged, and I bumped the version in Ant Design.

Please say if any documentation should be updated.

### 📝 Changelog


| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Image is now zoomable with the mouse wheel while on preview mode.        |
| 🇨🇳 Chinese |    Image Preview 支持通过鼠标滚轮缩放图片。       |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
