### PR TITLE
fix: Cannot read property 'removeChild' of null

### DIFF
--- a/components/_util/wave.tsx
+++ b/components/_util/wave.tsx
@@ -89,7 +89,9 @@ export default class Wave extends React.Component<{ insertExtraNode?: boolean }>
       extraNode.style.borderColor = waveColor;
 
       const nodeRoot = node.getRootNode?.() || node.ownerDocument;
-      const nodeBody = nodeRoot instanceof Document ? nodeRoot.body : nodeRoot as HTMLElement;
+      const nodeBody: Element =
+        nodeRoot instanceof Document ? nodeRoot.body : (nodeRoot.firstChild as Element) ?? nodeRoot;
+
       styleForPseudo = updateCSS(
         `
       [${getPrefixCls('')}-click-animating-without-extra-node='true']::after, .${getPrefixCls(


### PR DESCRIPTION
fix: Cannot read property 'removeChild' of null

<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)


### 💡 Background and solution
in certain situations, when used in shadow dom, clicking the antd button will cause a "Cannot read property 'removeChild' of null" error, caused by the wave effect updateCSS lib.
https://codesandbox.io/s/antd-reproduction-template-forked-orccz
this PR fixes this issue

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

(need Chinese changelog, is just google translate)
| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Button Wave Effect undefined Error |
| 🇨🇳 Chinese | 修复 Button 波浪效应 undefined 错误 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
