### PR TITLE
fix: Form label hide title on help icon and optional text

### DIFF
--- a/components/config-provider/__tests__/__snapshots__/form.test.js.snap
+++ b/components/config-provider/__tests__/__snapshots__/form.test.js.snap
@@ -18,6 +18,7 @@ exports[`ConfigProvider.Form form requiredMark set requiredMark optional 1`] = `
         年龄
         <span
           class="ant-form-item-optional"
+          title=""
         >
           (optional)
         </span>

--- a/components/form/FormItemLabel.tsx
+++ b/components/form/FormItemLabel.tsx
@@ -88,7 +88,7 @@ const FormItemLabel: React.FC<FormItemLabelProps & { required?: boolean; prefixC
           const { icon = <QuestionCircleOutlined />, ...restTooltipProps } = tooltipProps;
           const tooltipNode = (
             <Tooltip {...restTooltipProps}>
-              {React.cloneElement(icon, { className: `${prefixCls}-item-tooltip` })}
+              {React.cloneElement(icon, { className: `${prefixCls}-item-tooltip`, title: '' })}
             </Tooltip>
           );
 
@@ -105,7 +105,7 @@ const FormItemLabel: React.FC<FormItemLabelProps & { required?: boolean; prefixC
           labelChildren = (
             <>
               {labelChildren}
-              <span className={`${prefixCls}-item-optional`}>
+              <span className={`${prefixCls}-item-optional`} title="">
                 {formLocale?.optional || defaultLocale.Form?.optional}
               </span>
             </>

--- a/components/form/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/form/__tests__/__snapshots__/demo.test.js.snap
@@ -3244,6 +3244,7 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
           aria-label="question-circle"
           class="anticon anticon-question-circle ant-form-item-tooltip"
           role="img"
+          title=""
         >
           <svg
             aria-hidden="true"
@@ -3763,6 +3764,7 @@ exports[`renders ./components/form/demo/required-mark.md correctly 1`] = `
         Required Mark
         <span
           class="ant-form-item-optional"
+          title=""
         >
           (optional)
         </span>
@@ -3859,6 +3861,7 @@ exports[`renders ./components/form/demo/required-mark.md correctly 1`] = `
           aria-label="question-circle"
           class="anticon anticon-question-circle ant-form-item-tooltip"
           role="img"
+          title=""
         >
           <svg
             aria-hidden="true"
@@ -3913,6 +3916,7 @@ exports[`renders ./components/form/demo/required-mark.md correctly 1`] = `
           aria-label="info-circle"
           class="anticon anticon-info-circle ant-form-item-tooltip"
           role="img"
+          title=""
         >
           <svg
             aria-hidden="true"
@@ -3933,6 +3937,7 @@ exports[`renders ./components/form/demo/required-mark.md correctly 1`] = `
         </span>
         <span
           class="ant-form-item-optional"
+          title=""
         >
           (optional)
         </span>


### PR DESCRIPTION


<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close #31769

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fix Form shows `title` on help icon and optional text.         |
| 🇨🇳 Chinese | 修复 Form 帮助图标和可选文案上有 `title` 提示的问题。    |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
