### PR TITLE
fix: Button loading margin lost when children is fragment

### DIFF
--- a/components/button/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/button/__tests__/__snapshots__/index.test.tsx.snap
@@ -263,6 +263,17 @@ exports[`Button rtl render component should be rendered correctly in RTL directi
 />
 `;
 
+exports[`Button should handle fragment as children 1`] = `
+<button
+  class="ant-btn"
+  type="button"
+>
+  <span>
+    text
+  </span>
+</button>
+`;
+
 exports[`Button should merge text if children using variable 1`] = `
 <button
   class="ant-btn"

--- a/components/button/__tests__/index.test.tsx
+++ b/components/button/__tests__/index.test.tsx
@@ -38,7 +38,7 @@ describe('Button', () => {
   it('warns if size is wrong', () => {
     const mockWarn = jest.fn();
     jest.spyOn(console, 'warn').mockImplementation(mockWarn);
-    const size = ('who am I' as any) as SizeType;
+    const size = 'who am I' as any as SizeType;
     render(<Button.Group size={size} />);
     expect(mockWarn).toHaveBeenCalledTimes(1);
     expect(mockWarn.mock.calls[0][0]).toMatchObject({
@@ -310,5 +310,15 @@ describe('Button', () => {
     );
     wrapper.simulate('click');
     expect(onClick).not.toHaveBeenCalled();
+  });
+
+  // https://github.com/ant-design/ant-design/issues/30953
+  it('should handle fragment as children', () => {
+    const wrapper = mount(
+      <Button>
+        <>text</>
+      </Button>,
+    );
+    expect(wrapper).toMatchRenderedSnapshot();
   });
 });

--- a/components/button/button.tsx
+++ b/components/button/button.tsx
@@ -22,6 +22,10 @@ function isUnborderedButtonType(type: ButtonType | undefined) {
   return type === 'text' || type === 'link';
 }
 
+function isReactFragment(node: React.ReactNode) {
+  return React.isValidElement(node) && node.type === React.Fragment;
+}
+
 // Insert one space between two chinese characters automatically.
 function insertSpace(child: React.ReactChild, needInserted: boolean) {
   // Check the child if is undefined or null.
@@ -41,9 +45,9 @@ function insertSpace(child: React.ReactChild, needInserted: boolean) {
     });
   }
   if (typeof child === 'string') {
-    if (isTwoCNChar(child)) {
-      child = child.split('').join(SPACE);
-    }
+    return isTwoCNChar(child) ? <span>{child.split('').join(SPACE)}</span> : <span>{child}</span>;
+  }
+  if (isReactFragment(child)) {
     return <span>{child}</span>;
   }
   return child;


### PR DESCRIPTION

<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->
close #30953

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Button lost margin between loading icon and text when children is fragment.  |
| 🇨🇳 Chinese | 修复 Button 加载中图标间距丢失的问题。   |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
