### PR TITLE
fix: the path error when packaging the component style export file in the windows environment:

### DIFF
--- a/.antd-tools.config.js
+++ b/.antd-tools.config.js
@@ -22,7 +22,7 @@ function finalizeCompile() {
     fs.readdir(componentsPath, (err, files) => {
       files.forEach(file => {
         if (fs.existsSync(path.join(componentsPath, file, 'style', 'index.less'))) {
-          componentsLessContent += `@import "../${path.join(file, 'style', 'index.less')}";\n`;
+          componentsLessContent += `@import "../${path.posix.join(file, 'style', 'index.less')}";\n`;
         }
       });
       fs.writeFileSync(


### PR DESCRIPTION
Fix the path error when packaging the component style export file in the windows environment:

"Lib/style/components.less" will generate the following path "@import "../xx\style\index.less";" This is wrong
Now use path.posix.join to be compatible with multi-platform packaging

<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Fix the path error when packaging the component style export file in the windows environment       |
| 🇨🇳 Chinese |    修复在windeos环境下打包组件样式导出文件时路径错误      |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
