### PR TITLE
fix: percent={(3 / 9) * 100} steps={9} shows 2

### DIFF
--- a/components/progress/Steps.tsx
+++ b/components/progress/Steps.tsx
@@ -20,7 +20,7 @@ const Steps: React.FC<StepsProps> = props => {
     prefixCls,
     children,
   } = props;
-  const current = Math.floor(steps * (percent / 100));
+  const current = Math.round(steps * (percent / 100));
   const stepWidth = size === 'small' ? 2 : 14;
   const styledSteps = [];
   for (let i = 0; i < steps; i += 1) {

--- a/components/progress/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/progress/__tests__/__snapshots__/demo.test.js.snap
@@ -1415,7 +1415,7 @@ Array [
         style="width:14px;height:8px"
       />
       <div
-        class="ant-progress-steps-item"
+        class="ant-progress-steps-item ant-progress-steps-item-active"
         style="width:14px;height:8px"
       />
       <div
@@ -1442,7 +1442,7 @@ Array [
         style="width:14px;height:8px"
       />
       <div
-        class="ant-progress-steps-item"
+        class="ant-progress-steps-item ant-progress-steps-item-active"
         style="width:14px;height:8px"
       />
       <div

--- a/components/progress/__tests__/index.test.js
+++ b/components/progress/__tests__/index.test.js
@@ -175,6 +175,13 @@ describe('Progress', () => {
     );
   });
 
+  it('should display correct step', () => {
+    const wrapper = mount(<Progress steps={9} percent={33.33} trailColor="#1890ee" />);
+    expect(wrapper.find('.ant-progress-steps-item').at(3).getDOMNode().style.backgroundColor).toBe(
+      'rgb(24, 144, 238)',
+    );
+  });
+
   it('steps should have default percent 0', () => {
     const wrapper = mount(<ProgressSteps />);
     expect(wrapper.render()).toMatchSnapshot();

--- a/components/progress/__tests__/index.test.js
+++ b/components/progress/__tests__/index.test.js
@@ -176,10 +176,12 @@ describe('Progress', () => {
   });
 
   it('should display correct step', () => {
-    const wrapper = mount(<Progress steps={9} percent={33.33} trailColor="#1890ee" />);
-    expect(wrapper.find('.ant-progress-steps-item').at(3).getDOMNode().style.backgroundColor).toBe(
-      'rgb(24, 144, 238)',
-    );
+    const wrapper = mount(<Progress steps={9} percent={22.22} />);
+    expect(wrapper.find('.ant-progress-steps-item-active').length).toBe(2);
+    wrapper.setProps({ percent: 33.33 });
+    expect(wrapper.find('.ant-progress-steps-item-active').length).toBe(3);
+    wrapper.setProps({ percent: 44.44 });
+    expect(wrapper.find('.ant-progress-steps-item-active').length).toBe(4);
   });
 
   it('steps should have default percent 0', () => {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->
N/A
### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->
![image](https://user-images.githubusercontent.com/5306513/103082891-204bde80-4616-11eb-905f-952409756831.png)
```js
<Progress percent={(3 / 9) * 100} steps={9} />
```

supposed to display 3 blocks, but there's only 2

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Progress steps display accuracy.  |
| 🇨🇳 Chinese | 修复 Progress `steps` 显示精度问题。 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
