### PR TITLE
style: Rate focus ring style in safari

### DIFF
--- a/components/rate/style/index.less
+++ b/components/rate/style/index.less
@@ -33,15 +33,19 @@
     }
 
     > div {
-      transition: all 0.3s;
+      transition: all 0.3s, outline 0s;
 
       &:hover,
       &:focus-visible {
         transform: @rate-star-hover-scale;
       }
 
-      &:focus:not(:focus-visible) {
+      &:focus {
         outline: 0;
+      }
+
+      &:focus-visible {
+        outline: 1px dashed @rate-star-color;
       }
     }
 


### PR DESCRIPTION


<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

Safari don't support `:focus-visible`.

<img width="176" alt="图片" src="https://user-images.githubusercontent.com/507615/124233634-9ee58380-db45-11eb-8878-5501797c19d8.png">


### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fix Rate focus ring style in Safari. |
| 🇨🇳 Chinese | 修复 Rate 在 Safari 下聚焦外框的样式。    |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
