### PR TITLE
ci: create release-helper.yml

### DIFF
--- a/.github/workflows/release-helper.yml
+++ b/.github/workflows/release-helper.yml
@@ -1,0 +1,18 @@
+name: Release Helper
+
+on:
+  create
+
+jobs:
+  release-helper:
+    runs-on: ubuntu-latest
+    steps:
+      - name: make release
+        if: github.event.ref_type == 'tag'
+        uses: actions-cool/release-helper@v1
+        with:
+          triger: 'tag'
+          changelogs: 'CHANGELOG.en-US.md, CHANGELOG.zh-CN.md'
+          branch: 'master'
+          dingding-token: ${{ secrets.DINGDING_BOT_TOKEN }}
+          dingding-msg: 'CHANGELOG.zh-CN.md'

--- a/.github/workflows/release-helper.yml
+++ b/.github/workflows/release-helper.yml
@@ -1,3 +1,10 @@
+# Current release process:
+# 1. `npm run pub` will call antd-tools `run pub`
+# 2. antd-tools `run pub` will generate a new tag
+# 3. antd-tools `run pub` will trigger `npm publish` at the same time
+# 4. Then the new tag will trigger this current action
+# 5. The action will generate a new release, and publish DingDing notification at the same time
+
 name: Release Helper
 
 on:


### PR DESCRIPTION
用于发布新版后，发布 release 和 钉钉通知

当前发布流程：

pub 会调用 antd-tools run pub ，生成一个新的 tag，同时会进行 npm publish，然后新的 tag 会触发当前 Action，生成一个新的 release，同时进行 钉钉通知