### PR TITLE
fix: Tabs centered property invalid

### DIFF
--- a/components/style/themes/default.less
+++ b/components/style/themes/default.less
@@ -734,15 +734,16 @@
 @tabs-title-font-size-sm: @font-size-base;
 @tabs-ink-bar-color: @primary-color;
 @tabs-bar-margin: 0 0 @margin-md 0;
-@tabs-horizontal-margin: 0 32px 0 0;
-@tabs-horizontal-gutter: 0 0 0 32px;
+@tabs-horizontal-gutter: 32px;
+@tabs-horizontal-margin: 0 0 0 @tabs-horizontal-gutter;
 @tabs-horizontal-margin-rtl: 0 0 0 32px;
 @tabs-horizontal-padding: @padding-sm 0;
 @tabs-horizontal-padding-lg: @padding-md 0;
 @tabs-horizontal-padding-sm: @padding-xs 0;
 @tabs-vertical-padding: @padding-xs @padding-lg;
-@tabs-vertical-margin: 0 0 @margin-md 0;
-@tabs-vertical-gutter: @margin-md 0 0 0;
+@tabs-vertical-gutter: @margin-md;
+@tabs-vertical-margin: @margin-md 0 0 0;
+
 @tabs-scrolling-size: 32px;
 @tabs-highlight-color: @primary-color;
 @tabs-hover-color: @primary-5;

--- a/components/style/themes/default.less
+++ b/components/style/themes/default.less
@@ -734,13 +734,13 @@
 @tabs-title-font-size-sm: @font-size-base;
 @tabs-ink-bar-color: @primary-color;
 @tabs-bar-margin: 0 0 @margin-md 0;
-@tabs-horizontal-margin: 0 32px 0 0;
+@tabs-horizontal-margin: 0 0 0 32px;
 @tabs-horizontal-margin-rtl: 0 0 0 32px;
 @tabs-horizontal-padding: @padding-sm 0;
 @tabs-horizontal-padding-lg: @padding-md 0;
 @tabs-horizontal-padding-sm: @padding-xs 0;
 @tabs-vertical-padding: @padding-xs @padding-lg;
-@tabs-vertical-margin: 0 0 @margin-md 0;
+@tabs-vertical-margin: @margin-md 0 0 0;
 @tabs-scrolling-size: 32px;
 @tabs-highlight-color: @primary-color;
 @tabs-hover-color: @primary-5;

--- a/components/style/themes/default.less
+++ b/components/style/themes/default.less
@@ -741,7 +741,6 @@
 @tabs-horizontal-padding-lg: @padding-md 0;
 @tabs-horizontal-padding-sm: @padding-xs 0;
 @tabs-vertical-padding: @padding-xs @padding-lg;
-@tabs-vertical-gutter: @margin-md;
 @tabs-vertical-margin: @margin-md 0 0 0;
 @tabs-scrolling-size: 32px;
 @tabs-highlight-color: @primary-color;

--- a/components/style/themes/default.less
+++ b/components/style/themes/default.less
@@ -734,13 +734,15 @@
 @tabs-title-font-size-sm: @font-size-base;
 @tabs-ink-bar-color: @primary-color;
 @tabs-bar-margin: 0 0 @margin-md 0;
-@tabs-horizontal-margin: 0 0 0 32px;
+@tabs-horizontal-margin: 0 32px 0 0;
+@tabs-horizontal-gutter: 0 0 0 32px;
 @tabs-horizontal-margin-rtl: 0 0 0 32px;
 @tabs-horizontal-padding: @padding-sm 0;
 @tabs-horizontal-padding-lg: @padding-md 0;
 @tabs-horizontal-padding-sm: @padding-xs 0;
 @tabs-vertical-padding: @padding-xs @padding-lg;
-@tabs-vertical-margin: @margin-md 0 0 0;
+@tabs-vertical-margin: 0 0 @margin-md 0;
+@tabs-vertical-gutter: @margin-md 0 0 0;
 @tabs-scrolling-size: 32px;
 @tabs-highlight-color: @primary-color;
 @tabs-hover-color: @primary-5;

--- a/components/style/themes/default.less
+++ b/components/style/themes/default.less
@@ -743,7 +743,6 @@
 @tabs-vertical-padding: @padding-xs @padding-lg;
 @tabs-vertical-gutter: @margin-md;
 @tabs-vertical-margin: @margin-md 0 0 0;
-
 @tabs-scrolling-size: 32px;
 @tabs-highlight-color: @primary-color;
 @tabs-hover-color: @primary-5;

--- a/components/tabs/style/card.less
+++ b/components/tabs/style/card.less
@@ -31,6 +31,9 @@
       .@{tab-prefix-cls}-tab:not(:last-of-type) {
         margin-right: @tabs-card-gutter;
       }
+      .@{tab-prefix-cls}-tab:nth-last-child(2) {
+        margin-right: 0;
+      }
     }
   }
 
