### PR TITLE
fix: bug that scrollToFirstError dont work when <Form.Item></Form.Item> is first children of <\Form></\Form>.#28869

### DIFF
--- a/components/form/hooks/useForm.ts
+++ b/components/form/hooks/useForm.ts
@@ -45,7 +45,17 @@ export default function useForm<Values = any>(form?: FormInstance<Values>): [For
           const node: HTMLElement | null = fieldId ? document.getElementById(fieldId) : null;
 
           if (node) {
-            scrollIntoView(node, {
+            let levelCount = 8;
+            let newNode: HTMLElement = node;
+            // find dom that's classname is ant-form-item-control
+            while (levelCount) {
+              newNode = newNode.parentElement as HTMLElement;
+              if (newNode.className.includes('ant-form-item-control')) {
+                break;
+              }
+              levelCount--;
+            }
+            scrollIntoView(newNode || node, {
               scrollMode: 'if-needed',
               block: 'nearest',
               ...options,


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

close #28869
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

1. hotfix-#28869
2. bug原因是，error滚动需要定位，定位是以input的id的node作为定位依据的，upload的input是display:none的，scrollIntoView失效，没看这个函数，因为即使block能定位到，真是的input也是在中间的，而不是滚动upload的图片框子上方，so，直接去定位ant-form-item-control的元素，因为我对antd场景并不是很熟，不确定ant-form-item-control是否都存在，以及添加了不存在的逻辑兼容。1


### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |   fix bug that scrollToFirstError dont work when <Form.Item><Upload /></Form.Item> is first children of <\Form></\Form> |
| 🇨🇳 中文 |   处理当upload在form首位时，scrollToFirstError失效的问题       |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ x ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
