### PR TITLE
fix: Dropdown.Button don't support overlayClassName

### DIFF
--- a/components/dropdown/__tests__/dropdown-button.test.js
+++ b/components/dropdown/__tests__/dropdown-button.test.js
@@ -16,7 +16,7 @@ describe('DropdownButton', () => {
       },
       overlay: (
         <Menu>
-          <Menu.Item>foo</Menu.Item>
+          <Menu.Item key="1">foo</Menu.Item>
         </Menu>
       ),
       disabled: false,
@@ -36,7 +36,7 @@ describe('DropdownButton', () => {
   it("don't pass visible to Dropdown if it's not exits", () => {
     const menu = (
       <Menu>
-        <Menu.Item>foo</Menu.Item>
+        <Menu.Item key="1">foo</Menu.Item>
       </Menu>
     );
     const wrapper = mount(<Dropdown.Button overlay={menu} />);
@@ -48,7 +48,7 @@ describe('DropdownButton', () => {
   it('should support href like Button', () => {
     const menu = (
       <Menu>
-        <Menu.Item>foo</Menu.Item>
+        <Menu.Item key="1">foo</Menu.Item>
       </Menu>
     );
     const wrapper = mount(<Dropdown.Button overlay={menu} href="https://ant.design" />);
@@ -58,7 +58,7 @@ describe('DropdownButton', () => {
   it('have static property for type detecting', () => {
     const menu = (
       <Menu>
-        <Menu.Item>foo</Menu.Item>
+        <Menu.Item key="1">foo</Menu.Item>
       </Menu>
     );
     const wrapper = mount(<Dropdown.Button overlay={menu} />);
@@ -68,7 +68,7 @@ describe('DropdownButton', () => {
   it('should pass mouseEnterDelay and mouseLeaveDelay to Dropdown', () => {
     const menu = (
       <Menu>
-        <Menu.Item>foo</Menu.Item>
+        <Menu.Item key="1">foo</Menu.Item>
       </Menu>
     );
     const wrapper = mount(
@@ -76,5 +76,23 @@ describe('DropdownButton', () => {
     );
     expect(wrapper.find('Dropdown').props().mouseEnterDelay).toBe(1);
     expect(wrapper.find('Dropdown').props().mouseLeaveDelay).toBe(2);
+  });
+
+  it('should support overlayClassName and overlayStyle', () => {
+    const menu = (
+      <Menu>
+        <Menu.Item key="1">foo</Menu.Item>
+      </Menu>
+    );
+    const wrapper = mount(
+      <Dropdown.Button
+        overlayClassName="className"
+        overlayStyle={{ color: 'red' }}
+        overlay={menu}
+        visible
+      />,
+    );
+    expect(wrapper.find('.ant-dropdown').getDOMNode().className).toContain('className');
+    expect(wrapper.find('.ant-dropdown').getDOMNode().style.color).toContain('red');
   });
 });

--- a/components/dropdown/__tests__/index.test.js
+++ b/components/dropdown/__tests__/index.test.js
@@ -41,9 +41,9 @@ describe('Dropdown', () => {
     const props = {
       overlay: (
         <Menu expandIcon={<span id="customExpandIcon" />}>
-          <Menu.Item>foo</Menu.Item>
+          <Menu.Item key="1">foo</Menu.Item>
           <Menu.SubMenu title="SubMenu">
-            <Menu.Item>foo</Menu.Item>
+            <Menu.Item key="1">foo</Menu.Item>
           </Menu.SubMenu>
         </Menu>
       ),

--- a/components/dropdown/dropdown-button.tsx
+++ b/components/dropdown/dropdown-button.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import classNames from 'classnames';
 import EllipsisOutlined from '@ant-design/icons/EllipsisOutlined';
-
 import Button from '../button';
 import { ButtonHTMLType } from '../button/button';
 import { ButtonGroupProps } from '../button/button-group';
@@ -56,6 +55,8 @@ const DropdownButton: DropdownButtonInterface = props => {
     buttonsRender,
     mouseEnterDelay,
     mouseLeaveDelay,
+    overlayClassName,
+    overlayStyle,
     ...restProps
   } = props;
 
@@ -69,6 +70,8 @@ const DropdownButton: DropdownButtonInterface = props => {
     getPopupContainer: getPopupContainer || getContextPopupContainer,
     mouseEnterDelay,
     mouseLeaveDelay,
+    overlayClassName,
+    overlayStyle,
   } as DropDownProps;
 
   if ('visible' in props) {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close #31147

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Dropdown.Button don't support  `overlayClassName` and `overlayStyle`. |
| 🇨🇳 Chinese | 修复 Dropdown.Button 不支持 `overlayClassName` 和 `overlayStyle` 的问题。   |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
