### PR TITLE
Pr/form a11y

### DIFF
--- a/components/config-provider/__tests__/__snapshots__/components.test.js.snap
+++ b/components/config-provider/__tests__/__snapshots__/components.test.js.snap
@@ -13273,10 +13273,9 @@ exports[`ConfigProvider components Form configProvider 1`] = `
       </div>
       <div
         class="config-form-item-explain config-form-item-explain-error"
+        role="alert"
       >
-        <div
-          role="alert"
-        >
+        <div>
           Bamboo is Light
         </div>
       </div>
@@ -13310,10 +13309,9 @@ exports[`ConfigProvider components Form configProvider componentSize large 1`] =
       </div>
       <div
         class="config-form-item-explain config-form-item-explain-error"
+        role="alert"
       >
-        <div
-          role="alert"
-        >
+        <div>
           Bamboo is Light
         </div>
       </div>
@@ -13347,10 +13345,9 @@ exports[`ConfigProvider components Form configProvider componentSize middle 1`] 
       </div>
       <div
         class="config-form-item-explain config-form-item-explain-error"
+        role="alert"
       >
-        <div
-          role="alert"
-        >
+        <div>
           Bamboo is Light
         </div>
       </div>
@@ -13384,10 +13381,9 @@ exports[`ConfigProvider components Form configProvider virtual and dropdownMatch
       </div>
       <div
         class="ant-form-item-explain ant-form-item-explain-error"
+        role="alert"
       >
-        <div
-          role="alert"
-        >
+        <div>
           Bamboo is Light
         </div>
       </div>
@@ -13421,10 +13417,9 @@ exports[`ConfigProvider components Form normal 1`] = `
       </div>
       <div
         class="ant-form-item-explain ant-form-item-explain-error"
+        role="alert"
       >
-        <div
-          role="alert"
-        >
+        <div>
           Bamboo is Light
         </div>
       </div>
@@ -13458,10 +13453,9 @@ exports[`ConfigProvider components Form prefixCls 1`] = `
       </div>
       <div
         class="prefix-Form-item-explain prefix-Form-item-explain-error"
+        role="alert"
       >
-        <div
-          role="alert"
-        >
+        <div>
           Bamboo is Light
         </div>
       </div>

