### PR TITLE
fix: DatePicker disabled cell style when customize dateRender

### DIFF
--- a/components/date-picker/style/panel.less
+++ b/components/date-picker/style/panel.less
@@ -340,10 +340,10 @@
 
     // >>> Disabled
     &-disabled {
+      color: @disabled-color;
       pointer-events: none;
 
       .@{cellClassName} {
-        color: @disabled-color;
         background: transparent;
       }
 
@@ -366,11 +366,6 @@
       color: @text-color;
     }
 
-    // Disabled
-    &-disabled {
-      cursor: not-allowed;
-    }
-
     .picker-cell-inner(~'@{picker-cell-inner-cls}');
   }
 
@@ -384,12 +379,6 @@
 
     .@{picker-cell-inner-cls} {
       padding: 0 @padding-xs;
-    }
-
-    .@{picker-prefix-cls}-cell {
-      &-disabled .@{picker-cell-inner-cls} {
-        background: @picker-basic-cell-disabled-bg;
-      }
     }
   }
 

--- a/components/style/themes/default.less
+++ b/components/style/themes/default.less
@@ -638,7 +638,7 @@
 @picker-basic-cell-hover-color: @item-hover-bg;
 @picker-basic-cell-active-with-range-color: @primary-1;
 @picker-basic-cell-hover-with-range-color: lighten(@primary-color, 35%);
-@picker-basic-cell-disabled-bg: @disabled-bg;
+@picker-basic-cell-disabled-bg: rgba(0, 0, 0, 0.04);
 @picker-border-color: @border-color-split;
 @picker-date-hover-range-border-color: lighten(@primary-color, 20%);
 @picker-date-hover-range-color: @picker-basic-cell-hover-with-range-color;


### PR DESCRIPTION


<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close #31248

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix DatePicker disabled cell style when customize `dateRender`.  |
| 🇨🇳 Chinese | 修复 DatePicker 自定义 `dateRender` 时禁用日期样式错误的问题。 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
