### PR TITLE
Add children before after

### DIFF
--- a/components/form/FormItem.tsx
+++ b/components/form/FormItem.tsx
@@ -159,11 +159,11 @@ function FormItem<Values = any>(props: FormItemProps<Values>): React.ReactElemen
     isRequired?: boolean,
   ): React.ReactNode {
     const thisChildren = (
-      <>
+      <React.Fragment>
         {childrenBefore}
         {baseChildren}
         {childrenAfter}
-      </>
+      </React.Fragment>
     );
     if (noStyle && !hidden) {
       return thisChildren;

--- a/components/form/FormItem.tsx
+++ b/components/form/FormItem.tsx
@@ -159,11 +159,11 @@ function FormItem<Values = any>(props: FormItemProps<Values>): React.ReactElemen
     isRequired?: boolean,
   ): React.ReactNode {
     const thisChildren = (
-      <React.Fragment>
+      <>
         {childrenBefore}
         {baseChildren}
         {childrenAfter}
-      </React.Fragment>
+      </>
     );
     if (noStyle && !hidden) {
       return thisChildren;

--- a/components/form/FormItem.tsx
+++ b/components/form/FormItem.tsx
@@ -49,6 +49,8 @@ export interface FormItemProps<Values = any>
   style?: React.CSSProperties;
   className?: string;
   children?: ChildrenType<Values>;
+  childrenBefore?: React.ReactNode;
+  childrenAfter?: React.ReactNode;
   id?: string;
   hasFeedback?: boolean;
   validateStatus?: ValidateStatus;
@@ -83,6 +85,8 @@ function FormItem<Values = any>(props: FormItemProps<Values>): React.ReactElemen
     rules,
     validateStatus,
     children,
+    childrenBefore,
+    childrenAfter,
     required,
     label,
     messageVariables,
@@ -154,8 +158,15 @@ function FormItem<Values = any>(props: FormItemProps<Values>): React.ReactElemen
     meta?: Meta,
     isRequired?: boolean,
   ): React.ReactNode {
+    const thisChildren = (
+      <>
+        {childrenBefore}
+        {baseChildren}
+        {childrenAfter}
+      </>
+    );
     if (noStyle && !hidden) {
-      return baseChildren;
+      return thisChildren;
     }
 
     // ======================== Errors ========================
@@ -245,7 +256,7 @@ function FormItem<Values = any>(props: FormItemProps<Values>): React.ReactElemen
           validateStatus={mergedValidateStatus}
         >
           <FormItemContext.Provider value={{ updateItemErrors: updateChildItemErrors }}>
-            {baseChildren}
+            {thisChildren}
           </FormItemContext.Provider>
         </FormItemInput>
       </Row>

--- a/components/form/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/form/__tests__/__snapshots__/demo.test.js.snap
@@ -6333,6 +6333,81 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
     class="ant-row ant-form-item"
   >
     <div
+      class="ant-col ant-col-6 ant-form-item-label"
+    >
+      <label
+        class="ant-form-item-required"
+        for="validate_other_childrenAfter"
+        title="childrenAfter"
+      >
+        childrenAfter
+      </label>
+    </div>
+    <div
+      class="ant-col ant-col-14 ant-form-item-control"
+    >
+      <div
+        class="ant-form-item-control-input"
+      >
+        <div
+          class="ant-form-item-control-input-content"
+        >
+          <input
+            class="ant-input"
+            id="validate_other_childrenAfter"
+            type="text"
+            value=""
+          />
+          <span
+            style="position:absolute;top:4px;padding-left:4px"
+          >
+            after
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-row ant-form-item"
+  >
+    <div
+      class="ant-col ant-col-6 ant-form-item-label"
+    >
+      <label
+        class="ant-form-item-required"
+        for="validate_other_childrenBefore"
+        title="childrenBefore"
+      >
+        childrenBefore
+      </label>
+    </div>
+    <div
+      class="ant-col ant-col-14 ant-form-item-control"
+    >
+      <div
+        class="ant-form-item-control-input"
+      >
+        <div
+          class="ant-form-item-control-input-content"
+        >
+          <span>
+            after
+          </span>
+          <input
+            class="ant-input"
+            id="validate_other_childrenBefore"
+            style="width:90%"
+            type="text"
+            value=""
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-row ant-form-item"
+  >
+    <div
       class="ant-col ant-col-12 ant-col-offset-6 ant-form-item-control"
     >
       <div

--- a/components/form/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/form/__tests__/__snapshots__/demo.test.js.snap
@@ -6396,7 +6396,7 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
           <input
             class="ant-input"
             id="validate_other_childrenBefore"
-            style="width:90%"
+            style="width:80%"
             type="text"
             value=""
           />

--- a/components/form/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/form/__tests__/__snapshots__/demo.test.js.snap
@@ -6391,7 +6391,7 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
           class="ant-form-item-control-input-content"
         >
           <span>
-            after
+            before
           </span>
           <input
             class="ant-input"

--- a/components/form/demo/validate-other.md
+++ b/components/form/demo/validate-other.md
@@ -198,7 +198,7 @@ const Demo = () => {
       <Form.Item
         label="childrenBefore"
         name="childrenBefore"
-        childrenBefore={<span>after</span>}
+        childrenBefore={<span>before</span>}
         rules={[{ required: true, message: 'Please input your childrenBefore!' }]}
       >
         <Input style={{ width: '90%' }} />

--- a/components/form/demo/validate-other.md
+++ b/components/form/demo/validate-other.md
@@ -76,7 +76,6 @@ const Demo = () => {
           <Option value="usa">U.S.A</Option>
         </Select>
       </Form.Item>
-
       <Form.Item
         name="select-multiple"
         label="Select[multiple]"
@@ -88,18 +87,15 @@ const Demo = () => {
           <Option value="blue">Blue</Option>
         </Select>
       </Form.Item>
-
       <Form.Item label="InputNumber">
         <Form.Item name="input-number" noStyle>
           <InputNumber min={1} max={10} />
         </Form.Item>
         <span className="ant-form-text"> machines</span>
       </Form.Item>
-
       <Form.Item name="switch" label="Switch" valuePropName="checked">
         <Switch />
       </Form.Item>
-
       <Form.Item name="slider" label="Slider">
         <Slider
           marks={{
@@ -112,7 +108,6 @@ const Demo = () => {
           }}
         />
       </Form.Item>
-
       <Form.Item name="radio-group" label="Radio.Group">
         <Radio.Group>
           <Radio value="a">item 1</Radio>
@@ -120,7 +115,6 @@ const Demo = () => {
           <Radio value="c">item 3</Radio>
         </Radio.Group>
       </Form.Item>
-
       <Form.Item
         name="radio-button"
         label="Radio.Button"
@@ -132,7 +126,6 @@ const Demo = () => {
           <Radio.Button value="c">item 3</Radio.Button>
         </Radio.Group>
       </Form.Item>
-
       <Form.Item name="checkbox-group" label="Checkbox.Group">
         <Checkbox.Group>
           <Row>
@@ -169,11 +162,9 @@ const Demo = () => {
           </Row>
         </Checkbox.Group>
       </Form.Item>
-
       <Form.Item name="rate" label="Rate">
         <Rate />
       </Form.Item>
-
       <Form.Item
         name="upload"
         label="Upload"
@@ -185,7 +176,6 @@ const Demo = () => {
           <Button icon={<UploadOutlined />}>Click to upload</Button>
         </Upload>
       </Form.Item>
-
       <Form.Item label="Dragger">
         <Form.Item name="dragger" valuePropName="fileList" getValueFromEvent={normFile} noStyle>
           <Upload.Dragger name="files" action="/upload.do">
@@ -205,7 +195,14 @@ const Demo = () => {
       >
         <Input />
       </Form.Item>
-
+      <Form.Item
+        label="childrenBefore"
+        name="childrenBefore"
+        childrenBefore={<span>after</span>}
+        rules={[{ required: true, message: 'Please input your childrenBefore!' }]}
+      >
+        <Input style={{ width: '90%' }} />
+      </Form.Item>
       <Form.Item wrapperCol={{ span: 12, offset: 6 }}>
         <Button type="primary" htmlType="submit">
           Submit

--- a/components/form/demo/validate-other.md
+++ b/components/form/demo/validate-other.md
@@ -27,6 +27,7 @@ import {
   Checkbox,
   Row,
   Col,
+  Input,
 } from 'antd';
 import { UploadOutlined, InboxOutlined } from '@ant-design/icons';
 
@@ -195,6 +196,14 @@ const Demo = () => {
             <p className="ant-upload-hint">Support for a single or bulk upload.</p>
           </Upload.Dragger>
         </Form.Item>
+      </Form.Item>
+      <Form.Item
+        label="childrenAfter"
+        name="childrenAfter"
+        childrenAfter={<span style={{ position: 'absolute', top: 4, paddingLeft: 4 }}>after</span>}
+        rules={[{ required: true, message: 'Please input your childrenAfter!' }]}
+      >
+        <Input />
       </Form.Item>
 
       <Form.Item wrapperCol={{ span: 12, offset: 6 }}>

--- a/components/form/demo/validate-other.md
+++ b/components/form/demo/validate-other.md
@@ -201,7 +201,7 @@ const Demo = () => {
         childrenBefore={<span>before</span>}
         rules={[{ required: true, message: 'Please input your childrenBefore!' }]}
       >
-        <Input style={{ width: '90%' }} />
+        <Input style={{ width: '80%' }} />
       </Form.Item>
       <Form.Item wrapperCol={{ span: 12, offset: 6 }}>
         <Button type="primary" htmlType="submit">

--- a/components/form/index.en-US.md
+++ b/components/form/index.en-US.md
@@ -100,6 +100,8 @@ Form field component for data bidirectional binding, validation, layout, and so 
 | validateTrigger | When to validate the value of children node | string \| string\[] | `onChange` |  |
 | valuePropName | Props of children node, for example, the prop of Switch is 'checked'. This prop is an encapsulation of `getValueProps`, which will be invalid after customizing `getValueProps` | string | `value` |  |
 | wrapperCol | The layout for input controls, same as `labelCol`. You can set `wrapperCol` on Form which will not affect nest Item. If both exists, use Item first | [object](/components/grid/#Col) | - |  |
+| childrenBefore | `children` before element | React.ReactNode | - |  |
+| childrenAfter | `children` after element | React.ReactNode | - |  |
 
 After wrapped by `Form.Item` with `name` property, `value`(or other property defined by `valuePropName`) `onChange`(or other property defined by `trigger`) props will be added to form controls, the flow of form data will be handled by Form which will cause:
 

--- a/components/form/index.zh-CN.md
+++ b/components/form/index.zh-CN.md
@@ -101,6 +101,8 @@ const validateMessages = {
 | validateTrigger | 设置字段校验的时机 | string \| string\[] | `onChange` |  |
 | valuePropName | 子节点的值的属性，如 Switch 的是 'checked'。该属性为 `getValueProps` 的封装，自定义 `getValueProps` 后会失效 | string | `value` |  |
 | wrapperCol | 需要为输入控件设置布局样式时，使用该属性，用法同 `labelCol`。你可以通过 Form 的 `wrapperCol` 进行统一设置，不会作用于嵌套 Item。当和 Form 同时设置时，以 Item 为准 | [object](/components/grid/#Col) | - |  |
+| childrenBefore | `children` 前面的元素 | React.ReactNode | - |  |
+| childrenAfter | `children` 后面的元素 | React.ReactNode | - |  |
 
 被设置了 `name` 属性的 `Form.Item` 包装的控件，表单控件会自动添加 `value`（或 `valuePropName` 指定的其他属性） `onChange`（或 `trigger` 指定的其他属性），数据同步将被 Form 接管，这会导致以下结果：
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |  FormItem children 添加前后元素支持  |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/form/demo/validate-other.md](https://github.com/crazyair/ant-design/blob/add-children-before-after/components/form/demo/validate-other.md)
[View rendered components/form/index.en-US.md](https://github.com/crazyair/ant-design/blob/add-children-before-after/components/form/index.en-US.md)
[View rendered components/form/index.zh-CN.md](https://github.com/crazyair/ant-design/blob/add-children-before-after/components/form/index.zh-CN.md)