### PR TITLE
Support override anchor default onClick scroll behavior by respect preventDefault

### DIFF
--- a/components/anchor/Anchor.tsx
+++ b/components/anchor/Anchor.tsx
@@ -54,7 +54,7 @@ export interface AnchorProps {
   onClick?: (
     e: React.MouseEvent<HTMLElement>,
     link: { title: React.ReactNode; href: string },
-  ) => void;
+  ) => void | boolean;
   /** Scroll to target offset value, if none, it's offsetTop prop value or 0. */
   targetOffset?: number;
   /** Listening event when scrolling change active link */
@@ -80,7 +80,7 @@ export interface AntAnchor {
   onClick?: (
     e: React.MouseEvent<HTMLElement>,
     link: { title: React.ReactNode; href: string },
-  ) => void;
+  ) => void | boolean;
 }
 
 export default class Anchor extends React.Component<AnchorProps, AnchorState, ConfigConsumerProps> {

--- a/components/anchor/AnchorLink.tsx
+++ b/components/anchor/AnchorLink.tsx
@@ -42,7 +42,9 @@ class AnchorLink extends React.Component<AnchorLinkProps, any, AntAnchor> {
     const { scrollTo, onClick } = this.context;
     const { href, title } = this.props;
     if (onClick) {
-      onClick(e, { title, href });
+      if (onClick(e, { title, href }) === false || e.isDefaultPrevented()) {
+        return;
+      }
     }
     scrollTo(href);
   };


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [x] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [x] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution
Anchor onClick handler does not respect preventDefault, currently it always call scrollTo. But, if the target anchor is hidden (e.g. collapsed), if I want to first expand it, then scroll to, currently there is no way to avoid the scrollTo jumping since AnchorLink always calls scrollTo after onClick, does not check whether the event isDefaultPrevented().
With this PR, now user can do their own logic in the onClick, without the default scrollTo behavior.
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is not needed
- [x] Demo is not needed
- [x] TypeScript definition is updated
- [ ] Changelog is provided or not needed
