### PR TITLE
refactor:rewrite input with hook

### DIFF
--- a/components/cascader/index.tsx
+++ b/components/cascader/index.tsx
@@ -10,7 +10,8 @@ import RightOutlined from '@ant-design/icons/RightOutlined';
 import RedoOutlined from '@ant-design/icons/RedoOutlined';
 import LeftOutlined from '@ant-design/icons/LeftOutlined';
 
-import Input from '../input';
+import Input, { InputRef } from '../input';
+
 import {
   ConfigConsumer,
   ConfigConsumerProps,
@@ -287,7 +288,7 @@ class Cascader extends React.Component<CascaderProps, CascaderState> {
 
   clearSelectionTimeout: any;
 
-  private input: Input;
+  private input: InputRef;
 
   constructor(props: CascaderProps) {
     super(props);
@@ -329,7 +330,7 @@ class Cascader extends React.Component<CascaderProps, CascaderState> {
     return displayRender(label, selectedOptions);
   }
 
-  saveInput = (node: Input) => {
+  saveInput = (node: InputRef) => {
     this.input = node;
   };
 
@@ -599,7 +600,7 @@ class Cascader extends React.Component<CascaderProps, CascaderState> {
         // The default value of `matchInputWidth` is `true`
         const resultListMatchInputWidth = (showSearch as ShowSearchType).matchInputWidth !== false;
         if (resultListMatchInputWidth && (state.inputValue || isNotFound) && this.input) {
-          dropdownMenuColumnStyle.width = this.input.input.offsetWidth;
+          dropdownMenuColumnStyle.width = this.input?.input?.offsetWidth;
         }
 
         let inputIcon: React.ReactNode;

--- a/components/input/Search.tsx
+++ b/components/input/Search.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import classNames from 'classnames';
 import { composeRef } from 'rc-util/lib/ref';
 import SearchOutlined from '@ant-design/icons/SearchOutlined';
-import Input, { InputProps } from './Input';
+import Input, { InputRef, InputProps } from './Input';
 import Button from '../button';
 import SizeContext from '../config-provider/SizeContext';
 import { ConfigContext } from '../config-provider';
@@ -21,7 +21,7 @@ export interface SearchProps extends InputProps {
   loading?: boolean;
 }
 
-const Search = React.forwardRef<Input, SearchProps>((props, ref) => {
+const Search = React.forwardRef<InputRef, SearchProps>((props, ref) => {
   const {
     prefixCls: customizePrefixCls,
     inputPrefixCls: customizeInputPrefixCls,
@@ -42,7 +42,7 @@ const Search = React.forwardRef<Input, SearchProps>((props, ref) => {
 
   const size = customizeSize || contextSize;
 
-  const inputRef = React.useRef<Input>(null);
+  const inputRef = React.useRef<InputRef>(null);
 
   const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (e && e.target && e.type === 'click' && customOnSearch) {
@@ -61,7 +61,7 @@ const Search = React.forwardRef<Input, SearchProps>((props, ref) => {
 
   const onSearch = (e: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLInputElement>) => {
     if (customOnSearch) {
-      customOnSearch(inputRef.current?.input.value!, e);
+      customOnSearch(inputRef.current?.input?.value!, e);
     }
   };
 
@@ -129,7 +129,7 @@ const Search = React.forwardRef<Input, SearchProps>((props, ref) => {
 
   return (
     <Input
-      ref={composeRef<Input>(inputRef, ref)}
+      ref={composeRef<InputRef>(inputRef, ref)}
       onPressEnter={onSearch}
       {...restProps}
       size={size}

--- a/components/input/TextArea.tsx
+++ b/components/input/TextArea.tsx
@@ -4,7 +4,7 @@ import ResizableTextArea from 'rc-textarea/lib/ResizableTextArea';
 import omit from 'rc-util/lib/omit';
 import classNames from 'classnames';
 import useMergedState from 'rc-util/lib/hooks/useMergedState';
-import ClearableLabeledInput from './ClearableLabeledInput';
+import ClearableLabeledInput, { ClearableLabeledInputRef } from './ClearableLabeledInput';
 import { ConfigContext } from '../config-provider';
 import { fixControlledValue, resolveOnChange, triggerFocus, InputFocusOptions } from './Input';
 import SizeContext, { SizeType } from '../config-provider/SizeContext';
@@ -44,7 +44,7 @@ const TextArea = React.forwardRef<TextAreaRef, TextAreaProps>(
     const size = React.useContext(SizeContext);
 
     const innerRef = React.useRef<RcTextArea>(null);
-    const clearableInputRef = React.useRef<ClearableLabeledInput>(null);
+    const clearableInputRef = React.useRef<ClearableLabeledInputRef>(null);
 
     const [value, setValue] = useMergedState(props.defaultValue, {
       value: props.value,

--- a/components/input/__tests__/Password.test.js
+++ b/components/input/__tests__/Password.test.js
@@ -88,10 +88,10 @@ describe('Input.Password', () => {
       .simulate('change', { target: { value: 'value' } });
     await sleep();
     expect(wrapper.find('input').at('0').getDOMNode().getAttribute('value')).toBeFalsy();
-    wrapper.find('input').at('0').simulate('blur');
+    wrapper.find('input').at('0').simulate('focus');
     await sleep();
     expect(wrapper.find('input').at('0').getDOMNode().getAttribute('value')).toBeFalsy();
-    wrapper.find('input').at('0').simulate('focus');
+    wrapper.find('input').at('0').simulate('blur');
     await sleep();
     expect(wrapper.find('input').at('0').getDOMNode().getAttribute('value')).toBeFalsy();
   });

--- a/components/input/__tests__/focus.test.tsx
+++ b/components/input/__tests__/focus.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import { spyElementPrototypes } from 'rc-util/lib/test/domHook';
-import Input from '..';
+import Input, { InputRef } from '..';
 
 const { TextArea } = Input;
 
@@ -30,7 +30,7 @@ describe('Input.Focus', () => {
   });
 
   it('start', () => {
-    const ref = React.createRef<Input>();
+    const ref = React.createRef<InputRef>();
     mount(<Input ref={ref} defaultValue="light" />);
     ref.current!.focus({ cursor: 'start' });
 
@@ -39,7 +39,7 @@ describe('Input.Focus', () => {
   });
 
   it('end', () => {
-    const ref = React.createRef<Input>();
+    const ref = React.createRef<InputRef>();
     mount(<Input ref={ref} defaultValue="light" />);
     ref.current!.focus({ cursor: 'end' });
 

--- a/components/input/__tests__/index.test.js
+++ b/components/input/__tests__/index.test.js
@@ -18,7 +18,7 @@ describe('Input', () => {
     errorSpy.mockRestore();
   });
 
-  focusTest(Input);
+  focusTest(Input, { refFocus: true });
   mountTest(Input);
   mountTest(Input.Group);
 
@@ -31,8 +31,9 @@ describe('Input', () => {
   });
 
   it('select()', () => {
-    const wrapper = mount(<Input />);
-    wrapper.instance().select();
+    const ref = React.createRef();
+    mount(<Input ref={ref} />);
+    ref.current.select();
   });
 
   it('should support size', () => {
@@ -76,12 +77,13 @@ describe('Input', () => {
   });
 
   it('set mouse cursor position', () => {
+    const ref = React.createRef();
     const defaultValue = '11111';
     const valLength = defaultValue.length;
-    const wrapper = mount(<Input autoFocus defaultValue={defaultValue} />);
-    wrapper.instance().setSelectionRange(valLength, valLength);
-    expect(wrapper.instance().input.selectionStart).toEqual(5);
-    expect(wrapper.instance().input.selectionEnd).toEqual(5);
+    mount(<Input autoFocus defaultValue={defaultValue} ref={ref} />);
+    ref.current.setSelectionRange(valLength, valLength);
+    expect(ref.current.input.selectionStart).toEqual(5);
+    expect(ref.current.input.selectionEnd).toEqual(5);
   });
 });
 

--- a/components/input/index.tsx
+++ b/components/input/index.tsx
@@ -4,7 +4,7 @@ import Search from './Search';
 import TextArea from './TextArea';
 import Password from './Password';
 
-export { InputProps } from './Input';
+export { InputProps, InputRef } from './Input';
 export { GroupProps } from './Group';
 export { SearchProps } from './Search';
 export { TextAreaProps } from './TextArea';


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 重构

### 💡 需求背景和解决方案
将Input组件和ClearableLabeledInput组件重构为函数式组件。


### 📝 更新日志
Input组件上暴露的属性和方法保留了`input`, `clearableInput`, `blur`, `focus`, `select`, `setSelectionRange`。
`renderComponent`,`handleKeyDown`,`handleChange`,`clearPasswordValueAttribute`,`renderInput`, `handleReset`, `setValue`,`onBlur`,`onFocus`没有暴露出来。
修改了测试用例。
- 以前通过instance()调用的改到了在ref上调用。
- 修改了password上focus和blur的调用顺序。

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |          |
| 🇨🇳 中文 |          |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供