### PR TITLE
feat: add onCancel and onEnd option for editable

### DIFF
--- a/components/typography/Base.tsx
+++ b/components/typography/Base.tsx
@@ -37,6 +37,8 @@ interface EditConfig {
   tooltip?: boolean | React.ReactNode;
   onStart?: () => void;
   onChange?: (value: string) => void;
+  onCancel?: () => void;
+  onEnd?: () => void;
   maxLength?: number;
   autoSize?: boolean | AutoSizeType;
 }
@@ -210,6 +212,7 @@ class Base extends React.Component<InternalBlockProps, BaseState> {
   };
 
   onEditCancel = () => {
+    this.getEditable().onCancel?.();
     this.triggerEdit(false);
   };
 
@@ -416,12 +419,13 @@ class Base extends React.Component<InternalBlockProps, BaseState> {
   renderEditInput() {
     const { children, className, style } = this.props;
     const { direction } = this.context;
-    const { maxLength, autoSize } = this.getEditable();
+    const { maxLength, autoSize, onEnd = () => {} } = this.getEditable();
     return (
       <Editable
         value={typeof children === 'string' ? children : ''}
         onSave={this.onEditChange}
         onCancel={this.onEditCancel}
+        onEnd={onEnd}
         prefixCls={this.getPrefixCls()}
         className={className}
         style={style}

--- a/components/typography/Base.tsx
+++ b/components/typography/Base.tsx
@@ -419,7 +419,7 @@ class Base extends React.Component<InternalBlockProps, BaseState> {
   renderEditInput() {
     const { children, className, style } = this.props;
     const { direction } = this.context;
-    const { maxLength, autoSize, onEnd = () => {} } = this.getEditable();
+    const { maxLength, autoSize, onEnd } = this.getEditable();
     return (
       <Editable
         value={typeof children === 'string' ? children : ''}

--- a/components/typography/Editable.tsx
+++ b/components/typography/Editable.tsx
@@ -12,6 +12,7 @@ interface EditableProps {
   ['aria-label']?: string;
   onSave: (value: string) => void;
   onCancel: () => void;
+  onEnd?: () => void;
   className?: string;
   style?: React.CSSProperties;
   direction?: DirectionType;
@@ -30,6 +31,7 @@ const Editable: React.FC<EditableProps> = ({
   value,
   onSave,
   onCancel,
+  onEnd,
 }) => {
   const ref = React.useRef<any>();
 
@@ -92,6 +94,7 @@ const Editable: React.FC<EditableProps> = ({
     ) {
       if (keyCode === KeyCode.ENTER) {
         confirmChange();
+        onEnd?.();
       } else if (keyCode === KeyCode.ESC) {
         onCancel();
       }

--- a/components/typography/__tests__/index.test.js
+++ b/components/typography/__tests__/index.test.js
@@ -469,6 +469,24 @@ describe('Typography', () => {
       testStep({ name: 'customize edit hide tooltip', tooltip: false });
       testStep({ name: 'customize edit tooltip text', tooltip: 'click to edit text' });
 
+      it('should trigger onEnd when type Enter', () => {
+        const onEnd = jest.fn();
+        const wrapper = mount(<Paragraph editable={{ onEnd }}>Bamboo</Paragraph>);
+        wrapper.find('.ant-typography-edit').first().simulate('click');
+        wrapper.find('textarea').simulate('keyDown', { keyCode: KeyCode.ENTER });
+        wrapper.find('textarea').simulate('keyUp', { keyCode: KeyCode.ENTER });
+        expect(onEnd).toHaveBeenCalledTimes(1);
+      });
+
+      it('should trigger onCancel when type ESC', () => {
+        const onCancel = jest.fn();
+        const wrapper = mount(<Paragraph editable={{ onCancel }}>Bamboo</Paragraph>);
+        wrapper.find('.ant-typography-edit').first().simulate('click');
+        wrapper.find('textarea').simulate('keyDown', { keyCode: KeyCode.ESC });
+        wrapper.find('textarea').simulate('keyUp', { keyCode: KeyCode.ESC });
+        expect(onCancel).toHaveBeenCalledTimes(1);
+      });
+
       it('should only trigger focus on the first time', () => {
         let triggerTimes = 0;
         const mockFocus = spyElementPrototype(HTMLElement, 'focus', () => {

--- a/components/typography/index.en-US.md
+++ b/components/typography/index.en-US.md
@@ -90,6 +90,8 @@ Basic text writing, including headings, body text, lists, and more.
       autoSize: boolean | { minRows: number, maxRows: number },
       onStart: function,
       onChange: function(string),
+      onCancel: function,
+      onEnd: function,
     }
 
 | Property | Description | Type | Default | Version |
@@ -101,6 +103,8 @@ Basic text writing, including headings, body text, lists, and more.
 | tooltip | Custom tooltip text, hide when it is false | boolean \| ReactNode | `Edit` | 4.6.0 |
 | onChange | Called when input at textarea | function(event) | - |  |
 | onStart | Called when enter editable state | function | - |  |
+| onCancel | Called when type ESC to exit editable state | function | - |  |
+| onEnd | Called when type ENTER to exit editable state | function | - |  |
 
 ### ellipsis
 

--- a/components/typography/index.zh-CN.md
+++ b/components/typography/index.zh-CN.md
@@ -90,6 +90,8 @@ cover: https://gw.alipayobjects.com/zos/alicdn/GOM1KQ24O/Typography.svg
       autoSize: boolean | { minRows: number, maxRows: number },
       onStart: function,
       onChange: function(string),
+      onCancel: function,
+      onEnd: function,
     }
 
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
@@ -101,6 +103,8 @@ cover: https://gw.alipayobjects.com/zos/alicdn/GOM1KQ24O/Typography.svg
 | tooltip | 自定义提示文本，为 false 时关闭 | boolean \| ReactNode | `编辑` | 4.6.0 |
 | onChange | 文本域编辑时触发 | function(event) | - |  |
 | onStart | 进入编辑中状态时触发 | function | - |  |
+| onCancel | 按 ESC 退出编辑状态时触发 | function | - |  |
+| onEnd | 按 ENTER 结束编辑状态时触发 | function | - |  |
 
 ### ellipsis
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->
close https://github.com/ant-design/ant-design/issues/29371
### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Typography `editable` 新增 `onCancel` 和 `onEnd` 回调。 |
| 🇨🇳 Chinese | Typography `editable` supports `onCancel` and `onEnd`.  |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
