### PR TITLE
fix: custom table filterDropdown

### DIFF
--- a/components/table/__tests__/Table.filter.test.js
+++ b/components/table/__tests__/Table.filter.test.js
@@ -5,6 +5,7 @@ import Table from '..';
 import Input from '../../input';
 import Tooltip from '../../tooltip';
 import Button from '../../button';
+import Select from '../../select';
 import ConfigProvider from '../../config-provider';
 
 // https://github.com/Semantic-Org/Semantic-UI-React/blob/72c45080e4f20b531fda2e3e430e384083d6766b/test/specs/modules/Dropdown/Dropdown-test.js#L73
@@ -909,6 +910,87 @@ describe('Table.filter', () => {
     onChange.mock.calls.forEach(([, currentFilters]) => {
       const [, val] = Object.entries(currentFilters)[0];
       expect(val).toEqual(['test']);
+    });
+  });
+
+  it('should work as expected with complex custom filterDropdown', () => {
+    const onChange = jest.fn();
+    const filterDropdown = ({ setSelectedKeys, selectedKeys, confirm }) => {
+      const handleChange = selectedValues => {
+        setSelectedKeys(selectedValues);
+      };
+
+      return (
+        <div>
+          <Select
+            mode="multiple"
+            allowClear
+            labelInValue
+            style={{ width: 200 }}
+            value={selectedKeys}
+            onChange={handleChange}
+            options={[
+              {
+                value: 1,
+                label: 'Not Identified',
+              },
+              {
+                value: 2,
+                label: 'Closed',
+              },
+              {
+                value: 3,
+                label: 'Communicated',
+              },
+            ]}
+          />
+          <button className="confirm-btn" type="submit" onClick={confirm}>
+            Confirm
+          </button>
+        </div>
+      );
+    };
+    const filteredValue = [
+      {
+        value: 2,
+        label: 'Closed',
+      },
+    ];
+    const selectedValue = [
+      {
+        key: 2,
+        value: 2,
+        label: 'Closed',
+      },
+      {
+        key: 1,
+        value: 1,
+        label: 'Not Identified',
+      },
+    ];
+    const wrapper = mount(
+      createTable({
+        onChange,
+        columns: [
+          {
+            title: 'Name',
+            dataIndex: 'name',
+            key: 'name',
+            filterDropdown,
+            filteredValue,
+          },
+        ],
+      }),
+    );
+    expect(wrapper.find('FilterDropdown').props().filterState.filteredKeys).toEqual(filteredValue);
+    wrapper.find('.ant-dropdown-trigger').first().simulate('click');
+    wrapper.find('.ant-select-selector').simulate('mousedown');
+    wrapper.find('.ant-select-item-option').first().simulate('click');
+    wrapper.find('.confirm-btn').first().simulate('click');
+    expect(onChange).toHaveBeenCalled();
+    onChange.mock.calls.forEach(([, currentFilters]) => {
+      const [, val] = Object.entries(currentFilters)[0];
+      expect(val).toEqual(selectedValue);
     });
   });
 

--- a/components/table/__tests__/Table.filter.test.js
+++ b/components/table/__tests__/Table.filter.test.js
@@ -507,6 +507,7 @@ describe('Table.filter', () => {
   });
 
   it('three levels menu', () => {
+    const onChange = jest.fn();
     const filters = [
       { text: 'Upper', value: 'Upper' },
       { text: 'Lower', value: 'Lower' },
@@ -536,6 +537,7 @@ describe('Table.filter', () => {
             filters,
           },
         ],
+        onChange,
       }),
     );
     jest.useFakeTimers();
