### PR TITLE
fix: Button pseudo-element (before) not adapting to the btn-border-width when loading

### DIFF
--- a/components/button/style/index.less
+++ b/components/button/style/index.less
@@ -117,10 +117,10 @@
 
   &::before {
     position: absolute;
-    top: -1px;
-    right: -1px;
-    bottom: -1px;
-    left: -1px;
+    top: -@btn-border-width;
+    right: -@btn-border-width;
+    bottom: -@btn-border-width;
+    left: -@btn-border-width;
     z-index: 1;
     display: none;
     background: @component-background;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

Currently when setting a custom `@btn-border-width` the loading state does not take this into consideration (which is having a fixed `-1px` definition). Visually this causes the original color to show as an additional outline which does not show in the 1px state.

How it currently renders (3px as an example)

![image](https://user-images.githubusercontent.com/287422/104749267-e40e2880-5752-11eb-8284-5c90c1d1b89a.png)

How I expect it to render

![image](https://user-images.githubusercontent.com/287422/104749368-056f1480-5753-11eb-9972-13e9adbc52dd.png)

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix: Button pseudo-element (before) not adapting to the btn-border-width for its loading state |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [X] Doc is updated/provided or not needed
- [X] Demo is updated/provided or not needed
- [X] TypeScript definition is updated/provided or not needed
- [X] Changelog is provided or not needed