--- a/components/form/ErrorList.tsx
+++ b/components/form/ErrorList.tsx
@@ -64,6 +64,11 @@ export default function ErrorList({
 
   const baseClassName = `${prefixCls}-item-explain`;
   const rootPrefixCls = getPrefixCls();
+  const helpProps: { id?: string } = {};
+
+  if (fieldId) {
+    helpProps.id = `${fieldId}_help`;
+  }
 
   return (
     <CSSMotion
@@ -78,6 +83,7 @@ export default function ErrorList({
     >
       {({ className: motionClassName }: { className?: string }) => (
         <div
+          {...helpProps}
           className={classNames(
             baseClassName,
             {
@@ -86,7 +92,6 @@ export default function ErrorList({
             motionClassName,
           )}
           key="help"
-          id={`${fieldId}_help`}
           role="alert"
         >
           {memoErrors.map((error, index) => (

--- a/components/form/ErrorList.tsx
+++ b/components/form/ErrorList.tsx
@@ -87,12 +87,11 @@ export default function ErrorList({
           )}
           key="help"
           id={`${fieldId}_help`}
+          role="alert"
         >
           {memoErrors.map((error, index) => (
             // eslint-disable-next-line react/no-array-index-key
-            <div key={index} role="alert">
-              {error}
-            </div>
+            <div key={index}>{error}</div>
           ))}
         </div>
       )}

--- a/components/form/ErrorList.tsx
+++ b/components/form/ErrorList.tsx
@@ -11,7 +11,9 @@ const EMPTY_LIST: React.ReactNode[] = [];
 
 export interface ErrorListProps {
   errors?: React.ReactNode[];
-  /** @private Internal Usage. Do not use in your production */
+  /** @private Internal usage. Do not use in your production */
+  fieldId?: string;
+  /** @private Internal usage. Do not use in your production */
   help?: React.ReactNode;
   /** @private Internal Usage. Do not use in your production */
   onDomErrorVisibleChange?: (visible: boolean) => void;
@@ -21,6 +23,7 @@ export default function ErrorList({
   errors = EMPTY_LIST,
   help,
   onDomErrorVisibleChange,
+  fieldId,
 }: ErrorListProps) {
   const forceUpdate = useForceUpdate();
   const { prefixCls, status } = React.useContext(FormItemPrefixContext);
@@ -83,6 +86,7 @@ export default function ErrorList({
             motionClassName,
           )}
           key="help"
+          id={`${fieldId}_help`}
         >
           {memoErrors.map((error, index) => (
             // eslint-disable-next-line react/no-array-index-key

--- a/components/form/FormItem.tsx
+++ b/components/form/FormItem.tsx
@@ -369,6 +369,10 @@ function FormItem<Values = any>(props: FormItemProps<Values>): React.ReactElemen
             childProps['aria-invalid'] = 'true';
           }
 
+          if (isRequired) {
+            childProps['aria-required'] = 'true';
+          }
+
           if (supportRef(children)) {
             childProps.ref = getItemRef(mergedName, children);
           }

--- a/components/form/FormItem.tsx
+++ b/components/form/FormItem.tsx
@@ -379,6 +379,10 @@ function FormItem<Values = any>(props: FormItemProps<Values>): React.ReactElemen
             childProps['aria-required'] = 'true';
           }
 
+          if (errors.length > 0) {
+            childProps['aria-invalid'] = 'true';
+          }
+
           if (supportRef(children)) {
             childProps.ref = getItemRef(mergedName, children);
           }

--- a/components/form/FormItem.tsx
+++ b/components/form/FormItem.tsx
@@ -360,9 +360,15 @@ function FormItem<Values = any>(props: FormItemProps<Values>): React.ReactElemen
             childProps.id = fieldId;
           }
 
-          if (props.help || errors.length > 0) {
-            const describedby = `${fieldId}_help`;
-            childProps['aria-describedby'] = describedby;
+          if (props.help || errors.length > 0 || props.extra) {
+            const describedbyArr = [];
+            if (props.help || errors.length > 0) {
+              describedbyArr.push(`${fieldId}_help`);
+            }
+            if (props.extra) {
+              describedbyArr.push(`${fieldId}_extra`);
+            }
+            childProps['aria-describedby'] = describedbyArr.join(' ');
           }
 
           if (errors.length > 0) {

--- a/components/form/FormItem.tsx
+++ b/components/form/FormItem.tsx
@@ -360,7 +360,7 @@ function FormItem<Values = any>(props: FormItemProps<Values>): React.ReactElemen
             childProps.id = fieldId;
           }
 
-          if (props.help) {
+          if (props.help || errors.length > 0) {
             const describedby = `${fieldId}_help`;
             childProps['aria-describedby'] = describedby;
           }

--- a/components/form/FormItem.tsx
+++ b/components/form/FormItem.tsx
@@ -243,6 +243,7 @@ function FormItem<Values = any>(props: FormItemProps<Values>): React.ReactElemen
           status={mergedValidateStatus}
           onDomErrorVisibleChange={setDomErrorVisible}
           validateStatus={mergedValidateStatus}
+          fieldId={fieldId}
         >
           <FormItemContext.Provider value={{ updateItemErrors: updateChildItemErrors }}>
             {baseChildren}
@@ -357,6 +358,11 @@ function FormItem<Values = any>(props: FormItemProps<Values>): React.ReactElemen
           const childProps = { ...children.props, ...mergedControl };
           if (!childProps.id) {
             childProps.id = fieldId;
+          }
+
+          if (props.help) {
+            const describedby = `${fieldId}_help`;
+            childProps['aria-describedby'] = describedby;
           }
 
           if (supportRef(children)) {

--- a/components/form/FormItem.tsx
+++ b/components/form/FormItem.tsx
@@ -365,6 +365,10 @@ function FormItem<Values = any>(props: FormItemProps<Values>): React.ReactElemen
             childProps['aria-describedby'] = describedby;
           }
 
+          if (errors.length > 0) {
+            childProps['aria-invalid'] = 'true';
+          }
+
           if (supportRef(children)) {
             childProps.ref = getItemRef(mergedName, children);
           }

--- a/components/form/FormItemInput.tsx
+++ b/components/form/FormItemInput.tsx
@@ -36,6 +36,7 @@ export interface FormItemInputProps {
   help?: React.ReactNode;
   extra?: React.ReactNode;
   status?: ValidateStatus;
+  fieldId?: string;
 }
 
 const iconMap: { [key: string]: any } = {
@@ -58,6 +59,7 @@ const FormItemInput: React.FC<FormItemInputProps & FormItemInputMiscProps> = pro
     _internalItemRender: formItemRender,
     validateStatus,
     extra,
+    fieldId,
   } = props;
   const baseClassName = `${prefixCls}-item`;
 
@@ -96,7 +98,12 @@ const FormItemInput: React.FC<FormItemInputProps & FormItemInputMiscProps> = pro
   );
   const errorListDom = (
     <FormItemPrefixContext.Provider value={{ prefixCls, status }}>
-      <ErrorList errors={errors} help={help} onDomErrorVisibleChange={onDomErrorVisibleChange} />
+      <ErrorList
+        fieldId={fieldId}
+        errors={errors}
+        help={help}
+        onDomErrorVisibleChange={onDomErrorVisibleChange}
+      />
     </FormItemPrefixContext.Provider>
   );
 

--- a/components/form/FormItemInput.tsx
+++ b/components/form/FormItemInput.tsx
@@ -109,7 +109,11 @@ const FormItemInput: React.FC<FormItemInputProps & FormItemInputMiscProps> = pro
 
   // If extra = 0, && will goes wrong
   // 0&&error -> 0
-  const extraDom = extra ? <div className={`${baseClassName}-extra`}>{extra}</div> : null;
+  const extraDom = extra ? (
+    <div className={`${baseClassName}-extra`} id={`${fieldId}_extra`}>
+      {extra}
+    </div>
+  ) : null;
 
   const dom =
     formItemRender && formItemRender.mark === 'pro_table_render' && formItemRender.render ? (

--- a/components/form/FormItemInput.tsx
+++ b/components/form/FormItemInput.tsx
@@ -109,8 +109,14 @@ const FormItemInput: React.FC<FormItemInputProps & FormItemInputMiscProps> = pro
 
   // If extra = 0, && will goes wrong
   // 0&&error -> 0
+  const extraProps: { id?: string } = {};
+
+  if (fieldId) {
+    extraProps.id = `${fieldId}_extra`;
+  }
+
   const extraDom = extra ? (
-    <div className={`${baseClassName}-extra`} id={`${fieldId}_extra`}>
+    <div {...extraProps} className={`${baseClassName}-extra`}>
       {extra}
     </div>
   ) : null;

--- a/components/form/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/form/__tests__/__snapshots__/demo.test.js.snap
@@ -38,6 +38,7 @@ exports[`renders ./components/form/demo/advanced-search.md correctly 1`] = `
                 class="ant-form-item-control-input-content"
               >
                 <input
+                  aria-required="true"
                   class="ant-input"
                   id="advanced_search_field-0"
                   placeholder="placeholder"
@@ -77,6 +78,7 @@ exports[`renders ./components/form/demo/advanced-search.md correctly 1`] = `
                 class="ant-form-item-control-input-content"
               >
                 <input
+                  aria-required="true"
                   class="ant-input"
                   id="advanced_search_field-1"
                   placeholder="placeholder"
@@ -116,6 +118,7 @@ exports[`renders ./components/form/demo/advanced-search.md correctly 1`] = `
                 class="ant-form-item-control-input-content"
               >
                 <input
+                  aria-required="true"
                   class="ant-input"
                   id="advanced_search_field-2"
                   placeholder="placeholder"
@@ -155,6 +158,7 @@ exports[`renders ./components/form/demo/advanced-search.md correctly 1`] = `
                 class="ant-form-item-control-input-content"
               >
                 <input
+                  aria-required="true"
                   class="ant-input"
                   id="advanced_search_field-3"
                   placeholder="placeholder"
@@ -194,6 +198,7 @@ exports[`renders ./components/form/demo/advanced-search.md correctly 1`] = `
                 class="ant-form-item-control-input-content"
               >
                 <input
+                  aria-required="true"
                   class="ant-input"
                   id="advanced_search_field-4"
                   placeholder="placeholder"
@@ -233,6 +238,7 @@ exports[`renders ./components/form/demo/advanced-search.md correctly 1`] = `
                 class="ant-form-item-control-input-content"
               >
                 <input
+                  aria-required="true"
                   class="ant-input"
                   id="advanced_search_field-5"
                   placeholder="placeholder"
@@ -333,6 +339,7 @@ exports[`renders ./components/form/demo/basic.md correctly 1`] = `
           class="ant-form-item-control-input-content"
         >
           <input
+            aria-required="true"
             class="ant-input"
             id="basic_username"
             type="text"
@@ -370,6 +377,7 @@ exports[`renders ./components/form/demo/basic.md correctly 1`] = `
           >
             <input
               action="click"
+              aria-required="true"
               class="ant-input"
               id="basic_password"
               type="password"
@@ -499,6 +507,7 @@ exports[`renders ./components/form/demo/control-hooks.md correctly 1`] = `
           class="ant-form-item-control-input-content"
         >
           <input
+            aria-required="true"
             class="ant-input"
             id="control-hooks_note"
             type="text"
@@ -532,6 +541,7 @@ exports[`renders ./components/form/demo/control-hooks.md correctly 1`] = `
           class="ant-form-item-control-input-content"
         >
           <div
+            aria-required="true"
             class="ant-select ant-select-single ant-select-allow-clear ant-select-show-arrow"
           >
             <div
@@ -546,6 +556,7 @@ exports[`renders ./components/form/demo/control-hooks.md correctly 1`] = `
                   aria-controls="control-hooks_gender_list"
                   aria-haspopup="listbox"
                   aria-owns="control-hooks_gender_list"
+                  aria-required="true"
                   autocomplete="off"
                   class="ant-select-selection-search-input"
                   id="control-hooks_gender"
@@ -666,6 +677,7 @@ exports[`renders ./components/form/demo/control-ref.md correctly 1`] = `
           class="ant-form-item-control-input-content"
         >
           <input
+            aria-required="true"
             class="ant-input"
             id="control-ref_note"
             type="text"
@@ -699,6 +711,7 @@ exports[`renders ./components/form/demo/control-ref.md correctly 1`] = `
           class="ant-form-item-control-input-content"
         >
           <div
+            aria-required="true"
             class="ant-select ant-select-single ant-select-allow-clear ant-select-show-arrow"
           >
             <div
@@ -713,6 +726,7 @@ exports[`renders ./components/form/demo/control-ref.md correctly 1`] = `
                   aria-controls="control-ref_gender_list"
                   aria-haspopup="listbox"
                   aria-owns="control-ref_gender_list"
+                  aria-required="true"
                   autocomplete="off"
                   class="ant-select-selection-search-input"
                   id="control-ref_gender"
@@ -1074,10 +1088,9 @@ exports[`renders ./components/form/demo/disabled-input-debug.md correctly 1`] = 
       </div>
       <div
         class="ant-form-item-explain ant-form-item-explain-error"
+        role="alert"
       >
-        <div
-          role="alert"
-        >
+        <div>
           Buggy!
         </div>
       </div>
@@ -1116,10 +1129,9 @@ exports[`renders ./components/form/demo/disabled-input-debug.md correctly 1`] = 
       </div>
       <div
         class="ant-form-item-explain ant-form-item-explain-error"
+        role="alert"
       >
-        <div
-          role="alert"
-        >
+        <div>
           Buggy!
         </div>
       </div>
@@ -1189,10 +1201,9 @@ exports[`renders ./components/form/demo/disabled-input-debug.md correctly 1`] = 
       </div>
       <div
         class="ant-form-item-explain ant-form-item-explain-error"
+        role="alert"
       >
-        <div
-          role="alert"
-        >
+        <div>
           Buggy!
         </div>
       </div>
@@ -1231,10 +1242,9 @@ exports[`renders ./components/form/demo/disabled-input-debug.md correctly 1`] = 
       </div>
       <div
         class="ant-form-item-explain ant-form-item-explain-error"
+        role="alert"
       >
-        <div
-          role="alert"
-        >
+        <div>
           Buggy!
         </div>
       </div>
@@ -1330,10 +1340,9 @@ exports[`renders ./components/form/demo/disabled-input-debug.md correctly 1`] = 
       </div>
       <div
         class="ant-form-item-explain ant-form-item-explain-error"
+        role="alert"
       >
-        <div
-          role="alert"
-        >
+        <div>
           Buggy!
         </div>
       </div>
@@ -1385,10 +1394,9 @@ exports[`renders ./components/form/demo/disabled-input-debug.md correctly 1`] = 
       </div>
       <div
         class="ant-form-item-explain ant-form-item-explain-error"
+        role="alert"
       >
-        <div
-          role="alert"
-        >
+        <div>
           Buggy!
         </div>
       </div>
@@ -1476,10 +1484,9 @@ exports[`renders ./components/form/demo/disabled-input-debug.md correctly 1`] = 
       </div>
       <div
         class="ant-form-item-explain ant-form-item-explain-error"
+        role="alert"
       >
-        <div
-          role="alert"
-        >
+        <div>
           Buggy!
         </div>
       </div>
@@ -1527,10 +1534,9 @@ exports[`renders ./components/form/demo/disabled-input-debug.md correctly 1`] = 
       </div>
       <div
         class="ant-form-item-explain ant-form-item-explain-error"
+        role="alert"
       >
-        <div
-          role="alert"
-        >
+        <div>
           Buggy!
         </div>
       </div>
@@ -1761,6 +1767,7 @@ exports[`renders ./components/form/demo/dynamic-form-items-complex.md correctly 
           class="ant-form-item-control-input-content"
         >
           <div
+            aria-required="true"
             class="ant-select ant-select-single ant-select-show-arrow"
           >
             <div
@@ -1775,6 +1782,7 @@ exports[`renders ./components/form/demo/dynamic-form-items-complex.md correctly 
                   aria-controls="dynamic_form_nest_item_area_list"
                   aria-haspopup="listbox"
                   aria-owns="dynamic_form_nest_item_area_list"
+                  aria-required="true"
                   autocomplete="off"
                   class="ant-select-selection-search-input"
                   id="dynamic_form_nest_item_area"
@@ -1924,6 +1932,7 @@ exports[`renders ./components/form/demo/dynamic-rule.md correctly 1`] = `
           class="ant-form-item-control-input-content"
         >
           <input
+            aria-required="true"
             class="ant-input"
             id="dynamic_rule_username"
             placeholder="Please input your name"
@@ -2058,6 +2067,7 @@ exports[`renders ./components/form/demo/form-context.md correctly 1`] = `
           class="ant-form-item-control-input-content"
         >
           <input
+            aria-required="true"
             class="ant-input"
             id="basicForm_group"
             type="text"
@@ -2197,6 +2207,7 @@ Array [
             class="ant-form-item-control-input-content"
           >
             <input
+              aria-required="true"
               class="ant-input"
               id="global_state_username"
               type="text"
@@ -2266,6 +2277,7 @@ exports[`renders ./components/form/demo/inline-login.md correctly 1`] = `
               </span>
             </span>
             <input
+              aria-required="true"
               class="ant-input"
               id="horizontal_login_username"
               placeholder="Username"
@@ -2316,6 +2328,7 @@ exports[`renders ./components/form/demo/inline-login.md correctly 1`] = `
               </span>
             </span>
             <input
+              aria-required="true"
               class="ant-input"
               id="horizontal_login_password"
               placeholder="Password"
@@ -2568,6 +2581,7 @@ exports[`renders ./components/form/demo/nest-messages.md correctly 1`] = `
           class="ant-form-item-control-input-content"
         >
           <input
+            aria-required="true"
             class="ant-input"
             id="nest-messages_user_name"
             type="text"
@@ -2846,6 +2860,7 @@ exports[`renders ./components/form/demo/normal-login.md correctly 1`] = `
               </span>
             </span>
             <input
+              aria-required="true"
               class="ant-input"
               id="normal_login_username"
               placeholder="Username"
@@ -2896,6 +2911,7 @@ exports[`renders ./components/form/demo/normal-login.md correctly 1`] = `
               </span>
             </span>
             <input
+              aria-required="true"
               class="ant-input"
               id="normal_login_password"
               placeholder="Password"
@@ -3089,6 +3105,7 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
           class="ant-form-item-control-input-content"
         >
           <input
+            aria-required="true"
             class="ant-input"
             id="register_email"
             type="text"
@@ -3126,6 +3143,7 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
           >
             <input
               action="click"
+              aria-required="true"
               class="ant-input"
               id="register_password"
               type="password"
@@ -3191,6 +3209,7 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
           >
             <input
               action="click"
+              aria-required="true"
               class="ant-input"
               id="register_confirm"
               type="password"
@@ -3274,6 +3293,7 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
           class="ant-form-item-control-input-content"
         >
           <input
+            aria-required="true"
             class="ant-input"
             id="register_nickname"
             type="text"
@@ -3316,6 +3336,7 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
               Zhejiang / Hangzhou / West Lake
             </span>
             <input
+              aria-required="true"
               autocomplete="off"
               class="ant-input ant-cascader-input "
               id="register_residence"
@@ -3464,6 +3485,7 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
                 </div>
               </span>
               <input
+                aria-required="true"
                 class="ant-input"
                 id="register_phone"
                 type="text"
@@ -3499,6 +3521,7 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
           class="ant-form-item-control-input-content"
         >
           <div
+            aria-required="true"
             class="ant-select ant-select-auto-complete ant-select-single ant-select-customize-input ant-select-show-search"
           >
             <div
@@ -3513,6 +3536,7 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
                   aria-controls="register_website_list"
                   aria-haspopup="listbox"
                   aria-owns="register_website_list"
+                  aria-required="true"
                   autocomplete="off"
                   class="ant-input ant-select-selection-search-input"
                   id="register_website"
@@ -3563,6 +3587,7 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
               style="padding-left:4px;padding-right:4px"
             >
               <input
+                aria-required="true"
                 class="ant-input"
                 id="register_captcha"
                 type="text"
@@ -4524,6 +4549,7 @@ exports[`renders ./components/form/demo/time-related-controls.md correctly 1`] =
               class="ant-picker-input"
             >
               <input
+                aria-required="true"
                 autocomplete="off"
                 id="time_related_controls_date-picker"
                 placeholder="Select date"
@@ -4591,6 +4617,7 @@ exports[`renders ./components/form/demo/time-related-controls.md correctly 1`] =
               class="ant-picker-input"
             >
               <input
+                aria-required="true"
                 autocomplete="off"
                 id="time_related_controls_date-time-picker"
                 placeholder="Select date"
@@ -4658,6 +4685,7 @@ exports[`renders ./components/form/demo/time-related-controls.md correctly 1`] =
               class="ant-picker-input"
             >
               <input
+                aria-required="true"
                 autocomplete="off"
                 id="time_related_controls_month-picker"
                 placeholder="Select month"
@@ -4719,6 +4747,7 @@ exports[`renders ./components/form/demo/time-related-controls.md correctly 1`] =
           class="ant-form-item-control-input-content"
         >
           <div
+            aria-required="true"
             class="ant-picker ant-picker-range"
           >
             <div
@@ -4828,6 +4857,7 @@ exports[`renders ./components/form/demo/time-related-controls.md correctly 1`] =
           class="ant-form-item-control-input-content"
         >
           <div
+            aria-required="true"
             class="ant-picker ant-picker-range"
           >
             <div
@@ -4943,6 +4973,7 @@ exports[`renders ./components/form/demo/time-related-controls.md correctly 1`] =
               class="ant-picker-input"
             >
               <input
+                aria-required="true"
                 autocomplete="off"
                 id="time_related_controls_time-picker"
                 placeholder="Select time"
@@ -5070,6 +5101,7 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
           class="ant-form-item-control-input-content"
         >
           <div
+            aria-required="true"
             class="ant-select ant-select-single ant-select-show-arrow"
           >
             <div
@@ -5084,6 +5116,7 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
                   aria-controls="validate_other_select_list"
                   aria-haspopup="listbox"
                   aria-owns="validate_other_select_list"
+                  aria-required="true"
                   autocomplete="off"
                   class="ant-select-selection-search-input"
                   id="validate_other_select"
@@ -5156,6 +5189,7 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
           class="ant-form-item-control-input-content"
         >
           <div
+            aria-required="true"
             class="ant-select ant-select-multiple ant-select-show-search"
           >
             <div
@@ -5178,6 +5212,7 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
                       aria-controls="validate_other_select-multiple_list"
                       aria-haspopup="listbox"
                       aria-owns="validate_other_select-multiple_list"
+                      aria-required="true"
                       autocomplete="off"
                       class="ant-select-selection-search-input"
                       id="validate_other_select-multiple"
@@ -6193,6 +6228,7 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
               >
                 <input
                   accept=""
+                  aria-describedby="validate_other_upload_extra"
                   id="validate_other_upload"
                   style="display:none"
                   type="file"
@@ -6234,6 +6270,7 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
       </div>
       <div
         class="ant-form-item-extra"
+        id="validate_other_upload_extra"
       >
         longgggggggggggggggggggggggggggggggggg
       </div>
@@ -6387,10 +6424,9 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
       </div>
       <div
         class="ant-form-item-explain ant-form-item-explain-error"
+        role="alert"
       >
-        <div
-          role="alert"
-        >
+        <div>
           Should be combination of numbers & alphabets
         </div>
       </div>
@@ -6512,10 +6548,9 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
       </div>
       <div
         class="ant-form-item-explain ant-form-item-explain-validating"
+        role="alert"
       >
-        <div
-          role="alert"
-        >
+        <div>
           The information is being validated...
         </div>
       </div>
@@ -6689,10 +6724,9 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
       </div>
       <div
         class="ant-form-item-explain ant-form-item-explain-error"
+        role="alert"
       >
-        <div
-          role="alert"
-        >
+        <div>
           Should be combination of numbers & alphabets
         </div>
       </div>
@@ -7069,10 +7103,9 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
       </div>
       <div
         class="ant-form-item-explain ant-form-item-explain-validating"
+        role="alert"
       >
-        <div
-          role="alert"
-        >
+        <div>
           The information is being validated...
         </div>
       </div>
@@ -7157,10 +7190,9 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
               </div>
               <div
                 class="ant-form-item-explain ant-form-item-explain-error"
+                role="alert"
               >
-                <div
-                  role="alert"
-                >
+                <div>
                   Please select the correct date
                 </div>
               </div>
@@ -7740,10 +7772,9 @@ exports[`renders ./components/form/demo/without-form-create.md correctly 1`] = `
       </div>
       <div
         class="ant-form-item-explain"
+        role="alert"
       >
-        <div
-          role="alert"
-        >
+        <div>
           A prime is a natural number greater than 1 that has no positive divisors other than 1 and itself.
         </div>
       </div>

--- a/components/form/__tests__/index.test.js
+++ b/components/form/__tests__/index.test.js
@@ -214,6 +214,24 @@ describe('Form', () => {
     expect(help.prop('id')).toBe('test_help');
   });
 
+  it('input element should have the prop aria-invalid when there are errors', async () => {
+    const wrapper = mount(
+      <Form>
+        <Form.Item name="test" rules={[{ len: 3 }, { type: 'number' }]}>
+          <input />
+        </Form.Item>
+      </Form>,
+    );
+
+    const input = wrapper.find('input');
+    input.simulate('change', { target: { value: 'Invalid number' } });
+    await sleep(800);
+    wrapper.update();
+
+    const inputChanged = wrapper.find('input');
+    expect(inputChanged.prop('aria-invalid')).toBe('true');
+  });
+
   describe('scrollToField', () => {
     function test(name, genForm) {
       it(name, () => {
@@ -646,9 +664,7 @@ describe('Form', () => {
     await sleep(100);
     wrapper.update();
     await sleep(100);
-    expect(wrapper.find('.ant-form-item-explain div').getDOMNode().getAttribute('role')).toBe(
-      'alert',
-    );
+    expect(wrapper.find('.ant-form-item-explain').getDOMNode().getAttribute('role')).toBe('alert');
   });
 
   it('return same form instance', () => {

--- a/components/form/__tests__/index.test.js
+++ b/components/form/__tests__/index.test.js
@@ -172,6 +172,7 @@ describe('Form', () => {
         </Form.Item>
       </Form>,
     );
+
     const input = wrapper.find('input');
     expect(input.prop('aria-describedby')).toBe('test_help');
     const help = wrapper.find('.ant-form-item-explain');
@@ -201,6 +202,7 @@ describe('Form', () => {
         </Form.Item>
       </Form>,
     );
+
     const input = wrapper.find('input');
     expect(input.prop('aria-describedby')).toBe('form_test_help');
     const help = wrapper.find('.ant-form-item-explain');

--- a/components/form/__tests__/index.test.js
+++ b/components/form/__tests__/index.test.js
@@ -172,6 +172,7 @@ describe('Form', () => {
         </Form.Item>
       </Form>,
     );
+
     const input = wrapper.find('input');
     expect(input.prop('aria-describedby')).toBe('test_help');
     const help = wrapper.find('.ant-form-item-explain');
@@ -186,10 +187,31 @@ describe('Form', () => {
         </Form.Item>
       </Form>,
     );
+
     const input = wrapper.find('input');
     expect(input.prop('aria-describedby')).toBe('form_test_help');
     const help = wrapper.find('.ant-form-item-explain');
     expect(help.prop('id')).toBe('form_test_help');
+  });
+
+  it('input element should have the prop aria-describedby pointing to the help id when there are errors', async () => {
+    const wrapper = mount(
+      <Form>
+        <Form.Item name="test" rules={[{ len: 3 }, { type: 'number' }]}>
+          <input />
+        </Form.Item>
+      </Form>,
+    );
+
+    const input = wrapper.find('input');
+    input.simulate('change', { target: { value: 'Invalid number' } });
+    await sleep(800);
+    wrapper.update();
+
+    const inputChanged = wrapper.find('input');
+    expect(inputChanged.prop('aria-describedby')).toBe('test_help');
+    const help = wrapper.find('.ant-form-item-explain');
+    expect(help.prop('id')).toBe('test_help');
   });
 
   describe('scrollToField', () => {

--- a/components/form/__tests__/index.test.js
+++ b/components/form/__tests__/index.test.js
@@ -179,6 +179,21 @@ describe('Form', () => {
     expect(help.prop('id')).toBe('test_help');
   });
 
+  it('input element should not have the prop aria-describedby pointing to the help id when there is a help message and name is not defined', () => {
+    const wrapper = mount(
+      <Form>
+        <Form.Item help="This is a help">
+          <input />
+        </Form.Item>
+      </Form>,
+    );
+
+    const input = wrapper.find('input');
+    expect(input.prop('aria-describedby')).toBeUndefined();
+    const help = wrapper.find('.ant-form-item-explain');
+    expect(help.prop('id')).toBeUndefined();
+  });
+
   it('input element should have the prop aria-describedby concatenated with the form name pointing to the help id when there is a help message', () => {
     const wrapper = mount(
       <Form name="form">
@@ -271,6 +286,21 @@ describe('Form', () => {
     expect(input.prop('aria-describedby')).toBe('test_extra');
     const extra = wrapper.find('.ant-form-item-extra');
     expect(extra.prop('id')).toBe('test_extra');
+  });
+
+  it('input element should not have the prop aria-describedby pointing to the extra id when there is a extra message and name is not defined', () => {
+    const wrapper = mount(
+      <Form>
+        <Form.Item extra="This is a extra message">
+          <input />
+        </Form.Item>
+      </Form>,
+    );
+
+    const input = wrapper.find('input');
+    expect(input.prop('aria-describedby')).toBeUndefined();
+    const extra = wrapper.find('.ant-form-item-extra');
+    expect(extra.prop('id')).toBeUndefined();
   });
 
   it('input element should have the prop aria-describedby pointing to the help and extra id when there is a help and extra message', () => {

--- a/components/form/__tests__/index.test.js
+++ b/components/form/__tests__/index.test.js
@@ -172,7 +172,6 @@ describe('Form', () => {
         </Form.Item>
       </Form>,
     );
-
     const input = wrapper.find('input');
     expect(input.prop('aria-describedby')).toBe('test_help');
     const help = wrapper.find('.ant-form-item-explain');
@@ -202,7 +201,6 @@ describe('Form', () => {
         </Form.Item>
       </Form>,
     );
-
     const input = wrapper.find('input');
     expect(input.prop('aria-describedby')).toBe('form_test_help');
     const help = wrapper.find('.ant-form-item-explain');

--- a/components/form/__tests__/index.test.js
+++ b/components/form/__tests__/index.test.js
@@ -232,6 +232,32 @@ describe('Form', () => {
     expect(inputChanged.prop('aria-invalid')).toBe('true');
   });
 
+  it('input element should have the prop aria-required when the prop `required` is true', async () => {
+    const wrapper = mount(
+      <Form>
+        <Form.Item name="test" required>
+          <input />
+        </Form.Item>
+      </Form>,
+    );
+
+    const input = wrapper.find('input');
+    expect(input.prop('aria-required')).toBe('true');
+  });
+
+  it('input element should have the prop aria-required when there is a rule with required', async () => {
+    const wrapper = mount(
+      <Form>
+        <Form.Item name="test" rules={[{ required: true }]}>
+          <input />
+        </Form.Item>
+      </Form>,
+    );
+
+    const input = wrapper.find('input');
+    expect(input.prop('aria-required')).toBe('true');
+  });
+
   describe('scrollToField', () => {
     function test(name, genForm) {
       it(name, () => {

--- a/components/form/__tests__/index.test.js
+++ b/components/form/__tests__/index.test.js
@@ -164,6 +164,34 @@ describe('Form', () => {
     );
   });
 
+  it('input element should have the prop aria-describedby pointing to the help id when there is a help message', () => {
+    const wrapper = mount(
+      <Form>
+        <Form.Item name="test" help="This is a help">
+          <input />
+        </Form.Item>
+      </Form>,
+    );
+    const input = wrapper.find('input');
+    expect(input.prop('aria-describedby')).toBe('test_help');
+    const help = wrapper.find('.ant-form-item-explain');
+    expect(help.prop('id')).toBe('test_help');
+  });
+
+  it('input element should have the prop aria-describedby concatenated with the form name pointing to the help id when there is a help message', () => {
+    const wrapper = mount(
+      <Form name="form">
+        <Form.Item name="test" help="This is a help">
+          <input />
+        </Form.Item>
+      </Form>,
+    );
+    const input = wrapper.find('input');
+    expect(input.prop('aria-describedby')).toBe('form_test_help');
+    const help = wrapper.find('.ant-form-item-explain');
+    expect(help.prop('id')).toBe('form_test_help');
+  });
+
   describe('scrollToField', () => {
     function test(name, genForm) {
       it(name, () => {

--- a/components/form/__tests__/index.test.js
+++ b/components/form/__tests__/index.test.js
@@ -258,6 +258,34 @@ describe('Form', () => {
     expect(input.prop('aria-required')).toBe('true');
   });
 
+  it('input element should have the prop aria-describedby pointing to the extra id when there is a extra message', () => {
+    const wrapper = mount(
+      <Form>
+        <Form.Item name="test" extra="This is a extra message">
+          <input />
+        </Form.Item>
+      </Form>,
+    );
+
+    const input = wrapper.find('input');
+    expect(input.prop('aria-describedby')).toBe('test_extra');
+    const extra = wrapper.find('.ant-form-item-extra');
+    expect(extra.prop('id')).toBe('test_extra');
+  });
+
+  it('input element should have the prop aria-describedby pointing to the help and extra id when there is a help and extra message', () => {
+    const wrapper = mount(
+      <Form>
+        <Form.Item name="test" help="This is a help" extra="This is a extra message">
+          <input />
+        </Form.Item>
+      </Form>,
+    );
+
+    const input = wrapper.find('input');
+    expect(input.prop('aria-describedby')).toBe('test_help test_extra');
+  });
+
   describe('scrollToField', () => {
     function test(name, genForm) {
       it(name, () => {

--- a/components/mentions/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/mentions/__tests__/__snapshots__/demo.test.js.snap
@@ -105,6 +105,7 @@ exports[`renders ./components/mentions/demo/form.md correctly 1`] = `
             class="ant-mentions"
           >
             <textarea
+              aria-required="true"
               class="rc-textarea"
               id="bio"
               placeholder="You can use @ to ref user here"

--- a/components/upload/__tests__/__snapshots__/uploadlist.test.js.snap
+++ b/components/upload/__tests__/__snapshots__/uploadlist.test.js.snap
@@ -28,8 +28,8 @@ exports[`Upload List handle error 1`] = `
     class="ant-upload-list ant-upload-list-text"
   >
     <div
-      class="ant-upload-list-text-container ant-upload-animate-appear ant-upload-animate-appear-start ant-upload-animate"
-      style="height: 0px; opacity: 0;"
+      class="ant-upload-list-text-container ant-upload-animate-appear ant-upload-animate-appear-active ant-upload-animate"
+      style="height: 0px; opacity: 1;"
     >
       <div
         class="ant-upload-list-item ant-upload-list-item-error ant-upload-list-item-list-type-text"

--- a/components/upload/__tests__/__snapshots__/uploadlist.test.js.snap
+++ b/components/upload/__tests__/__snapshots__/uploadlist.test.js.snap
@@ -28,8 +28,8 @@ exports[`Upload List handle error 1`] = `
     class="ant-upload-list ant-upload-list-text"
   >
     <div
-      class="ant-upload-list-text-container ant-upload-animate-appear ant-upload-animate-appear-active ant-upload-animate"
-      style="height: 0px; opacity: 1;"
+      class="ant-upload-list-text-container ant-upload-animate-appear ant-upload-animate-appear-start ant-upload-animate"
+      style="height: 0px; opacity: 0;"
     >
       <div
         class="ant-upload-list-item ant-upload-list-item-error ant-upload-list-item-list-type-text"


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ x] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

https://github.com/ant-design/ant-design/issues/28748

### 💡 Background and solution

For accessibility is important that the help and extra message be linked to the input.
And the input needs to have appropriate aria-invalid and aria-required when necessary.

### 📝 Changelog

#### Added
- Created a link between the input field inside the component form item and help and extra messages through aria-describedby
- Pass aria-required to inputs fields inside the component form item when it is required
- Pass aria-invalid to inputs fields inside the component form item when it has errors

#### Changed
- Move the attribute role="alert" on errors messages to its container. Making the screen reader anounce messages when they appear and in the user's focus

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ x] Doc is updated/provided or not needed
- [ x] Demo is updated/provided or not needed
- [ x] TypeScript definition is updated/provided or not needed
- [ x] Changelog is provided or not needed
