### PR TITLE
Update type for Menu onOpenChange in docs.

### DIFF
--- a/components/menu/index.en-US.md
+++ b/components/menu/index.en-US.md
@@ -53,7 +53,7 @@ More layouts with navigation: [Layout](/components/layout).
 | triggerSubMenuAction | Which action can trigger submenu open/close | `hover` \| `click` | `hover` |  |
 | onClick | Called when a menu item is clicked | function({ item, key, keyPath, domEvent }) | - |  |
 | onDeselect | Called when a menu item is deselected (multiple mode only) | function({ item, key, keyPath, selectedKeys, domEvent }) | - |  |
-| onOpenChange | Called when sub-menus are opened or closed | function(openKeys: string\[]) | - |  |
+| onOpenChange | Called when sub-menus are opened or closed | function(openKeys: React.Key\[]) | - |  |
 | onSelect | Called when a menu item is selected | function({ item, key, keyPath, selectedKeys, domEvent }) | - |  |
 
 > More options in [rc-menu](https://github.com/react-component/menu#api)

--- a/components/menu/index.zh-CN.md
+++ b/components/menu/index.zh-CN.md
@@ -54,7 +54,7 @@ cover: https://gw.alipayobjects.com/zos/alicdn/3XZcjGpvK/Menu.svg
 | triggerSubMenuAction | SubMenu 展开/关闭的触发行为 | `hover` \| `click` | `hover` |  |
 | onClick | 点击 MenuItem 调用此函数 | function({ item, key, keyPath, domEvent }) | - |  |
 | onDeselect | 取消选中时调用，仅在 multiple 生效 | function({ item, key, keyPath, selectedKeys, domEvent }) | - |  |
-| onOpenChange | SubMenu 展开/关闭的回调 | function(openKeys: string\[]) | - |  |
+| onOpenChange | SubMenu 展开/关闭的回调 | function(openKeys: React.Key\[]) | - |  |
 | onSelect | 被选中时调用 | function({ item, key, keyPath, selectedKeys, domEvent }) | -   |  |
 
 > 更多属性查看 [rc-menu](https://github.com/react-component/menu#api)


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [X] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

N/A

### 💡 Background and solution

Looks like `react-component` has updated the argument type to `React.Key[]` instead of `string[]` [1]

[1] https://github.com/react-component/menu/blob/571c52f35a9d0ba582f58c26e06f44c0619d4253/src/Menu.tsx#L112

### 📝 Changelog

N/A