### PR TITLE
fix: Select mode="tags" large size (41px => 40px)

### DIFF
--- a/components/select/style/multiple.less
+++ b/components/select/style/multiple.less
@@ -184,8 +184,8 @@
         }
 
         .@{select-prefix-cls}-selection-search {
-          height: @select-selection-height + @select-multiple-padding;
-          line-height: @select-selection-height + @select-multiple-padding;
+          height: @select-selection-height;
+          line-height: @select-selection-height;
 
           &-input,
           &-mirror {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

close #29374

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Select `mode="tags"` large size (41px => 40px). |
| 🇨🇳 Chinese | 修复 Select 标签模式下大号小号控件的高度多了 `1px` 的问题。 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
