### PR TITLE
chore: fix typo `initTreeDate` -> `initTreeData`

### DIFF
--- a/components/tree/demo/dynamic.md
+++ b/components/tree/demo/dynamic.md
@@ -24,7 +24,7 @@ interface DataNode {
   children?: DataNode[];
 }
 
-const initTreeDate: DataNode[] = [
+const initTreeData: DataNode[] = [
   { title: 'Expand to load', key: '0' },
   { title: 'Expand to load', key: '1' },
   { title: 'Tree Node', key: '2', isLeaf: true },
@@ -50,7 +50,7 @@ function updateTreeData(list: DataNode[], key: React.Key, children: DataNode[]):
 }
 
 const Demo: React.FC<{}> = () => {
-  const [treeData, setTreeData] = useState(initTreeDate);
+  const [treeData, setTreeData] = useState(initTreeData);
 
   function onLoadData({ key, children }: any) {
     return new Promise<void>(resolve => {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [X] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

Rename `initTreeDate` to `initTreeData` in demo as it was probably a typo.

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Rename `initTreeDate` to `initTreeData` in demo as it was probably a typo.      |
| 🇨🇳 Chinese |     在演示中将“ initTreeDate”重命名为“ initTreeData”，因为这可能是拼写错误。     |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [X] Doc is updated/provided or not needed
- [X] Demo is updated/provided or not needed
- [X] TypeScript definition is updated/provided or not needed
- [X] Changelog is provided or not needed
