### PR TITLE
Changed specific to specify in basic.md

### DIFF
--- a/components/icon/demo/basic.md
+++ b/components/icon/demo/basic.md
@@ -11,7 +11,7 @@ title:
 
 ## en-US
 
-Import icons from `@ant-design/icons`, component name of icons with different theme is the icon name suffixed by the theme name. Specific the `spin` property to show spinning animation.
+Import icons from `@ant-design/icons`, component name of icons with different theme is the icon name suffixed by the theme name. Specify the `spin` property to show spinning animation.
 
 ```jsx
 import {


### PR DESCRIPTION
Specify is the correct word to use instead of specific in the current scenario.

<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [✓] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [✓] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Incorrect usage of the word "specific".
-->

### 💡 Background and solution

<!--
1. Specific was being used in the Icon component documentation demo
2. Specify is the correct word to use.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
Ant design website now uses "specify" instead of "specific" in the icons documentation.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     ✓     |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [✓] Doc is updated/provided or not needed
- [✓] Demo is updated/provided or not needed
- [✓] TypeScript definition is updated/provided or not needed
- [✓] Changelog is provided or not needed
