### PR TITLE
chore(descriptions): children can be component that wraps DescriptionsItem

### DIFF
--- a/components/descriptions/__tests__/__snapshots__/index.test.js.snap
+++ b/components/descriptions/__tests__/__snapshots__/index.test.js.snap
@@ -452,6 +452,475 @@ exports[`Descriptions vertical layout 1`] = `
 </div>
 `;
 
+exports[`Descriptions when item is component that wrap DescriptionsItem 1`] = `
+<Descriptions
+  title="User Info"
+>
+  <div
+    className="ant-descriptions"
+  >
+    <div
+      className="ant-descriptions-header"
+    >
+      <div
+        className="ant-descriptions-title"
+      >
+        User Info
+      </div>
+    </div>
+    <div
+      className="ant-descriptions-view"
+    >
+      <table>
+        <tbody>
+          <Row
+            colon={true}
+            index={0}
+            key="0"
+            prefixCls="ant-descriptions"
+            row={
+              Array [
+                <DescriptionsItem
+                  label="Test1"
+                >
+                  Test Data1
+                </DescriptionsItem>,
+              ]
+            }
+            vertical={false}
+          >
+            <tr
+              className="ant-descriptions-row"
+              key="0"
+            >
+              <Cell
+                colon={true}
+                component="td"
+                content="Test Data1"
+                contentStyle={Object {}}
+                itemPrefixCls="ant-descriptions"
+                key="item-0"
+                label="Test1"
+                labelStyle={Object {}}
+                span={1}
+              >
+                <td
+                  className="ant-descriptions-item"
+                  colSpan={1}
+                >
+                  <div
+                    className="ant-descriptions-item-container"
+                  >
+                    <span
+                      className="ant-descriptions-item-label"
+                      style={Object {}}
+                    >
+                      Test1
+                    </span>
+                    <span
+                      className="ant-descriptions-item-content"
+                      style={Object {}}
+                    >
+                      Test Data1
+                    </span>
+                  </div>
+                </td>
+              </Cell>
+            </tr>
+          </Row>
+          <Row
+            colon={true}
+            index={1}
+            key="1"
+            prefixCls="ant-descriptions"
+            row={
+              Array [
+                <DescriptionsItem
+                  label="Test3"
+                >
+                  Test Data3
+                </DescriptionsItem>,
+              ]
+            }
+            vertical={false}
+          >
+            <tr
+              className="ant-descriptions-row"
+              key="1"
+            >
+              <Cell
+                colon={true}
+                component="td"
+                content="Test Data3"
+                contentStyle={Object {}}
+                itemPrefixCls="ant-descriptions"
+                key="item-0"
+                label="Test3"
+                labelStyle={Object {}}
+                span={1}
+              >
+                <td
+                  className="ant-descriptions-item"
+                  colSpan={1}
+                >
+                  <div
+                    className="ant-descriptions-item-container"
+                  >
+                    <span
+                      className="ant-descriptions-item-label"
+                      style={Object {}}
+                    >
+                      Test3
+                    </span>
+                    <span
+                      className="ant-descriptions-item-content"
+                      style={Object {}}
+                    >
+                      Test Data3
+                    </span>
+                  </div>
+                </td>
+              </Cell>
+            </tr>
+          </Row>
+          <Row
+            colon={true}
+            index={2}
+            key="2"
+            prefixCls="ant-descriptions"
+            row={
+              Array [
+                <DescriptionsItem
+                  label="Product"
+                >
+                  Cloud Database
+                </DescriptionsItem>,
+              ]
+            }
+            vertical={false}
+          >
+            <tr
+              className="ant-descriptions-row"
+              key="2"
+            >
+              <Cell
+                colon={true}
+                component="td"
+                content="Cloud Database"
+                contentStyle={Object {}}
+                itemPrefixCls="ant-descriptions"
+                key="item-0"
+                label="Product"
+                labelStyle={Object {}}
+                span={1}
+              >
+                <td
+                  className="ant-descriptions-item"
+                  colSpan={1}
+                >
+                  <div
+                    className="ant-descriptions-item-container"
+                  >
+                    <span
+                      className="ant-descriptions-item-label"
+                      style={Object {}}
+                    >
+                      Product
+                    </span>
+                    <span
+                      className="ant-descriptions-item-content"
+                      style={Object {}}
+                    >
+                      Cloud Database
+                    </span>
+                  </div>
+                </td>
+              </Cell>
+            </tr>
+          </Row>
+          <Row
+            colon={true}
+            index={3}
+            key="3"
+            prefixCls="ant-descriptions"
+            row={
+              Array [
+                <DescriptionsItem
+                  label="Billing"
+                >
+                  Prepaid
+                </DescriptionsItem>,
+              ]
+            }
+            vertical={false}
+          >
+            <tr
+              className="ant-descriptions-row"
+              key="3"
+            >
+              <Cell
+                colon={true}
+                component="td"
+                content="Prepaid"
+                contentStyle={Object {}}
+                itemPrefixCls="ant-descriptions"
+                key="item-0"
+                label="Billing"
+                labelStyle={Object {}}
+                span={1}
+              >
+                <td
+                  className="ant-descriptions-item"
+                  colSpan={1}
+                >
+                  <div
+                    className="ant-descriptions-item-container"
+                  >
+                    <span
+                      className="ant-descriptions-item-label"
+                      style={Object {}}
+                    >
+                      Billing
+                    </span>
+                    <span
+                      className="ant-descriptions-item-content"
+                      style={Object {}}
+                    >
+                      Prepaid
+                    </span>
+                  </div>
+                </td>
+              </Cell>
+            </tr>
+          </Row>
+          <Row
+            colon={true}
+            index={4}
+            key="4"
+            prefixCls="ant-descriptions"
+            row={
+              Array [
+                <DescriptionsItem
+                  label="Test2"
+                >
+                  Test Data2
+                </DescriptionsItem>,
+              ]
+            }
+            vertical={false}
+          >
+            <tr
+              className="ant-descriptions-row"
+              key="4"
+            >
+              <Cell
+                colon={true}
+                component="td"
+                content="Test Data2"
+                contentStyle={Object {}}
+                itemPrefixCls="ant-descriptions"
+                key="item-0"
+                label="Test2"
+                labelStyle={Object {}}
+                span={1}
+              >
+                <td
+                  className="ant-descriptions-item"
+                  colSpan={1}
+                >
+                  <div
+                    className="ant-descriptions-item-container"
+                  >
+                    <span
+                      className="ant-descriptions-item-label"
+                      style={Object {}}
+                    >
+                      Test2
+                    </span>
+                    <span
+                      className="ant-descriptions-item-content"
+                      style={Object {}}
+                    >
+                      Test Data2
+                    </span>
+                  </div>
+                </td>
+              </Cell>
+            </tr>
+          </Row>
+          <Row
+            colon={true}
+            index={5}
+            key="5"
+            prefixCls="ant-descriptions"
+            row={
+              Array [
+                <DescriptionsItem
+                  label="Test5"
+                >
+                  Test Data5
+                </DescriptionsItem>,
+              ]
+            }
+            vertical={false}
+          >
+            <tr
+              className="ant-descriptions-row"
+              key="5"
+            >
+              <Cell
+                colon={true}
+                component="td"
+                content="Test Data5"
+                contentStyle={Object {}}
+                itemPrefixCls="ant-descriptions"
+                key="item-0"
+                label="Test5"
+                labelStyle={Object {}}
+                span={1}
+              >
+                <td
+                  className="ant-descriptions-item"
+                  colSpan={1}
+                >
+                  <div
+                    className="ant-descriptions-item-container"
+                  >
+                    <span
+                      className="ant-descriptions-item-label"
+                      style={Object {}}
+                    >
+                      Test5
+                    </span>
+                    <span
+                      className="ant-descriptions-item-content"
+                      style={Object {}}
+                    >
+                      Test Data5
+                    </span>
+                  </div>
+                </td>
+              </Cell>
+            </tr>
+          </Row>
+          <Row
+            colon={true}
+            index={6}
+            key="6"
+            prefixCls="ant-descriptions"
+            row={
+              Array [
+                <DescriptionsItem
+                  label="Test6"
+                >
+                  Test Data6
+                </DescriptionsItem>,
+              ]
+            }
+            vertical={false}
+          >
+            <tr
+              className="ant-descriptions-row"
+              key="6"
+            >
+              <Cell
+                colon={true}
+                component="td"
+                content="Test Data6"
+                contentStyle={Object {}}
+                itemPrefixCls="ant-descriptions"
+                key="item-0"
+                label="Test6"
+                labelStyle={Object {}}
+                span={1}
+              >
+                <td
+                  className="ant-descriptions-item"
+                  colSpan={1}
+                >
+                  <div
+                    className="ant-descriptions-item-container"
+                  >
+                    <span
+                      className="ant-descriptions-item-label"
+                      style={Object {}}
+                    >
+                      Test6
+                    </span>
+                    <span
+                      className="ant-descriptions-item-content"
+                      style={Object {}}
+                    >
+                      Test Data6
+                    </span>
+                  </div>
+                </td>
+              </Cell>
+            </tr>
+          </Row>
+          <Row
+            colon={true}
+            index={7}
+            key="7"
+            prefixCls="ant-descriptions"
+            row={
+              Array [
+                <DescriptionsItem
+                  label="Test4"
+                  span={1}
+                >
+                  Test Data4
+                </DescriptionsItem>,
+              ]
+            }
+            vertical={false}
+          >
+            <tr
+              className="ant-descriptions-row"
+              key="7"
+            >
+              <Cell
+                colon={true}
+                component="td"
+                content="Test Data4"
+                contentStyle={Object {}}
+                itemPrefixCls="ant-descriptions"
+                key="item-0"
+                label="Test4"
+                labelStyle={Object {}}
+                span={1}
+              >
+                <td
+                  className="ant-descriptions-item"
+                  colSpan={1}
+                >
+                  <div
+                    className="ant-descriptions-item-container"
+                  >
+                    <span
+                      className="ant-descriptions-item-label"
+                      style={Object {}}
+                    >
+                      Test4
+                    </span>
+                    <span
+                      className="ant-descriptions-item-content"
+                      style={Object {}}
+                    >
+                      Test Data4
+                    </span>
+                  </div>
+                </td>
+              </Cell>
+            </tr>
+          </Row>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</Descriptions>
+`;
+
 exports[`Descriptions when item is rendered conditionally 1`] = `
 <div
   class="ant-descriptions"

--- a/components/descriptions/__tests__/index.test.js
+++ b/components/descriptions/__tests__/index.test.js
@@ -238,4 +238,60 @@ describe('Descriptions', () => {
     wrapper.setProps({ extra: undefined });
     expect(wrapper.find('.ant-descriptions-extra').exists()).toBe(false);
   });
+
+  // https://github.com/ant-design/ant-design/issues/28254
+  it('when item is component that wrap DescriptionsItem', () => {
+    // eslint-disable-next-line react/prefer-stateless-function
+    class ClassComponentItem extends React.Component {
+      render() {
+        return <Descriptions.Item label="Test6">Test Data6</Descriptions.Item>;
+      }
+    }
+
+    // eslint-disable-next-line react/prefer-stateless-function
+    class ClassComponent extends React.Component {
+      render() {
+        switch (this.props.type) {
+          case 'more':
+            return (
+              <>
+                <Descriptions.Item label="Test5">Test Data5</Descriptions.Item>
+                <ClassComponentItem />
+              </>
+            );
+          default:
+            return <Descriptions.Item label="Test4">Test Data4</Descriptions.Item>;
+        }
+      }
+    }
+
+    const FunctionComponent = () => <Descriptions.Item label="Test3">Test Data3</Descriptions.Item>;
+
+    const Item = ({ type }) => {
+      switch (type) {
+        case 'more':
+          return (
+            <>
+              <Descriptions.Item label="Test1">Test Data1</Descriptions.Item>
+              <FunctionComponent />
+            </>
+          );
+        default:
+          return <Descriptions.Item label="Test2">Test Data2</Descriptions.Item>;
+      }
+    };
+
+    const wrapper = mount(
+      <Descriptions title="User Info">
+        <Item type="more" />
+        <Descriptions.Item label="Product">Cloud Database</Descriptions.Item>
+        <Descriptions.Item label="Billing">Prepaid</Descriptions.Item>
+        <Item />
+        <ClassComponent type="more" />
+        <ClassComponent />
+      </Descriptions>,
+    );
+
+    expect(wrapper).toMatchSnapshot();
+  });
 });

--- a/components/descriptions/index.tsx
+++ b/components/descriptions/index.tsx
@@ -77,7 +77,7 @@ function getItems(children: React.ReactNode): React.ReactElement[] {
     } else if (typeof type === 'function') {
       const isClass = Object.getPrototypeOf(type) === React.Component;
       const ChildComponent = type as any;
-      let childElement: React.ReactElement = null!;
+      let childElement: React.ReactElement;
       if (isClass) {
         childElement = new ChildComponent(props).render();
       } else {

--- a/components/descriptions/index.tsx
+++ b/components/descriptions/index.tsx
@@ -75,7 +75,7 @@ function getItems(children: React.ReactNode): React.ReactElement[] {
     if (type === DescriptionsItem) {
       items.push(node);
     } else if (typeof type === 'function') {
-      const isClass = Object.getPrototypeOf(type) === React.Component;
+      const isClass = Object.prototype.isPrototypeOf.call(React.Component, type);
       const ChildComponent = type as any;
       let childElement: React.ReactElement;
       if (isClass) {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

fix https://github.com/ant-design/ant-design/issues/28254

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Children of `Descriptions` allow to be component that wraps `Descriptions.Item`.  |
| 🇨🇳 Chinese | `Descriptions` 的子元素允许是包裹 `Descriptions.Item` 的组件。 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
