### PR TITLE
fix: span element should not contains p element in badge component

### DIFF
--- a/components/avatar/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/avatar/__tests__/__snapshots__/demo.test.js.snap
@@ -40,11 +40,11 @@ Array [
           class="ant-scroll-number-only"
           style="transition:none"
         >
-          <p
+          <span
             class="ant-scroll-number-only-unit current"
           >
             1
-          </p>
+          </span>
         </span>
       </sup>
     </span>

--- a/components/badge/SingleNumber.tsx
+++ b/components/badge/SingleNumber.tsx
@@ -20,14 +20,14 @@ function UnitNumber({ prefixCls, value, current, offset = 0 }: UnitNumberProps) 
   }
 
   return (
-    <p
+    <span
       style={style}
       className={classNames(`${prefixCls}-only-unit`, {
         current,
       })}
     >
       {value}
-    </p>
+    </span>
   );
 }
 

--- a/components/badge/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/badge/__tests__/__snapshots__/demo.test.js.snap
@@ -18,11 +18,11 @@ exports[`renders ./components/badge/demo/basic.md correctly 1`] = `
         class="ant-scroll-number-only"
         style="transition:none"
       >
-        <p
+        <span
           class="ant-scroll-number-only-unit current"
         >
           5
-        </p>
+        </span>
       </span>
     </sup>
   </span>
@@ -94,11 +94,11 @@ exports[`renders ./components/badge/demo/change.md correctly 1`] = `
           class="ant-scroll-number-only"
           style="transition:none"
         >
-          <p
+          <span
             class="ant-scroll-number-only-unit current"
           >
             5
-          </p>
+          </span>
         </span>
       </sup>
     </span>
@@ -568,11 +568,11 @@ exports[`renders ./components/badge/demo/link.md correctly 1`] = `
         class="ant-scroll-number-only"
         style="transition:none"
       >
-        <p
+        <span
           class="ant-scroll-number-only-unit current"
         >
           5
-        </p>
+        </span>
       </span>
     </sup>
   </span>
@@ -617,21 +617,21 @@ exports[`renders ./components/badge/demo/no-wrapper.md correctly 1`] = `
           class="ant-scroll-number-only"
           style="transition:none"
         >
-          <p
+          <span
             class="ant-scroll-number-only-unit current"
           >
             2
-          </p>
+          </span>
         </span>
         <span
           class="ant-scroll-number-only"
           style="transition:none"
         >
-          <p
+          <span
             class="ant-scroll-number-only-unit current"
           >
             5
-          </p>
+          </span>
         </span>
       </sup>
     </span>
@@ -684,11 +684,11 @@ exports[`renders ./components/badge/demo/no-wrapper.md correctly 1`] = `
           class="ant-scroll-number-only"
           style="transition:none"
         >
-          <p
+          <span
             class="ant-scroll-number-only-unit current"
           >
             4
-          </p>
+          </span>
         </span>
       </sup>
     </span>
@@ -730,11 +730,11 @@ exports[`renders ./components/badge/demo/offset.md correctly 1`] = `
       class="ant-scroll-number-only"
       style="transition:none"
     >
-      <p
+      <span
         class="ant-scroll-number-only-unit current"
       >
         5
-      </p>
+      </span>
     </span>
   </sup>
 </span>
@@ -758,21 +758,21 @@ exports[`renders ./components/badge/demo/overflow.md correctly 1`] = `
         class="ant-scroll-number-only"
         style="transition:none"
       >
-        <p
+        <span
           class="ant-scroll-number-only-unit current"
         >
           9
-        </p>
+        </span>
       </span>
       <span
         class="ant-scroll-number-only"
         style="transition:none"
       >
-        <p
+        <span
           class="ant-scroll-number-only-unit current"
         >
           9
-        </p>
+        </span>
       </span>
     </sup>
   </span>
@@ -1033,11 +1033,11 @@ Array [
         class="ant-scroll-number-only"
         style="transition:none"
       >
-        <p
+        <span
           class="ant-scroll-number-only-unit current"
         >
           5
-        </p>
+        </span>
       </span>
     </sup>
   </span>,
@@ -1057,11 +1057,11 @@ Array [
         class="ant-scroll-number-only"
         style="transition:none"
       >
-        <p
+        <span
           class="ant-scroll-number-only-unit current"
         >
           5
-        </p>
+        </span>
       </span>
     </sup>
   </span>,
@@ -1206,11 +1206,11 @@ exports[`renders ./components/badge/demo/title.md correctly 1`] = `
         class="ant-scroll-number-only"
         style="transition:none"
       >
