### PR TITLE
fix: Add the totalBoundaryShowSizeChanger property

### DIFF
--- a/components/pagination/Pagination.tsx
+++ b/components/pagination/Pagination.tsx
@@ -43,6 +43,7 @@ export interface PaginationProps {
   ) => React.ReactNode;
   role?: string;
   showLessItems?: boolean;
+  totalBoundaryShowSizeChanger?: number;
 }
 
 export type PaginationPosition = 'top' | 'bottom' | 'both';


### PR DESCRIPTION
Fix the problem of the wrong type of totalBoundaryShowSizeChanger

<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close #31540

### 💡 Background and solution

The user can freely decide when the SizeChanger appears according to the business scenario

```typescript
export interface PaginationProps {
  ...;
  showLessItems?: boolean;
  totalBoundaryShowSizeChanger?: number;
}
```

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Pagination's totalBoundaryShowSizeChanger property type error |
| 🇨🇳 Chinese | 修复Pagination 的 totalBoundaryShowSizeChanger 属性类型错误 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
