### PR TITLE
feat: Apply ConfigProvider componentSize on Tabs component

### DIFF
--- a/components/config-provider/__tests__/__snapshots__/components.test.js.snap
+++ b/components/config-provider/__tests__/__snapshots__/components.test.js.snap
@@ -24435,7 +24435,7 @@ exports[`ConfigProvider components Tabs configProvider 1`] = `
 
 exports[`ConfigProvider components Tabs configProvider componentSize large 1`] = `
 <div
-  class="config-tabs config-tabs-top"
+  class="config-tabs config-tabs-top config-tabs-large"
 >
   <div
     class="config-tabs-nav"
@@ -24520,7 +24520,7 @@ exports[`ConfigProvider components Tabs configProvider componentSize large 1`] =
 
 exports[`ConfigProvider components Tabs configProvider componentSize middle 1`] = `
 <div
-  class="config-tabs config-tabs-top"
+  class="config-tabs config-tabs-top config-tabs-middle"
 >
   <div
     class="config-tabs-nav"

--- a/components/config-provider/demo/size.md
+++ b/components/config-provider/demo/size.md
@@ -25,7 +25,10 @@ import {
   Divider,
   Table,
   Card,
+  Tabs,
 } from 'antd';
+
+const { TabPane } = Tabs;
 
 const FormSizeDemo = () => {
   const [componentSize, setComponentSize] = useState('small');
@@ -45,6 +48,19 @@ const FormSizeDemo = () => {
       <ConfigProvider componentSize={componentSize}>
         <div className="example">
           <Input />
+        </div>
+        <div className="example">
+          <Tabs defaultActiveKey="1">
+            <TabPane tab="Tab 1" key="1">
+              Content of Tab Pane 1
+            </TabPane>
+            <TabPane tab="Tab 2" key="2">
+              Content of Tab Pane 2
+            </TabPane>
+            <TabPane tab="Tab 3" key="3">
+              Content of Tab Pane 3
+            </TabPane>
+          </Tabs>
         </div>
         <div className="example">
           <Input.Search allowClear />

--- a/components/tabs/index.tsx
+++ b/components/tabs/index.tsx
@@ -8,7 +8,7 @@ import CloseOutlined from '@ant-design/icons/CloseOutlined';
 
 import devWarning from '../_util/devWarning';
 import { ConfigContext } from '../config-provider';
-import { SizeType } from '../config-provider/SizeContext';
+import SizeContext, { SizeType } from '../config-provider/SizeContext';
 
 export type TabsType = 'line' | 'card' | 'editable-card';
 export type TabsPosition = 'top' | 'right' | 'bottom' | 'left';
@@ -24,11 +24,17 @@ export interface TabsProps extends Omit<RcTabsProps, 'editable'> {
   onEdit?: (e: React.MouseEvent | React.KeyboardEvent | string, action: 'add' | 'remove') => void;
 }
 
-function Tabs({ type, className, size, onEdit, hideAdd, centered, addIcon, ...props }: TabsProps) {
-  const { 
-    prefixCls: customizePrefixCls,
-    moreIcon = <EllipsisOutlined />,
-  } = props;
+function Tabs({
+  type,
+  className,
+  size: propSize,
+  onEdit,
+  hideAdd,
+  centered,
+  addIcon,
+  ...props
+}: TabsProps) {
+  const { prefixCls: customizePrefixCls, moreIcon = <EllipsisOutlined /> } = props;
   const { getPrefixCls, direction } = React.useContext(ConfigContext);
   const prefixCls = getPrefixCls('tabs', customizePrefixCls);
 
@@ -52,23 +58,30 @@ function Tabs({ type, className, size, onEdit, hideAdd, centered, addIcon, ...pr
   );
 
   return (
-    <RcTabs
-      direction={direction}
-      moreTransitionName={`${rootPrefixCls}-slide-up`}
-      {...props}
-      className={classNames(
-        {
-          [`${prefixCls}-${size}`]: size,
-          [`${prefixCls}-card`]: ['card', 'editable-card'].includes(type as string),
-          [`${prefixCls}-editable-card`]: type === 'editable-card',
-          [`${prefixCls}-centered`]: centered,
-        },
-        className,
-      )}
-      editable={editable}
-      moreIcon={moreIcon}
-      prefixCls={prefixCls}
-    />
+    <SizeContext.Consumer>
+      {contextSize => {
+        const size = propSize !== undefined ? propSize : contextSize;
+        return (
+          <RcTabs
+            direction={direction}
+            moreTransitionName={`${rootPrefixCls}-slide-up`}
+            {...props}
+            className={classNames(
+              {
+                [`${prefixCls}-${size}`]: size,
+                [`${prefixCls}-card`]: ['card', 'editable-card'].includes(type as string),
+                [`${prefixCls}-editable-card`]: type === 'editable-card',
+                [`${prefixCls}-centered`]: centered,
+              },
+              className,
+            )}
+            editable={editable}
+            moreIcon={moreIcon}
+            prefixCls={prefixCls}
+          />
+        );
+      }}
+    </SizeContext.Consumer>
   );
 }
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

https://github.com/ant-design/ant-design/issues/28549

### 💡 Background and solution

I have encapsulated the tabs component implementation into a SizeContext.Consumer. This allows to get the size defined in a ConfigProvider. If the size is already provided as props it takes precedence over the one coming from the config provider.

I have updated the demo for the config provider size section to show how the Tabs behaves when changing ConfigProvider size setting.

It could be a breaking change for users that are using Tabs but don't specify a size. Tabs could change size. Despite that, I think it makes sense that Tabs follows the ConfigProvider size preference.

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Apply ConfigProvider componentSize on Tabs component        |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
