### PR TITLE
fix: onChange should always return proxy file

### DIFF
--- a/components/upload/Upload.tsx
+++ b/components/upload/Upload.tsx
@@ -129,7 +129,7 @@ const InternalUpload: React.ForwardRefRenderFunction<unknown, UploadProps> = (pr
       }
     });
 
-    onInternalChange(filteredFileInfoList[0]?.file, newFileList);
+    onInternalChange(objectFileList[0], newFileList);
   };
 
   const onStart = (file: RcFile) => {

--- a/components/upload/__tests__/upload.test.js
+++ b/components/upload/__tests__/upload.test.js
@@ -635,12 +635,12 @@ describe('Upload', () => {
 
         switch (callTimes) {
           case 1:
+            expect(e.file.originFileObj).toBeTruthy();
             expect(file.status).toBe(undefined);
             break;
 
           case 2:
           case 3:
-            console.log('===>', file.status);
             expect(file).toEqual(expect.objectContaining({ status: 'uploading', percent: 0 }));
             break;
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

ref https://github.com/ant-design/ant-design/pull/29614#issuecomment-790766086

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fix Upload `onChange` sometime return origin File object instead of Proxy.         |
| 🇨🇳 Chinese |   Fix Upload `onChange` 有时返回原始文件而不是 Proxy 对象的问题。       |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