-        <p
+        <span
           class="ant-scroll-number-only-unit current"
         >
           5
-        </p>
+        </span>
       </span>
     </sup>
   </span>
@@ -1230,21 +1230,21 @@ exports[`renders ./components/badge/demo/title.md correctly 1`] = `
         class="ant-scroll-number-only"
         style="transition:none"
       >
-        <p
+        <span
           class="ant-scroll-number-only-unit current"
         >
           -
-        </p>
+        </span>
       </span>
       <span
         class="ant-scroll-number-only"
         style="transition:none"
       >
-        <p
+        <span
           class="ant-scroll-number-only-unit current"
         >
           5
-        </p>
+        </span>
       </span>
     </sup>
   </span>

--- a/components/badge/__tests__/__snapshots__/index.test.js.snap
+++ b/components/badge/__tests__/__snapshots__/index.test.js.snap
@@ -50,31 +50,31 @@ exports[`Badge render correct with negative number 1`] = `
         class="ant-scroll-number-only"
         style="transition: none;"
       >
-        <p
+        <span
           class="ant-scroll-number-only-unit current"
         >
           -
-        </p>
+        </span>
       </span>
       <span
         class="ant-scroll-number-only"
         style="transition: none;"
       >
-        <p
+        <span
           class="ant-scroll-number-only-unit current"
         >
           1
-        </p>
+        </span>
       </span>
       <span
         class="ant-scroll-number-only"
         style="transition: none;"
       >
-        <p
+        <span
           class="ant-scroll-number-only-unit current"
         >
           0
-        </p>
+        </span>
       </span>
     </sup>
   </span>
@@ -90,31 +90,31 @@ exports[`Badge render correct with negative number 1`] = `
         class="ant-scroll-number-only"
         style="transition: none;"
       >
-        <p
+        <span
           class="ant-scroll-number-only-unit current"
         >
           -
-        </p>
+        </span>
       </span>
       <span
         class="ant-scroll-number-only"
         style="transition: none;"
       >
-        <p
+        <span
           class="ant-scroll-number-only-unit current"
         >
           1
-        </p>
+        </span>
       </span>
       <span
         class="ant-scroll-number-only"
         style="transition: none;"
       >
-        <p
+        <span
           class="ant-scroll-number-only-unit current"
         >
           0
-        </p>
+        </span>
       </span>
     </sup>
   </span>
@@ -147,11 +147,11 @@ exports[`Badge rtl render component should be rendered correctly in RTL directio
       class="ant-scroll-number-only"
       style="transition:none"
     >
-      <p
+      <span
         class="ant-scroll-number-only-unit current"
       >
         5
-      </p>
+      </span>
     </span>
   </sup>
 </span>
@@ -171,11 +171,11 @@ exports[`Badge should be compatible with borderColor style 1`] = `
       class="ant-scroll-number-only"
       style="transition: none;"
     >
-      <p
+      <span
         class="ant-scroll-number-only-unit current"
       >
         4
-      </p>
+      </span>
     </span>
   </sup>
 </span>
@@ -194,81 +194,81 @@ exports[`Badge should render when count is changed 1`] = `
       class="ant-scroll-number-only"
       style="transition: none;"
     >
-      <p
+      <span
         class="ant-scroll-number-only-unit current"
       >
         1
-      </p>
+      </span>
     </span>
     <span
       class="ant-scroll-number-only"
       style="transform: translateY(-100%);"
     >
-      <p
+      <span
         class="ant-scroll-number-only-unit"
         style="position: absolute; top: -900%; left: 0px;"
       >
         0
-      </p>
-      <p
+      </span>
+      <span
         class="ant-scroll-number-only-unit"
         style="position: absolute; top: -800%; left: 0px;"
       >
         1
-      </p>
-      <p
+      </span>
+      <span
         class="ant-scroll-number-only-unit"
         style="position: absolute; top: -700%; left: 0px;"
       >
         2
-      </p>
-      <p
+      </span>
+      <span
         class="ant-scroll-number-only-unit"
         style="position: absolute; top: -600%; left: 0px;"
       >
         3
-      </p>
-      <p
+      </span>
+      <span
         class="ant-scroll-number-only-unit"
         style="position: absolute; top: -500%; left: 0px;"
       >
         4
-      </p>
-      <p
+      </span>
+      <span
         class="ant-scroll-number-only-unit"
         style="position: absolute; top: -400%; left: 0px;"
       >
         5
-      </p>
-      <p
+      </span>
+      <span
         class="ant-scroll-number-only-unit"
         style="position: absolute; top: -300%; left: 0px;"
       >
         6
