### PR TITLE
fix(Badge): update cached isDotRef when isHidden

### DIFF
--- a/components/badge/__tests__/index.test.js
+++ b/components/badge/__tests__/index.test.js
@@ -155,6 +155,19 @@ describe('Badge', () => {
 
     expect(wrapper.find('.ant-badge')).toHaveLength(2);
   });
+
+  it('Badge should work when status changes', () => {
+    const wrapper = mount(
+      <Badge status="warning">
+        <button type="button">Click me</button>
+      </Badge>,
+    );
+    wrapper.setProps({ status: undefined });
+
+    expect(wrapper.find('.ant-badge-count')).toHaveLength(0);
+    expect(wrapper.find('.ant-badge-dot')).toHaveLength(0);
+    expect(wrapper.find('.ant-badge-count-sm')).toHaveLength(0);
+  });
 });
 
 describe('Ribbon', () => {

--- a/components/badge/index.tsx
+++ b/components/badge/index.tsx
@@ -94,6 +94,8 @@ const Badge: CompoundedComponent = ({
   const isDotRef = useRef(showAsDot);
   if (!isHidden) {
     isDotRef.current = showAsDot;
+  } else {
+    isDotRef.current = false;
   }
 
   // =============================== Styles ===============================
@@ -186,8 +188,8 @@ const Badge: CompoundedComponent = ({
 
           const scrollNumberCls = classNames({
             [`${prefixCls}-dot`]: isDot,
-            [`${prefixCls}-count`]: !isDot,
-            [`${prefixCls}-count-sm`]: size === 'small',
+            [`${prefixCls}-count`]: !isDot && !isHidden,
+            [`${prefixCls}-count-sm`]: !isDot && !isHidden && size === 'small',
             [`${prefixCls}-multiple-words`]:
               !isDot && displayCount && displayCount?.toString().length > 1,
             [`${prefixCls}-status-${status}`]: !!status,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->
Fix #30088

### 💡 Background and solution
When `status` change to `undefined` or `null`, `isDotRef` does not update, which will show `red dot` in transition. 

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Badge toggle style when `status` is `warning`. |
| 🇨🇳 Chinese | 修复 Badge `status="warning"` 时切换样式异常的问题。 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
