### PR TITLE
fix: `undefined` was added to the `SelectValue` type

### DIFF
--- a/components/select/index.tsx
+++ b/components/select/index.tsx
@@ -22,7 +22,7 @@ export interface LabeledValue {
   label: React.ReactNode;
 }
 
-export type SelectValue = RawValue | RawValue[] | LabeledValue | LabeledValue[];
+export type SelectValue = RawValue | RawValue[] | LabeledValue | LabeledValue[] | undefined;
 
 export interface InternalSelectProps<VT> extends Omit<RcSelectProps<VT>, 'mode'> {
   suffixIcon?: React.ReactNode;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

1. Describe the problem and the scenario.
The problem appears when you want to specify a return type for the Select value. Let's take the following code:
```tsx
<Select<string | undefined>
  placeholder={"Gender"}
  value={gender}
  allowClear
  onChange={(value) => setGender(value)}
>
  <Option value="female">Female</Option>
  <Option value="male">Male</Option>
  ...
</Select>,
```

As you can see I wanted to specify the type of the `value` returned by the `onChange` function by specifying `<string | undefined>` next to the `Select` tag. When I did that, Typescript is complaining that "*Type 'undefined' is not assignable to type 'SelectValue'.*". But I know for sure that, when `allowClear` is `true` the value can be `undefined`.

2. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
To fix this I've made the following change:
```diff
- export declare type SelectValue = RawValue | RawValue[] | LabeledValue | LabeledValue[];
+ export declare type SelectValue = RawValue | RawValue[] | LabeledValue | LabeledValue[] | undefined;
```

### 📝 Changelog

The `SelectValue` type was updated to contain `undefined`. No braking changes.

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
