### PR TITLE
fix(layout-sider): menu-item width is wrong when collapsedWidth is set

### DIFF
--- a/components/menu/style/index.less
+++ b/components/menu/style/index.less
@@ -460,7 +460,9 @@
   }
 
   &-inline-collapsed {
-    width: @menu-collapsed-width;
+    &:not(.@{ant-prefix}-layout-sider-children > ul) {
+      width: @menu-collapsed-width;
+    }
     > .@{menu-prefix-cls}-item,
     > .@{menu-prefix-cls}-item-group
       > .@{menu-prefix-cls}-item-group-list


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
close #30355
<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

当collapsedWidth设置时，内部menu-item的宽度是固定的，不能根据设置的宽度自适应。

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     修复当设置collapsedWidth时menu-item宽度错误的问题      |
| 🇨🇳 Chinese |     Fix the problem that menu-item width is wrong when collapsedWidth is set      |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
