### PR TITLE
fix: useNotification className should work correctly

### DIFF
--- a/components/notification/style/index.less
+++ b/components/notification/style/index.less
@@ -31,14 +31,19 @@
     cursor: pointer;
   }
 
-  &-hook-holder,
+  &-hook-holder {
+    position: relative;
+  }
+
   &-notice {
     position: relative;
     width: @notification-width;
     max-width: ~'calc(100vw - @{notification-margin-edge} * 2)';
     margin-bottom: @notification-margin-bottom;
     margin-left: auto;
+    padding: @notification-padding;
     overflow: hidden;
+    line-height: @line-height-base;
     word-wrap: break-word;
     background: @notification-bg;
     border-radius: @border-radius-base;
@@ -49,16 +54,6 @@
       margin-right: auto;
       margin-left: 0;
     }
-  }
-
-  &-hook-holder > &-notice {
-    margin-bottom: 0;
-    box-shadow: none;
-  }
-
-  &-notice {
-    padding: @notification-padding;
-    line-height: @line-height-base;
 
     &-message {
       margin-bottom: 8px;


### PR DESCRIPTION


<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close #30576

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Notification custom styles don't apply to correct div by `className` when using `useNotification`.  |
| 🇨🇳 Chinese | 修复 Notification `useNotification` 生成的通知框 `className` 作用范围不一致的问题。  |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
