### PR TITLE
fix: File constructor in Upload component.

### DIFF
--- a/components/upload/Upload.tsx
+++ b/components/upload/Upload.tsx
@@ -170,9 +170,21 @@ const InternalUpload: React.ForwardRefRenderFunction<unknown, UploadProps> = (pr
       if (!filteredFileInfoList[index].parsedFile) {
         // `beforeUpload` return false
         const { originFileObj } = fileObj;
-        const clone = (new File([originFileObj], originFileObj.name, {
-          type: originFileObj.type,
-        }) as any) as UploadFile;
+        let clone;
+
+        try {
+          clone = (new File([originFileObj], originFileObj.name, {
+            type: originFileObj.type,
+          }) as any) as UploadFile;
+        } catch (e) {
+          clone = (new Blob([originFileObj], {
+            type: originFileObj.type,
+          }) as any) as UploadFile;
+          clone.name = originFileObj.name;
+          clone.lastModifiedDate = new Date();
+          clone.lastModified = new Date().getTime();
+        }
+
         clone.uid = fileObj.uid;
         triggerFileObj = clone;
       } else {

--- a/components/upload/__tests__/upload.test.js
+++ b/components/upload/__tests__/upload.test.js
@@ -843,4 +843,25 @@ describe('Upload', () => {
       await sleep();
     });
   });
+
+  // https://github.com/ant-design/ant-design/issues/30390
+  // IE11 Does not support the File constructor
+  it('should not break in IE if beforeUpload returns false', async () => {
+    const onChange = jest.fn();
+    const wrapper = mount(<Upload beforeUpload={() => false} fileList={[]} onChange={onChange} />);
+    const fileConstructor = () => {
+      throw new TypeError("Object doesn't support this action");
+    };
+    global.File = jest.fn().mockImplementationOnce(fileConstructor);
+
+    await act(async () =>
+      wrapper.find('input').simulate('change', {
+        target: {
+          files: [{ file: 'foo.png' }],
+        },
+      }),
+    );
+
+    expect(onChange.mock.calls[0][0].fileList).toHaveLength(1);
+  });
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

https://github.com/ant-design/ant-design/issues/30390

### 💡 Background and solution

The problem is described in the related issue. The solution was to cover the file constructor with a try-catch block and in case of failure create a similar object based on the blob. I think it might a good idea to initially create a blob but I decided to make fewer changes as possible. 

### 📝 Changelog

There are no global changes. There was added just one try-catch block.

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
