### PR TITLE
fix: Table filterDropdown confirm closeDropdown

### DIFF
--- a/components/table/__tests__/Table.filter.test.js
+++ b/components/table/__tests__/Table.filter.test.js
@@ -1513,6 +1513,7 @@ describe('Table.filter', () => {
 
     expect(wrapper.find('.ant-table-filter-column')).toHaveLength(3);
   });
+
   it('should pagination.current be 1 after filtering', () => {
     const onChange = jest.fn();
     const columns = [
@@ -1561,5 +1562,47 @@ describe('Table.filter', () => {
     wrapper.find('FilterDropdown').find('MenuItem').at(1).simulate('click');
     wrapper.find('.ant-btn-primary').first().simulate('click');
     expect(onChange.mock.calls[1][0].current).toBe(1);
+  });
+
+  // https://github.com/ant-design/ant-design/issues/30454
+  it('should not trigger onFilterDropdownVisibleChange when call confirm({ closeDropdown: false })', () => {
+    const onFilterDropdownVisibleChange = jest.fn();
+    const wrapper = mount(
+      createTable({
+        columns: [
+          {
+            title: 'Name',
+            dataIndex: 'name',
+            key: 'name',
+            filteredValue: name,
+            filterDropdown: ({ confirm }) => (
+              <>
+                <button id="confirm-and-close" type="button" onClick={() => confirm()}>
+                  confirm
+                </button>
+                <button
+                  id="confirm-only"
+                  type="button"
+                  onClick={() => confirm({ closeDropdown: false })}
+                >
+                  confirm
+                </button>
+              </>
+            ),
+            onFilterDropdownVisibleChange,
+          },
+        ],
+      }),
+    );
+
+    wrapper.find('.ant-dropdown-trigger').first().simulate('click');
+    expect(onFilterDropdownVisibleChange).toHaveBeenCalledTimes(1);
+
+    wrapper.find('#confirm-only').simulate('click');
+    expect(onFilterDropdownVisibleChange).toHaveBeenCalledTimes(1);
+
+    wrapper.find('#confirm-and-close').simulate('click');
+    expect(onFilterDropdownVisibleChange).toHaveBeenCalledTimes(2);
+    expect(onFilterDropdownVisibleChange).toHaveBeenLastCalledWith(false);
   });
 });

--- a/components/table/demo/custom-filter-panel.md
+++ b/components/table/demo/custom-filter-panel.md
@@ -64,7 +64,7 @@ class App extends React.Component {
           value={selectedKeys[0]}
           onChange={e => setSelectedKeys(e.target.value ? [e.target.value] : [])}
           onPressEnter={() => this.handleSearch(selectedKeys, confirm, dataIndex)}
-          style={{ width: 188, marginBottom: 8, display: 'block' }}
+          style={{ marginBottom: 8, display: 'block' }}
         />
         <Space>
           <Button

--- a/components/table/hooks/useFilter/FilterDropdown.tsx
+++ b/components/table/hooks/useFilter/FilterDropdown.tsx
@@ -8,14 +8,7 @@ import Checkbox from '../../../checkbox';
 import Radio from '../../../radio';
 import Dropdown from '../../../dropdown';
 import Empty from '../../../empty';
-import {
-  ColumnType,
-  ColumnFilterItem,
-  Key,
-  TableLocale,
-  GetPopupContainer,
-  FilterConfirmProps,
-} from '../../interface';
+import { ColumnType, ColumnFilterItem, Key, TableLocale, GetPopupContainer } from '../../interface';
 import FilterDropdownMenuWrapper from './FilterWrapper';
 import { FilterState } from '.';
 import useSyncState from '../../../_util/hooks/useSyncState';
@@ -192,8 +185,10 @@ function FilterDropdown<RecordType>(props: FilterDropdownProps<RecordType>) {
     internalTriggerFilter([]);
   };
 
-  const doFilter = (param: FilterConfirmProps = { closeDropdown: true }) => {
-    triggerVisible(!param.closeDropdown);
+  const doFilter = ({ closeDropdown } = { closeDropdown: true }) => {
+    if (closeDropdown) {
+      triggerVisible(false);
+    }
     internalTriggerFilter(getFilteredKeysSync());
   };
 


### PR DESCRIPTION


<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close #30454

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Table call `confirm({ closeDropdown: true })` in `filterDropdown` should not trigger  `onFilterDropdownVisibleChange`.  |
| 🇨🇳 Chinese | 修复 Table `filterDropdown` 调用 `confirm({ closeDropdown: true })` 时也会触发 `onFilterDropdownVisibleChange` 的问题。 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
