### PR TITLE
fix: Add a missing export to a TS interface

### DIFF
--- a/components/select/index.tsx
+++ b/components/select/index.tsx
@@ -151,7 +151,7 @@ const SelectRef = React.forwardRef(InternalSelect) as <VT extends SelectValue = 
 
 type InternalSelectType = typeof SelectRef;
 
-interface SelectInterface extends InternalSelectType {
+export interface SelectInterface extends InternalSelectType {
   SECRET_COMBOBOX_MODE_DO_NOT_USE: string;
   Option: typeof Option;
   OptGroup: typeof OptGroup;


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 💡 Background and solution

I have a library with something like:

```ts
import AntSelect from "antd/lib/select";

export const Select = AntSelect;
```

when I run `tsc --emitDeclarationOnly` there's an error:

```
src/index.ts:3:14 - error TS4023: Exported variable 'Select' has or is using name 'SelectInterface' from external module "[..]/antd-ts-err/node_modules/antd/lib/select/index" but cannot be named.

3 export const Select = AntSelect;
               ~~~~~~
```

Adding this `export` solves it.

There were other similar PRs in the past like: https://github.com/ant-design/ant-design/pull/19846

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Export Select type to fix an issue with generating TypeScript declarations |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
