### PR TITLE
chore: add theme color meta

### DIFF
--- a/site/theme/static/template.html
+++ b/site/theme/static/template.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#1890ff" />
     <title>{% if title %}{{ title | safe }}{% else %}{% endif %}</title>
     {% if meta %}{{ meta | safe }}{% endif %}
     <link
@@ -23,6 +24,13 @@
     <script src="https://b.alicdn.com/s/polyfill.min.js?features=default,es2015,Intl"></script>
     <link id="darkThemeLink" rel="stylesheet" href="/dark.css" />
     <script>
+      /* 设置 meta theme-color 的值，默认会设置一个 #1890ff   */
+      function setColor(isDarken) {
+        try {
+          const theme = document.getElementsByTagName('meta')['theme-color'];
+          theme.setAttribute('content', isDarken ? 'rgba(0,0,0,0.65)' : '#1890ff');
+        } catch (error) {}
+      }
       /* -------------------------- 主题相关 -------------------------- */
       (function () {
         /* 获取查询参数对象 */
@@ -58,7 +66,7 @@
           );
           // load后卸载
           window.addEventListener('load', () => darkThemeLinkEl.remove(), { once: true });
-
+          setColor(true);
           // 清除dark.css中的全部transition 待解析完后恢复
           var styleElement = document.createElement('style');
           styleElement.type = 'text/css';
@@ -71,6 +79,7 @@
           // 设置系统主题
           document.documentElement.style.colorScheme = 'dark';
         } else {
+          setColor(false);
           document.documentElement.style.colorScheme = 'light';
           darkThemeLinkEl.remove();
         }

--- a/site/theme/template/Content/MainContent.jsx
+++ b/site/theme/template/Content/MainContent.jsx
@@ -320,9 +320,13 @@ class MainContent extends Component {
       setTheme(theme);
       if (theme === 'default') {
         document.documentElement.style.colorScheme = 'light';
+        setColor(false);
         delete query.theme;
       } else {
-        if (theme === 'dark') document.documentElement.style.colorScheme = 'dark';
+        if (theme === 'dark') {
+          document.documentElement.style.colorScheme = 'dark';
+          setColor(true);
+        }
         query.theme = theme;
       }
       browserHistory.push({


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

新特性请提交至 feature 分支，其余可提交至 master 分支。
在维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

[[English Template / 英文模板](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE.md)]

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [x] 其他改动（是关于什么的改动？）


### 📝 更新日志

新版的 safari 浏览器加个meta 就可以配置顶栏的颜色

<img width="1552" alt="lALPDgtYx8YxBIvNB6TNDCA_3104_1956" src="https://user-images.githubusercontent.com/8186664/130350060-0af5edd0-79f9-41bf-be39-99d84231d03d.png">

<img width="1552" alt="lALPDhmOwllQr0jNB6TNDCA_3104_1956" src="https://user-images.githubusercontent.com/8186664/130350081-7e14b8f3-c21d-4cb3-8a7c-025c58a00d9b.png">


⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
