### PR TITLE
Fix Input component styles when using prefixCls

### DIFF
--- a/components/input/style/index.less
+++ b/components/input/style/index.less
@@ -4,15 +4,17 @@
 @import './affix';
 @import './allow-clear';
 
+@input-prefix-cls: ~'@{ant-prefix}-input';
+
 // Input styles
-.@{ant-prefix}-input {
+.@{input-prefix-cls} {
   .reset-component();
   .input();
 
   //== Style for input-group: input with label, with button or dropdown...
   &-group {
     .reset-component();
-    .input-group(~'@{ant-prefix}-input');
+    .input-group(~'@{input-prefix-cls}');
     &-wrapper {
       display: inline-block;
       width: 100%;
@@ -34,10 +36,10 @@
   &[type='color'] {
     height: @input-height-base;
 
-    &.@{ant-prefix}-input-lg {
+    &.@{input-prefix-cls}-lg {
       height: @input-height-lg;
     }
-    &.@{ant-prefix}-input-sm {
+    &.@{input-prefix-cls}-sm {
       height: @input-height-sm;
       padding-top: 3px;
       padding-bottom: 3px;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [x] Bug fix

### 🔗 Related issue link

I am trying to use two versions of antd in a project simultanously.
To separate the styles, I am trying to use `prefixCls` for one of them.

Most components do work correctly, receiving an appropriate class name, and the less styles
match the class name. However the `Input` component does not seem to have any matching styles for the prefixed class name.

### 💡 Background and solution

Changed according to https://github.com/ant-design/ant-design/blob/master/components/input-number/style/index.less

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 🐞 Fix Input component styles when using prefixCls |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
