### PR TITLE
fix: Anchor should trigger onChange when have getCurrentAnchor

### DIFF
--- a/components/anchor/Anchor.tsx
+++ b/components/anchor/Anchor.tsx
@@ -163,12 +163,6 @@ export default class Anchor extends React.Component<AnchorProps, AnchorState, Co
   }
 
   getCurrentAnchor(offsetTop = 0, bounds = 5): string {
-    const { getCurrentAnchor } = this.props;
-
-    if (typeof getCurrentAnchor === 'function') {
-      return getCurrentAnchor();
-    }
-
     const linkSections: Array<Section> = [];
     const container = this.getContainer();
     this.links.forEach(link => {
@@ -229,14 +223,15 @@ export default class Anchor extends React.Component<AnchorProps, AnchorState, Co
 
   setCurrentActiveLink = (link: string) => {
     const { activeLink } = this.state;
-    const { onChange } = this.props;
-
-    if (activeLink !== link) {
-      this.setState({
-        activeLink: link,
-      });
-      onChange?.(link);
+    const { onChange, getCurrentAnchor } = this.props;
+    if (activeLink === link) {
+      return;
     }
+    // https://github.com/ant-design/ant-design/issues/30584
+    this.setState({
+      activeLink: typeof getCurrentAnchor === 'function' ? getCurrentAnchor() : link,
+    });
+    onChange?.(link);
   };
 
   handleScroll = () => {

--- a/components/anchor/__tests__/Anchor.test.tsx
+++ b/components/anchor/__tests__/Anchor.test.tsx
@@ -359,6 +359,23 @@ describe('Anchor Render', () => {
     expect(onChange).toHaveBeenCalledWith(hash2);
   });
 
+  // https://github.com/ant-design/ant-design/issues/30584
+  it('should trigger onChange when have getCurrentAnchor', async () => {
+    const hash1 = getHashUrl();
+    const hash2 = getHashUrl();
+    const onChange = jest.fn();
+    const wrapper = mount<Anchor>(
+      <Anchor onChange={onChange} getCurrentAnchor={() => hash1}>
+        <Link href={`#${hash1}`} title={hash1} />
+        <Link href={`#${hash2}`} title={hash2} />
+      </Anchor>,
+    );
+    expect(onChange).toHaveBeenCalledTimes(1);
+    wrapper.instance().handleScrollTo(hash2);
+    expect(onChange).toHaveBeenCalledTimes(2);
+    expect(onChange).toHaveBeenCalledWith(hash2);
+  });
+
   it('invalid hash', async () => {
     const wrapper = mount<Anchor>(
       <Anchor>


### PR DESCRIPTION


<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close #30584

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Anchor cannot trigger `onChange` when have `getCurrentAnchor` prop. |
| 🇨🇳 Chinese | 修复 Anchor 指定 `getCurrentAnchor` 后无法触发 `onChange` 的问题。 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