@@ -66,6 +69,9 @@
     > div > .@{tab-prefix-cls}-nav {
       .@{tab-prefix-cls}-tab:not(:last-of-type) {
         margin-bottom: @tabs-card-gutter;
+      }
+      .@{tab-prefix-cls}-tab:nth-last-child(2) {
+        margin-bottom: 0;
       }
     }
   }

--- a/components/tabs/style/card.less
+++ b/components/tabs/style/card.less
@@ -28,11 +28,8 @@
   &.@{tab-prefix-cls}-bottom {
     > .@{tab-prefix-cls}-nav,
     > div > .@{tab-prefix-cls}-nav {
-      .@{tab-prefix-cls}-tab {
+      .@{tab-prefix-cls}-tab + .@{tab-prefix-cls}-tab {
         margin-left: @tabs-card-gutter;
-      }
-      .@{tab-prefix-cls}-tab:first-of-type {
-        margin-left: 0;
       }
     }
   }

--- a/components/tabs/style/card.less
+++ b/components/tabs/style/card.less
@@ -67,11 +67,8 @@
   &.@{tab-prefix-cls}-right {
     > .@{tab-prefix-cls}-nav,
     > div > .@{tab-prefix-cls}-nav {
-      .@{tab-prefix-cls}-tab {
+      .@{tab-prefix-cls}-tab + .@{tab-prefix-cls}-tab {
         margin-top: @tabs-card-gutter;
-      }
-      .@{tab-prefix-cls}-tab:first-of-type {
-        margin-top: 0;
       }
     }
   }

--- a/components/tabs/style/card.less
+++ b/components/tabs/style/card.less
@@ -28,11 +28,11 @@
   &.@{tab-prefix-cls}-bottom {
     > .@{tab-prefix-cls}-nav,
     > div > .@{tab-prefix-cls}-nav {
-      .@{tab-prefix-cls}-tab:not(:last-of-type) {
-        margin-right: @tabs-card-gutter;
+      .@{tab-prefix-cls}-tab {
+        margin-left: @tabs-card-gutter;
       }
-      .@{tab-prefix-cls}-tab:nth-last-child(2) {
-        margin-right: 0;
+      .@{tab-prefix-cls}-tab:first-of-type {
+        margin-left: 0;
       }
     }
   }
@@ -67,11 +67,11 @@
   &.@{tab-prefix-cls}-right {
     > .@{tab-prefix-cls}-nav,
     > div > .@{tab-prefix-cls}-nav {
-      .@{tab-prefix-cls}-tab:not(:last-of-type) {
-        margin-bottom: @tabs-card-gutter;
+      .@{tab-prefix-cls}-tab {
+        margin-top: @tabs-card-gutter;
       }
-      .@{tab-prefix-cls}-tab:nth-last-child(2) {
-        margin-bottom: 0;
+      .@{tab-prefix-cls}-tab:first-of-type {
+        margin-top: 0;
       }
     }
   }

--- a/components/tabs/style/index.less
+++ b/components/tabs/style/index.less
@@ -196,11 +196,9 @@
     }
   }
 
-  // last child is div.ant-tabs-ink-bar, so it is invalid.
-  // and :last-of-type(and nth-last-child) just valid for HTML Tag(eg: div).
-  &-nav &-tab:nth-last-child(2) {
+  &-nav &-tab:first-of-type {
+    margin-top: 0;
     margin-right: 0;
-    margin-bottom: 0;
     margin-left: 0;
   }
 

--- a/components/tabs/style/index.less
+++ b/components/tabs/style/index.less
@@ -196,7 +196,7 @@
   }
 
   &-tab + &-tab {
-    margin: @tabs-horizontal-margin;
+    margin: @tabs-horizontal-gutter;
   }
 
   // =========================== TabPanes ===========================

--- a/components/tabs/style/index.less
+++ b/components/tabs/style/index.less
@@ -196,7 +196,7 @@
   }
 
   &-tab + &-tab {
-    margin: @tabs-horizontal-gutter;
+    margin: @tabs-horizontal-margin;
   }
 
   // =========================== TabPanes ===========================

--- a/components/tabs/style/index.less
+++ b/components/tabs/style/index.less
@@ -127,7 +127,6 @@
     position: relative;
     display: inline-flex;
     align-items: center;
-    margin: @tabs-horizontal-margin;
     padding: @tabs-horizontal-padding;
     font-size: @tabs-title-font-size;
     background: transparent;
@@ -196,10 +195,8 @@
     }
   }
 
-  &-nav &-tab:first-of-type {
-    margin-top: 0;
-    margin-right: 0;
-    margin-left: 0;
+  &-tab + &-tab {
+    margin: @tabs-horizontal-margin;
   }
 
   // =========================== TabPanes ===========================

--- a/components/tabs/style/index.less
+++ b/components/tabs/style/index.less
@@ -134,12 +134,6 @@
     border: 0;
     outline: none;
     cursor: pointer;
-    // last child is div.ant-tabs-ink-bar, so it is invalid.
-    // and last-of-type(and nth-last-child) is invalid for className(eg: .ant-tabs-tab), just valid for HTML Tag(eg: div).
-    &:nth-last-child(2) {
-      margin-right: 0;
-      margin-left: 0;
-    }
 
     &-btn,
     &-remove {
@@ -200,6 +194,14 @@
     .@{iconfont-css-prefix} {
       margin-right: @margin-sm;
     }
+  }
+
+  // last child is div.ant-tabs-ink-bar, so it is invalid.
+  // and :last-of-type(and nth-last-child) just valid for HTML Tag(eg: div).
+  &-nav &-tab:nth-last-child(2) {
+    margin-right: 0;
+    margin-bottom: 0;
+    margin-left: 0;
   }
 
   // =========================== TabPanes ===========================

--- a/components/tabs/style/index.less
+++ b/components/tabs/style/index.less
@@ -134,8 +134,9 @@
     border: 0;
     outline: none;
     cursor: pointer;
-
-    &:last-of-type {
+    // last child is div.ant-tabs-ink-bar, so it is invalid.
+    // and last-of-type(and nth-last-child) is invalid for className(eg: .ant-tabs-tab), just valid for HTML Tag(eg: div).
+    &:nth-last-child(2) {
       margin-right: 0;
       margin-left: 0;
     }

--- a/components/tabs/style/position.less
+++ b/components/tabs/style/position.less
@@ -99,18 +99,17 @@
 
       // >>>>>>>>>>> Tab
       .@{tab-prefix-cls}-tab {
-        margin: @tabs-vertical-margin;
         padding: @tabs-vertical-padding;
         text-align: center;
-
-        &:last-of-type {
-          margin-bottom: 0;
-        }
 
         &-active .@{tab-prefix-cls}-tab-btn {
           font-weight: normal;
           text-shadow: 0 0 0.25px @tabs-active-color;
         }
+      }
+
+      .@{tab-prefix-cls}-tab + .@{tab-prefix-cls}-tab {
+        margin: @tabs-vertical-margin;
       }
 
       // >>>>>>>>>>> Nav

--- a/components/tabs/style/position.less
+++ b/components/tabs/style/position.less
@@ -109,7 +109,7 @@
       }
 
       .@{tab-prefix-cls}-tab + .@{tab-prefix-cls}-tab {
-        margin: @tabs-vertical-margin;
+        margin: @tabs-vertical-gutter;
       }
 
       // >>>>>>>>>>> Nav

--- a/components/tabs/style/position.less
+++ b/components/tabs/style/position.less
@@ -109,7 +109,7 @@
       }
 
       .@{tab-prefix-cls}-tab + .@{tab-prefix-cls}-tab {
-        margin: @tabs-vertical-gutter;
+        margin: @tabs-vertical-margin;
       }
 
       // >>>>>>>>>>> Nav

--- a/components/tabs/style/rtl.less
+++ b/components/tabs/style/rtl.less
@@ -56,15 +56,10 @@
     &.@{tab-prefix-cls}-bottom {
       > .@{tab-prefix-cls}-nav,
       > div > .@{tab-prefix-cls}-nav {
-        .@{tab-prefix-cls}-tab {
+        .@{tab-prefix-cls}-tab + .@{tab-prefix-cls}-tab {
           .@{tab-prefix-cls}-rtl& {
             margin-right: 0;
             margin-left: @tabs-card-gutter;
-          }
-        }
-        .@{tab-prefix-cls}-tab:first-of-type {
-          .@{tab-prefix-cls}-rtl& {
-            margin-left: 0;
           }
         }
       }

--- a/components/tabs/style/rtl.less
+++ b/components/tabs/style/rtl.less
@@ -56,13 +56,13 @@
     &.@{tab-prefix-cls}-bottom {
       > .@{tab-prefix-cls}-nav,
       > div > .@{tab-prefix-cls}-nav {
-        .@{tab-prefix-cls}-tab:not(:last-of-type) {
+        .@{tab-prefix-cls}-tab {
           .@{tab-prefix-cls}-rtl& {
             margin-right: 0;
             margin-left: @tabs-card-gutter;
           }
         }
-        .@{tab-prefix-cls}-tab:nth-last-child(2) {
+        .@{tab-prefix-cls}-tab:first-of-type {
           .@{tab-prefix-cls}-rtl& {
             margin-left: 0;
           }

--- a/components/tabs/style/rtl.less
+++ b/components/tabs/style/rtl.less
@@ -62,6 +62,11 @@
             margin-left: @tabs-card-gutter;
           }
         }
+        .@{tab-prefix-cls}-tab:nth-last-child(2) {
+          .@{tab-prefix-cls}-rtl& {
+            margin-left: 0;
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
close https://github.com/ant-design/ant-design/issues/29482
<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Tabs `centered` prop is not actually center.  |
| 🇨🇳 Chinese |   修复 Tabs 设置 `centered` 后居中位置有便宜。      |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
