### PR TITLE
feat: Allow breadcrumb component in PageHeader

### DIFF
--- a/components/page-header/__tests__/index.test.js
+++ b/components/page-header/__tests__/index.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { mount, render } from 'enzyme';
 import PageHeader from '..';
+import Breadcrumb from '../../breadcrumb';
 import ConfigProvider from '../../config-provider';
 import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
@@ -46,6 +47,20 @@ describe('PageHeader', () => {
       },
     ];
     const wrapper = mount(<PageHeader title="Page Title" breadcrumb={{ routes }} />);
+    expect(wrapper.find('.ant-breadcrumb')).toHaveLength(1);
+    expect(wrapper.find('.ant-page-header-back')).toHaveLength(0);
+  });
+
+  it('pageHeader should have breadcrumb (component)', () => {
+    const routes = [
+      {
+        path: 'index',
+        breadcrumbName: 'First-level Menu',
+      },
+    ];
+    const wrapper = mount(
+      <PageHeader title="Page Title" breadcrumb={<Breadcrumb routes={routes} />} />,
+    );
     expect(wrapper.find('.ant-breadcrumb')).toHaveLength(1);
     expect(wrapper.find('.ant-page-header-back')).toHaveLength(0);
   });

--- a/components/page-header/index.tsx
+++ b/components/page-header/index.tsx
@@ -16,7 +16,7 @@ export interface PageHeaderProps {
   title?: React.ReactNode;
   subTitle?: React.ReactNode;
   style?: React.CSSProperties;
-  breadcrumb?: BreadcrumbProps;
+  breadcrumb?: BreadcrumbProps | React.ReactElement<typeof Breadcrumb>;
   breadcrumbRender?: (props: PageHeaderProps, defaultDom: React.ReactNode) => React.ReactNode;
   tags?: React.ReactElement<TagType> | React.ReactElement<TagType>[];
   footer?: React.ReactNode;
@@ -156,9 +156,12 @@ const PageHeader: React.FC<PageHeaderProps> = props => {
 
         const defaultBreadcrumbDom = getDefaultBreadcrumbDom();
 
+        const isBreadcrumbComponent = breadcrumb && 'props' in breadcrumb;
         //  support breadcrumbRender function
-        const breadcrumbDom =
+        const _breadcrumbRender =
           breadcrumbRender?.(props, defaultBreadcrumbDom) || defaultBreadcrumbDom;
+
+        const breadcrumbDom = isBreadcrumbComponent ? breadcrumb : _breadcrumbRender;
 
         const className = classNames(prefixCls, customizeClassName, {
           'has-breadcrumb': breadcrumbDom,

--- a/components/page-header/index.tsx
+++ b/components/page-header/index.tsx
@@ -158,10 +158,10 @@ const PageHeader: React.FC<PageHeaderProps> = props => {
 
         const isBreadcrumbComponent = breadcrumb && 'props' in breadcrumb;
         //  support breadcrumbRender function
-        const _breadcrumbRender =
+        const breadcrumbRenderDomFromProps =
           breadcrumbRender?.(props, defaultBreadcrumbDom) || defaultBreadcrumbDom;
 
-        const breadcrumbDom = isBreadcrumbComponent ? breadcrumb : _breadcrumbRender;
+        const breadcrumbDom = isBreadcrumbComponent ? breadcrumb : breadcrumbRenderDomFromProps;
 
         const className = classNames(prefixCls, customizeClassName, {
           'has-breadcrumb': breadcrumbDom,


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [x] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

https://github.com/ant-design/ant-design/issues/24217

### 💡 Background and solution

Currently you can only pass breadcrumb properties to the PageHeader component, but not the component itself. This will allow to have both options

### 📝 Changelog

PageHeader component allow to pass a `<Breadcrumb />` component in the `breadcrumb` prop

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Allows to pass a `<Breadcrumb />` component in the `breadcrumb` prop |
| 🇨🇳 Chinese | 允許在麵包屑道具中傳遞<Breadcrumb />組件 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
