### PR TITLE
fix: input verification failed style when mouse hover

### DIFF
--- a/components/form/style/mixin.less
+++ b/components/form/style/mixin.less
@@ -25,11 +25,14 @@
   }
 
   .@{ant-prefix}-input-affix-wrapper-disabled {
-    background-color: @input-disabled-bg;
-    border-color: @input-border-color;
+    &,
+    &:hover {
+      background-color: @input-disabled-bg;
+      border-color: @input-border-color;
 
-    input:focus {
-      box-shadow: none !important;
+      input:focus {
+        box-shadow: none !important;
+      }
     }
   }
 

--- a/components/form/style/mixin.less
+++ b/components/form/style/mixin.less
@@ -20,8 +20,11 @@
   }
 
   .@{ant-prefix}-input-disabled {
-    background-color: @input-disabled-bg;
-    border-color: @input-border-color;
+    &,
+    &:hover {
+      background-color: @input-disabled-bg;
+      border-color: @input-border-color;
+    }
   }
 
   .@{ant-prefix}-input-affix-wrapper-disabled {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
补充 [#30294](https://github.com/ant-design/ant-design/issues/30294)  

![gif](https://user-images.githubusercontent.com/23151576/115987141-54e09e80-a5e6-11eb-90ec-b04cf9420081.gif)
<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  fix the hover background color problem after the input component verification fails in the disabled state   |
| 🇨🇳 Chinese |  修复disabled状态下Input组件校验失败后hover背景色问题 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
