### PR TITLE
feat(Cascader): title attributes are added to the selected content text by default

### DIFF
--- a/components/cascader/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/cascader/__tests__/__snapshots__/demo.test.js.snap
@@ -209,6 +209,7 @@ exports[`renders ./components/cascader/demo/default-value.md correctly 1`] = `
 >
   <span
     class="ant-cascader-picker-label"
+    title="Zhejiang / Hangzhou / West Lake"
   >
     Zhejiang / Hangzhou / West Lake
   </span>

--- a/components/cascader/__tests__/__snapshots__/index.test.js.snap
+++ b/components/cascader/__tests__/__snapshots__/index.test.js.snap
@@ -1117,6 +1117,7 @@ exports[`Cascader support controlled mode 1`] = `
 >
   <span
     class="ant-cascader-picker-label"
+    title="Zhejiang / Hangzhou / West Lake"
   >
     Zhejiang / Hangzhou / West Lake
   </span>

--- a/components/cascader/index.tsx
+++ b/components/cascader/index.tsx
@@ -316,7 +316,7 @@ class Cascader extends React.Component<CascaderProps, CascaderState> {
   };
 
   getLabel() {
-    const { options, displayRender = defaultDisplayRender as Function } = this.props;
+    const { options, displayRender = defaultDisplayRender } = this.props;
     const names = getFilledFieldNames(this.props);
     const { value } = this.state;
     const unwrappedValue = Array.isArray(value[0]) ? value[0] : value;
@@ -618,9 +618,15 @@ class Cascader extends React.Component<CascaderProps, CascaderState> {
           inputIcon = <DownOutlined className={arrowCls} />;
         }
 
+        const label = this.getLabel();
         const input: React.ReactElement = children || (
           <span style={style} className={pickerCls}>
-            <span className={`${prefixCls}-picker-label`}>{this.getLabel()}</span>
+            <span
+              className={`${prefixCls}-picker-label`}
+              title={typeof label === 'string' && label ? label : undefined}
+            >
+              {label}
+            </span>
             <Input
               {...inputProps}
               tabIndex={-1}

--- a/components/form/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/form/__tests__/__snapshots__/demo.test.js.snap
@@ -3321,6 +3321,7 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
           >
             <span
               class="ant-cascader-picker-label"
+              title="Zhejiang / Hangzhou / West Lake"
             >
               Zhejiang / Hangzhou / West Lake
             </span>

--- a/components/input/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/input/__tests__/__snapshots__/demo.test.js.snap
@@ -632,6 +632,7 @@ Array [
   >
     <span
       class="ant-cascader-picker-label"
+      title="Zhejiang / Hangzhou / West Lake"
     >
       Zhejiang / Hangzhou / West Lake
     </span>


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

While `displayRender` prop can be used for this effect, I think it should be available by default, such as in the `Select` component.

![image](https://user-images.githubusercontent.com/37143265/124226606-f7b01e80-db3b-11eb-8341-d38683b76c18.png)

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Title attributes are added to the selected content text by default |
| 🇨🇳 Chinese | 在 `Cascader` 组件中，默认给选中值的文本添加 `title` 属性 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
