### PR TITLE
fix: Dropdown menu should support expandIcon

### DIFF
--- a/components/dropdown/__tests__/index.test.js
+++ b/components/dropdown/__tests__/index.test.js
@@ -4,6 +4,7 @@ import Dropdown from '..';
 import Menu from '../../menu';
 import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
+import { sleep } from '../../../tests/utils';
 
 describe('Dropdown', () => {
   mountTest(() => (
@@ -34,5 +35,28 @@ describe('Dropdown', () => {
       </Dropdown>,
     );
     expect(wrapper).toMatchRenderedSnapshot();
+  });
+
+  it('support Menu expandIcon', async () => {
+    const props = {
+      overlay: (
+        <Menu expandIcon={<span id="customExpandIcon" />}>
+          <Menu.Item>foo</Menu.Item>
+          <Menu.SubMenu title="SubMenu">
+            <Menu.Item>foo</Menu.Item>
+          </Menu.SubMenu>
+        </Menu>
+      ),
+      visible: true,
+      getPopupContainer: node => node,
+    };
+
+    const wrapper = mount(
+      <Dropdown {...props}>
+        <button type="button">button</button>
+      </Dropdown>,
+    );
+    await sleep(500);
+    expect(wrapper.find(Dropdown).find('#customExpandIcon').length).toBe(1);
   });
 });

--- a/components/dropdown/dropdown.tsx
+++ b/components/dropdown/dropdown.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import RcDropdown from 'rc-dropdown';
 import classNames from 'classnames';
 import RightOutlined from '@ant-design/icons/RightOutlined';
-
 import DropdownButton from './dropdown-button';
 import { ConfigContext } from '../config-provider';
 import devWarning from '../_util/devWarning';
@@ -17,6 +16,7 @@ const Placements = tuple(
   'bottomCenter',
   'bottomRight',
 );
+
 type Placement = typeof Placements[number];
 
 type OverlayFunc = () => React.ReactElement;
@@ -102,13 +102,16 @@ const Dropdown: DropdownInterface = props => {
 
     // menu cannot be selectable in dropdown defaultly
     // menu should be focusable in dropdown defaultly
-    const { selectable = false, focusable = true } = overlayProps;
+    const { selectable = false, focusable = true, expandIcon } = overlayProps;
 
-    const expandIcon = (
-      <span className={`${prefixCls}-menu-submenu-arrow`}>
-        <RightOutlined className={`${prefixCls}-menu-submenu-arrow-icon`} />
-      </span>
-    );
+    const overlayNodeExpandIcon =
+      typeof expandIcon !== 'undefined' && React.isValidElement(expandIcon) ? (
+        expandIcon
+      ) : (
+        <span className={`${prefixCls}-menu-submenu-arrow`}>
+          <RightOutlined className={`${prefixCls}-menu-submenu-arrow-icon`} />
+        </span>
+      );
 
     const fixedModeOverlay =
       typeof overlayNode.type === 'string'
@@ -117,7 +120,7 @@ const Dropdown: DropdownInterface = props => {
             mode: 'vertical',
             selectable,
             focusable,
-            expandIcon,
+            expandIcon: overlayNodeExpandIcon,
           });
 
     return fixedModeOverlay as React.ReactElement;


### PR DESCRIPTION


<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close #29332

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Dropdown menu not support `expandIcon`. |
| 🇨🇳 Chinese | 修复 Dropdown 内 Menu 不支持 `expandIcon` 的问题。 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
