### PR TITLE
Pr/form a11y

### DIFF
--- a/.github/workflows/verify-files-modify.yml
+++ b/.github/workflows/verify-files-modify.yml
@@ -2,18 +2,19 @@ name: Verify Files modify
 
 on:
   pull_request_target:
-    types: [opened, edited, reopened, synchronize, ready_for_review]
+    types: [opened, edited, synchronize, ready_for_review]
 
 jobs:
   verify:
     runs-on: ubuntu-latest
     steps:
       - name: verify-version
-        uses: actions-cool/verify-files-modify@v1.1.1
+        uses: actions-cool/verify-files-modify@v1.2.2
         with:
           forbid-paths: '.github/, scripts/'
+          forbid-files: 'CHANGELOG.zh-CN.md, CHANGELOG.en-US.md, package.json, LICENSE'
           skip-verify-authority: 'write'
-          assignees: 'afc163, zombieJ, yesmeck, shaodahong, xrkffgg'
+          assignees: 'afc163, zombieJ, xrkffgg'
           comment: |
-            Hi @${{ github.event.pull_request.user.login }}. Thanks for your contribution. The path `.github/` or `scripts/` is only maintained by team members. This current PR will be closed and team members will help on this.
+            Hi @${{ github.event.pull_request.user.login }}. Thanks for your contribution. The path `.github/` or `scripts/` and `CHANGELOG` `package.json` is only maintained by team members. This current PR will be closed and team members will help on this.
           close: true

--- a/.github/workflows/verify-files-modify.yml
+++ b/.github/workflows/verify-files-modify.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions-cool/verify-files-modify@v1.2.2
         with:
           forbid-paths: '.github/, scripts/'
-          forbid-files: 'CHANGELOG.zh-CN.md, CHANGELOG.en-US.md, package.json, LICENSE'
+          forbid-files: 'CHANGELOG.zh-CN.md, CHANGELOG.en-US.md, LICENSE'
           skip-verify-authority: 'write'
           assignees: 'afc163, zombieJ, xrkffgg'
           comment: |

--- a/components/config-provider/__tests__/__snapshots__/components.test.js.snap
+++ b/components/config-provider/__tests__/__snapshots__/components.test.js.snap
@@ -13273,10 +13273,9 @@ exports[`ConfigProvider components Form configProvider 1`] = `
       </div>
       <div
         class="config-form-item-explain config-form-item-explain-error"
+        role="alert"
       >
-        <div
-          role="alert"
-        >
+        <div>
           Bamboo is Light
         </div>
       </div>
@@ -13310,10 +13309,9 @@ exports[`ConfigProvider components Form configProvider componentSize large 1`] =
       </div>
       <div
         class="config-form-item-explain config-form-item-explain-error"
+        role="alert"
       >
-        <div
-          role="alert"
-        >
+        <div>
           Bamboo is Light
         </div>
       </div>
@@ -13347,10 +13345,9 @@ exports[`ConfigProvider components Form configProvider componentSize middle 1`] 
       </div>
       <div
         class="config-form-item-explain config-form-item-explain-error"
+        role="alert"
       >
-        <div
-          role="alert"
-        >
+        <div>
           Bamboo is Light
         </div>
       </div>
@@ -13384,10 +13381,9 @@ exports[`ConfigProvider components Form configProvider virtual and dropdownMatch
       </div>
       <div
         class="ant-form-item-explain ant-form-item-explain-error"
+        role="alert"
       >
-        <div
-          role="alert"
-        >
+        <div>
           Bamboo is Light
         </div>
       </div>
@@ -13421,10 +13417,9 @@ exports[`ConfigProvider components Form normal 1`] = `
       </div>
       <div
         class="ant-form-item-explain ant-form-item-explain-error"
+        role="alert"
       >
-        <div
-          role="alert"
-        >
+        <div>
           Bamboo is Light
         </div>
       </div>
@@ -13458,10 +13453,9 @@ exports[`ConfigProvider components Form prefixCls 1`] = `
       </div>
       <div
         class="prefix-Form-item-explain prefix-Form-item-explain-error"
+        role="alert"
       >
-        <div
-          role="alert"
-        >
+        <div>
           Bamboo is Light
         </div>
       </div>

