### PR TITLE
feat(tree):add replaceFields to map title,key and children fields

### DIFF
--- a/components/tree/Tree.tsx
+++ b/components/tree/Tree.tsx
@@ -8,6 +8,7 @@ import { ConfigContext } from '../config-provider';
 import collapseMotion from '../_util/motion';
 import renderSwitcherIcon from './utils/iconUtil';
 import dropIndicatorRender from './utils/dropIndicator';
+import { updateTreeData } from './utils/updateTreeData';
 
 export interface AntdTreeNodeAttribute {
   eventKey: string;
@@ -134,6 +135,7 @@ export interface TreeProps extends Omit<RcTreeProps, 'prefixCls' | 'showLine' | 
   prefixCls?: string;
   children?: React.ReactNode;
   blockNode?: boolean;
+  replaceFields?: { key?: string; children?: string; title?: string } | undefined;
 }
 
 interface CompoundedComponent
@@ -154,10 +156,22 @@ const Tree = React.forwardRef<RcTree, TreeProps>((props, ref) => {
     children,
     checkable,
     selectable,
+    replaceFields,
+    treeData,
   } = props;
   const prefixCls = getPrefixCls('tree', customizePrefixCls);
+  let newTreeData: DataNode[] = [];
+  if (
+    treeData !== undefined &&
+    ((replaceFields?.key !== undefined && replaceFields?.key !== 'key') ||
+      (replaceFields?.children !== undefined && replaceFields?.children !== 'children') ||
+      (replaceFields?.title !== undefined && replaceFields?.title !== 'title'))
+  ) {
+    newTreeData = updateTreeData(treeData, replaceFields);
+  }
   const newProps = {
     ...props,
+    treeData: newTreeData.length === 0 ? treeData : newTreeData,
     showLine: Boolean(showLine),
     dropIndicatorRender,
   };

--- a/components/tree/index.en-US.md
+++ b/components/tree/index.en-US.md
@@ -44,6 +44,7 @@ Almost anything can be represented in a tree structure. Examples include directo
 | switcherIcon | Customize collapse/expand icon of tree node | ReactNode | - |  |
 | titleRender | Customize tree node title render | (nodeData) => ReactNode | - | 4.5.0 |
 | treeData | The treeNodes data Array, if set it then you need not to construct children TreeNode. (key should be unique across the whole array) | array&lt;{ key, title, children, \[disabled, selectable] }> | - |  |
+| replaceFields | Replace the title,key and children fields in treeNode with the corresponding fields in treeData | object | {children:'children', title:'title', key:'key' } |  |
 | treeLoadedKeys | (Controlled) Set loaded tree nodes, work with `loadData` only | string[] | [] |  |
 | virtual | Disable virtual scroll when set to false | boolean | true | 4.1.0 |
 | onCheck | Callback function for when the onCheck event occurs | function(checkedKeys, e:{checked: bool, checkedNodes, node, event, halfCheckedKeys}) | - |  |

--- a/components/tree/index.zh-CN.md
+++ b/components/tree/index.zh-CN.md
@@ -45,6 +45,7 @@ cover: https://gw.alipayobjects.com/zos/alicdn/Xh-oWqg9k/Tree.svg
 | switcherIcon | 自定义树节点的展开/折叠图标 | ReactNode | - |  |
 | titleRender | 自定义渲染节点 | (nodeData) => ReactNode | - | 4.5.0 |
 | treeData | treeNodes 数据，如果设置则不需要手动构造 TreeNode 节点（key 在整个树范围内唯一） | array&lt;{key, title, children, \[disabled, selectable]}> | - |  |
+| replaceFields | 替换 treeNode 中 title,key,children 字段为 treeData 中对应的字段 | object | {children:'children', title:'title', key:'key' } |  |
 | treeLoadedKeys | （受控）已经加载的节点，需要配合 `loadData` 使用 | string[] | [] |  |
 | virtual | 设置 false 时关闭虚拟滚动 | boolean | true | 4.1.0 |
 | onCheck | 点击复选框触发 | function(checkedKeys, e:{checked: bool, checkedNodes, node, event, halfCheckedKeys}) | - |  |

--- a/components/tree/utils/updateTreeData.ts
+++ b/components/tree/utils/updateTreeData.ts
@@ -1,0 +1,22 @@
+import { DataNode } from 'rc-tree/lib/interface';
+
+export function updateTreeData(treeData: DataNode[], replaceField = {}) {
+  let newTreeData: DataNode[] = treeData;
+  const defaultFields = { children: 'children', title: 'title', key: 'key' };
+  const replaceFields = { ...defaultFields, ...replaceField };
+  newTreeData = newTreeData.map((item: { [x: string]: any; title?: any }) => {
+    const key = item['key'];
+    const children = item[replaceFields.children];
+    const { ...restProps } = item;
+    const treeNodeProps = {
+      ...restProps,
+      title: item.title || restProps[replaceFields.title],
+      key,
+    };
+    if (children) {
+      return { ...treeNodeProps, children: updateTreeData(children, replaceField) };
+    }
+    return treeNodeProps;
+  });
+  return newTreeData;
+}


### PR DESCRIPTION
[[English Template / 英文模板](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE.md)]

### 🤔 这个变动的性质是？

- [x] 新特性提交
- [ ] 日常 bug 修复
- [x] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [x] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue
[Tree 中TreeNode从treeData取值，没办法配置相应的key及title对应的取值字段](https://github.com/ant-design/ant-design/issues/24282)
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
1. Tree 中TreeNode从treeData取值，没办法配置相应的key及title对应的取值字段
2. 增加replaceFields字段替换 treeNode 中 title,key,children 字段为 treeData 中对应的字段


### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |     add `replaceFields` to map   title,key,children fields   |
| 🇨🇳 中文 |     增加replaceFields字段替换 treeNode 中 title,key,children 字段为 treeData 中对应的字段     |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供