### PR TITLE
fix: [Slider] Fix forcePopupAlign null when unmounted

### DIFF
--- a/components/slider/SliderTooltip.tsx
+++ b/components/slider/SliderTooltip.tsx
@@ -17,7 +17,7 @@ const SliderTooltip = React.forwardRef<unknown, TooltipProps>((props, ref) => {
 
   function keepAlign() {
     rafRef.current = raf(() => {
-      innerRef.current.forcePopupAlign();
+      innerRef.current?.forcePopupAlign();
       rafRef.current = null;
       keepAlign();
     });


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

Proper fix for https://github.com/ant-design/ant-design/issues/27834

### 💡 Background and solution

It's a backport of the fix made in `rc-slider`: https://github.com/react-component/slider/commit/69dc59270ca46ae2d3c4b5aa073d2bc75dfc5b16

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |
