### PR TITLE
fix: 修复切换页面 changeConfirmLocale 被清空问题

### DIFF
--- a/components/locale-provider/__tests__/config.test.js
+++ b/components/locale-provider/__tests__/config.test.js
@@ -1,0 +1,73 @@
+import React from 'react';
+
+import { mount } from 'enzyme';
+
+import ConfigProvider from '../../config-provider';
+
+import { Modal } from '../..';
+
+import zhCN from '../zh_CN';
+
+class Demo extends React.Component {
+  static defaultProps = {};
+
+  constructor(props) {
+    super(props);
+    console.log('constructor', props.type);
+  }
+
+  componentDidMount() {
+    if (this.props.type === 'dashboard') {
+      Modal.confirm({ title: 'Hello World!' });
+    }
+    console.log('componentDidMount', this.props.type);
+  }
+
+  componentWillUnmount() {
+    console.log('componentWillUnmount', this.props.type);
+  }
+
+  render() {
+    return <div>{this.props.type}</div>;
+  }
+}
+
+describe('Locale Provider demo', () => {
+  it('change type', () => {
+    jest.useFakeTimers();
+
+    const BasicExample = () => {
+      const [type, setType] = React.useState('');
+      return (
+        <div>
+          <a className="about" onClick={() => setType('about')}>
+            about
+          </a>
+          <a className="dashboard" onClick={() => setType('dashboard')}>
+            dashboard
+          </a>
+          <div>
+            {type === 'about' && (
+              <ConfigProvider locale={zhCN}>
+                <Demo type="about" />
+              </ConfigProvider>
+            )}
+            {type === 'dashboard' && (
+              <ConfigProvider locale={zhCN}>
+                <Demo type="dashboard" />
+              </ConfigProvider>
+            )}
+          </div>
+        </div>
+      );
+    };
+    const wrapper = mount(<BasicExample />);
+    wrapper.find('.about').at(0).simulate('click');
+    jest.runAllTimers();
+    wrapper.find('.dashboard').at(0).simulate('click');
+    jest.runAllTimers();
+    expect(document.body.querySelectorAll('.ant-btn-primary span')[0].textContent).toBe('确 定');
+    Modal.destroyAll();
+    jest.useRealTimers();
+  });
+});

--- a/components/locale-provider/index.tsx
+++ b/components/locale-provider/index.tsx
@@ -53,13 +53,15 @@ export default class LocaleProvider extends React.Component<LocaleProviderProps,
 
   constructor(props: LocaleProviderProps) {
     super(props);
-    changeConfirmLocale(props.locale && props.locale.Modal);
-
     devWarning(
       props._ANT_MARK__ === ANT_MARK,
       'LocaleProvider',
       '`LocaleProvider` is deprecated. Please use `locale` with `ConfigProvider` instead: http://u.ant.design/locale',
     );
+  }
+
+  componentDidMount() {
+    changeConfirmLocale(this.props.locale && this.props.locale.Modal);
   }
 
   componentDidUpdate(prevProps: LocaleProviderProps) {

--- a/components/locale-provider/index.tsx
+++ b/components/locale-provider/index.tsx
@@ -53,6 +53,8 @@ export default class LocaleProvider extends React.Component<LocaleProviderProps,
 
   constructor(props: LocaleProviderProps) {
     super(props);
+    changeConfirmLocale(props.locale && props.locale.Modal);
+
     devWarning(
       props._ANT_MARK__ === ANT_MARK,
       'LocaleProvider',


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Fix ConfigProvider within multiple page switch will lose locale issue.      |
| 🇨🇳 Chinese |    修复多页面使用 ConfigProvider 在切换时，locale 会丢失的问题。      |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
