### PR TITLE
fix: dark mode @text-color-inverse maps to black

### DIFF
--- a/components/style/themes/dark.less
+++ b/components/style/themes/dark.less
@@ -166,7 +166,7 @@
 
 @text-color: fade(@white, 85%);
 @text-color-secondary: fade(@white, 45%);
-@text-color-inverse: @white;
+@text-color-inverse: @black;
 @icon-color-hover: fade(@white, 75%);
 @heading-color: fade(@white, 85%);
 


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [X] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [X] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

https://github.com/ant-design/ant-design/issues/29424

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

Dark mode's @text-color-inverse was mapped to @white instead of @black

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [X] Doc is updated/provided or not needed
- [X] Demo is updated/provided or not needed
- [X] TypeScript definition is updated/provided or not needed
- [X] Changelog is provided or not needed
