### PR TITLE
fix(textarea): lose origin ref attributes

### DIFF
--- a/components/input/TextArea.tsx
+++ b/components/input/TextArea.tsx
@@ -81,7 +81,7 @@ const TextArea = React.forwardRef<TextAreaRef, TextAreaProps>(
     const prefixCls = getPrefixCls('input', customizePrefixCls);
 
     React.useImperativeHandle(ref, () => ({
-      resizableTextArea: innerRef.current?.resizableTextArea,
+      ...(innerRef.current || {}),
       focus: (option?: InputFocusOptions) => {
         triggerFocus(innerRef.current?.resizableTextArea?.textArea, option);
       },


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

https://github.com/ant-design/ant-design/pull/28602

### 💡 Background and solution

如果旧代码有通过 ref 取值的，现在取不到 state 了..

```js
...
const value = this.remarkInput.current.state.value 
//                                    ⬆️error!
...
<Input.TextArea
  maxLength={100}
  rows={3}
  ref={this.remarkInput}
  placeholder="请输入备注信息，不超过100个字。"
/>
```
新返回的 ref 没有返回 state，报错了。

### 📝 Changelog


| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese | 修复丢失原始`Input.TextArea` ref属性的问题 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
