### PR TITLE
fix: align TextArea `maxLength` logic

### DIFF
--- a/components/input/Input.tsx
+++ b/components/input/Input.tsx
@@ -65,24 +65,40 @@ export function resolveOnChange(
   target: HTMLInputElement | HTMLTextAreaElement,
   e:
     | React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>
-    | React.MouseEvent<HTMLElement, MouseEvent>,
-  onChange?: (event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void,
+    | React.MouseEvent<HTMLElement, MouseEvent>
+    | React.CompositionEvent<HTMLElement>,
+  onChange:
+    | undefined
+    | ((event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void),
+  targetValue?: string,
 ) {
   if (!onChange) {
     return;
   }
   let event = e;
+  const originalInputValue = target.value;
+
   if (e.type === 'click') {
     // click clear icon
     event = Object.create(e);
     event.target = target;
     event.currentTarget = target;
-    const originalInputValue = target.value;
     // change target ref value cause e.target.value should be '' when clear input
     target.value = '';
     onChange(event as React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>);
     // reset target ref value
     target.value = originalInputValue;
+    return;
+  }
+
+  // Trigger by composition event, this means we need force change the input value
+  if (targetValue !== undefined) {
+    event = Object.create(e);
+    event.target = target;
+    event.currentTarget = target;
+
+    target.value = targetValue;
+    onChange(event as React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>);
     return;
   }
   onChange(event as React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>);

--- a/components/input/TextArea.tsx
+++ b/components/input/TextArea.tsx
@@ -140,7 +140,7 @@ const TextArea = React.forwardRef<TextAreaRef, TextAreaProps>(
 
     let val = fixControlledValue(value) as string;
 
-    if (!compositing && hasMaxLength && props.value === null && props.value === undefined) {
+    if (!compositing && hasMaxLength && (props.value === null || props.value === undefined)) {
       // fix #27612 将value转为数组进行截取，解决 '😂'.length === 2 等emoji表情导致的截取乱码的问题
       val = fixEmojiLength(val, maxLength!);
     }

--- a/components/input/TextArea.tsx
+++ b/components/input/TextArea.tsx
@@ -82,8 +82,6 @@ const TextArea = React.forwardRef<TextAreaRef, TextAreaProps>(
         triggerValue = fixEmojiLength(triggerValue, maxLength!);
       }
 
-      console.log('composition', triggerValue, value);
-
       // Patch composition onChange when value changed
       if (triggerValue !== value) {
         handleSetValue(triggerValue);
@@ -139,7 +137,7 @@ const TextArea = React.forwardRef<TextAreaRef, TextAreaProps>(
 
     let val = fixControlledValue(value) as string;
 
-    if (!compositing && hasMaxLength) {
+    if (!compositing && hasMaxLength && props.value === null && props.value === undefined) {
       // fix #27612 将value转为数组进行截取，解决 '😂'.length === 2 等emoji表情导致的截取乱码的问题
       val = fixEmojiLength(val, maxLength!);
     }
@@ -161,7 +159,7 @@ const TextArea = React.forwardRef<TextAreaRef, TextAreaProps>(
 
     // Only show text area wrapper when needed
     if (showCount) {
-      const valueLength = Math.min(val.length, maxLength ?? Infinity);
+      const valueLength = [...val].length;
 
       let dataCount = '';
       if (typeof showCount === 'object') {

--- a/components/input/TextArea.tsx
+++ b/components/input/TextArea.tsx
@@ -70,8 +70,9 @@ const TextArea = React.forwardRef<TextAreaRef, TextAreaProps>(
     // Max length value
     const hasMaxLength = Number(maxLength) > 0;
 
-    const onInternalCompositionStart: React.CompositionEventHandler = () => {
+    const onInternalCompositionStart: React.CompositionEventHandler<HTMLTextAreaElement> = e => {
       setCompositing(true);
+      onCompositionStart?.(e);
     };
 
     const onInternalCompositionEnd: React.CompositionEventHandler<HTMLTextAreaElement> = e => {
@@ -87,6 +88,8 @@ const TextArea = React.forwardRef<TextAreaRef, TextAreaProps>(
         handleSetValue(triggerValue);
         resolveOnChange(innerRef.current as any, e, onChange, triggerValue);
       }
+
+      onCompositionEnd?.(e);
     };
 
     const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {

--- a/components/input/TextArea.tsx
+++ b/components/input/TextArea.tsx
@@ -13,6 +13,10 @@ interface ShowCountProps {
   formatter: (args: { count: number; maxLength?: number }) => string;
 }
 
+function fixEmojiLength(value: string, maxLength: number) {
+  return [...(value || '')].slice(0, maxLength).join('');
+}
+
 export interface TextAreaProps extends RcTextAreaProps {
   allowClear?: boolean;
   bordered?: boolean;
@@ -36,6 +40,9 @@ const TextArea = React.forwardRef<TextAreaRef, TextAreaProps>(
       className,
       style,
       size: customizeSize,
+      onCompositionStart,
+      onCompositionEnd,
+      onChange,
       ...props
     },
     ref,
@@ -46,18 +53,11 @@ const TextArea = React.forwardRef<TextAreaRef, TextAreaProps>(
     const innerRef = React.useRef<RcTextArea>(null);
     const clearableInputRef = React.useRef<ClearableLabeledInput>(null);
 
+    const [compositing, setCompositing] = React.useState(false);
+
     const [value, setValue] = useMergedState(props.defaultValue, {
       value: props.value,
     });
-
-    const prevValue = React.useRef(props.value);
-
-    React.useEffect(() => {
-      if (props.value !== undefined || prevValue.current !== props.value) {
-        setValue(props.value);
-        prevValue.current = props.value;
-      }
-    }, [props.value, prevValue.current]);
 
     const handleSetValue = (val: string, callback?: () => void) => {
       if (props.value === undefined) {
@@ -66,16 +66,47 @@ const TextArea = React.forwardRef<TextAreaRef, TextAreaProps>(
       }
     };
 
-    const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-      handleSetValue(e.target.value);
-      resolveOnChange(innerRef.current as any, e, props.onChange);
+    // =========================== Value Update ===========================
+    // Max length value
+    const hasMaxLength = Number(maxLength) > 0;
+
+    const onInternalCompositionStart: React.CompositionEventHandler = () => {
+      setCompositing(true);
     };
 
+    const onInternalCompositionEnd: React.CompositionEventHandler<HTMLTextAreaElement> = e => {
+      setCompositing(false);
+
+      let triggerValue = e.currentTarget.value;
+      if (hasMaxLength) {
+        triggerValue = fixEmojiLength(triggerValue, maxLength!);
+      }
+
+      console.log('composition', triggerValue, value);
+
+      // Patch composition onChange when value changed
+      if (triggerValue !== value) {
+        handleSetValue(triggerValue);
+        resolveOnChange(innerRef.current as any, e, onChange, triggerValue);
+      }
+    };
+
+    const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+      let triggerValue = e.target.value;
+      if (!compositing && hasMaxLength) {
+        triggerValue = fixEmojiLength(triggerValue, maxLength!);
+      }
+
+      handleSetValue(triggerValue);
+      resolveOnChange(innerRef.current as any, e, onChange);
+    };
+
+    // ============================== Reset ===============================
     const handleReset = (e: React.MouseEvent<HTMLElement, MouseEvent>) => {
       handleSetValue('', () => {
         innerRef.current?.focus();
       });
-      resolveOnChange(innerRef.current as any, e, props.onChange);
+      resolveOnChange(innerRef.current as any, e, onChange);
     };
 
     const prefixCls = getPrefixCls('input', customizePrefixCls);
@@ -91,7 +122,6 @@ const TextArea = React.forwardRef<TextAreaRef, TextAreaProps>(
     const textArea = (
       <RcTextArea
         {...omit(props, ['allowClear'])}
-        maxLength={maxLength}
         className={classNames({
           [`${prefixCls}-borderless`]: !bordered,
           [className!]: className && !showCount,
@@ -100,17 +130,19 @@ const TextArea = React.forwardRef<TextAreaRef, TextAreaProps>(
         })}
         style={showCount ? undefined : style}
         prefixCls={prefixCls}
+        onCompositionStart={onInternalCompositionStart}
         onChange={handleChange}
+        onCompositionEnd={onInternalCompositionEnd}
         ref={innerRef}
       />
     );
 
     let val = fixControlledValue(value) as string;
 
-    // Max length value
-    const hasMaxLength = Number(maxLength) > 0;
-    // fix #27612 将value转为数组进行截取，解决 '😂'.length === 2 等emoji表情导致的截取乱码的问题
-    val = hasMaxLength ? [...val].slice(0, maxLength).join('') : val;
+    if (!compositing && hasMaxLength) {
+      // fix #27612 将value转为数组进行截取，解决 '😂'.length === 2 等emoji表情导致的截取乱码的问题
+      val = fixEmojiLength(val, maxLength!);
+    }
 
     // TextArea
     const textareaNode = (

--- a/components/input/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/input/__tests__/__snapshots__/demo.test.js.snap
@@ -3153,7 +3153,6 @@ exports[`renders ./components/input/demo/textarea-show-count.md correctly 1`] = 
 >
   <textarea
     class="ant-input"
-    maxlength="100"
   />
 </div>
 `;

--- a/components/input/__tests__/__snapshots__/textarea.test.js.snap
+++ b/components/input/__tests__/__snapshots__/textarea.test.js.snap
@@ -242,17 +242,16 @@ exports[`TextArea allowClear should not show icon if value is undefined, null or
 </span>
 `;
 
+exports[`TextArea maxLength should support maxLength 1`] = `
+<textarea
+  class="ant-input"
+/>
+`;
+
 exports[`TextArea should support disabled 1`] = `
 <textarea
   class="ant-input ant-input-disabled"
   disabled=""
-/>
-`;
-
-exports[`TextArea should support maxLength 1`] = `
-<textarea
-  class="ant-input"
-  maxlength="10"
 />
 `;
 

--- a/components/input/__tests__/textarea.test.js
+++ b/components/input/__tests__/textarea.test.js
@@ -79,6 +79,11 @@ describe('TextArea', () => {
     expect(wrapper.render()).toMatchSnapshot();
   });
 
+  it('maxLength should not block control', () => {
+    const wrapper = mount(<TextArea maxLength={1} value="light" />);
+    expect(wrapper.find('textarea').props().value).toEqual('light');
+  });
+
   it('when prop value not in this.props, resizeTextarea should be called', async () => {
     const ref = React.createRef();
     const wrapper = mount(<TextArea aria-label="textarea" ref={ref} />);
@@ -144,7 +149,7 @@ describe('TextArea', () => {
       expect(textarea.prop('data-count')).toBe('5 / 5');
     });
 
-    it('should  minimize value between emoji length and maxLength', () => {
+    it('should minimize value between emoji length and maxLength', () => {
       const wrapper = mount(<TextArea maxLength={1} showCount value="👀" />);
       const textarea = wrapper.find('.ant-input-textarea');
       expect(wrapper.find('textarea').prop('value')).toBe('👀');

--- a/components/input/__tests__/textarea.test.js
+++ b/components/input/__tests__/textarea.test.js
@@ -172,25 +172,32 @@ describe('TextArea', () => {
       expect(textarea.prop('data-count')).toBe('8 / 5');
     });
 
-    it('should minimize value between emoji length and maxLength', () => {
-      const wrapper = mount(<TextArea maxLength={1} showCount value="👀" />);
-      const textarea = wrapper.find('.ant-input-textarea');
-      expect(wrapper.find('textarea').prop('value')).toBe('👀');
-      expect(textarea.prop('data-count')).toBe('1 / 1');
+    describe('emoji', () => {
+      it('should minimize value between emoji length and maxLength', () => {
+        const wrapper = mount(<TextArea maxLength={1} showCount value="👀" />);
+        const textarea = wrapper.find('.ant-input-textarea');
+        expect(wrapper.find('textarea').prop('value')).toBe('👀');
+        expect(textarea.prop('data-count')).toBe('1 / 1');
 
-      // fix: 当 maxLength 长度为 2 的时候，输入 emoji 之后 showCount 会显示 1/2，但是不能再输入了
-      // zombieJ: 逻辑统一了，emoji 现在也可以正确计数了
-      const wrapper1 = mount(<TextArea maxLength={2} showCount value="👀" />);
-      const textarea1 = wrapper1.find('.ant-input-textarea');
-      expect(textarea1.prop('data-count')).toBe('1 / 2');
-    });
+        // fix: 当 maxLength 长度为 2 的时候，输入 emoji 之后 showCount 会显示 1/2，但是不能再输入了
+        // zombieJ: 逻辑统一了，emoji 现在也可以正确计数了
+        const wrapper1 = mount(<TextArea maxLength={2} showCount value="👀" />);
+        const textarea1 = wrapper1.find('.ant-input-textarea');
+        expect(textarea1.prop('data-count')).toBe('1 / 2');
+      });
 
-    // 修改TextArea value截取规则后新增单测
-    it('slice emoji', () => {
-      const wrapper = mount(<TextArea maxLength={5} showCount value="1234😂" />);
-      const textarea = wrapper.find('.ant-input-textarea');
-      expect(wrapper.find('textarea').prop('value')).toBe('1234😂');
-      expect(textarea.prop('data-count')).toBe('5 / 5');
+      it('defaultValue should slice', () => {
+        const wrapper = mount(<TextArea maxLength={1} defaultValue="🧐cut" />);
+        expect(wrapper.find('textarea').prop('value')).toBe('🧐');
+      });
+
+      // 修改TextArea value截取规则后新增单测
+      it('slice emoji', () => {
+        const wrapper = mount(<TextArea maxLength={5} showCount value="1234😂" />);
+        const textarea = wrapper.find('.ant-input-textarea');
+        expect(wrapper.find('textarea').prop('value')).toBe('1234😂');
+        expect(textarea.prop('data-count')).toBe('5 / 5');
+      });
     });
 
     it('className & style patch to outer', () => {

--- a/components/input/__tests__/textarea.test.js
+++ b/components/input/__tests__/textarea.test.js
@@ -84,6 +84,20 @@ describe('TextArea', () => {
       const wrapper = mount(<TextArea maxLength={1} value="light" />);
       expect(wrapper.find('textarea').props().value).toEqual('light');
     });
+
+    it('should exceed maxLength when use IME', () => {
+      const onChange = jest.fn();
+
+      const wrapper = mount(<TextArea maxLength={1} onChange={onChange} />);
+      wrapper.find('textarea').simulate('compositionStart');
+      wrapper.find('textarea').simulate('change', { target: { value: 'zhu' } });
+      wrapper.find('textarea').simulate('compositionEnd', { currentTarget: { value: '竹' } });
+      wrapper.find('textarea').simulate('change', { target: { value: '竹' } });
+
+      expect(onChange).toHaveBeenLastCalledWith(
+        expect.objectContaining({ target: expect.objectContaining({ value: '竹' }) }),
+      );
+    });
   });
 
   it('when prop value not in this.props, resizeTextarea should be called', async () => {

--- a/components/input/__tests__/textarea.test.js
+++ b/components/input/__tests__/textarea.test.js
@@ -74,14 +74,16 @@ describe('TextArea', () => {
     expect(wrapper.render()).toMatchSnapshot();
   });
 
-  it('should support maxLength', () => {
-    const wrapper = mount(<TextArea maxLength={10} />);
-    expect(wrapper.render()).toMatchSnapshot();
-  });
+  describe('maxLength', () => {
+    it('should support maxLength', () => {
+      const wrapper = mount(<TextArea maxLength={10} />);
+      expect(wrapper.render()).toMatchSnapshot();
+    });
 
-  it('maxLength should not block control', () => {
-    const wrapper = mount(<TextArea maxLength={1} value="light" />);
-    expect(wrapper.find('textarea').props().value).toEqual('light');
+    it('maxLength should not block control', () => {
+      const wrapper = mount(<TextArea maxLength={1} value="light" />);
+      expect(wrapper.find('textarea').props().value).toEqual('light');
+    });
   });
 
   it('when prop value not in this.props, resizeTextarea should be called', async () => {
@@ -143,10 +145,17 @@ describe('TextArea', () => {
 
   describe('should support showCount', () => {
     it('maxLength', () => {
-      const wrapper = mount(<TextArea maxLength={5} showCount value="12345678" />);
+      const wrapper = mount(<TextArea maxLength={5} showCount value="12345" />);
       const textarea = wrapper.find('.ant-input-textarea');
       expect(wrapper.find('textarea').prop('value')).toBe('12345');
       expect(textarea.prop('data-count')).toBe('5 / 5');
+    });
+
+    it('control exceed maxLength', () => {
+      const wrapper = mount(<TextArea maxLength={5} showCount value="12345678" />);
+      const textarea = wrapper.find('.ant-input-textarea');
+      expect(wrapper.find('textarea').prop('value')).toBe('12345678');
+      expect(textarea.prop('data-count')).toBe('8 / 5');
     });
 
     it('should minimize value between emoji length and maxLength', () => {
@@ -156,9 +165,10 @@ describe('TextArea', () => {
       expect(textarea.prop('data-count')).toBe('1 / 1');
 
       // fix: 当 maxLength 长度为 2 的时候，输入 emoji 之后 showCount 会显示 1/2，但是不能再输入了
+      // zombieJ: 逻辑统一了，emoji 现在也可以正确计数了
       const wrapper1 = mount(<TextArea maxLength={2} showCount value="👀" />);
       const textarea1 = wrapper1.find('.ant-input-textarea');
-      expect(textarea1.prop('data-count')).toBe('2 / 2');
+      expect(textarea1.prop('data-count')).toBe('1 / 2');
     });
 
     // 修改TextArea value截取规则后新增单测
@@ -188,7 +198,7 @@ describe('TextArea', () => {
         <TextArea
           maxLength={5}
           showCount={{ formatter: ({ count, maxLength }) => `${count}, ${maxLength}` }}
-          value="12345678"
+          value="12345"
         />,
       );
       const textarea = wrapper.find('.ant-input-textarea');

--- a/components/input/demo/textarea-show-count.md
+++ b/components/input/demo/textarea-show-count.md
@@ -18,5 +18,9 @@ import { Input } from 'antd';
 
 const { TextArea } = Input;
 
-ReactDOM.render(<TextArea showCount maxLength={100} />, mountNode);
+const onChange = e => {
+  console.log('Change:', e.target.value);
+};
+
+ReactDOM.render(<TextArea showCount maxLength={10} onChange={onChange} />, mountNode);
 ```

--- a/components/input/demo/textarea-show-count.md
+++ b/components/input/demo/textarea-show-count.md
@@ -22,5 +22,5 @@ const onChange = e => {
   console.log('Change:', e.target.value);
 };
 
-ReactDOM.render(<TextArea showCount maxLength={10} onChange={onChange} />, mountNode);
+ReactDOM.render(<TextArea showCount maxLength={100} onChange={onChange} />, mountNode);
 ```

--- a/components/input/index.en-US.md
+++ b/components/input/index.en-US.md
@@ -103,3 +103,7 @@ const suffix = condition ? <Icon type="smile" /> : <span />;
 
 <Input suffix={suffix} />;
 ```
+
+### Why TextArea in control can make `value` exceed `maxLength`?
+
+When in control, component should show as what it set to avoid submit value not align with store value in Form.

--- a/components/input/index.zh-CN.md
+++ b/components/input/index.zh-CN.md
@@ -105,3 +105,7 @@ const suffix = condition ? <Icon type="smile" /> : <span />;
 
 <Input suffix={suffix} />;
 ```
+
+### 为何 TextArea 受控时，`value` 可以超过 `maxLength`？
+
+受控时，组件应该按照受控内容展示。以防止在表单组件内使用时显示值和提交值不同的问题。


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

fix #28940
ref #29057
close #29066

### 💡 Background and solution

基本都是因为这个 `maxLength` 导致的，现在改成模拟原生元素逻辑。

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Fix TextArea display value will be cut by `maxLength` when in controlled. Fix `onCompositionEnd` not trigger when input exceed `maxLength`. Fix emoji count not align with `maxLength` & `showCount`.          |
| 🇨🇳 Chinese |   修复 TextArea 受控时展示值会被 `maxLength` 截取的问题；修复 `maxLength` 下超出部分无法触发 `onCompositionEnd` 事件的问题；修复使用 emoji 时 `maxLength` 和 `showCount` 计数逻辑不一致的问题。        |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
