### PR TITLE
style(tooltip): add max-content width to size correctly

### DIFF
--- a/components/tooltip/style/index.less
+++ b/components/tooltip/style/index.less
@@ -18,6 +18,7 @@
   position: absolute;
   z-index: @zindex-tooltip;
   display: block;
+  width: max-content;
   max-width: @tooltip-max-width;
   visibility: visible;
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

Issue: #30821
Repro: https://codesandbox.io/s/antd-tooltip-repro-s1up6

### 💡 Background and solution

Element with `position: absolute` under `position: relative` without width specified will take as little space as possible, causing tooltip content to wraps unnecessarily.

![image](https://user-images.githubusercontent.com/410792/120430337-72edab80-c3a9-11eb-9e5d-8727d1fd3d67.png)

adding `width: max-content` allows tooltip content to take as much width, capped at specified max-width

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Optimize Tooltip content width. |
| 🇨🇳 Chinese | 优化 Tooltip 内容的宽度。  |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
