### PR TITLE
Fix image ru_RU locale

### DIFF
--- a/components/drawer/index.en-US.md
+++ b/components/drawer/index.en-US.md
@@ -22,6 +22,7 @@ A Drawer is a panel that is typically overlaid on top of a page and slides in fr
 | --- | --- | --- | --- | --- |
 | afterVisibleChange | Callback after the animation ends when switching drawers | function(visible) | - |  |
 | bodyStyle | Style of the drawer content part | object | - |  |
+| contentWrapperStyle | Style of the drawer wrapper of content part | CSSProperties | - |  |
 | className | The class name of the container of the Drawer dialog | string | - |  |
 | closable | Whether a close (x) button is visible on top right of the Drawer dialog or not | boolean | true |  |
 | closeIcon | Custom close icon | ReactNode | &lt;CloseOutlined /> |  |

--- a/components/drawer/index.zh-CN.md
+++ b/components/drawer/index.zh-CN.md
@@ -21,6 +21,7 @@ cover: https://gw.alipayobjects.com/zos/alicdn/7z8NJQhFb/Drawer.svg
 | --- | --- | --- | --- | --- |
 | afterVisibleChange | 切换抽屉时动画结束后的回调 | function(visible) | - |  |
 | bodyStyle | 可用于设置 Drawer 内容部分的样式 | CSSProperties | - |  |
+| contentWrapperStyle | 可用于设置 Drawer 包裹内容部分的样式 | CSSProperties | - |  |
 | className | 对话框外层容器的类名 | string | - |  |
 | closable | 是否显示右上角的关闭按钮 | boolean | true |  |
 | closeIcon | 自定义关闭图标 | ReactNode | &lt;CloseOutlined /> |  |

--- a/components/layout/Sider.tsx
+++ b/components/layout/Sider.tsx
@@ -59,168 +59,179 @@ const generateId = (() => {
   };
 })();
 
