### PR TITLE
fix(date-picker): allow props locale to override ConfigProvider

### DIFF
--- a/components/date-picker/__tests__/DatePicker.test.js
+++ b/components/date-picker/__tests__/DatePicker.test.js
@@ -3,8 +3,11 @@ import { mount } from 'enzyme';
 import moment from 'moment';
 import MockDate from 'mockdate';
 import DatePicker from '..';
+import ConfigProvider from '../../config-provider';
 import { selectDate, openPanel, clearInput, nextYear, nextMonth, hasSelected } from './utils';
 import focusTest from '../../../tests/shared/focusTest';
+import zhCNDatePicker from '../locale/zh_CN';
+import zhCNAll from '../../locale-provider/zh_CN';
 
 describe('DatePicker', () => {
   const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
@@ -67,6 +70,23 @@ describe('DatePicker', () => {
     const birthday = moment('2000-01-01', 'YYYY-MM-DD');
     const wrapper = mount(<DatePicker open locale={locale} value={birthday} />);
     expect(wrapper.render()).toMatchSnapshot();
+  });
+
+  it('prop locale overrides ConfigProvider locale', () => {
+    const birthday = moment('2000-01-01', 'YYYY-MM-DD');
+    const locale = {
+      ...zhCNDatePicker,
+      lang: {
+        ...zhCNDatePicker.lang,
+        today: '即刻发送',
+      },
+    };
+    const wrapper = mount(
+      <ConfigProvider locale={zhCNAll}>
+        <DatePicker open locale={locale} value={birthday} />
+      </ConfigProvider>,
+    );
+    expect(wrapper.find('.ant-calendar-today-btn').text()).toBe('即刻发送');
   });
 
   // Fix https://github.com/ant-design/ant-design/issues/8885

--- a/components/date-picker/wrapPicker.tsx
+++ b/components/date-picker/wrapPicker.tsx
@@ -146,12 +146,12 @@ export default function wrapPicker(Picker: React.ComponentClass<any>, pickerType
       this.picker.blur();
     }
 
-    renderPicker = (locale: any, localeCode: string) => {
-      const { format, showTime } = this.props;
+    renderPicker = (ctxLocale: any, localeCode: string) => {
+      const { locale, format, showTime } = this.props;
       const mergedPickerType = showTime ? `${pickerType}Time` : pickerType;
       const mergedFormat =
         format ||
-        locale[LOCALE_FORMAT_MAPPING[mergedPickerType]] ||
+        ctxLocale[LOCALE_FORMAT_MAPPING[mergedPickerType]] ||
         DEFAULT_FORMAT[mergedPickerType];
 
       return (
@@ -190,7 +190,7 @@ export default function wrapPicker(Picker: React.ComponentClass<any>, pickerType
                 {...showTime}
                 prefixCls={`${prefixCls}-time-picker`}
                 className={timePickerCls}
-                placeholder={locale.timePickerLocale.placeholder}
+                placeholder={ctxLocale.timePickerLocale.placeholder}
                 transitionName="slide-up"
                 onEsc={() => {}}
               />
@@ -204,7 +204,7 @@ export default function wrapPicker(Picker: React.ComponentClass<any>, pickerType
                 ref={this.savePicker}
                 pickerClass={pickerClass}
                 pickerInputClass={pickerInputClass}
-                locale={locale}
+                locale={{ ...ctxLocale, ...locale }}
                 localeCode={localeCode}
                 timePicker={timePicker}
                 onOpenChange={this.handleOpenChange}


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [x] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

https://codesandbox.io/s/funny-glitter-l5prf?file=/index.js

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

`DatePicker` does not respect `locale` prop when `ConfigProvider` is configured.

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

-  No risks involved.

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Allow `props.locale` to override `ConfigProvider` locale  |
| 🇨🇳 Chinese | 允许 `props.locale` 覆盖 `ConfigProvider` locale          |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
