### PR TITLE
fix: warn about miss matched filter key

### DIFF
--- a/components/table/hooks/useFilter/index.tsx
+++ b/components/table/hooks/useFilter/index.tsx
@@ -1,4 +1,5 @@
 import isEqual from 'lodash/isEqual';
+import sortBy from 'lodash/sortBy';
 import * as React from 'react';
 import {
   TransformColumns,
@@ -220,7 +221,10 @@ function useFilter<RecordType>({
     // If `filterStates` is controlled has different filteredKeys then warn the user
     const hasMismatchedControlledKeys = collectedStates.some(
       ({ key, filteredKeys }) =>
-        !isEqual(filterStates.find(item => item.key === key)?.filteredKeys, filteredKeys),
+        !isEqual(
+          sortBy(filterStates.find(item => item.key === key)?.filteredKeys || []),
+          sortBy(filteredKeys),
+        ),
     );
     if (hasMismatchedControlledKeys) {
       // eslint-disable-next-line no-console

--- a/components/table/hooks/useFilter/index.tsx
+++ b/components/table/hooks/useFilter/index.tsx
@@ -1,6 +1,7 @@
 import isEqual from 'lodash/isEqual';
 import sortBy from 'lodash/sortBy';
 import * as React from 'react';
+import devWarning from '../../../_util/devWarning';
 import {
   TransformColumns,
   ColumnsType,
@@ -218,20 +219,15 @@ function useFilter<RecordType>({
       return filterStates;
     }
 
-    // If `filterStates` is controlled has different filteredKeys then warn the user
-    const hasMismatchedControlledKeys = collectedStates.some(
-      ({ key, filteredKeys }) =>
-        !isEqual(
-          sortBy(filterStates.find(item => item.key === key)?.filteredKeys || []),
-          sortBy(filteredKeys),
-        ),
+    const filteredKeysIsAllControlled = collectedStates.every(
+      ({ filteredKeys }) => filteredKeys !== undefined,
     );
-    if (hasMismatchedControlledKeys) {
-      // eslint-disable-next-line no-console
-      console.warn(
-        'You pass `filteredKeys` in to make it controlled but not change it when filter states changes. Please change it in `onFilterChange` callback.',
-      );
-    }
+
+    devWarning(
+      filteredKeysIsNotControlled || filteredKeysIsAllControlled,
+      'Table',
+      '`FilteredKeys` should all be controlled or not controlled.',
+    );
 
     return collectedStates;
   }, [mergedColumns, filterStates]);

--- a/components/table/hooks/useFilter/index.tsx
+++ b/components/table/hooks/useFilter/index.tsx
@@ -1,5 +1,3 @@
-import isEqual from 'lodash/isEqual';
-import sortBy from 'lodash/sortBy';
 import * as React from 'react';
 import devWarning from '../../../_util/devWarning';
 import {

--- a/components/table/hooks/useFilter/index.tsx
+++ b/components/table/hooks/useFilter/index.tsx
@@ -1,3 +1,4 @@
+import isEqual from 'lodash/isEqual';
 import * as React from 'react';
 import {
   TransformColumns,
@@ -207,9 +208,25 @@ function useFilter<RecordType>({
   const mergedFilterStates = React.useMemo(() => {
     const collectedStates = collectFilterStates(mergedColumns, false);
 
+    const filteredKeysIsNotControlled = collectedStates.every(
+      ({ filteredKeys }) => filteredKeys === undefined,
+    );
+
     // Return if not controlled
-    if (collectedStates.every(({ filteredKeys }) => filteredKeys === undefined)) {
+    if (filteredKeysIsNotControlled) {
       return filterStates;
+    }
+
+    // If `filterStates` is controlled has different filteredKeys then warn the user
+    const hasMismatchedControlledKeys = collectedStates.some(
+      ({ key, filteredKeys }) =>
+        !isEqual(filterStates.find(item => item.key === key)?.filteredKeys, filteredKeys),
+    );
+    if (hasMismatchedControlledKeys) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        'You pass `filteredKeys` in to make it controlled but not change it when filter states changes. Please change it in `onFilterChange` callback.',
+      );
     }
 
     return collectedStates;


### PR DESCRIPTION
close #28107

<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Table 增加内外部 `filteredKeys` 状态不一致的提示。 |
| 🇨🇳 Chinese | Table adds warning when `filteredKeys` is controlled and not reflecting internal changes. |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
