### PR TITLE
fix: Long text of menu ellipsis issue

### DIFF
--- a/components/config-provider/__tests__/__snapshots__/components.test.js.snap
+++ b/components/config-provider/__tests__/__snapshots__/components.test.js.snap
@@ -15054,9 +15054,12 @@ exports[`ConfigProvider components Menu configProvider 1`] = `
       role="menuitem"
       style="padding-left:24px"
       tabindex="-1"
-      title="bamboo"
     >
-      bamboo
+      <span
+        class="config-menu-title-content"
+      >
+        bamboo
+      </span>
       <i
         class="config-menu-submenu-arrow"
       />
@@ -15083,7 +15086,11 @@ exports[`ConfigProvider components Menu configProvider 1`] = `
             style="padding-left:48px"
             tabindex="-1"
           >
-            Light
+            <span
+              class="config-menu-title-content"
+            >
+              Light
+            </span>
           </li>
         </ul>
       </li>
@@ -15110,9 +15117,12 @@ exports[`ConfigProvider components Menu configProvider componentSize large 1`] =
       role="menuitem"
       style="padding-left:24px"
       tabindex="-1"
-      title="bamboo"
     >
-      bamboo
+      <span
+        class="config-menu-title-content"
+      >
+        bamboo
+      </span>
       <i
         class="config-menu-submenu-arrow"
       />
@@ -15139,7 +15149,11 @@ exports[`ConfigProvider components Menu configProvider componentSize large 1`] =
             style="padding-left:48px"
             tabindex="-1"
           >
-            Light
+            <span
+              class="config-menu-title-content"
+            >
+              Light
+            </span>
           </li>
         </ul>
       </li>
@@ -15166,9 +15180,12 @@ exports[`ConfigProvider components Menu configProvider componentSize middle 1`] 
       role="menuitem"
       style="padding-left:24px"
       tabindex="-1"
-      title="bamboo"
     >
-      bamboo
+      <span
+        class="config-menu-title-content"
+      >
+        bamboo
+      </span>
       <i
         class="config-menu-submenu-arrow"
       />
@@ -15195,7 +15212,11 @@ exports[`ConfigProvider components Menu configProvider componentSize middle 1`] 
             style="padding-left:48px"
             tabindex="-1"
           >
-            Light
+            <span
+              class="config-menu-title-content"
+            >
+              Light
+            </span>
           </li>
         </ul>
       </li>
