### PR TITLE
feat: table 组件 rowSelection 添加 defaultSelectedRowKeys 属性

### DIFF
--- a/components/table/__tests__/Table.rowSelection.test.js
+++ b/components/table/__tests__/Table.rowSelection.test.js
@@ -66,6 +66,22 @@ describe('Table.rowSelection', () => {
       .filter(key => key !== null);
   }
 
+  it('select default row', () => {
+    const wrapper = mount(createTable({ rowSelection: { defaultSelectedRowKeys: [0] } }));
+    const checkboxes = wrapper.find('input');
+
+    expect(getSelections(wrapper)).toEqual([0]);
+
+    checkboxes.at(1).simulate('change', { target: { checked: false } });
+    expect(getSelections(wrapper)).toEqual([]);
+
+    checkboxes.at(0).simulate('change', { target: { checked: true } });
+    expect(getSelections(wrapper)).toEqual([0, 1, 2, 3]);
+
+    checkboxes.at(0).simulate('change', { target: { checked: false } });
+    expect(getSelections(wrapper)).toEqual([]);
+  });
+
   it('select by checkbox', () => {
     const wrapper = mount(createTable());
     const checkboxes = wrapper.find('input');

--- a/components/table/hooks/useSelection.tsx
+++ b/components/table/hooks/useSelection.tsx
@@ -79,6 +79,7 @@ export default function useSelection<RecordType>(
   const {
     preserveSelectedRowKeys,
     selectedRowKeys,
+    defaultSelectedRowKeys,
     getCheckboxProps,
     onChange: onSelectionChange,
     onSelect,
@@ -112,9 +113,12 @@ export default function useSelection<RecordType>(
   const preserveRecordsRef = React.useRef(new Map<Key, RecordType>());
 
   // ========================= Keys =========================
-  const [mergedSelectedKeys, setMergedSelectedKeys] = useMergedState(selectedRowKeys || [], {
-    value: selectedRowKeys,
-  });
+  const [mergedSelectedKeys, setMergedSelectedKeys] = useMergedState(
+    selectedRowKeys || defaultSelectedRowKeys || [],
+    {
+      value: selectedRowKeys,
+    },
+  );
 
   const { keyEntities } = useMemo(
     () =>

--- a/components/table/index.zh-CN.md
+++ b/components/table/index.zh-CN.md
@@ -155,9 +155,9 @@ const columns = [
 
 ### ColumnGroup
 
-| 参数 | 说明 | 类型 | 默认值 |
-| --- | --- | --- | --- |
-| title | 列头显示文字 | ReactNode | - |
+| 参数  | 说明         | 类型      | 默认值 |
+| ----- | ------------ | --------- | ------ |
+| title | 列头显示文字 | ReactNode | -      |
 
 ### pagination
 
@@ -205,6 +205,7 @@ const columns = [
 | preserveSelectedRowKeys | 当数据被删除时仍然保留选项的 `key` | boolean | - | 4.4.0 |
 | renderCell | 渲染勾选框，用法与 Column 的 `render` 相同 | function(checked, record, index, originNode) {} | - | 4.1.0 |
 | selectedRowKeys | 指定选中项的 key 数组，需要和 onChange 进行配合 | string\[] \| number\[] | \[] |  |
+| defaultSelectedRowKeys | 默认选中项的 key 数组 | string\[] \| number\[] | \[] |  |
 | selections | 自定义选择项 [配置项](#selection), 设为 `true` 时使用默认选择项 | object\[] \| boolean | true |  |
 | type | 多选/单选 | `checkbox` \| `radio` | `checkbox` |  |
 | onChange | 选中项发生变化时的回调 | function(selectedRowKeys, selectedRows) | - |  |
@@ -223,11 +224,11 @@ const columns = [
 
 ### selection
 
-| 参数 | 说明 | 类型 | 默认值 |
-| --- | --- | --- | --- |
-| key | React 需要的 key，建议设置 | string | - |
-| text | 选择项显示的文字 | ReactNode | - |
-| onSelect | 选择项点击回调 | function(changeableRowKeys) | - |
+| 参数     | 说明                       | 类型                        | 默认值 |
+| -------- | -------------------------- | --------------------------- | ------ |
+| key      | React 需要的 key，建议设置 | string                      | -      |
+| text     | 选择项显示的文字           | ReactNode                   | -      |
+| onSelect | 选择项点击回调             | function(changeableRowKeys) | -      |
 
 ## 在 TypeScript 中使用
 

--- a/components/table/interface.tsx
+++ b/components/table/interface.tsx
@@ -143,6 +143,7 @@ export interface TableRowSelection<T> {
   preserveSelectedRowKeys?: boolean;
   type?: RowSelectionType;
   selectedRowKeys?: Key[];
+  defaultSelectedRowKeys?: Key[];
   onChange?: (selectedRowKeys: Key[], selectedRows: T[]) => void;
   getCheckboxProps?: (record: T) => Partial<Omit<CheckboxProps, 'checked' | 'defaultChecked'>>;
   onSelect?: SelectionSelectFn<T>;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->
### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

`defaultSelectedRowKeys` 属性可以让用户在不触碰 state 的情况下定义 table 组件 rowSelection 中的默认选中行。

### 📝 Changelog
<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Table now supports `rowSelection.defaultSelectedRowKeys`. |
| 🇨🇳 Chinese | Table 新增 `rowSelection.defaultSelectedRowKeys` 支持。  |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
