### PR TITLE
feat(drawer): support contentWrapperStyle

### DIFF
--- a/components/drawer/index.en-US.md
+++ b/components/drawer/index.en-US.md
@@ -22,6 +22,7 @@ A Drawer is a panel that is typically overlaid on top of a page and slides in fr
 | --- | --- | --- | --- | --- |
 | afterVisibleChange | Callback after the animation ends when switching drawers | function(visible) | - |  |
 | bodyStyle | Style of the drawer content part | object | - |  |
+| contentWrapperStyle | Style of the drawer wrapper of content part | CSSProperties | - |  |
 | className | The class name of the container of the Drawer dialog | string | - |  |
 | closable | Whether a close (x) button is visible on top right of the Drawer dialog or not | boolean | true |  |
 | closeIcon | Custom close icon | ReactNode | &lt;CloseOutlined /> |  |

--- a/components/drawer/index.zh-CN.md
+++ b/components/drawer/index.zh-CN.md
@@ -21,6 +21,7 @@ cover: https://gw.alipayobjects.com/zos/alicdn/7z8NJQhFb/Drawer.svg
 | --- | --- | --- | --- | --- |
 | afterVisibleChange | 切换抽屉时动画结束后的回调 | function(visible) | - |  |
 | bodyStyle | 可用于设置 Drawer 内容部分的样式 | CSSProperties | - |  |
+| contentWrapperStyle | 可用于设置 Drawer 包裹内容部分的样式 | CSSProperties | - |  |
 | className | 对话框外层容器的类名 | string | - |  |
 | closable | 是否显示右上角的关闭按钮 | boolean | true |  |
 | closeIcon | 自定义关闭图标 | ReactNode | &lt;CloseOutlined /> |  |

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "rc-checkbox": "~2.3.0",
     "rc-collapse": "~3.1.0",
     "rc-dialog": "~8.5.1",
-    "rc-drawer": "~4.2.0",
+    "rc-drawer": "~4.3.0",
     "rc-dropdown": "~3.2.0",
     "rc-field-form": "~1.18.0",
     "rc-image": "~5.2.0",


### PR DESCRIPTION
[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close https://github.com/ant-design/ant-design/issues/28683

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Drawer support `contentWrapperStyle`.          |
| 🇨🇳 Chinese | Drawer 支持 `contentWrapperStyle`。          |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/drawer/index.en-US.md](https://github.com/ant-design/ant-design/blob/bump-drawer/components/drawer/index.en-US.md)
[View rendered components/drawer/index.zh-CN.md](https://github.com/ant-design/ant-design/blob/bump-drawer/components/drawer/index.zh-CN.md)