### PR TITLE
fix: table shadow when user set sticky

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -15,6 +15,26 @@ timeline: true
 
 ---
 
+## 4.10.3
+
+`2021-01-18`
+
+- 🐞 Fix Button not adapting to the `@btn-border-width` when loading. [#28886](https://github.com/ant-design/ant-design/pull/28886) [@jjanssen](https://github.com/jjanssen)
+- Table
+  - 💄 Add `@table-border-color` less variable. [#28903](https://github.com/ant-design/ant-design/pull/28903)
+  - 🐞 Fix that invalid params passed to `onChange` event if define custom filterDropdown and nested filters. [#28850](https://github.com/ant-design/ant-design/pull/28850) [@Meowu](https://github.com/Meowu)
+  - 💄 Tweak Table selection column width to `32px`. [#28073](https://github.com/ant-design/ant-design/pull/28073)
+- Transfer
+  - 🛠 Refactor Transfer Search with React hooks. [#28895](https://github.com/ant-design/ant-design/pull/28895) [@susiwen8](https://github.com/susiwen8)
+  - 🌐 Added German translations for the Transfer component. [#28826](https://github.com/ant-design/ant-design/pull/28826) [@aequi42](https://github.com/aequi42)
+- Upload
+  - 🐞 Support for capturing Error message for the Upload error tooltip. [#28716](https://github.com/ant-design/ant-design/pull/28716) [@wangcch](https://github.com/wangcch)
+  - 🆕 Upload auto fills `uid` of `fileList` when not provided. [#28832](https://github.com/ant-design/ant-design/pull/28832)
+- 🐞 Fix Slider `getPopupContainer` prop has no default value `document.body`. [#28865](https://github.com/ant-design/ant-design/pull/28865) [@rinick](https://github.com/rinick)
+- 🐞 Fix Empty description validateDOMNesting warning. [#28862](https://github.com/ant-design/ant-design/pull/28862)
+- 💄 Fix Tree `filterTreeNode` missing style. [#28866](https://github.com/ant-design/ant-design/pull/28866)
+- 💄 fix Badge `dot` width issue when `size="small"`. [#28854](https://github.com/ant-design/ant-design/pull/28854)
+
 ## 4.10.2
 
 `2021-01-11`

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -15,6 +15,26 @@ timeline: true
 
 ---
 
+## 4.10.3
+
+`2021-01-18`
+
+- 🐞 修复按钮在 loading 加载时 `@btn-border-width` 失效问题。[#28886](https://github.com/ant-design/ant-design/pull/28886) [@jjanssen](https://github.com/jjanssen)
+- Table
+  - 🐞 修复 Table 自定义过滤器时 `onChange` 参数 `filters` 被错误转换及为空数组的问题。[#28850](https://github.com/ant-design/ant-design/pull/28850) [@Meowu](https://github.com/Meowu)
+  - 💄 调整 Table 选中列宽度至 `32px`。[#28073](https://github.com/ant-design/ant-design/pull/28073)
+  - 💄 新增 `@table-border-color` less 变量。[#28903](https://github.com/ant-design/ant-design/pull/28903)
+- Transfer
+  - 🛠 穿梭框 Search 组件使用 React Hooks 重构。[#28895](https://github.com/ant-design/ant-design/pull/28895) [@susiwen8](https://github.com/susiwen8)
+  - 🌐 增加了 German 德语翻译。[#28826](https://github.com/ant-design/ant-design/pull/28826) [@aequi42](https://github.com/aequi42)
+- Upload
+  - 🐞 支持 Upload 报错提示对 Error 文本信息的捕获（Tooltip）。[#28716](https://github.com/ant-design/ant-design/pull/28716) [@wangcch](https://github.com/wangcch)
+  - 🆕 Upload 在 `fileList` 没有提供 `uid` 时，会自动对其进行填充。[#28832](https://github.com/ant-design/ant-design/pull/28832)
+- 🐞 修复 Slider `getPopupContainer` 属性没有默认值 `document.body` 问题。[#28865](https://github.com/ant-design/ant-design/pull/28865) [@rinick](https://github.com/rinick)
+- 🐞 修复 Empty `description` 内使用 div 会报 `validateDOMNesting` 的问题。[#28862](https://github.com/ant-design/ant-design/pull/28862)
+- 💄 修复 Tree `filterTreeNode` 高亮样式丢失的问题。[#28866](https://github.com/ant-design/ant-design/pull/28866)
+- 💄 修复 Badge `dot` 宽度样式。[#28854](https://github.com/ant-design/ant-design/pull/28854)
+
 ## 4.10.2
 
 `2021-01-11`

--- a/components/style/themes/default.less
+++ b/components/style/themes/default.less
@@ -599,6 +599,7 @@
 @table-padding-horizontal-md: (@table-padding-horizontal / 2);
 @table-padding-vertical-sm: (@table-padding-vertical / 2);
 @table-padding-horizontal-sm: (@table-padding-horizontal / 2);
+@table-border-color: @border-color-split;
 @table-border-radius-base: @border-radius-base;
 @table-footer-bg: @background-color-light;
 @table-footer-color: @heading-color;

--- a/components/table/style/bordered.less
+++ b/components/table/style/bordered.less
@@ -1,7 +1,7 @@
 @import './index';
 @import './size';
 
-@table-border: @border-width-base @border-style-base @border-color-split;
+@table-border: @border-width-base @border-style-base @table-border-color;
 
 .@{table-prefix-cls}.@{table-prefix-cls}-bordered {
   // ============================ Title =============================
@@ -30,7 +30,7 @@
         // ============================ Header ============================
         > thead {
           > tr:not(:last-child) > th {
-            border-bottom: @border-width-base @border-style-base @border-color-split;
+            border-bottom: @border-width-base @border-style-base @table-border-color;
           }
         }
 

--- a/components/table/style/index.less
+++ b/components/table/style/index.less
@@ -579,6 +579,7 @@
       position: relative;
 
       &::before {
+        z-index: calc(@table-sticky-zindex + 1);
         box-shadow: inset 10px 0 8px -8px darken(@shadow-color, 5%);
       }
     }
@@ -586,7 +587,6 @@
     .@{table-prefix-cls}-cell-fix-left-first::after,
     .@{table-prefix-cls}-cell-fix-left-last::after {
       box-shadow: inset 10px 0 8px -8px darken(@shadow-color, 5%);
-      z-index: @table-sticky-zindex;
     }
   }
 
@@ -595,8 +595,8 @@
       position: relative;
 
       &::after {
-        box-shadow: inset -10px 0 8px -8px darken(@shadow-color, 5%);
         z-index: @table-sticky-zindex;
+        box-shadow: inset -10px 0 8px -8px darken(@shadow-color, 5%);
       }
     }
 

--- a/components/table/style/index.less
+++ b/components/table/style/index.less
@@ -83,7 +83,7 @@
         font-weight: 500;
         text-align: left;
         background: @table-header-bg;
-        border-bottom: @border-width-base @border-style-base @border-color-split;
+        border-bottom: @border-width-base @border-style-base @table-border-color;
         transition: background 0.3s ease;
 
         &[colspan]:not([colspan='1']) {
@@ -103,7 +103,7 @@
   &-tbody {
     > tr {
       > td {
-        border-bottom: @border-width-base @border-style-base @border-color-split;
+        border-bottom: @border-width-base @border-style-base @table-border-color;
         transition: background 0.3s;
 
         // ========================= Nest Table ===========================
@@ -150,7 +150,7 @@
     > tr {
       > th,
       > td {
-        border-bottom: @border-width-base @border-style-base @border-color-split;
+        border-bottom: @border-width-base @border-style-base @table-border-color;
       }
     }
   }
@@ -351,7 +351,7 @@
       padding: 7px 8px 7px 3px;
       overflow: hidden;
       background-color: @table-filter-btns-bg;
-      border-top: @border-width-base @border-style-base @border-color-split;
+      border-top: @border-width-base @border-style-base @table-border-color;
     }
   }
 
@@ -424,7 +424,7 @@
     line-height: ceil(((@font-size-sm * 1.4 - @border-width-base * 3) / 2)) * 2 + @border-width-base *
       3;
     background: @table-expand-icon-bg;
-    border: @border-width-base @border-style-base @border-color-split;
+    border: @border-width-base @border-style-base @table-border-color;
     border-radius: @border-radius-base;
     outline: none;
     transition: all 0.3s;
@@ -614,8 +614,8 @@
       z-index: @table-sticky-zindex;
       display: flex;
       align-items: center;
-      background: lighten(@border-color-split, 80%);
-      border-top: 1px solid @border-color-split;
+      background: lighten(@table-border-color, 80%);
+      border-top: 1px solid @table-border-color;
       opacity: 0.6;
       &:hover {
         transform-origin: center bottom;

--- a/components/table/style/index.less
+++ b/components/table/style/index.less
@@ -588,6 +588,7 @@
     .@{table-prefix-cls}-cell-fix-left-first::after,
     .@{table-prefix-cls}-cell-fix-left-last::after {
       box-shadow: inset 10px 0 8px -8px darken(@shadow-color, 5%);
+      z-index: @table-sticky-zindex;
     }
   }
 
@@ -597,6 +598,7 @@
 
       &::after {
         box-shadow: inset -10px 0 8px -8px darken(@shadow-color, 5%);
+        z-index: @table-sticky-zindex;
       }
     }
 

--- a/components/table/style/index.less
+++ b/components/table/style/index.less
@@ -586,6 +586,7 @@
     .@{table-prefix-cls}-cell-fix-left-first::after,
     .@{table-prefix-cls}-cell-fix-left-last::after {
       box-shadow: inset 10px 0 8px -8px darken(@shadow-color, 5%);
+      z-index: @table-sticky-zindex;
     }
   }
 
@@ -595,6 +596,7 @@
 
       &::after {
         box-shadow: inset -10px 0 8px -8px darken(@shadow-color, 5%);
+        z-index: @table-sticky-zindex;
       }
     }
 

--- a/components/table/style/index.less
+++ b/components/table/style/index.less
@@ -581,6 +581,7 @@
       position: relative;
 
       &::before {
+        z-index: calc(@table-sticky-zindex + 1);
         box-shadow: inset 10px 0 8px -8px darken(@shadow-color, 5%);
       }
     }
@@ -588,7 +589,6 @@
     .@{table-prefix-cls}-cell-fix-left-first::after,
     .@{table-prefix-cls}-cell-fix-left-last::after {
       box-shadow: inset 10px 0 8px -8px darken(@shadow-color, 5%);
-      z-index: @table-sticky-zindex;
     }
   }
 
@@ -597,8 +597,8 @@
       position: relative;
 
       &::after {
-        box-shadow: inset -10px 0 8px -8px darken(@shadow-color, 5%);
         z-index: @table-sticky-zindex;
+        box-shadow: inset -10px 0 8px -8px darken(@shadow-color, 5%);
       }
     }
 

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "rc-dialog": "~8.5.1",
     "rc-drawer": "~4.2.0",
     "rc-dropdown": "~3.2.0",
-    "rc-field-form": "~1.17.3",
+    "rc-field-form": "~1.18.0",
     "rc-image": "~5.0.2",
     "rc-input-number": "~6.1.0",
     "rc-mentions": "~1.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "antd",
-  "version": "4.10.2",
+  "version": "4.10.3",
   "description": "An enterprise-class UI design language and React components implementation",
   "title": "Ant Design",
   "keywords": [


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

fix https://github.com/ant-design/ant-design/issues/28096

### 💡 Background and solution
Background: This issues that raised by @EvertEt. It caused by use Table component when users set stricky property also have fixed column. For example :
`import { Table } from 'antd';

const columns = [
  {
    title: 'Full Name',
    width: 100,
    dataIndex: 'name',
    key: 'name',
    fixed: 'left',
  },
  {
    title: 'Age',
    width: 100,
    dataIndex: 'age',
    key: 'age',
    fixed: 'left',
  },
  { title: 'Column 1', dataIndex: 'address', key: '1' },
  { title: 'Column 2', dataIndex: 'address', key: '2' },
  { title: 'Column 3', dataIndex: 'address', key: '3' },
  { title: 'Column 4', dataIndex: 'address', key: '4' },
  { title: 'Column 5', dataIndex: 'address', key: '5' },
  { title: 'Column 6', dataIndex: 'address', key: '6' },
  { title: 'Column 7', dataIndex: 'address', key: '7' },
  { title: 'Column 8', dataIndex: 'address', key: '8' },
];

const data = [
  {
    key: '1',
    name: 'John Brown',
    age: 32,
    address: 'New York Park',
  },
  {
    key: '2',
    name: 'Jim Green',
    age: 40,
    address: 'London Park',
  },
];

ReactDOM.render(<Table sticky columns={columns} dataSource={data} scroll={{ x: 1300 }} />, mountNode);`

The reason that sticky-table header's  z-index will set '@table-sticky-zindex'(3) but  'ant-table-container::after' is 2.

The best solution should set [rc-table](https://github.com/react-component/table/blob/master/src/Table.tsx#L704) , for example:
` <div className={isSticky? `${prefixCls}-container ${prefixCls}-sticky` : `${prefixCls}-container`}>{groupTableNode}</div>`
and then you set ant-table-sticky ,like([code](https://github.com/ant-design/ant-design/blob/master/components/table/style/index.less#L606)) ：
` &-sticky {
    &::after {
         z-index: @table-sticky-zindex;
    }
    &-header {
      position: sticky;
      z-index: @table-sticky-zindex;
    }
  .......
`

But rc-table[https://github.com/react-component/table] is as denpency for antd, not sure I can do this.


### 📝 Changelog
this code that I commit is work for this issue. But will set antd-table-contianer 's z-index will be 3 for forever. 


| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Fix shadow issues when user set table has sticky property but set fixed colum.        |
| 🇨🇳 Chinese |     修复具备 sticky 属性和scroll 属性的 Table 在水平滚动过程中，右侧(或左侧)阴影被头覆盖的情况       |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
