### PR TITLE
fix: TextArea onChange event obj

### DIFF
--- a/components/input/TextArea.tsx
+++ b/components/input/TextArea.tsx
@@ -86,7 +86,7 @@ const TextArea = React.forwardRef<TextAreaRef, TextAreaProps>(
       // Patch composition onChange when value changed
       if (triggerValue !== value) {
         handleSetValue(triggerValue);
-        resolveOnChange(innerRef.current as any, e, onChange, triggerValue);
+        resolveOnChange(e.currentTarget, e, onChange, triggerValue);
       }
 
       onCompositionEnd?.(e);
@@ -99,7 +99,7 @@ const TextArea = React.forwardRef<TextAreaRef, TextAreaProps>(
       }
 
       handleSetValue(triggerValue);
-      resolveOnChange(innerRef.current as any, e, onChange, triggerValue);
+      resolveOnChange(e.currentTarget, e, onChange, triggerValue);
     };
 
     // ============================== Reset ===============================
@@ -107,7 +107,7 @@ const TextArea = React.forwardRef<TextAreaRef, TextAreaProps>(
       handleSetValue('', () => {
         innerRef.current?.focus();
       });
-      resolveOnChange(innerRef.current as any, e, onChange);
+      resolveOnChange(innerRef.current?.resizableTextArea?.textArea!, e, onChange);
     };
 
     const prefixCls = getPrefixCls('input', customizePrefixCls);

--- a/components/input/__tests__/textarea.test.js
+++ b/components/input/__tests__/textarea.test.js
@@ -379,4 +379,36 @@ describe('TextArea allowClear', () => {
     const wrapper = mount(<Input.TextArea defaultValue="Light" value={undefined} />);
     expect(wrapper.find('textarea').at(0).getDOMNode().value).toBe('Light');
   });
+
+  it('onChange event should return HTMLInputElement', () => {
+    const onChange = jest.fn();
+    const wrapper = mount(<Input.TextArea onChange={onChange} allowClear />);
+
+    function isNativeElement() {
+      expect(onChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          target: wrapper.find('textarea').instance(),
+        }),
+      );
+
+      onChange.mockReset();
+    }
+
+    // Change
+    wrapper.find('textarea').simulate('change', {
+      target: {
+        value: 'bamboo',
+      },
+    });
+    isNativeElement();
+
+    // Composition End
+    wrapper.find('textarea').instance().value = 'light'; // enzyme not support change `currentTarget`
+    wrapper.find('textarea').simulate('compositionEnd');
+    isNativeElement();
+
+    // Reset
+    wrapper.find('.ant-input-clear-icon').first().simulate('click');
+    isNativeElement();
+  });
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

resolves #30117 #30115

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Fix TextArea `onChange` event return `target` object is not a HTMLTextArea object.       |
| 🇨🇳 Chinese |     修复 TextArea `onChange` 事件返回 `target` 对象不是 HTMLTextArea 对象的问题。     |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
