### PR TITLE
fix: Lodash can clone FileProxy

### DIFF
--- a/components/upload/__tests__/upload.test.js
+++ b/components/upload/__tests__/upload.test.js
@@ -133,7 +133,7 @@ describe('Upload', () => {
     });
   });
 
-  it('should not stop upload when return value of beforeUpload is false', done => {
+  it.only('should not stop upload when return value of beforeUpload is false', done => {
     const fileList = [
       {
         uid: 'bar',

--- a/components/upload/__tests__/upload.test.js
+++ b/components/upload/__tests__/upload.test.js
@@ -810,9 +810,10 @@ describe('Upload', () => {
     await sleep();
 
     const { file } = onChange.mock.calls[0][0];
-    const keys = new Set(Object.keys(cloneDeep(file)));
+    const clone = cloneDeep(file);
+
     ['uid', 'name', 'lastModified', 'lastModifiedDate', 'size', 'type'].forEach(key => {
-      expect(keys.has(key)).toBeTruthy();
+      expect(key in clone).toBeTruthy();
     });
   });
 });

--- a/components/upload/__tests__/upload.test.js
+++ b/components/upload/__tests__/upload.test.js
@@ -133,7 +133,7 @@ describe('Upload', () => {
     });
   });
 
-  it.only('should not stop upload when return value of beforeUpload is false', done => {
+  it('should not stop upload when return value of beforeUpload is false', done => {
     const fileList = [
       {
         uid: 'bar',

--- a/components/upload/__tests__/upload.test.js
+++ b/components/upload/__tests__/upload.test.js
@@ -812,6 +812,10 @@ describe('Upload', () => {
     const { file } = onChange.mock.calls[0][0];
     const clone = cloneDeep(file);
 
+    expect(Object.getOwnPropertyDescriptor(file, 'name')).toEqual(
+      expect.objectContaining({ value: 'foo.png' }),
+    );
+
     ['uid', 'name', 'lastModified', 'lastModifiedDate', 'size', 'type'].forEach(key => {
       expect(key in clone).toBeTruthy();
     });

--- a/components/upload/__tests__/upload.test.js
+++ b/components/upload/__tests__/upload.test.js
@@ -3,6 +3,7 @@ import React from 'react';
 import { mount } from 'enzyme';
 import { act } from 'react-dom/test-utils';
 import produce from 'immer';
+import { cloneDeep } from 'lodash';
 import Upload from '..';
 import Form from '../../form';
 import { T, wrapFile, getFileItem, removeFileItem } from '../utils';
@@ -785,5 +786,33 @@ describe('Upload', () => {
     );
 
     expect(fileList[0].uid).toBeTruthy();
+  });
+
+  it('Proxy should support deepClone', async () => {
+    const onChange = jest.fn();
+
+    const wrapper = mount(
+      <Upload onChange={onChange}>
+        <button type="button">upload</button>
+      </Upload>,
+    );
+
+    wrapper.find('input').simulate('change', {
+      target: {
+        files: [
+          new File(['foo'], 'foo.png', {
+            type: 'image/png',
+          }),
+        ],
+      },
+    });
+
+    await sleep();
+
+    const { file } = onChange.mock.calls[0][0];
+    const keys = new Set(Object.keys(cloneDeep(file)));
+    ['uid', 'name', 'lastModified', 'lastModifiedDate', 'size', 'type'].forEach(key => {
+      expect(keys.has(key)).toBeTruthy();
+    });
   });
 });

--- a/components/upload/demo/basic.md
+++ b/components/upload/demo/basic.md
@@ -3,7 +3,6 @@ order: 0
 title:
   zh-CN: 点击上传
   en-US: Upload by clicking
-only: true
 ---
 
 ## zh-CN
@@ -17,7 +16,6 @@ Classic mode. File selection dialog pops up when upload button is clicked.
 ```jsx
 import { Upload, message, Button } from 'antd';
 import { UploadOutlined } from '@ant-design/icons';
-import { cloneDeep } from 'lodash';
 
 const props = {
   name: 'file',
@@ -26,9 +24,6 @@ const props = {
     authorization: 'authorization-text',
   },
   onChange(info) {
-    window.file = info.file;
-    window.cloneDeep = cloneDeep;
-
     if (info.file.status !== 'uploading') {
       console.log(info.file, info.fileList);
     }

--- a/components/upload/demo/basic.md
+++ b/components/upload/demo/basic.md
@@ -3,6 +3,7 @@ order: 0
 title:
   zh-CN: 点击上传
   en-US: Upload by clicking
+only: true
 ---
 
 ## zh-CN
@@ -16,6 +17,7 @@ Classic mode. File selection dialog pops up when upload button is clicked.
 ```jsx
 import { Upload, message, Button } from 'antd';
 import { UploadOutlined } from '@ant-design/icons';
+import { cloneDeep } from 'lodash';
 
 const props = {
   name: 'file',
@@ -24,6 +26,9 @@ const props = {
     authorization: 'authorization-text',
   },
   onChange(info) {
+    window.file = info.file;
+    window.cloneDeep = cloneDeep;
+
     if (info.file.status !== 'uploading') {
       console.log(info.file, info.fileList);
     }

--- a/components/upload/utils.tsx
+++ b/components/upload/utils.tsx
@@ -26,12 +26,12 @@ export function wrapFile(file: WrapFile): UploadFile {
   if (typeof Proxy !== 'undefined') {
     const data = new Map<string | symbol, any>(Object.entries(filledProps));
 
-    function getValue(key: string | symbol) {
+    const getValue = (key: string | symbol) => {
       if (data.has(key)) {
         return data.get(key);
       }
       return (file as any)[key];
-    }
+    };
 
     return new Proxy(file, {
       get(_, key) {

--- a/components/upload/utils.tsx
+++ b/components/upload/utils.tsx
@@ -61,6 +61,8 @@ export function wrapFile(file: WrapFile): UploadFile {
 
         [...fileProtoKeys, 'size', 'type'].forEach(key => {
           Object.defineProperty(ProxyFile.prototype, key, {
+            // Get will never reach but we provide fallback here
+            /* istanbul ignore next */
             get: () => getValue(key),
           });
         });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

resolve #29646

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fix Upload `onChange` params `file` can not `cloneDeep` by lodash.         |
| 🇨🇳 Chinese |    修复 Upload `onChange` 参数 `file` 不能被 lodash `cloneDeep` 的问题。      |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
