### PR TITLE
fix(DatePicker): locale in DatePicker cannot override ConfigProvider locale

### DIFF
--- a/components/date-picker/__tests__/other.test.js
+++ b/components/date-picker/__tests__/other.test.js
@@ -4,6 +4,9 @@ import moment from 'moment';
 import DatePicker from '..';
 import LocaleProvider from '../../locale-provider';
 import locale from '../../locale-provider/zh_CN';
+import ConfigProvider from '../../config-provider';
+import jaJP from '../../locale/ja_JP';
+import zhTW from '../locale/zh_TW';
 
 const { MonthPicker, WeekPicker } = DatePicker;
 
@@ -51,5 +54,25 @@ describe('MonthPicker and WeekPicker', () => {
     const wrapper = mount(<WeekPicker open />);
     wrapper.setProps({ value: birthday });
     expect(render(wrapper.find('Trigger').instance().getComponent())).toMatchSnapshot();
+  });
+});
+
+describe('Override locale setting of the ConfigProvider', () => {
+  it('DatePicker', () => {
+    const wrapper = mount(
+      <ConfigProvider locale={jaJP}>
+        <DatePicker locale={zhTW} />
+      </ConfigProvider>,
+    );
+    expect(wrapper.find('input').props().placeholder).toEqual('請選擇日期');
+  });
+  it('RangePicker', () => {
+    const wrapper = mount(
+      <ConfigProvider locale={jaJP}>
+        <DatePicker.RangePicker locale={zhTW} />
+      </ConfigProvider>,
+    );
+    expect(wrapper.find('input').at(0).props().placeholder).toEqual('開始日期');
+    expect(wrapper.find('input').at(1).props().placeholder).toEqual('結束日期');
   });
 });

--- a/components/date-picker/generatePicker/generateRangePicker.tsx
+++ b/components/date-picker/generatePicker/generateRangePicker.tsx
@@ -35,20 +35,8 @@ export default function generateRangePicker<DateType>(
       }
     };
 
-    getDefaultLocale = () => {
-      const { locale } = this.props;
-      const result = {
-        ...enUS,
-        ...locale,
-      };
-      result.lang = {
-        ...result.lang,
-        ...((locale || {}) as PickerLocale).lang,
-      };
-      return result;
-    };
-
-    renderPicker = (locale: PickerLocale) => {
+    renderPicker = (contextLocale: PickerLocale) => {
+      const locale = { ...contextLocale, ...this.props.locale };
       const { getPrefixCls, direction, getPopupContainer } = this.context;
       const {
         prefixCls: customizePrefixCls,
@@ -117,7 +105,7 @@ export default function generateRangePicker<DateType>(
 
     render() {
       return (
-        <LocaleReceiver componentName="DatePicker" defaultLocale={this.getDefaultLocale}>
+        <LocaleReceiver componentName="DatePicker" defaultLocale={enUS}>
           {this.renderPicker}
         </LocaleReceiver>
       );

--- a/components/date-picker/generatePicker/generateSinglePicker.tsx
+++ b/components/date-picker/generatePicker/generateSinglePicker.tsx
@@ -58,20 +58,8 @@ export default function generatePicker<DateType>(generateConfig: GenerateConfig<
         }
       };
 
-      getDefaultLocale = () => {
-        const { locale } = this.props;
-        const result = {
-          ...enUS,
-          ...locale,
-        };
-        result.lang = {
-          ...result.lang,
-          ...((locale || {}) as PickerLocale).lang,
-        };
-        return result;
-      };
-
-      renderPicker = (locale: PickerLocale) => {
+      renderPicker = (contextLocale: PickerLocale) => {
+        const locale = { ...contextLocale, ...this.props.locale };
         const { getPrefixCls, direction, getPopupContainer } = this.context;
         const {
           prefixCls: customizePrefixCls,
@@ -148,7 +136,7 @@ export default function generatePicker<DateType>(generateConfig: GenerateConfig<
 
       render() {
         return (
-          <LocaleReceiver componentName="DatePicker" defaultLocale={this.getDefaultLocale}>
+          <LocaleReceiver componentName="DatePicker" defaultLocale={enUS}>
             {this.renderPicker}
           </LocaleReceiver>
         );


### PR DESCRIPTION


<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
close #30374
<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution
Fix the problem that setting locale in DatePicker cannot override ConfigProvider locale
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fix the problem that setting locale in DatePicker cannot override ConfigProvider locale      |
| 🇨🇳 Chinese |     修复在DatePicker里设置locale不能覆盖ConfigProvider locale的问题      |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
