### PR TITLE
fix: Menu overflow with `horizontal` should not affect by `float` element

### DIFF
--- a/components/layout/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/layout/__tests__/__snapshots__/demo.test.js.snap
@@ -1352,6 +1352,150 @@ exports[`renders ./components/layout/demo/top.md correctly 1`] = `
         </span>
       </li>
       <li
+        class="ant-menu-overflow-item ant-menu-item ant-menu-item-only-child"
+        role="menuitem"
+        style="opacity:1;order:3"
+        tabindex="-1"
+      >
+        <span
+          class="ant-menu-title-content"
+        >
+          nav 4
+        </span>
+      </li>
+      <li
+        class="ant-menu-overflow-item ant-menu-item ant-menu-item-only-child"
+        role="menuitem"
+        style="opacity:1;order:4"
+        tabindex="-1"
+      >
+        <span
+          class="ant-menu-title-content"
+        >
+          nav 5
+        </span>
+      </li>
+      <li
+        class="ant-menu-overflow-item ant-menu-item ant-menu-item-only-child"
+        role="menuitem"
+        style="opacity:1;order:5"
+        tabindex="-1"
+      >
+        <span
+          class="ant-menu-title-content"
+        >
+          nav 6
+        </span>
+      </li>
+      <li
+        class="ant-menu-overflow-item ant-menu-item ant-menu-item-only-child"
+        role="menuitem"
+        style="opacity:1;order:6"
+        tabindex="-1"
+      >
+        <span
+          class="ant-menu-title-content"
+        >
+          nav 7
+        </span>
+      </li>
+      <li
+        class="ant-menu-overflow-item ant-menu-item ant-menu-item-only-child"
+        role="menuitem"
+        style="opacity:1;order:7"
+        tabindex="-1"
+      >
+        <span
+          class="ant-menu-title-content"
+        >
+          nav 8
+        </span>
+      </li>
+      <li
+        class="ant-menu-overflow-item ant-menu-item ant-menu-item-only-child"
+        role="menuitem"
+        style="opacity:1;order:8"
+        tabindex="-1"
+      >
+        <span
+          class="ant-menu-title-content"
+        >
+          nav 9
+        </span>
+      </li>
+      <li
+        class="ant-menu-overflow-item ant-menu-item ant-menu-item-only-child"
+        role="menuitem"
+        style="opacity:1;order:9"
+        tabindex="-1"
+      >
+        <span
+          class="ant-menu-title-content"
+        >
+          nav 10
+        </span>
+      </li>
+      <li
+        class="ant-menu-overflow-item ant-menu-item ant-menu-item-only-child"
+        role="menuitem"
+        style="opacity:1;order:10"
+        tabindex="-1"
+      >
+        <span
+          class="ant-menu-title-content"
+        >
+          nav 11
+        </span>
+      </li>
+      <li
+        class="ant-menu-overflow-item ant-menu-item ant-menu-item-only-child"
+        role="menuitem"
+        style="opacity:1;order:11"
+        tabindex="-1"
+      >
+        <span
+          class="ant-menu-title-content"
+        >
+          nav 12
+        </span>
+      </li>
+      <li
+        class="ant-menu-overflow-item ant-menu-item ant-menu-item-only-child"
+        role="menuitem"
+        style="opacity:1;order:12"
+        tabindex="-1"
+      >
+        <span
+          class="ant-menu-title-content"
+        >
+          nav 13
+        </span>
+      </li>
+      <li
+        class="ant-menu-overflow-item ant-menu-item ant-menu-item-only-child"
+        role="menuitem"
+        style="opacity:1;order:13"
+        tabindex="-1"
+      >
+        <span
+          class="ant-menu-title-content"
+        >
+          nav 14
+        </span>
+      </li>
+      <li
+        class="ant-menu-overflow-item ant-menu-item ant-menu-item-only-child"
+        role="menuitem"
+        style="opacity:1;order:14"
+        tabindex="-1"
+      >
+        <span
+          class="ant-menu-title-content"
+        >
+          nav 15
+        </span>
+      </li>
+      <li
         aria-hidden="true"
         class="ant-menu-overflow-item ant-menu-overflow-item-rest ant-menu-submenu ant-menu-submenu-horizontal"
         role="none"

--- a/components/layout/demo/top.md
+++ b/components/layout/demo/top.md
@@ -29,9 +29,10 @@ ReactDOM.render(
     <Header>
       <div className="logo" />
       <Menu theme="dark" mode="horizontal" defaultSelectedKeys={['2']}>
-        {new Array(15).fill(null).map((_, index) => (
-          <Menu.Item key={index}>nav {index + 1}</Menu.Item>
-        ))}
+        {new Array(15).fill(null).map((_, index) => {
+          const key = index + 1;
+          return <Menu.Item key={key}>{`nav ${key}`}</Menu.Item>;
+        })}
       </Menu>
     </Header>
     <Content style={{ padding: '0 50px' }}>

--- a/components/layout/demo/top.md
+++ b/components/layout/demo/top.md
@@ -29,9 +29,9 @@ ReactDOM.render(
     <Header>
       <div className="logo" />
       <Menu theme="dark" mode="horizontal" defaultSelectedKeys={['2']}>
-        <Menu.Item key="1">nav 1</Menu.Item>
-        <Menu.Item key="2">nav 2</Menu.Item>
-        <Menu.Item key="3">nav 3</Menu.Item>
+        {new Array(15).fill(null).map((_, index) => (
+          <Menu.Item key={index}>nav {index + 1}</Menu.Item>
+        ))}
       </Menu>
     </Header>
     <Content style={{ padding: '0 50px' }}>

--- a/components/menu/style/index.less
+++ b/components/menu/style/index.less
@@ -54,10 +54,6 @@
     transition: all @animation-duration-slow;
   }
 
-  &-horizontal {
-    display: flex;
-  }
-
   &-horizontal &-submenu {
     transition: border-color @animation-duration-slow @ease-in-out,
       background @animation-duration-slow @ease-in-out;
@@ -359,6 +355,7 @@
   }
 
   &-horizontal {
+    display: flex;
     line-height: @menu-horizontal-line-height;
     border: 0;
     border-bottom: @border-width-base @border-style-base @border-color-split;

--- a/components/menu/style/index.less
+++ b/components/menu/style/index.less
@@ -54,6 +54,10 @@
     transition: all @animation-duration-slow;
   }
 
+  &-horizontal {
+    display: flex;
+  }
+
   &-horizontal &-submenu {
     transition: border-color @animation-duration-slow @ease-in-out,
       background @animation-duration-slow @ease-in-out;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

resolve #30819

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fix Menu auto overflow with `horizontal` mod breaks by `float` element.        |
| 🇨🇳 Chinese |    修复 Menu `horizontal` 模式下的自动省略布局会被 `float` 破坏的问题。    |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
