### PR TITLE
fix: affix Input disabled hover style

### DIFF
--- a/components/input/style/affix.less
+++ b/components/input/style/affix.less
@@ -8,7 +8,7 @@
     .input();
     display: inline-flex;
 
-    &:hover {
+    &:not(&-disabled):hover {
       .hover();
       z-index: 1;
       .@{ant-prefix}-input-search-with-button & {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution
https://ant.design/components/input-cn/#components-input-demo-presuffix

#### disabled hover 颜色错误

![image](https://user-images.githubusercontent.com/29775873/110419677-c5823900-80d4-11eb-8dd4-781ecd39a854.png)


<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fixed the error style where the `disabled` Input has affix elements.         |
| 🇨🇳 Chinese | 修复 Input 组件配置附件元素时禁用样式异常的问题。            |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
