### PR TITLE
fix: message with prefixCls should not break

### DIFF
--- a/components/config-provider/__tests__/static.test.js
+++ b/components/config-provider/__tests__/static.test.js
@@ -1,0 +1,12 @@
+import ConfigProvider, { globalConfig } from '..';
+
+describe('ConfigProvider.config', () => {
+  it('rootPrefixCls', () => {
+    expect(globalConfig().getRootPrefixCls()).toEqual('ant');
+
+    ConfigProvider.config({
+      prefixCls: 'light',
+    });
+    expect(globalConfig().getRootPrefixCls()).toEqual('light');
+  });
+});

--- a/components/config-provider/index.tsx
+++ b/components/config-provider/index.tsx
@@ -84,7 +84,7 @@ interface ProviderChildrenProps extends ConfigProviderProps {
 }
 
 export const defaultPrefixCls = 'ant';
-let globalPrefixCls = defaultPrefixCls;
+let globalPrefixCls: string;
 
 const setGlobalConfig = (params: Pick<ConfigProviderProps, 'prefixCls'>) => {
   if (params.prefixCls !== undefined) {
@@ -92,10 +92,33 @@ const setGlobalConfig = (params: Pick<ConfigProviderProps, 'prefixCls'>) => {
   }
 };
 
+function getGlobalPrefixCls() {
+  return globalPrefixCls || defaultPrefixCls;
+}
+
 export const globalConfig = () => ({
   getPrefixCls: (suffixCls?: string, customizePrefixCls?: string) => {
     if (customizePrefixCls) return customizePrefixCls;
-    return suffixCls ? `${globalPrefixCls}-${suffixCls}` : globalPrefixCls;
+    return suffixCls ? `${getGlobalPrefixCls()}-${suffixCls}` : getGlobalPrefixCls();
+  },
+  getRootPrefixCls: (rootPrefixCls?: string, customizePrefixCls?: string) => {
+    // Customize rootPrefixCls is first priority
+    if (rootPrefixCls) {
+      return rootPrefixCls;
+    }
+
+    // If Global prefixCls provided, use this
+    if (globalPrefixCls) {
+      return globalPrefixCls;
+    }
+
+    // [Legacy] If customize prefixCls provided, we cut it to get the prefixCls
+    if (customizePrefixCls && customizePrefixCls.includes('-')) {
+      return customizePrefixCls.replace(/^(.*)-[^-]*$/, '$1');
+    }
+
+    // Fallback to default prefixCls
+    return getGlobalPrefixCls();
   },
 });
 

--- a/components/message/__tests__/config.test.js
+++ b/components/message/__tests__/config.test.js
@@ -76,6 +76,25 @@ describe('message.config', () => {
       duration: 3,
     });
   });
+
+  it('customize prefix should auto get transition prefixCls', () => {
+    message.config({
+      prefixCls: 'light-message',
+    });
+
+    message.info('bamboo');
+
+    expect(getInstance().config).toEqual(
+      expect.objectContaining({
+        transitionName: 'light-move-up',
+      }),
+    );
+
+    message.config({
+      prefixCls: '',
+    });
+  });
+
   it('should be able to global config rootPrefixCls', () => {
     ConfigProvider.config({ prefixCls: 'prefix-test' });
     message.info('last');

--- a/components/message/index.tsx
+++ b/components/message/index.tsx
@@ -34,7 +34,6 @@ export interface ConfigOptions {
   top?: number;
   duration?: number;
   prefixCls?: string;
-  rootPrefixCls?: string;
   getContainer?: () => HTMLElement;
   transitionName?: string;
   maxCount?: number;

--- a/components/modal/__tests__/confirm.test.js
+++ b/components/modal/__tests__/confirm.test.js
@@ -2,11 +2,11 @@ import TestUtils, { act } from 'react-dom/test-utils';
 import CSSMotion from 'rc-motion';
 import { genCSSMotion } from 'rc-motion/lib/CSSMotion';
 import KeyCode from 'rc-util/lib/KeyCode';
+import { resetWarned } from 'rc-util/lib/warning';
 import Modal from '..';
 import { destroyFns } from '../Modal';
 import { sleep } from '../../../tests/utils';
 import ConfigProvider from '../../config-provider';
-import { resetWarned } from 'rc-util/lib/warning';
 
 const { confirm } = Modal;
 

--- a/components/modal/__tests__/confirm.test.js
+++ b/components/modal/__tests__/confirm.test.js
@@ -6,6 +6,7 @@ import Modal from '..';
 import { destroyFns } from '../Modal';
 import { sleep } from '../../../tests/utils';
 import ConfigProvider from '../../config-provider';
+import { resetWarned } from 'rc-util/lib/warning';
 
 const { confirm } = Modal;
 
@@ -482,10 +483,17 @@ describe('Modal.confirm triggers callbacks correctly', () => {
   });
 
   it('should be able to config rootPrefixCls', () => {
+    resetWarned();
+
     jest.useFakeTimers();
+
     Modal.config({
       rootPrefixCls: 'my',
     });
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Warning: [antd: Modal] Modal.config is deprecated. Please use ConfigProvider.config instead.',
+    );
+
     confirm({
       title: 'title',
     });

--- a/components/modal/confirm.tsx
+++ b/components/modal/confirm.tsx
@@ -8,6 +8,7 @@ import { getConfirmLocale } from './locale';
 import { ModalFuncProps, destroyFns } from './Modal';
 import ConfirmDialog from './ConfirmDialog';
 import { globalConfig } from '../config-provider';
+import devWarning from '../_util/devWarning';
 
 let defaultRootPrefixCls = '';
 
@@ -159,5 +160,10 @@ export function withConfirm(props: ModalFuncProps): ModalFuncProps {
 }
 
 export function modalGlobalConfig({ rootPrefixCls }: { rootPrefixCls: string }) {
+  devWarning(
+    false,
+    'Modal',
+    'Modal.config is deprecated. Please use ConfigProvider.config instead.',
+  );
   defaultRootPrefixCls = rootPrefixCls;
 }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Fix message.config with `prefixCls` missing enter and leave motion.        |
| 🇨🇳 Chinese |   修复 message.config 配置 `prefixCls` 时丢失淡入淡出动画的问题。        |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
