### PR TITLE
fix: PageHeader tabs remove padding setting

### DIFF
--- a/components/page-header/style/index.less
+++ b/components/page-header/style/index.less
@@ -111,7 +111,6 @@
       }
 
       .@{ant-prefix}-tabs-tab {
-        padding: @tabs-horizontal-padding-sm;
         font-size: @page-header-tabs-tab-font-size;
       }
     }

--- a/components/page-header/style/index.less
+++ b/components/page-header/style/index.less
@@ -111,6 +111,8 @@
       }
 
       .@{ant-prefix}-tabs-tab {
+        padding-top: @padding-xs;
+        padding-bottom: @padding-xs;
         font-size: @page-header-tabs-tab-font-size;
       }
     }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [x] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

PageHeader 组件下 tabs 为 卡片类型时左右的 padding 会被覆盖。
![image](https://user-images.githubusercontent.com/4705237/111732808-5a451d80-88b1-11eb-83e3-325a870689cc.png)

修复为只改变 padding-top 和 padding-bottom ，不要覆盖 padding-left和right
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
