### PR TITLE
feat: add parent class for different notification types

### DIFF
--- a/components/notification/__tests__/index.test.js
+++ b/components/notification/__tests__/index.test.js
@@ -143,6 +143,24 @@ describe('notification', () => {
     await Promise.all(promises);
   });
 
+  it('should be able to add parent class for different notification types', async () => {
+    const openNotificationWithIcon = async type => {
+      notification[type]({
+        message: 'Notification Title',
+        duration: 0,
+        description: 'This is the content of the notification.',
+      });
+      await Promise.resolve();
+      expect(document.querySelectorAll(`.ant-notification-notice-${type}`).length).toBe(1);
+    };
+
+    const promises = ['success', 'info', 'warning', 'error'].map(type =>
+      openNotificationWithIcon(type),
+    );
+
+    await Promise.all(promises);
+  });
+
   it('trigger onClick', () => {
     notification.open({
       message: 'Notification Title',

--- a/components/notification/index.tsx
+++ b/components/notification/index.tsx
@@ -189,19 +189,33 @@ export interface ArgsProps {
 }
 
 function getRCNoticeProps(args: ArgsProps, prefixCls: string) {
-  const duration = args.duration === undefined ? defaultDuration : args.duration;
+  const {
+    duration: durationArg,
+    icon,
+    type,
+    description,
+    message,
+    btn,
+    onClose,
+    onClick,
+    key,
+    style,
+    className,
+  } = args;
+
+  const duration = durationArg === undefined ? defaultDuration : durationArg;
 
   let iconNode: React.ReactNode = null;
-  if (args.icon) {
+  if (icon) {
     iconNode = <span className={`${prefixCls}-icon`}>{args.icon}</span>;
-  } else if (args.type) {
-    iconNode = React.createElement(typeToIcon[args.type] || null, {
-      className: `${prefixCls}-icon ${prefixCls}-icon-${args.type}`,
+  } else if (type) {
+    iconNode = React.createElement(typeToIcon[type] || null, {
+      className: `${prefixCls}-icon ${prefixCls}-icon-${type}`,
     });
   }
 
   const autoMarginTag =
-    !args.description && iconNode ? (
+    !description && iconNode ? (
       <span className={`${prefixCls}-message-single-line-auto-margin`} />
     ) : null;
 
@@ -211,19 +225,21 @@ function getRCNoticeProps(args: ArgsProps, prefixCls: string) {
         {iconNode}
         <div className={`${prefixCls}-message`}>
           {autoMarginTag}
-          {args.message}
+          {message}
         </div>
-        <div className={`${prefixCls}-description`}>{args.description}</div>
-        {args.btn ? <span className={`${prefixCls}-btn`}>{args.btn}</span> : null}
+        <div className={`${prefixCls}-description`}>{description}</div>
+        {btn ? <span className={`${prefixCls}-btn`}>{btn}</span> : null}
       </div>
     ),
     duration,
     closable: true,
-    onClose: args.onClose,
-    onClick: args.onClick,
-    key: args.key,
-    style: args.style || {},
-    className: args.className,
+    onClose,
+    onClick,
+    key,
+    style: style || {},
+    className: classNames(className, {
+      [`${prefixCls}-${type}`]: type != null,
+    }),
   };
 }
 

--- a/components/notification/index.tsx
+++ b/components/notification/index.tsx
@@ -238,7 +238,7 @@ function getRCNoticeProps(args: ArgsProps, prefixCls: string) {
     key,
     style: style || {},
     className: classNames(className, {
-      [`${prefixCls}-${type}`]: type != null,
+      [`${prefixCls}-${type}`]: !!type,
     }),
   };
 }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->
[Notification-add parent class for different variants](https://github.com/ant-design/ant-design/issues/29417)

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

A new proposal/feature to add parent class for different notification types

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   add parent class for different notification types  |
| 🇨🇳 Chinese |  为不同的notification类型添加相应默认类名  |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
