### PR TITLE
fix(table): pagination.current display error when result of filter is empty

### DIFF
--- a/components/table/__tests__/Table.filter.test.js
+++ b/components/table/__tests__/Table.filter.test.js
@@ -1529,7 +1529,7 @@ describe('Table.filter', () => {
         sortDirections: ['descend'],
       },
     ];
-    const data = [
+    const dataSource = [
       {
         key: '1',
         name: 'John Brown',
@@ -1545,7 +1545,7 @@ describe('Table.filter', () => {
     ];
 
     const wrapper = mount(
-      <Table onChange={onChange} rowKey="name" columns={columns} dataSource={data} />,
+      <Table onChange={onChange} rowKey="name" columns={columns} dataSource={dataSource} />,
     );
     wrapper.find('.ant-dropdown-trigger').first().simulate('click');
     wrapper.find('FilterDropdown').find('MenuItem').at(0).simulate('click');

--- a/components/table/__tests__/Table.filter.test.js
+++ b/components/table/__tests__/Table.filter.test.js
@@ -1543,18 +1543,18 @@ describe('Table.filter', () => {
         address: 'Sidney No. 1 Lake Park',
       },
     ];
-    const Test = () => (
-      <Table onChange={onChange} rowKey="name" columns={columns} dataSource={data} />
+
+    const wrapper = mount(
+      <Table onChange={onChange} rowKey="name" columns={columns} dataSource={data} />,
     );
-    const wrapper = mount(<Test />);
     wrapper.find('.ant-dropdown-trigger').first().simulate('click');
-    wrapper.find('FilterDropdown').find('MenuItem').first().simulate('click');
+    wrapper.find('FilterDropdown').find('MenuItem').at(0).simulate('click');
     wrapper.find('.ant-btn-primary').first().simulate('click');
     expect(onChange.mock.calls[0][0].current).toBe(1);
 
     wrapper.find('.ant-dropdown-trigger').first().simulate('click');
-    wrapper.find('FilterDropdown').find('MenuItem').last().simulate('click');
+    wrapper.find('FilterDropdown').find('MenuItem').at(1).simulate('click');
     wrapper.find('.ant-btn-primary').first().simulate('click');
-    expect(onChange.mock.calls[0][0].current).toBe(1);
+    expect(onChange.mock.calls[1][0].current).toBe(1);
   });
 });

--- a/components/table/__tests__/Table.filter.test.js
+++ b/components/table/__tests__/Table.filter.test.js
@@ -1508,4 +1508,53 @@ describe('Table.filter', () => {
 
     expect(wrapper.find('.ant-table-filter-column')).toHaveLength(3);
   });
+  it('should pagination.current be 1 after filtering', () => {
+    const onChange = jest.fn();
+    const columns = [
+      {
+        title: 'Name',
+        dataIndex: 'name',
+        filters: [
+          {
+            text: 'Jim',
+            value: 'Jim',
+          },
+          {
+            text: 'Joe',
+            value: 'Joe',
+          },
+        ],
+        onFilter: (value, record) => record.name.indexOf(value) === 0,
+        sorter: (a, b) => a.name.length - b.name.length,
+        sortDirections: ['descend'],
+      },
+    ];
+    const data = [
+      {
+        key: '1',
+        name: 'John Brown',
+        age: 32,
+        address: 'New York No. 1 Lake Park',
+      },
+      {
+        key: '2',
+        name: 'Joe Black',
+        age: 32,
+        address: 'Sidney No. 1 Lake Park',
+      },
+    ];
+    const Test = () => (
+      <Table onChange={onChange} rowKey="name" columns={columns} dataSource={data} />
+    );
+    const wrapper = mount(<Test />);
+    wrapper.find('.ant-dropdown-trigger').first().simulate('click');
+    wrapper.find('FilterDropdown').find('MenuItem').first().simulate('click');
+    wrapper.find('.ant-btn-primary').first().simulate('click');
+    expect(onChange.mock.calls[0][0].current).toBe(1);
+
+    wrapper.find('.ant-dropdown-trigger').first().simulate('click');
+    wrapper.find('FilterDropdown').find('MenuItem').last().simulate('click');
+    wrapper.find('.ant-btn-primary').first().simulate('click');
+    expect(onChange.mock.calls[0][0].current).toBe(1);
+  });
 });

--- a/components/table/hooks/usePagination.ts
+++ b/components/table/hooks/usePagination.ts
@@ -71,7 +71,8 @@ export default function usePagination(
   // Reset `current` if data length or pageSize changed
   const maxPage = Math.ceil((paginationTotal || total) / mergedPagination.pageSize!);
   if (mergedPagination.current! > maxPage) {
-    mergedPagination.current = maxPage;
+    // Prevent a maximum page count of 0
+    mergedPagination.current = maxPage || 1;
   }
 
   const refreshPagination = (current: number = 1, pageSize?: number) => {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
https://github.com/ant-design/ant-design/issues/29364
<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Table `pagination.current` display error when result of filter is empty.        |
| 🇨🇳 Chinese |  修复表格当过滤结果为空时，`pagination.current` 展示错误。  |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
