### PR TITLE
Fix the issue of not triggering by default when `<Text ellipisis={} />

### DIFF
--- a/components/typography/Base.tsx
+++ b/components/typography/Base.tsx
@@ -524,13 +524,15 @@ class Base extends React.Component<InternalBlockProps, BaseState> {
                     [`${prefixCls}-${type}`]: type,
                     [`${prefixCls}-disabled`]: disabled,
                     [`${prefixCls}-ellipsis`]: rows,
-                    [`${prefixCls}-single-line`]: rows === 1,
+                    // fix flush
+                    [`${prefixCls}-no-wrap`]: rows === 1,
                     [`${prefixCls}-ellipsis-single-line`]: cssTextOverflow,
                     [`${prefixCls}-ellipsis-multiple-line`]: cssLineClamp,
                   },
                   className,
                 )}
                 style={{
+                  width: rows === 1 && '100%',
                   ...style,
                   WebkitLineClamp: cssLineClamp ? rows : undefined,
                 }}

--- a/components/typography/Base.tsx
+++ b/components/typography/Base.tsx
@@ -532,7 +532,6 @@ class Base extends React.Component<InternalBlockProps, BaseState> {
                   className,
                 )}
                 style={{
-                  width: rows === 1 && '100%',
                   ...style,
                   WebkitLineClamp: cssLineClamp ? rows : undefined,
                 }}

--- a/components/typography/demo/ellipsis-debug.md
+++ b/components/typography/demo/ellipsis-debug.md
@@ -26,6 +26,7 @@ class Demo extends React.Component {
     copyable: false,
     editable: false,
     expandable: false,
+    narrow: true,
   };
 
   onChange = rows => {
@@ -33,7 +34,7 @@ class Demo extends React.Component {
   };
 
   render() {
-    const { rows, longText, copyable, editable, expandable } = this.state;
+    const { rows, longText, copyable, editable, expandable, narrow } = this.state;
     return (
       <>
         <Switch
@@ -66,6 +67,11 @@ class Demo extends React.Component {
 
         <p>
           2333<Text ellipsis>2333</Text>2333
+        </p>
+
+        <Switch onChange={val => this.setState({ narrow: val })} checked={narrow} />
+        <p style={{ width: narrow ? '50px' : '100%', border: '1px solid red' }}>
+          <Text ellipsis={{ tooltip: true }}>How are you ? I am fine; thank you; and you ?</Text>
         </p>
       </>
     );

--- a/components/typography/style/index.less
+++ b/components/typography/style/index.less
@@ -260,6 +260,7 @@
 
   // ============ Ellipsis ============
   &-no-wrap {
+    width: 100%;
     white-space: nowrap;
   }
 

--- a/components/typography/style/index.less
+++ b/components/typography/style/index.less
@@ -259,14 +259,14 @@
   }
 
   // ============ Ellipsis ============
-  &-single-line {
+  &-no-wrap {
     white-space: nowrap;
   }
 
   &-ellipsis-single-line {
     overflow: hidden;
+    white-space: nowrap;
     text-overflow: ellipsis;
-
     // https://blog.csdn.net/iefreer/article/details/50421025
     a&,
     span& {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [x] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

关联：https://github.com/ant-design/ant-design/pull/30582


### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

之前：如果 Text 配置了 ellipsis={} 属性，无需配置 width: 100%，即可触发 ellipsis；
之后：需要手动添加 width: 100% 才能触发；

由于在配置 ellipsis 时，预设了 nowrap
导致在 measure 计算时[ref](https://github.com/elrrrrrrr/ant-design/commit/c80136a9a751cf1e4146d3a478acb54fde6ff717#diff-1affc89a717f8e6b3d578abebc18c3ba6e40c18a64370704592685679d49b930R103)，无法通过监听元素高度计算触发剪裁；

在 ellipisis 场景下(row=1)，添加预设宽度 100% 解决；

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the issue of not triggering by default when `<Text ellipisis={} />`|
| 🇨🇳 Chinese | 修复 `<Text ellipisis={} />` 时不默认触发剪裁逻辑|

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
