### PR TITLE
feat: added ref support to Sider component

### DIFF
--- a/components/layout/Sider.tsx
+++ b/components/layout/Sider.tsx
@@ -59,168 +59,179 @@ const generateId = (() => {
   };
 })();
 
-const Sider: React.FC<SiderProps> = ({
-  prefixCls: customizePrefixCls,
-  className,
-  trigger,
-  children,
-  defaultCollapsed = false,
-  theme = 'dark',
-  style = {},
-  collapsible = false,
-  reverseArrow = false,
-  width = 200,
-  collapsedWidth = 80,
-  zeroWidthTriggerStyle,
-  breakpoint,
-  onCollapse,
-  onBreakpoint,
-  ...props
-}) => {
-  const { siderHook } = useContext(LayoutContext);
-
-  const [collapsed, setCollapsed] = useState(
-    'collapsed' in props ? props.collapsed : defaultCollapsed,
-  );
-  const [below, setBelow] = useState(false);
-
-  useEffect(() => {
-    if ('collapsed' in props) {
-      setCollapsed(props.collapsed);
-    }
-  }, [props.collapsed]);
-
-  const handleSetCollapsed = (value: boolean, type: CollapseType) => {
-    if (!('collapsed' in props)) {
-      setCollapsed(value);
-    }
-    if (onCollapse) {
-      onCollapse(value, type);
-    }
-  };
-
-  // ========================= Responsive =========================
-  const responsiveHandlerRef = useRef<(mql: MediaQueryListEvent | MediaQueryList) => void>();
-  responsiveHandlerRef.current = (mql: MediaQueryListEvent | MediaQueryList) => {
-    setBelow(mql.matches);
-    if (onBreakpoint) {
-      onBreakpoint(mql.matches);
-    }
-
-    if (collapsed !== mql.matches) {
-      handleSetCollapsed(mql.matches, 'responsive');
-    }
-  };
-
-  useEffect(() => {
-    function responsiveHandler(mql: MediaQueryListEvent | MediaQueryList) {
-      return responsiveHandlerRef.current!(mql);
-    }
-
-    let mql: MediaQueryList;
-    if (typeof window !== 'undefined') {
-      const { matchMedia } = window;
-      if (matchMedia && breakpoint && breakpoint in dimensionMaxMap) {
-        mql = matchMedia(`(max-width: ${dimensionMaxMap[breakpoint]})`);
-        try {
-          mql.addEventListener('change', responsiveHandler);
-        } catch (error) {
-          mql.addListener(responsiveHandler);
-        }
-        responsiveHandler(mql);
-      }
-    }
-    return () => {
-      try {
-        mql?.removeEventListener('change', responsiveHandler);
-      } catch (error) {
-        mql?.removeListener(responsiveHandler);
-      }
-    };
-  }, []);
-
-  useEffect(() => {
-    const uniqueId = generateId('ant-sider-');
-    siderHook.addSider(uniqueId);
-    return () => siderHook.removeSider(uniqueId);
-  }, []);
-
-  const toggle = () => {
-    handleSetCollapsed(!collapsed, 'clickTrigger');
-  };
-
-  const { getPrefixCls } = useContext(ConfigContext);
-
-  const renderSider = () => {
-    const prefixCls = getPrefixCls('layout-sider', customizePrefixCls);
-    const divProps = omit(props, ['collapsed']);
-    const rawWidth = collapsed ? collapsedWidth : width;
-    // use "px" as fallback unit for width
-    const siderWidth = isNumeric(rawWidth) ? `${rawWidth}px` : String(rawWidth);
-    // special trigger when collapsedWidth == 0
-    const zeroWidthTrigger =
-      parseFloat(String(collapsedWidth || 0)) === 0 ? (
-        <span
-          onClick={toggle}
-          className={classNames(
-            `${prefixCls}-zero-width-trigger`,
-            `${prefixCls}-zero-width-trigger-${reverseArrow ? 'right' : 'left'}`,
-          )}
-          style={zeroWidthTriggerStyle}
-        >
-          {trigger || <BarsOutlined />}
-        </span>
-      ) : null;
-    const iconObj = {
-      expanded: reverseArrow ? <RightOutlined /> : <LeftOutlined />,
-      collapsed: reverseArrow ? <LeftOutlined /> : <RightOutlined />,
-    };
-    const status = collapsed ? 'collapsed' : 'expanded';
-    const defaultTrigger = iconObj[status];
-    const triggerDom =
-      trigger !== null
-        ? zeroWidthTrigger || (
-            <div className={`${prefixCls}-trigger`} onClick={toggle} style={{ width: siderWidth }}>
-              {trigger || defaultTrigger}
-            </div>
-          )
-        : null;
-    const divStyle = {
-      ...style,
-      flex: `0 0 ${siderWidth}`,
-      maxWidth: siderWidth, // Fix width transition bug in IE11
-      minWidth: siderWidth, // https://github.com/ant-design/ant-design/issues/6349
-      width: siderWidth,
-    };
-    const siderCls = classNames(
-      prefixCls,
-      `${prefixCls}-${theme}`,
-      {
-        [`${prefixCls}-collapsed`]: !!collapsed,
-        [`${prefixCls}-has-trigger`]: collapsible && trigger !== null && !zeroWidthTrigger,
-        [`${prefixCls}-below`]: !!below,
-        [`${prefixCls}-zero-width`]: parseFloat(siderWidth) === 0,
-      },
+const Sider = React.forwardRef<HTMLDivElement, SiderProps>(
+  (
+    {
+      prefixCls: customizePrefixCls,
       className,
-    );
-    return (
-      <aside className={siderCls} {...divProps} style={divStyle}>
-        <div className={`${prefixCls}-children`}>{children}</div>
-        {collapsible || (below && zeroWidthTrigger) ? triggerDom : null}
-      </aside>
-    );
-  };
+      trigger,
+      children,
+      defaultCollapsed = false,
+      theme = 'dark',
+      style = {},
+      collapsible = false,
+      reverseArrow = false,
+      width = 200,
+      collapsedWidth = 80,
+      zeroWidthTriggerStyle,
+      breakpoint,
+      onCollapse,
+      onBreakpoint,
+      ...props
+    },
+    ref,
+  ) => {
+    const { siderHook } = useContext(LayoutContext);
 
-  return (
-    <SiderContext.Provider
-      value={{
-        siderCollapsed: collapsed,
-        collapsedWidth,
-      }}
-    >
-      {renderSider()}
-    </SiderContext.Provider>
-  );
-};
+    const [collapsed, setCollapsed] = useState(
+      'collapsed' in props ? props.collapsed : defaultCollapsed,
+    );
+    const [below, setBelow] = useState(false);
+
+    useEffect(() => {
+      if ('collapsed' in props) {
+        setCollapsed(props.collapsed);
+      }
+    }, [props.collapsed]);
+
+    const handleSetCollapsed = (value: boolean, type: CollapseType) => {
+      if (!('collapsed' in props)) {
+        setCollapsed(value);
+      }
+      if (onCollapse) {
+        onCollapse(value, type);
+      }
+    };
+
+    // ========================= Responsive =========================
+    const responsiveHandlerRef = useRef<(mql: MediaQueryListEvent | MediaQueryList) => void>();
+    responsiveHandlerRef.current = (mql: MediaQueryListEvent | MediaQueryList) => {
+      setBelow(mql.matches);
+      if (onBreakpoint) {
+        onBreakpoint(mql.matches);
+      }
+
+      if (collapsed !== mql.matches) {
+        handleSetCollapsed(mql.matches, 'responsive');
+      }
+    };
+
+    useEffect(() => {
+      function responsiveHandler(mql: MediaQueryListEvent | MediaQueryList) {
+        return responsiveHandlerRef.current!(mql);
+      }
+
+      let mql: MediaQueryList;
+      if (typeof window !== 'undefined') {
+        const { matchMedia } = window;
+        if (matchMedia && breakpoint && breakpoint in dimensionMaxMap) {
+          mql = matchMedia(`(max-width: ${dimensionMaxMap[breakpoint]})`);
+          try {
+            mql.addEventListener('change', responsiveHandler);
+          } catch (error) {
+            mql.addListener(responsiveHandler);
+          }
+          responsiveHandler(mql);
+        }
+      }
+      return () => {
+        try {
+          mql?.removeEventListener('change', responsiveHandler);
+        } catch (error) {
+          mql?.removeListener(responsiveHandler);
+        }
+      };
+    }, []);
+
+    useEffect(() => {
+      const uniqueId = generateId('ant-sider-');
+      siderHook.addSider(uniqueId);
+      return () => siderHook.removeSider(uniqueId);
+    }, []);
+
+    const toggle = () => {
+      handleSetCollapsed(!collapsed, 'clickTrigger');
+    };
+
+    const { getPrefixCls } = useContext(ConfigContext);
+
+    const renderSider = () => {
+      const prefixCls = getPrefixCls('layout-sider', customizePrefixCls);
+      const divProps = omit(props, ['collapsed']);
+      const rawWidth = collapsed ? collapsedWidth : width;
+      // use "px" as fallback unit for width
+      const siderWidth = isNumeric(rawWidth) ? `${rawWidth}px` : String(rawWidth);
+      // special trigger when collapsedWidth == 0
+      const zeroWidthTrigger =
+        parseFloat(String(collapsedWidth || 0)) === 0 ? (
+          <span
+            onClick={toggle}
+            className={classNames(
+              `${prefixCls}-zero-width-trigger`,
+              `${prefixCls}-zero-width-trigger-${reverseArrow ? 'right' : 'left'}`,
+            )}
+            style={zeroWidthTriggerStyle}
+          >
+            {trigger || <BarsOutlined />}
+          </span>
+        ) : null;
+      const iconObj = {
+        expanded: reverseArrow ? <RightOutlined /> : <LeftOutlined />,
+        collapsed: reverseArrow ? <LeftOutlined /> : <RightOutlined />,
+      };
+      const status = collapsed ? 'collapsed' : 'expanded';
+      const defaultTrigger = iconObj[status];
+      const triggerDom =
+        trigger !== null
+          ? zeroWidthTrigger || (
+              <div
+                className={`${prefixCls}-trigger`}
+                onClick={toggle}
+                style={{ width: siderWidth }}
+              >
+                {trigger || defaultTrigger}
+              </div>
+            )
+          : null;
+      const divStyle = {
+        ...style,
+        flex: `0 0 ${siderWidth}`,
+        maxWidth: siderWidth, // Fix width transition bug in IE11
+        minWidth: siderWidth, // https://github.com/ant-design/ant-design/issues/6349
+        width: siderWidth,
+      };
+      const siderCls = classNames(
+        prefixCls,
+        `${prefixCls}-${theme}`,
+        {
+          [`${prefixCls}-collapsed`]: !!collapsed,
+          [`${prefixCls}-has-trigger`]: collapsible && trigger !== null && !zeroWidthTrigger,
+          [`${prefixCls}-below`]: !!below,
+          [`${prefixCls}-zero-width`]: parseFloat(siderWidth) === 0,
+        },
+        className,
+      );
+      return (
+        <aside className={siderCls} {...divProps} style={divStyle} ref={ref}>
+          <div className={`${prefixCls}-children`}>{children}</div>
+          {collapsible || (below && zeroWidthTrigger) ? triggerDom : null}
+        </aside>
+      );
+    };
+
+    return (
+      <SiderContext.Provider
+        value={{
+          siderCollapsed: collapsed,
+          collapsedWidth,
+        }}
+      >
+        {renderSider()}
+      </SiderContext.Provider>
+    );
+  },
+);
+
+Sider.displayName = 'Sider';
 
 export default Sider;

--- a/components/layout/__tests__/index.test.js
+++ b/components/layout/__tests__/index.test.js
@@ -284,4 +284,16 @@ describe('Sider', () => {
     );
     expect(wrapper.find('.ant-layout-sider-zero-width-trigger').find('.my-trigger').length).toBe(1);
   });
+
+  it('should get aside element from ref', () => {
+    const ref = React.createRef();
+    const onSelect = jest.fn();
+
+    mount(
+      <Sider onSelect={onSelect} ref={ref}>
+        Sider
+      </Sider>,
+    );
+    expect(ref.current instanceof HTMLElement).toBe(true);
+  });
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

The problem was that the component did not support `ref` prop. The solution allows to work with DOM-node (`<aside/>` tag)
### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | added ref support to Layout.Sider component |
| 🇨🇳 Chinese | 向Layout.Sider組件添加了ref支持 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
