### PR TITLE
style: fix compact css menu style

### DIFF
--- a/components/style/themes/compact.less
+++ b/components/style/themes/compact.less
@@ -58,7 +58,7 @@
 @menu-inline-toplevel-item-height: 32px;
 @menu-item-height: 32px;
 @menu-item-vertical-margin: 0px;
-@menu-item-boundary-margin: 0px;
+@menu-item-boundary-margin: 8px;
 @menu-icon-margin-right: 8px;
 
 // Checkbox


### PR DESCRIPTION


[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)


### 💡 Background and solution

antdcss与darkcss编出来的menu间距都是8px，但是使用compact编出来则是0，这样在切换时有很明显间隔不同的问题


### 📝 Changelog



| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |       change less variable menu-item-boundary-margin  to 8px   |
| 🇨🇳 Chinese |    修改menu-item-boundary-margin变量为8px       |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
