### PR TITLE
fix: Space use gap should not keep negative margin

### DIFF
--- a/components/space/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/space/__tests__/__snapshots__/demo.test.js.snap
@@ -424,40 +424,44 @@ Array [
     />
   </button>,
   <div
-    class="ant-space ant-space-horizontal ant-space-align-center"
-    style="flex-wrap:wrap;margin-bottom:-8px;width:310px;background:blue"
+    style="box-shadow:0 0 5px green"
   >
     <div
-      class="ant-space-item"
-      style="margin-right:8px;padding-bottom:8px"
+      class="ant-space ant-space-horizontal ant-space-align-center"
+      style="flex-wrap:wrap;margin-bottom:-8px;width:310px;background:blue"
     >
       <div
-        style="width:150px;height:100px;background:red"
-      />
-    </div>
-    <div
-      class="ant-space-item"
-      style="margin-right:8px;padding-bottom:8px"
-    >
+        class="ant-space-item"
+        style="margin-right:8px;padding-bottom:8px"
+      >
+        <div
+          style="width:150px;height:100px;background:red"
+        />
+      </div>
       <div
-        style="width:150px;height:100px;background:red"
-      />
-    </div>
-    <div
-      class="ant-space-item"
-      style="margin-right:8px;padding-bottom:8px"
-    >
+        class="ant-space-item"
+        style="margin-right:8px;padding-bottom:8px"
+      >
+        <div
+          style="width:150px;height:100px;background:red"
+        />
+      </div>
       <div
-        style="width:150px;height:100px;background:red"
-      />
-    </div>
-    <div
-      class="ant-space-item"
-      style="padding-bottom:8px"
-    >
+        class="ant-space-item"
+        style="margin-right:8px;padding-bottom:8px"
+      >
+        <div
+          style="width:150px;height:100px;background:red"
+        />
+      </div>
       <div
-        style="width:150px;height:100px;background:red"
-      />
+        class="ant-space-item"
+        style="padding-bottom:8px"
+      >
+        <div
+          style="width:150px;height:100px;background:red"
+        />
+      </div>
     </div>
   </div>,
 ]

--- a/components/space/demo/gap-in-line.md
+++ b/components/space/demo/gap-in-line.md
@@ -34,12 +34,14 @@ const Demo = () => {
           setSingleCol(!singleCol);
         }}
       />
-      <Space style={{ width: singleCol ? 307 : 310, background: 'blue' }} size={[8, 8]} wrap>
-        <div style={style} />
-        <div style={style} />
-        <div style={style} />
-        <div style={style} />
-      </Space>
+      <div style={{ boxShadow: '0 0 5px green' }}>
+        <Space style={{ width: singleCol ? 307 : 310, background: 'blue' }} size={[8, 8]} wrap>
+          <div style={style} />
+          <div style={style} />
+          <div style={style} />
+          <div style={style} />
+        </Space>
+      </div>
     </>
   );
 };

--- a/components/space/index.tsx
+++ b/components/space/index.tsx
@@ -116,6 +116,16 @@ const Space: React.FC<SpaceProps> = props => {
   }
 
   const gapStyle: React.CSSProperties = {};
+
+  if (wrap) {
+    gapStyle.flexWrap = 'wrap';
+
+    // Patch for gap not support
+    if (!supportFlexGap) {
+      gapStyle.marginBottom = -verticalSize;
+    }
+  }
+
   if (supportFlexGap) {
     gapStyle.columnGap = horizontalSize;
     gapStyle.rowGap = verticalSize;
@@ -126,7 +136,6 @@ const Space: React.FC<SpaceProps> = props => {
       className={cn}
       style={{
         ...gapStyle,
-        ...(wrap && { flexWrap: 'wrap', marginBottom: -verticalSize }),
         ...style,
       }}
       {...otherProps}


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

resolve #30989

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Fix Space with `wrap` takes additional negative margin style.       |
| 🇨🇳 Chinese |     修复 Space 设置 `wrap` 时额外设置了负 `margin` 的样式问题。    |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
