### PR TITLE
fix: add grayscale colors (neutral palette) to colors.less

### DIFF
--- a/components/style/color/colors.less
+++ b/components/style/color/colors.less
@@ -159,7 +159,7 @@
 @gold-10: color(~`colorPalette('@{gold-6}', 10) `);
 
 // neutral color palette
-@gray-base: #bfbfbf;
+@gray-base: #666666;
 @gray-1: color(~`colorPalette('@{gray-6}', 1) `);
 @gray-2: color(~`colorPalette('@{gray-6}', 2) `);
 @gray-3: color(~`colorPalette('@{gray-6}', 3) `);

--- a/components/style/color/colors.less
+++ b/components/style/color/colors.less
@@ -157,7 +157,7 @@
 @gold-8: color(~`colorPalette('@{gold-6}', 8) `);
 @gold-9: color(~`colorPalette('@{gold-6}', 9) `);
 @gold-10: color(~`colorPalette('@{gold-6}', 10) `);
-
+// neutral color palette
 @gray-base: #bfbfbf;
 @gray-1: color(~`colorPalette('@{gray-6}', 1) `);
 @gray-2: color(~`colorPalette('@{gray-6}', 2) `);

--- a/components/style/color/colors.less
+++ b/components/style/color/colors.less
@@ -158,5 +158,17 @@
 @gold-9: color(~`colorPalette('@{gold-6}', 9) `);
 @gold-10: color(~`colorPalette('@{gold-6}', 10) `);
 
+@gray-base: #bfbfbf;
+@gray-1: color(~`colorPalette('@{gray-6}', 1) `);
+@gray-2: color(~`colorPalette('@{gray-6}', 2) `);
+@gray-3: color(~`colorPalette('@{gray-6}', 3) `);
+@gray-4: color(~`colorPalette('@{gray-6}', 4) `);
+@gray-5: color(~`colorPalette('@{gray-6}', 5) `);
+@gray-6: @gray-base;
+@gray-7: color(~`colorPalette('@{gray-6}', 7) `);
+@gray-8: color(~`colorPalette('@{gray-6}', 8) `);
+@gray-9: color(~`colorPalette('@{gray-6}', 9) `);
+@gray-10: color(~`colorPalette('@{gray-6}', 10) `);
+
 @preset-colors: pink, magenta, red, volcano, orange, yellow, gold, cyan, lime, green, blue, geekblue,
-  purple;
+  purple gray;

--- a/components/style/color/colors.less
+++ b/components/style/color/colors.less
@@ -159,17 +159,19 @@
 @gold-10: color(~`colorPalette('@{gold-6}', 10) `);
 
 // neutral color palette
-@gray-base: #666666;
-@gray-1: color(~`colorPalette('@{gray-6}', 1) `);
-@gray-2: color(~`colorPalette('@{gray-6}', 2) `);
-@gray-3: color(~`colorPalette('@{gray-6}', 3) `);
-@gray-4: color(~`colorPalette('@{gray-6}', 4) `);
-@gray-5: color(~`colorPalette('@{gray-6}', 5) `);
-@gray-6: @gray-base;
-@gray-7: color(~`colorPalette('@{gray-6}', 7) `);
-@gray-8: color(~`colorPalette('@{gray-6}', 8) `);
-@gray-9: color(~`colorPalette('@{gray-6}', 9) `);
-@gray-10: color(~`colorPalette('@{gray-6}', 10) `);
+@gray-1: #ffffff;
+@gray-2: #fafafa;
+@gray-3: #f5f5f5;
+@gray-4: #f0f0f0;
+@gray-5: #d9d9d9;
+@gray-6: #bfbfbf;
+@gray-7: #8c8c8c;
+@gray-8: #595959;
+@gray-9: #434343;
+@gray-10: #262626;
+@gray-11: #1f1f1f;
+@gray-12: #141414;
+@gray-13: #000000;
 
 @preset-colors: pink, magenta, red, volcano, orange, yellow, gold, cyan, lime, green, blue, geekblue,
   purple, gray;

--- a/components/style/color/colors.less
+++ b/components/style/color/colors.less
@@ -171,4 +171,4 @@
 @gray-10: color(~`colorPalette('@{gray-6}', 10) `);
 
 @preset-colors: pink, magenta, red, volcano, orange, yellow, gold, cyan, lime, green, blue, geekblue,
-  purple gray;
+  purple, gray;

--- a/components/style/color/colors.less
+++ b/components/style/color/colors.less
@@ -157,6 +157,7 @@
 @gold-8: color(~`colorPalette('@{gold-6}', 8) `);
 @gold-9: color(~`colorPalette('@{gold-6}', 9) `);
 @gold-10: color(~`colorPalette('@{gold-6}', 10) `);
+
 // neutral color palette
 @gray-base: #bfbfbf;
 @gray-1: color(~`colorPalette('@{gray-6}', 1) `);


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [x] Other (about what?) - this adds Less variables for the grayscale colors mentioned in [the docs](https://ant.design/docs/spec/colors). They were previously undefined.

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

1. The antd docs on color palettes mention a gray palette ([source](https://ant.design/docs/spec/colors#Neutral-Color-Palette)):
![image](https://user-images.githubusercontent.com/13430288/123350507-fe251180-d50f-11eb-9ba6-0e481a4ec270.png)

2. `ant-design-colors` also includes a gray palette for use within JS ([source](https://github.com/ant-design/ant-design-colors/blob/master/src/index.ts#L22))

3. The `@gray-*` variables are undefined in the colors.less (bundled with `antd`) which causes a compiler error if you try to import them:
![image](https://user-images.githubusercontent.com/13430288/123350388-c6b66500-d50f-11eb-82f5-698554fb6db7.png)

**Solution**: added variable definitions for gray colors in colors.less

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Non-breaking change: applications can now import `@gray-1` through `@gray-10` from the Less theme. |
| 🇨🇳 Chinese | 在样式表中定义 `@gray-1` ... `@gray-10` |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed (not needed, docs already mention gray)
- [x] Demo is updated/provided or not needed (not needed)
- [x] TypeScript definition is updated/provided or not needed (no TS changes)
- [x] Changelog is provided or not needed
