### PR TITLE
fix: Collapse crashing of hot-reload on change

### DIFF
--- a/components/_util/motion.tsx
+++ b/components/_util/motion.tsx
@@ -4,7 +4,7 @@ import { MotionEvent } from 'rc-motion/lib/interface';
 // ================== Collapse Motion ==================
 const getCollapsedHeight: MotionEventHandler = () => ({ height: 0, opacity: 0 });
 const getRealHeight: MotionEventHandler = node => ({ height: node.scrollHeight, opacity: 1 });
-const getCurrentHeight: MotionEventHandler = node => ({ height: node.offsetHeight });
+const getCurrentHeight: MotionEventHandler = node => ({ height: node ? node.offsetHeight : 0 });
 const skipOpacityTransition: MotionEndEventHandler = (_, event: MotionEvent) =>
   event?.deadline === true || (event as TransitionEvent).propertyName === 'height';
 


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close #29918

### 💡 Background and solution

An error occurs when using the collapse panel in combination with hot-reload in the motion util. 

I do not have a clear idea why this happens, maybe because hot-reload changes the dom before the transition can complete? I simply fixed it by first checking if the node exists. 

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Check first if collapse node exists before getting height, and if it does not, treat it as 0 |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
