### PR TITLE
fix: styleForPseudo of wave should be added to ownerDocument instead of document

### DIFF
--- a/components/_util/wave.tsx
+++ b/components/_util/wave.tsx
@@ -98,8 +98,7 @@ export default class Wave extends React.Component<{ insertExtraNode?: boolean }>
       )}-click-animating-node {
         --antd-wave-shadow-color: ${waveColor};
       }`;
-      const node = this.containerRef.current as HTMLDivElement;
-      if (node && !node.ownerDocument.body.contains(styleForPseudo)) {
+      if (!node.ownerDocument.body.contains(styleForPseudo)) {
         node.ownerDocument.body.appendChild(styleForPseudo);
       }
     }

--- a/components/_util/wave.tsx
+++ b/components/_util/wave.tsx
@@ -98,8 +98,9 @@ export default class Wave extends React.Component<{ insertExtraNode?: boolean }>
       )}-click-animating-node {
         --antd-wave-shadow-color: ${waveColor};
       }`;
-      if (!document.body.contains(styleForPseudo)) {
-        document.body.appendChild(styleForPseudo);
+      const node = this.containerRef.current as HTMLDivElement;
+      if (node && !node.ownerDocument.body.contains(styleForPseudo)) {
+        node.ownerDocument.body.appendChild(styleForPseudo);
       }
     }
     if (insertExtraNode) {


### PR DESCRIPTION

### 🤔 This is a ...

- [x] Bug fix

### 🔗 Related issue link

https://github.com/ant-design/ant-design/issues/28934

### 💡 Background and solution

style element of Button's wave effect was always added to document.body, when Button is in popup window or in Shadow DOM, style won't be applied to the element

### 📝 Changelog


| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  styleForPseudo of wave should be added to ownerDocument instead of document |
| 🇨🇳 Chinese | wave效果的styleForPseudo应该被添加到ownerDocument而不是document   |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
