### PR TITLE
docs(✨): release 4.16.11

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -15,6 +15,16 @@ timeline: true
 
 ---
 
+## 4.16.11
+
+`2021-08-08`
+
+- 🐞 Fix ConfigProvider rerender unexpectedly when switching some languages. [#31630](https://github.com/ant-design/ant-design/pull/31630) [@Map1en](https://github.com/Map1en)
+- 💄 Improve ghost button style rules, no more `!important`. [#31659](https://github.com/ant-design/ant-design/pull/31659)
+- 💄 Improve RangePicker range transition style. [#31645](https://github.com/ant-design/ant-design/pull/31645)
+- 🤖 Fix Dropdown `destroyPopupOnHide` TypeScript definition missing. [#31700](https://github.com/ant-design/ant-design/pull/31700) [@linxianxi](https://github.com/linxianxi)
+- 🤖 Remove useless Omit type which is built-in in TypeScript 3.5+. [#31661](https://github.com/ant-design/ant-design/pull/31661) [@Dreamerryao](https://github.com/Dreamerryao)
+
 ## 4.16.10
 
 `2021-08-02`

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -15,6 +15,16 @@ timeline: true
 
 ---
 
+## 4.16.11
+
+`2021-08-08`
+
+- 🐞 修复 ConfigProvider 切换国际化时子组件 rerender 的问题。[#31630](https://github.com/ant-design/ant-design/pull/31630) [@Map1en](https://github.com/Map1en)
+- 💄 简化 ghost 按钮的样式代码，去掉 `!important` 样式规则。[#31659](https://github.com/ant-design/ant-design/pull/31659)
+- 💄 优化 RangePicker 的范围样式的 transition 效果。[#31645](https://github.com/ant-design/ant-design/pull/31645)
+- 🤖 修复 Dropdown `destroyPopupOnHide` TypeScript 定义丢失的问题。[#31700](https://github.com/ant-design/ant-design/pull/31700) [@linxianxi](https://github.com/linxianxi)
+- 🤖 移除多余的 Omit 类型定义。[#31661](https://github.com/ant-design/ant-design/pull/31661) [@Dreamerryao](https://github.com/Dreamerryao)
+
 ## 4.16.10
 
 `2021-08-02`

--- a/components/config-provider/__tests__/__snapshots__/components.test.js.snap
+++ b/components/config-provider/__tests__/__snapshots__/components.test.js.snap
@@ -16169,14 +16169,14 @@ exports[`ConfigProvider components Pagination configProvider 1`] = `
       </button>
     </li>
     <li
-      class="config-pagination-item config-pagination-item-0 config-pagination-disabled config-pagination-item-disabled"
+      class="config-pagination-item config-pagination-item-1 config-pagination-item-disabled"
       tabindex="0"
-      title="0"
+      title="1"
     >
       <a
         rel="nofollow"
       >
-        0
+        1
       </a>
     </li>
     <li
@@ -16321,14 +16321,14 @@ exports[`ConfigProvider components Pagination configProvider 1`] = `
       </button>
     </li>
     <li
-      class="config-pagination-item config-pagination-item-0 config-pagination-disabled config-pagination-item-disabled"
+      class="config-pagination-item config-pagination-item-1 config-pagination-item-disabled"
       tabindex="0"
-      title="0"
+      title="1"
     >
       <a
         rel="nofollow"
       >
-        0
+        1
       </a>
     </li>
     <li
@@ -16478,14 +16478,14 @@ exports[`ConfigProvider components Pagination configProvider componentSize large
       </button>
     </li>
     <li
-      class="config-pagination-item config-pagination-item-0 config-pagination-disabled config-pagination-item-disabled"
+      class="config-pagination-item config-pagination-item-1 config-pagination-item-disabled"
       tabindex="0"
-      title="0"
+      title="1"
     >
       <a
         rel="nofollow"
       >
-        0
+        1
       </a>
     </li>
     <li
@@ -16630,14 +16630,14 @@ exports[`ConfigProvider components Pagination configProvider componentSize large
       </button>
     </li>
     <li
-      class="config-pagination-item config-pagination-item-0 config-pagination-disabled config-pagination-item-disabled"
+      class="config-pagination-item config-pagination-item-1 config-pagination-item-disabled"
       tabindex="0"
-      title="0"
+      title="1"
     >
       <a
         rel="nofollow"
       >
-        0
+        1
       </a>
     </li>
     <li
@@ -16787,14 +16787,14 @@ exports[`ConfigProvider components Pagination configProvider componentSize middl
       </button>
     </li>
     <li
-      class="config-pagination-item config-pagination-item-0 config-pagination-disabled config-pagination-item-disabled"
+      class="config-pagination-item config-pagination-item-1 config-pagination-item-disabled"
       tabindex="0"
-      title="0"
+      title="1"
     >
       <a
         rel="nofollow"
       >
-        0
+        1
       </a>
     </li>
     <li
@@ -16939,14 +16939,14 @@ exports[`ConfigProvider components Pagination configProvider componentSize middl
       </button>
     </li>
     <li
-      class="config-pagination-item config-pagination-item-0 config-pagination-disabled config-pagination-item-disabled"
+      class="config-pagination-item config-pagination-item-1 config-pagination-item-disabled"
       tabindex="0"
-      title="0"
+      title="1"
     >
       <a
         rel="nofollow"
       >
-        0
+        1
       </a>
     </li>
     <li
@@ -17096,14 +17096,14 @@ exports[`ConfigProvider components Pagination configProvider virtual and dropdow
       </button>
     </li>
     <li
-      class="ant-pagination-item ant-pagination-item-0 ant-pagination-disabled ant-pagination-item-disabled"
+      class="ant-pagination-item ant-pagination-item-1 ant-pagination-item-disabled"
       tabindex="0"
-      title="0"
+      title="1"
     >
       <a
         rel="nofollow"
       >
-        0
+        1
       </a>
     </li>
     <li
@@ -17248,14 +17248,14 @@ exports[`ConfigProvider components Pagination configProvider virtual and dropdow
       </button>
     </li>
     <li
-      class="ant-pagination-item ant-pagination-item-0 ant-pagination-disabled ant-pagination-item-disabled"
+      class="ant-pagination-item ant-pagination-item-1 ant-pagination-item-disabled"
       tabindex="0"
-      title="0"
+      title="1"
     >
       <a
         rel="nofollow"
       >
-        0
+        1
       </a>
     </li>
     <li
@@ -17405,14 +17405,14 @@ exports[`ConfigProvider components Pagination normal 1`] = `
       </button>
     </li>
     <li
-      class="ant-pagination-item ant-pagination-item-0 ant-pagination-disabled ant-pagination-item-disabled"
+      class="ant-pagination-item ant-pagination-item-1 ant-pagination-item-disabled"
       tabindex="0"
-      title="0"
+      title="1"
     >
       <a
         rel="nofollow"
       >
-        0
+        1
       </a>
     </li>
     <li
@@ -17557,14 +17557,14 @@ exports[`ConfigProvider components Pagination normal 1`] = `
       </button>
     </li>
     <li
-      class="ant-pagination-item ant-pagination-item-0 ant-pagination-disabled ant-pagination-item-disabled"
+      class="ant-pagination-item ant-pagination-item-1 ant-pagination-item-disabled"
       tabindex="0"
-      title="0"
+      title="1"
     >
       <a
         rel="nofollow"
       >
-        0
+        1
       </a>
     </li>
     <li
@@ -17714,14 +17714,14 @@ exports[`ConfigProvider components Pagination prefixCls 1`] = `
       </button>
     </li>
     <li
-      class="prefix-Pagination-item prefix-Pagination-item-0 prefix-Pagination-disabled prefix-Pagination-item-disabled"
+      class="prefix-Pagination-item prefix-Pagination-item-1 prefix-Pagination-item-disabled"
       tabindex="0"
-      title="0"
+      title="1"
     >
       <a
         rel="nofollow"
       >
-        0
+        1
       </a>
     </li>
     <li
@@ -17866,14 +17866,14 @@ exports[`ConfigProvider components Pagination prefixCls 1`] = `
       </button>
     </li>
     <li
-      class="prefix-Pagination-item prefix-Pagination-item-0 prefix-Pagination-disabled prefix-Pagination-item-disabled"
+      class="prefix-Pagination-item prefix-Pagination-item-1 prefix-Pagination-item-disabled"
       tabindex="0"
-      title="0"
+      title="1"
     >
       <a
         rel="nofollow"
       >
-        0
+        1
       </a>
     </li>
     <li

--- a/components/pagination/__tests__/__snapshots__/index.test.js.snap
+++ b/components/pagination/__tests__/__snapshots__/index.test.js.snap
@@ -38,14 +38,14 @@ exports[`Pagination rtl render component should be rendered correctly in RTL dir
     </button>
   </li>
   <li
-    class="ant-pagination-item ant-pagination-item-0 ant-pagination-disabled ant-pagination-item-disabled"
+    class="ant-pagination-item ant-pagination-item-1 ant-pagination-item-disabled"
     tabindex="0"
-    title="0"
+    title="1"
   >
     <a
       rel="nofollow"
     >
-      0
+      1
     </a>
   </li>
   <li

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "antd",
-  "version": "4.16.10",
+  "version": "4.16.11",
   "description": "An enterprise-class UI design language and React components implementation",
   "title": "Ant Design",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "rc-menu": "~9.0.12",
     "rc-motion": "^2.4.0",
     "rc-notification": "~4.5.7",
-    "rc-pagination": "~3.1.6",
+    "rc-pagination": "~3.1.9",
     "rc-picker": "~2.5.10",
     "rc-progress": "~3.1.0",
     "rc-rate": "~2.9.0",


### PR DESCRIPTION
- 🐞 Fix ConfigProvider rerender unexpectedly when switching some languages. [#31630](https://github.com/ant-design/ant-design/pull/31630) [@Map1en](https://github.com/Map1en)
- 💄 Improve ghost button style rules, no more `!important`. [#31659](https://github.com/ant-design/ant-design/pull/31659)
- 💄 Improve RangePicker range transition style. [#31645](https://github.com/ant-design/ant-design/pull/31645)
- 🤖 Fix Dropdown `destroyPopupOnHide` TypeScript definition missing. [#31700](https://github.com/ant-design/ant-design/pull/31700) [@linxianxi](https://github.com/linxianxi)
- 🤖 Remove useless Omit type which is built-in in TypeScript 3.5+. [#31661](https://github.com/ant-design/ant-design/pull/31661) [@Dreamerryao](https://github.com/Dreamerryao)

---

- 🐞 修复 ConfigProvider 切换国际化时子组件 rerender 的问题。[#31630](https://github.com/ant-design/ant-design/pull/31630) [@Map1en](https://github.com/Map1en)
- 💄 简化 ghost 按钮的样式代码，去掉 `!important` 样式规则。[#31659](https://github.com/ant-design/ant-design/pull/31659)
- 💄 优化 RangePicker 的范围样式的 transition 效果。[#31645](https://github.com/ant-design/ant-design/pull/31645)
- 🤖 修复 Dropdown `destroyPopupOnHide` TypeScript 定义丢失的问题。[#31700](https://github.com/ant-design/ant-design/pull/31700) [@linxianxi](https://github.com/linxianxi)
- 🤖 移除多余的 Omit 类型定义。[#31661](https://github.com/ant-design/ant-design/pull/31661) [@Dreamerryao](https://github.com/Dreamerryao)