-const Sider: React.FC<SiderProps> = ({
-  prefixCls: customizePrefixCls,
-  className,
-  trigger,
-  children,
-  defaultCollapsed = false,
-  theme = 'dark',
-  style = {},
-  collapsible = false,
-  reverseArrow = false,
-  width = 200,
-  collapsedWidth = 80,
-  zeroWidthTriggerStyle,
-  breakpoint,
-  onCollapse,
-  onBreakpoint,
-  ...props
-}) => {
-  const { siderHook } = useContext(LayoutContext);
-
-  const [collapsed, setCollapsed] = useState(
-    'collapsed' in props ? props.collapsed : defaultCollapsed,
-  );
-  const [below, setBelow] = useState(false);
-
-  useEffect(() => {
-    if ('collapsed' in props) {
-      setCollapsed(props.collapsed);
-    }
-  }, [props.collapsed]);
-
-  const handleSetCollapsed = (value: boolean, type: CollapseType) => {
-    if (!('collapsed' in props)) {
-      setCollapsed(value);
-    }
-    if (onCollapse) {
-      onCollapse(value, type);
-    }
-  };
-
-  // ========================= Responsive =========================
-  const responsiveHandlerRef = useRef<(mql: MediaQueryListEvent | MediaQueryList) => void>();
-  responsiveHandlerRef.current = (mql: MediaQueryListEvent | MediaQueryList) => {
-    setBelow(mql.matches);
-    if (onBreakpoint) {
-      onBreakpoint(mql.matches);
-    }
-
-    if (collapsed !== mql.matches) {
-      handleSetCollapsed(mql.matches, 'responsive');
-    }
-  };
-
-  useEffect(() => {
-    function responsiveHandler(mql: MediaQueryListEvent | MediaQueryList) {
-      return responsiveHandlerRef.current!(mql);
-    }
-
-    let mql: MediaQueryList;
-    if (typeof window !== 'undefined') {
-      const { matchMedia } = window;
-      if (matchMedia && breakpoint && breakpoint in dimensionMaxMap) {
-        mql = matchMedia(`(max-width: ${dimensionMaxMap[breakpoint]})`);
-        try {
-          mql.addEventListener('change', responsiveHandler);
-        } catch (error) {
-          mql.addListener(responsiveHandler);
-        }
-        responsiveHandler(mql);
-      }
-    }
-    return () => {
-      try {
-        mql?.removeEventListener('change', responsiveHandler);
-      } catch (error) {
-        mql?.removeListener(responsiveHandler);
-      }
-    };
-  }, []);
-
-  useEffect(() => {
-    const uniqueId = generateId('ant-sider-');
-    siderHook.addSider(uniqueId);
-    return () => siderHook.removeSider(uniqueId);
-  }, []);
-
-  const toggle = () => {
-    handleSetCollapsed(!collapsed, 'clickTrigger');
-  };
-
-  const { getPrefixCls } = useContext(ConfigContext);
-
-  const renderSider = () => {
-    const prefixCls = getPrefixCls('layout-sider', customizePrefixCls);
-    const divProps = omit(props, ['collapsed']);
-    const rawWidth = collapsed ? collapsedWidth : width;
-    // use "px" as fallback unit for width
-    const siderWidth = isNumeric(rawWidth) ? `${rawWidth}px` : String(rawWidth);
-    // special trigger when collapsedWidth == 0
-    const zeroWidthTrigger =
-      parseFloat(String(collapsedWidth || 0)) === 0 ? (
-        <span
-          onClick={toggle}
-          className={classNames(
-            `${prefixCls}-zero-width-trigger`,
-            `${prefixCls}-zero-width-trigger-${reverseArrow ? 'right' : 'left'}`,
-          )}
-          style={zeroWidthTriggerStyle}
-        >
-          {trigger || <BarsOutlined />}
-        </span>
-      ) : null;
-    const iconObj = {
-      expanded: reverseArrow ? <RightOutlined /> : <LeftOutlined />,
-      collapsed: reverseArrow ? <LeftOutlined /> : <RightOutlined />,
-    };
-    const status = collapsed ? 'collapsed' : 'expanded';
-    const defaultTrigger = iconObj[status];
-    const triggerDom =
-      trigger !== null
-        ? zeroWidthTrigger || (
-            <div className={`${prefixCls}-trigger`} onClick={toggle} style={{ width: siderWidth }}>
-              {trigger || defaultTrigger}
-            </div>
-          )
-        : null;
-    const divStyle = {
-      ...style,
-      flex: `0 0 ${siderWidth}`,
-      maxWidth: siderWidth, // Fix width transition bug in IE11
-      minWidth: siderWidth, // https://github.com/ant-design/ant-design/issues/6349
-      width: siderWidth,
-    };
-    const siderCls = classNames(
-      prefixCls,
-      `${prefixCls}-${theme}`,
-      {
-        [`${prefixCls}-collapsed`]: !!collapsed,
-        [`${prefixCls}-has-trigger`]: collapsible && trigger !== null && !zeroWidthTrigger,
-        [`${prefixCls}-below`]: !!below,
-        [`${prefixCls}-zero-width`]: parseFloat(siderWidth) === 0,
-      },
+const Sider = React.forwardRef<HTMLDivElement, SiderProps>(
+  (
+    {
+      prefixCls: customizePrefixCls,
       className,
-    );
-    return (
-      <aside className={siderCls} {...divProps} style={divStyle}>
-        <div className={`${prefixCls}-children`}>{children}</div>
-        {collapsible || (below && zeroWidthTrigger) ? triggerDom : null}
-      </aside>
-    );
-  };
+      trigger,
+      children,
+      defaultCollapsed = false,
+      theme = 'dark',
+      style = {},
+      collapsible = false,
+      reverseArrow = false,
+      width = 200,
+      collapsedWidth = 80,
+      zeroWidthTriggerStyle,
+      breakpoint,
+      onCollapse,
+      onBreakpoint,
+      ...props
+    },
+    ref,
+  ) => {
+    const { siderHook } = useContext(LayoutContext);
 
-  return (
-    <SiderContext.Provider
-      value={{
-        siderCollapsed: collapsed,
-        collapsedWidth,
-      }}
-    >
-      {renderSider()}
-    </SiderContext.Provider>
-  );
-};
+    const [collapsed, setCollapsed] = useState(
+      'collapsed' in props ? props.collapsed : defaultCollapsed,
+    );
+    const [below, setBelow] = useState(false);
+
+    useEffect(() => {
+      if ('collapsed' in props) {
+        setCollapsed(props.collapsed);
+      }
+    }, [props.collapsed]);
+
+    const handleSetCollapsed = (value: boolean, type: CollapseType) => {
+      if (!('collapsed' in props)) {
+        setCollapsed(value);
+      }
+      if (onCollapse) {
+        onCollapse(value, type);
+      }
+    };
+
+    // ========================= Responsive =========================
+    const responsiveHandlerRef = useRef<(mql: MediaQueryListEvent | MediaQueryList) => void>();
+    responsiveHandlerRef.current = (mql: MediaQueryListEvent | MediaQueryList) => {
+      setBelow(mql.matches);
+      if (onBreakpoint) {
+        onBreakpoint(mql.matches);
+      }
+
+      if (collapsed !== mql.matches) {
+        handleSetCollapsed(mql.matches, 'responsive');
+      }
+    };
+
+    useEffect(() => {
+      function responsiveHandler(mql: MediaQueryListEvent | MediaQueryList) {
+        return responsiveHandlerRef.current!(mql);
+      }
+
+      let mql: MediaQueryList;
+      if (typeof window !== 'undefined') {
+        const { matchMedia } = window;
+        if (matchMedia && breakpoint && breakpoint in dimensionMaxMap) {
+          mql = matchMedia(`(max-width: ${dimensionMaxMap[breakpoint]})`);
+          try {
+            mql.addEventListener('change', responsiveHandler);
+          } catch (error) {
+            mql.addListener(responsiveHandler);
+          }
+          responsiveHandler(mql);
+        }
+      }
+      return () => {
+        try {
+          mql?.removeEventListener('change', responsiveHandler);
+        } catch (error) {
+          mql?.removeListener(responsiveHandler);
+        }
+      };
+    }, []);
+
+    useEffect(() => {
+      const uniqueId = generateId('ant-sider-');
+      siderHook.addSider(uniqueId);
+      return () => siderHook.removeSider(uniqueId);
+    }, []);
+
+    const toggle = () => {
+      handleSetCollapsed(!collapsed, 'clickTrigger');
+    };
+
+    const { getPrefixCls } = useContext(ConfigContext);
+
+    const renderSider = () => {
+      const prefixCls = getPrefixCls('layout-sider', customizePrefixCls);
+      const divProps = omit(props, ['collapsed']);
+      const rawWidth = collapsed ? collapsedWidth : width;
+      // use "px" as fallback unit for width
+      const siderWidth = isNumeric(rawWidth) ? `${rawWidth}px` : String(rawWidth);
+      // special trigger when collapsedWidth == 0
+      const zeroWidthTrigger =
+        parseFloat(String(collapsedWidth || 0)) === 0 ? (
+          <span
+            onClick={toggle}
+            className={classNames(
+              `${prefixCls}-zero-width-trigger`,
+              `${prefixCls}-zero-width-trigger-${reverseArrow ? 'right' : 'left'}`,
+            )}
+            style={zeroWidthTriggerStyle}
+          >
+            {trigger || <BarsOutlined />}
+          </span>
+        ) : null;
+      const iconObj = {
+        expanded: reverseArrow ? <RightOutlined /> : <LeftOutlined />,
+        collapsed: reverseArrow ? <LeftOutlined /> : <RightOutlined />,
+      };
+      const status = collapsed ? 'collapsed' : 'expanded';
+      const defaultTrigger = iconObj[status];
+      const triggerDom =
+        trigger !== null
+          ? zeroWidthTrigger || (
+              <div
+                className={`${prefixCls}-trigger`}
+                onClick={toggle}
+                style={{ width: siderWidth }}
+              >
+                {trigger || defaultTrigger}
+              </div>
+            )
+          : null;
+      const divStyle = {
+        ...style,
+        flex: `0 0 ${siderWidth}`,
+        maxWidth: siderWidth, // Fix width transition bug in IE11
+        minWidth: siderWidth, // https://github.com/ant-design/ant-design/issues/6349
+        width: siderWidth,
+      };
+      const siderCls = classNames(
+        prefixCls,
+        `${prefixCls}-${theme}`,
+        {
+          [`${prefixCls}-collapsed`]: !!collapsed,
+          [`${prefixCls}-has-trigger`]: collapsible && trigger !== null && !zeroWidthTrigger,
+          [`${prefixCls}-below`]: !!below,
+          [`${prefixCls}-zero-width`]: parseFloat(siderWidth) === 0,
+        },
+        className,
+      );
+      return (
+        <aside className={siderCls} {...divProps} style={divStyle} ref={ref}>
+          <div className={`${prefixCls}-children`}>{children}</div>
+          {collapsible || (below && zeroWidthTrigger) ? triggerDom : null}
+        </aside>
+      );
+    };
+
+    return (
+      <SiderContext.Provider
+        value={{
+          siderCollapsed: collapsed,
+          collapsedWidth,
+        }}
+      >
+        {renderSider()}
+      </SiderContext.Provider>
+    );
+  },
+);
+
+Sider.displayName = 'Sider';
 
 export default Sider;