-      </p>
-      <p
+      </span>
+      <span
         class="ant-scroll-number-only-unit"
         style="position: absolute; top: -200%; left: 0px;"
       >
         7
-      </p>
-      <p
+      </span>
+      <span
         class="ant-scroll-number-only-unit"
         style="position: absolute; top: -100%; left: 0px;"
       >
         8
-      </p>
-      <p
+      </span>
+      <span
         class="ant-scroll-number-only-unit current"
       >
         9
-      </p>
-      <p
+      </span>
+      <span
         class="ant-scroll-number-only-unit"
         style="position: absolute; top: 100%; left: 0px;"
       >
         0
-      </p>
+      </span>
     </span>
   </sup>
 </span>
@@ -287,81 +287,81 @@ exports[`Badge should render when count is changed 2`] = `
       class="ant-scroll-number-only"
       style="transition: none;"
     >
-      <p
+      <span
         class="ant-scroll-number-only-unit current"
       >
         1
-      </p>
+      </span>
     </span>
     <span
       class="ant-scroll-number-only"
       style="transform: translateY(-100%);"
     >
-      <p
+      <span
         class="ant-scroll-number-only-unit"
         style="position: absolute; top: -900%; left: 0px;"
       >
         1
-      </p>
-      <p
+      </span>
+      <span
         class="ant-scroll-number-only-unit"
         style="position: absolute; top: -800%; left: 0px;"
       >
         2
-      </p>
-      <p
+      </span>
+      <span
         class="ant-scroll-number-only-unit"
         style="position: absolute; top: -700%; left: 0px;"
       >
         3
-      </p>
-      <p
+      </span>
+      <span
         class="ant-scroll-number-only-unit"
         style="position: absolute; top: -600%; left: 0px;"
       >
         4
-      </p>
-      <p
+      </span>
+      <span
         class="ant-scroll-number-only-unit"
         style="position: absolute; top: -500%; left: 0px;"
       >
         5
-      </p>
-      <p
+      </span>
+      <span
         class="ant-scroll-number-only-unit"
         style="position: absolute; top: -400%; left: 0px;"
       >
         6
-      </p>
-      <p
+      </span>
+      <span
         class="ant-scroll-number-only-unit"
         style="position: absolute; top: -300%; left: 0px;"
       >
         7
-      </p>
-      <p
+      </span>
+      <span
         class="ant-scroll-number-only-unit"
         style="position: absolute; top: -200%; left: 0px;"
       >
         8
-      </p>
-      <p
+      </span>
+      <span
         class="ant-scroll-number-only-unit"
         style="position: absolute; top: -100%; left: 0px;"
       >
         9
-      </p>
-      <p
+      </span>
+      <span
         class="ant-scroll-number-only-unit current"
       >
         0
-      </p>
-      <p
+      </span>
+      <span
         class="ant-scroll-number-only-unit"
         style="position: absolute; top: 100%; left: 0px;"
       >
         1
-      </p>
+      </span>
     </span>
   </sup>
 </span>
@@ -380,22 +380,22 @@ exports[`Badge should render when count is changed 3`] = `
       class="ant-scroll-number-only"
       style="transition: none;"
     >
-      <p
+      <span
         class="ant-scroll-number-only-unit current"
       >
         1
-      </p>
+      </span>
     </span>
     <span
       class="ant-scroll-number-only"
       style="transition: none;"
     >
-      <p
+      <span
         class="ant-scroll-number-only-unit current"
         style=""
       >
         1
-      </p>
+      </span>
     </span>
   </sup>
 </span>
@@ -428,21 +428,21 @@ exports[`Badge should render when count is changed 5`] = `
       class="ant-scroll-number-only"
       style="transition: none;"
     >
-      <p
+      <span
         class="ant-scroll-number-only-unit current"
       >
         1
-      </p>
+      </span>
     </span>
     <span
       class="ant-scroll-number-only"
       style="transition: none;"
     >
-      <p
+      <span
         class="ant-scroll-number-only-unit current"
       >
         0
-      </p>
+      </span>
     </span>
   </sup>
 </span>
@@ -461,71 +461,71 @@ exports[`Badge should render when count is changed 6`] = `
       class="ant-scroll-number-only"
       style="transform: translateY(100%);"
     >
-      <p
+      <span
         class="ant-scroll-number-only-unit"
         style="position: absolute; top: -100%; left: 0px;"
       >
         9
-      </p>
-      <p
+      </span>
+      <span
         class="ant-scroll-number-only-unit current"
       >
         0
-      </p>
-      <p
+      </span>
+      <span
         class="ant-scroll-number-only-unit"
         style="position: absolute; top: 100%; left: 0px;"
       >
         1
