### PR TITLE
fix(Collapse): end motion when set activeKey while hiding

### DIFF
--- a/components/_util/motion.tsx
+++ b/components/_util/motion.tsx
@@ -1,11 +1,12 @@
 import { CSSMotionProps, MotionEventHandler, MotionEndEventHandler } from 'rc-motion';
+import { MotionEvent } from 'rc-motion/lib/interface';
 
 // ================== Collapse Motion ==================
 const getCollapsedHeight: MotionEventHandler = () => ({ height: 0, opacity: 0 });
 const getRealHeight: MotionEventHandler = node => ({ height: node.scrollHeight, opacity: 1 });
 const getCurrentHeight: MotionEventHandler = node => ({ height: node.offsetHeight });
-const skipOpacityTransition: MotionEndEventHandler = (_, event) =>
-  (event as TransitionEvent).propertyName === 'height';
+const skipOpacityTransition: MotionEndEventHandler = (_, event: MotionEvent) =>
+  event?.deadline === true || (event as TransitionEvent).propertyName === 'height';
 
 const collapseMotion: CSSMotionProps = {
   motionName: 'ant-motion-collapse',

--- a/components/collapse/__tests__/index.test.js
+++ b/components/collapse/__tests__/index.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { mount } from 'enzyme';
+import { act } from 'react-dom/test-utils';
 import { sleep } from '../../../tests/utils';
 import { resetWarned } from '../../_util/devWarning';
 
@@ -100,5 +101,40 @@ describe('Collapse', () => {
 
     wrapper.find('.ant-collapse-header').simulate('click');
     expect(wrapper.find('.ant-collapse-item-active').length).toBe(0);
+  });
+
+  it('should end motion when set activeKey while hiding', async () => {
+    jest.useFakeTimers();
+    jest.spyOn(window, 'requestAnimationFrame').mockImplementation(cb => {
+      setTimeout(cb, 16.66);
+    });
+
+    let setActiveKeyOuter;
+    const Test = () => {
+      const [activeKey, setActiveKey] = React.useState();
+      setActiveKeyOuter = setActiveKey;
+      return (
+        <div hidden>
+          <Collapse activeKey={activeKey}>
+            <Collapse.Panel header="header" key="1">
+              content
+            </Collapse.Panel>
+          </Collapse>
+        </div>
+      );
+    };
+
+    const wrapper = mount(<Test />);
+
+    await act(async () => {
+      setActiveKeyOuter('1');
+      await Promise.resolve();
+      jest.runAllTimers();
+    });
+
+    expect(wrapper.render().find('.ant-motion-collapse').length).toBe(0);
+
+    window.requestAnimationFrame.mockRestore();
+    jest.useRealTimers();
   });
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

fix #30527
fix #30609

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

Let `skipOpacityTransition` return true when `event?.deadline` is true for end motion.

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix(Collapse): The content of collapse panel hide when set activeKey while hiding. |
| 🇨🇳 Chinese | 修复 Collapse：在隐藏时设置 activeKey， panel 的内容会消失。 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
