### PR TITLE
fix: style normalization for th element

### DIFF
--- a/components/style/core/global.less
+++ b/components/style/core/global.less
@@ -322,12 +322,6 @@ caption {
   caption-side: bottom;
 }
 
-th {
-  // Matches default `<td>` alignment by inheriting from the `<body>`, or the
-  // closest parent with a set `text-align`.
-  text-align: inherit;
-}
-
 //
 // Forms
 //

--- a/components/table/style/index.less
+++ b/components/table/style/index.less
@@ -34,13 +34,6 @@
     border-spacing: 0;
   }
 
-  // https://github.com/ant-design/ant-design/issues/30398
-  th {
-    // Matches default `<td>` alignment by inheriting from the `<body>`, or the
-    // closest parent with a set `text-align`.
-    text-align: inherit;
-  }
-
   // ============================= Cell =============================
   &-thead > tr > th,
   &-tbody > tr > td,

--- a/components/table/style/index.less
+++ b/components/table/style/index.less
@@ -34,6 +34,13 @@
     border-spacing: 0;
   }
 
+  // https://github.com/ant-design/ant-design/issues/30398
+  th {
+    // Matches default `<td>` alignment by inheriting from the `<body>`, or the
+    // closest parent with a set `text-align`.
+    text-align: inherit;
+  }
+
   // ============================= Cell =============================
   &-thead > tr > th,
   &-tbody > tr > td,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [x] Bug fix
- [x] Component style update

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

close #30398

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

pr 背景摘自 #30398，主要为了解决现有 components/style/core/global.less 中与一些主流 markdown parser 对表格样式的定义冲突问题，导致 markdown parser 产出的 `<th align="center">` 无法生效。

为什么一定要兼容 th 的 align 属性？因为在现有的不限于 github markdown parser、remark parser 中，表格居中语法最终都是编译为 align 属性，而不是 text-align，故不应额外定义 th 的 text-align 来覆盖 align 属性，否则在 markdown parser 编译后的表格中，所有的居中语法将默认失效，除非 antd 的用户每次都手动覆写 css rule。

一个典型的不方便使用的场景，可见 https://github.com/umijs/dumi/issues/669

#### 对现有 table rule 的影响

现有 antd table 中的 th rule 在 [components/table/style](https://github.com/ant-design/ant-design/tree/4.15.4/components/table/style) 已有多种 text-align 具体定义。故 pr 的删除并 **不会影响现有组件样式**。

#### 社区实践

与 components/style/core/global.less 相同使用场景定位的，且在得到广泛使用的 [normalize.css](https://github.com/necolas/normalize.css/blob/master/normalize.css) 和 [modern-normalize](https://github.com/sindresorhus/modern-normalize/blob/main/modern-normalize.css) 均无对 th 元素的 text-align 的定义

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  revoke global th text-align rule         |
| 🇨🇳 Chinese |       撤消对 th 的 text-align 的定义    |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
