### PR TITLE
fix: form.item is not type safe due to not forwarding their type para…

### DIFF
--- a/components/form/FormItem.tsx
+++ b/components/form/FormItem.tsx
@@ -26,7 +26,7 @@ const ValidateStatuses = tuple('success', 'warning', 'error', 'validating', '');
 export type ValidateStatus = typeof ValidateStatuses[number];
 
 type RenderChildren<Values = any> = (form: FormInstance<Values>) => React.ReactNode;
-type RcFieldProps = Omit<FieldProps, 'children'>;
+type RcFieldProps<Values = any> = Omit<FieldProps<Values>, 'children'>;
 type ChildrenType<Values = any> = RenderChildren<Values> | React.ReactNode;
 
 interface MemoInputProps {
@@ -43,7 +43,7 @@ const MemoInput = React.memo(
 export interface FormItemProps<Values = any>
   extends FormItemLabelProps,
     FormItemInputProps,
-    RcFieldProps {
+    RcFieldProps<Values> {
   prefixCls?: string;
   noStyle?: boolean;
   style?: React.CSSProperties;

--- a/components/form/__tests__/type.test.tsx
+++ b/components/form/__tests__/type.test.tsx
@@ -73,8 +73,10 @@ describe('Form.typescript', () => {
       <Form<FormValues>>
         <Form.Item<FormValues>>
           {({ getFieldsValue }) => {
-            const values: FormValues = getFieldsValue();
+            const values = getFieldsValue();
             expect(values).toBeTruthy();
+            expect(values.username).toBeTruthy();
+            expect(values.path1?.path2).toBeTruthy();
             return null;
           }}
         </Form.Item>


### PR DESCRIPTION
…meters to the rcForm components

<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
closed  https://github.com/ant-design/ant-design/issues/29315
<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    fix  form.item is not type safe due to not forwarding their type parameters to the rcForm components        |
| 🇨🇳 Chinese |   修复formItem继承成rcForm组件时Values类型丢失的问题        |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
