### PR TITLE
feat: allow data and aria props to input, button, checkbox, notification

### DIFF
--- a/components/button/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/button/__tests__/__snapshots__/index.test.tsx.snap
@@ -292,6 +292,19 @@ exports[`Button should render empty button without errors 1`] = `
 />
 `;
 
+exports[`Button should support data-*、aria-* and custom attribute 1`] = `
+<button
+  aria-hidden="true"
+  class="ant-btn"
+  data-text="123"
+  type="button"
+>
+  <span>
+    Test
+  </span>
+</button>
+`;
+
 exports[`Button should support link button 1`] = `
 <a
   class="ant-btn"

--- a/components/button/__tests__/index.test.tsx
+++ b/components/button/__tests__/index.test.tsx
@@ -300,4 +300,13 @@ describe('Button', () => {
       },
     });
   });
+
+  it('should support data-*、aria-* and custom attribute', () => {
+    const wrapper = mount(
+      <Button data-text="123" aria-hidden="true">
+        Test
+      </Button>,
+    );
+    expect(wrapper.render()).toMatchSnapshot();
+  });
 });

--- a/components/button/button.tsx
+++ b/components/button/button.tsx
@@ -11,7 +11,6 @@ import devWarning from '../_util/devWarning';
 import SizeContext, { SizeType } from '../config-provider/SizeContext';
 import LoadingIcon from './LoadingIcon';
 import { cloneElement } from '../_util/reactNode';
-import getDataOrAriaProps from '../_util/getDataOrAriaProps';
 
 const rxTwoCNChar = /^[\u4e00-\u9fa5]{2}$/;
 const isTwoCNChar = rxTwoCNChar.test.bind(rxTwoCNChar);
@@ -270,7 +269,6 @@ const InternalButton: React.ForwardRefRenderFunction<unknown, ButtonProps> = (pr
       </a>
     );
   }
-  const dataOrAriaProps = getDataOrAriaProps(props);
 
   const buttonNode = (
     <button
@@ -279,7 +277,6 @@ const InternalButton: React.ForwardRefRenderFunction<unknown, ButtonProps> = (pr
       className={classes}
       onClick={handleClick}
       ref={buttonRef}
-      {...dataOrAriaProps}
     >
       {iconNode}
       {kids}

--- a/components/button/button.tsx
+++ b/components/button/button.tsx
@@ -11,6 +11,7 @@ import devWarning from '../_util/devWarning';
 import SizeContext, { SizeType } from '../config-provider/SizeContext';
 import LoadingIcon from './LoadingIcon';
 import { cloneElement } from '../_util/reactNode';
+import getDataOrAriaProps from '../_util/getDataOrAriaProps';
 
 const rxTwoCNChar = /^[\u4e00-\u9fa5]{2}$/;
 const isTwoCNChar = rxTwoCNChar.test.bind(rxTwoCNChar);
@@ -269,6 +270,7 @@ const InternalButton: React.ForwardRefRenderFunction<unknown, ButtonProps> = (pr
       </a>
     );
   }
+  const dataOrAriaProps = getDataOrAriaProps(props);
 
   const buttonNode = (
     <button
@@ -277,6 +279,7 @@ const InternalButton: React.ForwardRefRenderFunction<unknown, ButtonProps> = (pr
       className={classes}
       onClick={handleClick}
       ref={buttonRef}
+      {...dataOrAriaProps}
     >
       {iconNode}
       {kids}

--- a/components/checkbox/Checkbox.tsx
+++ b/components/checkbox/Checkbox.tsx
@@ -4,6 +4,7 @@ import RcCheckbox from 'rc-checkbox';
 import { GroupContext } from './Group';
 import { ConfigContext } from '../config-provider';
 import devWarning from '../_util/devWarning';
+import getDataOrAriaProps from '../_util/getDataOrAriaProps';
 
 export interface AbstractCheckboxProps<T> {
   prefixCls?: string;
@@ -109,6 +110,7 @@ const InternalCheckbox: React.ForwardRefRenderFunction<HTMLInputElement, Checkbo
   const checkboxClass = classNames({
     [`${prefixCls}-indeterminate`]: indeterminate,
   });
+  const dataOrAriaProps = getDataOrAriaProps(checkboxProps);
   return (
     // eslint-disable-next-line jsx-a11y/label-has-associated-control
     <label
@@ -116,6 +118,7 @@ const InternalCheckbox: React.ForwardRefRenderFunction<HTMLInputElement, Checkbo
       style={style}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
+      {...dataOrAriaProps}
     >
       <RcCheckbox {...checkboxProps} prefixCls={prefixCls} className={checkboxClass} ref={ref} />
       {children !== undefined && <span>{children}</span>}

--- a/components/checkbox/__tests__/__snapshots__/checkbox.test.js.snap
+++ b/components/checkbox/__tests__/__snapshots__/checkbox.test.js.snap
@@ -17,3 +17,26 @@ exports[`Checkbox rtl render component should be rendered correctly in RTL direc
   </span>
 </label>
 `;
+
+exports[`Checkbox should support data-*、aria-* and custom attribute 1`] = `
+<label
+  aria-hidden="true"
+  class="ant-checkbox-wrapper"
+  data-text="123"
+>
+  <span
+    class="ant-checkbox"
+  >
+    <input
+      aria-hidden="true"
+      class="ant-checkbox-input"
+      data-text="123"
+      type="checkbox"
+      value=""
+    />
+    <span
+      class="ant-checkbox-inner"
+    />
+  </span>
+</label>
+`;

--- a/components/checkbox/__tests__/checkbox.test.js
+++ b/components/checkbox/__tests__/checkbox.test.js
@@ -34,4 +34,9 @@ describe('Checkbox', () => {
     );
     errorSpy.mockRestore();
   });
+
+  it('should support data-*、aria-* and custom attribute', () => {
+    const wrapper = mount(<Checkbox data-text="123" aria-hidden="true" />);
+    expect(wrapper.render()).toMatchSnapshot();
+  });
 });

--- a/components/input/Input.tsx
+++ b/components/input/Input.tsx
@@ -10,6 +10,7 @@ import ClearableLabeledInput, { hasPrefixSuffix } from './ClearableLabeledInput'
 import { ConfigConsumer, ConfigConsumerProps, DirectionType } from '../config-provider';
 import SizeContext, { SizeType } from '../config-provider/SizeContext';
 import devWarning from '../_util/devWarning';
+import getDataOrAriaProps from '../_util/getDataOrAriaProps';
 
 export interface InputFocusOptions extends FocusOptions {
   cursor?: 'start' | 'end' | 'all';
@@ -278,6 +279,7 @@ class Input extends React.Component<InputProps, InputState> {
       'inputType',
       'bordered',
     ]);
+    const dataOrAriaProps = getDataOrAriaProps(this.props);
     return (
       <input
         autoComplete={input.autoComplete}
@@ -293,6 +295,7 @@ class Input extends React.Component<InputProps, InputState> {
           },
         )}
         ref={this.saveInput}
+        {...dataOrAriaProps}
       />
     );
   };

--- a/components/input/__tests__/__snapshots__/index.test.js.snap
+++ b/components/input/__tests__/__snapshots__/index.test.js.snap
@@ -288,6 +288,17 @@ exports[`Input allowClear should not show icon if value is undefined, null or em
 </span>
 `;
 
+exports[`Input allowClear should support data-*、aria-* and custom attribute 1`] = `
+<input
+  aria-hidden="true"
+  cccc="bbbb"
+  class="ant-input"
+  data-text="123"
+  type="text"
+  value=""
+/>
+`;
+
 exports[`Input rtl render component should be rendered correctly in RTL direction 1`] = `
 <input
   class="ant-input ant-input-rtl"

