### PR TITLE
fix: circular dependencies in Modal & Input

### DIFF
--- a/components/input/ClearableLabeledInput.tsx
+++ b/components/input/ClearableLabeledInput.tsx
@@ -2,16 +2,13 @@ import * as React from 'react';
 import classNames from 'classnames';
 import CloseCircleFilled from '@ant-design/icons/CloseCircleFilled';
 import { tuple } from '../_util/type';
-import { InputProps, getInputClassName } from './Input';
+import type { InputProps } from './Input';
 import { DirectionType } from '../config-provider';
 import { SizeType } from '../config-provider/SizeContext';
 import { cloneElement } from '../_util/reactNode';
+import { getInputClassName, hasPrefixSuffix } from './utils';
 
 const ClearableInputType = tuple('text', 'input');
-
-export function hasPrefixSuffix(props: InputProps | ClearableInputProps) {
-  return !!(props.prefix || props.suffix || props.allowClear);
-}
 
 function hasAddon(props: InputProps | ClearableInputProps) {
   return !!(props.addonBefore || props.addonAfter);
@@ -35,7 +32,7 @@ interface BasicProps {
 }
 
 /** This props only for input. */
-interface ClearableInputProps extends BasicProps {
+export interface ClearableInputProps extends BasicProps {
   size?: SizeType;
   suffix?: React.ReactNode;
   prefix?: React.ReactNode;

--- a/components/input/Input.tsx
+++ b/components/input/Input.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
 import classNames from 'classnames';
 import omit from 'rc-util/lib/omit';
-import Group from './Group';
-import Search from './Search';
-import TextArea from './TextArea';
-import Password from './Password';
+import type Group from './Group';
+import type Search from './Search';
+import type TextArea from './TextArea';
+import type Password from './Password';
 import { LiteralUnion } from '../_util/type';
 import ClearableLabeledInput from './ClearableLabeledInput';
 import { ConfigConsumer, ConfigConsumerProps, DirectionType } from '../config-provider';

--- a/components/input/Input.tsx
+++ b/components/input/Input.tsx
@@ -6,10 +6,11 @@ import Search from './Search';
 import TextArea from './TextArea';
 import Password from './Password';
 import { LiteralUnion } from '../_util/type';
-import ClearableLabeledInput, { hasPrefixSuffix } from './ClearableLabeledInput';
+import ClearableLabeledInput from './ClearableLabeledInput';
 import { ConfigConsumer, ConfigConsumerProps, DirectionType } from '../config-provider';
 import SizeContext, { SizeType } from '../config-provider/SizeContext';
 import devWarning from '../_util/devWarning';
+import { getInputClassName, hasPrefixSuffix } from './utils';
 
 export interface InputFocusOptions extends FocusOptions {
   cursor?: 'start' | 'end' | 'all';
@@ -100,22 +101,6 @@ export function resolveOnChange<E extends HTMLInputElement | HTMLTextAreaElement
     return;
   }
   onChange(event as React.ChangeEvent<E>);
-}
-
-export function getInputClassName(
-  prefixCls: string,
-  bordered: boolean,
-  size?: SizeType,
-  disabled?: boolean,
-  direction?: DirectionType,
-) {
-  return classNames(prefixCls, {
-    [`${prefixCls}-sm`]: size === 'small',
-    [`${prefixCls}-lg`]: size === 'large',
-    [`${prefixCls}-disabled`]: disabled,
-    [`${prefixCls}-rtl`]: direction === 'rtl',
-    [`${prefixCls}-borderless`]: !bordered,
-  });
 }
 
 export function triggerFocus(

--- a/components/input/utils.ts
+++ b/components/input/utils.ts
@@ -1,8 +1,8 @@
 import classNames from 'classnames';
-import { DirectionType } from '../config-provider';
-import { SizeType } from '../config-provider/SizeContext';
-import { ClearableInputProps } from './ClearableLabeledInput';
-import { InputProps } from './Input';
+import type { DirectionType } from '../config-provider';
+import type { SizeType } from '../config-provider/SizeContext';
+import type { ClearableInputProps } from './ClearableLabeledInput';
+import type { InputProps } from './Input';
 
 export function getInputClassName(
   prefixCls: string,

--- a/components/input/utils.ts
+++ b/components/input/utils.ts
@@ -1,0 +1,25 @@
+import classNames from 'classnames';
+import { DirectionType } from '../config-provider';
+import { SizeType } from '../config-provider/SizeContext';
+import { ClearableInputProps } from './ClearableLabeledInput';
+import { InputProps } from './Input';
+
+export function getInputClassName(
+  prefixCls: string,
+  bordered: boolean,
+  size?: SizeType,
+  disabled?: boolean,
+  direction?: DirectionType,
+) {
+  return classNames(prefixCls, {
+    [`${prefixCls}-sm`]: size === 'small',
+    [`${prefixCls}-lg`]: size === 'large',
+    [`${prefixCls}-disabled`]: disabled,
+    [`${prefixCls}-rtl`]: direction === 'rtl',
+    [`${prefixCls}-borderless`]: !bordered,
+  });
+}
+
+export function hasPrefixSuffix(props: InputProps | ClearableInputProps) {
+  return !!(props.prefix || props.suffix || props.allowClear);
+}

--- a/components/modal/Modal.tsx
+++ b/components/modal/Modal.tsx
@@ -3,7 +3,6 @@ import Dialog from 'rc-dialog';
 import classNames from 'classnames';
 import CloseOutlined from '@ant-design/icons/CloseOutlined';
 
-import useModal from './useModal';
 import { getConfirmLocale } from './locale';
 import Button from '../button';
 import { LegacyButtonType, ButtonProps, convertLegacyProps } from '../button/button';
@@ -13,7 +12,6 @@ import { canUseDocElement } from '../_util/styleChecker';
 import { getTransitionName } from '../_util/motion';
 
 let mousePosition: { x: number; y: number } | null;
-export const destroyFns: Array<() => void> = [];
 
 // ref: https://github.com/ant-design/ant-design/issues/15795
 const getClickPosition = (e: MouseEvent) => {
@@ -131,11 +129,7 @@ export interface ModalLocale {
   justOkText: string;
 }
 
-interface ModalInterface extends React.FC<ModalProps> {
-  useModal: typeof useModal;
-}
-
-const Modal: ModalInterface = props => {
+const Modal: React.FC<ModalProps> = props => {
   const {
     getPopupContainer: getContextPopupContainer,
     getPrefixCls,
@@ -221,8 +215,6 @@ const Modal: ModalInterface = props => {
     />
   );
 };
-
-Modal.useModal = useModal;
 
 Modal.defaultProps = {
   width: 520,

--- a/components/modal/__tests__/confirm.test.js
+++ b/components/modal/__tests__/confirm.test.js
@@ -4,7 +4,7 @@ import { genCSSMotion } from 'rc-motion/lib/CSSMotion';
 import KeyCode from 'rc-util/lib/KeyCode';
 import { resetWarned } from 'rc-util/lib/warning';
 import Modal from '..';
-import { destroyFns } from '../Modal';
+import destroyFns from '../destroyFns';
 import { sleep } from '../../../tests/utils';
 import ConfigProvider from '../../config-provider';
 

--- a/components/modal/confirm.tsx
+++ b/components/modal/confirm.tsx
@@ -5,10 +5,11 @@ import CheckCircleOutlined from '@ant-design/icons/CheckCircleOutlined';
 import CloseCircleOutlined from '@ant-design/icons/CloseCircleOutlined';
 import ExclamationCircleOutlined from '@ant-design/icons/ExclamationCircleOutlined';
 import { getConfirmLocale } from './locale';
-import { ModalFuncProps, destroyFns } from './Modal';
+import type { ModalFuncProps } from './Modal';
 import ConfirmDialog from './ConfirmDialog';
 import { globalConfig } from '../config-provider';
 import devWarning from '../_util/devWarning';
+import destroyFns from './destroyFns';
 
 let defaultRootPrefixCls = '';
 
@@ -18,9 +19,7 @@ function getRootPrefixCls() {
 
 type ConfigUpdate = ModalFuncProps | ((prevConfig: ModalFuncProps) => ModalFuncProps);
 
-export type ModalFunc = (
-  props: ModalFuncProps,
-) => {
+export type ModalFunc = (props: ModalFuncProps) => {
   destroy: () => void;
   update: (configUpdate: ConfigUpdate) => void;
 };

--- a/components/modal/destroyFns.ts
+++ b/components/modal/destroyFns.ts
@@ -1,0 +1,2 @@
+const destroyFns: Array<() => void> = [];
+export default destroyFns;

--- a/components/modal/index.tsx
+++ b/components/modal/index.tsx
@@ -1,4 +1,4 @@
-import OriginModal, { ModalFuncProps, destroyFns } from './Modal';
+import OriginModal, { ModalFuncProps } from './Modal';
 import confirm, {
   withWarn,
   withInfo,
@@ -8,6 +8,8 @@ import confirm, {
   ModalStaticFunctions,
   modalGlobalConfig,
 } from './confirm';
+import useModal from './useModal';
+import destroyFns from './destroyFns';
 
 export { ActionButtonProps } from './ActionButton';
 export { ModalProps, ModalFuncProps } from './Modal';
@@ -17,9 +19,15 @@ function modalWarn(props: ModalFuncProps) {
 }
 
 type ModalType = typeof OriginModal &
-  ModalStaticFunctions & { destroyAll: () => void; config: typeof modalGlobalConfig };
+  ModalStaticFunctions & {
+    useModal: typeof useModal;
+    destroyAll: () => void;
+    config: typeof modalGlobalConfig;
+  };
 
 const Modal = OriginModal as ModalType;
+
+Modal.useModal = useModal;
 
 Modal.info = function infoFn(props: ModalFuncProps) {
   return confirm(withInfo(props));


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

Partially fixed #27209 

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

Resolved circular dependencies by moving part of exports to separate file.

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix circular dependencies in Modal and Input. No potential break changes. |
| 🇨🇳 Chinese | 修复 Modal 和 Input 组件中的循环依赖 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
