### PR TITLE
fix: Form Input error outline color

### DIFF
--- a/components/form/style/mixin.less
+++ b/components/form/style/mixin.less
@@ -5,8 +5,8 @@
     color: @text-color;
   }
   // 输入框的不同校验状态
-  .@{ant-prefix}-input:not(.@{ant-prefix}-input-disabled),
-  .@{ant-prefix}-input-affix-wrapper:not(.@{ant-prefix}-input-affix-wrapper-disabled) {
+  :not(.@{ant-prefix}-input-disabled).@{ant-prefix}-input,
+  :not(.@{ant-prefix}-input-affix-wrapper-disabled).@{ant-prefix}-input-affix-wrapper {
     &,
     &:hover {
       background-color: @background-color;


### PR DESCRIPTION


<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

close #31236

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Form Input outline color under Form validation. |
| 🇨🇳 Chinese | 修复 Form 错误校验状态下 Input 的聚焦外框色。  |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
