### PR TITLE
fix(tabs): can't scroll when vertical mode in safari

### DIFF
--- a/components/tabs/style/index.less
+++ b/components/tabs/style/index.less
@@ -47,7 +47,7 @@
     .@{tab-prefix-cls}-nav-list {
       position: relative;
       display: flex;
-      flex: 1 0 auto; // fix safari scrool problem
+      flex: 1 0 auto; // fix safari scroll problem
       transition: transform @animation-duration-slow;
     }
 

--- a/components/tabs/style/index.less
+++ b/components/tabs/style/index.less
@@ -47,6 +47,7 @@
     .@{tab-prefix-cls}-nav-list {
       position: relative;
       display: flex;
+      flex: 1 0 auto; // fix safari scrool problem
       transition: transform @animation-duration-slow;
     }
 

--- a/components/tabs/style/index.less
+++ b/components/tabs/style/index.less
@@ -54,6 +54,7 @@
     // >>>>>>>> Operations
     .@{tab-prefix-cls}-nav-operations {
       display: flex;
+      flex: 1 0 auto; // fix safari scroll problem
       align-self: stretch;
 
       &-hidden {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

fix https://github.com/ant-design/ant-design/issues/29964

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fix Tabs can't scroll when vertical mode in Safari 13.1.         |
| 🇨🇳 Chinese |  修复 Tabs 在 Safari 13.1 垂直模式下不能滚动问题。         |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