@@ -15222,9 +15243,12 @@ exports[`ConfigProvider components Menu configProvider virtual and dropdownMatch
       role="menuitem"
       style="padding-left:24px"
       tabindex="-1"
-      title="bamboo"
     >
-      bamboo
+      <span
+        class="ant-menu-title-content"
+      >
+        bamboo
+      </span>
       <i
         class="ant-menu-submenu-arrow"
       />
@@ -15251,7 +15275,11 @@ exports[`ConfigProvider components Menu configProvider virtual and dropdownMatch
             style="padding-left:48px"
             tabindex="-1"
           >
-            Light
+            <span
+              class="ant-menu-title-content"
+            >
+              Light
+            </span>
           </li>
         </ul>
       </li>
@@ -15278,9 +15306,12 @@ exports[`ConfigProvider components Menu normal 1`] = `
       role="menuitem"
       style="padding-left:24px"
       tabindex="-1"
-      title="bamboo"
     >
-      bamboo
+      <span
+        class="ant-menu-title-content"
+      >
+        bamboo
+      </span>
       <i
         class="ant-menu-submenu-arrow"
       />
@@ -15307,7 +15338,11 @@ exports[`ConfigProvider components Menu normal 1`] = `
             style="padding-left:48px"
             tabindex="-1"
           >
-            Light
+            <span
+              class="ant-menu-title-content"
+            >
+              Light
+            </span>
           </li>
         </ul>
       </li>
@@ -15334,9 +15369,12 @@ exports[`ConfigProvider components Menu prefixCls 1`] = `
       role="menuitem"
       style="padding-left:24px"
       tabindex="-1"
-      title="bamboo"
     >
-      bamboo
+      <span
+        class="prefix-Menu-title-content"
+      >
+        bamboo
+      </span>
       <i
         class="prefix-Menu-submenu-arrow"
       />
@@ -15365,7 +15403,11 @@ exports[`ConfigProvider components Menu prefixCls 1`] = `
             style="padding-left:48px"
             tabindex="-1"
           >
-            Light
+            <span
+              class="prefix-Menu-title-content"
+            >
+              Light
+            </span>
           </li>
         </ul>
       </li>
@@ -22866,23 +22908,27 @@ exports[`ConfigProvider components Table configProvider 1`] = `
                                 role="menuitem"
                                 tabindex="-1"
                               >
-                                <label
-                                  class="config-checkbox-wrapper"
+                                <span
+                                  class="config-dropdown-menu-title-content"
                                 >
-                                  <span
-                                    class="config-checkbox"
+                                  <label
+                                    class="config-checkbox-wrapper"
                                   >
-                                    <input
-                                      class="config-checkbox-input"
-                                      type="checkbox"
-                                    />
                                     <span
-                                      class="config-checkbox-inner"
-                                    />
+                                      class="config-checkbox"
+                                    >
+                                      <input
+                                        class="config-checkbox-input"
+                                        type="checkbox"
+                                      />
+                                      <span
+                                        class="config-checkbox-inner"
+                                      />
+                                    </span>
+                                  </label>
+                                  <span>
+                                    Joe
                                   </span>
-                                </label>
-                                <span>
-                                  Joe
                                 </span>
                               </li>
                               <li
@@ -22895,9 +22941,12 @@ exports[`ConfigProvider components Table configProvider 1`] = `
                                   class="config-dropdown-menu-submenu-title"
                                   role="menuitem"
                                   tabindex="-1"
-                                  title="Submenu"
                                 >
-                                  Submenu
+                                  <span
+                                    class="config-dropdown-menu-title-content"
+                                  >
+                                    Submenu
+                                  </span>
                                   <i
                                     class="config-dropdown-menu-submenu-arrow"
                                   />
@@ -23129,23 +23178,27 @@ exports[`ConfigProvider components Table configProvider componentSize large 1`] 
                                 role="menuitem"
                                 tabindex="-1"
                               >
-                                <label
-                                  class="config-checkbox-wrapper"
+                                <span
+                                  class="config-dropdown-menu-title-content"
                                 >
-                                  <span
-                                    class="config-checkbox"
+                                  <label
+                                    class="config-checkbox-wrapper"
                                   >
-                                    <input
-                                      class="config-checkbox-input"
-                                      type="checkbox"
-                                    />
                                     <span
-                                      class="config-checkbox-inner"
-                                    />
+                                      class="config-checkbox"
+                                    >
+                                      <input
+                                        class="config-checkbox-input"
+                                        type="checkbox"
+                                      />
+                                      <span
+                                        class="config-checkbox-inner"
+                                      />
+                                    </span>
+                                  </label>
+                                  <span>
+                                    Joe
                                   </span>
-                                </label>
-                                <span>
-                                  Joe
                                 </span>
                               </li>
                               <li
@@ -23158,9 +23211,12 @@ exports[`ConfigProvider components Table configProvider componentSize large 1`] 
                                   class="config-dropdown-menu-submenu-title"
                                   role="menuitem"
                                   tabindex="-1"
-                                  title="Submenu"
                                 >
-                                  Submenu
+                                  <span
+                                    class="config-dropdown-menu-title-content"
+                                  >
+                                    Submenu
+                                  </span>
                                   <i
                                     class="config-dropdown-menu-submenu-arrow"
                                   />
@@ -23392,23 +23448,27 @@ exports[`ConfigProvider components Table configProvider componentSize middle 1`]
                                 role="menuitem"
                                 tabindex="-1"
                               >
-                                <label
-                                  class="config-checkbox-wrapper"
+                                <span
+                                  class="config-dropdown-menu-title-content"
                                 >
-                                  <span
-                                    class="config-checkbox"
+                                  <label
+                                    class="config-checkbox-wrapper"
                                   >
-                                    <input
-                                      class="config-checkbox-input"
-                                      type="checkbox"
-                                    />
                                     <span
-                                      class="config-checkbox-inner"
-                                    />
+                                      class="config-checkbox"
+                                    >
+                                      <input
+                                        class="config-checkbox-input"
+                                        type="checkbox"
+                                      />
+                                      <span
+                                        class="config-checkbox-inner"
+                                      />
+                                    </span>
+                                  </label>
+                                  <span>
+                                    Joe
                                   </span>
-                                </label>
-                                <span>
-                                  Joe
                                 </span>
                               </li>
                               <li
@@ -23421,9 +23481,12 @@ exports[`ConfigProvider components Table configProvider componentSize middle 1`]
                                   class="config-dropdown-menu-submenu-title"
                                   role="menuitem"
                                   tabindex="-1"
-                                  title="Submenu"
                                 >
-                                  Submenu
+                                  <span
+                                    class="config-dropdown-menu-title-content"
+                                  >
+                                    Submenu
+                                  </span>
                                   <i
                                     class="config-dropdown-menu-submenu-arrow"
                                   />
@@ -23655,23 +23718,27 @@ exports[`ConfigProvider components Table configProvider virtual and dropdownMatc
                                 role="menuitem"
                                 tabindex="-1"
                               >
-                                <label
-                                  class="ant-checkbox-wrapper"
+                                <span
+                                  class="ant-dropdown-menu-title-content"
                                 >
-                                  <span
-                                    class="ant-checkbox"
+                                  <label
+                                    class="ant-checkbox-wrapper"
                                   >
-                                    <input
-                                      class="ant-checkbox-input"
-                                      type="checkbox"
-                                    />
                                     <span
-                                      class="ant-checkbox-inner"
-                                    />
+                                      class="ant-checkbox"
+                                    >
+                                      <input
+                                        class="ant-checkbox-input"
+                                        type="checkbox"
+                                      />
+                                      <span
+                                        class="ant-checkbox-inner"
+                                      />
+                                    </span>
+                                  </label>
+                                  <span>
+                                    Joe
                                   </span>
-                                </label>
-                                <span>
-                                  Joe
                                 </span>
                               </li>
                               <li
@@ -23684,9 +23751,12 @@ exports[`ConfigProvider components Table configProvider virtual and dropdownMatc
                                   class="ant-dropdown-menu-submenu-title"
                                   role="menuitem"
                                   tabindex="-1"
-                                  title="Submenu"
                                 >
-                                  Submenu
+                                  <span
+                                    class="ant-dropdown-menu-title-content"
+                                  >
+                                    Submenu
+                                  </span>
                                   <i
                                     class="ant-dropdown-menu-submenu-arrow"
                                   />
@@ -23918,23 +23988,27 @@ exports[`ConfigProvider components Table normal 1`] = `
                                 role="menuitem"
                                 tabindex="-1"
                               >
-                                <label
-                                  class="ant-checkbox-wrapper"
+                                <span
+                                  class="ant-dropdown-menu-title-content"
                                 >
-                                  <span
-                                    class="ant-checkbox"
+                                  <label
+                                    class="ant-checkbox-wrapper"
                                   >
-                                    <input
-                                      class="ant-checkbox-input"
-                                      type="checkbox"
-                                    />
                                     <span
-                                      class="ant-checkbox-inner"
-                                    />
+                                      class="ant-checkbox"
+                                    >
+                                      <input
+                                        class="ant-checkbox-input"
+                                        type="checkbox"
+                                      />
+                                      <span
+                                        class="ant-checkbox-inner"
+                                      />
+                                    </span>
+                                  </label>
+                                  <span>
+                                    Joe
                                   </span>
-                                </label>
-                                <span>
-                                  Joe
                                 </span>
                               </li>
                               <li
@@ -23947,9 +24021,12 @@ exports[`ConfigProvider components Table normal 1`] = `
                                   class="ant-dropdown-menu-submenu-title"
                                   role="menuitem"
                                   tabindex="-1"
-                                  title="Submenu"
                                 >
-                                  Submenu
+                                  <span
+                                    class="ant-dropdown-menu-title-content"
+                                  >
+                                    Submenu
+                                  </span>
                                   <i
                                     class="ant-dropdown-menu-submenu-arrow"
                                   />
@@ -24181,23 +24258,27 @@ exports[`ConfigProvider components Table prefixCls 1`] = `
                                 role="menuitem"
                                 tabindex="-1"
                               >
-                                <label
-                                  class="ant-checkbox-wrapper"
+                                <span
+                                  class="ant-dropdown-menu-title-content"
                                 >
-                                  <span
-                                    class="ant-checkbox"
+                                  <label
+                                    class="ant-checkbox-wrapper"
                                   >
-                                    <input
-                                      class="ant-checkbox-input"
-                                      type="checkbox"
-                                    />
                                     <span
-                                      class="ant-checkbox-inner"
-                                    />
+                                      class="ant-checkbox"
+                                    >
+                                      <input
+                                        class="ant-checkbox-input"
+                                        type="checkbox"
+                                      />
+                                      <span
+                                        class="ant-checkbox-inner"
+                                      />
+                                    </span>
+                                  </label>
+                                  <span>
+                                    Joe
                                   </span>
-                                </label>
-                                <span>
-                                  Joe
                                 </span>
                               </li>
                               <li
@@ -24210,9 +24291,12 @@ exports[`ConfigProvider components Table prefixCls 1`] = `
                                   class="ant-dropdown-menu-submenu-title"
                                   role="menuitem"
                                   tabindex="-1"
-                                  title="Submenu"
                                 >
-                                  Submenu
+                                  <span
+                                    class="ant-dropdown-menu-title-content"
+                                  >
+                                    Submenu
+                                  </span>
                                   <i
                                     class="ant-dropdown-menu-submenu-arrow"
                                   />

--- a/components/layout/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/layout/__tests__/__snapshots__/demo.test.js.snap
@@ -300,7 +300,11 @@ exports[`renders ./components/layout/demo/fixed.md correctly 1`] = `
         style="opacity:1;order:0"
         tabindex="-1"
       >
-        nav 1
+        <span
+          class="ant-menu-title-content"
+        >
+          nav 1
+        </span>
       </li>
       <li
         class="ant-menu-overflow-item ant-menu-item ant-menu-item-selected ant-menu-item-only-child"
@@ -308,7 +312,11 @@ exports[`renders ./components/layout/demo/fixed.md correctly 1`] = `
         style="opacity:1;order:1"
         tabindex="-1"
       >
-        nav 2
+        <span
+          class="ant-menu-title-content"
+        >
+          nav 2
+        </span>
       </li>
       <li
         class="ant-menu-overflow-item ant-menu-item ant-menu-item-only-child"
@@ -316,7 +324,11 @@ exports[`renders ./components/layout/demo/fixed.md correctly 1`] = `
         style="opacity:1;order:2"
         tabindex="-1"
       >
-        nav 3
+        <span
+          class="ant-menu-title-content"
+        >
+          nav 3
+        </span>
       </li>
       <li
         aria-hidden="true"
@@ -1289,7 +1301,11 @@ exports[`renders ./components/layout/demo/top.md correctly 1`] = `
         style="opacity:1;order:0"
         tabindex="-1"
       >
-        nav 1
+        <span
+          class="ant-menu-title-content"
+        >
+          nav 1
+        </span>
       </li>
       <li
         class="ant-menu-overflow-item ant-menu-item ant-menu-item-selected ant-menu-item-only-child"
@@ -1297,7 +1313,11 @@ exports[`renders ./components/layout/demo/top.md correctly 1`] = `
         style="opacity:1;order:1"
         tabindex="-1"
       >
-        nav 2
+        <span
+          class="ant-menu-title-content"
+        >
+          nav 2
+        </span>
       </li>
       <li
         class="ant-menu-overflow-item ant-menu-item ant-menu-item-only-child"
@@ -1305,7 +1325,11 @@ exports[`renders ./components/layout/demo/top.md correctly 1`] = `
         style="opacity:1;order:2"
         tabindex="-1"
       >
-        nav 3
+        <span
+          class="ant-menu-title-content"
+        >
+          nav 3
+        </span>
       </li>
       <li
         aria-hidden="true"
@@ -1428,7 +1452,11 @@ exports[`renders ./components/layout/demo/top-side.md correctly 1`] = `
         style="opacity:1;order:0"
         tabindex="-1"
       >
-        nav 1
+        <span
+          class="ant-menu-title-content"
+        >
+          nav 1
+        </span>
       </li>
       <li
         class="ant-menu-overflow-item ant-menu-item ant-menu-item-selected ant-menu-item-only-child"
@@ -1436,7 +1464,11 @@ exports[`renders ./components/layout/demo/top-side.md correctly 1`] = `
         style="opacity:1;order:1"
         tabindex="-1"
       >
-        nav 2
+        <span
+          class="ant-menu-title-content"
+        >
+          nav 2
+        </span>
       </li>
       <li
         class="ant-menu-overflow-item ant-menu-item ant-menu-item-only-child"
@@ -1444,7 +1476,11 @@ exports[`renders ./components/layout/demo/top-side.md correctly 1`] = `
         style="opacity:1;order:2"
         tabindex="-1"
       >
-        nav 3
+        <span
+          class="ant-menu-title-content"
+        >
+          nav 3
+        </span>
       </li>
       <li
         aria-hidden="true"
@@ -1598,7 +1634,11 @@ exports[`renders ./components/layout/demo/top-side.md correctly 1`] = `
                   style="padding-left:48px"
                   tabindex="-1"
                 >
-                  option1
+                  <span
+                    class="ant-menu-title-content"
+                  >
+                    option1
+                  </span>
                 </li>
                 <li
                   class="ant-menu-item ant-menu-item-only-child"
@@ -1606,7 +1646,11 @@ exports[`renders ./components/layout/demo/top-side.md correctly 1`] = `
                   style="padding-left:48px"
                   tabindex="-1"
                 >
-                  option2
+                  <span
+                    class="ant-menu-title-content"
+                  >
+                    option2
+                  </span>
                 </li>
                 <li
                   class="ant-menu-item ant-menu-item-only-child"
@@ -1614,7 +1658,11 @@ exports[`renders ./components/layout/demo/top-side.md correctly 1`] = `
                   style="padding-left:48px"
                   tabindex="-1"
                 >
-                  option3
+                  <span
+                    class="ant-menu-title-content"
+                  >
+                    option3
+                  </span>
                 </li>
                 <li
                   class="ant-menu-item ant-menu-item-only-child"
@@ -1622,7 +1670,11 @@ exports[`renders ./components/layout/demo/top-side.md correctly 1`] = `
                   style="padding-left:48px"
                   tabindex="-1"
                 >
-                  option4
+                  <span
+                    class="ant-menu-title-content"
+                  >
+                    option4
+                  </span>
                 </li>
               </ul>
             </li>
@@ -1750,7 +1802,11 @@ exports[`renders ./components/layout/demo/top-side-2.md correctly 1`] = `
         style="opacity:1;order:0"
         tabindex="-1"
       >
-        nav 1
+        <span
+          class="ant-menu-title-content"
+        >
+          nav 1
+        </span>
       </li>
       <li
         class="ant-menu-overflow-item ant-menu-item ant-menu-item-selected ant-menu-item-only-child"
@@ -1758,7 +1814,11 @@ exports[`renders ./components/layout/demo/top-side-2.md correctly 1`] = `
         style="opacity:1;order:1"
         tabindex="-1"
       >
-        nav 2
+        <span
+          class="ant-menu-title-content"
+        >
+          nav 2
+        </span>
       </li>
       <li
         class="ant-menu-overflow-item ant-menu-item ant-menu-item-only-child"
@@ -1766,7 +1826,11 @@ exports[`renders ./components/layout/demo/top-side-2.md correctly 1`] = `
         style="opacity:1;order:2"
         tabindex="-1"
       >
-        nav 3
+        <span
+          class="ant-menu-title-content"
+        >
+          nav 3
+        </span>
       </li>
       <li
         aria-hidden="true"
@@ -1874,7 +1938,11 @@ exports[`renders ./components/layout/demo/top-side-2.md correctly 1`] = `
                 style="padding-left:48px"
                 tabindex="-1"
               >
-                option1
+                <span
+                  class="ant-menu-title-content"
+                >
+                  option1
+                </span>
               </li>
               <li
                 class="ant-menu-item ant-menu-item-only-child"
@@ -1882,7 +1950,11 @@ exports[`renders ./components/layout/demo/top-side-2.md correctly 1`] = `
                 style="padding-left:48px"
                 tabindex="-1"
               >
-                option2
+                <span
+                  class="ant-menu-title-content"
+                >
+                  option2
+                </span>
               </li>
               <li
                 class="ant-menu-item ant-menu-item-only-child"
@@ -1890,7 +1962,11 @@ exports[`renders ./components/layout/demo/top-side-2.md correctly 1`] = `
                 style="padding-left:48px"
                 tabindex="-1"
               >
-                option3
+                <span
+                  class="ant-menu-title-content"
+                >
+                  option3
+                </span>
               </li>
               <li
                 class="ant-menu-item ant-menu-item-only-child"
@@ -1898,7 +1974,11 @@ exports[`renders ./components/layout/demo/top-side-2.md correctly 1`] = `
                 style="padding-left:48px"
                 tabindex="-1"
               >
-                option4
+                <span
+                  class="ant-menu-title-content"
+                >
+                  option4
+                </span>
               </li>
             </ul>
           </li>

--- a/components/menu/MenuItem.tsx
+++ b/components/menu/MenuItem.tsx
@@ -21,15 +21,16 @@ export default class MenuItem extends React.Component<MenuItemProps> {
   renderItemChildren(inlineCollapsed: boolean) {
     const { prefixCls, firstLevel } = this.context;
     const { icon, children } = this.props;
+
+    const wrapNode = <span className={`${prefixCls}-title-content`}>{children}</span>;
     // inline-collapsed.md demo 依赖 span 来隐藏文字,有 icon 属性，则内部包裹一个 span
     // ref: https://github.com/ant-design/ant-design/pull/23456
     if (!icon || (isValidElement(children) && children.type === 'span')) {
       if (children && inlineCollapsed && firstLevel && typeof children === 'string') {
         return <div className={`${prefixCls}-inline-collapsed-noicon`}>{children.charAt(0)}</div>;
       }
-      return children;
     }
-    return <span className={`${prefixCls}-title-content`}>{children}</span>;
+    return wrapNode;
   }
 
   renderItem = ({ siderCollapsed }: SiderContextProps) => {

--- a/components/menu/SubMenu.tsx
+++ b/components/menu/SubMenu.tsx
@@ -39,7 +39,7 @@ function SubMenu(props: SubMenuProps) {
       inlineCollapsed && !parentPath.length && title && typeof title === 'string' ? (
         <div className={`${prefixCls}-inline-collapsed-noicon`}>{title.charAt(0)}</div>
       ) : (
-        title
+        <span className={`${prefixCls}-title-content`}>{title}</span>
       );
   } else {
     // inline-collapsed.md demo 依赖 span 来隐藏文字,有 icon 属性，则内部包裹一个 span

--- a/components/menu/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/menu/__tests__/__snapshots__/demo.test.js.snap
@@ -116,13 +116,17 @@ exports[`renders ./components/menu/demo/horizontal.md correctly 1`] = `
     style="opacity:1;order:3"
     tabindex="-1"
   >
-    <a
-      href="https://ant.design"
-      rel="noopener noreferrer"
-      target="_blank"
+    <span
+      class="ant-menu-title-content"
     >
-      Navigation Four - Link
-    </a>
+      <a
+        href="https://ant.design"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        Navigation Four - Link
+      </a>
+    </span>
   </li>
   <li
     aria-hidden="true"
@@ -234,7 +238,11 @@ exports[`renders ./components/menu/demo/inline.md correctly 1`] = `
             style="padding-left:48px"
             tabindex="-1"
           >
-            Option 1
+            <span
+              class="ant-menu-title-content"
+            >
+              Option 1
+            </span>
           </li>
           <li
             class="ant-menu-item ant-menu-item-only-child"
@@ -242,7 +250,11 @@ exports[`renders ./components/menu/demo/inline.md correctly 1`] = `
             style="padding-left:48px"
             tabindex="-1"
           >
-            Option 2
+            <span
+              class="ant-menu-title-content"
+            >
+              Option 2
+            </span>
           </li>
         </ul>
       </li>
@@ -264,7 +276,11 @@ exports[`renders ./components/menu/demo/inline.md correctly 1`] = `
             style="padding-left:48px"
             tabindex="-1"
           >
-            Option 3
+            <span
+              class="ant-menu-title-content"
+            >
+              Option 3
+            </span>
           </li>
           <li
             class="ant-menu-item ant-menu-item-only-child"
@@ -272,7 +288,11 @@ exports[`renders ./components/menu/demo/inline.md correctly 1`] = `
             style="padding-left:48px"
             tabindex="-1"
           >
-            Option 4
+            <span
+              class="ant-menu-title-content"
+            >
+              Option 4
+            </span>
           </li>
         </ul>
       </li>
@@ -541,7 +561,11 @@ exports[`renders ./components/menu/demo/inline-collapsed.md correctly 1`] = `
           style="padding-left:48px"
           tabindex="-1"
         >
-          Option 5
+          <span
+            class="ant-menu-title-content"
+          >
+            Option 5
+          </span>
         </li>
         <li
           class="ant-menu-item ant-menu-item-only-child"
@@ -549,7 +573,11 @@ exports[`renders ./components/menu/demo/inline-collapsed.md correctly 1`] = `
           style="padding-left:48px"
           tabindex="-1"
         >
-          Option 6
+          <span
+            class="ant-menu-title-content"
+          >
+            Option 6
+          </span>
         </li>
         <li
           class="ant-menu-item ant-menu-item-only-child"
@@ -557,7 +585,11 @@ exports[`renders ./components/menu/demo/inline-collapsed.md correctly 1`] = `
           style="padding-left:48px"
           tabindex="-1"
         >
-          Option 7
+          <span
+            class="ant-menu-title-content"
+          >
+            Option 7
+          </span>
         </li>
         <li
           class="ant-menu-item ant-menu-item-only-child"
@@ -565,7 +597,11 @@ exports[`renders ./components/menu/demo/inline-collapsed.md correctly 1`] = `
           style="padding-left:48px"
           tabindex="-1"
         >
-          Option 8
+          <span
+            class="ant-menu-title-content"
+          >
+            Option 8
+          </span>
         </li>
       </ul>
     </li>
@@ -672,7 +708,11 @@ exports[`renders ./components/menu/demo/sider-current.md correctly 1`] = `
         style="padding-left:48px"
         tabindex="-1"
       >
-        Option 1
+        <span
+          class="ant-menu-title-content"
+        >
+          Option 1
+        </span>
       </li>
       <li
         class="ant-menu-item ant-menu-item-only-child"
@@ -680,7 +720,11 @@ exports[`renders ./components/menu/demo/sider-current.md correctly 1`] = `
         style="padding-left:48px"
         tabindex="-1"
       >
-        Option 2
+        <span
+          class="ant-menu-title-content"
+        >
+          Option 2
+        </span>
       </li>
       <li
         class="ant-menu-item ant-menu-item-only-child"
@@ -688,7 +732,11 @@ exports[`renders ./components/menu/demo/sider-current.md correctly 1`] = `
         style="padding-left:48px"
         tabindex="-1"
       >
-        Option 3
+        <span
+          class="ant-menu-title-content"
+        >
+          Option 3
+        </span>
       </li>
       <li
         class="ant-menu-item ant-menu-item-only-child"
@@ -696,7 +744,11 @@ exports[`renders ./components/menu/demo/sider-current.md correctly 1`] = `
         style="padding-left:48px"
         tabindex="-1"
       >
-        Option 4
+        <span
+          class="ant-menu-title-content"
+        >
+          Option 4
+        </span>
       </li>
     </ul>
   </li>
@@ -898,7 +950,11 @@ Array [
       style="opacity:1;order:2"
       tabindex="-1"
     >
-      Option 11
+      <span
+        class="ant-menu-title-content"
+      >
+        Option 11
+      </span>
     </li>
     <li
       class="ant-menu-overflow-item ant-menu-item ant-menu-item-only-child"
@@ -906,7 +962,11 @@ Array [
       style="opacity:1;order:3"
       tabindex="-1"
     >
-      Option 12
+      <span
+        class="ant-menu-title-content"
+      >
+        Option 12
+      </span>
     </li>
     <li
       aria-hidden="true"
@@ -1104,7 +1164,11 @@ Array [
           style="padding-left:48px"
           tabindex="-1"
         >
-          Option 3
+          <span
+            class="ant-menu-title-content"
+          >
+            Option 3
+          </span>
         </li>
         <li
           class="ant-menu-item ant-menu-item-only-child"
@@ -1112,7 +1176,11 @@ Array [
           style="padding-left:48px"
           tabindex="-1"
         >
-          Option 4
+          <span
+            class="ant-menu-title-content"
+          >
+            Option 4
+          </span>
         </li>
         <li
           class="ant-menu-submenu ant-menu-submenu-inline"
@@ -1125,9 +1193,12 @@ Array [
             role="menuitem"
             style="padding-left:48px"
             tabindex="-1"
-            title="Submenu"
           >
-            Submenu
+            <span
+              class="ant-menu-title-content"
+            >
+              Submenu
+            </span>
             <i
               class="ant-menu-submenu-arrow"
             />
@@ -1293,7 +1364,11 @@ Array [
           style="padding-left:48px"
           tabindex="-1"
         >
-          Option 1
+          <span
+            class="ant-menu-title-content"
+          >
+            Option 1
+          </span>
         </li>
         <li
           class="ant-menu-item ant-menu-item-only-child"
@@ -1301,7 +1376,11 @@ Array [
           style="padding-left:48px"
           tabindex="-1"
         >
-          Option 2
+          <span
+            class="ant-menu-title-content"
+          >
+            Option 2
+          </span>
         </li>
         <li
           class="ant-menu-item ant-menu-item-only-child"
@@ -1309,7 +1388,11 @@ Array [
           style="padding-left:48px"
           tabindex="-1"
         >
-          Option 3
+          <span
+            class="ant-menu-title-content"
+          >
+            Option 3
+          </span>
         </li>
         <li
           class="ant-menu-item ant-menu-item-only-child"
@@ -1317,7 +1400,11 @@ Array [
           style="padding-left:48px"
           tabindex="-1"
         >
-          Option 4
+          <span
+            class="ant-menu-title-content"
+          >
+            Option 4
+          </span>
         </li>
       </ul>
     </li>

--- a/components/menu/__tests__/__snapshots__/index.test.js.snap
+++ b/components/menu/__tests__/__snapshots__/index.test.js.snap
@@ -63,8 +63,12 @@ exports[`Menu Menu.Item with icon children auto wrap span 1`] = `
         />
       </svg>
     </span>
-    <span>
-      Navigation One
+    <span
+      class="ant-menu-title-content"
+    >
+      <span>
+        Navigation One
+      </span>
     </span>
   </li>
   <li
@@ -164,7 +168,11 @@ exports[`Menu rtl render component should be rendered correctly in RTL direction
     class="ant-menu-item"
     role="menuitem"
     tabindex="-1"
-  />
+  >
+    <span
+      class="ant-menu-title-content"
+    />
+  </li>
   <li
     class="ant-menu-item-group"
   >
@@ -186,6 +194,9 @@ exports[`Menu rtl render component should be rendered correctly in RTL direction
       role="menuitem"
       tabindex="-1"
     >
+      <span
+        class="ant-menu-title-content"
+      />
       <i
         class="ant-menu-submenu-arrow"
       />

--- a/components/table/__tests__/__snapshots__/Table.filter.test.js.snap
+++ b/components/table/__tests__/__snapshots__/Table.filter.test.js.snap
@@ -573,24 +573,28 @@ exports[`Table.filter should support getPopupContainer 1`] = `
                                 role="menuitem"
                                 tabindex="-1"
                               >
-                                <label
-                                  class="ant-checkbox-wrapper"
+                                <span
+                                  class="ant-dropdown-menu-title-content"
                                 >
-                                  <span
-                                    class="ant-checkbox"
+                                  <label
+                                    class="ant-checkbox-wrapper"
                                   >
-                                    <input
-                                      class="ant-checkbox-input"
-                                      type="checkbox"
-                                      value=""
-                                    />
                                     <span
-                                      class="ant-checkbox-inner"
-                                    />
+                                      class="ant-checkbox"
+                                    >
+                                      <input
+                                        class="ant-checkbox-input"
+                                        type="checkbox"
+                                        value=""
+                                      />
+                                      <span
+                                        class="ant-checkbox-inner"
+                                      />
+                                    </span>
+                                  </label>
+                                  <span>
+                                    Boy
                                   </span>
-                                </label>
-                                <span>
-                                  Boy
                                 </span>
                               </li>
                               <li
@@ -599,24 +603,28 @@ exports[`Table.filter should support getPopupContainer 1`] = `
                                 role="menuitem"
                                 tabindex="-1"
                               >
-                                <label
-                                  class="ant-checkbox-wrapper"
+                                <span
+                                  class="ant-dropdown-menu-title-content"
                                 >
-                                  <span
-                                    class="ant-checkbox"
+                                  <label
+                                    class="ant-checkbox-wrapper"
                                   >
-                                    <input
-                                      class="ant-checkbox-input"
-                                      type="checkbox"
-                                      value=""
-                                    />
                                     <span
-                                      class="ant-checkbox-inner"
-                                    />
+                                      class="ant-checkbox"
+                                    >
+                                      <input
+                                        class="ant-checkbox-input"
+                                        type="checkbox"
+                                        value=""
+                                      />
+                                      <span
+                                        class="ant-checkbox-inner"
+                                      />
+                                    </span>
+                                  </label>
+                                  <span>
+                                    Girl
                                   </span>
-                                </label>
-                                <span>
-                                  Girl
                                 </span>
                               </li>
                               <li
@@ -631,9 +639,12 @@ exports[`Table.filter should support getPopupContainer 1`] = `
                                   data-menu-id="rc-menu-uuid-test-title"
                                   role="menuitem"
                                   tabindex="-1"
-                                  title="Title"
                                 >
-                                  Title
+                                  <span
+                                    class="ant-dropdown-menu-title-content"
+                                  >
+                                    Title
+                                  </span>
                                   <i
                                     class="ant-dropdown-menu-submenu-arrow"
                                   />
@@ -806,24 +817,28 @@ exports[`Table.filter should support getPopupContainer from ConfigProvider 1`] =
                                 role="menuitem"
                                 tabindex="-1"
                               >
-                                <label
-                                  class="ant-checkbox-wrapper"
+                                <span
+                                  class="ant-dropdown-menu-title-content"
                                 >
-                                  <span
-                                    class="ant-checkbox"
+                                  <label
+                                    class="ant-checkbox-wrapper"
                                   >
-                                    <input
-                                      class="ant-checkbox-input"
-                                      type="checkbox"
-                                      value=""
-                                    />
                                     <span
-                                      class="ant-checkbox-inner"
-                                    />
+                                      class="ant-checkbox"
+                                    >
+                                      <input
+                                        class="ant-checkbox-input"
+                                        type="checkbox"
+                                        value=""
+                                      />
+                                      <span
+                                        class="ant-checkbox-inner"
+                                      />
+                                    </span>
+                                  </label>
+                                  <span>
+                                    Boy
                                   </span>
-                                </label>
-                                <span>
-                                  Boy
                                 </span>
                               </li>
                               <li
@@ -832,24 +847,28 @@ exports[`Table.filter should support getPopupContainer from ConfigProvider 1`] =
                                 role="menuitem"
                                 tabindex="-1"
                               >
-                                <label
-                                  class="ant-checkbox-wrapper"
+                                <span
+                                  class="ant-dropdown-menu-title-content"
                                 >
-                                  <span
-                                    class="ant-checkbox"
+                                  <label
+                                    class="ant-checkbox-wrapper"
                                   >
-                                    <input
-                                      class="ant-checkbox-input"
-                                      type="checkbox"
-                                      value=""
-                                    />
                                     <span
-                                      class="ant-checkbox-inner"
-                                    />
+                                      class="ant-checkbox"
+                                    >
+                                      <input
+                                        class="ant-checkbox-input"
+                                        type="checkbox"
+                                        value=""
+                                      />
+                                      <span
+                                        class="ant-checkbox-inner"
+                                      />
+                                    </span>
+                                  </label>
+                                  <span>
+                                    Girl
                                   </span>
-                                </label>
-                                <span>
-                                  Girl
                                 </span>
                               </li>
                               <li
@@ -864,9 +883,12 @@ exports[`Table.filter should support getPopupContainer from ConfigProvider 1`] =
                                   data-menu-id="rc-menu-uuid-test-title"
                                   role="menuitem"
                                   tabindex="-1"
-                                  title="Title"
                                 >
-                                  Title
+                                  <span
+                                    class="ant-dropdown-menu-title-content"
+                                  >
+                                    Title
+                                  </span>
                                   <i
                                     class="ant-dropdown-menu-submenu-arrow"
                                   />

--- a/components/table/__tests__/__snapshots__/Table.rowSelection.test.js.snap
+++ b/components/table/__tests__/__snapshots__/Table.rowSelection.test.js.snap
@@ -1062,7 +1062,11 @@ exports[`Table.rowSelection should support getPopupContainer 1`] = `
                                 role="menuitem"
                                 tabindex="-1"
                               >
-                                Select all data
+                                <span
+                                  class="ant-dropdown-menu-title-content"
+                                >
+                                  Select all data
+                                </span>
                               </li>
                               <li
                                 class="ant-dropdown-menu-item ant-dropdown-menu-item-only-child"
@@ -1070,7 +1074,11 @@ exports[`Table.rowSelection should support getPopupContainer 1`] = `
                                 role="menuitem"
                                 tabindex="-1"
                               >
-                                Invert current page
+                                <span
+                                  class="ant-dropdown-menu-title-content"
+                                >
+                                  Invert current page
+                                </span>
                               </li>
                               <li
                                 class="ant-dropdown-menu-item ant-dropdown-menu-item-only-child"
@@ -1078,7 +1086,11 @@ exports[`Table.rowSelection should support getPopupContainer 1`] = `
                                 role="menuitem"
                                 tabindex="-1"
                               >
-                                Clear all data
+                                <span
+                                  class="ant-dropdown-menu-title-content"
+                                >
+                                  Clear all data
+                                </span>
                               </li>
                             </ul>
                           </div>
@@ -1402,7 +1414,11 @@ exports[`Table.rowSelection should support getPopupContainer from ConfigProvider
                                 role="menuitem"
                                 tabindex="-1"
                               >
-                                Select all data
+                                <span
+                                  class="ant-dropdown-menu-title-content"
+                                >
+                                  Select all data
+                                </span>
                               </li>
                               <li
                                 class="ant-dropdown-menu-item ant-dropdown-menu-item-only-child"
@@ -1410,7 +1426,11 @@ exports[`Table.rowSelection should support getPopupContainer from ConfigProvider
                                 role="menuitem"
                                 tabindex="-1"
                               >
-                                Invert current page
+                                <span
+                                  class="ant-dropdown-menu-title-content"
+                                >
+                                  Invert current page
+                                </span>
                               </li>
                               <li
                                 class="ant-dropdown-menu-item ant-dropdown-menu-item-only-child"
@@ -1418,7 +1438,11 @@ exports[`Table.rowSelection should support getPopupContainer from ConfigProvider
                                 role="menuitem"
                                 tabindex="-1"
                               >
-                                Clear all data
+                                <span
+                                  class="ant-dropdown-menu-title-content"
+                                >
+                                  Clear all data
+                                </span>
                               </li>
                             </ul>
                           </div>


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

resolve #30679

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Fix Menu `inline` mode not correct handle ellipsis when `icon` not provided.     |
| 🇨🇳 Chinese |    修复 Menu `inline` 模式下，没有 `icon` 的条目不能正确处理省略样式的问题。      |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
