### PR TITLE
onChange not firing when InputNumber changes #30096

### DIFF
--- a/components/input-number/index.tsx
+++ b/components/input-number/index.tsx
@@ -31,12 +31,9 @@ const InputNumber = React.forwardRef<HTMLInputElement, InputNumberProps>((props,
     ...others
   } = props;
 
-  console.log(onChange);
-  
   const prefixCls = getPrefixCls('input-number', customizePrefixCls);
   const upIcon = <UpOutlined className={`${prefixCls}-handler-up-inner`} />;
   const downIcon = <DownOutlined className={`${prefixCls}-handler-down-inner`} />;
-
   const mergeSize = customizeSize || size;
   const inputNumberClass = classNames(
     {
@@ -57,6 +54,7 @@ const InputNumber = React.forwardRef<HTMLInputElement, InputNumberProps>((props,
       downHandler={downIcon}
       prefixCls={prefixCls}
       readOnly={readOnly}
+      onChange = {onChange}
       {...others}
     />
   );

--- a/components/input-number/index.tsx
+++ b/components/input-number/index.tsx
@@ -27,9 +27,12 @@ const InputNumber = React.forwardRef<HTMLInputElement, InputNumberProps>((props,
     prefixCls: customizePrefixCls,
     bordered = true,
     readOnly,
+    onChange,
     ...others
   } = props;
 
+  console.log(onChange);
+  
   const prefixCls = getPrefixCls('input-number', customizePrefixCls);
   const upIcon = <UpOutlined className={`${prefixCls}-handler-up-inner`} />;
   const downIcon = <DownOutlined className={`${prefixCls}-handler-down-inner`} />;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->
Needs to update rc-input-number component as well
### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->
when deleting the input-number's last character, the `onChange` is not firing. 
### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     explicitly extract onChange from props and pass it to the return component |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