--- a/components/form/ErrorList.tsx
+++ b/components/form/ErrorList.tsx
@@ -64,6 +64,11 @@ export default function ErrorList({
 
   const baseClassName = `${prefixCls}-item-explain`;
   const rootPrefixCls = getPrefixCls();
+  const helpProps: { id?: string } = {};
+
+  if (fieldId) {
+    helpProps.id = `${fieldId}_help`;
+  }
 
   return (
     <CSSMotion
@@ -78,6 +83,7 @@ export default function ErrorList({
     >
       {({ className: motionClassName }: { className?: string }) => (
         <div
+          {...helpProps}
           className={classNames(
             baseClassName,
             {
@@ -86,7 +92,6 @@ export default function ErrorList({
             motionClassName,
           )}
           key="help"
-          id={`${fieldId}_help`}
           role="alert"
         >
           {memoErrors.map((error, index) => (

--- a/components/form/ErrorList.tsx
+++ b/components/form/ErrorList.tsx
@@ -87,12 +87,11 @@ export default function ErrorList({
           )}
           key="help"
           id={`${fieldId}_help`}
+          role="alert"
         >
           {memoErrors.map((error, index) => (
             // eslint-disable-next-line react/no-array-index-key
-            <div key={index} role="alert">
-              {error}
-            </div>
+            <div key={index}>{error}</div>
           ))}
         </div>
       )}

--- a/components/form/ErrorList.tsx
+++ b/components/form/ErrorList.tsx
@@ -11,7 +11,9 @@ const EMPTY_LIST: React.ReactNode[] = [];
 
 export interface ErrorListProps {
   errors?: React.ReactNode[];
-  /** @private Internal Usage. Do not use in your production */
+  /** @private Internal usage. Do not use in your production */
+  fieldId?: string;
+  /** @private Internal usage. Do not use in your production */
   help?: React.ReactNode;
   /** @private Internal Usage. Do not use in your production */
   onDomErrorVisibleChange?: (visible: boolean) => void;
@@ -21,6 +23,7 @@ export default function ErrorList({
   errors = EMPTY_LIST,
   help,
   onDomErrorVisibleChange,
+  fieldId,
 }: ErrorListProps) {
   const forceUpdate = useForceUpdate();
   const { prefixCls, status } = React.useContext(FormItemPrefixContext);
@@ -83,6 +86,7 @@ export default function ErrorList({
             motionClassName,
           )}
           key="help"
+          id={`${fieldId}_help`}
         >
           {memoErrors.map((error, index) => (
             // eslint-disable-next-line react/no-array-index-key

--- a/components/form/FormItem.tsx
+++ b/components/form/FormItem.tsx
@@ -369,6 +369,10 @@ function FormItem<Values = any>(props: FormItemProps<Values>): React.ReactElemen
             childProps['aria-invalid'] = 'true';
           }
 
+          if (isRequired) {
+            childProps['aria-required'] = 'true';
+          }
+
           if (supportRef(children)) {
             childProps.ref = getItemRef(mergedName, children);
           }

--- a/components/form/FormItem.tsx
+++ b/components/form/FormItem.tsx
@@ -379,6 +379,10 @@ function FormItem<Values = any>(props: FormItemProps<Values>): React.ReactElemen
             childProps['aria-required'] = 'true';
           }
 
+          if (errors.length > 0) {
+            childProps['aria-invalid'] = 'true';
+          }
+
           if (supportRef(children)) {
             childProps.ref = getItemRef(mergedName, children);
           }

--- a/components/form/FormItem.tsx
+++ b/components/form/FormItem.tsx
@@ -360,9 +360,15 @@ function FormItem<Values = any>(props: FormItemProps<Values>): React.ReactElemen
             childProps.id = fieldId;
           }
 
-          if (props.help || errors.length > 0) {
-            const describedby = `${fieldId}_help`;
-            childProps['aria-describedby'] = describedby;
+          if (props.help || errors.length > 0 || props.extra) {
+            const describedbyArr = [];
+            if (props.help || errors.length > 0) {
+              describedbyArr.push(`${fieldId}_help`);
+            }
+            if (props.extra) {
+              describedbyArr.push(`${fieldId}_extra`);
+            }
+            childProps['aria-describedby'] = describedbyArr.join(' ');
           }
 
           if (errors.length > 0) {

--- a/components/form/FormItem.tsx
+++ b/components/form/FormItem.tsx
@@ -360,7 +360,7 @@ function FormItem<Values = any>(props: FormItemProps<Values>): React.ReactElemen
             childProps.id = fieldId;
           }
 
-          if (props.help) {
+          if (props.help || errors.length > 0) {
             const describedby = `${fieldId}_help`;
             childProps['aria-describedby'] = describedby;
           }

--- a/components/form/FormItem.tsx
+++ b/components/form/FormItem.tsx
@@ -243,6 +243,7 @@ function FormItem<Values = any>(props: FormItemProps<Values>): React.ReactElemen
           status={mergedValidateStatus}
           onDomErrorVisibleChange={setDomErrorVisible}
           validateStatus={mergedValidateStatus}
+          fieldId={fieldId}
         >
           <FormItemContext.Provider value={{ updateItemErrors: updateChildItemErrors }}>
             {baseChildren}
@@ -357,6 +358,11 @@ function FormItem<Values = any>(props: FormItemProps<Values>): React.ReactElemen
           const childProps = { ...children.props, ...mergedControl };
           if (!childProps.id) {
             childProps.id = fieldId;
+          }
+
+          if (props.help) {
+            const describedby = `${fieldId}_help`;
+            childProps['aria-describedby'] = describedby;
           }
 
           if (supportRef(children)) {

--- a/components/form/FormItem.tsx
+++ b/components/form/FormItem.tsx
@@ -365,6 +365,10 @@ function FormItem<Values = any>(props: FormItemProps<Values>): React.ReactElemen
             childProps['aria-describedby'] = describedby;
           }
 
+          if (errors.length > 0) {
+            childProps['aria-invalid'] = 'true';
+          }
+
           if (supportRef(children)) {
             childProps.ref = getItemRef(mergedName, children);
           }

--- a/components/form/FormItem.tsx
+++ b/components/form/FormItem.tsx
@@ -379,10 +379,6 @@ function FormItem<Values = any>(props: FormItemProps<Values>): React.ReactElemen
             childProps['aria-required'] = 'true';
           }
 
-          if (errors.length > 0) {
-            childProps['aria-invalid'] = 'true';
-          }
-
           if (supportRef(children)) {
             childProps.ref = getItemRef(mergedName, children);
           }

--- a/components/form/FormItemInput.tsx
+++ b/components/form/FormItemInput.tsx
@@ -36,6 +36,7 @@ export interface FormItemInputProps {
   help?: React.ReactNode;
   extra?: React.ReactNode;
   status?: ValidateStatus;
+  fieldId?: string;
 }
 
 const iconMap: { [key: string]: any } = {
@@ -58,6 +59,7 @@ const FormItemInput: React.FC<FormItemInputProps & FormItemInputMiscProps> = pro
     _internalItemRender: formItemRender,
     validateStatus,
     extra,
+    fieldId,
   } = props;
   const baseClassName = `${prefixCls}-item`;
 
@@ -96,7 +98,12 @@ const FormItemInput: React.FC<FormItemInputProps & FormItemInputMiscProps> = pro
   );
   const errorListDom = (
     <FormItemPrefixContext.Provider value={{ prefixCls, status }}>
-      <ErrorList errors={errors} help={help} onDomErrorVisibleChange={onDomErrorVisibleChange} />
+      <ErrorList
+        fieldId={fieldId}
+        errors={errors}
+        help={help}
+        onDomErrorVisibleChange={onDomErrorVisibleChange}
+      />
     </FormItemPrefixContext.Provider>
   );
 

--- a/components/form/FormItemInput.tsx
+++ b/components/form/FormItemInput.tsx
@@ -109,7 +109,11 @@ const FormItemInput: React.FC<FormItemInputProps & FormItemInputMiscProps> = pro
 
   // If extra = 0, && will goes wrong
   // 0&&error -> 0
-  const extraDom = extra ? <div className={`${baseClassName}-extra`}>{extra}</div> : null;
+  const extraDom = extra ? (
+    <div className={`${baseClassName}-extra`} id={`${fieldId}_extra`}>
+      {extra}
+    </div>
+  ) : null;
 
   const dom =
     formItemRender && formItemRender.mark === 'pro_table_render' && formItemRender.render ? (

--- a/components/form/FormItemInput.tsx
+++ b/components/form/FormItemInput.tsx
@@ -109,8 +109,14 @@ const FormItemInput: React.FC<FormItemInputProps & FormItemInputMiscProps> = pro
 
   // If extra = 0, && will goes wrong
   // 0&&error -> 0
+  const extraProps: { id?: string } = {};
+
+  if (fieldId) {
+    extraProps.id = `${fieldId}_extra`;
+  }
+
   const extraDom = extra ? (
-    <div className={`${baseClassName}-extra`} id={`${fieldId}_extra`}>
+    <div {...extraProps} className={`${baseClassName}-extra`}>
       {extra}
     </div>
   ) : null;

--- a/components/form/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/form/__tests__/__snapshots__/demo.test.js.snap
@@ -38,6 +38,7 @@ exports[`renders ./components/form/demo/advanced-search.md correctly 1`] = `
                 class="ant-form-item-control-input-content"
               >
                 <input
+                  aria-required="true"
                   class="ant-input"
                   id="advanced_search_field-0"
                   placeholder="placeholder"
@@ -77,6 +78,7 @@ exports[`renders ./components/form/demo/advanced-search.md correctly 1`] = `
                 class="ant-form-item-control-input-content"
               >
                 <input
+                  aria-required="true"
                   class="ant-input"
                   id="advanced_search_field-1"
                   placeholder="placeholder"
@@ -116,6 +118,7 @@ exports[`renders ./components/form/demo/advanced-search.md correctly 1`] = `
                 class="ant-form-item-control-input-content"
               >
                 <input
+                  aria-required="true"
                   class="ant-input"
                   id="advanced_search_field-2"
                   placeholder="placeholder"
@@ -155,6 +158,7 @@ exports[`renders ./components/form/demo/advanced-search.md correctly 1`] = `
                 class="ant-form-item-control-input-content"
               >
                 <input
+                  aria-required="true"
                   class="ant-input"
                   id="advanced_search_field-3"
                   placeholder="placeholder"
@@ -194,6 +198,7 @@ exports[`renders ./components/form/demo/advanced-search.md correctly 1`] = `
                 class="ant-form-item-control-input-content"
               >
                 <input
+                  aria-required="true"
                   class="ant-input"
                   id="advanced_search_field-4"
                   placeholder="placeholder"
@@ -233,6 +238,7 @@ exports[`renders ./components/form/demo/advanced-search.md correctly 1`] = `
                 class="ant-form-item-control-input-content"
               >
                 <input
+                  aria-required="true"
                   class="ant-input"
                   id="advanced_search_field-5"
                   placeholder="placeholder"
@@ -333,6 +339,7 @@ exports[`renders ./components/form/demo/basic.md correctly 1`] = `
           class="ant-form-item-control-input-content"
         >
           <input
+            aria-required="true"
             class="ant-input"
             id="basic_username"
             type="text"
@@ -370,6 +377,7 @@ exports[`renders ./components/form/demo/basic.md correctly 1`] = `
           >
             <input
               action="click"
+              aria-required="true"
               class="ant-input"
               id="basic_password"
               type="password"
@@ -499,6 +507,7 @@ exports[`renders ./components/form/demo/control-hooks.md correctly 1`] = `
           class="ant-form-item-control-input-content"
         >
           <input
+            aria-required="true"
             class="ant-input"
             id="control-hooks_note"
             type="text"
@@ -532,6 +541,7 @@ exports[`renders ./components/form/demo/control-hooks.md correctly 1`] = `
           class="ant-form-item-control-input-content"
         >
           <div
+            aria-required="true"
             class="ant-select ant-select-single ant-select-allow-clear ant-select-show-arrow"
           >
             <div
@@ -546,6 +556,7 @@ exports[`renders ./components/form/demo/control-hooks.md correctly 1`] = `
                   aria-controls="control-hooks_gender_list"
                   aria-haspopup="listbox"
                   aria-owns="control-hooks_gender_list"
+                  aria-required="true"
                   autocomplete="off"
                   class="ant-select-selection-search-input"
                   id="control-hooks_gender"
@@ -666,6 +677,7 @@ exports[`renders ./components/form/demo/control-ref.md correctly 1`] = `
           class="ant-form-item-control-input-content"
         >
           <input
+            aria-required="true"
             class="ant-input"
             id="control-ref_note"
             type="text"
@@ -699,6 +711,7 @@ exports[`renders ./components/form/demo/control-ref.md correctly 1`] = `
           class="ant-form-item-control-input-content"
         >
           <div
+            aria-required="true"
             class="ant-select ant-select-single ant-select-allow-clear ant-select-show-arrow"
           >
             <div
@@ -713,6 +726,7 @@ exports[`renders ./components/form/demo/control-ref.md correctly 1`] = `
                   aria-controls="control-ref_gender_list"
                   aria-haspopup="listbox"
                   aria-owns="control-ref_gender_list"
+                  aria-required="true"
                   autocomplete="off"
                   class="ant-select-selection-search-input"
                   id="control-ref_gender"
@@ -1074,10 +1088,9 @@ exports[`renders ./components/form/demo/disabled-input-debug.md correctly 1`] = 
       </div>
       <div
         class="ant-form-item-explain ant-form-item-explain-error"
+        role="alert"
       >
-        <div
-          role="alert"
-        >
+        <div>
           Buggy!
         </div>
       </div>
@@ -1116,10 +1129,9 @@ exports[`renders ./components/form/demo/disabled-input-debug.md correctly 1`] = 
       </div>
       <div
         class="ant-form-item-explain ant-form-item-explain-error"
+        role="alert"
       >
-        <div
-          role="alert"
-        >
+        <div>
           Buggy!
         </div>
       </div>
@@ -1189,10 +1201,9 @@ exports[`renders ./components/form/demo/disabled-input-debug.md correctly 1`] = 
       </div>
       <div
         class="ant-form-item-explain ant-form-item-explain-error"
+        role="alert"
       >
-        <div
-          role="alert"
-        >
+        <div>
           Buggy!
         </div>
       </div>
@@ -1231,10 +1242,9 @@ exports[`renders ./components/form/demo/disabled-input-debug.md correctly 1`] = 
       </div>
       <div
         class="ant-form-item-explain ant-form-item-explain-error"
+        role="alert"
       >
-        <div
-          role="alert"
-        >
+        <div>
           Buggy!
         </div>
       </div>
@@ -1330,10 +1340,9 @@ exports[`renders ./components/form/demo/disabled-input-debug.md correctly 1`] = 
       </div>
       <div
         class="ant-form-item-explain ant-form-item-explain-error"
+        role="alert"
       >
-        <div
-          role="alert"
-        >
+        <div>
           Buggy!
         </div>
       </div>
@@ -1385,10 +1394,9 @@ exports[`renders ./components/form/demo/disabled-input-debug.md correctly 1`] = 
       </div>
       <div
         class="ant-form-item-explain ant-form-item-explain-error"
+        role="alert"
       >
-        <div
-          role="alert"
-        >
+        <div>
           Buggy!
         </div>
       </div>
@@ -1476,10 +1484,9 @@ exports[`renders ./components/form/demo/disabled-input-debug.md correctly 1`] = 
       </div>
       <div
         class="ant-form-item-explain ant-form-item-explain-error"
+        role="alert"
       >
-        <div
-          role="alert"
-        >
+        <div>
           Buggy!
         </div>
       </div>
@@ -1527,10 +1534,9 @@ exports[`renders ./components/form/demo/disabled-input-debug.md correctly 1`] = 
       </div>
       <div
         class="ant-form-item-explain ant-form-item-explain-error"
+        role="alert"
       >
-        <div
-          role="alert"
-        >
+        <div>
           Buggy!
         </div>
       </div>
@@ -1761,6 +1767,7 @@ exports[`renders ./components/form/demo/dynamic-form-items-complex.md correctly 
           class="ant-form-item-control-input-content"
         >
           <div
+            aria-required="true"
             class="ant-select ant-select-single ant-select-show-arrow"
           >
             <div
@@ -1775,6 +1782,7 @@ exports[`renders ./components/form/demo/dynamic-form-items-complex.md correctly 
                   aria-controls="dynamic_form_nest_item_area_list"
                   aria-haspopup="listbox"
                   aria-owns="dynamic_form_nest_item_area_list"
+                  aria-required="true"
                   autocomplete="off"
                   class="ant-select-selection-search-input"
                   id="dynamic_form_nest_item_area"
@@ -1924,6 +1932,7 @@ exports[`renders ./components/form/demo/dynamic-rule.md correctly 1`] = `
           class="ant-form-item-control-input-content"
         >
           <input
+            aria-required="true"
             class="ant-input"
             id="dynamic_rule_username"
             placeholder="Please input your name"
@@ -2058,6 +2067,7 @@ exports[`renders ./components/form/demo/form-context.md correctly 1`] = `
           class="ant-form-item-control-input-content"
         >
           <input
+            aria-required="true"
             class="ant-input"
             id="basicForm_group"
             type="text"
@@ -2197,6 +2207,7 @@ Array [
             class="ant-form-item-control-input-content"
           >
             <input
+              aria-required="true"
               class="ant-input"
               id="global_state_username"
               type="text"
@@ -2266,6 +2277,7 @@ exports[`renders ./components/form/demo/inline-login.md correctly 1`] = `
               </span>
             </span>
             <input
+              aria-required="true"
               class="ant-input"
               id="horizontal_login_username"
               placeholder="Username"
@@ -2316,6 +2328,7 @@ exports[`renders ./components/form/demo/inline-login.md correctly 1`] = `
               </span>
             </span>
             <input
+              aria-required="true"
               class="ant-input"
               id="horizontal_login_password"
               placeholder="Password"
@@ -2568,6 +2581,7 @@ exports[`renders ./components/form/demo/nest-messages.md correctly 1`] = `
           class="ant-form-item-control-input-content"
         >
           <input
+            aria-required="true"
             class="ant-input"
             id="nest-messages_user_name"
             type="text"
@@ -2846,6 +2860,7 @@ exports[`renders ./components/form/demo/normal-login.md correctly 1`] = `
               </span>
             </span>
             <input
+              aria-required="true"
               class="ant-input"
               id="normal_login_username"
               placeholder="Username"
@@ -2896,6 +2911,7 @@ exports[`renders ./components/form/demo/normal-login.md correctly 1`] = `
               </span>
             </span>
             <input
+              aria-required="true"
               class="ant-input"
               id="normal_login_password"
               placeholder="Password"
@@ -3089,6 +3105,7 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
           class="ant-form-item-control-input-content"
         >
           <input
+            aria-required="true"
             class="ant-input"
             id="register_email"
             type="text"
@@ -3126,6 +3143,7 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
           >
             <input
               action="click"
+              aria-required="true"
               class="ant-input"
               id="register_password"
               type="password"
@@ -3191,6 +3209,7 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
           >
             <input
               action="click"
+              aria-required="true"
               class="ant-input"
               id="register_confirm"
               type="password"
@@ -3274,6 +3293,7 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
           class="ant-form-item-control-input-content"
         >
           <input
+            aria-required="true"
             class="ant-input"
             id="register_nickname"
             type="text"
@@ -3316,6 +3336,7 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
               Zhejiang / Hangzhou / West Lake
             </span>
             <input
+              aria-required="true"
               autocomplete="off"
               class="ant-input ant-cascader-input "
               id="register_residence"
@@ -3464,6 +3485,7 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
                 </div>
               </span>
               <input
+                aria-required="true"
                 class="ant-input"
                 id="register_phone"
                 type="text"
@@ -3499,6 +3521,7 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
           class="ant-form-item-control-input-content"
         >
           <div
+            aria-required="true"
             class="ant-select ant-select-auto-complete ant-select-single ant-select-customize-input ant-select-show-search"
           >
             <div
@@ -3513,6 +3536,7 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
                   aria-controls="register_website_list"
                   aria-haspopup="listbox"
                   aria-owns="register_website_list"
+                  aria-required="true"
                   autocomplete="off"
                   class="ant-input ant-select-selection-search-input"
                   id="register_website"
@@ -3649,6 +3673,7 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
               style="padding-left:4px;padding-right:4px"
             >
               <input
+                aria-required="true"
                 class="ant-input"
                 id="register_captcha"
                 type="text"
@@ -4610,6 +4635,7 @@ exports[`renders ./components/form/demo/time-related-controls.md correctly 1`] =
               class="ant-picker-input"
             >
               <input
+                aria-required="true"
                 autocomplete="off"
                 id="time_related_controls_date-picker"
                 placeholder="Select date"
@@ -4677,6 +4703,7 @@ exports[`renders ./components/form/demo/time-related-controls.md correctly 1`] =
               class="ant-picker-input"
             >
               <input
+                aria-required="true"
                 autocomplete="off"
                 id="time_related_controls_date-time-picker"
                 placeholder="Select date"
@@ -4744,6 +4771,7 @@ exports[`renders ./components/form/demo/time-related-controls.md correctly 1`] =
               class="ant-picker-input"
             >
               <input
+                aria-required="true"
                 autocomplete="off"
                 id="time_related_controls_month-picker"
                 placeholder="Select month"
@@ -4805,6 +4833,7 @@ exports[`renders ./components/form/demo/time-related-controls.md correctly 1`] =
           class="ant-form-item-control-input-content"
         >
           <div
+            aria-required="true"
             class="ant-picker ant-picker-range"
           >
             <div
@@ -4914,6 +4943,7 @@ exports[`renders ./components/form/demo/time-related-controls.md correctly 1`] =
           class="ant-form-item-control-input-content"
         >
           <div
+            aria-required="true"
             class="ant-picker ant-picker-range"
           >
             <div
@@ -5029,6 +5059,7 @@ exports[`renders ./components/form/demo/time-related-controls.md correctly 1`] =
               class="ant-picker-input"
             >
               <input
+                aria-required="true"
                 autocomplete="off"
                 id="time_related_controls_time-picker"
                 placeholder="Select time"
@@ -5156,6 +5187,7 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
           class="ant-form-item-control-input-content"
         >
           <div
+            aria-required="true"
             class="ant-select ant-select-single ant-select-show-arrow"
           >
             <div
@@ -5170,6 +5202,7 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
                   aria-controls="validate_other_select_list"
                   aria-haspopup="listbox"
                   aria-owns="validate_other_select_list"
+                  aria-required="true"
                   autocomplete="off"
                   class="ant-select-selection-search-input"
                   id="validate_other_select"
@@ -5242,6 +5275,7 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
           class="ant-form-item-control-input-content"
         >
           <div
+            aria-required="true"
             class="ant-select ant-select-multiple ant-select-show-search"
           >
             <div
@@ -5264,6 +5298,7 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
                       aria-controls="validate_other_select-multiple_list"
                       aria-haspopup="listbox"
                       aria-owns="validate_other_select-multiple_list"
+                      aria-required="true"
                       autocomplete="off"
                       class="ant-select-selection-search-input"
                       id="validate_other_select-multiple"
@@ -6279,6 +6314,7 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
               >
                 <input
                   accept=""
+                  aria-describedby="validate_other_upload_extra"
                   id="validate_other_upload"
                   style="display:none"
                   type="file"
@@ -6320,6 +6356,7 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
       </div>
       <div
         class="ant-form-item-extra"
+        id="validate_other_upload_extra"
       >
         longgggggggggggggggggggggggggggggggggg
       </div>
@@ -6473,10 +6510,9 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
       </div>
       <div
         class="ant-form-item-explain ant-form-item-explain-error"
+        role="alert"
       >
-        <div
-          role="alert"
-        >
+        <div>
           Should be combination of numbers & alphabets
         </div>
       </div>
@@ -6598,10 +6634,9 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
       </div>
       <div
         class="ant-form-item-explain ant-form-item-explain-validating"
+        role="alert"
       >
-        <div
-          role="alert"
-        >
+        <div>
           The information is being validated...
         </div>
       </div>
@@ -6775,10 +6810,9 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
       </div>
       <div
         class="ant-form-item-explain ant-form-item-explain-error"
+        role="alert"
       >
-        <div
-          role="alert"
-        >
+        <div>
           Should be combination of numbers & alphabets
         </div>
       </div>
@@ -7155,10 +7189,9 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
       </div>
       <div
         class="ant-form-item-explain ant-form-item-explain-validating"
+        role="alert"
       >
-        <div
-          role="alert"
-        >
+        <div>
           The information is being validated...
         </div>
       </div>
@@ -7243,10 +7276,9 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
               </div>
               <div
                 class="ant-form-item-explain ant-form-item-explain-error"
+                role="alert"
               >
-                <div
-                  role="alert"
-                >
+                <div>
                   Please select the correct date
                 </div>
               </div>
@@ -7826,10 +7858,9 @@ exports[`renders ./components/form/demo/without-form-create.md correctly 1`] = `
       </div>
       <div
         class="ant-form-item-explain"
+        role="alert"
       >
-        <div
-          role="alert"
-        >
+        <div>
           A prime is a natural number greater than 1 that has no positive divisors other than 1 and itself.
         </div>
       </div>

--- a/components/form/__tests__/index.test.js
+++ b/components/form/__tests__/index.test.js
@@ -214,6 +214,24 @@ describe('Form', () => {
     expect(help.prop('id')).toBe('test_help');
   });
 
+  it('input element should have the prop aria-invalid when there are errors', async () => {
+    const wrapper = mount(
+      <Form>
+        <Form.Item name="test" rules={[{ len: 3 }, { type: 'number' }]}>
+          <input />
+        </Form.Item>
+      </Form>,
+    );
+
+    const input = wrapper.find('input');
+    input.simulate('change', { target: { value: 'Invalid number' } });
+    await sleep(800);
+    wrapper.update();
+
+    const inputChanged = wrapper.find('input');
+    expect(inputChanged.prop('aria-invalid')).toBe('true');
+  });
+
   describe('scrollToField', () => {
     function test(name, genForm) {
       it(name, () => {
@@ -646,9 +664,7 @@ describe('Form', () => {
     await sleep(100);
     wrapper.update();
     await sleep(100);
-    expect(wrapper.find('.ant-form-item-explain div').getDOMNode().getAttribute('role')).toBe(
-      'alert',
-    );
+    expect(wrapper.find('.ant-form-item-explain').getDOMNode().getAttribute('role')).toBe('alert');
   });
 
   it('return same form instance', () => {

--- a/components/form/__tests__/index.test.js
+++ b/components/form/__tests__/index.test.js
@@ -172,6 +172,7 @@ describe('Form', () => {
         </Form.Item>
       </Form>,
     );
+
     const input = wrapper.find('input');
     expect(input.prop('aria-describedby')).toBe('test_help');
     const help = wrapper.find('.ant-form-item-explain');
@@ -201,6 +202,7 @@ describe('Form', () => {
         </Form.Item>
       </Form>,
     );
+
     const input = wrapper.find('input');
     expect(input.prop('aria-describedby')).toBe('form_test_help');
     const help = wrapper.find('.ant-form-item-explain');

--- a/components/form/__tests__/index.test.js
+++ b/components/form/__tests__/index.test.js
@@ -172,6 +172,7 @@ describe('Form', () => {
         </Form.Item>
       </Form>,
     );
+
     const input = wrapper.find('input');
     expect(input.prop('aria-describedby')).toBe('test_help');
     const help = wrapper.find('.ant-form-item-explain');
@@ -186,10 +187,31 @@ describe('Form', () => {
         </Form.Item>
       </Form>,
     );
+
     const input = wrapper.find('input');
     expect(input.prop('aria-describedby')).toBe('form_test_help');
     const help = wrapper.find('.ant-form-item-explain');
     expect(help.prop('id')).toBe('form_test_help');
+  });
+
+  it('input element should have the prop aria-describedby pointing to the help id when there are errors', async () => {
+    const wrapper = mount(
+      <Form>
+        <Form.Item name="test" rules={[{ len: 3 }, { type: 'number' }]}>
+          <input />
+        </Form.Item>
+      </Form>,
+    );
+
+    const input = wrapper.find('input');
+    input.simulate('change', { target: { value: 'Invalid number' } });
+    await sleep(800);
+    wrapper.update();
+
+    const inputChanged = wrapper.find('input');
+    expect(inputChanged.prop('aria-describedby')).toBe('test_help');
+    const help = wrapper.find('.ant-form-item-explain');
+    expect(help.prop('id')).toBe('test_help');
   });
 
   describe('scrollToField', () => {

--- a/components/form/__tests__/index.test.js
+++ b/components/form/__tests__/index.test.js
@@ -179,6 +179,21 @@ describe('Form', () => {
     expect(help.prop('id')).toBe('test_help');
   });
 
+  it('input element should not have the prop aria-describedby pointing to the help id when there is a help message and name is not defined', () => {
+    const wrapper = mount(
+      <Form>
+        <Form.Item help="This is a help">
+          <input />
+        </Form.Item>
+      </Form>,
+    );
+
+    const input = wrapper.find('input');
+    expect(input.prop('aria-describedby')).toBeUndefined();
+    const help = wrapper.find('.ant-form-item-explain');
+    expect(help.prop('id')).toBeUndefined();
+  });
+
   it('input element should have the prop aria-describedby concatenated with the form name pointing to the help id when there is a help message', () => {
     const wrapper = mount(
       <Form name="form">
@@ -271,6 +286,21 @@ describe('Form', () => {
     expect(input.prop('aria-describedby')).toBe('test_extra');
     const extra = wrapper.find('.ant-form-item-extra');
     expect(extra.prop('id')).toBe('test_extra');
+  });
+
+  it('input element should not have the prop aria-describedby pointing to the extra id when there is a extra message and name is not defined', () => {
+    const wrapper = mount(
+      <Form>
+        <Form.Item extra="This is a extra message">
+          <input />
+        </Form.Item>
+      </Form>,
+    );
+
+    const input = wrapper.find('input');
+    expect(input.prop('aria-describedby')).toBeUndefined();
+    const extra = wrapper.find('.ant-form-item-extra');
+    expect(extra.prop('id')).toBeUndefined();
   });
 
   it('input element should have the prop aria-describedby pointing to the help and extra id when there is a help and extra message', () => {

--- a/components/form/__tests__/index.test.js
+++ b/components/form/__tests__/index.test.js
@@ -172,7 +172,6 @@ describe('Form', () => {
         </Form.Item>
       </Form>,
     );
-
     const input = wrapper.find('input');
     expect(input.prop('aria-describedby')).toBe('test_help');
     const help = wrapper.find('.ant-form-item-explain');
@@ -202,7 +201,6 @@ describe('Form', () => {
         </Form.Item>
       </Form>,
     );
-
     const input = wrapper.find('input');
     expect(input.prop('aria-describedby')).toBe('form_test_help');
     const help = wrapper.find('.ant-form-item-explain');

--- a/components/form/__tests__/index.test.js
+++ b/components/form/__tests__/index.test.js
@@ -232,6 +232,32 @@ describe('Form', () => {
     expect(inputChanged.prop('aria-invalid')).toBe('true');
   });
 
+  it('input element should have the prop aria-required when the prop `required` is true', async () => {
+    const wrapper = mount(
+      <Form>
+        <Form.Item name="test" required>
+          <input />
+        </Form.Item>
+      </Form>,
+    );
+
+    const input = wrapper.find('input');
+    expect(input.prop('aria-required')).toBe('true');
+  });
+
+  it('input element should have the prop aria-required when there is a rule with required', async () => {
+    const wrapper = mount(
+      <Form>
+        <Form.Item name="test" rules={[{ required: true }]}>
+          <input />
+        </Form.Item>
+      </Form>,
+    );
+
+    const input = wrapper.find('input');
+    expect(input.prop('aria-required')).toBe('true');
+  });
+
   describe('scrollToField', () => {
     function test(name, genForm) {
       it(name, () => {

--- a/components/form/__tests__/index.test.js
+++ b/components/form/__tests__/index.test.js
@@ -164,6 +164,34 @@ describe('Form', () => {
     );
   });
 
+  it('input element should have the prop aria-describedby pointing to the help id when there is a help message', () => {
+    const wrapper = mount(
+      <Form>
+        <Form.Item name="test" help="This is a help">
+          <input />
+        </Form.Item>
+      </Form>,
+    );
+    const input = wrapper.find('input');
+    expect(input.prop('aria-describedby')).toBe('test_help');
+    const help = wrapper.find('.ant-form-item-explain');
+    expect(help.prop('id')).toBe('test_help');
+  });
+
+  it('input element should have the prop aria-describedby concatenated with the form name pointing to the help id when there is a help message', () => {
+    const wrapper = mount(
+      <Form name="form">
+        <Form.Item name="test" help="This is a help">
+          <input />
+        </Form.Item>
+      </Form>,
+    );
+    const input = wrapper.find('input');
+    expect(input.prop('aria-describedby')).toBe('form_test_help');
+    const help = wrapper.find('.ant-form-item-explain');
+    expect(help.prop('id')).toBe('form_test_help');
+  });
+
   describe('scrollToField', () => {
     function test(name, genForm) {
       it(name, () => {

--- a/components/form/__tests__/index.test.js
+++ b/components/form/__tests__/index.test.js
@@ -258,6 +258,34 @@ describe('Form', () => {
     expect(input.prop('aria-required')).toBe('true');
   });
 
+  it('input element should have the prop aria-describedby pointing to the extra id when there is a extra message', () => {
+    const wrapper = mount(
+      <Form>
+        <Form.Item name="test" extra="This is a extra message">
+          <input />
+        </Form.Item>
+      </Form>,
+    );
+
+    const input = wrapper.find('input');
+    expect(input.prop('aria-describedby')).toBe('test_extra');
+    const extra = wrapper.find('.ant-form-item-extra');
+    expect(extra.prop('id')).toBe('test_extra');
+  });
+
+  it('input element should have the prop aria-describedby pointing to the help and extra id when there is a help and extra message', () => {
+    const wrapper = mount(
+      <Form>
+        <Form.Item name="test" help="This is a help" extra="This is a extra message">
+          <input />
+        </Form.Item>
+      </Form>,
+    );
+
+    const input = wrapper.find('input');
+    expect(input.prop('aria-describedby')).toBe('test_help test_extra');
+  });
+
   describe('scrollToField', () => {
     function test(name, genForm) {
       it(name, () => {

--- a/components/mentions/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/mentions/__tests__/__snapshots__/demo.test.js.snap
@@ -105,6 +105,7 @@ exports[`renders ./components/mentions/demo/form.md correctly 1`] = `
             class="ant-mentions"
           >
             <textarea
+              aria-required="true"
               class="rc-textarea"
               id="bio"
               placeholder="You can use @ to ref user here"

--- a/components/menu/index.en-US.md
+++ b/components/menu/index.en-US.md
@@ -14,6 +14,9 @@ Navigation is an important part of any website, as a good navigation setup allow
 
 More layouts with navigation: [Layout](/components/layout).
 
+- Menu render as `ul` element. So it only support [`li` and `script-supporting` elements](https://html.spec.whatwg.org/multipage/grouping-content.html#the-ul-element) as children node。Your customize node should wrapped by `Menu.Item`.
+- Menu need collect node structure. So it's children node should be `Menu.*` or HOC which used by it.
+
 ## API
 
 ```jsx
@@ -55,13 +58,13 @@ More layouts with navigation: [Layout](/components/layout).
 
 ### Menu.Item
 
-| Param | Description | Type | Default value | Version |
-| --- | --- | --- | --- | --- |
-| danger | Display the danger style | boolean | false | 4.3.0 |
-| disabled | Whether menu item is disabled | boolean | false |  |
-| icon | The icon of the menu item | ReactNode | - | 4.2.0 |
-| key | Unique ID of the menu item | string | - |  |
-| title | Set display title for collapsed item | string | - |  |
+| Param    | Description                          | Type      | Default value | Version |
+| -------- | ------------------------------------ | --------- | ------------- | ------- |
+| danger   | Display the danger style             | boolean   | false         | 4.3.0   |
+| disabled | Whether menu item is disabled        | boolean   | false         |         |
+| icon     | The icon of the menu item            | ReactNode | -             | 4.2.0   |
+| key      | Unique ID of the menu item           | string    | -             |         |
+| title    | Set display title for collapsed item | string    | -             |         |
 
 > Note: `icon` is a newly added prop in `4.2.0`. For previous versions, please use the following method to define the icon.
 >
@@ -97,11 +100,17 @@ More layouts with navigation: [Layout](/components/layout).
 
 ### Menu.ItemGroup
 
-| Param | Description | Type | Default value | Version |
-| --- | --- | --- | --- | --- |
-| children | Sub-menu items | MenuItem\[] | - |  |
-| title | The title of the group | ReactNode | - |  |
+| Param    | Description            | Type        | Default value | Version |
+| -------- | ---------------------- | ----------- | ------------- | ------- |
+| children | Sub-menu items         | MenuItem\[] | -             |         |
+| title    | The title of the group | ReactNode   | -             |         |
 
 ### Menu.Divider
 
 Divider line in between menu items, only used in vertical popup Menu or Dropdown Menu.
+
+## FAQ
+
+### Why Menu children node will render twice?
+
+Menu collect structure info with [twice-render](https://github.com/react-component/menu/blob/f4684514096d6b7123339cbe72e7b0f68db0bce2/src/Menu.tsx#L543) to support HOC usage. Merge into one render may cause the logic much complex, welcome contribute to help improve collection logic.

--- a/components/menu/index.tsx
+++ b/components/menu/index.tsx
@@ -91,6 +91,7 @@ class InternalMenu extends React.Component<InternalMenuProps> {
         <RcMenu
           getPopupContainer={getPopupContainer}
           overflowedIndicator={<EllipsisOutlined />}
+          overflowedIndicatorPopupClassName={`${prefixCls}-${theme}`}
           {...passedProps}
           inlineCollapsed={inlineCollapsed}
           className={menuClassName}

--- a/components/menu/index.zh-CN.md
+++ b/components/menu/index.zh-CN.md
@@ -15,6 +15,9 @@ cover: https://gw.alipayobjects.com/zos/alicdn/3XZcjGpvK/Menu.svg
 
 更多布局和导航的使用可以参考：[通用布局](/components/layout)。
 
+- Menu 元素为 `ul`，因而仅支持 [`li` 以及 `script-supporting` 子元素](https://html.spec.whatwg.org/multipage/grouping-content.html#the-ul-element)。因而你的子节点元素应该都在 `Menu.Item` 内使用。
+- Menu 需要计算节点结构，因而其子元素仅支持 `Menu.*` 以及对此进行封装的 HOC 组件。
+
 ## API
 
 ```jsx
@@ -56,13 +59,13 @@ cover: https://gw.alipayobjects.com/zos/alicdn/3XZcjGpvK/Menu.svg
 
 ### Menu.Item
 
-| 参数 | 说明 | 类型 | 默认值 | 版本 |
-| --- | --- | --- | --- | --- |
-| danger | 展示错误状态样式 | boolean | false | 4.3.0 |
-| disabled | 是否禁用 | boolean | false |  |
-| icon | 菜单图标 | ReactNode | - | 4.2.0 |
-| key | item 的唯一标志 | string | - |  |
-| title | 设置收缩时展示的悬浮标题 | string | - |  |
+| 参数     | 说明                     | 类型      | 默认值 | 版本  |
+| -------- | ------------------------ | --------- | ------ | ----- |
+| danger   | 展示错误状态样式         | boolean   | false  | 4.3.0 |
+| disabled | 是否禁用                 | boolean   | false  |       |
+| icon     | 菜单图标                 | ReactNode | -      | 4.2.0 |
+| key      | item 的唯一标志          | string    | -      |       |
+| title    | 设置收缩时展示的悬浮标题 | string    | -      |       |
 
 > 注意：`icon` 是 `4.2.0` 新增的属性，之前的版本请使用下面的方式定义图标。
 >
@@ -98,11 +101,17 @@ cover: https://gw.alipayobjects.com/zos/alicdn/3XZcjGpvK/Menu.svg
 
 ### Menu.ItemGroup
 
-| 参数 | 说明 | 类型 | 默认值 | 版本 |
-| --- | --- | --- | --- | --- |
-| children | 分组的菜单项 | MenuItem\[] | - |  |
-| title | 分组标题 | ReactNode | - |  |
+| 参数     | 说明         | 类型        | 默认值 | 版本 |
+| -------- | ------------ | ----------- | ------ | ---- |
+| children | 分组的菜单项 | MenuItem\[] | -      |      |
+| title    | 分组标题     | ReactNode   | -      |      |
 
 ### Menu.Divider
 
 菜单项分割线，只用在弹出菜单内。
+
+## FAQ
+
+### 为何 Menu 的子元素会渲染两次？
+
+Menu 通过[二次渲染](https://github.com/react-component/menu/blob/f4684514096d6b7123339cbe72e7b0f68db0bce2/src/Menu.tsx#L543)收集嵌套结构信息以支持 HOC 的结构。合并成一个推导结构会使得逻辑变得十分复杂，欢迎 PR 以协助改进该设计。

--- a/components/message/index.en-US.md
+++ b/components/message/index.en-US.md
@@ -87,12 +87,12 @@ message.config({
 
 | Argument | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
-| duration | Time before auto-dismiss, in seconds | number | 1.5 |  |
+| duration | Time before auto-dismiss, in seconds | number | 3 |  |
 | getContainer | Return the mount node for Message | () => HTMLElement | () => document.body |  |
 | maxCount | Max message show, drop oldest if exceed limit | number | - |  |
 | prefixCls | The prefix className of message node | string | `ant-message` | 4.5.0 |
 | rtl | Whether to enable RTL mode | boolean | false |  |
-| top | Distance from top | number | 24 |  |
+| top | Distance from top | number | 8 |  |
 
 ## FAQ
 

--- a/components/message/index.zh-CN.md
+++ b/components/message/index.zh-CN.md
@@ -93,7 +93,7 @@ message.config({
 | maxCount | 最大显示数, 超过限制时，最早的消息会被自动关闭 | number | - |  |
 | prefixCls | 消息节点的 className 前缀 | string | `ant-message` | 4.5.0 |
 | rtl | 是否开启 RTL 模式 | boolean | false |  |
-| top | 消息距离顶部的位置 | number | 24 |  |
+| top | 消息距离顶部的位置 | number | 8 |  |
 
 ## FAQ
 

--- a/components/upload/__tests__/__snapshots__/uploadlist.test.js.snap
+++ b/components/upload/__tests__/__snapshots__/uploadlist.test.js.snap
@@ -28,8 +28,8 @@ exports[`Upload List handle error 1`] = `
     class="ant-upload-list ant-upload-list-text"
   >
     <div
-      class="ant-upload-list-text-container ant-upload-animate-appear ant-upload-animate-appear-active ant-upload-animate"
-      style="height: 0px; opacity: 1;"
+      class="ant-upload-list-text-container ant-upload-animate-appear ant-upload-animate-appear-start ant-upload-animate"
+      style="height: 0px; opacity: 0;"
     >
       <div
         class="ant-upload-list-item ant-upload-list-item-error ant-upload-list-item-list-type-text"

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "rc-image": "~5.2.4",
     "rc-input-number": "~7.1.0",
     "rc-mentions": "~1.6.1",
-    "rc-menu": "~9.0.9",
+    "rc-menu": "~9.0.12",
     "rc-motion": "^2.4.0",
     "rc-notification": "~4.5.7",
     "rc-pagination": "~3.1.6",

--- a/site/theme/template/Layout/Header/SearchBar.tsx
+++ b/site/theme/template/Layout/Header/SearchBar.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import { Link, browserHistory } from 'bisheng/router';
+import { Link } from 'bisheng/router';
 import classNames from 'classnames';
 import { Helmet } from 'react-helmet-async';
 import canUseDom from 'rc-util/lib/Dom/canUseDom';
@@ -8,7 +8,6 @@ import { Input, Tooltip, Typography } from 'antd';
 import { SearchOutlined } from '@ant-design/icons';
 import { DocSearchProps, useDocSearchKeyboardEvents, DocSearchModalProps } from '@docsearch/react';
 import '@docsearch/css';
-
 import { SharedProps } from './interface';
 import { IAlgoliaConfig, transformHitUrl } from './algolia-config';
 
@@ -20,6 +19,7 @@ export interface SearchBarProps extends SharedProps {
   onTriggerFocus?: (focus: boolean) => void;
   responsive: null | 'narrow' | 'crowded';
   algoliaConfig: IAlgoliaConfig;
+  router: any;
 }
 
 let SearchModal: React.FC<DocSearchModalProps> | null = null;
@@ -42,11 +42,12 @@ function isAppleDevice() {
  * - [@docusaurus-theme-search-algolia](https://docusaurus.io/docs/api/themes/@docusaurus/theme-search-algolia)
  * - [DocSearchModal Docs](https://autocomplete-experimental.netlify.app/docs/DocSearchModal)
  */
-export const SearchBar = ({
+const SearchBar = ({
   isZhCN,
   responsive,
   onTriggerFocus,
   algoliaConfig,
+  router,
 }: SearchBarProps) => {
   const [isInputFocus, setInputFocus] = React.useState(false);
   const [inputSearch, setInputSearch] = React.useState('');
@@ -114,9 +115,7 @@ export const SearchBar = ({
 
   const navigator = React.useRef({
     navigate({ itemUrl }: { itemUrl: string }) {
-      browserHistory.push(itemUrl);
-      // should use history from bisheng and remove this `reload` calls
-      window.location.reload(false);
+      router.push(itemUrl);
     },
   }).current;
 
@@ -196,3 +195,5 @@ export const SearchBar = ({
     </div>
   );
 };
+
+export default SearchBar;

--- a/site/theme/template/Layout/Header/index.tsx
+++ b/site/theme/template/Layout/Header/index.tsx
@@ -4,12 +4,10 @@ import classNames from 'classnames';
 import { UnorderedListOutlined } from '@ant-design/icons';
 import { Select, Row, Col, Popover, Button } from 'antd';
 import canUseDom from 'rc-util/lib/Dom/canUseDom';
-// import { browserHistory } from 'bisheng/router';
-
 import * as utils from '../../utils';
 import packageJson from '../../../../../package.json';
 import Logo from './Logo';
-import { SearchBar } from './SearchBar';
+import SearchBar from './SearchBar';
 import More from './More';
 import Navigation from './Navigation';
 import Github from './Github';
@@ -47,7 +45,7 @@ const triggerDocSearchImport = () => {
   });
 };
 
-function initDocSearch(isZhCN: boolean) {
+function initDocSearch({ isZhCN, router }: { isZhCN: boolean; router: any }) {
   if (!canUseDom()) {
     return;
   }
@@ -62,14 +60,12 @@ function initDocSearch(isZhCN: boolean) {
       transformData: AlgoliaConfig.transformData,
       debug: AlgoliaConfig.debug,
       // https://docsearch.algolia.com/docs/behavior#handleselected
-      // handleSelected: (input, _$1, suggestion, _$2, context) => {
-      // doesn't refresh
-      //   // Prevents the default behavior on click
-      //   if (context.selectionMethod === 'click') {
-      //     input.setVal('');
-      //     browserHistory.push(suggestion.url);
-      //   }
-      // },
+      handleSelected: (input: any, _$1: unknown, suggestion: any) => {
+        router.push(suggestion.url);
+        setTimeout(() => {
+          input.setVal('');
+        });
+      },
     });
   });
 }
@@ -97,7 +93,10 @@ class Header extends React.Component<HeaderProps, HeaderState> {
     const { intl, router } = this.props;
     router.listen(this.handleHideMenu);
 
-    initDocSearch(intl.locale === 'zh');
+    initDocSearch({
+      isZhCN: intl.locale === 'zh',
+      router,
+    });
 
     window.addEventListener('resize', this.onWindowResize);
     this.onWindowResize();
@@ -216,6 +215,7 @@ class Header extends React.Component<HeaderProps, HeaderState> {
             location,
             themeConfig,
             intl: { locale },
+            router,
           } = this.props;
           const docVersions: Record<string, string> = {
             [antdVersion]: antdVersion,
@@ -348,6 +348,7 @@ class Header extends React.Component<HeaderProps, HeaderState> {
                   <SearchBar
                     key="search"
                     {...sharedProps}
+                    router={router}
                     algoliaConfig={AlgoliaConfig}
                     responsive={responsive}
                     onTriggerFocus={this.onTriggerSearching}


### PR DESCRIPTION
### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

https://github.com/ant-design/ant-design/issues/28748
https://github.com/ant-design/ant-design/pull/29319 -> *Previous PR, just fixed a bug and rebased*
@yoyo837 @zombieJ @afc163 Can you please make sure somebody looks at this? Would be much appreciated 
@ruihbanki  @dgreene1 FYI

### 💡 Background and solution

For accessibility is important that the help and extra message be linked to the input.
And the input needs to have appropriate aria-invalid and aria-required when necessary.

### 📝 Changelog

Added

    Created a link between the input field inside the component form item and help and extra messages through aria-describedby
    Pass aria-required to inputs fields inside the component form item when it is required
    Pass aria-invalid to inputs fields inside the component form item when it has errors

Changed

    Move the attribute role="alert" on errors messages to its container. Making the screen reader anounce messages when they appear and in the user's focus


| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
