### PR TITLE
Pr/form a11y

### DIFF
--- a/components/avatar/__tests__/__snapshots__/Avatar.test.js.snap
+++ b/components/avatar/__tests__/__snapshots__/Avatar.test.js.snap
@@ -184,18 +184,25 @@ exports[`Avatar Render should show image on success after a failure state 1`] = 
     <ResizeObserver
       onResize={[Function]}
     >
-      <span
-        className="ant-avatar-string"
-        style={
-          Object {
-            "WebkitTransform": "scale(1) translateX(-50%)",
-            "msTransform": "scale(1) translateX(-50%)",
-            "transform": "scale(1) translateX(-50%)",
-          }
-        }
+      <SingleObserver
+        key="rc-observer-key-0"
+        onResize={[Function]}
       >
-        Fallback
-      </span>
+        <DomWrapper>
+          <span
+            className="ant-avatar-string"
+            style={
+              Object {
+                "WebkitTransform": "scale(1) translateX(-50%)",
+                "msTransform": "scale(1) translateX(-50%)",
+                "transform": "scale(1) translateX(-50%)",
+              }
+            }
+          >
+            Fallback
+          </span>
+        </DomWrapper>
+      </SingleObserver>
     </ResizeObserver>
   </span>
 </Avatar>

--- a/components/config-provider/__tests__/__snapshots__/components.test.js.snap
+++ b/components/config-provider/__tests__/__snapshots__/components.test.js.snap
@@ -13381,10 +13381,10 @@ exports[`ConfigProvider components Form configProvider 1`] = `
       </div>
       <div
         class="config-form-item-explain config-form-item-explain-connected"
+        role="alert"
       >
         <div
           class="config-form-item-explain-error"
-          role="alert"
         >
           Bamboo is Light
         </div>
@@ -13419,10 +13419,10 @@ exports[`ConfigProvider components Form configProvider componentSize large 1`] =
       </div>
       <div
         class="config-form-item-explain config-form-item-explain-connected"
+        role="alert"
       >
         <div
           class="config-form-item-explain-error"
-          role="alert"
         >
           Bamboo is Light
         </div>
@@ -13457,10 +13457,10 @@ exports[`ConfigProvider components Form configProvider componentSize middle 1`] 
       </div>
       <div
         class="config-form-item-explain config-form-item-explain-connected"
+        role="alert"
       >
         <div
           class="config-form-item-explain-error"
-          role="alert"
         >
           Bamboo is Light
         </div>
@@ -13495,10 +13495,10 @@ exports[`ConfigProvider components Form configProvider virtual and dropdownMatch
       </div>
       <div
         class="ant-form-item-explain ant-form-item-explain-connected"
+        role="alert"
       >
         <div
           class="ant-form-item-explain-error"
-          role="alert"
         >
           Bamboo is Light
         </div>
@@ -13533,10 +13533,10 @@ exports[`ConfigProvider components Form normal 1`] = `
       </div>
       <div
         class="ant-form-item-explain ant-form-item-explain-connected"
+        role="alert"
       >
         <div
           class="ant-form-item-explain-error"
-          role="alert"
         >
           Bamboo is Light
         </div>
@@ -13571,10 +13571,10 @@ exports[`ConfigProvider components Form prefixCls 1`] = `
       </div>
       <div
         class="prefix-Form-item-explain prefix-Form-item-explain-connected"
+        role="alert"
       >
         <div
           class="prefix-Form-item-explain-error"
-          role="alert"
         >
           Bamboo is Light
         </div>

--- a/components/form/ErrorList.tsx
+++ b/components/form/ErrorList.tsx
@@ -60,7 +60,12 @@ export default function ErrorList({
       ...warnings.map((warning, index) => toErrorEntity(warning, 'warning', 'warning', index)),
     ];
   }, [help, helpStatus, errors, warnings]);
+  
+  const helpProps: { id?: string } = {};
 
