### PR TITLE
fix: Menu.SubMenu icon margin with other icon libraries

### DIFF
--- a/components/layout/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/layout/__tests__/__snapshots__/demo.test.js.snap
@@ -1067,7 +1067,7 @@ exports[`renders ./components/layout/demo/side.md correctly 1`] = `
           >
             <span
               aria-label="user"
-              class="anticon anticon-user"
+              class="anticon anticon-user ant-menu-item-icon"
               role="img"
             >
               <svg
@@ -1108,7 +1108,7 @@ exports[`renders ./components/layout/demo/side.md correctly 1`] = `
           >
             <span
               aria-label="team"
-              class="anticon anticon-team"
+              class="anticon anticon-team ant-menu-item-icon"
               role="img"
             >
               <svg
@@ -1511,7 +1511,7 @@ exports[`renders ./components/layout/demo/top-side.md correctly 1`] = `
               >
                 <span
                   aria-label="user"
-                  class="anticon anticon-user"
+                  class="anticon anticon-user ant-menu-item-icon"
                   role="img"
                 >
                   <svg
@@ -1589,7 +1589,7 @@ exports[`renders ./components/layout/demo/top-side.md correctly 1`] = `
               >
                 <span
                   aria-label="laptop"
-                  class="anticon anticon-laptop"
+                  class="anticon anticon-laptop ant-menu-item-icon"
                   role="img"
                 >
                   <svg
@@ -1630,7 +1630,7 @@ exports[`renders ./components/layout/demo/top-side.md correctly 1`] = `
               >
                 <span
                   aria-label="notification"
-                  class="anticon anticon-notification"
+                  class="anticon anticon-notification ant-menu-item-icon"
                   role="img"
                 >
                   <svg
@@ -1770,7 +1770,7 @@ exports[`renders ./components/layout/demo/top-side-2.md correctly 1`] = `
             >
               <span
                 aria-label="user"
-                class="anticon anticon-user"
+                class="anticon anticon-user ant-menu-item-icon"
                 role="img"
               >
                 <svg
@@ -1848,7 +1848,7 @@ exports[`renders ./components/layout/demo/top-side-2.md correctly 1`] = `
             >
               <span
                 aria-label="laptop"
-                class="anticon anticon-laptop"
+                class="anticon anticon-laptop ant-menu-item-icon"
                 role="img"
               >
                 <svg
@@ -1889,7 +1889,7 @@ exports[`renders ./components/layout/demo/top-side-2.md correctly 1`] = `
             >
               <span
                 aria-label="notification"
-                class="anticon anticon-notification"
+                class="anticon anticon-notification ant-menu-item-icon"
                 role="img"
               >
                 <svg

--- a/components/menu/SubMenu.tsx
+++ b/components/menu/SubMenu.tsx
@@ -4,7 +4,7 @@ import { useFullPath } from 'rc-menu/lib/context/PathContext';
 import classNames from 'classnames';
 import omit from 'rc-util/lib/omit';
 import MenuContext from './MenuContext';
