### PR TITLE
style: fix Cascader style inside Input addon

### DIFF
--- a/components/input/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/input/__tests__/__snapshots__/demo.test.js.snap
@@ -1,9 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders ./components/input/demo/addon.md correctly 1`] = `
-Array [
+<div
+  class="ant-space ant-space-vertical"
+>
   <div
-    style="margin-bottom:16px"
+    class="ant-space-item"
+    style="margin-bottom:8px"
   >
     <span
       class="ant-input-group-wrapper"
@@ -28,9 +31,10 @@ Array [
         </span>
       </span>
     </span>
-  </div>,
+  </div>
   <div
-    style="margin-bottom:16px"
+    class="ant-space-item"
+    style="margin-bottom:8px"
   >
     <span
       class="ant-input-group-wrapper"
@@ -171,9 +175,10 @@ Array [
         </span>
       </span>
     </span>
-  </div>,
+  </div>
   <div
-    style="margin-bottom:16px"
+    class="ant-space-item"
+    style="margin-bottom:8px"
   >
     <span
       class="ant-input-group-wrapper"
@@ -211,9 +216,10 @@ Array [
         </span>
       </span>
     </span>
-  </div>,
+  </div>
   <div
-    style="margin-bottom:16px"
+    class="ant-space-item"
+    style="margin-bottom:8px"
   >
     <span
       class="ant-input-group-wrapper"
@@ -242,8 +248,66 @@ Array [
         </span>
       </span>
     </span>
-  </div>,
-]
+  </div>
+  <div
+    class="ant-space-item"
+  >
+    <span
+      class="ant-input-group-wrapper"
+    >
+      <span
+        class="ant-input-wrapper ant-input-group"
+      >
+        <span
+          class="ant-input-group-addon"
+        >
+          <span
+            class="ant-cascader-picker"
+            style="width:150px"
+            tabindex="0"
+          >
+            <span
+              class="ant-cascader-picker-label"
+            />
+            <input
+              autocomplete="off"
+              class="ant-input ant-cascader-input "
+              placeholder="cascader"
+              readonly=""
+              tabindex="-1"
+              type="text"
+              value=""
+            />
+            <span
+              aria-label="down"
+              class="anticon anticon-down ant-cascader-picker-arrow"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="down"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                />
+              </svg>
+            </span>
+          </span>
+        </span>
+        <input
+          class="ant-input"
+          type="text"
+          value="mysite"
+        />
+      </span>
+    </span>
+  </div>
+</div>
 `;
 
 exports[`renders ./components/input/demo/align.md correctly 1`] = `

--- a/components/input/demo/addon.md
+++ b/components/input/demo/addon.md
@@ -14,7 +14,7 @@ title:
 Using pre & post tabs example.
 
 ```jsx
-import { Input, Select } from 'antd';
+import { Input, Select, Space, Cascader } from 'antd';
 import { SettingOutlined } from '@ant-design/icons';
 
 const { Option } = Select;
@@ -35,20 +35,16 @@ const selectAfter = (
 );
 
 ReactDOM.render(
-  <>
-    <div style={{ marginBottom: 16 }}>
-      <Input addonBefore="http://" addonAfter=".com" defaultValue="mysite" />
-    </div>
-    <div style={{ marginBottom: 16 }}>
-      <Input addonBefore={selectBefore} addonAfter={selectAfter} defaultValue="mysite" />
-    </div>
-    <div style={{ marginBottom: 16 }}>
-      <Input addonAfter={<SettingOutlined />} defaultValue="mysite" />
-    </div>
-    <div style={{ marginBottom: 16 }}>
-      <Input addonBefore="http://" suffix=".com" defaultValue="mysite" />
-    </div>
-  </>,
+  <Space direction="vertical">
+    <Input addonBefore="http://" addonAfter=".com" defaultValue="mysite" />
+    <Input addonBefore={selectBefore} addonAfter={selectAfter} defaultValue="mysite" />
+    <Input addonAfter={<SettingOutlined />} defaultValue="mysite" />
+    <Input addonBefore="http://" suffix=".com" defaultValue="mysite" />
+    <Input
+      addonBefore={<Cascader placeholder="cascader" style={{ width: 150 }} />}
+      defaultValue="mysite"
+    />
+  </Space>,
   mountNode,
 );
 ```

--- a/components/input/style/mixin.less
+++ b/components/input/style/mixin.less
@@ -205,6 +205,17 @@
         }
       }
     }
+
+    // https://github.com/ant-design/ant-design/issues/31333
+    .@{ant-prefix}-cascader-picker {
+      margin: -9px (-@control-padding-horizontal);
+      background-color: transparent;
+      .@{ant-prefix}-cascader-input {
+        text-align: left;
+        border: 0;
+        box-shadow: none;
+      }
+    }
   }
 
   // Reset rounded corners


### PR DESCRIPTION

<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close #31333

### 💡 Background and solution

Before ❌ | After ✅
---|---
 <img width="210" alt="截屏2021-07-12 下午12 24 19" src="https://user-images.githubusercontent.com/507615/125230873-4b74f180-e30c-11eb-8bdf-acbb3afa6fbf.png"> | <img width="554" alt="截屏2021-07-12 下午12 25 16" src="https://user-images.githubusercontent.com/507615/125230869-487a0100-e30c-11eb-95a8-20724b579395.png">


### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Cascader style bug inside Input `addonBefore`.  |
| 🇨🇳 Chinese | 修复 Cascader 在 Input `addonBefore` 中的样式问题。   |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
