### PR TITLE
feat: ConfigProvider support `iconPrefixCls`

### DIFF
--- a/components/card/style/index.less
+++ b/components/card/style/index.less
@@ -186,7 +186,7 @@
         }
 
         a:not(.@{ant-prefix}-btn),
-        > .anticon {
+        > .@{iconfont-css-prefix} {
           display: inline-block;
           width: 100%;
           color: @text-color-secondary;
@@ -198,7 +198,7 @@
           }
         }
 
-        > .anticon {
+        > .@{iconfont-css-prefix} {
           font-size: @card-action-icon-size;
           line-height: 22px;
         }

--- a/components/config-provider/__tests__/index.test.js
+++ b/components/config-provider/__tests__/index.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { mount } from 'enzyme';
+import { SmileOutlined } from '@ant-design/icons';
 import ConfigProvider, { ConfigContext } from '..';
 import Button from '../../button';
 import Table from '../../table';
@@ -54,6 +55,17 @@ describe('ConfigProvider', () => {
     );
 
     expect(wrapper.find('button').props().className).toEqual('bamboo-btn');
+  });
+
+  it('iconPrefixCls', () => {
+    const wrapper = mount(
+      <ConfigProvider iconPrefixCls="bamboo">
+        <SmileOutlined />
+      </ConfigProvider>,
+    );
+
+    expect(wrapper.find('[role="img"]').hasClass('bamboo')).toBeTruthy();
+    expect(wrapper.find('[role="img"]').hasClass('bamboo-smile')).toBeTruthy();
   });
 
   it('input autoComplete', () => {

--- a/components/config-provider/context.tsx
+++ b/components/config-provider/context.tsx
@@ -14,6 +14,7 @@ export interface ConfigConsumerProps {
   getTargetContainer?: () => HTMLElement;
   getPopupContainer?: (triggerNode: HTMLElement) => HTMLElement;
   rootPrefixCls?: string;
+  iconPrefixCls?: string;
   getPrefixCls: (suffixCls?: string, customizePrefixCls?: string) => string;
   renderEmpty: RenderEmptyHandler;
   csp?: CSPConfig;

--- a/components/config-provider/demo/prefixCls.md
+++ b/components/config-provider/demo/prefixCls.md
@@ -4,7 +4,6 @@ title:
   zh-CN: 前缀
   en-US: prefixCls
 debug: true
-only: true
 ---
 
 ## zh-CN

--- a/components/config-provider/demo/prefixCls.md
+++ b/components/config-provider/demo/prefixCls.md
@@ -1,0 +1,33 @@
+---
+order: 99
+title:
+  zh-CN: 前缀
+  en-US: prefixCls
+debug: true
+only: true
+---
+
+## zh-CN
+
+修改组件和图标前缀。
+
+## en-US
+
+Config component and icon prefixCls.
+
+```jsx
+import { ConfigProvider, Select } from 'antd';
+import { SmileOutlined } from '@ant-design/icons';
+
+// Ant Design site use `es` module for view
+// but do not replace related lib `lib` with `es`
+// which do not show correct in site.
+// We may need do convert in site also.
+const FormSizeDemo = () => (
+  <ConfigProvider prefixCls="light" iconPrefixCls="bamboo">
+    <SmileOutlined />
+    <Select />
+  </ConfigProvider>
+);
+ReactDOM.render(<FormSizeDemo />, mountNode);
+```

--- a/components/config-provider/index.en-US.md
+++ b/components/config-provider/index.en-US.md
@@ -46,6 +46,7 @@ Some components use dynamic style to support wave effect. You can config `csp` p
 | form | Set Form common props | { validateMessages?: [ValidateMessages](/components/form/#validateMessages), requiredMark?: boolean \| `optional` } | - | requiredMark: 4.8.0 |
 | getPopupContainer | To set the container of the popup element. The default is to create a `div` element in `body` | function(triggerNode) | () => document.body |  |
 | getTargetContainer | Config Affix, Anchor scroll target container | () => HTMLElement | () => window | 4.2.0 |
+| iconPrefixCls | Set icon prefix className (cooperated with [@iconfont-css-prefix](https://github.com/ant-design/ant-design/blob/d943b85a523bdf181dabc12c928226f3b4b893de/components/style/themes/default.less#L106)) | string | `anticon` | 4.11.0 |
 | input | Set Input common props | { autoComplete?: string } | - | 4.2.0 |
 | locale | Language package setting, you can find the packages in [antd/lib/locale](http://unpkg.com/antd/lib/locale/) | object | - |  |
 | pageHeader | Unify the ghost of PageHeader, ref [PageHeader](/components/page-header) | { ghost: boolean } | true |  |

--- a/components/config-provider/index.zh-CN.md
+++ b/components/config-provider/index.zh-CN.md
@@ -47,6 +47,7 @@ export default () => (
 | form | 设置 Form 组件的通用属性 | { validateMessages?: [ValidateMessages](/components/form/#validateMessages), requiredMark?: boolean \| `optional` } | - | requiredMark: 4.8.0 |
 | getPopupContainer | 弹出框（Select, Tooltip, Menu 等等）渲染父节点，默认渲染到 body 上。 | function(triggerNode) | () => document.body |  |
 | getTargetContainer | 配置 Affix、Anchor 滚动监听容器。 | () => HTMLElement | () => window | 4.2.0 |
+| iconPrefixCls | 设置图标统一样式前缀。注意：需要配合 `less` 变量 [@iconfont-css-prefix](https://github.com/ant-design/ant-design/blob/d943b85a523bdf181dabc12c928226f3b4b893de/components/style/themes/default.less#L106) 使用 | string | `anticon` | 4.11.0 |
 | input | 设置 Input 组件的通用属性 | { autoComplete?: string } | - | 4.2.0 |
 | locale | 语言包配置，语言包可到 [antd/lib/locale](http://unpkg.com/antd/lib/locale/) 目录下寻找 | object | - |  |
 | pageHeader | 统一设置 PageHeader 的 ghost，参考 [PageHeader](/components/page-header) | { ghost: boolean } | true |  |

--- a/components/dropdown/style/rtl.less
+++ b/components/dropdown/style/rtl.less
@@ -47,8 +47,8 @@
         text-align: right;
       }
 
-      > .anticon:first-child,
-      > span > .anticon:first-child {
+      > .@{iconfont-css-prefix}:first-child,
+      > span > .@{iconfont-css-prefix}:first-child {
         .@{dropdown-prefix-cls}-rtl & {
           margin-right: 0;
           margin-left: 8px;

--- a/components/image/style/index.less
+++ b/components/image/style/index.less
@@ -148,11 +148,11 @@
       &-disabled {
         color: @image-preview-operation-disabled-color;
         cursor: not-allowed;
-        > .anticon {
+        > .@{iconfont-css-prefix} {
           cursor: not-allowed;
         }
       }
-      > .anticon {
+      > .@{iconfont-css-prefix} {
         font-size: 18px;
       }
     }

--- a/components/result/style/index.less
+++ b/components/result/style/index.less
@@ -6,19 +6,19 @@
 .@{result-prefix-cls} {
   padding: 48px 32px;
   // status color
-  &-success &-icon > .anticon {
+  &-success &-icon > .@{iconfont-css-prefix} {
     color: @success-color;
   }
 
-  &-error &-icon > .anticon {
+  &-error &-icon > .@{iconfont-css-prefix} {
     color: @error-color;
   }
 
-  &-info &-icon > .anticon {
+  &-info &-icon > .@{iconfont-css-prefix} {
     color: @info-color;
   }
 
-  &-warning &-icon > .anticon {
+  &-warning &-icon > .@{iconfont-css-prefix} {
     color: @warning-color;
   }
 
@@ -33,7 +33,7 @@
     margin-bottom: 24px;
     text-align: center;
 
-    > .anticon {
+    > .@{iconfont-css-prefix} {
       font-size: @result-icon-font-size;
     }
   }

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
   ],
   "dependencies": {
     "@ant-design/colors": "^5.0.0",
-    "@ant-design/icons": "^4.3.0",
+    "@ant-design/icons": "^4.4.0",
     "@ant-design/react-slick": "~0.28.1",
     "@babel/runtime": "^7.11.2",
     "array-tree-filter": "^2.1.0",


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

resolve #16547

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

目前 Site 不会自动 lib 转 es，但是用户实际使用应该是不影响的。

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     ConfigProvider support `iconPrefixCls`.      |
| 🇨🇳 Chinese |    ConfigProvider 支持 `iconPrefixCls` 修改图标样式前缀。       |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/config-provider/demo/prefixCls.md](https://github.com/ant-design/ant-design/blob/icon-prefixCls/components/config-provider/demo/prefixCls.md)
[View rendered components/config-provider/index.en-US.md](https://github.com/ant-design/ant-design/blob/icon-prefixCls/components/config-provider/index.en-US.md)
[View rendered components/config-provider/index.zh-CN.md](https://github.com/ant-design/ant-design/blob/icon-prefixCls/components/config-provider/index.zh-CN.md)