### PR TITLE
style: fix calendar style inside Form.Item

### DIFF
--- a/components/calendar/Header.tsx
+++ b/components/calendar/Header.tsx
@@ -31,7 +31,7 @@ function YearSelect<DateType>(props: SharedProps<DateType>) {
     divRef,
   } = props;
 
-  const year = generateConfig.getYear(value);
+  const year = generateConfig.getYear(value || generateConfig.getNow());
 
   let start = year - YearSelectOffset;
   let end = start + YearSelectTotal;
@@ -92,7 +92,7 @@ function MonthSelect<DateType>(props: SharedProps<DateType>) {
     onChange,
     divRef,
   } = props;
-  const month = generateConfig.getMonth(value);
+  const month = generateConfig.getMonth(value || generateConfig.getNow());
 
   let start = 0;
   let end = 11;

--- a/components/calendar/__tests__/index.test.js
+++ b/components/calendar/__tests__/index.test.js
@@ -27,6 +27,18 @@ describe('Calendar', () => {
     findSelectItem(wrapper).at(index).simulate('click');
   }
 
+  // https://github.com/ant-design/ant-design/issues/30392
+  it('should be able to set undefined or null', () => {
+    expect(() => {
+      const wrapper = mount(<Calendar />);
+      wrapper.setProps({ value: null });
+    }).not.toThrow();
+    expect(() => {
+      const wrapper = mount(<Calendar />);
+      wrapper.setProps({ value: undefined });
+    }).not.toThrow();
+  });
+
   it('Calendar should be selectable', () => {
     const onSelect = jest.fn();
     const onChange = jest.fn();

--- a/components/form/style/components.less
+++ b/components/form/style/components.less
@@ -56,12 +56,14 @@
     }
   }
 
-  .@{ant-prefix}-select:not(.ant-picker-calendar-year-select):not(.ant-picker-calendar-month-select),
+  .@{ant-prefix}-select,
   .@{ant-prefix}-cascader-picker {
     width: 100%;
   }
 
-  // Don't impact select inside input group
+  // Don't impact select inside input group and calendar header select
+  .@{ant-prefix}-picker-calendar-year-select,
+  .@{ant-prefix}-picker-calendar-month-select,
   .@{ant-prefix}-input-group .@{ant-prefix}-select,
   .@{ant-prefix}-input-group .@{ant-prefix}-cascader-picker {
     width: auto;

--- a/components/form/style/components.less
+++ b/components/form/style/components.less
@@ -56,7 +56,7 @@
     }
   }
 
-  .@{ant-prefix}-select,
+  .@{ant-prefix}-select:not(.ant-picker-calendar-year-select):not(.ant-picker-calendar-month-select),
   .@{ant-prefix}-cascader-picker {
     width: 100%;
   }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close #30392

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  - Fix Calendar broken style inside Form.Item.<br />- Fix Calendar throws error when set `value` to `null` or `undefined`.         |
| 🇨🇳 Chinese | - 修复 Calendar 在 Form.Item 下样式错乱的问题。<br />- 修复 Calendar `value` 设置 `null` 和 `undefined` 时报错的问题。  |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
