### PR TITLE
add prettier plugin for formatting jsdoc

### DIFF
--- a/components/_util/__tests__/getScrollNode.test.ts
+++ b/components/_util/__tests__/getScrollNode.test.ts
@@ -1,6 +1,4 @@
-/**
- * @jest-environment node
- */
+/** @jest-environment node */
 import getScroll from '../getScroll';
 
 describe('getScroll node', () => {

--- a/components/_util/transButton.tsx
+++ b/components/_util/transButton.tsx
@@ -1,5 +1,6 @@
 /**
  * Wrap of sub component which need use as Button capacity (like Icon component).
+ *
  * This helps accessibility reader to tread as a interactive button to operation.
  */
 import * as React from 'react';

--- a/components/_util/type.ts
+++ b/components/_util/type.ts
@@ -5,12 +5,10 @@ export const tuple = <T extends string[]>(...args: T) => args;
 export const tupleNum = <T extends number[]>(...args: T) => args;
 
 /**
- * https://stackoverflow.com/a/59187769
- * Extract the type of an element of an array/tuple without performing indexing
+ * https://stackoverflow.com/a/59187769 Extract the type of an element of an array/tuple without
+ * performing indexing
  */
 export type ElementOf<T> = T extends (infer E)[] ? E : T extends readonly (infer F)[] ? F : never;
 
-/**
- * https://github.com/Microsoft/TypeScript/issues/29729
- */
+/** https://github.com/Microsoft/TypeScript/issues/29729 */
 export type LiteralUnion<T extends U, U> = T | (U & {});

--- a/components/affix/index.tsx
+++ b/components/affix/index.tsx
@@ -19,9 +19,7 @@ function getDefaultTarget() {
 
 // Affix
 export interface AffixProps {
-  /**
-   * 距离窗口顶部达到指定偏移量后触发
-   */
+  /** 距离窗口顶部达到指定偏移量后触发 */
   offsetTop?: number;
   /** 距离窗口底部达到指定偏移量后触发 */
   offsetBottom?: number;

--- a/components/alert/index.tsx
+++ b/components/alert/index.tsx
@@ -17,9 +17,7 @@ import ErrorBoundary from './ErrorBoundary';
 import { replaceElement } from '../_util/reactNode';
 
 export interface AlertProps {
-  /**
-   * Type of Alert styles, options:`success`, `info`, `warning`, `error`
-   */
+  /** Type of Alert styles, options:`success`, `info`, `warning`, `error` */
   type?: 'success' | 'info' | 'warning' | 'error';
   /** Whether Alert can be closed */
   closable?: boolean;

--- a/components/auto-complete/index.tsx
+++ b/components/auto-complete/index.tsx
@@ -1,8 +1,8 @@
 /**
  * TODO: 4.0
- * - remove `dataSource`
- * - `size` not work with customizeInput
- * - customizeInput not feedback `ENTER` key since accessibility enhancement
+ *     - remove `dataSource`
+ *     - `size` not work with customizeInput
+ *     - customizeInput not feedback `ENTER` key since accessibility enhancement
  */
 
 import * as React from 'react';

--- a/components/avatar/avatar.tsx
+++ b/components/avatar/avatar.tsx
@@ -22,7 +22,7 @@ export interface AvatarProps {
   /** Srcset of image avatar */
   srcSet?: string;
   draggable?: boolean;
-  /** icon to be used in avatar */
+  /** Icon to be used in avatar */
   icon?: React.ReactNode;
   style?: React.CSSProperties;
   prefixCls?: string;

--- a/components/badge/index.tsx
+++ b/components/badge/index.tsx
@@ -22,7 +22,7 @@ export interface BadgeProps {
   showZero?: boolean;
   /** Max count to show */
   overflowCount?: number;
-  /** whether to show red dot without number */
+  /** Whether to show red dot without number */
   dot?: boolean;
   style?: React.CSSProperties;
   prefixCls?: string;

--- a/components/breadcrumb/BreadcrumbItem.tsx
+++ b/components/breadcrumb/BreadcrumbItem.tsx
@@ -26,10 +26,7 @@ const BreadcrumbItem: BreadcrumbItemInterface = ({
 }) => {
   const { getPrefixCls } = React.useContext(ConfigContext);
   const prefixCls = getPrefixCls('breadcrumb', customizePrefixCls);
-  /**
-   * if overlay is have
-   * Wrap a DropDown
-   */
+  /** If overlay is have Wrap a DropDown */
   const renderBreadcrumbNode = (breadcrumbItem: React.ReactNode) => {
     if (overlay) {
       return (

--- a/components/button/button.tsx
+++ b/components/button/button.tsx
@@ -140,7 +140,7 @@ const InternalButton: React.ForwardRefRenderFunction<unknown, ButtonProps> = (pr
     icon,
     ghost = false,
     block = false,
-    /** if we extract items here, we dont need use omit.js */
+    /** If we extract items here, we don't need use omit.js */
     // React does not recognize the `htmlType` prop on a DOM element. Here we pick it out of `rest`.
     htmlType = 'button' as ButtonProps['htmlType'],
     ...rest

--- a/components/cascader/index.tsx
+++ b/components/cascader/index.tsx
@@ -93,7 +93,7 @@ export interface CascaderProps {
   name?: string;
   /** 输入框id */
   id?: string;
-  /** whether has border style */
+  /** Whether has border style */
   bordered?: boolean;
   /** 禁用 */
   disabled?: boolean;
@@ -115,7 +115,7 @@ export interface CascaderProps {
   inputPrefixCls?: string;
   getPopupContainer?: (triggerNode: HTMLElement) => HTMLElement;
   popupVisible?: boolean;
-  /** use this after antd@3.7.0 */
+  /** Use this after antd@3.7.0 */
   fieldNames?: FieldNamesType;
   suffixIcon?: React.ReactNode;
   dropdownRender?: (menus: React.ReactNode) => React.ReactNode;

--- a/components/comment/index.tsx
+++ b/components/comment/index.tsx
@@ -9,7 +9,7 @@ export interface CommentProps {
   author?: React.ReactNode;
   /** The element to display as the comment avatar - generally an antd Avatar */
   avatar?: React.ReactNode;
-  /** className of comment */
+  /** ClassName of comment */
   className?: string;
   /** The main content of the comment */
   content: React.ReactNode;

--- a/components/date-picker/locale/ru_RU.tsx
+++ b/components/date-picker/locale/ru_RU.tsx
@@ -1,6 +1,4 @@
-/**
- * Created by Andrey Gayvoronsky on 13/04/16.
- */
+/** Created by Andrey Gayvoronsky on 13/04/16. */
 
 import CalendarLocale from 'rc-picker/lib/locale/ru_RU';
 import TimePickerLocale from '../../time-picker/locale/ru_RU';

--- a/components/drawer/index.tsx
+++ b/components/drawer/index.tsx
@@ -31,7 +31,7 @@ export interface DrawerProps {
   mask?: boolean;
   maskStyle?: React.CSSProperties;
   style?: React.CSSProperties;
-  /** wrapper dom node style of header and body */
+  /** Wrapper dom node style of header and body */
   drawerStyle?: React.CSSProperties;
   headerStyle?: React.CSSProperties;
   bodyStyle?: React.CSSProperties;

--- a/components/empty/index.tsx
+++ b/components/empty/index.tsx
@@ -16,9 +16,7 @@ export interface EmptyProps {
   prefixCls?: string;
   className?: string;
   style?: React.CSSProperties;
-  /**
-   * @since 3.16.0
-   */
+  /** @since 3.16.0 */
   imageStyle?: React.CSSProperties;
   image?: React.ReactNode;
   description?: React.ReactNode;

--- a/components/form/ErrorList.tsx
+++ b/components/form/ErrorList.tsx
@@ -30,6 +30,7 @@ export default function ErrorList({
       if (changedVisible) {
         /**
          * We trigger in sync to avoid dom shaking but this get warning in react 16.13.
+         *
          * So use Promise to keep in micro async to handle this.
          * https://github.com/ant-design/ant-design/issues/21698#issuecomment-593743485
          */

--- a/components/form/FormItemInput.tsx
+++ b/components/form/FormItemInput.tsx
@@ -17,9 +17,7 @@ interface FormItemInputMiscProps {
   hasFeedback?: boolean;
   validateStatus?: ValidateStatus;
   onDomErrorVisibleChange: (visible: boolean) => void;
-  /**
-   * @private Internal usage, do not use in any of your production.
-   */
+  /** @private Internal usage, do not use in any of your production. */
   _internalItemRender?: {
     mark: string;
     render: (

--- a/components/form/context.tsx
+++ b/components/form/context.tsx
@@ -7,10 +7,7 @@ import { FormLabelAlign } from './interface';
 import { RequiredMark } from './Form';
 import { ValidateStatus } from './FormItem';
 
-/**
- * Form Context
- * Set top form style and pass to Form Item usage.
- */
+/** Form Context. Set top form style and pass to Form Item usage. */
 export interface FormContextProps {
   vertical: boolean;
   name?: string;
@@ -28,10 +25,7 @@ export const FormContext = React.createContext<FormContextProps>({
   itemRef: (() => {}) as any,
 });
 
-/**
- * Form Item Context
- * Used for Form noStyle Item error collection
- */
+/** Form Item Context. Used for Form noStyle Item error collection */
 export interface FormItemContextProps {
   updateItemErrors: (name: string, errors: string[]) => void;
 }
@@ -40,10 +34,7 @@ export const FormItemContext = React.createContext<FormItemContextProps>({
   updateItemErrors: () => {},
 });
 
-/**
- * Form Provider
- *
- */
+/** Form Provider */
 export interface FormProviderProps extends Omit<RcFormProviderProps, 'validateMessages'> {}
 
 export const FormProvider: React.FC<FormProviderProps> = props => {
@@ -51,9 +42,7 @@ export const FormProvider: React.FC<FormProviderProps> = props => {
   return <RcFormProvider {...providerProps} />;
 };
 
-/**
- * Used for ErrorList only
- */
+/** Used for ErrorList only */
 export interface FormItemPrefixContextProps {
   prefixCls: string;
   status?: ValidateStatus;

--- a/components/form/hooks/useCacheErrors.ts
+++ b/components/form/hooks/useCacheErrors.ts
@@ -1,9 +1,7 @@
 import * as React from 'react';
 import useForceUpdate from '../../_util/hooks/useForceUpdate';
 
-/**
- * Always debounce error to avoid [error -> null -> error] blink
- */
+/** Always debounce error to avoid [error -> null -> error] blink */
 export default function useCacheErrors(
   errors: React.ReactNode[],
   changeTrigger: (visible: boolean) => void,

--- a/components/form/index.zh-CN.md
+++ b/components/form/index.zh-CN.md
@@ -176,11 +176,13 @@ Form 通过增量更新方式，只更新被修改的字段相关组件以达到
 
 ```tsx
 <Form.List>
-  {fields => fields.map(field => (
-    <Form.Item {...field}>
-      <Input />
-    </Form.Item>
-  ))}
+  {fields =>
+    fields.map(field => (
+      <Form.Item {...field}>
+        <Input />
+      </Form.Item>
+    ))
+  }
 </Form.List>
 ```
 

--- a/components/input/ClearableLabeledInput.tsx
+++ b/components/input/ClearableLabeledInput.tsx
@@ -17,9 +17,7 @@ function hasAddon(props: InputProps | ClearableInputProps) {
   return !!(props.addonBefore || props.addonAfter);
 }
 
-/**
- * This basic props required for input and textarea.
- */
+/** This basic props required for input and textarea. */
 interface BasicProps {
   prefixCls: string;
   inputType: typeof ClearableInputType[number];
@@ -36,9 +34,7 @@ interface BasicProps {
   bordered: boolean;
 }
 
-/**
- * This props only for input.
- */
+/** This props only for input. */
 interface ClearableInputProps extends BasicProps {
   size?: SizeType;
   suffix?: React.ReactNode;

--- a/components/input/__tests__/textarea.test.js
+++ b/components/input/__tests__/textarea.test.js
@@ -58,12 +58,12 @@ describe('TextArea', () => {
     const wrapper = mount(
       <TextArea onKeyDown={fakeHandleKeyDown} onPressEnter={fakeHandlePressEnter} />,
     );
-    /** keyCode 65 is A */
+    /** KeyCode 65 is A */
     wrapper.find('textarea').simulate('keydown', { keyCode: 65 });
     expect(fakeHandleKeyDown).toHaveBeenCalledTimes(1);
     expect(fakeHandlePressEnter).toHaveBeenCalledTimes(0);
 
-    /** keyCode 13 is Enter */
+    /** KeyCode 13 is Enter */
     wrapper.find('textarea').simulate('keydown', { keyCode: 13 });
     expect(fakeHandleKeyDown).toHaveBeenCalledTimes(2);
     expect(fakeHandlePressEnter).toHaveBeenCalledTimes(1);

--- a/components/modal/confirm.tsx
+++ b/components/modal/confirm.tsx
@@ -60,6 +60,7 @@ export default function confirm(config: ModalFuncProps) {
   function render({ okText, cancelText, prefixCls, ...props }: any) {
     /**
      * https://github.com/ant-design/ant-design/issues/23623
+     *
      * Sync render blocks React event. Let's make this async.
      */
     setTimeout(() => {

--- a/components/progress/Line.tsx
+++ b/components/progress/Line.tsx
@@ -11,13 +11,14 @@ interface LineProps extends ProgressProps {
 }
 
 /**
- * {
- *   '0%': '#afc163',
- *   '75%': '#009900',
- *   '50%': 'green',     ====>     '#afc163 0%, #66FF00 25%, #00CC00 50%, #009900 75%, #ffffff 100%'
- *   '25%': '#66FF00',
- *   '100%': '#ffffff'
- * }
+ * @example
+ *   {
+ *     "0%": "#afc163",
+ *     "75%": "#009900",
+ *     "50%": "green", // ====> '#afc163 0%, #66FF00 25%, #00CC00 50%, #009900 75%, #ffffff 100%'
+ *     "25%": "#66FF00",
+ *     "100%": "#ffffff"
+ *   }
  */
 export const sortGradient = (gradients: StringGradients) => {
   let tempArr: any[] = [];
@@ -35,19 +36,17 @@ export const sortGradient = (gradients: StringGradients) => {
 };
 
 /**
- * {
- *   '0%': '#afc163',
- *   '25%': '#66FF00',
- *   '50%': '#00CC00',     ====>  linear-gradient(to right, #afc163 0%, #66FF00 25%,
- *   '75%': '#009900',              #00CC00 50%, #009900 75%, #ffffff 100%)
- *   '100%': '#ffffff'
- * }
+ * Then this man came to realize the truth: Besides six pence, there is the moon. Besides bread and
+ * butter, there is the bug. And... Besides women, there is the code.
  *
- * Then this man came to realize the truth:
- * Besides six pence, there is the moon.
- * Besides bread and butter, there is the bug.
- * And...
- * Besides women, there is the code.
+ * @example
+ *   {
+ *     "0%": "#afc163",
+ *     "25%": "#66FF00",
+ *     "50%": "#00CC00", // ====>  linear-gradient(to right, #afc163 0%, #66FF00 25%,
+ *     "75%": "#009900", //        #00CC00 50%, #009900 75%, #ffffff 100%)
+ *     "100%": "#ffffff"
+ *   }
  */
 export const handleGradient = (strokeColor: ProgressGradient, directionConfig: DirectionType) => {
   const {

--- a/components/result/index.tsx
+++ b/components/result/index.tsx
@@ -43,9 +43,8 @@ export interface ResultProps {
 const ExceptionStatus = Object.keys(ExceptionMap);
 
 /**
- * render icon
- * if ExceptionStatus includes ,render svg image
- * else render iconNode
+ * Render icon if ExceptionStatus includes ,render svg image else render iconNode
+ *
  * @param prefixCls
  * @param {status, icon}
  */

--- a/components/table/Column.tsx
+++ b/components/table/Column.tsx
@@ -5,10 +5,7 @@ export interface ColumnProps<RecordType> extends ColumnType<RecordType> {
 }
 
 /* istanbul ignore next */
-/**
- * This is a syntactic sugar for `columns` prop.
- * So HOC will not work on this.
- */
+/** This is a syntactic sugar for `columns` prop. So HOC will not work on this. */
 // eslint-disable-next-line no-unused-vars
 function Column<RecordType>(_: ColumnProps<RecordType>) {
   return null;

--- a/components/table/ColumnGroup.tsx
+++ b/components/table/ColumnGroup.tsx
@@ -9,10 +9,7 @@ export interface ColumnGroupProps<RecordType> extends Omit<ColumnType<RecordType
 }
 
 /* istanbul ignore next */
-/**
- * This is a syntactic sugar for `columns` prop.
- * So HOC will not work on this.
- */
+/** This is a syntactic sugar for `columns` prop. So HOC will not work on this. */
 // eslint-disable-next-line no-unused-vars
 function ColumnGroup<RecordType>(_: ColumnGroupProps<RecordType>) {
   return null;

--- a/components/table/Table.tsx
+++ b/components/table/Table.tsx
@@ -233,10 +233,9 @@ function Table<RecordType extends object = any>(props: TableProps<RecordType>) {
   };
 
   /**
-   * Controlled state in `columns` is not a good idea that makes too many code (1000+ line?)
-   * to read state out and then put it back to title render.
-   * Move these code into `hooks` but still too complex.
-   * We should provides Table props like `sorter` & `filter` to handle control in next big version.
+   * Controlled state in `columns` is not a good idea that makes too many code (1000+ line?) to read
+   * state out and then put it back to title render. Move these code into `hooks` but still too
+   * complex. We should provides Table props like `sorter` & `filter` to handle control in next big version.
    */
 
   // ============================ Sorter =============================

--- a/components/table/__tests__/Table.pagination.test.js
+++ b/components/table/__tests__/Table.pagination.test.js
@@ -239,9 +239,8 @@ describe('Table.pagination', () => {
   });
 
   /**
-   * `pagination` is not designed to accept `true` value,
-   * but in practice, many people assign `true` to `pagination`,
-   * since they misunderstand that `pagination` can accept a boolean value.
+   * `pagination` is not designed to accept `true` value, but in practice, many people assign `true`
+   * to `pagination`, since they misunderstand that `pagination` can accept a boolean value.
    */
   it('Accepts pagination as true', () => {
     const wrapper = mount(createTable({ pagination: true }));

--- a/components/tag/CheckableTag.tsx
+++ b/components/tag/CheckableTag.tsx
@@ -7,8 +7,9 @@ export interface CheckableTagProps {
   className?: string;
   style?: React.CSSProperties;
   /**
-   * @description       it is an absolute controlled component and has no uncontrolled mode.
-   * @description.zh-CN 该组件为完全受控组件，不支持非受控用法。
+   * It is an absolute controlled component and has no uncontrolled mode.
+   *
+   * .zh-cn 该组件为完全受控组件，不支持非受控用法。
    */
   checked: boolean;
   onChange?: (checked: boolean) => void;

--- a/components/time-picker/locale/ru_RU.tsx
+++ b/components/time-picker/locale/ru_RU.tsx
@@ -1,6 +1,4 @@
-/**
- * Created by Andrey Gayvoronsky on 13/04/16.
- */
+/** Created by Andrey Gayvoronsky on 13/04/16. */
 import { TimePickerLocale } from '../index';
 
 const locale: TimePickerLocale = {

--- a/components/timeline/TimelineItem.tsx
+++ b/components/timeline/TimelineItem.tsx
@@ -25,7 +25,7 @@ const TimelineItem: React.FC<TimelineItemProps> = ({
   color = 'blue',
   dot,
   pending = false,
-  position /** dead, but do not pass in <li {...omit()} */,
+  position /** Dead, but do not pass in <li {...omit()} */,
   label,
   children,
   ...restProps

--- a/components/transfer/list.tsx
+++ b/components/transfer/list.tsx
@@ -52,7 +52,7 @@ export interface TransferListProps<RecordType> extends TransferLocale {
   onItemSelectAll: (dataSource: string[], checkAll: boolean) => void;
   onItemRemove?: (keys: string[]) => void;
   handleClear: () => void;
-  /** render item */
+  /** Render item */
   render?: (item: RecordType) => RenderResult;
   showSearch?: boolean;
   searchPlaceholder: string;

--- a/components/tree/Tree.tsx
+++ b/components/tree/Tree.tsx
@@ -99,7 +99,7 @@ export interface TreeProps extends Omit<RcTreeProps, 'prefixCls' | 'showLine' | 
   multiple?: boolean;
   /** 是否自动展开父节点 */
   autoExpandParent?: boolean;
-  /** checkable状态下节点选择完全受控（父子节点选中状态不再关联） */
+  /** Checkable状态下节点选择完全受控（父子节点选中状态不再关联） */
   checkStrictly?: boolean;
   /** 是否支持选中 */
   checkable?: boolean;

--- a/package.json
+++ b/package.json
@@ -234,6 +234,7 @@
     "node-fetch": "^2.6.0",
     "open": "^7.0.3",
     "prettier": "^2.2.0",
+    "prettier-plugin-jsdoc": "^0.2.12",
     "pretty-quick": "^3.0.0",
     "querystring": "^0.2.0",
     "rc-footer": "^0.6.3",

--- a/scripts/dark-vars.js
+++ b/scripts/dark-vars.js
@@ -1,7 +1,8 @@
 /**
- * convert dark.less into js vars
+ * Convert dark.less into js vars
  *
- * const darkVars = require('./dark-vars');
+ * @example
+ *   const darkVars = require('./dark-vars');
  */
 const fs = require('fs');
 const path = require('path');

--- a/scripts/default-vars.js
+++ b/scripts/default-vars.js
@@ -1,7 +1,8 @@
 /**
- * convert default.less into js vars
+ * Convert default.less into js vars
  *
- * const darkVars = require('./default-vars');
+ * @example
+ *   const darkVars = require('./default-vars');
  */
 const fs = require('fs');
 const path = require('path');

--- a/scripts/generateLegacyLocale.js
+++ b/scripts/generateLegacyLocale.js
@@ -1,7 +1,5 @@
 /* eslint-disable no-console */
-/**
- * Generate legacy locale file as shadow of `/locale` to `/locale-provider`.
- */
+/** Generate legacy locale file as shadow of `/locale` to `/locale-provider`. */
 
 const glob = require('glob');
 const fs = require('fs');

--- a/site/theme/template/AppShell.jsx
+++ b/site/theme/template/AppShell.jsx
@@ -1,5 +1,6 @@
 /**
  * Empty component for app shell
+ *
  * See https://github.com/NekR/offline-plugin/blob/master/docs/app-shell.md
  */
 import React from 'react';

--- a/tests/shared/demoTest.ts
+++ b/tests/shared/demoTest.ts
@@ -10,10 +10,10 @@ const USE_REPLACEMENT = false;
 const testDist = process.env.LIB_DIR === 'dist';
 
 /**
- * rc component will generate id for aria usage.
- * It's created as `test-uuid` when env === 'test'.
- * Or `f7fa7a3c-a675-47bc-912e-0c45fb6a74d9`(randomly) when not test env.
- * So we need hack of this to modify the `aria-controls`.
+ * Rc component will generate id for aria usage.
+ *     It's created as `test-uuid` when env === 'test'.
+ *     Or `f7fa7a3c-a675-47bc-912e-0c45fb6a74d9`(randomly) when not test env.
+ *     So we need hack of this to modify the `aria-controls`.
  */
 function ariaConvert(wrapper: CheerIO) {
   if (!testDist || !USE_REPLACEMENT) return wrapper;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [x] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

prettier-plugin-jsdoc is one of community plugins for prettier, I added that to formatting jsdoc easily. I hope this can be useful.
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed


-----
[View rendered components/form/index.zh-CN.md](https://github.com/hosseinmd/ant-design/blob/prettierJsdoc/components/form/index.zh-CN.md)