### PR TITLE
feat: 新增useToggleModal hooks（Draft）

### DIFF
--- a/components/modal/demo/form-in-modal.md
+++ b/components/modal/demo/form-in-modal.md
@@ -1,0 +1,88 @@
+---
+order: 14
+title:
+zh-CN: 在Modal中使用Form表单
+en-US: use Form in Modal Component
+---
+
+## zh-CN
+
+使用 useToggleModal 处理复杂表单
+
+## en-US
+
+use useToggleModal handle complex form
+
+```jsx
+import React, { useEffect, useState } from 'react';
+import { Form, Modal, useToggleModal, DatePicker, Button } from 'antd';
+
+const request = (data, timeout = 2000) =>
+  new Promise(resolve => {
+    setTimeout(() => {
+      resolve(data);
+    }, timeout);
+  });
+const useMounted = fn =>
+  useEffect(() => {
+    fn();
+  }, []);
+const list = [
+  {
+    jobId: 1,
+    jobTitle: '111',
+  },
+  {
+    jobId: 2,
+    jobTitle: '222',
+  },
+];
+const App = () => {
+  const [dataList, setDataList] = useState([]);
+  useMounted(() => {
+    request(list).then(value => setDataList(value));
+  });
+  // 传入一个函数（组件），将返回的组件在jsx中渲染一下即可。
+  const execModal = useToggleModal(record => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const [jobInfo, setJobInfo] = useState(null);
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    useMounted(() => {
+      request({
+        jobCreator: 'chen',
+      }).then(value => setJobInfo(value));
+    });
+    const onSubmit = formValue => {
+      // eslint-disable-next-line no-console
+      console.log(formValue);
+      // 关闭对话框
+      // execModal.hideComponent()
+    };
+    return (
+      <Modal
+        {...execModal.modalProps}
+        okButtonProps={execModal.okButtonProps}
+        title={`任务名-${record.jobTitle}`}
+      >
+        <Form {...execModal.formProps} onFinish={onSubmit}>
+          <Form.Item name="timeRange" label="同步分区" rules={rules.required}>
+            <DatePicker.RangePicker showTime />
+          </Form.Item>
+          <div>创建人: {jobInfo.jobCreator}</div>
+        </Form>
+      </Modal>
+    );
+  });
+  return (
+    <div>
+      {dataList.map(value => (
+        <Button onClick={() => execModal.showComponent(value)} key={value.jobId}>
+          edit
+        </Button>
+      ))}
+      <execModal.Component />
+    </div>
+  );
+};
+ReactDOM.render(<App />, mountNode);
+```