-import { isValidElement } from '../_util/reactNode';
+import { isValidElement, cloneElement } from '../_util/reactNode';
 
 interface TitleEventEntity {
   key: string;
@@ -48,7 +48,12 @@ function SubMenu(props: SubMenuProps) {
     const titleIsSpan = isValidElement(title) && title.type === 'span';
     titleNode = (
       <>
-        {icon}
+        {cloneElement(icon, {
+          className: classNames(
+            isValidElement(icon) ? icon.props?.className : '',
+            `${prefixCls}-item-icon`,
+          ),
+        })}
         {titleIsSpan ? title : <span className={`${prefixCls}-title-content`}>{title}</span>}
       </>
     );

--- a/components/menu/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/menu/__tests__/__snapshots__/demo.test.js.snap
@@ -83,7 +83,7 @@ exports[`renders ./components/menu/demo/horizontal.md correctly 1`] = `
     >
       <span
         aria-label="setting"
-        class="anticon anticon-setting"
+        class="anticon anticon-setting ant-menu-item-icon"
         role="img"
       >
         <svg
@@ -169,7 +169,7 @@ exports[`renders ./components/menu/demo/inline.md correctly 1`] = `
     >
       <span
         aria-label="mail"
-        class="anticon anticon-mail"
+        class="anticon anticon-mail ant-menu-item-icon"
         role="img"
       >
         <svg
@@ -275,7 +275,7 @@ exports[`renders ./components/menu/demo/inline.md correctly 1`] = `
     >
       <span
         aria-label="appstore"
-        class="anticon anticon-appstore"
+        class="anticon anticon-appstore ant-menu-item-icon"
         role="img"
       >
         <svg
@@ -316,7 +316,7 @@ exports[`renders ./components/menu/demo/inline.md correctly 1`] = `
     >
       <span
         aria-label="setting"
-        class="anticon anticon-setting"
+        class="anticon anticon-setting ant-menu-item-icon"
         role="img"
       >
         <svg
@@ -488,7 +488,7 @@ exports[`renders ./components/menu/demo/inline-collapsed.md correctly 1`] = `
       >
         <span
           aria-label="mail"
-          class="anticon anticon-mail"
+          class="anticon anticon-mail ant-menu-item-icon"
           role="img"
         >
           <svg
@@ -566,7 +566,7 @@ exports[`renders ./components/menu/demo/inline-collapsed.md correctly 1`] = `
       >
         <span
           aria-label="appstore"
-          class="anticon anticon-appstore"
+          class="anticon anticon-appstore ant-menu-item-icon"
           role="img"
         >
           <svg
@@ -619,7 +619,7 @@ exports[`renders ./components/menu/demo/sider-current.md correctly 1`] = `
     >
       <span
         aria-label="mail"
-        class="anticon anticon-mail"
+        class="anticon anticon-mail ant-menu-item-icon"
         role="img"
       >
         <svg
@@ -697,7 +697,7 @@ exports[`renders ./components/menu/demo/sider-current.md correctly 1`] = `
     >
       <span
         aria-label="appstore"
-        class="anticon anticon-appstore"
+        class="anticon anticon-appstore ant-menu-item-icon"
         role="img"
       >
         <svg
@@ -738,7 +738,7 @@ exports[`renders ./components/menu/demo/sider-current.md correctly 1`] = `
     >
       <span
         aria-label="setting"
-        class="anticon anticon-setting"
+        class="anticon anticon-setting ant-menu-item-icon"
         role="img"
       >
         <svg
@@ -807,7 +807,7 @@ Array [
       >
         <span
           aria-label="mail"
-          class="anticon anticon-mail"
+          class="anticon anticon-mail ant-menu-item-icon"
           role="img"
         >
           <svg
@@ -848,7 +848,7 @@ Array [
       >
         <span
           aria-label="appstore"
-          class="anticon anticon-appstore"
+          class="anticon anticon-appstore ant-menu-item-icon"
           role="img"
         >
           <svg
@@ -1034,7 +1034,7 @@ Array [
       >
         <span
           aria-label="appstore"
-          class="anticon anticon-appstore"
+          class="anticon anticon-appstore ant-menu-item-icon"
           role="img"
         >
           <svg
@@ -1115,7 +1115,7 @@ Array [
       >
         <span
           aria-label="setting"
-          class="anticon anticon-setting"
+          class="anticon anticon-setting ant-menu-item-icon"
           role="img"
         >
           <svg
@@ -1223,7 +1223,7 @@ Array [
       >
         <span
           aria-label="mail"
-          class="anticon anticon-mail"
+          class="anticon anticon-mail ant-menu-item-icon"
           role="img"
         >
           <svg
@@ -1301,7 +1301,7 @@ Array [
       >
         <span
           aria-label="appstore"
-          class="anticon anticon-appstore"
+          class="anticon anticon-appstore ant-menu-item-icon"
           role="img"
         >
           <svg
@@ -1342,7 +1342,7 @@ Array [
       >
         <span
           aria-label="setting"
-          class="anticon anticon-setting"
+          class="anticon anticon-setting ant-menu-item-icon"
           role="img"
         >
           <svg
@@ -1394,7 +1394,7 @@ exports[`renders ./components/menu/demo/vertical.md correctly 1`] = `
     >
       <span
         aria-label="mail"
-        class="anticon anticon-mail"
+        class="anticon anticon-mail ant-menu-item-icon"
         role="img"
       >
         <svg
@@ -1434,7 +1434,7 @@ exports[`renders ./components/menu/demo/vertical.md correctly 1`] = `
     >
       <span
         aria-label="appstore"
-        class="anticon anticon-appstore"
+        class="anticon anticon-appstore ant-menu-item-icon"
         role="img"
       >
         <svg
@@ -1474,7 +1474,7 @@ exports[`renders ./components/menu/demo/vertical.md correctly 1`] = `
     >
       <span
         aria-label="setting"
-        class="anticon anticon-setting"
+        class="anticon anticon-setting ant-menu-item-icon"
         role="img"
       >
         <svg

--- a/components/menu/__tests__/__snapshots__/index.test.js.snap
+++ b/components/menu/__tests__/__snapshots__/index.test.js.snap
@@ -82,7 +82,7 @@ exports[`Menu Menu.Item with icon children auto wrap span 1`] = `
     >
       <span
         aria-label="mail"
-        class="anticon anticon-mail"
+        class="anticon anticon-mail ant-menu-item-icon"
         role="img"
       >
         <svg
@@ -124,7 +124,7 @@ exports[`Menu Menu.Item with icon children auto wrap span 1`] = `
     >
       <span
         aria-label="mail"
-        class="anticon anticon-mail"
+        class="anticon anticon-mail ant-menu-item-icon"
         role="img"
       >
         <svg

--- a/components/menu/style/index.less
+++ b/components/menu/style/index.less
@@ -218,6 +218,10 @@
       }
     }
 
+    .@{menu-prefix-cls}-item-icon.svg {
+      vertical-align: -0.125em;
+    }
+
     &.@{menu-prefix-cls}-item-only-child {
       > .@{iconfont-css-prefix},
       > .@{menu-prefix-cls}-item-icon {


### PR DESCRIPTION


<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close #30605

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Menu.SubMenu icon margin issue when using third party icon libraries. |
| 🇨🇳 Chinese | 修复 Menu.SubMenu 的 `icon` 设置为第三方 icon 库时的样式问题。 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