-      </p>
-      <p
+      </span>
+      <span
         class="ant-scroll-number-only-unit"
         style="position: absolute; top: 200%; left: 0px;"
       >
         2
-      </p>
-      <p
+      </span>
+      <span
         class="ant-scroll-number-only-unit"
         style="position: absolute; top: 300%; left: 0px;"
       >
         3
-      </p>
-      <p
+      </span>
+      <span
         class="ant-scroll-number-only-unit"
         style="position: absolute; top: 400%; left: 0px;"
       >
         4
-      </p>
-      <p
+      </span>
+      <span
         class="ant-scroll-number-only-unit"
         style="position: absolute; top: 500%; left: 0px;"
       >
         5
-      </p>
-      <p
+      </span>
+      <span
         class="ant-scroll-number-only-unit"
         style="position: absolute; top: 600%; left: 0px;"
       >
         6
-      </p>
-      <p
+      </span>
+      <span
         class="ant-scroll-number-only-unit"
         style="position: absolute; top: 700%; left: 0px;"
       >
         7
-      </p>
-      <p
+      </span>
+      <span
         class="ant-scroll-number-only-unit"
         style="position: absolute; top: 800%; left: 0px;"
       >
         8
-      </p>
-      <p
+      </span>
+      <span
         class="ant-scroll-number-only-unit"
         style="position: absolute; top: 900%; left: 0px;"
       >
         9
-      </p>
+      </span>
     </span>
   </sup>
 </span>

--- a/components/config-provider/__tests__/__snapshots__/components.test.js.snap
+++ b/components/config-provider/__tests__/__snapshots__/components.test.js.snap
@@ -819,11 +819,11 @@ exports[`ConfigProvider components Badge configProvider 1`] = `
         class="config-scroll-number-only"
         style="transition:none"
       >
-        <p
+        <span
           class="config-scroll-number-only-unit current"
         >
           5
-        </p>
+        </span>
       </span>
     </sup>
   </span>
@@ -854,11 +854,11 @@ exports[`ConfigProvider components Badge configProvider componentSize large 1`] 
         class="config-scroll-number-only"
         style="transition:none"
       >
-        <p
+        <span
           class="config-scroll-number-only-unit current"
         >
           5
-        </p>
+        </span>
       </span>
     </sup>
   </span>
@@ -889,11 +889,11 @@ exports[`ConfigProvider components Badge configProvider componentSize middle 1`]
         class="config-scroll-number-only"
         style="transition:none"
       >
-        <p
+        <span
           class="config-scroll-number-only-unit current"
         >
           5
-        </p>
+        </span>
       </span>
     </sup>
   </span>
@@ -924,11 +924,11 @@ exports[`ConfigProvider components Badge configProvider virtual and dropdownMatc
         class="ant-scroll-number-only"
         style="transition:none"
       >
-        <p
+        <span
           class="ant-scroll-number-only-unit current"
         >
           5
-        </p>
+        </span>
       </span>
     </sup>
   </span>
@@ -959,11 +959,11 @@ exports[`ConfigProvider components Badge normal 1`] = `
         class="ant-scroll-number-only"
         style="transition:none"
       >
-        <p
+        <span
           class="ant-scroll-number-only-unit current"
         >
           5
-        </p>
+        </span>
       </span>
     </sup>
   </span>
@@ -994,11 +994,11 @@ exports[`ConfigProvider components Badge prefixCls 1`] = `
         class="prefix-scroll-number-only"
         style="transition:none"
       >
-        <p
+        <span
           class="prefix-scroll-number-only-unit current"
         >
           5
-        </p>
+        </span>
       </span>
     </sup>
   </span>

--- a/components/radio/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/radio/__tests__/__snapshots__/demo.test.js.snap
@@ -35,11 +35,11 @@ exports[`renders ./components/radio/demo/badge.md correctly 1`] = `
         class="ant-scroll-number-only"
         style="transition:none"
       >
-        <p
+        <span
           class="ant-scroll-number-only-unit current"
         >
           1
-        </p>
+        </span>
       </span>
     </sup>
   </span>
@@ -74,11 +74,11 @@ exports[`renders ./components/radio/demo/badge.md correctly 1`] = `
         class="ant-scroll-number-only"
         style="transition:none"
       >
-        <p
+        <span
           class="ant-scroll-number-only-unit current"
         >
           2
-        </p>
+        </span>
       </span>
     </sup>
   </span>


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

This PR fixes #30916

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     replace p element to span element in badge component      |
| 🇨🇳 Chinese |      在徽标数组件中，把展示数量的 p 标签改为 span 标签    |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
