### PR TITLE
Fix: Allow Badge count to accept custom color

### DIFF
--- a/components/badge/__tests__/__snapshots__/index.test.js.snap
+++ b/components/badge/__tests__/__snapshots__/index.test.js.snap
@@ -7,31 +7,64 @@ exports[`Badge render Badge status/color when contains children 1`] = `
   >
     <a />
     <sup
-      class="ant-scroll-number ant-badge-dot ant-badge-status-success"
+      class="ant-scroll-number ant-badge-count ant-badge-status-success"
       data-show="true"
       title="5"
-    />
+    >
+      <span
+        class="ant-scroll-number-only"
+        style="transition: none;"
+      >
+        <span
+          class="ant-scroll-number-only-unit current"
+        >
+          5
+        </span>
+      </span>
+    </sup>
   </span>
   <span
     class="ant-badge ant-badge-status"
   >
     <a />
     <sup
-      class="ant-scroll-number ant-badge-dot ant-badge-status-blue"
+      class="ant-scroll-number ant-badge-count ant-badge-status-blue"
       data-show="true"
       title="5"
-    />
+    >
+      <span
+        class="ant-scroll-number-only"
+        style="transition: none;"
+      >
+        <span
+          class="ant-scroll-number-only-unit current"
+        >
+          5
+        </span>
+      </span>
+    </sup>
   </span>
   <span
     class="ant-badge ant-badge-status"
   >
     <a />
     <sup
-      class="ant-scroll-number ant-badge-dot"
+      class="ant-scroll-number ant-badge-count"
       data-show="true"
       style="background: rgb(0, 136, 204);"
       title="5"
-    />
+    >
+      <span
+        class="ant-scroll-number-only"
+        style="transition: none;"
+      >
+        <span
+          class="ant-scroll-number-only-unit current"
+        >
+          5
+        </span>
+      </span>
+    </sup>
   </span>
 </div>
 `;

--- a/components/badge/demo/colorful.md
+++ b/components/badge/demo/colorful.md
@@ -51,6 +51,11 @@ ReactDOM.render(
       <Badge color="#87d068" text="#87d068" />
       <br />
       <Badge color="#108ee9" text="#108ee9" />
+      <br />
+      <br />
+      <Badge color="#ff8d07" count={5}>
+        #ff8d07
+      </Badge>
     </div>
   </>,
   mountNode,

--- a/components/badge/index.tsx
+++ b/components/badge/index.tsx
@@ -58,16 +58,16 @@ const Badge: CompoundedComponent = ({
   const prefixCls = getPrefixCls('badge', customizePrefixCls);
 
   // ================================ Misc ================================
-  const numberedDisplayCount = ((count as number) > (overflowCount as number)
-    ? `${overflowCount}+`
-    : count) as string | number | null;
+  const numberedDisplayCount = (
+    (count as number) > (overflowCount as number) ? `${overflowCount}+` : count
+  ) as string | number | null;
 
   const hasStatus =
     (status !== null && status !== undefined) || (color !== null && color !== undefined);
 
   const isZero = numberedDisplayCount === '0' || numberedDisplayCount === 0;
 
-  const showAsDot = (dot && !isZero) || hasStatus;
+  const showAsDot = dot && !isZero;
 
   const mergedCount = showAsDot ? '' : numberedDisplayCount;
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
#31590
<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

When using count style of the Badge component and a custom color is applied we get a dot instead, see the codesandbox;
https://codesandbox.io/s/antd-reproduction-template-forked-q6lfx?file=/index.js

The solution makes a simple change to the conditional that determines wether to use a dot or not

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Fix using badge count style with custom colour        |
| 🇨🇳 Chinese |  使用自定义颜色的徽章计数样式修复      |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
