### PR TITLE
feat: add api for transfer

### DIFF
--- a/components/transfer/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/transfer/__tests__/__snapshots__/demo.test.js.snap
@@ -150,7 +150,7 @@ exports[`renders ./components/transfer/demo/advanced.md correctly 1`] = `
         type="button"
       >
         <span>
-          reload
+          leftFooter
         </span>
       </button>
     </div>

--- a/components/transfer/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/transfer/__tests__/__snapshots__/demo.test.js.snap
@@ -150,7 +150,7 @@ exports[`renders ./components/transfer/demo/advanced.md correctly 1`] = `
         type="button"
       >
         <span>
-          leftFooter
+          reload
         </span>
       </button>
     </div>
@@ -216,7 +216,7 @@ exports[`renders ./components/transfer/demo/advanced.md correctly 1`] = `
     </button>
   </div>
   <div
-    class="ant-transfer-list ant-transfer-list-with-footer"
+    class="ant-transfer-list"
     style="width:250px;height:300px"
   >
     <div
@@ -351,19 +351,6 @@ exports[`renders ./components/transfer/demo/advanced.md correctly 1`] = `
           </div>
         </div>
       </div>
-    </div>
-    <div
-      class="ant-transfer-list-footer"
-    >
-      <button
-        class="ant-btn ant-btn-sm"
-        style="float:right;margin:5px"
-        type="button"
-      >
-        <span>
-          reload
-        </span>
-      </button>
     </div>
   </div>
 </div>

--- a/components/transfer/__tests__/index.test.js
+++ b/components/transfer/__tests__/index.test.js
@@ -558,3 +558,22 @@ describe('immutable data', () => {
     expect(wrapper).toMatchRenderedSnapshot();
   });
 });
+
+describe('footer render', () => {
+  // https://github.com/ant-design/ant-design/issues/28082
+  it('currently render footer', () => {
+    const defaultFooter = () => (
+      <Button size="small" className="defaultFooter">
+        reload
+      </Button>
+    );
+    const LeftFooter = () => (
+      <Button size="small" className="leftFooter">
+        leftFooter
+      </Button>
+    );
+    const wrapper = mount(<Transfer footer={defaultFooter} leftFooter={LeftFooter} />);
+    expect(wrapper.exists('.leftFooter')).toEqual(true);
+    expect(wrapper.exists('.defaultFooter')).toEqual(true);
+  });
+});

--- a/components/transfer/__tests__/index.test.js
+++ b/components/transfer/__tests__/index.test.js
@@ -559,17 +559,17 @@ describe('immutable data', () => {
   });
 });
 
