### PR TITLE
fix: Form label ellipsis should work

### DIFF
--- a/components/form/demo/label-debug.md
+++ b/components/form/demo/label-debug.md
@@ -1,0 +1,47 @@
+---
+order: 100
+title:
+  zh-CN: 测试 label 省略
+  en-US: label ellipsis
+debug: true
+---
+
+## zh-CN
+
+`label` 中使用 `<Typography.Text ellipsis>` 时应该显示 `...`。
+
+## en-US
+
+Use `<Typography.Text ellipsis>` in label should show `...`.
+
+```tsx
+import { Form, Input, Typography } from 'antd';
+
+const Demo = () => (
+  <Form name="label-ellipsis" labelCol={{ span: 8 }} wrapperCol={{ span: 16 }}>
+    <Form.Item
+      label={
+        <Typography.Text ellipsis>
+          longtextlongtextlongtextlongtextlongtextlongtextlongtext
+        </Typography.Text>
+      }
+      name="username"
+    >
+      <Input />
+    </Form.Item>
+
+    <Form.Item
+      label={
+        <Typography.Text ellipsis>
+          longtext longtext longtext longtext longtext longtext longtext
+        </Typography.Text>
+      }
+      name="password"
+    >
+      <Input.Password />
+    </Form.Item>
+  </Form>
+);
+
+ReactDOM.render(<Demo />, mountNode);
+```

--- a/components/form/style/index.less
+++ b/components/form/style/index.less
@@ -89,9 +89,9 @@
 
     > label {
       position: relative;
-      // display: inline;
       display: inline-flex;
       align-items: center;
+      max-width: 100%;
       height: @form-item-label-height;
       color: @label-color;
       font-size: @form-item-label-font-size;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

```jsx
    <Form.Item
      label={
        <Typography.Text ellipsis>
          longtext longtext longtext longtext longtext longtext longtext
        </Typography.Text>
      }
      name="password"
    >
      <Input.Password />
    </Form.Item>
```

| ❌ | ✅ |
| --- | --- |
| <img width="644" alt="图片" src="https://user-images.githubusercontent.com/507615/129883784-48493b2c-629a-4c51-b9da-58fd33153f0c.png"> | <img width="657" alt="图片" src="https://user-images.githubusercontent.com/507615/129883521-5f3cd829-89ad-4aa5-bd87-f090f5dbf83d.png"> |

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fix Form `label` and `<Typography.Text ellipsis />` don't work together.         |
| 🇨🇳 Chinese |  修复 Form `label` 中使用 `<Typography.Text ellipsis />` 时省略不生效的问题。         |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
