### PR TITLE
fix: ConfigProvider rerender unexpectedly when switching some language

### DIFF
--- a/components/config-provider/__tests__/locale.test.js
+++ b/components/config-provider/__tests__/locale.test.js
@@ -5,6 +5,9 @@ import LocaleProvider from '../../locale-provider';
 import zhCN from '../../locale/zh_CN';
 import enUS from '../../locale/en_US';
 import TimePicker from '../../time-picker';
+import DatePicker from '../../date-picker';
+import { openPicker, selectCell, closePicker } from '../../date-picker/__tests__/utils';
+import Pagination from '../../pagination';
 import Modal from '../../modal';
 
 describe('ConfigProvider.Locale', () => {
@@ -62,6 +65,51 @@ describe('ConfigProvider.Locale', () => {
     const wrapper = mount(<App />);
     wrapper.find('button').simulate('click');
     expect($$('.ant-btn-primary')[0].textContent).toBe('OK');
+  });
+
+  // https://github.com/ant-design/ant-design/issues/31592
+  it('should not reset the component state when switching locale', () => {
+    class App extends React.Component {
+      state = {
+        locale: zhCN,
+      };
+
+      render() {
+        return (
+          <ConfigProvider locale={this.state.locale}>
+            <DatePicker />
+            <Pagination total={50} />
+          </ConfigProvider>
+        );
+      }
+    }
+
+    const wrapper = mount(<App />);
+
+    const datepickerInitProps = wrapper.find('.ant-picker-input input').props();
+    expect(datepickerInitProps.value).toBe('');
+    expect(datepickerInitProps.placeholder).toBe('请选择日期');
+    expect(wrapper.find('.ant-pagination-item-1').props().className).toContain(
+      'ant-pagination-item-active',
+    );
+
+    openPicker(wrapper);
+    selectCell(wrapper, 10);
+    closePicker(wrapper);
+
+    expect(wrapper.find('.ant-picker-input input').props().value).not.toBe('');
+
+    wrapper.setState({ locale: {} });
+    wrapper.find('.ant-pagination-item-3').simulate('click');
+
+    const datepickerProps = wrapper.find('.ant-picker-input input').props();
+    expect(datepickerProps.placeholder).not.toBe('请选择日期');
+    expect(datepickerProps.value).not.toBe('');
+    expect(datepickerProps.value).toContain('-10');
+
+    expect(wrapper.find('.ant-pagination-item-3').props().className).toContain(
+      'ant-pagination-item-active',
+    );
   });
 
   describe('support legacy LocaleProvider', () => {

--- a/components/config-provider/index.tsx
+++ b/components/config-provider/index.tsx
@@ -198,11 +198,7 @@ const ProviderChildren: React.FC<ProviderChildrenProps> = props => {
   let validateMessages: ValidateMessages = {};
 
   if (locale) {
-    if (locale.Form && locale.Form.defaultValidateMessages) {
-      validateMessages = locale.Form.defaultValidateMessages;
-    } else {
-      validateMessages = defaultLocale.Form!.defaultValidateMessages;
-    }
+    validateMessages = locale.Form?.defaultValidateMessages || defaultLocale.Form?.defaultValidateMessages;
   }
   if (form && form.validateMessages) {
     validateMessages = { ...validateMessages, ...form.validateMessages };

--- a/components/config-provider/index.tsx
+++ b/components/config-provider/index.tsx
@@ -198,7 +198,8 @@ const ProviderChildren: React.FC<ProviderChildrenProps> = props => {
   let validateMessages: ValidateMessages = {};
 
   if (locale) {
-    validateMessages = locale.Form?.defaultValidateMessages || defaultLocale.Form?.defaultValidateMessages;
+    validateMessages =
+      locale.Form?.defaultValidateMessages || defaultLocale.Form?.defaultValidateMessages || {};
   }
   if (form && form.validateMessages) {
     validateMessages = { ...validateMessages, ...form.validateMessages };

--- a/components/config-provider/index.tsx
+++ b/components/config-provider/index.tsx
@@ -17,6 +17,7 @@ import SizeContext, { SizeContextProvider, SizeType } from './SizeContext';
 import message from '../message';
 import notification from '../notification';
 import { RequiredMark } from '../form/Form';
+import defaultLocale from '../locale/default';
 
 export {
   RenderEmptyHandler,
@@ -187,16 +188,21 @@ const ProviderChildren: React.FC<ProviderChildrenProps> = props => {
     },
   );
 
-  const memoIconContextValue = React.useMemo(() => ({ prefixCls: iconPrefixCls, csp }), [
-    iconPrefixCls,
-  ]);
+  const memoIconContextValue = React.useMemo(
+    () => ({ prefixCls: iconPrefixCls, csp }),
+    [iconPrefixCls],
+  );
 
   let childNode = children;
   // Additional Form provider
   let validateMessages: ValidateMessages = {};
 
-  if (locale && locale.Form && locale.Form.defaultValidateMessages) {
-    validateMessages = locale.Form.defaultValidateMessages;
+  if (locale) {
+    if (locale.Form && locale.Form.defaultValidateMessages) {
+      validateMessages = locale.Form.defaultValidateMessages;
+    } else {
+      validateMessages = defaultLocale.Form!.defaultValidateMessages;
+    }
   }
   if (form && form.validateMessages) {
     validateMessages = { ...validateMessages, ...form.validateMessages };


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
close #31592
<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution
修复了ConfigProvide在切换某些语言时下级组件状态不能被保持的问题
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fix ConfigProvide could not maintain the state of components when switching some lang      |
| 🇨🇳 Chinese |     修复了ConfigProvide在切换某些语言时下级组件状态不能被保持的问题      |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
