### PR TITLE
feat(transfer): add onBeforeChange event

### DIFF
--- a/components/transfer/demo/basic.md
+++ b/components/transfer/demo/basic.md
@@ -7,7 +7,7 @@ title:
 
 ## zh-CN
 
-最基本的用法，展示了 `dataSource`、`targetKeys`、每行的渲染函数 `render` 以及回调函数 `onChange` `onSelectChange` `onScroll` 的用法。
+最基本的用法，展示了 `dataSource`、`targetKeys`、每行的渲染函数 `render` 以及回调函数 `onBeforeChange` `onChange` `onSelectChange` `onScroll` 的用法。
 
 ## en-US
 
@@ -15,7 +15,7 @@ The most basic usage of `Transfer` involves providing the source data and target
 
 ```jsx
 import React, { useState } from 'react';
-import { Transfer } from 'antd';
+import { Transfer, Modal, Radio, Divider } from 'antd';
 
 const mockData = [];
 for (let i = 0; i < 20; i++) {
@@ -31,11 +31,26 @@ const initialTargetKeys = mockData.filter(item => +item.key > 10).map(item => it
 const App = () => {
   const [targetKeys, setTargetKeys] = useState(initialTargetKeys);
   const [selectedKeys, setSelectedKeys] = useState([]);
+  const [value, setValue] = React.useState(1);
   const onChange = (nextTargetKeys, direction, moveKeys) => {
     console.log('targetKeys:', nextTargetKeys);
     console.log('direction:', direction);
     console.log('moveKeys:', moveKeys);
     setTargetKeys(nextTargetKeys);
+  };
+
+  // onBeforeChange与onChange不能同时使用
+  const onBeforeChange = (nextTargetKeys, direction, moveKeys, next) => {
+    console.log('targetKeys:', nextTargetKeys);
+    console.log('direction:', direction);
+    console.log('moveKeys:', moveKeys);
+    Modal.confirm({
+      title: 'sue to move ?',
+      onOk: () => {
+        next();
+        setTargetKeys(nextTargetKeys);
+      },
+    });
   };
 
   const onSelectChange = (sourceSelectedKeys, targetSelectedKeys) => {
@@ -49,17 +64,31 @@ const App = () => {
     console.log('target:', e.target);
   };
 
+  const onEventTypeChange = e => {
+    console.log('radio checked', e.target.value);
+    setValue(e.target.value);
+    setSelectedKeys([]);
+  };
+
   return (
-    <Transfer
-      dataSource={mockData}
-      titles={['Source', 'Target']}
-      targetKeys={targetKeys}
-      selectedKeys={selectedKeys}
-      onChange={onChange}
-      onSelectChange={onSelectChange}
-      onScroll={onScroll}
-      render={item => item.title}
-    />
+    <div>
+      <Radio.Group onChange={onEventTypeChange} value={value}>
+        <Radio value={1}>use onChange</Radio>
+        <Radio value={2}>use onBeforeChange</Radio>
+      </Radio.Group>
+      <Divider />
+      <Transfer
+        dataSource={mockData}
+        titles={['Source', 'Target']}
+        targetKeys={targetKeys}
+        selectedKeys={selectedKeys}
+        onChange={value === 1 && onChange}
+        onBeforeChange={value === 2 && onBeforeChange}
+        onSelectChange={onSelectChange}
+        onScroll={onScroll}
+        render={item => item.title}
+      />
+    </div>
   );
 };
 

--- a/components/transfer/index.en-US.md
+++ b/components/transfer/index.en-US.md
@@ -38,6 +38,7 @@ One or more elements can be selected from either column, one click on the proper
 | showSelectAll | Show select all checkbox on the header | boolean | true |  |
 | targetKeys | A set of keys of elements that are listed on the right column | string\[] | \[] |  |
 | titles | A set of titles that are sorted from left to right | ReactNode\[] | - |  |
+| onBeforeChange | A callback function that is executed before the transfer between columns | (targetKeys, direction, moveKeys, next): void | - |  |
 | onChange | A callback function that is executed when the transfer between columns is complete | (targetKeys, direction, moveKeys): void | - |  |
 | onScroll | A callback function which is executed when scroll options list | (direction, event): void | - |  |
 | onSearch | A callback function which is executed when search field are changed | (direction: `left` \| `right`, value: string): void | - |  |

--- a/components/transfer/index.tsx
+++ b/components/transfer/index.tsx
@@ -205,9 +205,8 @@ class Transfer<RecordType extends TransferItem = TransferItem> extends React.Com
       onBeforeChange(newTargetKeys, direction, newMoveKeys, next);
     } else {
       next();
+      onChange?.(newTargetKeys, direction, newMoveKeys);
     }
-
-    onChange?.(newTargetKeys, direction, newMoveKeys);
   };
 
   moveToLeft = () => this.moveTo('left');

--- a/components/transfer/index.zh-CN.md
+++ b/components/transfer/index.zh-CN.md
@@ -40,6 +40,7 @@ cover: https://gw.alipayobjects.com/zos/alicdn/QAXskNI4G/Transfer.svg
 | showSelectAll | 是否展示全选勾选框 | boolean | true |  |
 | targetKeys | 显示在右侧框数据的 key 集合 | string\[] | \[] |  |
 | titles | 标题集合，顺序从左至右 | ReactNode\[] | - |  |
+| onBeforeChange | 选项在两栏之间转移前的回调函数, 可以做二次确认等操作 | (targetKeys, direction, moveKeys, next): void | - |  |
 | onChange | 选项在两栏之间转移时的回调函数 | (targetKeys, direction, moveKeys): void | - |  |
 | onScroll | 选项列表滚动时的回调函数 | (direction, event): void | - |  |
 | onSearch | 搜索框内容时改变时的回调函数 | (direction: `left` \| `right`, value: string): void | - |  |


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [x] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution


1. transfer 目前只支持onChange事件，当需要做前置判断的时候(例如 二次确认是否要移动)。不能很友好的支持，可以使用hack方式，但此时已经完成了数据操作。选中状态已改变，需要记录操作前的选中状态，强制再设置一遍。
2. 加入onBeforeChange事件后，targerKeys操作包在next方法中并暴露出来，用户做完自己的操作后再手动调用，最后执行setTargetKeys操作可以达到同样的效果。操作方便性能方面也有提升。


### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |          添加onBeforeChange方法  |
| 🇨🇳 Chinese |          add onBeforeChange event |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
