### PR TITLE
fix: TimePicker.RangePicker popupClassName not working

### DIFF
--- a/components/time-picker/__tests__/index.test.js
+++ b/components/time-picker/__tests__/index.test.js
@@ -73,6 +73,17 @@ describe('TimePicker', () => {
     expect(wrapper.find('Picker').prop('dropdownClassName')).toEqual(popupClassName);
   });
 
+  it('should pass popupClassName prop to RangePicker as dropdownClassName prop', () => {
+    const popupClassName = 'myCustomClassName';
+    const wrapper = mount(
+      <TimePicker.RangePicker
+        defaultOpenValue={moment('00:00:00', 'HH:mm:ss')}
+        popupClassName={popupClassName}
+      />,
+    );
+    expect(wrapper.find('Picker').prop('dropdownClassName')).toEqual(popupClassName);
+  });
+
   it('should support bordered', () => {
     const wrapper = mount(
       <TimePicker

--- a/components/time-picker/__tests__/index.test.js
+++ b/components/time-picker/__tests__/index.test.js
@@ -81,7 +81,7 @@ describe('TimePicker', () => {
         popupClassName={popupClassName}
       />,
     );
-    expect(wrapper.find('Picker').prop('dropdownClassName')).toEqual(popupClassName);
+    expect(wrapper.find('RangePicker').at(1).prop('dropdownClassName')).toEqual(popupClassName);
   });
 
   it('should support bordered', () => {

--- a/components/time-picker/demo/range-picker.md
+++ b/components/time-picker/demo/range-picker.md
@@ -2,21 +2,19 @@
 order: 13
 title:
   zh-CN: 范围选择器
-  en-US: Range Picker
+  en-US: Time Range Picker
 ---
 
 ## zh-CN
 
-通过 `RangePicker` 使用时间范围选择器。
+通过 `TimePicker.RangePicker` 使用时间范围选择器。
 
 ## en-US
 
-Use time range picker with `RangePicker`.
+Use time range picker with `TimePicker.RangePicker`.
 
 ```jsx
 import { TimePicker } from 'antd';
 
-const { RangePicker } = TimePicker;
-
-ReactDOM.render(<RangePicker />, mountNode);
+ReactDOM.render(<TimePicker.RangePicker />, mountNode);
 ```

--- a/components/time-picker/index.tsx
+++ b/components/time-picker/index.tsx
@@ -12,10 +12,18 @@ export interface TimePickerLocale {
   rangePlaceholder?: [string, string];
 }
 
-export interface TimeRangePickerProps extends Omit<RangePickerTimeProps<Moment>, 'picker'> {}
+export interface TimeRangePickerProps extends Omit<RangePickerTimeProps<Moment>, 'picker'> {
+  popupClassName?: string;
+}
 
 const RangePicker = React.forwardRef<any, TimeRangePickerProps>((props, ref) => (
-  <InternalRangePicker {...props} picker="time" mode={undefined} ref={ref} />
+  <InternalRangePicker
+    {...props}
+    dropdownClassName={props.popupClassName}
+    picker="time"
+    mode={undefined}
+    ref={ref}
+  />
 ));
 
 export interface TimePickerProps extends Omit<PickerTimeProps<Moment>, 'picker'> {


### PR DESCRIPTION


<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close #29583

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix TimePicker.RangePicker `popupClassName` not working.  |
| 🇨🇳 Chinese | 修复 TimePicker.RangePicker `popupClassName` 失效的问题。  |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
