### PR TITLE
fix: bug that scrollToFirstError dont work .#28869

### DIFF
--- a/components/form/ErrorList.tsx
+++ b/components/form/ErrorList.tsx
@@ -86,7 +86,7 @@ export default function ErrorList({
         >
           {memoErrors.map((error, index) => (
             // eslint-disable-next-line react/no-array-index-key
-            <div key={index} role="alert">
+            <div key={index} role="alert" data-scroll="form-item-error-alert">
               {error}
             </div>
           ))}

--- a/components/form/Form.tsx
+++ b/components/form/Form.tsx
@@ -85,7 +85,6 @@ const InternalForm: React.ForwardRefRenderFunction<unknown, FormProps> = (props,
   const [wrapForm] = useForm(form);
   const { __INTERNAL__ } = wrapForm;
   __INTERNAL__.name = name;
-  __INTERNAL__.prefixCls = prefixCls;
 
   const formContextValue = useMemo<FormContextProps>(
     () => ({
@@ -116,7 +115,7 @@ const InternalForm: React.ForwardRefRenderFunction<unknown, FormProps> = (props,
       }
       let errorNode: HTMLElement | null = null;
       if (formRef.current) {
-        errorNode = formRef.current.querySelector(`.${prefixCls}-item-explain-error`);
+        errorNode = formRef.current.querySelector('[data-scroll="form-item-error-alert"]');
       }
       wrapForm.scrollToField(errorNode || errorInfo.errorFields[0].name, defaultScrollToFirstError);
     }

--- a/components/form/FormItemInput.tsx
+++ b/components/form/FormItemInput.tsx
@@ -116,7 +116,7 @@ const FormItemInput: React.FC<FormItemInputProps & FormItemInputMiscProps> = pro
     );
   return (
     <FormContext.Provider value={subFormContext}>
-      <Col {...mergedWrapperCol} className={className}>
+      <Col {...mergedWrapperCol} className={className} data-scroll="form-item">
         {dom}
       </Col>
     </FormContext.Provider>

--- a/components/form/__tests__/index.test.js
+++ b/components/form/__tests__/index.test.js
@@ -190,7 +190,7 @@ describe('Form', () => {
           block: 'start',
         });
 
-        const inputNode = document.querySelector('.ant-form-item-control-input-content');
+        const inputNode = document.querySelector('.ant-form-item-control');
         expect(scrollIntoView).toHaveBeenCalledWith(inputNode, {
           block: 'start',
           scrollMode: 'if-needed',
@@ -238,7 +238,7 @@ describe('Form', () => {
     expect(scrollIntoView).not.toHaveBeenCalled();
     wrapper.find('form').simulate('submit');
     await sleep(50);
-    const inputNode = document.querySelector('.ant-form-item-control-input-content');
+    const inputNode = document.querySelector('.ant-form-item-control');
     expect(scrollIntoView).toHaveBeenCalledWith(inputNode, {
       block: 'center',
       scrollMode: 'if-needed',

--- a/components/form/__tests__/index.test.js
+++ b/components/form/__tests__/index.test.js
@@ -190,7 +190,7 @@ describe('Form', () => {
           block: 'start',
         });
 
-        const inputNode = document.getElementById('scroll_test');
+        const inputNode = document.querySelector('.ant-form-item-control-input-content');
         expect(scrollIntoView).toHaveBeenCalledWith(inputNode, {
           block: 'start',
           scrollMode: 'if-needed',
@@ -238,7 +238,7 @@ describe('Form', () => {
     expect(scrollIntoView).not.toHaveBeenCalled();
     wrapper.find('form').simulate('submit');
     await sleep(50);
-    const inputNode = document.getElementById('test');
+    const inputNode = document.querySelector('.ant-form-item-control-input-content');
     expect(scrollIntoView).toHaveBeenCalledWith(inputNode, {
       block: 'center',
       scrollMode: 'if-needed',

--- a/components/form/hooks/useForm.ts
+++ b/components/form/hooks/useForm.ts
@@ -57,9 +57,9 @@ export default function useForm<Values = any>(form?: FormInstance<Values>): [For
             }
           },
         },
-        scrollToField: (name: string | HTMLElement, options: ScrollOptions = {}) => {
+        scrollToField: (name: InternalNamePath | HTMLElement, options: ScrollOptions = {}) => {
           let node: HTMLElement | null = null;
-          if (typeof name === 'string') {
+          if (Array.isArray(name)) {
             const namePath = toArray(name);
             const fieldId = getFieldId(namePath, wrapForm.__INTERNAL__.name);
             node = fieldId ? document.getElementById(fieldId) : null;

--- a/components/form/hooks/useForm.ts
+++ b/components/form/hooks/useForm.ts
@@ -21,6 +21,21 @@ function toNamePathStr(name: NamePath) {
   return namePath.join('_');
 }
 
+function getFormItemCtrl(node: HTMLElement): HTMLElement {
+  const prefixCls = 'ant-form';
+  let levelCount = 8;
+  let newNode: HTMLElement = node;
+  // find dom that's classname is ant-form-item-control
+  while (levelCount) {
+    newNode = newNode.parentElement as HTMLElement;
+    if (newNode?.className.includes(`${prefixCls}-item-control`)) {
+      break;
+    }
+    levelCount--;
+  }
+  return newNode || node;
+}
+
 export default function useForm<Values = any>(form?: FormInstance<Values>): [FormInstance<Values>] {
   const [rcForm] = useRcForm();
   const itemsRef = React.useRef<Record<string, React.ReactElement>>({});
@@ -45,7 +60,8 @@ export default function useForm<Values = any>(form?: FormInstance<Values>): [For
           const node: HTMLElement | null = fieldId ? document.getElementById(fieldId) : null;
 
           if (node) {
-            scrollIntoView(node, {
+            const newNode = getFormItemCtrl(node);
+            scrollIntoView(newNode, {
               scrollMode: 'if-needed',
               block: 'nearest',
               ...options,

--- a/components/form/hooks/useForm.ts
+++ b/components/form/hooks/useForm.ts
@@ -23,17 +23,20 @@ function toNamePathStr(name: NamePath) {
 
 function getFormItemCtrl(node: HTMLElement): HTMLElement {
   const prefixCls = 'ant-form';
+  let newNode: HTMLElement | null = node.parentElement;
+  let rtNode: HTMLElement | null = null;
   let levelCount = 8;
-  let newNode: HTMLElement = node;
-  // find dom that's classname is ant-form-item-control
-  while (levelCount) {
-    newNode = newNode.parentElement as HTMLElement;
+  do {
+    if (!newNode) return node;
+    // find dom that's classname include ant-form-item-control
     if (newNode?.className.includes(`${prefixCls}-item-control`)) {
+      rtNode = newNode;
       break;
     }
+    newNode = newNode.parentElement;
     levelCount--;
-  }
-  return newNode || node;
+  } while (levelCount);
+  return rtNode || node;
 }
 
 export default function useForm<Values = any>(form?: FormInstance<Values>): [FormInstance<Values>] {

--- a/components/form/hooks/useForm.ts
+++ b/components/form/hooks/useForm.ts
@@ -10,7 +10,6 @@ export interface FormInstance<Values = any> extends RcFormInstance<Values> {
   __INTERNAL__: {
     /** No! Do not use this in your code! */
     name?: string;
-    prefixCls?: string;
     /** No! Do not use this in your code! */
     itemRef: (name: InternalNamePath) => (node: React.ReactElement) => void;
   };
@@ -22,14 +21,14 @@ function toNamePathStr(name: NamePath) {
   return namePath.join('_');
 }
 
-export function getNodeByClass(node: HTMLElement, className: string): HTMLElement {
+export function getNodeByDataScroll(node: HTMLElement, dataScroll: string): HTMLElement {
   let newNode: HTMLElement | null = node.parentElement;
   let rtNode: HTMLElement | null = null;
   let levelCount = 8;
   do {
     if (!newNode) return node;
     // find dom that's classname include ant-form-item-control
-    if (newNode?.className.split(' ').includes(className)) {
+    if (newNode?.dataset?.scroll === dataScroll) {
       rtNode = newNode;
       break;
     }
@@ -68,7 +67,7 @@ export default function useForm<Values = any>(form?: FormInstance<Values>): [For
           }
 
           if (node) {
-            const newNode = getNodeByClass(node, `${wrapForm.__INTERNAL__.prefixCls}-item-control`);
+            const newNode = getNodeByDataScroll(node, 'form-item');
             scrollIntoView(newNode, {
               scrollMode: 'if-needed',
               block: 'nearest',


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

close #28869
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

1. hotfix-#28869
2. bug原因是，error滚动需要定位，定位是以input的id的node作为定位依据的，upload的input是display:none的，scrollIntoView失效，即使block能定位到，实际的input也是在中间的，而不是滚动到upload的图片框子上方，so，直接去定位ant-form-item-control的元素，因为我对antd场景并不是很熟，不确定ant-form-item-control是否都存在，以及添加了不存在的逻辑兼容。--->更改后的，因为如果出现开头元素的增删errorInfo[0]并不准确是第一个，并且组件自由度比较高，注册时从父级去排序好像也很难cover全部场景，所以scrollToFirstError时选择使用有error的dom去定位，只能这样了...


### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |   fix bug that scrollToFirstError dont work when <Form.Item><Upload /></Form.Item> is first children of <\Form></\Form> |
| 🇨🇳 中文 |   处理当upload在form首位时，scrollToFirstError失效的问题       |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