-describe('footer render left and right', () => {
+describe('footer render source and target', () => {
   // https://github.com/ant-design/ant-design/issues/28082
   it('currently render footer', () => {
-    const defaultFooter = {
-      left: () => (
-        <Button size="small" className="leftFooter">
+    const defaultFooter = () => ({
+      source: (
+        <Button size="small" className="sourceFooter">
           reload
         </Button>
       ),
-    };
+    });
     const wrapper = mount(<Transfer footer={defaultFooter} />);
-    expect(wrapper.exists('.leftFooter')).toEqual(true);
+    expect(wrapper.exists('.sourceFooter')).toEqual(true);
   });
 });

--- a/components/transfer/__tests__/index.test.js
+++ b/components/transfer/__tests__/index.test.js
@@ -562,14 +562,27 @@ describe('immutable data', () => {
 describe('footer render source and target', () => {
   // https://github.com/ant-design/ant-design/issues/28082
   it('currently render footer', () => {
-    const defaultFooter = () => ({
+    const differentFooter = () => ({
       source: (
         <Button size="small" className="sourceFooter">
           reload
         </Button>
       ),
+      target: (
+        <Button size="small" className="targetFooter">
+          reload
+        </Button>
+      ),
     });
-    const wrapper = mount(<Transfer footer={defaultFooter} />);
+    const defaultFooter = () => (
+      <Button size="small" className="defaultFooter">
+        reload
+      </Button>
+    );
+    const wrapper = mount(<Transfer footer={differentFooter} />);
+    const wrapper2 = mount(<Transfer footer={defaultFooter} />);
     expect(wrapper.exists('.sourceFooter')).toEqual(true);
+    expect(wrapper.exists('.targetFooter')).toEqual(true);
+    expect(wrapper2.exists('.defaultFooter')).toEqual(true);
   });
 });

--- a/components/transfer/__tests__/index.test.js
+++ b/components/transfer/__tests__/index.test.js
@@ -559,7 +559,7 @@ describe('immutable data', () => {
   });
 });
 
-describe('footer render', () => {
+describe('footer render left and right', () => {
   // https://github.com/ant-design/ant-design/issues/28082
   it('currently render footer', () => {
     const defaultFooter = {

--- a/components/transfer/__tests__/index.test.js
+++ b/components/transfer/__tests__/index.test.js
@@ -562,18 +562,14 @@ describe('immutable data', () => {
 describe('footer render', () => {
   // https://github.com/ant-design/ant-design/issues/28082
   it('currently render footer', () => {
-    const defaultFooter = () => (
-      <Button size="small" className="defaultFooter">
-        reload
-      </Button>
-    );
-    const LeftFooter = () => (
-      <Button size="small" className="leftFooter">
-        leftFooter
-      </Button>
-    );
-    const wrapper = mount(<Transfer footer={defaultFooter} leftFooter={LeftFooter} />);
+    const defaultFooter = {
+      left: () => (
+        <Button size="small" className="leftFooter">
+          reload
+        </Button>
+      ),
+    };
+    const wrapper = mount(<Transfer footer={defaultFooter} />);
     expect(wrapper.exists('.leftFooter')).toEqual(true);
-    expect(wrapper.exists('.defaultFooter')).toEqual(true);
   });
 });

--- a/components/transfer/demo/advanced.md
+++ b/components/transfer/demo/advanced.md
@@ -50,17 +50,13 @@ class App extends React.Component {
     this.setState({ targetKeys });
   };
 
-  renderFooter = () => (
-    <Button size="small" style={{ float: 'right', margin: 5 }} onClick={this.getMock}>
-      reload
-    </Button>
-  );
-
-  renderLeftFooter = () => (
-    <Button size="small" style={{ float: 'right', margin: 5 }}>
-      leftFooter
-    </Button>
-  );
+  renderFooter = {
+    left: () => (
+      <Button size="small" style={{ float: 'right', margin: 5 }} onClick={this.getMock}>
+        reload
+      </Button>
+    ),
+  };
 
   render() {
     return (
@@ -76,7 +72,6 @@ class App extends React.Component {
         onChange={this.handleChange}
         render={item => `${item.title}-${item.description}`}
         footer={this.renderFooter}
-        leftFooter={this.renderLeftFooter}
       />
     );
   }

--- a/components/transfer/demo/advanced.md
+++ b/components/transfer/demo/advanced.md
@@ -50,13 +50,13 @@ class App extends React.Component {
     this.setState({ targetKeys });
   };
 
-  renderFooter = {
+  renderFooter = () => ({
     left: () => (
       <Button size="small" style={{ float: 'right', margin: 5 }} onClick={this.getMock}>
         reload
       </Button>
     ),
-  };
+  });
 
   render() {
     return (

--- a/components/transfer/demo/advanced.md
+++ b/components/transfer/demo/advanced.md
@@ -51,7 +51,7 @@ class App extends React.Component {
   };
 
   renderFooter = () => ({
-    left: () => (
+    source: (
       <Button size="small" style={{ float: 'right', margin: 5 }} onClick={this.getMock}>
         reload
       </Button>

--- a/components/transfer/demo/advanced.md
+++ b/components/transfer/demo/advanced.md
@@ -56,6 +56,12 @@ class App extends React.Component {
     </Button>
   );
 
+  renderLeftFooter = () => (
+    <Button size="small" style={{ float: 'right', margin: 5 }}>
+      leftFooter
+    </Button>
+  );
+
   render() {
     return (
       <Transfer
@@ -70,6 +76,7 @@ class App extends React.Component {
         onChange={this.handleChange}
         render={item => `${item.title}-${item.description}`}
         footer={this.renderFooter}
+        leftFooter={this.renderLeftFooter}
       />
     );
   }

--- a/components/transfer/index.en-US.md
+++ b/components/transfer/index.en-US.md
@@ -24,7 +24,7 @@ One or more elements can be selected from either column, one click on the proper
 | dataSource | Used for setting the source data. The elements that are part of this array will be present the left column. Except the elements whose keys are included in `targetKeys` prop | [RecordType extends TransferItem = TransferItem](https://git.io/vMM64)\[] | \[] |  |
 | disabled | Whether disabled transfer | boolean | false |  |
 | filterOption | A function to determine whether an item should show in search result list | (inputValue, option): boolean | - |  |
-| footer | A function used for rendering the footer | (props) => ReactNode\|{left:(props) => ReactNode,right:(props) => ReactNode} | - |  |
+| footer | A function used for rendering the footer | `props => ReactNode\|{ left: ReactNode, right: ReactNode }` | - |  |
 | listStyle | A custom CSS style used for rendering the transfer columns | object \| ({direction: `left` \| `right`}) => object | - |  |
 | locale | The i18n text including filter, empty text, item unit, etc | { itemUnit: string; itemsUnit: string; searchPlaceholder: string; notFoundContent: ReactNode; } | { itemUnit: `item`, itemsUnit: `items`, notFoundContent: `The list is empty`, searchPlaceholder: `Search here` } |  |
 | oneWay | Display as single direction style | boolean | false | 4.3.0 |

--- a/components/transfer/index.en-US.md
+++ b/components/transfer/index.en-US.md
@@ -25,6 +25,8 @@ One or more elements can be selected from either column, one click on the proper
 | disabled | Whether disabled transfer | boolean | false |  |
 | filterOption | A function to determine whether an item should show in search result list | (inputValue, option): boolean | - |  |
 | footer | A function used for rendering the footer | (props) => ReactNode | - |  |
+| leftFooter | A function used for rendering the left footer | (props) => ReactNode | - |  |
+| rightFooter | A function used for rendering the right footer | (props) => ReactNode | - |  |
 | listStyle | A custom CSS style used for rendering the transfer columns | object \| ({direction: `left` \| `right`}) => object | - |  |
 | locale | The i18n text including filter, empty text, item unit, etc | { itemUnit: string; itemsUnit: string; searchPlaceholder: string; notFoundContent: ReactNode; } | { itemUnit: `item`, itemsUnit: `items`, notFoundContent: `The list is empty`, searchPlaceholder: `Search here` } |  |
 | oneWay | Display as single direction style | boolean | false | 4.3.0 |

--- a/components/transfer/index.en-US.md
+++ b/components/transfer/index.en-US.md
@@ -20,11 +20,11 @@ One or more elements can be selected from either column, one click on the proper
 ## API
 
 | Property | Description | Type | Default | Version |
-| --- | --- | --- | --- | --- | --- |
+| --- | --- | --- | --- | --- |
 | dataSource | Used for setting the source data. The elements that are part of this array will be present the left column. Except the elements whose keys are included in `targetKeys` prop | [RecordType extends TransferItem = TransferItem](https://git.io/vMM64)\[] | \[] |  |
 | disabled | Whether disabled transfer | boolean | false |  |
 | filterOption | A function to determine whether an item should show in search result list | (inputValue, option): boolean | - |  |
-| footer | A function used for rendering the footer | `(props) => ReactNode | { source: ReactNode, target: ReactNode }` | - | { source: ReactNode, target: ReactNode }: 4.12.3 |
+| footer | A function used for rendering the footer | (props) => ReactNode \| { source: ReactNode, target: ReactNode } | - | { source: ReactNode, target: ReactNode }: 4.12.3 |
 | listStyle | A custom CSS style used for rendering the transfer columns | object \| ({direction: `left` \| `right`}) => object | - |  |
 | locale | The i18n text including filter, empty text, item unit, etc | { itemUnit: string; itemsUnit: string; searchPlaceholder: string; notFoundContent: ReactNode; } | { itemUnit: `item`, itemsUnit: `items`, notFoundContent: `The list is empty`, searchPlaceholder: `Search here` } |  |
 | oneWay | Display as single direction style | boolean | false | 4.3.0 |

--- a/components/transfer/index.en-US.md
+++ b/components/transfer/index.en-US.md
@@ -24,9 +24,7 @@ One or more elements can be selected from either column, one click on the proper
 | dataSource | Used for setting the source data. The elements that are part of this array will be present the left column. Except the elements whose keys are included in `targetKeys` prop | [RecordType extends TransferItem = TransferItem](https://git.io/vMM64)\[] | \[] |  |
 | disabled | Whether disabled transfer | boolean | false |  |
 | filterOption | A function to determine whether an item should show in search result list | (inputValue, option): boolean | - |  |
-| footer | A function used for rendering the footer | (props) => ReactNode | - |  |
-| leftFooter | A function used for rendering the left footer | (props) => ReactNode | - |  |
-| rightFooter | A function used for rendering the right footer | (props) => ReactNode | - |  |
+| footer | A function used for rendering the footer | (props) => ReactNode\|{left:(props) => ReactNode,right:(props) => ReactNode} | - |  |
 | listStyle | A custom CSS style used for rendering the transfer columns | object \| ({direction: `left` \| `right`}) => object | - |  |
 | locale | The i18n text including filter, empty text, item unit, etc | { itemUnit: string; itemsUnit: string; searchPlaceholder: string; notFoundContent: ReactNode; } | { itemUnit: `item`, itemsUnit: `items`, notFoundContent: `The list is empty`, searchPlaceholder: `Search here` } |  |
 | oneWay | Display as single direction style | boolean | false | 4.3.0 |

--- a/components/transfer/index.en-US.md
+++ b/components/transfer/index.en-US.md
@@ -24,7 +24,7 @@ One or more elements can be selected from either column, one click on the proper
 | dataSource | Used for setting the source data. The elements that are part of this array will be present the left column. Except the elements whose keys are included in `targetKeys` prop | [RecordType extends TransferItem = TransferItem](https://git.io/vMM64)\[] | \[] |  |
 | disabled | Whether disabled transfer | boolean | false |  |
 | filterOption | A function to determine whether an item should show in search result list | (inputValue, option): boolean | - |  |
-| footer | A function used for rendering the footer | `props => ReactNode\|{ left: ReactNode, right: ReactNode }` | - |  |
+| footer | A function used for rendering the footer | `props => ReactNode\|{ source: ReactNode, target: ReactNode }` | - |  |
 | listStyle | A custom CSS style used for rendering the transfer columns | object \| ({direction: `left` \| `right`}) => object | - |  |
 | locale | The i18n text including filter, empty text, item unit, etc | { itemUnit: string; itemsUnit: string; searchPlaceholder: string; notFoundContent: ReactNode; } | { itemUnit: `item`, itemsUnit: `items`, notFoundContent: `The list is empty`, searchPlaceholder: `Search here` } |  |
 | oneWay | Display as single direction style | boolean | false | 4.3.0 |

--- a/components/transfer/index.en-US.md
+++ b/components/transfer/index.en-US.md
@@ -20,11 +20,11 @@ One or more elements can be selected from either column, one click on the proper
 ## API
 
 | Property | Description | Type | Default | Version |
-| --- | --- | --- | --- | --- |
+| --- | --- | --- | --- | --- | --- |
 | dataSource | Used for setting the source data. The elements that are part of this array will be present the left column. Except the elements whose keys are included in `targetKeys` prop | [RecordType extends TransferItem = TransferItem](https://git.io/vMM64)\[] | \[] |  |
 | disabled | Whether disabled transfer | boolean | false |  |
 | filterOption | A function to determine whether an item should show in search result list | (inputValue, option): boolean | - |  |
-| footer | A function used for rendering the footer | `(props) => ReactNode\|{ source: ReactNode, target: ReactNode }` | - | { source: ReactNode, target: ReactNode }: 4.12.3 |
+| footer | A function used for rendering the footer | `(props) => ReactNode | { source: ReactNode, target: ReactNode }` | - | { source: ReactNode, target: ReactNode }: 4.12.3 |
 | listStyle | A custom CSS style used for rendering the transfer columns | object \| ({direction: `left` \| `right`}) => object | - |  |
 | locale | The i18n text including filter, empty text, item unit, etc | { itemUnit: string; itemsUnit: string; searchPlaceholder: string; notFoundContent: ReactNode; } | { itemUnit: `item`, itemsUnit: `items`, notFoundContent: `The list is empty`, searchPlaceholder: `Search here` } |  |
 | oneWay | Display as single direction style | boolean | false | 4.3.0 |

--- a/components/transfer/index.en-US.md
+++ b/components/transfer/index.en-US.md
@@ -24,7 +24,7 @@ One or more elements can be selected from either column, one click on the proper
 | dataSource | Used for setting the source data. The elements that are part of this array will be present the left column. Except the elements whose keys are included in `targetKeys` prop | [RecordType extends TransferItem = TransferItem](https://git.io/vMM64)\[] | \[] |  |
 | disabled | Whether disabled transfer | boolean | false |  |
 | filterOption | A function to determine whether an item should show in search result list | (inputValue, option): boolean | - |  |
-| footer | A function used for rendering the footer | `(props) => ReactNode\|{ source: ReactNode, target: ReactNode }` | - |  |
+| footer | A function used for rendering the footer | `(props) => ReactNode\|{ source: ReactNode, target: ReactNode }` | - | { source: ReactNode, target: ReactNode }: 4.12.3 |
 | listStyle | A custom CSS style used for rendering the transfer columns | object \| ({direction: `left` \| `right`}) => object | - |  |
 | locale | The i18n text including filter, empty text, item unit, etc | { itemUnit: string; itemsUnit: string; searchPlaceholder: string; notFoundContent: ReactNode; } | { itemUnit: `item`, itemsUnit: `items`, notFoundContent: `The list is empty`, searchPlaceholder: `Search here` } |  |
 | oneWay | Display as single direction style | boolean | false | 4.3.0 |

--- a/components/transfer/index.en-US.md
+++ b/components/transfer/index.en-US.md
@@ -24,7 +24,7 @@ One or more elements can be selected from either column, one click on the proper
 | dataSource | Used for setting the source data. The elements that are part of this array will be present the left column. Except the elements whose keys are included in `targetKeys` prop | [RecordType extends TransferItem = TransferItem](https://git.io/vMM64)\[] | \[] |  |
 | disabled | Whether disabled transfer | boolean | false |  |
 | filterOption | A function to determine whether an item should show in search result list | (inputValue, option): boolean | - |  |
-| footer | A function used for rendering the footer | `props => ReactNode\|{ source: ReactNode, target: ReactNode }` | - |  |
+| footer | A function used for rendering the footer | `(props) => ReactNode\|{ source: ReactNode, target: ReactNode }` | - |  |
 | listStyle | A custom CSS style used for rendering the transfer columns | object \| ({direction: `left` \| `right`}) => object | - |  |
 | locale | The i18n text including filter, empty text, item unit, etc | { itemUnit: string; itemsUnit: string; searchPlaceholder: string; notFoundContent: ReactNode; } | { itemUnit: `item`, itemsUnit: `items`, notFoundContent: `The list is empty`, searchPlaceholder: `Search here` } |  |
 | oneWay | Display as single direction style | boolean | false | 4.3.0 |

--- a/components/transfer/index.tsx
+++ b/components/transfer/index.tsx
@@ -76,10 +76,14 @@ export interface TransferProps<RecordType> {
   showSearch?: boolean;
   filterOption?: (inputValue: string, item: RecordType) => boolean;
   locale?: Partial<TransferLocale>;
-  footer?: (props: TransferListProps<RecordType>) => React.ReactNode | {
-    left?: React.ReactNode;
-    right?: React.ReactNode;
-  })
+  footer?: (
+    props: TransferListProps<RecordType>,
+  ) =>
+    | React.ReactNode
+    | {
+        source?: React.ReactNode;
+        target?: React.ReactNode;
+      };
   rowKey?: (record: RecordType) => string;
   onSearch?: (direction: TransferDirection, value: string) => void;
   onScroll?: (direction: TransferDirection, e: React.SyntheticEvent<HTMLUListElement>) => void;
@@ -397,21 +401,6 @@ class Transfer<RecordType extends TransferItem = TransferItem> extends React.Com
 
         const titles = this.getTitles(locale);
         const selectAllLabels = this.props.selectAllLabels || [];
-
-        // 底部渲染判断，兼容传入reactNode或对象
-        let leftFooter;
-        let rightFooter;
-        if (typeof footer === 'object') {
-          if (footer.left) {
-            leftFooter = footer.left;
-          }
-          if (footer.right) {
-            rightFooter = footer.right;
-          }
-        } else if (footer) {
-          leftFooter = footer;
-          rightFooter = footer;
-        }
         return (
           <div className={cls} style={style}>
             <List<KeyWise<RecordType>>
@@ -428,7 +417,7 @@ class Transfer<RecordType extends TransferItem = TransferItem> extends React.Com
               render={render}
               showSearch={showSearch}
               renderList={children}
-              footer={leftFooter}
+              footer={footer}
               onScroll={this.handleLeftScroll}
               disabled={disabled}
               direction="left"
@@ -465,7 +454,7 @@ class Transfer<RecordType extends TransferItem = TransferItem> extends React.Com
               render={render}
               showSearch={showSearch}
               renderList={children}
-              footer={rightFooter}
+              footer={footer}
               onScroll={this.handleRightScroll}
               disabled={disabled}
               direction="right"

--- a/components/transfer/index.tsx
+++ b/components/transfer/index.tsx
@@ -76,12 +76,10 @@ export interface TransferProps<RecordType> {
   showSearch?: boolean;
   filterOption?: (inputValue: string, item: RecordType) => boolean;
   locale?: Partial<TransferLocale>;
-  footer?:
-    | ((props: TransferListProps<RecordType>) => React.ReactNode)
-    | {
-        left?: (props: TransferListProps<RecordType>) => React.ReactNode;
-        right?: (props: TransferListProps<RecordType>) => React.ReactNode;
-      };
+  footer?: (props: TransferListProps<RecordType>) => React.ReactNode | {
+    left?: React.ReactNode;
+    right?: React.ReactNode;
+  })
   rowKey?: (record: RecordType) => string;
   onSearch?: (direction: TransferDirection, value: string) => void;
   onScroll?: (direction: TransferDirection, e: React.SyntheticEvent<HTMLUListElement>) => void;

--- a/components/transfer/index.tsx
+++ b/components/transfer/index.tsx
@@ -58,7 +58,6 @@ export interface TransferLocale {
   removeAll: string;
   removeCurrent: string;
 }
-
 export interface TransferProps<RecordType> {
   prefixCls?: string;
   className?: string;
@@ -77,9 +76,12 @@ export interface TransferProps<RecordType> {
   showSearch?: boolean;
   filterOption?: (inputValue: string, item: RecordType) => boolean;
   locale?: Partial<TransferLocale>;
-  footer?: (props: TransferListProps<RecordType>) => React.ReactNode;
-  leftFooter?: (props: TransferListProps<RecordType>) => React.ReactNode;
-  rightFooter?: (props: TransferListProps<RecordType>) => React.ReactNode;
+  footer?:
+    | ((props: TransferListProps<RecordType>) => React.ReactNode)
+    | {
+        left?: (props: TransferListProps<RecordType>) => React.ReactNode;
+        right?: (props: TransferListProps<RecordType>) => React.ReactNode;
+      };
   rowKey?: (record: RecordType) => string;
   onSearch?: (direction: TransferDirection, value: string) => void;
   onScroll?: (direction: TransferDirection, e: React.SyntheticEvent<HTMLUListElement>) => void;
@@ -397,8 +399,21 @@ class Transfer<RecordType extends TransferItem = TransferItem> extends React.Com
 
         const titles = this.getTitles(locale);
         const selectAllLabels = this.props.selectAllLabels || [];
-        const leftFooter = this.props.leftFooter || footer;
-        const rightFooter = this.props.rightFooter || footer;
+
+        // 底部渲染判断，兼容传入reactNode或对象
+        let leftFooter;
+        let rightFooter;
+        if (typeof footer === 'object') {
+          if (footer.left) {
+            leftFooter = footer.left;
+          }
+          if (footer.right) {
+            rightFooter = footer.right;
+          }
+        } else if (footer) {
+          leftFooter = footer;
+          rightFooter = footer;
+        }
         return (
           <div className={cls} style={style}>
             <List<KeyWise<RecordType>>

--- a/components/transfer/index.tsx
+++ b/components/transfer/index.tsx
@@ -78,6 +78,8 @@ export interface TransferProps<RecordType> {
   filterOption?: (inputValue: string, item: RecordType) => boolean;
   locale?: Partial<TransferLocale>;
   footer?: (props: TransferListProps<RecordType>) => React.ReactNode;
+  leftFooter?: (props: TransferListProps<RecordType>) => React.ReactNode;
+  rightFooter?: (props: TransferListProps<RecordType>) => React.ReactNode;
   rowKey?: (record: RecordType) => string;
   onSearch?: (direction: TransferDirection, value: string) => void;
   onScroll?: (direction: TransferDirection, e: React.SyntheticEvent<HTMLUListElement>) => void;
@@ -395,6 +397,8 @@ class Transfer<RecordType extends TransferItem = TransferItem> extends React.Com
 
         const titles = this.getTitles(locale);
         const selectAllLabels = this.props.selectAllLabels || [];
+        const leftFooter = this.props.leftFooter || footer;
+        const rightFooter = this.props.rightFooter || footer;
         return (
           <div className={cls} style={style}>
             <List<KeyWise<RecordType>>
@@ -411,7 +415,7 @@ class Transfer<RecordType extends TransferItem = TransferItem> extends React.Com
               render={render}
               showSearch={showSearch}
               renderList={children}
-              footer={footer}
+              footer={leftFooter}
               onScroll={this.handleLeftScroll}
               disabled={disabled}
               direction="left"
@@ -448,7 +452,7 @@ class Transfer<RecordType extends TransferItem = TransferItem> extends React.Com
               render={render}
               showSearch={showSearch}
               renderList={children}
-              footer={footer}
+              footer={rightFooter}
               onScroll={this.handleRightScroll}
               disabled={disabled}
               direction="right"

--- a/components/transfer/index.zh-CN.md
+++ b/components/transfer/index.zh-CN.md
@@ -27,7 +27,7 @@ cover: https://gw.alipayobjects.com/zos/alicdn/QAXskNI4G/Transfer.svg
 | dataSource | 数据源，其中的数据将会被渲染到左边一栏中，`targetKeys` 中指定的除外 | [RecordType extends TransferItem = TransferItem](https://git.io/vMM64)\[] | \[] |  |
 | disabled | 是否禁用 | boolean | false |  |
 | filterOption | 接收 `inputValue` `option` 两个参数，当 `option` 符合筛选条件时，应返回 true，反之则返回 false | (inputValue, option): boolean | - |  |
-| footer | 底部渲染函数 | (props) => ReactNode\|{left:(props) => ReactNode,right:(props) => ReactNode} | - |  |
+| footer | 底部渲染函数 | (props) => ReactNode\|{source:(props) => ReactNode,target:(props) => ReactNode} | - |  |
 | listStyle | 两个穿梭框的自定义样式 | object\|({direction: `left` \| `right`}) => object | - |  |
 | locale | 各种语言 | { itemUnit: string; itemsUnit: string; searchPlaceholder: string; notFoundContent: ReactNode; } | { itemUnit: `项`, itemsUnit: `项`, searchPlaceholder: `请输入搜索内容` } |  |
 | oneWay | 展示为单向样式 | boolean | false | 4.3.0 |

--- a/components/transfer/index.zh-CN.md
+++ b/components/transfer/index.zh-CN.md
@@ -27,9 +27,7 @@ cover: https://gw.alipayobjects.com/zos/alicdn/QAXskNI4G/Transfer.svg
 | dataSource | 数据源，其中的数据将会被渲染到左边一栏中，`targetKeys` 中指定的除外 | [RecordType extends TransferItem = TransferItem](https://git.io/vMM64)\[] | \[] |  |
 | disabled | 是否禁用 | boolean | false |  |
 | filterOption | 接收 `inputValue` `option` 两个参数，当 `option` 符合筛选条件时，应返回 true，反之则返回 false | (inputValue, option): boolean | - |  |
-| footer | 底部渲染函数 | (props) => ReactNode | - |  |
-| leftFooter | 左侧底部渲染函数 | (props) => ReactNode | - |  |
-| rightFooter | 右侧底部渲染函数 | (props) => ReactNode | - |  |
+| footer | 底部渲染函数 | (props) => ReactNode\|{left:(props) => ReactNode,right:(props) => ReactNode} | - |  |
 | listStyle | 两个穿梭框的自定义样式 | object\|({direction: `left` \| `right`}) => object | - |  |
 | locale | 各种语言 | { itemUnit: string; itemsUnit: string; searchPlaceholder: string; notFoundContent: ReactNode; } | { itemUnit: `项`, itemsUnit: `项`, searchPlaceholder: `请输入搜索内容` } |  |
 | oneWay | 展示为单向样式 | boolean | false | 4.3.0 |

--- a/components/transfer/index.zh-CN.md
+++ b/components/transfer/index.zh-CN.md
@@ -23,11 +23,11 @@ cover: https://gw.alipayobjects.com/zos/alicdn/QAXskNI4G/Transfer.svg
 ### Transfer
 
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
-| --- | --- | --- | --- | --- | --- |
+| --- | --- | --- | --- | --- |
 | dataSource | 数据源，其中的数据将会被渲染到左边一栏中，`targetKeys` 中指定的除外 | [RecordType extends TransferItem = TransferItem](https://git.io/vMM64)\[] | \[] |  |
 | disabled | 是否禁用 | boolean | false |  |
 | filterOption | 接收 `inputValue` `option` 两个参数，当 `option` 符合筛选条件时，应返回 true，反之则返回 false | (inputValue, option): boolean | - |  |
-| footer | 底部渲染函数 | `(props) => ReactNode | { source: ReactNode, target: ReactNode }` | - | { source: ReactNode, target: ReactNode }: 4.12.3 |
+| footer | 底部渲染函数 | (props) => ReactNode \| { source: ReactNode, target: ReactNode } | - | { source: ReactNode, target: ReactNode }: 4.12.3 |
 | listStyle | 两个穿梭框的自定义样式 | object\|({direction: `left` \| `right`}) => object | - |  |
 | locale | 各种语言 | { itemUnit: string; itemsUnit: string; searchPlaceholder: string; notFoundContent: ReactNode; } | { itemUnit: `项`, itemsUnit: `项`, searchPlaceholder: `请输入搜索内容` } |  |
 | oneWay | 展示为单向样式 | boolean | false | 4.3.0 |

--- a/components/transfer/index.zh-CN.md
+++ b/components/transfer/index.zh-CN.md
@@ -27,7 +27,7 @@ cover: https://gw.alipayobjects.com/zos/alicdn/QAXskNI4G/Transfer.svg
 | dataSource | 数据源，其中的数据将会被渲染到左边一栏中，`targetKeys` 中指定的除外 | [RecordType extends TransferItem = TransferItem](https://git.io/vMM64)\[] | \[] |  |
 | disabled | 是否禁用 | boolean | false |  |
 | filterOption | 接收 `inputValue` `option` 两个参数，当 `option` 符合筛选条件时，应返回 true，反之则返回 false | (inputValue, option): boolean | - |  |
-| footer | 底部渲染函数 | (props) => ReactNode\|{source:(props) => ReactNode,target:(props) => ReactNode} | - |  |
+| footer | 底部渲染函数 | `(props) => ReactNode\|{ source: ReactNode, target: ReactNode }` | - |  |
 | listStyle | 两个穿梭框的自定义样式 | object\|({direction: `left` \| `right`}) => object | - |  |
 | locale | 各种语言 | { itemUnit: string; itemsUnit: string; searchPlaceholder: string; notFoundContent: ReactNode; } | { itemUnit: `项`, itemsUnit: `项`, searchPlaceholder: `请输入搜索内容` } |  |
 | oneWay | 展示为单向样式 | boolean | false | 4.3.0 |

--- a/components/transfer/index.zh-CN.md
+++ b/components/transfer/index.zh-CN.md
@@ -28,6 +28,8 @@ cover: https://gw.alipayobjects.com/zos/alicdn/QAXskNI4G/Transfer.svg
 | disabled | 是否禁用 | boolean | false |  |
 | filterOption | 接收 `inputValue` `option` 两个参数，当 `option` 符合筛选条件时，应返回 true，反之则返回 false | (inputValue, option): boolean | - |  |
 | footer | 底部渲染函数 | (props) => ReactNode | - |  |
+| leftFooter | 左侧底部渲染函数 | (props) => ReactNode | - |  |
+| rightFooter | 右侧底部渲染函数 | (props) => ReactNode | - |  |
 | listStyle | 两个穿梭框的自定义样式 | object\|({direction: `left` \| `right`}) => object | - |  |
 | locale | 各种语言 | { itemUnit: string; itemsUnit: string; searchPlaceholder: string; notFoundContent: ReactNode; } | { itemUnit: `项`, itemsUnit: `项`, searchPlaceholder: `请输入搜索内容` } |  |
 | oneWay | 展示为单向样式 | boolean | false | 4.3.0 |

--- a/components/transfer/index.zh-CN.md
+++ b/components/transfer/index.zh-CN.md
@@ -27,7 +27,7 @@ cover: https://gw.alipayobjects.com/zos/alicdn/QAXskNI4G/Transfer.svg
 | dataSource | 数据源，其中的数据将会被渲染到左边一栏中，`targetKeys` 中指定的除外 | [RecordType extends TransferItem = TransferItem](https://git.io/vMM64)\[] | \[] |  |
 | disabled | 是否禁用 | boolean | false |  |
 | filterOption | 接收 `inputValue` `option` 两个参数，当 `option` 符合筛选条件时，应返回 true，反之则返回 false | (inputValue, option): boolean | - |  |
-| footer | 底部渲染函数 | `(props) => ReactNode\|{ source: ReactNode, target: ReactNode }` | - |  |
+| footer | 底部渲染函数 | `(props) => ReactNode\|{ source: ReactNode, target: ReactNode }` | - | { source: ReactNode, target: ReactNode }: 4.12.3 |
 | listStyle | 两个穿梭框的自定义样式 | object\|({direction: `left` \| `right`}) => object | - |  |
 | locale | 各种语言 | { itemUnit: string; itemsUnit: string; searchPlaceholder: string; notFoundContent: ReactNode; } | { itemUnit: `项`, itemsUnit: `项`, searchPlaceholder: `请输入搜索内容` } |  |
 | oneWay | 展示为单向样式 | boolean | false | 4.3.0 |

--- a/components/transfer/index.zh-CN.md
+++ b/components/transfer/index.zh-CN.md
@@ -23,11 +23,11 @@ cover: https://gw.alipayobjects.com/zos/alicdn/QAXskNI4G/Transfer.svg
 ### Transfer
 
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
-| --- | --- | --- | --- | --- |
+| --- | --- | --- | --- | --- | --- |
 | dataSource | 数据源，其中的数据将会被渲染到左边一栏中，`targetKeys` 中指定的除外 | [RecordType extends TransferItem = TransferItem](https://git.io/vMM64)\[] | \[] |  |
 | disabled | 是否禁用 | boolean | false |  |
 | filterOption | 接收 `inputValue` `option` 两个参数，当 `option` 符合筛选条件时，应返回 true，反之则返回 false | (inputValue, option): boolean | - |  |
-| footer | 底部渲染函数 | `(props) => ReactNode\|{ source: ReactNode, target: ReactNode }` | - | { source: ReactNode, target: ReactNode }: 4.12.3 |
+| footer | 底部渲染函数 | `(props) => ReactNode | { source: ReactNode, target: ReactNode }` | - | { source: ReactNode, target: ReactNode }: 4.12.3 |
 | listStyle | 两个穿梭框的自定义样式 | object\|({direction: `left` \| `right`}) => object | - |  |
 | locale | 各种语言 | { itemUnit: string; itemsUnit: string; searchPlaceholder: string; notFoundContent: ReactNode; } | { itemUnit: `项`, itemsUnit: `项`, searchPlaceholder: `请输入搜索内容` } |  |
 | oneWay | 展示为单向样式 | boolean | false | 4.3.0 |

--- a/components/transfer/list.tsx
+++ b/components/transfer/list.tsx
@@ -39,7 +39,10 @@ export interface RenderedItem<RecordType> {
 }
 
 type RenderListFunction<T> = (props: TransferListBodyProps<T>) => React.ReactNode;
-
+type footerRender = {
+  source?: React.ReactNode;
+  target?: React.ReactNode;
+};
 export interface TransferListProps<RecordType> extends TransferLocale {
   prefixCls: string;
   titleText: React.ReactNode;
@@ -59,7 +62,7 @@ export interface TransferListProps<RecordType> extends TransferLocale {
   itemUnit: string;
   itemsUnit: string;
   renderList?: RenderListFunction<RecordType>;
-  footer?: (props: TransferListProps<RecordType>) => React.ReactNode;
+  footer?: (props: TransferListProps<RecordType>) => React.ReactNode | footerRender;
   onScroll: (e: React.UIEvent<HTMLUListElement>) => void;
   disabled?: boolean;
   direction: TransferDirection;
@@ -312,11 +315,21 @@ export default class TransferList<
       showSelectAll,
       showRemove,
       pagination,
+      direction,
     } = this.props;
 
     // Custom Layout
-    const footerDom = footer && footer(this.props);
-
+    const tempDom = footer && footer(this.props);
+    let footerDom;
+    if (tempDom) {
+      if (direction === 'left') {
+        if ((tempDom as footerRender).source) {
+          footerDom = (tempDom as footerRender).source;
+        }
+      } else if ((tempDom as footerRender).target) {
+        footerDom = (tempDom as footerRender).target;
+      }
+    }
     const listCls = classNames(prefixCls, {
       [`${prefixCls}-with-pagination`]: pagination,
       [`${prefixCls}-with-footer`]: footerDom,

--- a/components/transfer/list.tsx
+++ b/components/transfer/list.tsx
@@ -319,9 +319,7 @@ export default class TransferList<
     } = this.props;
 
     // Custom Layout
-
     // Distinguish different footer
-
     const tempDom = footer && footer(this.props);
     let footerDom;
     if (tempDom) {

--- a/components/transfer/list.tsx
+++ b/components/transfer/list.tsx
@@ -39,7 +39,7 @@ export interface RenderedItem<RecordType> {
 }
 
 type RenderListFunction<T> = (props: TransferListBodyProps<T>) => React.ReactNode;
-type footerRender = {
+type FooterRender = {
   source?: React.ReactNode;
   target?: React.ReactNode;
 };
@@ -62,7 +62,7 @@ export interface TransferListProps<RecordType> extends TransferLocale {
   itemUnit: string;
   itemsUnit: string;
   renderList?: RenderListFunction<RecordType>;
-  footer?: (props: TransferListProps<RecordType>) => React.ReactNode | footerRender;
+  footer?: (props: TransferListProps<RecordType>) => React.ReactNode | FooterRender;
   onScroll: (e: React.UIEvent<HTMLUListElement>) => void;
   disabled?: boolean;
   direction: TransferDirection;
@@ -322,16 +322,18 @@ export default class TransferList<
     // Distinguish different footer
     const tempDom = footer && footer(this.props);
     let footerDom;
+    function isFooterRender(obj: any): obj is FooterRender {
+      return obj.source || obj.target;
+    }
     if (tempDom) {
-      if (!(tempDom as footerRender).source && !(tempDom as footerRender).target) {
-        footerDom = tempDom;
-      }
-      if (direction === 'left') {
-        if ((tempDom as footerRender).source) {
-          footerDom = (tempDom as footerRender).source;
+      if (isFooterRender(tempDom)) {
+        if (direction === 'left') {
+          footerDom = tempDom.source;
+        } else {
+          footerDom = tempDom.target;
         }
-      } else if ((tempDom as footerRender).target) {
-        footerDom = (tempDom as footerRender).target;
+      } else {
+        footerDom = tempDom;
       }
     }
 

--- a/components/transfer/list.tsx
+++ b/components/transfer/list.tsx
@@ -320,7 +320,8 @@ export default class TransferList<
 
     // Custom Layout
 
-    // 区分footer函数返回结果是否含有source/target，再结合左右渲染不同footer
+    // Distinguish different footer
+
     const tempDom = footer && footer(this.props);
     let footerDom;
     if (tempDom) {

--- a/components/transfer/list.tsx
+++ b/components/transfer/list.tsx
@@ -319,9 +319,14 @@ export default class TransferList<
     } = this.props;
 
     // Custom Layout
+
+    // 区分footer函数返回结果是否含有source/target，再结合左右渲染不同footer
     const tempDom = footer && footer(this.props);
     let footerDom;
     if (tempDom) {
+      if (!(tempDom as footerRender).source && !(tempDom as footerRender).target) {
+        footerDom = tempDom;
+      }
       if (direction === 'left') {
         if ((tempDom as footerRender).source) {
           footerDom = (tempDom as footerRender).source;
@@ -330,6 +335,7 @@ export default class TransferList<
         footerDom = (tempDom as footerRender).target;
       }
     }
+
     const listCls = classNames(prefixCls, {
       [`${prefixCls}-with-pagination`]: pagination,
       [`${prefixCls}-with-footer`]: footerDom,


### PR DESCRIPTION

### 🤔 这个变动的性质是？

- [x] 新特性提交
- [ ] 日常 bug 修复
- [x] 站点、文档改进
- [x] 演示代码改进
- [ ] 组件样式/交互改进
- [x] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [x] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. https://github.com/ant-design/ant-design/issues/28082
-->

### 💡 需求背景和解决方案

<!--

1. 新增左右底部的api
2. 不改动原有的footer api，新增leftFooter跟rightFooter，同时传入，优先级为leftFooter/rightFooter>footer，每个选项都支持单独传入或者不传
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
穿梭框可以新增两个api，支持自定义渲染左右底部
-->

| 语言    | 更新描述                                                     |
| ------- | ------------------------------------------------------------ |
| 🇺🇸 英文 | Transfer now able to support what should be displayed in the left footer or right footer. |
| 🇨🇳 中文 | 穿梭框现在支持配置左右底部的自定义渲染。                     |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供



-----
[View rendered components/transfer/demo/advanced.md](https://github.com/Eating-Eating/ant-design/blob/TransferFeature/components/transfer/demo/advanced.md)
[View rendered components/transfer/index.en-US.md](https://github.com/Eating-Eating/ant-design/blob/TransferFeature/components/transfer/index.en-US.md)
[View rendered components/transfer/index.zh-CN.md](https://github.com/Eating-Eating/ant-design/blob/TransferFeature/components/transfer/index.zh-CN.md)