### PR TITLE
DEMO - Add new comments below previously created ones instead of on top

### DIFF
--- a/components/comment/demo/editor.md
+++ b/components/comment/demo/editor.md
@@ -62,13 +62,13 @@ class App extends React.Component {
         submitting: false,
         value: '',
         comments: [
+          ...this.state.comments,
           {
             author: 'Han Solo',
             avatar: 'https://zos.alipayobjects.com/rmsportal/ODTLcjxAfvqbxHnVXCYX.png',
             content: <p>{this.state.value}</p>,
             datetime: moment().fromNow(),
           },
-          ...this.state.comments,
         ],
       });
     }, 1000);


### PR DESCRIPTION
In the example with the editor, the new comments are added on top of the older ones which is not following the way it is usually done in discussions.

<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [x] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

No issue - just an observation

### 💡 Background and solution

This is just a small update to the demo - in it, the new comments are added after the older ones, instead of in front. This makes the result follow the timeline instead of pushing the newest comment on top.

### 📝 Changelog

No changes from the user side

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/comment/demo/editor.md](https://github.com/doshyt/ant-design/blob/patch-1/components/comment/demo/editor.md)