### PR TITLE
fix: no need to filter filterdKeys for custom filterDropdown.

### DIFF
--- a/components/table/__tests__/Table.filter.test.js
+++ b/components/table/__tests__/Table.filter.test.js
@@ -453,7 +453,7 @@ describe('Table.filter', () => {
     const wrapper = mount(createTable({ onChange: handleChange }));
 
     wrapper.find('.ant-dropdown-trigger').first().simulate('click');
-    wrapper.find('.ant-table-filter-dropdown-btns .ant-btn-link').simulate('click');
+    wrapper.find('.ant-table-filter-dropdown-btns .ant-btn-primary').simulate('click');
 
     expect(handleChange).not.toHaveBeenCalled();
   });
@@ -840,6 +840,42 @@ describe('Table.filter', () => {
       .simulate('change', { target: { value: 'whatevervalue' } });
     wrapper.find('.ant-dropdown-trigger').first().simulate('click');
     expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('should trigger onChange with correct params if defines custom filterDropdown', () => {
+    const onChange = jest.fn();
+    const filterDropdown = ({ setSelectedKeys, confirm }) => (
+      <div>
+        <input onChange={e => setSelectedKeys([e.target.value])} />
+        <button className="confirm-btn" type="submit" onClick={confirm}>
+          Confirm
+        </button>
+      </div>
+    );
+    const wrapper = mount(
+      createTable({
+        onChange,
+        columns: [
+          {
+            title: 'Name',
+            dataIndex: 'name',
+            key: 'name',
+            filterDropdown,
+          },
+        ],
+      }),
+    );
+    wrapper.find('.ant-dropdown-trigger').first().simulate('click');
+    wrapper
+      .find('input')
+      .first()
+      .simulate('change', { target: { value: 'test' } });
+    wrapper.find('.confirm-btn').first().simulate('click');
+    expect(onChange).toHaveBeenCalled();
+    onChange.mock.calls.forEach(([, currentFilters]) => {
+      const [, val] = Object.entries(currentFilters)[0];
+      expect(val).toEqual(['test']);
+    });
   });
 
   // https://github.com/ant-design/ant-design/issues/17089

--- a/components/table/__tests__/Table.filter.test.js
+++ b/components/table/__tests__/Table.filter.test.js
@@ -304,6 +304,34 @@ describe('Table.filter', () => {
     expect(wrapper.find('tbody tr').length).toBe(4);
   });
 
+  it('should handle filteredValue and non-array filterValue as expected', () => {
+    const wrapper = mount(
+      createTable({
+        columns: [
+          {
+            ...column,
+            filteredValue: ['Lucy', 12, true],
+          },
+        ],
+      }),
+    );
+    function getFilterMenu() {
+      return wrapper.find('FilterDropdown');
+    }
+
+    expect(getFilterMenu().props().filterState.filteredKeys).toEqual(['Lucy', '12', 'true']);
+
+    wrapper.setProps({
+      columns: [
+        {
+          ...column,
+          filteredValue: null,
+        },
+      ],
+    });
+    expect(getFilterMenu().props().filterState.filteredKeys).toEqual(null);
+  });
+
   it('can be controlled by filteredValue null', () => {
     const wrapper = mount(
       createTable({

--- a/components/table/hooks/useFilter/index.tsx
+++ b/components/table/hooks/useFilter/index.tsx
@@ -121,17 +121,25 @@ function generateFilterInfo<RecordType>(filterStates: FilterState<RecordType>[])
   const currentFilters: Record<string, (Key | boolean)[] | null> = {};
 
   filterStates.forEach(({ key, filteredKeys, column }) => {
-    const { filters } = column;
-    const originKeys: ColumnFilterItem['value'][] = [];
-    if (Array.isArray(filteredKeys)) {
-      filters?.forEach((filter: ColumnFilterItem) => {
-        if (filteredKeys.includes(String(filter.value))) {
-          originKeys.push(filter.value);
-        }
-      });
-      currentFilters[key] = originKeys;
+    const { filters, filterDropdown } = column;
+    if (filterDropdown) {
+      currentFilters[key] = filteredKeys || null;
     } else {
-      currentFilters[key] = null;
+      const originKeys: ColumnFilterItem['value'][] = [];
+      if (Array.isArray(filteredKeys)) {
+        if (Array.isArray(filters)) {
+          filters.forEach((filter: ColumnFilterItem) => {
+            if (filteredKeys.includes(String(filter.value))) {
+              originKeys.push(filter.value);
+            }
+          });
+          currentFilters[key] = originKeys;
+        } else {
+          currentFilters[key] = filteredKeys || null;
+        }
+      } else {
+        currentFilters[key] = null;
+      }
     }
   });
 

--- a/components/table/hooks/useFilter/index.tsx
+++ b/components/table/hooks/useFilter/index.tsx
@@ -34,7 +34,9 @@ function collectFilterStates<RecordType>(
     } else if (column.filters || 'filterDropdown' in column || 'onFilter' in column) {
       if ('filteredValue' in column) {
         // Controlled
-        const filteredValues = (column.filteredValue || []).map(String);
+        const filteredValues = Array.isArray(column.filteredValue)
+          ? column.filteredValue.map(String)
+          : column.filteredValue;
         filterStates.push({
           column,
           key: getColumnKey(column, columnPos),
@@ -127,16 +129,12 @@ function generateFilterInfo<RecordType>(filterStates: FilterState<RecordType>[])
     } else {
       const originKeys: ColumnFilterItem['value'][] = [];
       if (Array.isArray(filteredKeys)) {
-        if (Array.isArray(filters)) {
-          filters.forEach((filter: ColumnFilterItem) => {
-            if (filteredKeys.includes(String(filter.value))) {
-              originKeys.push(filter.value);
-            }
-          });
-          currentFilters[key] = originKeys;
-        } else {
-          currentFilters[key] = filteredKeys || null;
-        }
+        filters?.forEach((filter: ColumnFilterItem) => {
+          if (filteredKeys.includes(String(filter.value))) {
+            originKeys.push(filter.value);
+          }
+        });
+        currentFilters[key] = originKeys;
       } else {
         currentFilters[key] = null;
       }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
fix #28603
fix #28640
close #28541

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     fix that onChange listener always receivces empty list as `filters` parameter if use a custom filterDropdown     |
| 🇨🇳 Chinese |    修复了如果用户自定义 filterDropdown， onChange 事件的 `filters` 参数总是接收空数组的问题       |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
