### PR TITLE
docs: Added alternate example to modify start day of week

### DIFF
--- a/components/date-picker/index.en-US.md
+++ b/components/date-picker/index.en-US.md
@@ -185,6 +185,8 @@ DatePicker default set `locale` as `en` in v4. You can config DatePicker `locale
 
 Please use correct [language](/docs/react/i18n) ([#5605](https://github.com/ant-design/ant-design/issues/5605)), or update moment `locale` config: <https://codesandbox.io/s/moment-day-of-week-6dby5>
 
+Alternate example: <https://stackblitz.com/edit/react-9aegkj>
+
 ### Why origin panel don't switch when using `panelRender`?
 
 When you change the layout of nodes by `panelRender`, React will unmount and re-mount it which reset the component state. You should keep the layout stable. Please ref [#27263](https://github.com/ant-design/ant-design/issues/27263) for more info.

--- a/components/date-picker/index.en-US.md
+++ b/components/date-picker/index.en-US.md
@@ -183,9 +183,10 @@ DatePicker default set `locale` as `en` in v4. You can config DatePicker `locale
 
 ### How to modify start day of week?
 
-Please use correct [language](/docs/react/i18n) ([#5605](https://github.com/ant-design/ant-design/issues/5605)), or update moment `locale` config: <https://codesandbox.io/s/moment-day-of-week-6dby5>
+Please use correct [language](/docs/react/i18n) ([#5605](https://github.com/ant-design/ant-design/issues/5605)), or update moment `locale` config: 
 
-Alternate example: <https://stackblitz.com/edit/react-9aegkj>
+- Example: <https://codesandbox.io/s/moment-day-of-week-6dby5>
+- Alternate example: <https://stackblitz.com/edit/react-9aegkj>
 
 ### Why origin panel don't switch when using `panelRender`?
 


### PR DESCRIPTION
When I looked at the documentation, The https://codesandbox.io/s/moment-day-of-week-6dby5 link did not work for me.

https://stackblitz.com/edit/react-9aegkj works

<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [x] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->
When I tried to browse to the example, it did not work

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->
I created the following working example that you may reference:
https://stackblitz.com/edit/react-9aegkj

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->
none

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
