### PR TITLE
feat: Add missing dutch translations

### DIFF
--- a/components/date-picker/locale/nl_BE.tsx
+++ b/components/date-picker/locale/nl_BE.tsx
@@ -5,8 +5,15 @@ import { PickerLocale } from '../generatePicker';
 // Merge into a locale object
 const locale: PickerLocale = {
   lang: {
+    monthPlaceholder: 'Selecteer maand',
     placeholder: 'Selecteer datum',
+    quarterPlaceholder: 'Selecteer kwartaal',
+    rangeMonthPlaceholder: ['Begin maand', 'Eind maand'],
     rangePlaceholder: ['Begin datum', 'Eind datum'],
+    rangeWeekPlaceholder: ['Begin week', 'Eind week'],
+    rangeYearPlaceholder: ['Begin jaar', 'Eind jaar'],
+    weekPlaceholder: 'Selecteer week',
+    yearPlaceholder: 'Selecteer jaar',
     ...CalendarLocale,
   },
   timePickerLocale: {

--- a/components/date-picker/locale/nl_NL.tsx
+++ b/components/date-picker/locale/nl_NL.tsx
@@ -5,8 +5,15 @@ import { PickerLocale } from '../generatePicker';
 // Merge into a locale object
 const locale: PickerLocale = {
   lang: {
+    monthPlaceholder: 'Selecteer maand',
     placeholder: 'Selecteer datum',
+    quarterPlaceholder: 'Selecteer kwartaal',
+    rangeMonthPlaceholder: ['Begin maand', 'Eind maand'],
     rangePlaceholder: ['Begin datum', 'Eind datum'],
+    rangeWeekPlaceholder: ['Begin week', 'Eind week'],
+    rangeYearPlaceholder: ['Begin jaar', 'Eind jaar'],
+    weekPlaceholder: 'Selecteer week',
+    yearPlaceholder: 'Selecteer jaar',
     ...CalendarLocale,
   },
   timePickerLocale: {

--- a/components/locale/nl_BE.tsx
+++ b/components/locale/nl_BE.tsx
@@ -1,8 +1,11 @@
-import Pagination from 'rc-pagination/lib/locale/nl_BE';
-import DatePicker from '../date-picker/locale/nl_BE';
-import TimePicker from '../time-picker/locale/nl_BE';
-import Calendar from '../calendar/locale/nl_BE';
+/* eslint-disable no-template-curly-in-string */
+import Pagination from 'rc-pagination/lib/locale/nl_NL';
+import DatePicker from '../date-picker/locale/nl_NL';
+import TimePicker from '../time-picker/locale/nl_NL';
+import Calendar from '../calendar/locale/nl_NL';
 import { Locale } from '../locale-provider';
+
+const typeTemplate = '${label} is geen geldige ${type}';
 
 const localeValues: Locale = {
   locale: 'nl-be',
@@ -10,12 +13,25 @@ const localeValues: Locale = {
   DatePicker,
   TimePicker,
   Calendar,
+  global: {
+    placeholder: 'Maak een selectie',
+  },
   Table: {
-    filterTitle: 'FilterMenu',
+    cancelSort: 'Click to cancel sorting',
+    collapse: 'Rij inklappen',
+    emptyText: 'Geen data',
+    expand: 'Rij uitklappen',
     filterConfirm: 'OK',
+    filterEmptyText: 'Geen filters',
     filterReset: 'Reset',
+    filterTitle: 'Filteren',
     selectAll: 'Selecteer huidige pagina',
-    selectInvert: 'Selecteer huidige pagina',
+    selectInvert: 'Keer volgorde om',
+    selectNone: 'Maak selectie leeg',
+    selectionAll: 'Selecteer alle data',
+    sortTitle: 'Sorteren',
+    triggerAsc: 'Klik om oplopend te sorteren',
+    triggerDesc: 'Klik om aflopend te sorteren',
   },
   Modal: {
     okText: 'OK',
@@ -27,19 +43,91 @@ const localeValues: Locale = {
     cancelText: 'Annuleer',
   },
   Transfer: {
-    searchPlaceholder: 'Zoek hier',
     itemUnit: 'item',
     itemsUnit: 'items',
+    remove: 'Verwijder',
+    removeAll: 'Verwijder alles',
+    removeCurrent: 'Verwijder huidige pagina',
+    searchPlaceholder: 'Zoek hier',
+    selectAll: 'Select alles',
+    selectCurrent: 'Selecteer huidige pagina',
+    selectInvert: 'Huidige pagina omkeren',
+    titles: ['', ''],
   },
   Upload: {
+    downloadFile: 'Bestand downloaden',
+    previewFile: 'Preview file',
+    removeFile: 'Verwijder bestand',
+    uploadError: 'Fout tijdens uploaden',
     uploading: 'Uploaden...',
-    removeFile: 'Bestand verwijderen',
-    uploadError: 'Upload fout',
-    previewFile: 'Preview bestand',
-    downloadFile: 'Download bestand',
   },
   Empty: {
     description: 'Geen gegevens',
+  },
+  Icon: {
+    icon: 'icoon',
+  },
+  Text: {
+    edit: 'Bewerken',
+    copy: 'kopiëren',
+    copied: 'Gekopieerd',
+    expand: 'Uitklappen',
+  },
+  PageHeader: {
+    back: 'Terug',
+  },
+  Form: {
+    optional: '(optioneel)',
+    defaultValidateMessages: {
+      default: 'Validatiefout voor ${label}',
+      required: 'Gelieve ${label} in te vullen',
+      enum: '${label} moet één van [${enum}] zijn',
+      whitespace: '${label} mag geen blanco teken zijn',
+      date: {
+        format: '${label} heeft een ongeldig formaat',
+        parse: '${label} kan niet naar een datum omgezet worden',
+        invalid: '${label} is een ongeldige datum',
+      },
+      types: {
+        string: typeTemplate,
+        method: typeTemplate,
+        array: typeTemplate,
+        object: typeTemplate,
+        number: typeTemplate,
+        date: typeTemplate,
+        boolean: typeTemplate,
+        integer: typeTemplate,
+        float: typeTemplate,
+        regexp: typeTemplate,
+        email: typeTemplate,
+        url: typeTemplate,
+        hex: typeTemplate,
+      },
+      string: {
+        len: '${label} moet ${len} karakters lang zijn',
+        min: '${label} moet minimaal ${min} karakters lang zijn',
+        max: '${label} mag maximaal ${max} karakters lang zijn',
+        range: '${label} moet tussen ${min}-${max} karakters lang zijn',
+      },
+      number: {
+        len: '${label} moet gelijk zijn aan ${len}',
+        min: '${label} moet minimaal ${min} zijn',
+        max: '${label} mag maximaal ${max} zijn',
+        range: '${label} moet tussen ${min}-${max} liggen',
+      },
+      array: {
+        len: 'Moeten ${len} ${label} zijn',
+        min: 'Minimaal ${min} ${label}',
+        max: 'maximaal ${max} ${label}',
+        range: 'Het aantal ${label} moet tussen ${min}-${max} liggen',
+      },
+      pattern: {
+        mismatch: '${label} komt niet overeen met het patroon ${pattern}',
+      },
+    },
+  },
+  Image: {
+    preview: 'Voorbeeld',
   },
 };
 

--- a/components/locale/nl_BE.tsx
+++ b/components/locale/nl_BE.tsx
@@ -17,7 +17,7 @@ const localeValues: Locale = {
     placeholder: 'Maak een selectie',
   },
   Table: {
-    cancelSort: 'Click to cancel sorting',
+    cancelSort: 'Klik om sortering te annuleren',
     collapse: 'Rij inklappen',
     emptyText: 'Geen data',
     expand: 'Rij uitklappen',
@@ -49,7 +49,7 @@ const localeValues: Locale = {
     removeAll: 'Verwijder alles',
     removeCurrent: 'Verwijder huidige pagina',
     searchPlaceholder: 'Zoek hier',
-    selectAll: 'Select alles',
+    selectAll: 'Selecteer alles',
     selectCurrent: 'Selecteer huidige pagina',
     selectInvert: 'Huidige pagina omkeren',
     titles: ['', ''],

--- a/components/locale/nl_NL.tsx
+++ b/components/locale/nl_NL.tsx
@@ -1,8 +1,11 @@
+/* eslint-disable no-template-curly-in-string */
 import Pagination from 'rc-pagination/lib/locale/nl_NL';
 import DatePicker from '../date-picker/locale/nl_NL';
 import TimePicker from '../time-picker/locale/nl_NL';
 import Calendar from '../calendar/locale/nl_NL';
 import { Locale } from '../locale-provider';
+
+const typeTemplate = '${label} is geen geldige ${type}';
 
 const localeValues: Locale = {
   locale: 'nl',
@@ -14,36 +17,49 @@ const localeValues: Locale = {
     placeholder: 'Maak een selectie',
   },
   Table: {
-    filterTitle: 'Filteren',
-    filterConfirm: 'OK',
-    filterReset: 'Reset',
-    selectAll: 'Selecteer huidige pagina',
-    selectInvert: 'Deselecteer huidige pagina',
-    sortTitle: 'Sorteren',
-    expand: 'Rij uitklappen',
+    cancelSort: 'Click to cancel sorting',
     collapse: 'Rij inklappen',
+    emptyText: 'Geen data',
+    expand: 'Rij uitklappen',
+    filterConfirm: 'OK',
+    filterEmptyText: 'Geen filters',
+    filterReset: 'Reset',
+    filterTitle: 'Filteren',
+    selectAll: 'Selecteer huidige pagina',
+    selectInvert: 'Keer volgorde om',
+    selectNone: 'Maak selectie leeg',
+    selectionAll: 'Selecteer alle data',
+    sortTitle: 'Sorteren',
+    triggerAsc: 'Klik om oplopend te sorteren',
+    triggerDesc: 'Klik om aflopend te sorteren',
   },
   Modal: {
     okText: 'OK',
-    cancelText: 'Annuleren',
+    cancelText: 'Annuleer',
     justOkText: 'OK',
   },
   Popconfirm: {
     okText: 'OK',
-    cancelText: 'Annuleren',
+    cancelText: 'Annuleer',
   },
   Transfer: {
-    titles: ['', ''],
-    searchPlaceholder: 'Zoeken',
     itemUnit: 'item',
     itemsUnit: 'items',
+    remove: 'Verwijder',
+    removeAll: 'Verwijder alles',
+    removeCurrent: 'Verwijder huidige pagina',
+    searchPlaceholder: 'Zoek hier',
+    selectAll: 'Select alles',
+    selectCurrent: 'Selecteer huidige pagina',
+    selectInvert: 'Huidige pagina omkeren',
+    titles: ['', ''],
   },
   Upload: {
-    uploading: 'Uploaden...',
+    downloadFile: 'Bestand downloaden',
+    previewFile: 'Preview file',
     removeFile: 'Verwijder bestand',
     uploadError: 'Fout tijdens uploaden',
-    previewFile: 'Bekijk bestand',
-    downloadFile: 'Downloaden bestand',
+    uploading: 'Uploaden...',
   },
   Empty: {
     description: 'Geen gegevens',
@@ -53,12 +69,65 @@ const localeValues: Locale = {
   },
   Text: {
     edit: 'Bewerken',
-    copy: 'Kopieren',
+    copy: 'kopiëren',
     copied: 'Gekopieerd',
     expand: 'Uitklappen',
   },
   PageHeader: {
     back: 'Terug',
+  },
+  Form: {
+    optional: '(optioneel)',
+    defaultValidateMessages: {
+      default: 'Validatiefout voor ${label}',
+      required: 'Gelieve ${label} in te vullen',
+      enum: '${label} moet één van [${enum}] zijn',
+      whitespace: '${label} mag geen blanco teken zijn',
+      date: {
+        format: '${label} heeft een ongeldig formaat',
+        parse: '${label} kan niet naar een datum omgezet worden',
+        invalid: '${label} is een ongeldige datum',
+      },
+      types: {
+        string: typeTemplate,
+        method: typeTemplate,
+        array: typeTemplate,
+        object: typeTemplate,
+        number: typeTemplate,
+        date: typeTemplate,
+        boolean: typeTemplate,
+        integer: typeTemplate,
+        float: typeTemplate,
+        regexp: typeTemplate,
+        email: typeTemplate,
+        url: typeTemplate,
+        hex: typeTemplate,
+      },
+      string: {
+        len: '${label} moet ${len} karakters lang zijn',
+        min: '${label} moet minimaal ${min} karakters lang zijn',
+        max: '${label} mag maximaal ${max} karakters lang zijn',
+        range: '${label} moet tussen ${min}-${max} karakters lang zijn',
+      },
+      number: {
+        len: '${label} moet gelijk zijn aan ${len}',
+        min: '${label} moet minimaal ${min} zijn',
+        max: '${label} mag maximaal ${max} zijn',
+        range: '${label} moet tussen ${min}-${max} liggen',
+      },
+      array: {
+        len: 'Moeten ${len} ${label} zijn',
+        min: 'Minimaal ${min} ${label}',
+        max: 'maximaal ${max} ${label}',
+        range: 'Het aantal ${label} moet tussen ${min}-${max} liggen',
+      },
+      pattern: {
+        mismatch: '${label} komt niet overeen met het patroon ${pattern}',
+      },
+    },
+  },
+  Image: {
+    preview: 'Voorbeeld',
   },
 };
 

--- a/components/locale/nl_NL.tsx
+++ b/components/locale/nl_NL.tsx
@@ -17,7 +17,7 @@ const localeValues: Locale = {
     placeholder: 'Maak een selectie',
   },
   Table: {
-    cancelSort: 'Click to cancel sorting',
+    cancelSort: 'Klik om sortering te annuleren',
     collapse: 'Rij inklappen',
     emptyText: 'Geen data',
     expand: 'Rij uitklappen',
@@ -49,7 +49,7 @@ const localeValues: Locale = {
     removeAll: 'Verwijder alles',
     removeCurrent: 'Verwijder huidige pagina',
     searchPlaceholder: 'Zoek hier',
-    selectAll: 'Select alles',
+    selectAll: 'Selecteer alles',
     selectCurrent: 'Selecteer huidige pagina',
     selectInvert: 'Huidige pagina omkeren',
     titles: ['', ''],

--- a/components/time-picker/locale/nl_BE.tsx
+++ b/components/time-picker/locale/nl_BE.tsx
@@ -2,6 +2,7 @@ import { TimePickerLocale } from '../index';
 
 const locale: TimePickerLocale = {
   placeholder: 'Selecteer tijd',
+  rangePlaceholder: ['Start tijd', 'Eind tijd'],
 };
 
 export default locale;

--- a/components/time-picker/locale/nl_NL.tsx
+++ b/components/time-picker/locale/nl_NL.tsx
@@ -2,6 +2,7 @@ import { TimePickerLocale } from '../index';
 
 const locale: TimePickerLocale = {
   placeholder: 'Selecteer tijd',
+  rangePlaceholder: ['Start tijd', 'Eind tijd'],
 };
 
 export default locale;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [x] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
fixes #30361 
trace: #23369 

### 💡 Background and solution
Adds in missing dutch translations, tried to translate to my best ability `nl_BE` and `nl_NL`. They are basically the same language, given some minor differences in wording. 

However having a translation specific to either Belgium or The Netherlands is still miles ahead of not having one at all :)

Basically started from scratch based upon the default translations.

**small side note:** 
```js
{
  Form: {
      array: {
        len: 'Moeten ${len} ${label} zijn',
      }
  }
}
```
Should actually be something in the form of 'Moet ${len} ${label} zijn' when `len == 1` and `Moeten` when `len > 1`.

Couldn't really find an example with plural translations so i guess this will suffice for now.

### 📝 Changelog
Added missing dutch and flemish translations.

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Added missing dutch and flemish translations.  |
| 🇨🇳 Chinese |    补充荷兰语(荷兰)及荷兰语(比利时)国际化       |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
