### PR TITLE
fix: fix the mistake that tooltip mount on wrong dom, when getPopupCo…

### DIFF
--- a/components/tooltip/index.tsx
+++ b/components/tooltip/index.tsx
@@ -202,10 +202,11 @@ const Tooltip = React.forwardRef<unknown, TooltipProps>((props, ref) => {
     return overlay || title || '';
   };
 
+  const { getPopupContainer, ...otherProps } = props;
+
   const {
     prefixCls: customizePrefixCls,
     openClassName,
-    getPopupContainer,
     getTooltipContainer,
     overlayClassName,
     color,
@@ -244,7 +245,7 @@ const Tooltip = React.forwardRef<unknown, TooltipProps>((props, ref) => {
 
   return (
     <RcTooltip
-      {...props}
+      {...otherProps}
       prefixCls={prefixCls}
       overlayClassName={customOverlayClassName}
       getTooltipContainer={getPopupContainer || getTooltipContainer || getContextPopupContainer}


### PR DESCRIPTION
…ntainer of tooltip's props is undefined or null

<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->
1. 当Tooltip的getPopupContainer属性为undefined或null时，getPopupContainer会覆盖掉传给RcTooltip的getTooltipContainer属性；这样，context中的getPopupContainer无效，造成Tooltip只能挂到body上。
2. 修复办法是不再向RcTooltip传递props中的getPopupContainer

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->


| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     fix the mistake that tooltip mount on wrong dom, when getPopupContainer of tooltip's props is undefined or null      |
| 🇨🇳 Chinese |     修复Tooltip的getPopupContainer属性为undefined时，Tooltip只能挂载到body上的问题     |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