--- a/components/input/__tests__/__snapshots__/index.test.js.snap
+++ b/components/input/__tests__/__snapshots__/index.test.js.snap
@@ -288,17 +288,6 @@ exports[`Input allowClear should not show icon if value is undefined, null or em
 </span>
 `;
 
-exports[`Input allowClear should support data-*、aria-* and custom attribute 1`] = `
-<input
-  aria-hidden="true"
-  cccc="bbbb"
-  class="ant-input"
-  data-text="123"
-  type="text"
-  value=""
-/>
-`;
-
 exports[`Input rtl render component should be rendered correctly in RTL direction 1`] = `
 <input
   class="ant-input ant-input-rtl"
@@ -310,6 +299,16 @@ exports[`Input rtl render component should be rendered correctly in RTL directio
 exports[`Input rtl render component should be rendered correctly in RTL direction 2`] = `
 <span
   class="ant-input-group ant-input-group-rtl"
+/>
+`;
+
+exports[`Input should support data-*、aria-* and custom attribute 1`] = `
+<input
+  aria-hidden="true"
+  class="ant-input"
+  data-text="123"
+  type="text"
+  value=""
 />
 `;
 

--- a/components/input/__tests__/index.test.js
+++ b/components/input/__tests__/index.test.js
@@ -53,6 +53,11 @@ describe('Input', () => {
     expect(wrapper.render()).toMatchSnapshot();
   });
 
+  it('should support data-*、aria-* and custom attribute', () => {
+    const wrapper = mount(<Input data-text="123" aria-hidden="true" />);
+    expect(wrapper.render()).toMatchSnapshot();
+  });
+
   describe('focus trigger warning', () => {
     it('not trigger', () => {
       const wrapper = mount(<Input suffix="bamboo" />);
@@ -211,10 +216,5 @@ describe('Input allowClear', () => {
     const wrapper = mount(<Input allowClear className="my-class-name" />);
     expect(wrapper.getDOMNode().className.includes('my-class-name')).toBe(true);
     expect(wrapper.find('input').getDOMNode().className.includes('my-class-name')).toBe(false);
-  });
-
-  it('should support data-*、aria-* and custom attribute', () => {
-    const wrapper = mount(<Input data-text="123" aria-hidden="true" cccc="bbbb" />);
-    expect(wrapper.render()).toMatchSnapshot();
   });
 });

--- a/components/input/__tests__/index.test.js
+++ b/components/input/__tests__/index.test.js
@@ -212,4 +212,9 @@ describe('Input allowClear', () => {
     expect(wrapper.getDOMNode().className.includes('my-class-name')).toBe(true);
     expect(wrapper.find('input').getDOMNode().className.includes('my-class-name')).toBe(false);
   });
+
+  it('should support data-*、aria-* and custom attribute', () => {
+    const wrapper = mount(<Input data-text="123" aria-hidden="true" cccc="bbbb" />);
+    expect(wrapper.render()).toMatchSnapshot();
+  });
 });

--- a/components/notification/__tests__/index.test.js
+++ b/components/notification/__tests__/index.test.js
@@ -208,4 +208,16 @@ describe('notification', () => {
     });
     expect(document.querySelectorAll('.anticon-user').length).toBe(1);
   });
