### PR TITLE
feat(upload): add onDrop prop and remove event stopPropagation

### DIFF
--- a/.github/workflows/release-helper.yml
+++ b/.github/workflows/release-helper.yml
@@ -16,10 +16,11 @@ jobs:
     steps:
       - name: make release
         if: github.event.ref_type == 'tag'
-        uses: actions-cool/release-helper@v1
+        uses: actions-cool/release-helper@v1.4.0
         with:
           triger: 'tag'
           changelogs: 'CHANGELOG.en-US.md, CHANGELOG.zh-CN.md'
           branch: 'master'
           dingding-token: ${{ secrets.DINGDING_BOT_TOKEN }}
           dingding-msg: 'CHANGELOG.zh-CN.md'
+          prerelease-filter: '-, a, b, A, B'

--- a/components/form/style/mixin.less
+++ b/components/form/style/mixin.less
@@ -20,16 +20,22 @@
   }
 
   .@{ant-prefix}-input-disabled {
-    background-color: @input-disabled-bg;
-    border-color: @input-border-color;
+    &,
+    &:hover {
+      background-color: @input-disabled-bg;
+      border-color: @input-border-color;
+    }
   }
 
   .@{ant-prefix}-input-affix-wrapper-disabled {
-    background-color: @input-disabled-bg;
-    border-color: @input-border-color;
+    &,
+    &:hover {
+      background-color: @input-disabled-bg;
+      border-color: @input-border-color;
 
-    input:focus {
-      box-shadow: none !important;
+      input:focus {
+        box-shadow: none !important;
+      }
     }
   }
 

--- a/components/table/demo/virtual-list.md
+++ b/components/table/demo/virtual-list.md
@@ -54,7 +54,7 @@ function VirtualTable(props: Parameters<typeof Table>[0]) {
   const resetVirtualGrid = () => {
     gridRef.current.resetAfterIndices({
       columnIndex: 0,
-      shouldForceUpdate: false,
+      shouldForceUpdate: true,
     });
   };
 

--- a/components/upload/Upload.tsx
+++ b/components/upload/Upload.tsx
@@ -34,6 +34,7 @@ const InternalUpload: React.ForwardRefRenderFunction<unknown, UploadProps> = (pr
     onPreview,
     onDownload,
     onChange,
+    onDrop,
     previewFile,
     disabled,
     locale: propLocale,
@@ -266,8 +267,11 @@ const InternalUpload: React.ForwardRefRenderFunction<unknown, UploadProps> = (pr
   };
 
   const onFileDrop = (e: React.DragEvent<HTMLDivElement>) => {
-    e.stopPropagation();
     setDragState(e.type);
+
+    if (e.type === 'drop' && typeof onDrop === 'function') {
+      onDrop(e);
+    }
   };
 
   // Test needs

--- a/components/upload/demo/drag.md
+++ b/components/upload/demo/drag.md
@@ -38,6 +38,9 @@ const props = {
       message.error(`${info.file.name} file upload failed.`);
     }
   },
+  onDrop(e) {
+    console.log('Dropped files', e.dataTransfer.files);
+  },
 };
 
 ReactDOM.render(

--- a/components/upload/index.en-US.md
+++ b/components/upload/index.en-US.md
@@ -43,6 +43,7 @@ Uploading is the process of publishing information (web pages, text, pictures, v
 | showUploadList | Whether to show default upload list, could be an object to specify `showPreviewIcon`, `showRemoveIcon`, `showDownloadIcon`, `removeIcon` and `downloadIcon` individually | boolean \| { showPreviewIcon?: boolean, showDownloadIcon?: boolean, showRemoveIcon?: boolean, removeIcon?: ReactNode \| (file: UploadFile) => ReactNode, downloadIcon?: ReactNode \| (file: UploadFile) => ReactNode } | true | function: 4.7.0 |
 | withCredentials | The ajax upload with cookie sent | boolean | false |  |
 | onChange | A callback function, can be executed when uploading state is changing, see [onChange](#onChange) | function | - |  |
+| onDrop | A callback function executed when files are dragged and dropped into upload area | (event: React.DragEvent) => void | - |  |
 | onDownload | Click the method to download the file, pass the method to perform the method logic, do not pass the default jump to the new TAB | function(file): void | (Jump to new TAB) |  |
 | onPreview | A callback function, will be executed when file link or preview icon is clicked | function(file) | - |  |
 | onRemove | A callback function, will be executed when removing file button is clicked, remove event will be prevented when return value is false or a Promise which resolve(false) or reject | function(file): boolean \| Promise | - |  |

--- a/components/upload/index.zh-CN.md
+++ b/components/upload/index.zh-CN.md
@@ -44,6 +44,7 @@ cover: https://gw.alipayobjects.com/zos/alicdn/QaeBt_ZMg/Upload.svg
 | showUploadList | 是否展示文件列表, 可设为一个对象，用于单独设定 `showPreviewIcon`, `showRemoveIcon`, `showDownloadIcon`, `removeIcon` 和 `downloadIcon` | boolean \| { showPreviewIcon?: boolean, showRemoveIcon?: boolean, showDownloadIcon?: boolean, removeIcon?: ReactNode \| (file: UploadFile) => ReactNode, downloadIcon?: ReactNode \| (file: UploadFile) => ReactNode } | true | function: 4.7.0 |
 | withCredentials | 上传请求时是否携带 cookie | boolean | false |  |
 | onChange | 上传文件改变时的状态，详见 [onChange](#onChange) | function | - |  |
+| onDrop | 当文件被拖入上传区域时执行的回调功能 | (event: React.DragEvent) => void | - |  |
 | onDownload | 点击下载文件时的回调，如果没有指定，则默认跳转到文件 url 对应的标签页 | function(file): void | (跳转新标签页) |  |
 | onPreview | 点击文件链接或预览图标时的回调 | function(file) | - |  |
 | onRemove   | 点击移除文件时的回调，返回值为 false 时不移除。支持返回一个 Promise 对象，Promise 对象 resolve(false) 或 reject 时不移除               | function(file): boolean \| Promise | -   |  |

--- a/components/upload/interface.tsx
+++ b/components/upload/interface.tsx
@@ -86,8 +86,12 @@ export interface UploadProps<T = any> {
   showUploadList?: boolean | ShowUploadListInterface;
   multiple?: boolean;
   accept?: string;
-  beforeUpload?: (file: RcFile, FileList: RcFile[]) => boolean | string | Promise<void | Blob | File>;
+  beforeUpload?: (
+    file: RcFile,
+    FileList: RcFile[],
+  ) => boolean | string | Promise<void | Blob | File>;
   onChange?: (info: UploadChangeParam) => void;
+  onDrop?: (event: React.DragEvent<HTMLDivElement>) => void;
   listType?: UploadListType;
   className?: string;
   onPreview?: (file: UploadFile<T>) => void;


### PR DESCRIPTION
### 🤔 This is a ...

- [x] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
https://github.com/ant-design/ant-design/pull/29832
https://github.com/ant-design/ant-design/pull/30120#issuecomment-820954934

### 💡 Background and solution

I was looking for a way to notify the user if any rejected file types were dropped into the Uploader. Further reading into the issue tracker and merge requests led me to another dead end as the event was no longer being propagated as a result of https://github.com/ant-design/ant-design/pull/29832.

While the author did attempt to resolve this by creating a new boolean prop https://github.com/ant-design/ant-design/pull/30120, IMO I feel this is too narrow in scope to be helpful to a wider community.

This PR instead resolves the breaking change by removing stopPropagation from the event handler and introduces a new `onDrop` prop. This callback is passed the drop event so that the original intent of stopping propagation can be fulfilled while also allowing users to determine the dropped files from `event.dataTransfer.files`

```jsx
const onDrop = e => console.log(event.dataTransfer.files)

return <Uploader onDrop={onDrop} {...otherProps />
```

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Uploader fix to undo stopPropagation on drop event.   Add new `onDrop` prop to Uploader component.   |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
