### PR TITLE
fix: Input clear icon margin lost bug

### DIFF
--- a/components/affix/__tests__/Affix.test.tsx
+++ b/components/affix/__tests__/Affix.test.tsx
@@ -171,13 +171,13 @@ describe('Affix Render', () => {
       const originLength = getObserverLength();
       const getTarget = () => target;
       affixWrapper = mount(<Affix target={getTarget}>{null}</Affix>);
-      await sleep(50);
+      await sleep(100);
 
       expect(getObserverLength()).toBe(originLength + 1);
       target = null;
       affixWrapper.setProps({});
       affixWrapper.update();
-      await sleep(50);
+      await sleep(100);
       expect(getObserverLength()).toBe(originLength);
     });
   });

--- a/components/form/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/form/__tests__/__snapshots__/demo.test.js.snap
@@ -7647,7 +7647,7 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
             >
               <span
                 aria-label="close-circle"
-                class="anticon anticon-close-circle ant-input-clear-icon-hidden ant-input-clear-icon"
+                class="anticon anticon-close-circle ant-input-clear-icon-hidden ant-input-clear-icon-has-suffix ant-input-clear-icon"
                 role="button"
                 tabindex="-1"
               >

--- a/components/input/ClearableLabeledInput.tsx
+++ b/components/input/ClearableLabeledInput.tsx
@@ -56,7 +56,7 @@ class ClearableLabeledInput extends React.Component<ClearableInputProps> {
   };
 
   renderClearIcon(prefixCls: string) {
-    const { allowClear, value, disabled, readOnly, handleReset } = this.props;
+    const { allowClear, value, disabled, readOnly, handleReset, suffix } = this.props;
     if (!allowClear) {
       return null;
     }
@@ -71,6 +71,7 @@ class ClearableLabeledInput extends React.Component<ClearableInputProps> {
         className={classNames(
           {
             [`${className}-hidden`]: !needClear,
+            [`${className}-has-suffix`]: !!suffix,
           },
           className,
         )}

--- a/components/input/style/allow-clear.less
+++ b/components/input/style/allow-clear.less
@@ -2,7 +2,7 @@
 
 // ========================= Input =========================
 .@{iconfont-css-prefix}.@{ant-prefix}-input-clear-icon {
-  margin: 0 @input-affix-margin;
+  margin: 0;
   color: @disabled-color;
   font-size: @font-size-sm;
   vertical-align: -1px;
@@ -23,8 +23,8 @@
     visibility: hidden;
   }
 
-  &:last-child {
-    margin-right: 0;
+  &-has-suffix {
+    margin: 0 @input-affix-margin;
   }
 }
 

--- a/components/input/style/rtl.less
+++ b/components/input/style/rtl.less
@@ -47,10 +47,10 @@
 
 // allow-clear
 .@{ant-prefix}-input-clear-icon {
-  &:last-child {
+  &-has-suffix {
     .@{ant-prefix}-input-affix-wrapper-rtl & {
-      margin-right: @input-affix-margin;
-      margin-left: 0;
+      margin-right: 0;
+      margin-left: @input-affix-margin;
     }
   }
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close #31741

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fix Input clear icon margin missing with `suffix`.         |
| 🇨🇳 Chinese | 修复 Input 清除图标和 `suffix` 之间边距丢失的问题。  |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
