### PR TITLE
ci: add issue more

### DIFF
--- a/.github/workflows/issue-check-inactive.yml
+++ b/.github/workflows/issue-check-inactive.yml
@@ -1,0 +1,17 @@
+name: Issue Check Inactive
+
+on:
+  schedule:
+    - cron: "0 */15 * * *"
+
+jobs:
+  check-inactive:
+    runs-on: ubuntu-latest
+    steps:
+      - name: check-inactive
+        uses: actions-cool/issues-helper@v1
+        with:
+          actions: 'check-inactive'
+          token: ${{ secrets.ANT_BOT_TOKEN }}
+          inactive-label: 'Inactive'
+          inactive-day: 30

--- a/.github/workflows/issue-close-need-reproduce.yml
+++ b/.github/workflows/issue-close-need-reproduce.yml
@@ -1,0 +1,17 @@
+name: Issue Close Need Reproduce
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    steps:
+      - name: close-issues
+        uses: actions-cool/issues-helper@v1
+        with:
+          actions: 'close-issues'
+          token: ${{ secrets.ANT_BOT_TOKEN }}
+          labels: '🤔 Need Reproduce'
+          inactive-day: 7

--- a/.github/workflows/issue-close-require.yml
+++ b/.github/workflows/issue-close-require.yml
@@ -14,4 +14,4 @@ jobs:
           actions: 'close-issues'
           token: ${{ secrets.ANT_BOT_TOKEN }}
           labels: '🤔 Need Reproduce'
-          inactive-day: 7
+          inactive-day: 3

--- a/.github/workflows/issue-close-require.yml
+++ b/.github/workflows/issue-close-require.yml
@@ -1,4 +1,4 @@
-name: Issue Close Need Reproduce
+name: Issue Close Require
 
 on:
   schedule:

