### PR TITLE
feat: add select none functionality

### DIFF
--- a/components/locale/default.tsx
+++ b/components/locale/default.tsx
@@ -24,6 +24,7 @@ const localeValues: Locale = {
     emptyText: 'No data',
     selectAll: 'Select current page',
     selectInvert: 'Invert current page',
+    selectNone: 'Clear all data',
     selectionAll: 'Select all data',
     sortTitle: 'Sort',
     expand: 'Expand row',

--- a/components/locale/zh_CN.tsx
+++ b/components/locale/zh_CN.tsx
@@ -24,6 +24,7 @@ const localeValues: Locale = {
     filterEmptyText: '无筛选项',
     selectAll: '全选当页',
     selectInvert: '反选当页',
+    selectNone: '清空所有',
     selectionAll: '全选所有',
     sortTitle: '排序',
     expand: '展开行',

--- a/components/locale/zh_HK.tsx
+++ b/components/locale/zh_HK.tsx
@@ -23,6 +23,7 @@ const localeValues: Locale = {
     filterEmptyText: '無篩選項',
     selectAll: '全部選取',
     selectInvert: '反向選取',
+    selectNone: '清空所有',
     selectionAll: '全選所有',
     sortTitle: '排序',
     expand: '展開行',

--- a/components/locale/zh_TW.tsx
+++ b/components/locale/zh_TW.tsx
@@ -23,6 +23,7 @@ const localeValues: Locale = {
     filterEmptyText: '無篩選項',
     selectAll: '全部選取',
     selectInvert: '反向選取',
+    selectNone: '清空所有',
     selectionAll: '全選所有',
     sortTitle: '排序',
     expand: '展開行',

--- a/components/table/Table.tsx
+++ b/components/table/Table.tsx
@@ -26,7 +26,11 @@ import {
   TableLocale,
   TableAction,
 } from './interface';
-import useSelection, { SELECTION_ALL, SELECTION_INVERT } from './hooks/useSelection';
+import useSelection, {
+  SELECTION_ALL,
+  SELECTION_INVERT,
+  SELECTION_NONE,
+} from './hooks/useSelection';
 import useSorter, { getSortData, SortState } from './hooks/useSorter';
 import useFilter, { getFilterData, FilterState } from './hooks/useFilter';
 import useTitleColumns from './hooks/useTitleColumns';
@@ -509,6 +513,7 @@ Table.defaultProps = {
 
 Table.SELECTION_ALL = SELECTION_ALL;
 Table.SELECTION_INVERT = SELECTION_INVERT;
+Table.SELECTION_NONE = SELECTION_NONE;
 Table.Column = Column;
 Table.ColumnGroup = ColumnGroup;
 Table.Summary = Summary;

--- a/components/table/__tests__/Table.rowSelection.test.js
+++ b/components/table/__tests__/Table.rowSelection.test.js
@@ -294,9 +294,26 @@ describe('Table.rowSelection', () => {
     checkboxes.at(1).simulate('change', { target: { checked: true } });
 
     const dropdownWrapper = mount(wrapper.find('Trigger').instance().getComponent());
-    dropdownWrapper.find('.ant-dropdown-menu-item').last().simulate('click');
+    dropdownWrapper.find('.ant-dropdown-menu-item').at(1).simulate('click');
 
     expect(handleSelectInvert).toHaveBeenCalledWith([1, 2, 3]);
+  });
+
+  it('fires selectNone event', () => {
+    const handleSelectNone = jest.fn();
+    const rowSelection = {
+      onSelectNone: handleSelectNone,
+      selections: true,
+    };
+    const wrapper = mount(createTable({ rowSelection }));
+    const checkboxes = wrapper.find('input');
+
+    checkboxes.at(1).simulate('change', { target: { checked: true } });
+
+    const dropdownWrapper = mount(wrapper.find('Trigger').instance().getComponent());
+    dropdownWrapper.find('.ant-dropdown-menu-item').last().simulate('click');
+
+    expect(handleSelectNone).toHaveBeenCalled();
   });
 
   it('fires selection event', () => {

--- a/components/table/__tests__/__snapshots__/Table.rowSelection.test.js.snap
+++ b/components/table/__tests__/__snapshots__/Table.rowSelection.test.js.snap
@@ -984,6 +984,12 @@ exports[`Table.rowSelection render with default selection correctly 1`] = `
       >
         Invert current page
       </li>
+      <li
+        class="ant-dropdown-menu-item ant-dropdown-menu-item-only-child"
+        role="menuitem"
+      >
+        Clear all data
+      </li>
     </ul>
   </div>
 </div>
@@ -1092,6 +1098,12 @@ exports[`Table.rowSelection should support getPopupContainer 1`] = `
                                 role="menuitem"
                               >
                                 Invert current page
+                              </li>
+                              <li
+                                class="ant-dropdown-menu-item ant-dropdown-menu-item-only-child"
+                                role="menuitem"
+                              >
+                                Clear all data
                               </li>
                             </ul>
                           </div>
@@ -1419,6 +1431,12 @@ exports[`Table.rowSelection should support getPopupContainer from ConfigProvider
                                 role="menuitem"
                               >
                                 Invert current page
+                              </li>
+                              <li
+                                class="ant-dropdown-menu-item ant-dropdown-menu-item-only-child"
+                                role="menuitem"
+                              >
+                                Clear all data
                               </li>
                             </ul>
                           </div>

--- a/components/table/demo/row-selection-custom.md
+++ b/components/table/demo/row-selection-custom.md
@@ -59,6 +59,7 @@ class App extends React.Component {
       selections: [
         Table.SELECTION_ALL,
         Table.SELECTION_INVERT,
+        Table.SELECTION_NONE,
         {
           key: 'odd',
           text: 'Select Odd Row',

--- a/components/table/hooks/useSelection.tsx
+++ b/components/table/hooks/useSelection.tsx
@@ -28,6 +28,7 @@ import {
 // TODO: warning if use ajax!!!
 export const SELECTION_ALL = 'SELECT_ALL' as const;
 export const SELECTION_INVERT = 'SELECT_INVERT' as const;
+export const SELECTION_NONE = 'SELECT_NONE' as const;
 
 function getFixedType<RecordType>(column: ColumnsType<RecordType>[number]): FixedType | undefined {
   return column && column.fixed;
@@ -49,7 +50,8 @@ interface UseSelectionConfig<RecordType> {
 export type INTERNAL_SELECTION_ITEM =
   | SelectionItem
   | typeof SELECTION_ALL
-  | typeof SELECTION_INVERT;
+  | typeof SELECTION_INVERT
+  | typeof SELECTION_NONE;
 
 function flattenData<RecordType>(
   data: RecordType[] | undefined,
@@ -82,6 +84,7 @@ export default function useSelection<RecordType>(
     onSelect,
     onSelectAll,
     onSelectInvert,
+    onSelectNone,
     onSelectMultiple,
     columnWidth: selectionColWidth,
     type: selectionType,
@@ -255,7 +258,7 @@ export default function useSelection<RecordType>(
     }
 
     const selectionList: INTERNAL_SELECTION_ITEM[] =
-      selections === true ? [SELECTION_ALL, SELECTION_INVERT] : selections;
+      selections === true ? [SELECTION_ALL, SELECTION_INVERT, SELECTION_NONE] : selections;
 
     return selectionList.map((selection: INTERNAL_SELECTION_ITEM) => {
       if (selection === SELECTION_ALL) {
@@ -292,6 +295,18 @@ export default function useSelection<RecordType>(
                 '`onSelectInvert` will be removed in future. Please use `onChange` instead.',
               );
               onSelectInvert(keys);
+            }
+          },
+        };
+      }
+      if (selection === SELECTION_NONE) {
+        return {
+          key: 'none',
+          text: tableLocale.selectNone,
+          onSelect() {
+            setSelectedKeys([]);
+            if (onSelectNone) {
+              onSelectNone();
             }
           },
         };

--- a/components/table/index.en-US.md
+++ b/components/table/index.en-US.md
@@ -203,6 +203,7 @@ Properties for row selection.
 | onSelect | Callback executed when select/deselect one row | function(record, selected, selectedRows, nativeEvent) | - |  |
 | onSelectAll | Callback executed when select/deselect all rows | function(selected, selectedRows, changeRows) | - |  |
 | onSelectInvert | Callback executed when row selection is inverted | function(selectedRowKeys) | - |  |
+| onSelectNone | Callback executed when row selection is cleared | function() | - |  |
 
 ### scroll
 

--- a/components/table/index.zh-CN.md
+++ b/components/table/index.zh-CN.md
@@ -210,6 +210,7 @@ const columns = [
 | onSelect | 用户手动选择/取消选择某行的回调 | function(record, selected, selectedRows, nativeEvent) | - |  |
 | onSelectAll | 用户手动选择/取消选择所有行的回调 | function(selected, selectedRows, changeRows) | - |  |
 | onSelectInvert | 用户手动选择反选的回调 | function(selectedRowKeys) | - |  |
+| onSelectNone | 用户清空选择的回调 | function() | - |  |
 
 ### scroll
 

--- a/components/table/interface.tsx
+++ b/components/table/interface.tsx
@@ -29,6 +29,7 @@ export interface TableLocale {
   filterEmptyText?: React.ReactNode;
   emptyText?: React.ReactNode | (() => React.ReactNode);
   selectAll?: React.ReactNode;
+  selectNone?: React.ReactNode;
   selectInvert?: React.ReactNode;
   selectionAll?: React.ReactNode;
   sortTitle?: string;
@@ -143,6 +144,7 @@ export interface TableRowSelection<T> {
   onSelectAll?: (selected: boolean, selectedRows: T[], changeRows: T[]) => void;
   /** @deprecated This function is meaningless and should use `onChange` instead */
   onSelectInvert?: (selectedRowKeys: Key[]) => void;
+  onSelectNone?: () => void;
   selections?: INTERNAL_SELECTION_ITEM[] | boolean;
   hideSelectAll?: boolean;
   fixed?: boolean;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close #27733

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

Support SELECTION_NONE which clears all the selection

[SELECTION_NONE for table selection option](https://github.com/ant-design/ant-design/issues/27733)

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  SELECTION_NONE for table selection option  |
| 🇨🇳 Chinese |  表格选择项内置清空所有选项  |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/table/demo/row-selection-custom.md](https://github.com/n0ruSh/ant-design/blob/select-none/components/table/demo/row-selection-custom.md)
[View rendered components/table/index.en-US.md](https://github.com/n0ruSh/ant-design/blob/select-none/components/table/index.en-US.md)
[View rendered components/table/index.zh-CN.md](https://github.com/n0ruSh/ant-design/blob/select-none/components/table/index.zh-CN.md)