+
+  it('should support data-test-id attribute', () => {
+    notification.open({
+      message: 'Notification Title',
+      duration: 0,
+      icon: <UserOutlined />,
+      dataTestId: 'notification-open',
+    });
+    const div = document.getElementById('notification');
+    expect(div.hasAttribute("data-test-id")).toBeTruthy();
+    expect(div.getAttribute("data-test-id")).toEqual("notification-open");
+  });
 });

--- a/components/notification/index.tsx
+++ b/components/notification/index.tsx
@@ -186,6 +186,7 @@ export interface ArgsProps {
   bottom?: number;
   getContainer?: () => HTMLElement;
   closeIcon?: React.ReactNode;
+  dataTestId?: string;
 }
 
 function getRCNoticeProps(args: ArgsProps, prefixCls: string) {
@@ -201,6 +202,7 @@ function getRCNoticeProps(args: ArgsProps, prefixCls: string) {
     key,
     style,
     className,
+    dataTestId = "",
   } = args;
 
   const duration = durationArg === undefined ? defaultDuration : durationArg;
@@ -221,7 +223,7 @@ function getRCNoticeProps(args: ArgsProps, prefixCls: string) {
 
   return {
     content: (
-      <div className={iconNode ? `${prefixCls}-with-icon` : ''} role="alert">
+      <div id="notification" data-test-id={dataTestId} className={iconNode ? `${prefixCls}-with-icon` : ''} role="alert">
         {iconNode}
         <div className={`${prefixCls}-message`}>
           {autoMarginTag}


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [x] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

Allow data-* and aria-* props to be passed through to the Input, Button, Checkbox and Notification components, to allow for e2e UI testing e.g. cypress or testcafe in the proper way.

### 💡 Background and solution

Currently Antd components don't all accept the data-* or aria-* props, which makes it very difficult to create e2e tests properly, coinciding with good practices. As it means they must be tied to JS and CSS selectors, rather than to data-test-ids for example.

This takes advantage of an already existing function for the Form component and extends it to the Input, Button, Checkbox and Notification. 

### 📝 Changelog

🆕 Input supports `data-*` and `aria-*` props
🆕 Checkbox supports `data-*` and `aria-*` props
🆕 Notification accepts `dataTestId` prop

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  🆕 Input supports `data-*` and `aria-*` props 🆕 Checkbox supports `data-*` and `aria-*` props 🆕 Notification accepts `dataTestId` prop          |
| 🇨🇳 Chinese |  🆕 Input supports `data-*` and `aria-*` props 🆕 Checkbox supports `data-*` and `aria-*` props 🆕 Notification accepts `dataTestId` prop          |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