--- a/components/layout/__tests__/index.test.js
+++ b/components/layout/__tests__/index.test.js
@@ -284,4 +284,16 @@ describe('Sider', () => {
     );
     expect(wrapper.find('.ant-layout-sider-zero-width-trigger').find('.my-trigger').length).toBe(1);
   });
+
+  it('should get aside element from ref', () => {
+    const ref = React.createRef();
+    const onSelect = jest.fn();
+
+    mount(
+      <Sider onSelect={onSelect} ref={ref}>
+        Sider
+      </Sider>,
+    );
+    expect(ref.current instanceof HTMLElement).toBe(true);
+  });
 });

--- a/components/locale/ru_RU.tsx
+++ b/components/locale/ru_RU.tsx
@@ -124,6 +124,9 @@ const localeValues: Locale = {
       },
     },
   },
+  Image: {
+    preview: 'Превью',
+  },
 };
 
 export default localeValues;

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "rc-checkbox": "~2.3.0",
     "rc-collapse": "~3.1.0",
     "rc-dialog": "~8.5.1",
-    "rc-drawer": "~4.2.0",
+    "rc-drawer": "~4.3.0",
     "rc-dropdown": "~3.2.0",
     "rc-field-form": "~1.18.0",
     "rc-image": "~5.2.0",


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [x] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
fix #29145
<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution
Added `Image` key with `preview` prop with `Превью` value
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |Added Image component's preview word translation|
| 🇨🇳 Chinese |添加了Image 組件的預覽詞翻譯|

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


-----
[View rendered components/drawer/index.en-US.md](https://github.com/qramilq/ant-design/blob/fix-image-locale-ru/components/drawer/index.en-US.md)
[View rendered components/drawer/index.zh-CN.md](https://github.com/qramilq/ant-design/blob/fix-image-locale-ru/components/drawer/index.zh-CN.md)