### PR TITLE
fix: keep selected theme when searching

### DIFF
--- a/site/theme/template/Layout/Header/index.tsx
+++ b/site/theme/template/Layout/Header/index.tsx
@@ -40,9 +40,11 @@ function initDocSearch(locale: string) {
     inputSelector: '#search-box input',
     algoliaOptions: { facetFilters: [`tags:${lang}`] },
     transformData(hits: { url: string }[]) {
+      const a = document.createElement('a');
       hits.forEach(hit => {
-        hit.url = hit.url.replace('ant.design', window.location.host);
-        hit.url = hit.url.replace('https:', window.location.protocol);
+        // `new URL` is not supported in IE
+        a.href = hit.url;
+        hit.url = `${a.pathname}${window.location.search || ''}${a.hash}`;
       });
       return hits;
     },


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [x] Site / documentation update

### 🔗 Related issue link

Noop

<!--
1. Describe the source of requirement, like related issue link.
-->


### 💡 Background and solution

Keep selected theme when searching docs

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Keep selected theme when searching docs        |
| 🇨🇳 Chinese |   搜索文档时保持当前选中的主题        |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
