### PR TITLE
fix: Switch tabIndex type

### DIFF
--- a/components/switch/index.tsx
+++ b/components/switch/index.tsx
@@ -27,6 +27,7 @@ export interface SwitchProps {
   autoFocus?: boolean;
   style?: React.CSSProperties;
   title?: string;
+  tabIndex?: number;
 }
 
 interface CompoundedComponent


### PR DESCRIPTION
…ition

<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [X] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

Added the `tabIndex` property in the Switch components TS props definition.

### 💡 Background and solution

The Switch component does not currently contain a tabIndex property. The underlying rc-switch component has support for this feature so is was a simple fix.

### 📝 Changelog

Added tabIndex support for the Switch component.

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Added tabIndex support for the Switch component.  |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [X] Doc is updated/provided or not needed
- [X] Demo is updated/provided or not needed
- [X] TypeScript definition is updated/provided or not needed
- [X] Changelog is provided or not needed
