### PR TITLE
fix: TextArea showCount should not be interactive

### DIFF
--- a/components/form/style/index.less
+++ b/components/form/style/index.less
@@ -191,9 +191,7 @@
 
   .@{ant-prefix}-input-textarea-show-count {
     &::after {
-      position: absolute;
-      bottom: -22px;
-      width: 100%;
+      margin-bottom: -22px;
     }
   }
 }

--- a/components/input/style/index.less
+++ b/components/input/style/index.less
@@ -46,10 +46,11 @@
 
   &-textarea {
     &-show-count::after {
-      display: block;
+      float: right;
       color: @text-color-secondary;
-      text-align: right;
+      white-space: nowrap;
       content: attr(data-count);
+      pointer-events: none;
     }
   }
 }


### PR DESCRIPTION


<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->
close #29240

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix TextArea `showCount` should not be interactive. |
| 🇨🇳 Chinese | 修复 TextArea `showCount` 字数会遮挡 Form.Item `extra` 的问题。 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
