### PR TITLE
fix: Upload `originFileObj` not correct

### DIFF
--- a/components/upload/Upload.tsx
+++ b/components/upload/Upload.tsx
@@ -14,7 +14,7 @@ import {
   UploadType,
   UploadListType,
 } from './interface';
-import { T, wrapFile, getFileItem, removeFileItem } from './utils';
+import { T, wrapFile, getFileItem, removeFileItem, replaceFileList } from './utils';
 import LocaleReceiver from '../locale-provider/LocaleReceiver';
 import defaultLocale from '../locale/default';
 import { ConfigContext } from '../config-provider';
@@ -136,14 +136,7 @@ const InternalUpload: React.ForwardRefRenderFunction<unknown, UploadProps> = (pr
     const targetItem = wrapFile(file);
     targetItem.status = 'uploading';
 
-    const nextFileList = [...mergedFileList];
-
-    const fileIndex = nextFileList.findIndex(({ uid }: UploadFile) => uid === targetItem.uid);
-    if (fileIndex === -1) {
-      nextFileList.push(targetItem);
-    } else {
-      nextFileList[fileIndex] = targetItem;
-    }
+    const nextFileList = replaceFileList(targetItem, mergedFileList);
 
     onInternalChange(targetItem, nextFileList);
   };
@@ -156,37 +149,51 @@ const InternalUpload: React.ForwardRefRenderFunction<unknown, UploadProps> = (pr
     } catch (e) {
       /* do nothing */
     }
-    const targetItem = getFileItem(file, mergedFileList);
+
     // removed
-    if (!targetItem) {
+    if (!getFileItem(file, mergedFileList)) {
       return;
     }
+
+    const targetItem = wrapFile(file);
     targetItem.status = 'done';
     targetItem.response = response;
     targetItem.xhr = xhr;
-    onInternalChange(wrapFile(targetItem), [...mergedFileList]);
+
+    const nextFileList = replaceFileList(targetItem, mergedFileList);
+
+    onInternalChange(targetItem, nextFileList);
   };
 
   const onProgress = (e: { percent: number }, file: UploadFile) => {
-    const targetItem = getFileItem(file, mergedFileList);
     // removed
-    if (!targetItem) {
+    if (!getFileItem(file, mergedFileList)) {
       return;
     }
+
+    const targetItem = wrapFile(file);
+    targetItem.status = 'uploading';
     targetItem.percent = e.percent;
-    onInternalChange(wrapFile(targetItem), [...mergedFileList], e);
+
+    const nextFileList = replaceFileList(targetItem, mergedFileList);
+
+    onInternalChange(targetItem, nextFileList, e);
   };
 
   const onError = (error: Error, response: any, file: UploadFile) => {
-    const targetItem = getFileItem(file, mergedFileList);
     // removed
-    if (!targetItem) {
+    if (!getFileItem(file, mergedFileList)) {
       return;
     }
+
+    const targetItem = wrapFile(file);
     targetItem.error = error;
     targetItem.response = response;
     targetItem.status = 'error';
-    onInternalChange(wrapFile(targetItem), [...mergedFileList]);
+
+    const nextFileList = replaceFileList(targetItem, mergedFileList);
+
+    onInternalChange(targetItem, nextFileList);
   };
 
   const handleRemove = (file: UploadFile) => {

--- a/components/upload/Upload.tsx
+++ b/components/upload/Upload.tsx
@@ -157,6 +157,7 @@ const InternalUpload: React.ForwardRefRenderFunction<unknown, UploadProps> = (pr
 
     const targetItem = wrapFile(file);
     targetItem.status = 'done';
+    targetItem.percent = 100;
     targetItem.response = response;
     targetItem.xhr = xhr;
 

--- a/components/upload/__tests__/uploadlist.test.js
+++ b/components/upload/__tests__/uploadlist.test.js
@@ -1045,14 +1045,18 @@ describe('Upload List', () => {
 
   it('[deprecated] should support transformFile', done => {
     let wrapper;
+    let lastFile;
 
     const handleTransformFile = jest.fn();
     const onChange = ({ file }) => {
       if (file.status === 'done') {
+        expect(file).not.toBe(lastFile);
         expect(handleTransformFile).toHaveBeenCalled();
         wrapper.unmount();
         done();
       }
+
+      lastFile = file;
     };
     wrapper = mount(
       <Upload

--- a/components/upload/utils.tsx
+++ b/components/upload/utils.tsx
@@ -57,6 +57,17 @@ export function wrapFile(file: RcFile | UploadFile): UploadFile {
   } as UploadFile;
 }
 
+export function replaceFileList(file: UploadFile<any>, fileList: UploadFile<any>[]) {
+  const nextFileList = [...fileList];
+  const fileIndex = nextFileList.findIndex(({ uid }: UploadFile) => uid === file.uid);
+  if (fileIndex === -1) {
+    nextFileList.push(file);
+  } else {
+    nextFileList[fileIndex] = file;
+  }
+  return nextFileList;
+}
+
 export function getFileItem(file: UploadFile, fileList: UploadFile[]) {
   const matchKey = file.uid !== undefined ? 'uid' : 'name';
   return fileList.filter(item => item[matchKey] === file[matchKey])[0];


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fix Upload `onChange` param of `file.originFileObj` return nest Proxy object.         |
| 🇨🇳 Chinese |     修复 Upload `onChange` 参数 `file.originFileObj` 返回嵌套 Proxy 对象的问题。       |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
