### PR TITLE
fix: Modal hooks update & destroy

### DIFF
--- a/components/modal/__tests__/hook.test.js
+++ b/components/modal/__tests__/hook.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import CSSMotion from 'rc-motion';
+import { act } from 'react-dom/test-utils';
 import { genCSSMotion } from 'rc-motion/lib/CSSMotion';
 import { mount } from 'enzyme';
 import Modal from '..';
@@ -48,15 +49,19 @@ describe('Modal.hook', () => {
     expect(wrapper.find('.ant-modal-body').length).toBeTruthy();
 
     // Update instance
-    instance.update({
-      content: <div className="updated-content" />,
+    act(() => {
+      instance.update({
+        content: <div className="updated-content" />,
+      });
     });
     wrapper.update();
     expect(wrapper.find('.updated-content')).toHaveLength(1);
 
     // Destroy
-    instance.destroy();
-    jest.runAllTimers();
+    act(() => {
+      instance.destroy();
+      jest.runAllTimers();
+    });
     wrapper.update();
     expect(wrapper.find('Modal')).toHaveLength(0);
 
@@ -99,5 +104,35 @@ describe('Modal.hook', () => {
     wrapper.find('.open-hook-modal-btn').simulate('click');
     wrapper.find('.ant-modal-wrap').simulate('click');
     expect(cancelCount).toEqual(2); // click modal wrapper, trigger onCancel
+  });
+
+  it('update before render', () => {
+    const Demo = () => {
+      const [modal, contextHolder] = Modal.useModal();
+
+      const openBrokenModal = React.useCallback(() => {
+        const instance = modal.info({
+          title: 'Light',
+        });
+
+        instance.update({
+          title: 'Bamboo',
+        });
+      }, [modal]);
+
+      return (
+        <div className="App">
+          {contextHolder}
+          <div className="open-hook-modal-btn" onClick={openBrokenModal}>
+            Test hook modal
+          </div>
+        </div>
+      );
+    };
+
+    const wrapper = mount(<Demo />);
+    wrapper.find('.open-hook-modal-btn').simulate('click');
+
+    expect(wrapper.find('.ant-modal-confirm-title').text()).toEqual('Bamboo');
   });
 });

--- a/components/modal/__tests__/hook.test.js
+++ b/components/modal/__tests__/hook.test.js
@@ -135,4 +135,32 @@ describe('Modal.hook', () => {
 
     expect(wrapper.find('.ant-modal-confirm-title').text()).toEqual('Bamboo');
   });
+
+  it('destroy before render', () => {
+    const Demo = () => {
+      const [modal, contextHolder] = Modal.useModal();
+
+      const openBrokenModal = React.useCallback(() => {
+        const instance = modal.info({
+          title: 'Light',
+        });
+
+        instance.destroy();
+      }, [modal]);
+
+      return (
+        <div className="App">
+          {contextHolder}
+          <div className="open-hook-modal-btn" onClick={openBrokenModal}>
+            Test hook modal
+          </div>
+        </div>
+      );
+    };
+
+    const wrapper = mount(<Demo />);
+    wrapper.find('.open-hook-modal-btn').simulate('click');
+
+    expect(wrapper.exists('.ant-modal-confirm-title')).toBeFalsy();
+  });
 });

--- a/components/modal/useModal/index.tsx
+++ b/components/modal/useModal/index.tsx
@@ -34,6 +34,21 @@ const ElementsHolder = React.memo(
 export default function useModal(): [Omit<ModalStaticFunctions, 'warn'>, React.ReactElement] {
   const holderRef = React.useRef<ElementsHolderRef>(null as any);
 
+  // ========================== Effect ==========================
+  const [actionQueue, setActionQueue] = React.useState<(() => void)[]>([]);
+
+  React.useEffect(() => {
+    if (actionQueue.length) {
+      const cloneQueue = [...actionQueue];
+      cloneQueue.forEach(action => {
+        action();
+      });
+
+      setActionQueue([]);
+    }
+  }, [actionQueue]);
+
+  // =========================== Hook ===========================
   const getConfirmFunc = React.useCallback(
     (withFunc: (config: ModalFuncProps) => ModalFuncProps) =>
       function hookConfirm(config: ModalFuncProps) {
@@ -57,13 +72,25 @@ export default function useModal(): [Omit<ModalStaticFunctions, 'warn'>, React.R
 
         return {
           destroy: () => {
+            function destroyAction() {
+              modalRef.current?.destroy();
+            }
+
             if (modalRef.current) {
-              modalRef.current.destroy();
+              destroyAction();
+            } else {
+              setActionQueue(prev => [...prev, destroyAction]);
             }
           },
           update: (newConfig: ModalFuncProps) => {
+            function updateAction() {
+              modalRef.current?.update(newConfig);
+            }
+
             if (modalRef.current) {
-              modalRef.current.update(newConfig);
+              updateAction();
+            } else {
+              setActionQueue(prev => [...prev, updateAction]);
             }
           },
         };


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

resolve #29441

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Fix Modal with hooks call `update` or `destroy` not work before render.       |
| 🇨🇳 Chinese |   修复 Modal 的 hooks 在渲染前调用 `update` 与 `destroy` 无效的问题。      |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