@@ -551,6 +553,10 @@ describe('Table.filter', () => {
     dropdownWrapper = getDropdownWrapper(wrapper);
     dropdownWrapper.find('MenuItem').last().simulate('click');
     dropdownWrapper.find('.ant-table-filter-dropdown-btns .ant-btn-primary').simulate('click');
+    onChange.mock.calls.forEach(([, currentFilters]) => {
+      const [, val] = Object.entries(currentFilters)[0];
+      expect(val).toEqual(['Jack']);
+    });
     wrapper.update();
     expect(renderedNames(wrapper)).toEqual(['Jack']);
     dropdownWrapper.find('MenuItem').last().simulate('click');

--- a/components/table/hooks/useFilter/index.tsx
+++ b/components/table/hooks/useFilter/index.tsx
@@ -138,19 +138,11 @@ function generateFilterInfo<RecordType>(filterStates: FilterState<RecordType>[])
     const { filters, filterDropdown } = column;
     if (filterDropdown) {
       currentFilters[key] = filteredKeys || null;
+    } else if (Array.isArray(filteredKeys)) {
+      const keys = flattenKeys(filters);
+      currentFilters[key] = keys.filter(originKey => filteredKeys.includes(String(originKey)));
     } else {
-      const originKeys: ColumnFilterItem['value'][] = [];
-      if (Array.isArray(filteredKeys)) {
-        const keys = flattenKeys(filters);
-        keys?.forEach(originKey => {
-          if (filteredKeys.includes(String(originKey))) {
-            originKeys.push(originKey);
-          }
-        });
-        currentFilters[key] = originKeys;
-      } else {
-        currentFilters[key] = null;
-      }
+      currentFilters[key] = null;
     }
   });
 

--- a/components/table/hooks/useFilter/index.tsx
+++ b/components/table/hooks/useFilter/index.tsx
@@ -119,6 +119,17 @@ function injectFilter<RecordType>(
   });
 }
 
+function flattenKeys(filters?: ColumnFilterItem[]) {
+  let keys: (string | number | boolean)[] = [];
+  (filters || []).forEach(({ value, children }) => {
+    keys.push(value);
+    if (children) {
+      keys = [...keys, ...flattenKeys(children)];
+    }
+  });
+  return keys;
+}
+
 function generateFilterInfo<RecordType>(filterStates: FilterState<RecordType>[]) {
   const currentFilters: Record<string, (Key | boolean)[] | null> = {};
 
@@ -129,9 +140,10 @@ function generateFilterInfo<RecordType>(filterStates: FilterState<RecordType>[])
     } else {
       const originKeys: ColumnFilterItem['value'][] = [];
       if (Array.isArray(filteredKeys)) {
-        filters?.forEach((filter: ColumnFilterItem) => {
-          if (filteredKeys.includes(String(filter.value))) {
-            originKeys.push(filter.value);
+        const keys = flattenKeys(filters);
+        keys?.forEach(originKey => {
+          if (filteredKeys.includes(String(originKey))) {
+            originKeys.push(originKey);
           }
         });
         currentFilters[key] = originKeys;
@@ -142,17 +154,6 @@ function generateFilterInfo<RecordType>(filterStates: FilterState<RecordType>[])
   });
 
   return currentFilters;
-}
-
-function flattenKeys(filters?: ColumnFilterItem[]) {
-  let keys: (string | number | boolean)[] = [];
-  (filters || []).forEach(({ value, children }) => {
-    keys.push(value);
-    if (children) {
-      keys = [...keys, ...flattenKeys(children)];
-    }
-  });
-  return keys;
 }
 
 export function getFilterData<RecordType>(

--- a/components/table/hooks/useFilter/index.tsx
+++ b/components/table/hooks/useFilter/index.tsx
@@ -34,9 +34,10 @@ function collectFilterStates<RecordType>(
     } else if (column.filters || 'filterDropdown' in column || 'onFilter' in column) {
       if ('filteredValue' in column) {
         // Controlled
-        const filteredValues = Array.isArray(column.filteredValue)
-          ? column.filteredValue.map(String)
-          : column.filteredValue;
+        let filteredValues = column.filteredValue;
+        if (!('filterDropdown' in column)) {
+          filteredValues = filteredValues?.map(String) ?? filteredValues;
+        }
         filterStates.push({
           column,
           key: getColumnKey(column, columnPos),


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
close https://github.com/ant-design/ant-design/issues/28801
<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      fix that invalid params passed to onChange event if define custom filterDropdown and nested filters     |
| 🇨🇳 Chinese |    修复 Table 自定义过滤器时 onChange 参数 filters 被错误转换，以及多级过滤器时 onChange 的 filters 参数为空数组的问题       |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
