### PR TITLE
fix: Description full width

### DIFF
--- a/components/table/style/index.less
+++ b/components/table/style/index.less
@@ -497,8 +497,13 @@
     }
 
     // https://github.com/ant-design/ant-design/issues/25573
-    .@{descriptions-prefix-cls}-view table {
-      width: auto;
+    .@{descriptions-prefix-cls}-view {
+      display: flex;
+
+      table {
+        flex: auto;
+        width: auto;
+      }
     }
   }
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

ref #25573

### 💡 Background and solution

云凤蝶侧反馈 Description 在 Table 下长度不全，看了一下历史是因为和 `max-content` 冲突。用 flex 来顶出 100% 宽度。

reproduce：
https://codesandbox.io/s/jibenyongfa-antd4130-forked-el0tt

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fix Description under Table will not have 100% width.         |
| 🇨🇳 Chinese |   修复 Description 在 Table 下没有 100% 宽度的问题。       |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
