### PR TITLE
fix(FormItem): add name as default variables.label value

### DIFF
--- a/components/form/FormItem.tsx
+++ b/components/form/FormItem.tsx
@@ -265,6 +265,8 @@ function FormItem<Values = any>(props: FormItemProps<Values>): React.ReactElemen
   let variables: Record<string, string> = {};
   if (typeof label === 'string') {
     variables.label = label;
+  } else if (name) {
+    variables.label = String(name);
   }
   if (messageVariables) {
     variables = { ...variables, ...messageVariables };

--- a/components/form/__tests__/index.test.js
+++ b/components/form/__tests__/index.test.js
@@ -564,6 +564,23 @@ describe('Form', () => {
     expect(wrapper.find('.ant-form-item-explain').first().text()).toEqual('Bamboo is good!');
   });
 
+  it('`name` support template when label is not provided', async () => {
+    const wrapper = mount(
+      // eslint-disable-next-line no-template-curly-in-string
+      <Form validateMessages={{ required: '${label} is good!' }}>
+        <Form.Item name="Bamboo" rules={[{ required: true }]}>
+          <input />
+        </Form.Item>
+      </Form>,
+    );
+
+    wrapper.find('form').simulate('submit');
+    await sleep(100);
+    wrapper.update();
+    await sleep(100);
+    expect(wrapper.find('.ant-form-item-explain').first().text()).toEqual('Bamboo is good!');
+  });
+
   it('`messageVariables` support validate', async () => {
     const wrapper = mount(
       // eslint-disable-next-line no-template-curly-in-string


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
Fix #30146. When `label` is not given, `${label}` will be replaced by `undefined`. I think we could add `name` as a default `variables.label` value. 
<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | add `name` as a default label value in `validationMessages`. |
| 🇨🇳 Chinese | 增加`name`作为验证消息`label`的默认值|

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
