### PR TITLE
ci: add verify-package-version

### DIFF
--- a/.github/workflows/verify-package-version.yml
+++ b/.github/workflows/verify-package-version.yml
@@ -12,6 +12,7 @@ jobs:
       - name: verify-version
         uses: actions-cool/verify-package-version@v1.0.0
         with:
+          token: ${{ secrets.ANT_BOT_TOKEN }}
           title-include-content: 'docs'
           title-include-version: true
           open-comment: true

--- a/.github/workflows/verify-package-version.yml
+++ b/.github/workflows/verify-package-version.yml
@@ -1,0 +1,17 @@
+name: Verify Package Version
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize, ready_for_review, review_requested]
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.title, 'changelog')
+    steps:
+      - name: verify-version
+        uses: actions-cool/verify-package-version@v1.0.0
+        with:
+          title-include-content: 'docs'
+          title-include-version: true
+          open-comment: true

--- a/.github/workflows/verify-package-version.yml
+++ b/.github/workflows/verify-package-version.yml
@@ -9,8 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     if: contains(github.event.pull_request.title, 'changelog')
     steps:
+      - uses: actions/checkout@v2
       - name: verify-version
-        uses: actions-cool/verify-package-version@v1.0.0
+        uses: actions-cool/verify-package-version@v1.1.0
         with:
           token: ${{ secrets.ANT_BOT_TOKEN }}
           title-include-content: 'docs'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "antd",
-  "version": "4.12.2",
+  "version": "4.12.1",
   "description": "An enterprise-class UI design language and React components implementation",
   "title": "Ant Design",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "antd",
-  "version": "4.12.1",
+  "version": "4.12.2",
   "description": "An enterprise-class UI design language and React components implementation",
   "title": "Ant Design",
   "keywords": [


### PR DESCRIPTION
### 背景

https://github.com/ant-design/ant-design/pull/29198#issuecomment-772212716

### 说明
```yml
# 新增 PR title 只有包含 changelog 才进行触发，避免所有 PR 都触发
if: contains(github.event.pull_request.title, 'changelog')
```

```yml
# title 包含校验。此处为 docs
title-include-content: 'docs'
# title 包含版本校验，不过默认就是 true。这里会根据 PR 里的 package.json 中 version 和 title 对比。支持 Fork 的 PR
title-include-version: true
# 是否进行评论。Fork 的 PR 无权限，不会进行这个操作，只会纯校验。在 CI 显示结果。
open-comment: true
```

### 图示

![image](https://user-images.githubusercontent.com/29775873/106716853-e5d45900-6639-11eb-9861-4d3b8e019e81.png)

![image](https://user-images.githubusercontent.com/29775873/106716892-eff65780-6639-11eb-95a4-a0b1eb1879f8.png)

![image](https://user-images.githubusercontent.com/29775873/106716912-f389de80-6639-11eb-9a72-c3dd19a0ed88.png)

![image](https://user-images.githubusercontent.com/29775873/106716929-f7b5fc00-6639-11eb-8af8-58809de9ea4e.png)

![image](https://user-images.githubusercontent.com/29775873/106716940-fab0ec80-6639-11eb-8f0f-445ce6d407c3.png)