+  if (fieldId) {
+    helpProps.id = `${fieldId}_help`;
+  }
   return (
     <CSSMotion
       {...collapseMotion}
@@ -79,10 +84,10 @@ export default function ErrorList({
 
         return (
           <div
+            {...helpProps}
             className={classNames(baseClassName, holderClassName, rootClassName)}
             style={holderStyle}
             role="alert"
-            id={`${fieldId}_help`}
           >
             <CSSMotionList
               keys={fullKeyList}

--- a/components/form/ErrorList.tsx
+++ b/components/form/ErrorList.tsx
@@ -81,6 +81,7 @@ export default function ErrorList({
           <div
             className={classNames(baseClassName, holderClassName, rootClassName)}
             style={holderStyle}
+            role="alert"
             id={`${fieldId}_help`}
           >
             <CSSMotionList
@@ -101,7 +102,6 @@ export default function ErrorList({
                 return (
                   <div
                     key={key}
-                    role="alert"
                     className={classNames(itemClassName, {
                       [`${baseClassName}-${errorStatus}`]: errorStatus,
                     })}

--- a/components/form/ErrorList.tsx
+++ b/components/form/ErrorList.tsx
@@ -28,6 +28,7 @@ function toErrorEntity(
 }
 
 export interface ErrorListProps {
+  fieldId?: string;
   help?: React.ReactNode;
   helpStatus?: ValidateStatus;
   errors?: React.ReactNode[];
@@ -41,6 +42,7 @@ export default function ErrorList({
   errors = EMPTY_LIST,
   warnings = EMPTY_LIST,
   className: rootClassName,
+  fieldId,
 }: ErrorListProps) {
   const { prefixCls } = React.useContext(FormItemPrefixContext);
   const { getPrefixCls } = React.useContext(ConfigContext);
@@ -79,6 +81,7 @@ export default function ErrorList({
           <div
             className={classNames(baseClassName, holderClassName, rootClassName)}
             style={holderStyle}
+            id={`${fieldId}_help`}
           >
             <CSSMotionList
               keys={fullKeyList}

--- a/components/form/FormItem.tsx
+++ b/components/form/FormItem.tsx
@@ -389,6 +389,10 @@ function FormItem<Values = any>(props: FormItemProps<Values>): React.ReactElemen
             childProps['aria-invalid'] = 'true';
           }
 
+          if (isRequired) {
+            childProps['aria-required'] = 'true';
+          }
+
           if (supportRef(children)) {
             childProps.ref = getItemRef(mergedName, children);
           }

--- a/components/form/FormItem.tsx
+++ b/components/form/FormItem.tsx
@@ -282,6 +282,7 @@ function FormItem<Values = any>(props: FormItemProps<Values>): React.ReactElemen
           status={mergedValidateStatus}
           validateStatus={mergedValidateStatus}
           help={help}
+          fieldId={fieldId}
         >
           <NoStyleItemContext.Provider value={onSubItemMetaChange}>
             {baseChildren}
@@ -377,6 +378,11 @@ function FormItem<Values = any>(props: FormItemProps<Values>): React.ReactElemen
           const childProps = { ...children.props, ...mergedControl };
           if (!childProps.id) {
             childProps.id = fieldId;
+          }
+
+          if (props.help) {
+            const describedby = `${fieldId}_help`;
+            childProps['aria-describedby'] = describedby;
           }
 
           if (supportRef(children)) {

--- a/components/form/FormItem.tsx
+++ b/components/form/FormItem.tsx
@@ -385,6 +385,10 @@ function FormItem<Values = any>(props: FormItemProps<Values>): React.ReactElemen
             childProps['aria-describedby'] = describedby;
           }
 
+          if (errors.length > 0) {
+            childProps['aria-invalid'] = 'true';
+          }
+
           if (supportRef(children)) {
             childProps.ref = getItemRef(mergedName, children);
           }

--- a/components/form/FormItem.tsx
+++ b/components/form/FormItem.tsx
@@ -36,16 +36,16 @@ type ChildrenType<Values = any> = RenderChildren<Values> | React.ReactNode;
 interface MemoInputProps {
   value: any;
   update: any;
-  childProps: any;
+  childProps: any[];
   children: React.ReactNode;
 }
 
 const MemoInput = React.memo(
   ({ children }: MemoInputProps) => children as JSX.Element,
-  (prev, next) =>
-    prev.value === next.value &&
+  (prev, next) => prev.value === next.value &&
     prev.update === next.update &&
-    JSON.stringify(prev.childProps) === JSON.stringify(next.childProps),
+    prev.childProps.length === next.childProps.length && 
+    prev.childProps.every((value, index) => value === next.childProps[index]),
 );
 
 export interface FormItemProps<Values = any>
@@ -419,11 +419,14 @@ function FormItem<Values = any>(props: FormItemProps<Values>): React.ReactElemen
             };
           });
 
+          // List of props that need to be watched for changes -> if changes are detected in MemoInput -> rerender
+          const watchingChildProps = [childProps['aria-required'], childProps['aria-invalid'], childProps['aria-describedby']];
+
           childNode = (
             <MemoInput
               value={mergedControl[props.valuePropName || 'value']}
               update={children}
-              childProps={childProps}
+              childProps={watchingChildProps}
             >
               {cloneElement(children, childProps)}
             </MemoInput>

--- a/components/form/FormItem.tsx
+++ b/components/form/FormItem.tsx
@@ -380,7 +380,7 @@ function FormItem<Values = any>(props: FormItemProps<Values>): React.ReactElemen
             childProps.id = fieldId;
           }
 
-          if (props.help) {
+          if (props.help || errors.length > 0) {
             const describedby = `${fieldId}_help`;
             childProps['aria-describedby'] = describedby;
           }

--- a/components/form/FormItem.tsx
+++ b/components/form/FormItem.tsx
@@ -36,12 +36,16 @@ type ChildrenType<Values = any> = RenderChildren<Values> | React.ReactNode;
 interface MemoInputProps {
   value: any;
   update: any;
+  childProps: any;
   children: React.ReactNode;
 }
 
 const MemoInput = React.memo(
   ({ children }: MemoInputProps) => children as JSX.Element,
-  (prev, next) => prev.value === next.value && prev.update === next.update,
+  (prev, next) =>
+    prev.value === next.value &&
+    prev.update === next.update &&
+    JSON.stringify(prev.childProps) === JSON.stringify(next.childProps),
 );
 
 export interface FormItemProps<Values = any>
@@ -379,10 +383,9 @@ function FormItem<Values = any>(props: FormItemProps<Values>): React.ReactElemen
           if (!childProps.id) {
             childProps.id = fieldId;
           }
-
-          if (props.help || errors.length > 0 || props.extra) {
+          if (props.help || mergedErrors.length > 0 || mergedWarnings.length > 0 || props.extra) {
             const describedbyArr = [];
-            if (props.help || errors.length > 0) {
+            if (props.help || mergedErrors.length > 0) {
               describedbyArr.push(`${fieldId}_help`);
             }
             if (props.extra) {
@@ -391,7 +394,7 @@ function FormItem<Values = any>(props: FormItemProps<Values>): React.ReactElemen
             childProps['aria-describedby'] = describedbyArr.join(' ');
           }
 
-          if (errors.length > 0) {
+          if (mergedErrors.length > 0) {
             childProps['aria-invalid'] = 'true';
           }
 
@@ -417,7 +420,11 @@ function FormItem<Values = any>(props: FormItemProps<Values>): React.ReactElemen
           });
 
           childNode = (
-            <MemoInput value={mergedControl[props.valuePropName || 'value']} update={children}>
+            <MemoInput
+              value={mergedControl[props.valuePropName || 'value']}
+              update={children}
+              childProps={childProps}
+            >
               {cloneElement(children, childProps)}
             </MemoInput>
           );

--- a/components/form/FormItem.tsx
+++ b/components/form/FormItem.tsx
@@ -380,9 +380,15 @@ function FormItem<Values = any>(props: FormItemProps<Values>): React.ReactElemen
             childProps.id = fieldId;
           }
 
-          if (props.help || errors.length > 0) {
-            const describedby = `${fieldId}_help`;
-            childProps['aria-describedby'] = describedby;
+          if (props.help || errors.length > 0 || props.extra) {
+            const describedbyArr = [];
+            if (props.help || errors.length > 0) {
+              describedbyArr.push(`${fieldId}_help`);
+            }
+            if (props.extra) {
+              describedbyArr.push(`${fieldId}_extra`);
+            }
+            childProps['aria-describedby'] = describedbyArr.join(' ');
           }
 
           if (errors.length > 0) {

--- a/components/form/FormItemInput.tsx
+++ b/components/form/FormItemInput.tsx
@@ -36,6 +36,7 @@ export interface FormItemInputProps {
   extra?: React.ReactNode;
   status?: ValidateStatus;
   help?: React.ReactNode;
+  fieldId?: string;
 }
 
 const iconMap: { [key: string]: any } = {
@@ -58,6 +59,7 @@ const FormItemInput: React.FC<FormItemInputProps & FormItemInputMiscProps> = pro
     validateStatus,
     extra,
     help,
+    fieldId,
   } = props;
   const baseClassName = `${prefixCls}-item`;
 
@@ -91,6 +93,7 @@ const FormItemInput: React.FC<FormItemInputProps & FormItemInputMiscProps> = pro
   const errorListDom = (
     <FormItemPrefixContext.Provider value={formItemContext}>
       <ErrorList
+        fieldId={fieldId}
         errors={errors}
         warnings={warnings}
         help={help}

--- a/components/form/FormItemInput.tsx
+++ b/components/form/FormItemInput.tsx
@@ -105,7 +105,11 @@ const FormItemInput: React.FC<FormItemInputProps & FormItemInputMiscProps> = pro
 
   // If extra = 0, && will goes wrong
   // 0&&error -> 0
-  const extraDom = extra ? <div className={`${baseClassName}-extra`}>{extra}</div> : null;
+  const extraDom = extra ? (
+    <div className={`${baseClassName}-extra`} id={`${fieldId}_extra`}>
+      {extra}
+    </div>
+  ) : null;
 
   const dom =
     formItemRender && formItemRender.mark === 'pro_table_render' && formItemRender.render ? (

--- a/components/form/FormItemInput.tsx
+++ b/components/form/FormItemInput.tsx
@@ -103,10 +103,15 @@ const FormItemInput: React.FC<FormItemInputProps & FormItemInputMiscProps> = pro
     </FormItemPrefixContext.Provider>
   );
 
+  const extraProps: { id?: string } = {};
+
+  if (fieldId) {
+    extraProps.id = `${fieldId}_extra`;
+  }
   // If extra = 0, && will goes wrong
   // 0&&error -> 0
   const extraDom = extra ? (
-    <div className={`${baseClassName}-extra`} id={`${fieldId}_extra`}>
+    <div {...extraProps} className={`${baseClassName}-extra`}>
       {extra}
     </div>
   ) : null;

--- a/components/form/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/form/__tests__/__snapshots__/demo.test.js.snap
@@ -38,6 +38,7 @@ exports[`renders ./components/form/demo/advanced-search.md correctly 1`] = `
                 class="ant-form-item-control-input-content"
               >
                 <input
+                  aria-required="true"
                   class="ant-input"
                   id="advanced_search_field-0"
                   placeholder="placeholder"
@@ -77,6 +78,7 @@ exports[`renders ./components/form/demo/advanced-search.md correctly 1`] = `
                 class="ant-form-item-control-input-content"
               >
                 <input
+                  aria-required="true"
                   class="ant-input"
                   id="advanced_search_field-1"
                   placeholder="placeholder"
@@ -116,6 +118,7 @@ exports[`renders ./components/form/demo/advanced-search.md correctly 1`] = `
                 class="ant-form-item-control-input-content"
               >
                 <input
+                  aria-required="true"
                   class="ant-input"
                   id="advanced_search_field-2"
                   placeholder="placeholder"
@@ -155,6 +158,7 @@ exports[`renders ./components/form/demo/advanced-search.md correctly 1`] = `
                 class="ant-form-item-control-input-content"
               >
                 <input
+                  aria-required="true"
                   class="ant-input"
                   id="advanced_search_field-3"
                   placeholder="placeholder"
@@ -194,6 +198,7 @@ exports[`renders ./components/form/demo/advanced-search.md correctly 1`] = `
                 class="ant-form-item-control-input-content"
               >
                 <input
+                  aria-required="true"
                   class="ant-input"
                   id="advanced_search_field-4"
                   placeholder="placeholder"
@@ -233,6 +238,7 @@ exports[`renders ./components/form/demo/advanced-search.md correctly 1`] = `
                 class="ant-form-item-control-input-content"
               >
                 <input
+                  aria-required="true"
                   class="ant-input"
                   id="advanced_search_field-5"
                   placeholder="placeholder"
@@ -334,6 +340,7 @@ exports[`renders ./components/form/demo/basic.md correctly 1`] = `
           class="ant-form-item-control-input-content"
         >
           <input
+            aria-required="true"
             class="ant-input"
             id="basic_username"
             type="text"
@@ -371,6 +378,7 @@ exports[`renders ./components/form/demo/basic.md correctly 1`] = `
           >
             <input
               action="click"
+              aria-required="true"
               class="ant-input"
               id="basic_password"
               type="password"
@@ -631,6 +639,7 @@ exports[`renders ./components/form/demo/control-hooks.md correctly 1`] = `
           class="ant-form-item-control-input-content"
         >
           <input
+            aria-required="true"
             class="ant-input"
             id="control-hooks_note"
             type="text"
@@ -664,6 +673,7 @@ exports[`renders ./components/form/demo/control-hooks.md correctly 1`] = `
           class="ant-form-item-control-input-content"
         >
           <div
+            aria-required="true"
             class="ant-select ant-select-single ant-select-allow-clear ant-select-show-arrow"
           >
             <div
@@ -678,6 +688,7 @@ exports[`renders ./components/form/demo/control-hooks.md correctly 1`] = `
                   aria-controls="control-hooks_gender_list"
                   aria-haspopup="listbox"
                   aria-owns="control-hooks_gender_list"
+                  aria-required="true"
                   autocomplete="off"
                   class="ant-select-selection-search-input"
                   id="control-hooks_gender"
@@ -798,6 +809,7 @@ exports[`renders ./components/form/demo/control-ref.md correctly 1`] = `
           class="ant-form-item-control-input-content"
         >
           <input
+            aria-required="true"
             class="ant-input"
             id="control-ref_note"
             type="text"
@@ -831,6 +843,7 @@ exports[`renders ./components/form/demo/control-ref.md correctly 1`] = `
           class="ant-form-item-control-input-content"
         >
           <div
+            aria-required="true"
             class="ant-select ant-select-single ant-select-allow-clear ant-select-show-arrow"
           >
             <div
@@ -845,6 +858,7 @@ exports[`renders ./components/form/demo/control-ref.md correctly 1`] = `
                   aria-controls="control-ref_gender_list"
                   aria-haspopup="listbox"
                   aria-owns="control-ref_gender_list"
+                  aria-required="true"
                   autocomplete="off"
                   class="ant-select-selection-search-input"
                   id="control-ref_gender"
@@ -1206,10 +1220,10 @@ exports[`renders ./components/form/demo/disabled-input-debug.md correctly 1`] = 
       </div>
       <div
         class="ant-form-item-explain ant-form-item-explain-connected"
+        role="alert"
       >
         <div
           class="ant-form-item-explain-error"
-          role="alert"
         >
           Buggy!
         </div>
@@ -1249,10 +1263,10 @@ exports[`renders ./components/form/demo/disabled-input-debug.md correctly 1`] = 
       </div>
       <div
         class="ant-form-item-explain ant-form-item-explain-connected"
+        role="alert"
       >
         <div
           class="ant-form-item-explain-error"
-          role="alert"
         >
           Buggy!
         </div>
@@ -1323,10 +1337,10 @@ exports[`renders ./components/form/demo/disabled-input-debug.md correctly 1`] = 
       </div>
       <div
         class="ant-form-item-explain ant-form-item-explain-connected"
+        role="alert"
       >
         <div
           class="ant-form-item-explain-error"
-          role="alert"
         >
           Buggy!
         </div>
@@ -1366,10 +1380,10 @@ exports[`renders ./components/form/demo/disabled-input-debug.md correctly 1`] = 
       </div>
       <div
         class="ant-form-item-explain ant-form-item-explain-connected"
+        role="alert"
       >
         <div
           class="ant-form-item-explain-error"
-          role="alert"
         >
           Buggy!
         </div>
@@ -1466,10 +1480,10 @@ exports[`renders ./components/form/demo/disabled-input-debug.md correctly 1`] = 
       </div>
       <div
         class="ant-form-item-explain ant-form-item-explain-connected"
+        role="alert"
       >
         <div
           class="ant-form-item-explain-error"
-          role="alert"
         >
           Buggy!
         </div>
@@ -1522,10 +1536,10 @@ exports[`renders ./components/form/demo/disabled-input-debug.md correctly 1`] = 
       </div>
       <div
         class="ant-form-item-explain ant-form-item-explain-connected"
+        role="alert"
       >
         <div
           class="ant-form-item-explain-error"
-          role="alert"
         >
           Buggy!
         </div>
@@ -1614,10 +1628,10 @@ exports[`renders ./components/form/demo/disabled-input-debug.md correctly 1`] = 
       </div>
       <div
         class="ant-form-item-explain ant-form-item-explain-connected"
+        role="alert"
       >
         <div
           class="ant-form-item-explain-error"
-          role="alert"
         >
           Buggy!
         </div>
@@ -1666,10 +1680,10 @@ exports[`renders ./components/form/demo/disabled-input-debug.md correctly 1`] = 
       </div>
       <div
         class="ant-form-item-explain ant-form-item-explain-connected"
+        role="alert"
       >
         <div
           class="ant-form-item-explain-error"
-          role="alert"
         >
           Buggy!
         </div>
@@ -1901,6 +1915,7 @@ exports[`renders ./components/form/demo/dynamic-form-items-complex.md correctly 
           class="ant-form-item-control-input-content"
         >
           <div
+            aria-required="true"
             class="ant-select ant-select-single ant-select-show-arrow"
           >
             <div
@@ -1915,6 +1930,7 @@ exports[`renders ./components/form/demo/dynamic-form-items-complex.md correctly 
                   aria-controls="dynamic_form_nest_item_area_list"
                   aria-haspopup="listbox"
                   aria-owns="dynamic_form_nest_item_area_list"
+                  aria-required="true"
                   autocomplete="off"
                   class="ant-select-selection-search-input"
                   id="dynamic_form_nest_item_area"
@@ -2170,6 +2186,7 @@ exports[`renders ./components/form/demo/dynamic-rule.md correctly 1`] = `
           class="ant-form-item-control-input-content"
         >
           <input
+            aria-required="true"
             class="ant-input"
             id="dynamic_rule_username"
             placeholder="Please input your name"
@@ -2304,6 +2321,7 @@ exports[`renders ./components/form/demo/form-context.md correctly 1`] = `
           class="ant-form-item-control-input-content"
         >
           <input
+            aria-required="true"
             class="ant-input"
             id="basicForm_group"
             type="text"
@@ -2338,7 +2356,7 @@ exports[`renders ./components/form/demo/form-context.md correctly 1`] = `
           <span
             class="ant-typography ant-typography-secondary ant-form-text"
           >
-            ( 
+            (
             <span
               aria-label="smile"
               class="anticon anticon-smile"
@@ -2443,6 +2461,7 @@ Array [
             class="ant-form-item-control-input-content"
           >
             <input
+              aria-required="true"
               class="ant-input"
               id="global_state_username"
               type="text"
@@ -2512,6 +2531,7 @@ exports[`renders ./components/form/demo/inline-login.md correctly 1`] = `
               </span>
             </span>
             <input
+              aria-required="true"
               class="ant-input"
               id="horizontal_login_username"
               placeholder="Username"
@@ -2562,6 +2582,7 @@ exports[`renders ./components/form/demo/inline-login.md correctly 1`] = `
               </span>
             </span>
             <input
+              aria-required="true"
               class="ant-input"
               id="horizontal_login_password"
               placeholder="Password"
@@ -2985,7 +3006,7 @@ exports[`renders ./components/form/demo/layout-can-wrap.md correctly 1`] = `
         class="ant-form-item-no-colon"
         title=" "
       >
-         
+
       </label>
     </div>
     <div
@@ -3042,6 +3063,7 @@ exports[`renders ./components/form/demo/nest-messages.md correctly 1`] = `
           class="ant-form-item-control-input-content"
         >
           <input
+            aria-required="true"
             class="ant-input"
             id="nest-messages_user_name"
             type="text"
@@ -3320,6 +3342,7 @@ exports[`renders ./components/form/demo/normal-login.md correctly 1`] = `
               </span>
             </span>
             <input
+              aria-required="true"
               class="ant-input"
               id="normal_login_username"
               placeholder="Username"
@@ -3370,6 +3393,7 @@ exports[`renders ./components/form/demo/normal-login.md correctly 1`] = `
               </span>
             </span>
             <input
+              aria-required="true"
               class="ant-input"
               id="normal_login_password"
               placeholder="Password"
@@ -3443,7 +3467,7 @@ exports[`renders ./components/form/demo/normal-login.md correctly 1`] = `
               Log in
             </span>
           </button>
-          Or 
+          Or
           <a
             href=""
           >
@@ -3563,6 +3587,7 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
           class="ant-form-item-control-input-content"
         >
           <input
+            aria-required="true"
             class="ant-input"
             id="register_email"
             type="text"
@@ -3600,6 +3625,7 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
           >
             <input
               action="click"
+              aria-required="true"
               class="ant-input"
               id="register_password"
               type="password"
@@ -3665,6 +3691,7 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
           >
             <input
               action="click"
+              aria-required="true"
               class="ant-input"
               id="register_confirm"
               type="password"
@@ -3749,6 +3776,7 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
           class="ant-form-item-control-input-content"
         >
           <input
+            aria-required="true"
             class="ant-input"
             id="register_nickname"
             type="text"
@@ -3791,6 +3819,7 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
                 class="ant-select-selection-search"
               >
                 <input
+                  aria-required="true"
                   aria-activedescendant="register_residence_list_0"
                   aria-autocomplete="list"
                   aria-controls="register_residence_list"
@@ -3802,6 +3831,7 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
                   readonly=""
                   role="combobox"
                   style="opacity:0"
+                  tabindex="-1"
                   type="search"
                   unselectable="on"
                   value=""
@@ -3967,6 +3997,7 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
                 </div>
               </span>
               <input
+                aria-required="true"
                 class="ant-input"
                 id="register_phone"
                 type="text"
@@ -4174,6 +4205,7 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
           class="ant-form-item-control-input-content"
         >
           <div
+            aria-required="true"
             class="ant-select ant-select-auto-complete ant-select-single ant-select-customize-input ant-select-show-search"
           >
             <div
@@ -4188,6 +4220,7 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
                   aria-controls="register_website_list"
                   aria-haspopup="listbox"
                   aria-owns="register_website_list"
+                  aria-required="true"
                   autocomplete="off"
                   class="ant-input ant-select-selection-search-input"
                   id="register_website"
@@ -4361,6 +4394,7 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
               style="padding-left:4px;padding-right:4px"
             >
               <input
+                aria-required="true"
                 class="ant-input"
                 id="register_captcha"
                 type="text"
@@ -4418,7 +4452,7 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
               />
             </span>
             <span>
-              I have read the 
+              I have read the
               <a
                 href=""
               >
@@ -5346,6 +5380,7 @@ exports[`renders ./components/form/demo/time-related-controls.md correctly 1`] =
               class="ant-picker-input"
             >
               <input
+                aria-required="true"
                 autocomplete="off"
                 id="time_related_controls_date-picker"
                 placeholder="Select date"
@@ -5413,6 +5448,7 @@ exports[`renders ./components/form/demo/time-related-controls.md correctly 1`] =
               class="ant-picker-input"
             >
               <input
+                aria-required="true"
                 autocomplete="off"
                 id="time_related_controls_date-time-picker"
                 placeholder="Select date"
@@ -5480,6 +5516,7 @@ exports[`renders ./components/form/demo/time-related-controls.md correctly 1`] =
               class="ant-picker-input"
             >
               <input
+                aria-required="true"
                 autocomplete="off"
                 id="time_related_controls_month-picker"
                 placeholder="Select month"
@@ -5541,6 +5578,7 @@ exports[`renders ./components/form/demo/time-related-controls.md correctly 1`] =
           class="ant-form-item-control-input-content"
         >
           <div
+            aria-required="true"
             class="ant-picker ant-picker-range"
           >
             <div
@@ -5650,6 +5688,7 @@ exports[`renders ./components/form/demo/time-related-controls.md correctly 1`] =
           class="ant-form-item-control-input-content"
         >
           <div
+            aria-required="true"
             class="ant-picker ant-picker-range"
           >
             <div
@@ -5765,6 +5804,7 @@ exports[`renders ./components/form/demo/time-related-controls.md correctly 1`] =
               class="ant-picker-input"
             >
               <input
+                aria-required="true"
                 autocomplete="off"
                 id="time_related_controls_time-picker"
                 placeholder="Select time"
@@ -5892,6 +5932,7 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
           class="ant-form-item-control-input-content"
         >
           <div
+            aria-required="true"
             class="ant-select ant-select-single ant-select-show-arrow"
           >
             <div
@@ -5906,6 +5947,7 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
                   aria-controls="validate_other_select_list"
                   aria-haspopup="listbox"
                   aria-owns="validate_other_select_list"
+                  aria-required="true"
                   autocomplete="off"
                   class="ant-select-selection-search-input"
                   id="validate_other_select"
@@ -5978,6 +6020,7 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
           class="ant-form-item-control-input-content"
         >
           <div
+            aria-required="true"
             class="ant-select ant-select-multiple ant-select-show-search"
           >
             <div
@@ -6000,6 +6043,7 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
                       aria-controls="validate_other_select-multiple_list"
                       aria-haspopup="listbox"
                       aria-owns="validate_other_select-multiple_list"
+                      aria-required="true"
                       autocomplete="off"
                       class="ant-select-selection-search-input"
                       id="validate_other_select-multiple"
@@ -7015,6 +7059,7 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
               >
                 <input
                   accept=""
+                  aria-describedby="validate_other_upload_extra"
                   id="validate_other_upload"
                   style="display:none"
                   type="file"
@@ -7056,6 +7101,7 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
       </div>
       <div
         class="ant-form-item-extra"
+        id="validate_other_upload_extra"
       >
         longgggggggggggggggggggggggggggggggggg
       </div>
@@ -7209,10 +7255,10 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
       </div>
       <div
         class="ant-form-item-explain ant-form-item-explain-connected"
+        role="alert"
       >
         <div
           class="ant-form-item-explain-error"
-          role="alert"
         >
           Should be combination of numbers & alphabets
         </div>
@@ -7335,10 +7381,10 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
       </div>
       <div
         class="ant-form-item-explain ant-form-item-explain-connected"
+        role="alert"
       >
         <div
           class="ant-form-item-explain-validating"
-          role="alert"
         >
           The information is being validated...
         </div>
@@ -7513,10 +7559,10 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
       </div>
       <div
         class="ant-form-item-explain ant-form-item-explain-connected"
+        role="alert"
       >
         <div
           class="ant-form-item-explain-error"
-          role="alert"
         >
           Should be combination of numbers & alphabets
         </div>
@@ -7914,10 +7960,10 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
       </div>
       <div
         class="ant-form-item-explain ant-form-item-explain-connected"
+        role="alert"
       >
         <div
           class="ant-form-item-explain-validating"
-          role="alert"
         >
           The information is being validated...
         </div>
@@ -8003,10 +8049,10 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
               </div>
               <div
                 class="ant-form-item-explain ant-form-item-explain-connected"
+                role="alert"
               >
                 <div
                   class="ant-form-item-explain-error"
-                  role="alert"
                 >
                   Please select right date
                 </div>
@@ -8708,10 +8754,10 @@ exports[`renders ./components/form/demo/without-form-create.md correctly 1`] = `
       </div>
       <div
         class="ant-form-item-explain ant-form-item-explain-connected"
+        role="alert"
       >
         <div
           class=""
-          role="alert"
         >
           A prime is a natural number greater than 1 that has no positive divisors other than 1 and itself.
         </div>

--- a/components/form/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/form/__tests__/__snapshots__/demo.test.js.snap
@@ -509,6 +509,7 @@ exports[`renders ./components/form/demo/col-24-debug.md correctly 1`] = `
           class="ant-form-item-control-input-content"
         >
           <input
+            aria-required="true"
             class="ant-input"
             id="basic_username"
             type="text"
@@ -546,6 +547,7 @@ exports[`renders ./components/form/demo/col-24-debug.md correctly 1`] = `
           >
             <input
               action="click"
+              aria-required="true"
               class="ant-input"
               id="basic_password"
               type="password"
@@ -2356,7 +2358,7 @@ exports[`renders ./components/form/demo/form-context.md correctly 1`] = `
           <span
             class="ant-typography ant-typography-secondary ant-form-text"
           >
-            (
+            ( 
             <span
               aria-label="smile"
               class="anticon anticon-smile"
@@ -2951,6 +2953,7 @@ exports[`renders ./components/form/demo/layout-can-wrap.md correctly 1`] = `
           class="ant-form-item-control-input-content"
         >
           <input
+            aria-required="true"
             class="ant-input"
             id="wrap_username"
             type="text"
@@ -2986,6 +2989,7 @@ exports[`renders ./components/form/demo/layout-can-wrap.md correctly 1`] = `
           class="ant-form-item-control-input-content"
         >
           <input
+            aria-required="true"
             class="ant-input"
             id="wrap_password"
             type="text"
@@ -3006,7 +3010,7 @@ exports[`renders ./components/form/demo/layout-can-wrap.md correctly 1`] = `
         class="ant-form-item-no-colon"
         title=" "
       >
-
+         
       </label>
     </div>
     <div
@@ -3467,7 +3471,7 @@ exports[`renders ./components/form/demo/normal-login.md correctly 1`] = `
               Log in
             </span>
           </button>
-          Or
+          Or 
           <a
             href=""
           >
@@ -3810,6 +3814,7 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
           class="ant-form-item-control-input-content"
         >
           <div
+            aria-required="true"
             class="ant-select ant-cascader ant-select-single ant-select-allow-clear ant-select-show-arrow"
           >
             <div
@@ -3819,19 +3824,18 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
                 class="ant-select-selection-search"
               >
                 <input
-                  aria-required="true"
                   aria-activedescendant="register_residence_list_0"
                   aria-autocomplete="list"
                   aria-controls="register_residence_list"
                   aria-haspopup="listbox"
                   aria-owns="register_residence_list"
+                  aria-required="true"
                   autocomplete="off"
                   class="ant-select-selection-search-input"
                   id="register_residence"
                   readonly=""
                   role="combobox"
                   style="opacity:0"
-                  tabindex="-1"
                   type="search"
                   unselectable="on"
                   value=""
@@ -4104,6 +4108,7 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
                   class="ant-input-number-input-wrap"
                 >
                   <input
+                    aria-required="true"
                     autocomplete="off"
                     class="ant-input-number-input"
                     id="register_donation"
@@ -4268,6 +4273,7 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
             data-count="0 / 100"
           >
             <textarea
+              aria-required="true"
               class="ant-input"
               id="register_intro"
               maxlength="100"
@@ -4301,6 +4307,7 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
           class="ant-form-item-control-input-content"
         >
           <div
+            aria-required="true"
             class="ant-select ant-select-single ant-select-show-arrow"
           >
             <div
@@ -4315,6 +4322,7 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
                   aria-controls="register_gender_list"
                   aria-haspopup="listbox"
                   aria-owns="register_gender_list"
+                  aria-required="true"
                   autocomplete="off"
                   class="ant-select-selection-search-input"
                   id="register_gender"
@@ -4452,7 +4460,7 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
               />
             </span>
             <span>
-              I have read the
+              I have read the 
               <a
                 href=""
               >
@@ -6452,6 +6460,7 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
           class="ant-form-item-control-input-content"
         >
           <div
+            aria-required="true"
             class="ant-radio-group ant-radio-group-outline"
             id="validate_other_radio-button"
           >
@@ -8590,6 +8599,7 @@ exports[`renders ./components/form/demo/warning-only.md correctly 1`] = `
           class="ant-form-item-control-input-content"
         >
           <input
+            aria-required="true"
             class="ant-input"
             id="url"
             placeholder="input placeholder"

--- a/components/form/__tests__/index.test.js
+++ b/components/form/__tests__/index.test.js
@@ -274,6 +274,34 @@ describe('Form', () => {
     expect(input.prop('aria-required')).toBe('true');
   });
 
+  it('input element should have the prop aria-describedby pointing to the extra id when there is a extra message', () => {
+    const wrapper = mount(
+      <Form>
+        <Form.Item name="test" extra="This is a extra message">
+          <input />
+        </Form.Item>
+      </Form>,
+    );
+
+    const input = wrapper.find('input');
+    expect(input.prop('aria-describedby')).toBe('test_extra');
+    const extra = wrapper.find('.ant-form-item-extra');
+    expect(extra.prop('id')).toBe('test_extra');
+  });
+
+  it('input element should have the prop aria-describedby pointing to the help and extra id when there is a help and extra message', () => {
+    const wrapper = mount(
+      <Form>
+        <Form.Item name="test" help="This is a help" extra="This is a extra message">
+          <input />
+        </Form.Item>
+      </Form>,
+    );
+
+    const input = wrapper.find('input');
+    expect(input.prop('aria-describedby')).toBe('test_help test_extra');
+  });
+
   describe('scrollToField', () => {
     function test(name, genForm) {
       it(name, () => {

--- a/components/form/__tests__/index.test.js
+++ b/components/form/__tests__/index.test.js
@@ -188,6 +188,7 @@ describe('Form', () => {
         </Form.Item>
       </Form>,
     );
+
     const input = wrapper.find('input');
     expect(input.prop('aria-describedby')).toBe('test_help');
     const help = wrapper.find('.ant-form-item-explain');
@@ -202,10 +203,31 @@ describe('Form', () => {
         </Form.Item>
       </Form>,
     );
+
     const input = wrapper.find('input');
     expect(input.prop('aria-describedby')).toBe('form_test_help');
     const help = wrapper.find('.ant-form-item-explain');
     expect(help.prop('id')).toBe('form_test_help');
+  });
+
+  it('input element should have the prop aria-describedby pointing to the help id when there are errors', async () => {
+    const wrapper = mount(
+      <Form>
+        <Form.Item name="test" rules={[{ len: 3 }, { type: 'number' }]}>
+          <input />
+        </Form.Item>
+      </Form>,
+    );
+
+    const input = wrapper.find('input');
+    input.simulate('change', { target: { value: 'Invalid number' } });
+    await sleep(800);
+    wrapper.update();
+
+    const inputChanged = wrapper.find('input');
+    expect(inputChanged.prop('aria-describedby')).toBe('test_help');
+    const help = wrapper.find('.ant-form-item-explain');
+    expect(help.prop('id')).toBe('test_help');
   });
 
   describe('scrollToField', () => {

--- a/components/form/__tests__/index.test.js
+++ b/components/form/__tests__/index.test.js
@@ -180,6 +180,34 @@ describe('Form', () => {
     );
   });
 
+  it('input element should have the prop aria-describedby pointing to the help id when there is a help message', () => {
+    const wrapper = mount(
+      <Form>
+        <Form.Item name="test" help="This is a help">
+          <input />
+        </Form.Item>
+      </Form>,
+    );
+    const input = wrapper.find('input');
+    expect(input.prop('aria-describedby')).toBe('test_help');
+    const help = wrapper.find('.ant-form-item-explain');
+    expect(help.prop('id')).toBe('test_help');
+  });
+
+  it('input element should have the prop aria-describedby concatenated with the form name pointing to the help id when there is a help message', () => {
+    const wrapper = mount(
+      <Form name="form">
+        <Form.Item name="test" help="This is a help">
+          <input />
+        </Form.Item>
+      </Form>,
+    );
+    const input = wrapper.find('input');
+    expect(input.prop('aria-describedby')).toBe('form_test_help');
+    const help = wrapper.find('.ant-form-item-explain');
+    expect(help.prop('id')).toBe('form_test_help');
+  });
+
   describe('scrollToField', () => {
     function test(name, genForm) {
       it(name, () => {

--- a/components/form/__tests__/index.test.js
+++ b/components/form/__tests__/index.test.js
@@ -230,6 +230,24 @@ describe('Form', () => {
     expect(help.prop('id')).toBe('test_help');
   });
 
+  it('input element should have the prop aria-invalid when there are errors', async () => {
+    const wrapper = mount(
+      <Form>
+        <Form.Item name="test" rules={[{ len: 3 }, { type: 'number' }]}>
+          <input />
+        </Form.Item>
+      </Form>,
+    );
+
+    const input = wrapper.find('input');
+    input.simulate('change', { target: { value: 'Invalid number' } });
+    await sleep(800);
+    wrapper.update();
+
+    const inputChanged = wrapper.find('input');
+    expect(inputChanged.prop('aria-invalid')).toBe('true');
+  });
+
   describe('scrollToField', () => {
     function test(name, genForm) {
       it(name, () => {
@@ -693,9 +711,7 @@ describe('Form', () => {
     await sleep(100);
     wrapper.update();
     await sleep(100);
-    expect(wrapper.find('.ant-form-item-explain div').getDOMNode().getAttribute('role')).toBe(
-      'alert',
-    );
+    expect(wrapper.find('.ant-form-item-explain').getDOMNode().getAttribute('role')).toBe('alert');
   });
 
   it('return same form instance', () => {

--- a/components/form/__tests__/index.test.js
+++ b/components/form/__tests__/index.test.js
@@ -195,6 +195,21 @@ describe('Form', () => {
     expect(help.prop('id')).toBe('test_help');
   });
 
+  it('input element should not have the prop aria-describedby pointing to the help id when there is a help message and name is not defined', () => {
+    const wrapper = mount(
+      <Form>
+        <Form.Item help="This is a help">
+          <input />
+        </Form.Item>
+      </Form>,
+    );
+
+    const input = wrapper.find('input');
+    expect(input.prop('aria-describedby')).toBeUndefined();
+    const help = wrapper.find('.ant-form-item-explain');
+    expect(help.prop('id')).toBeUndefined();
+  });
+
   it('input element should have the prop aria-describedby concatenated with the form name pointing to the help id when there is a help message', () => {
     const wrapper = mount(
       <Form name="form">
@@ -287,6 +302,21 @@ describe('Form', () => {
     expect(input.prop('aria-describedby')).toBe('test_extra');
     const extra = wrapper.find('.ant-form-item-extra');
     expect(extra.prop('id')).toBe('test_extra');
+  });
+
+  it('input element should not have the prop aria-describedby pointing to the extra id when there is a extra message and name is not defined', () => {
+    const wrapper = mount(
+      <Form>
+        <Form.Item extra="This is a extra message">
+          <input />
+        </Form.Item>
+      </Form>,
+    );
+
+    const input = wrapper.find('input');
+    expect(input.prop('aria-describedby')).toBeUndefined();
+    const extra = wrapper.find('.ant-form-item-extra');
+    expect(extra.prop('id')).toBeUndefined();
   });
 
   it('input element should have the prop aria-describedby pointing to the help and extra id when there is a help and extra message', () => {

--- a/components/form/__tests__/index.test.js
+++ b/components/form/__tests__/index.test.js
@@ -248,6 +248,32 @@ describe('Form', () => {
     expect(inputChanged.prop('aria-invalid')).toBe('true');
   });
 
+  it('input element should have the prop aria-required when the prop `required` is true', async () => {
+    const wrapper = mount(
+      <Form>
+        <Form.Item name="test" required>
+          <input />
+        </Form.Item>
+      </Form>,
+    );
+
+    const input = wrapper.find('input');
+    expect(input.prop('aria-required')).toBe('true');
+  });
+
+  it('input element should have the prop aria-required when there is a rule with required', async () => {
+    const wrapper = mount(
+      <Form>
+        <Form.Item name="test" rules={[{ required: true }]}>
+          <input />
+        </Form.Item>
+      </Form>,
+    );
+
+    const input = wrapper.find('input');
+    expect(input.prop('aria-required')).toBe('true');
+  });
+
   describe('scrollToField', () => {
     function test(name, genForm) {
       it(name, () => {

--- a/components/mentions/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/mentions/__tests__/__snapshots__/demo.test.js.snap
@@ -105,6 +105,7 @@ exports[`renders ./components/mentions/demo/form.md correctly 1`] = `
             class="ant-mentions"
           >
             <textarea
+              aria-required="true"
               class="rc-textarea"
               id="bio"
               placeholder="You can use @ to ref user here"


### PR DESCRIPTION
### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

https://github.com/ant-design/ant-design/issues/28748
https://github.com/ant-design/ant-design/pull/29319 -> *Previous PR*

### 💡 Background and solution

For accessibility is important that the help and extra message be linked to the input.
And the input needs to have appropriate aria-invalid and aria-required when necessary.

**Please pay attention to the MemoInput change, which is a bit weird...but wasn't sure what you wanna accomplish with it in the long run**

### 📝 Changelog

Added

- Created a link between the input field inside the component form item and help and extra messages through aria-describedby
- Pass aria-required to inputs fields inside the component form item when it is required
- Pass aria-invalid to inputs fields inside the component form item when it has errors

Changed

- Move the attribute role="alert" on errors messages to its container. Making the screen reader anounce messages when they appear and in the user's focus

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