--- a/.github/workflows/issue-open-check.yml
+++ b/.github/workflows/issue-open-check.yml
@@ -13,10 +13,47 @@ jobs:
         uses: actions-cool/issues-helper@v1
         with:
           actions: 'create-comment,add-labels,close-issue'
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.ANT_BOT_TOKEN }}
           issue-number: ${{ github.event.issue.number }}
           labels: 'Invalid'
           body: |
             Hello @${{ github.event.issue.user.login }}, your issue has been closed because it does not conform to our issue requirements. Please use the [Issue Helper](http://new-issue.ant.design) to create an issue, thank you!
 
             你好 @${{ github.event.issue.user.login }}，为了能够进行高效沟通，我们对 issue 有一定的格式要求，你的 issue 因为不符合要求而被自动关闭。你可以通过 [issue 助手](http://new-issue.ant.design) 来创建 issue 以方便我们定位错误。谢谢配合！
+
+      - name: check-website
+        uses: actions-cool/issues-helper@v1.2
+        id: checkid
+        with:
+          actions: 'check-issue'
+          token: ${{ secrets.ANT_BOT_TOKEN }}
+          issue-number: ${{ github.event.issue.number }}
+          # 格式如：'x1,x2/y1,y2' 只支持 2 个数组           
+          title-includes: '官网,网站,国内,镜像,mobile ant design,mobile.ant.design,ant design,ant.design,pro/挂了,无法访问,不能访问,访问不了,出问题,打不开,登不上,can not open,can not be reached'
+
+      - name: deal-website
+        if: steps.checkid.outputs.check-result == true
+        uses: actions-cool/issues-helper@v1.2
+        with:
+          actions: 'create-comment,close-issue'
+          token: ${{ secrets.ANT_BOT_TOKEN }}
+          issue-number: ${{ github.event.issue.number }}
+          body: |
+            Ant Design 系列官网由于某些众所周知的原因无法访问，建议翻墙或访问国内镜像站点。
+
+            ## 官网
+            * Ant Design: https://ant.design
+            * Ant Design Pro: https://pro.ant.design
+            * Ant Design Pro Preview : https://preview.pro.ant.design
+            * Ant Design Mobile: https://mobile.ant.design
+            * Ant Motion: https://motion.ant.design
+
+            ## 国内镜像
+            * Ant Design: http://ant-design.gitee.io
+            * Ant Design 3.x: http://ant-design-3x.gitee.io
+            * Ant Design 2.x: http://ant-design-2x.gitee.io
+            * Ant Design 1.x: http://ant-design-1x.gitee.io
+            * Ant Design Pro: http://ant-design-pro.gitee.io
+            * Ant Design Mobile: http://antd-mobile.gitee.io
+            * Ant Motion: http://ant-motion.gitee.io
+            * Ant Design Pro Preview : https://prosite.z23.web.core.windows.net

--- a/.github/workflows/issue-open-check.yml
+++ b/.github/workflows/issue-open-check.yml
@@ -29,7 +29,7 @@ jobs:
           actions: 'check-issue'
           token: ${{ secrets.ANT_BOT_TOKEN }}
           issue-number: ${{ github.event.issue.number }}
-          # 格式如：'x1,x2/y1,y2' 只支持 2 个数组           
+          # 格式如：'x1,x2' or  'x1,x2/y1,y2' 最多支持 2 个数组           
           title-includes: '官网,网站,国内,镜像,mobile ant design,mobile.ant.design,ant design,ant.design,pro/挂了,无法访问,不能访问,访问不了,出问题,打不开,登不上,can not open,can not be reached'
 
       - name: deal-website

--- a/.github/workflows/issue-open-check.yml
+++ b/.github/workflows/issue-open-check.yml
@@ -1,0 +1,22 @@
+name: Issue Open Check
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  check-issue:
+    runs-on: ubuntu-latest
+    steps:
+      - name: check invalid
+        if: contains(github.event.issue.body, 'ant-design-issue-helper') == false
+        uses: actions-cool/issues-helper@v1
+        with:
+          actions: 'create-comment,add-labels,close-issue'
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.issue.number }}
+          labels: 'Invalid'
+          body: |
+            Hello @${{ github.event.issue.user.login }}, your issue has been closed because it does not conform to our issue requirements. Please use the [Issue Helper](http://new-issue.ant.design) to create an issue, thank you!
+
+            你好 @${{ github.event.issue.user.login }}，为了能够进行高效沟通，我们对 issue 有一定的格式要求，你的 issue 因为不符合要求而被自动关闭。你可以通过 [issue 助手](http://new-issue.ant.design) 来创建 issue 以方便我们定位错误。谢谢配合！

--- a/.github/workflows/issue-open-check.yml
+++ b/.github/workflows/issue-open-check.yml
@@ -22,6 +22,7 @@ jobs:
             你好 @${{ github.event.issue.user.login }}，为了能够进行高效沟通，我们对 issue 有一定的格式要求，你的 issue 因为不符合要求而被自动关闭。你可以通过 [issue 助手](http://new-issue.ant.design) 来创建 issue 以方便我们定位错误。谢谢配合！
 
       - name: check-website
+        if: contains(github.event.issue.body, 'ant-design-issue-helper') == true
         uses: actions-cool/issues-helper@v1.2
         id: checkid
         with:

--- a/.github/workflows/issue-remove-inactive.yml
+++ b/.github/workflows/issue-remove-inactive.yml
@@ -1,0 +1,19 @@
+name: Issue Remove Inactive
+
+on:
+  issues:
+    types: [edited, reopened]
+  issue_comment:
+    types: [created, edited]
+
+jobs:
+  remove-inactive:
+    runs-on: ubuntu-latest
+    steps:
+      - name: remove inactive
+        uses: actions-cool/issues-helper@v1.2
+        with:
+          actions: 'remove-labels'
+          token: ${{ secrets.ANT_BOT_TOKEN }}
+          issue-number: ${{ github.event.issue.number }}
+          labels: 'Inactive'

--- a/.github/workflows/issue-reply.yml
+++ b/.github/workflows/issue-reply.yml
@@ -1,11 +1,11 @@
-name: Issue Replay
+name: Issue Reply
 
 on:
   issues:
     types: [labeled]
 
 jobs:
-  replay-help:
+  reply-helper:
     runs-on: ubuntu-latest
     steps:
       - name: help wanted


### PR DESCRIPTION
- `🤔 Need Reproduce` 3天未活跃关闭 issue —— 1 天触发一次
-  `check-inactive` 给 30 天未活跃的 issue 增加 `Inactive` label —— 半月触发一次
- issue 新增时
   - 校验是否包含 `ant-design-issue-helper`，否则加 label 评论 关闭
   - 校验标题是否满足 2 个数组，否则评论 关闭
- 当 issue 更新、重新打开、进行评论、修改评论时，移除 `Inactive` label，不影响其他 label