### PR TITLE
ci: fix contains check

### DIFF
--- a/.github/workflows/issue-open-check.yml
+++ b/.github/workflows/issue-open-check.yml
@@ -60,7 +60,7 @@ jobs:
             * Ant Design Pro Preview : https://prosite.z23.web.core.windows.net
             
       - name: check-ie
-        if: contains(github.event.issue.body, 'ant-design-issue-helper') == true && (contains(github.event.issue.title, 'IE') == true || contains(github.event.issue.title, 'Internet Explorer') == true)
+        if: contains(github.event.issue.body, 'ant-design-issue-helper') == true && github.event.issue.title.includes('IE') == true || contains(github.event.issue.title, 'Internet Explorer') == true)
         uses: actions-cool/issues-helper@v1.2
         with:
           actions: 'add-labels'

--- a/.github/workflows/issue-open-check.yml
+++ b/.github/workflows/issue-open-check.yml
@@ -60,7 +60,7 @@ jobs:
             * Ant Design Pro Preview : https://prosite.z23.web.core.windows.net
             
       - name: check-ie
-        if: contains(github.event.issue.body, 'ant-design-issue-helper') == true && github.event.issue.title.includes('IE') == true || contains(github.event.issue.title, 'Internet Explorer') == true)
+        if: contains(github.event.issue.body, 'ant-design-issue-helper') == true && github.event.issue.title.includes('IE9') == true || github.event.issue.title.includes('IE 9') == true || github.event.issue.title.includes('IE10') == true || github.event.issue.title.includes('IE 10') == true || github.event.issue.title.includes('IE11') == true || github.event.issue.title.includes('IE 11') == true || contains(github.event.issue.title, 'Internet Explorer') == true)
         uses: actions-cool/issues-helper@v1.2
         with:
           actions: 'add-labels'


### PR DESCRIPTION
github 的自带函数不区分大小写校验

- https://docs.github.com/en/free-pro-team@latest/actions/reference/context-and-expression-syntax-for-github-actions#contains

导致 https://github.com/ant-design/ant-design/issues/28659 校验 IE 通过

@kerm1it  有没有好的校验单个 IE 的办法，用 split(' ') ？但有人会用 IE11 之类的，所以还是决定直接校验大写 'IE'  