### PR TITLE
fix: Dropdown selected keys

### DIFF
--- a/components/dropdown/style/index.less
+++ b/components/dropdown/style/index.less
@@ -32,7 +32,7 @@
     }
 
     .@{iconfont-css-prefix}-down::before {
-      transition: transform 0.2s;
+      transition: transform @animation-duration-base;
     }
   }
 
@@ -133,7 +133,7 @@
     &-item-group-title {
       padding: 5px @control-padding-horizontal;
       color: @text-color-secondary;
-      transition: all 0.3s;
+      transition: all @animation-duration-slow;
     }
 
     &-submenu-popup {
@@ -170,7 +170,7 @@
     &-title-content {
       > a {
         color: inherit;
-        transition: all 0.3s;
+        transition: all @animation-duration-slow;
 
         &:hover {
           color: inherit;
@@ -199,7 +199,7 @@
       line-height: @dropdown-line-height;
       white-space: nowrap;
       cursor: pointer;
-      transition: all 0.3s;
+      transition: all @animation-duration-slow;
 
       &:first-child {
         & when (@dropdown-edge-child-vertical-padding = 0) {

--- a/components/dropdown/style/index.less
+++ b/components/dropdown/style/index.less
@@ -154,6 +154,40 @@
       }
     }
 
+    // ======================= Item Content =======================
+    &-item {
+      position: relative;
+      display: flex;
+      align-items: center;
+    }
+
+    &-item-icon {
+      min-width: 12px;
+      margin-right: 8px;
+      font-size: @font-size-sm;
+    }
+
+    &-title-content {
+      > a {
+        color: inherit;
+        transition: all 0.3s;
+
+        &:hover {
+          color: inherit;
+        }
+
+        &::after {
+          position: absolute;
+          top: 0;
+          right: 0;
+          bottom: 0;
+          left: 0;
+          content: '';
+        }
+      }
+    }
+
+    // =========================== Item ===========================
     &-item,
     &-submenu-title {
       clear: both;
@@ -167,34 +201,6 @@
       cursor: pointer;
       transition: all 0.3s;
 
-      > .@{iconfont-css-prefix}:first-child,
-      > a > .@{iconfont-css-prefix}:first-child,
-      > span > .@{iconfont-css-prefix}:first-child {
-        min-width: 12px;
-        margin-right: 8px;
-        font-size: @font-size-sm;
-        vertical-align: -0.1em;
-      }
-
-      > a {
-        display: block;
-        margin: -5px -@control-padding-horizontal;
-        padding: 5px @control-padding-horizontal;
-        color: @text-color;
-        transition: all 0.3s;
-        &:hover {
-          color: @text-color;
-        }
-      }
-
-      > .@{iconfont-css-prefix} + span > a {
-        color: @text-color;
-        transition: all 0.3s;
-        &:hover {
-          color: @text-color;
-        }
-      }
-
       &:first-child {
         & when (@dropdown-edge-child-vertical-padding = 0) {
           border-radius: @border-radius-base @border-radius-base 0 0;
@@ -207,8 +213,7 @@
         }
       }
 
-      &-selected,
-      &-selected > a {
+      &-selected {
         color: @dropdown-selected-color;
         background-color: @item-active-bg;
       }
@@ -227,21 +232,8 @@
           cursor: not-allowed;
         }
 
-        > .@{iconfont-css-prefix} + span > a,
-        > a {
-          position: relative;
-          color: @disabled-color;
+        a {
           pointer-events: none;
-
-          &::after {
-            position: absolute;
-            top: 0;
-            left: 0;
-            width: 100%;
-            height: 100%;
-            cursor: not-allowed;
-            content: '';
-          }
         }
       }
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

resolve #30786

### 💡 Background and solution

看起来原本带图标的 Dropdown Item hover 到图标点击无法触发 a 效果，一并修了。有统一 className 后感觉代码量还少了？帮忙确认一下。

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Fix Dropdown Item with link color style and click icon can also trigger link effect now.        |
| 🇨🇳 Chinese |   修复 Dropdown 条目包含超链接时的颜色样式，另外现在点击图标也能触发超链接效果。       |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
