### PR TITLE
fix: dont use document.body as slider's popup container

### DIFF
--- a/components/slider/index.tsx
+++ b/components/slider/index.tsx
@@ -116,7 +116,7 @@ const Slider = React.forwardRef<unknown, SliderSingleProps | SliderRangeProps>(
           transitionName="zoom-down"
           key={index}
           overlayClassName={`${prefixCls}-tooltip`}
-          getPopupContainer={getTooltipPopupContainer || getPopupContainer || (() => document.body)}
+          getPopupContainer={getTooltipPopupContainer || getPopupContainer}
         >
           <RcHandle
             {...restProps}


### PR DESCRIPTION
when getPopupContainer  is not defined, it should rely on rc-tooltip's default behavior instead of forcing it to use document.body

<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [x] Bug fix

### 🔗 Related issue link

https://github.com/ant-design/ant-design/issues/28435

### 💡 Background and solution

The Slider component shows tooltip in document.body by default. That means when slider is in a different document, like popup window or iframe, tooltip will be shown in the wrong location.

Solution:
Since this is already handled properly by rc-trigger and rc-tooltip, we only need to make sure slider doesn't override the default getPopupContainer  behavior


### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Slider should not use document.body as default tooltip container, it should rely on rc-tooltip's default behavior  |
| 🇨🇳 Chinese |  Slider不应使用document.body作为默认的tooltip容器，应该留空让rc-tooltip默认机制决定  |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