--- a/components/modal/hook/useToggleComponent.tsx
+++ b/components/modal/hook/useToggleComponent.tsx
@@ -1,0 +1,44 @@
+import React, { useState, useRef, FunctionComponent, useEffect, DependencyList, FC } from 'react';
+
+export type ToggleComponentReturnType<Props> = {
+  showComponent: (props: Props) => void;
+  hideComponent: () => void;
+  isShow: boolean;
+  Component: FC;
+};
+/**
+ * 控制组件是否show，和常规的在组件里声明一个isShow状态相比，这个hooks可以将一个jsx(React.Element) 包装成一个组件，同时可以通过showComponent方法传递props进来。
+ *
+ * @param Component 渲染的组件，常用的可能就是modal
+ * @param dependency 当组件内部引用到外部的状态时，要把外部状态填到依赖里，注意依赖更新时，会reMount组件，重新执行生命周期。基本上用不到这个参数
+ */
+function useToggleComponent<Props = any>(
+  Component: FunctionComponent<Props>,
+  dependency: DependencyList = [],
+): ToggleComponentReturnType<Props> {
+  const [show, setShow] = useState<boolean>(false);
+  const [ClonedComponent, setClonedComponent] = useState<React.FunctionComponent>(() => () => null);
+  const cachedPropsRef = useRef<Props>();
+  const showComponent = (props: Props) => {
+    setShow(true);
+    cachedPropsRef.current = props;
+    setClonedComponent(() => () => <Component {...props} />);
+  };
+  const hideComponent = () => {
+    setShow(false);
+    setClonedComponent(() => () => null);
+  };
+  useEffect(() => {
+    if (show) {
+      setClonedComponent(() => () => <Component {...cachedPropsRef.current!} />);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, dependency);
+  return {
+    showComponent,
+    hideComponent,
+    isShow: show,
+    Component: ClonedComponent,
+  };
+}
+export default useToggleComponent;

--- a/components/modal/hook/useToggleModal.ts
+++ b/components/modal/hook/useToggleModal.ts
@@ -1,0 +1,36 @@
+import { DependencyList, FunctionComponent, useMemo } from 'react';
+import useToggleComponent from './useToggleComponent';
+import { ModalProps } from '../index';
+import Form, { FormProps } from '../../form';
+import { ButtonProps } from '../../button';
+
+const useToggleModal = <Props, FormValue = any>(
+  Component: FunctionComponent<Props>,
+  dependency: DependencyList = [],
+) => {
+  const toggleComponent = useToggleComponent<Props>(Component, dependency);
+  const [form] = Form.useForm<FormValue>();
+  const randomFormId = useMemo(() => `form${Math.random()}`, []);
+  const modalProps: ModalProps = {
+    visible: true,
+    onCancel: toggleComponent.hideComponent,
+  };
+  // OkButton的form指向Form的id。这样Modal的确认按钮点击后会触发Form的OnFinish
+  const okButtonProps: ButtonProps = {
+    htmlType: 'submit',
+    form: randomFormId,
+  };
+  const formProps: Required<Pick<FormProps, 'form' | 'id'>> = {
+    form: form!,
+    id: randomFormId,
+  };
+  return {
+    ...toggleComponent,
+    form,
+    formProps,
+    okButtonProps,
+    modalProps,
+  };
+};
+
+export default useToggleModal;

--- a/components/modal/index.tsx
+++ b/components/modal/index.tsx
@@ -8,7 +8,10 @@ import confirm, {
   ModalStaticFunctions,
   modalGlobalConfig,
 } from './confirm';
+import useToggleModal from './hook/useToggleModal';
+import useToggleComponent from './hook/useToggleComponent';
 
+export { useToggleComponent, useToggleModal };
 export { ActionButtonProps } from './ActionButton';
 export { ModalProps, ModalFuncProps } from './Modal';
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Other (about what?)
- [ ] Test Case
- [ ] Branch merge

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->
#25092  #21740 #24248 


### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->
#### 背景
总所周知 antd主要用于中后台管理系统。在后台系统中有个很常见的需求=> 一个列表，点击编辑弹出一个表单对话框，编辑完成后重新刷新数据。

这是一个比较常见的需求，也比较简单。但是在常用的几种实现方式上，各有一些小小的问题。

以下列举一些常用的实现方式，以及对应的demo。

- 直接在组件中使用visible控制弹窗展示。[codesanbox](https://codesandbox.io/s/zhijievisibledefangshi-ddrgd?file=/src/App.tsx)

这种方式本质上是把modal中的状态提升到了父组件中，一般而言我们期望每次打开一个对话框都是全新的，不要去夹杂老的数据。  
但是这种方式多个对话框用的是同一份数据，每次关闭对话框还需要重新设置toggle为false。而且会需要一个讨厌的临时变量selectedItemValue。  
这个变量在ts中使用的话，还需要做判空处理。而且对话框内部的一些状态全部提升到上层，对话框内的表单较为复杂时，状态会很多，难以维护。

- 基于Modal封装一层业务组件使用。[codesandbox](https://codesandbox.io/s/modalfengzhuangyewuzujian-pl84z?file=/src/App.tsx)

这种方式将组件内部和外部状态隔离开了。降低了父组件的复杂度。但是提升了组件间通信的复杂度。  
由于业务Modal无法自己控制是否visible。，业务中需要不少的组件间通信的场景。  
而且依然存在selectedItemValue这种临时变量，也要做判空处理。  

- 使用Modal的静态方法，给content传表单jsx。时间有限，后续再补充例子。

这种方式和第一种类似，不过不再需要一个临时的selectedItemValue变量了。但是所有的状态和方法依然被提升到了父组件中，表单较多的话父组件的复杂度提升很快。


#### 有没有更简单的解决方案？
综上所述，上述常见的方案，要么增加需要判空的临时变量；要么把状态和方法都堆积在父组件中，容易造成组件膨胀；要么需要不少的组件间通信成本，来回定义Props，关闭对话框还需要父组件处理。  
我个人觉得上述方案都不太优雅。

结合antd的使用经验，和业务经验，我摸索了一个hooks来解决上述问题。请看[codesandbox](https://codesandbox.io/s/hooksfangan-hi6fl?file=/src/App.tsx)  

通过这种hooks的方式，相比上述的一些方案，有以下优势。 
1. modal可以自己关闭自己。更加简单。
2. 也不需要临时的selectedItemValue状态，类型更安全.  
3. Modal内的状态跟父组件隔离，不会把逻辑都堆放在父组件中。Modal中相当于一个组件，可以调用任何hooks.遇见复杂表单也不会影响到父组件的逻辑。
4. 每次开启关闭对话框，都会是一个全新的，不需要关闭对话框后重新恢复一些状态。
5. 不存在组件间通信的麻烦事儿了，可以在Modal中直接通过闭包获取父组件的状态
6. 不存在visible这个状态了。我一直觉得组件的状态应该尽量的少，否则复杂度会上升的比较快。

同时也有一点儿问题。
1. eslint开启了hooks规则的话，这么写会报错。因为我个人不太用得到这个规则，所以我把它关了。
2. hooks接受一个组件，返回一个组件的操作比较少见，不过针对一些特别的场景，感觉还不错。


#### 总结
本次PR权当抛砖引玉，欢迎大家提出自己的解决方案。

也可以讨论一下如何改进这个方案，合适的话，我可以再补充单元测试文档等。

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   add useToggleModal hooks        |
| 🇨🇳 Chinese |  新增useToggleModal hooks         |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
