### PR TITLE
fix: InputNumber support null

### DIFF
--- a/components/input-number/__tests__/index.test.js
+++ b/components/input-number/__tests__/index.test.js
@@ -15,9 +15,6 @@ describe('InputNumber', () => {
     const onChange = jest.fn();
     const wrapper = mount(<InputNumber defaultValue="1" onChange={onChange} />);
     wrapper.find('input').simulate('change', { target: { value: '' } });
-    expect(onChange).not.toHaveBeenCalled();
-
-    wrapper.find('input').simulate('blur');
     expect(onChange).toHaveBeenLastCalledWith(null);
   });
 

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "rc-dropdown": "~3.2.0",
     "rc-field-form": "~1.20.0",
     "rc-image": "~5.2.4",
-    "rc-input-number": "~7.0.1",
+    "rc-input-number": "~7.1.0",
     "rc-mentions": "~1.5.0",
     "rc-menu": "~8.10.0",
     "rc-motion": "^2.4.0",


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

resolve #30096

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   InputNumber clean up input will trigger `onChange(null)` now.        |
| 🇨🇳 Chinese |     InputNumber 现在清空输入框时会触发 `onChange(null)`。      |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
