### PR TITLE
Revert "Fix typography type"

### DIFF
--- a/components/typography/Base.tsx
+++ b/components/typography/Base.tsx
@@ -44,7 +44,7 @@ interface EditConfig {
 interface EllipsisConfig {
   rows?: number;
   expandable?: boolean;
-  suffix?: React.ReactNode;
+  suffix?: string;
   symbol?: React.ReactNode;
   onExpand?: React.MouseEventHandler<HTMLElement>;
   onEllipsis?: (ellipsis: boolean) => void;

--- a/components/typography/index.en-US.md
+++ b/components/typography/index.en-US.md
@@ -107,7 +107,7 @@ Basic text writing, including headings, body text, lists, and more.
     {
       rows: number,
       expandable: boolean,
-      suffix: ReactNode,
+      suffix: string,
       symbol: ReactNode,
       onExpand: function(event),
       onEllipsis: function(ellipsis),

--- a/components/typography/index.zh-CN.md
+++ b/components/typography/index.zh-CN.md
@@ -107,7 +107,7 @@ cover: https://gw.alipayobjects.com/zos/alicdn/GOM1KQ24O/Typography.svg
     {
       rows: number,
       expandable: boolean,
-      suffix: ReactNode,
+      suffix: string,
       symbol: ReactNode,
       onExpand: function(event),
       onEllipsis: function(ellipsis),


### PR DESCRIPTION
Reverts ant-design/ant-design#28959

-----
[View rendered components/typography/index.en-US.md](https://github.com/ant-design/ant-design/blob/revert-28959-fix_typography_type/components/typography/index.en-US.md)
[View rendered components/typography/index.zh-CN.md](https://github.com/ant-design/ant-design/blob/revert-28959-fix_typography_type/components/typography/index.zh-CN.md)