### PR TITLE
feat: sync rc-drawer autoFocus prop into ant-design Drawer

### DIFF
--- a/components/drawer/index.en-US.md
+++ b/components/drawer/index.en-US.md
@@ -20,6 +20,7 @@ A Drawer is a panel that is typically overlaid on top of a page and slides in fr
 
 | Props | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
+| autoFocus | Whether Drawer should get focused after open | boolean | true | 4.17.0+ |
 | afterVisibleChange | Callback after the animation ends when switching drawers | function(visible) | - |  |
 | bodyStyle | Style of the drawer content part | object | - |  |
 | className | The class name of the container of the Drawer dialog | string | - |  |

--- a/components/drawer/index.tsx
+++ b/components/drawer/index.tsx
@@ -27,6 +27,7 @@ export interface PushState {
   distance: string | number;
 }
 export interface DrawerProps {
+  autoFocus?: boolean;
   closable?: boolean;
   closeIcon?: React.ReactNode;
   destroyOnClose?: boolean;

--- a/components/drawer/index.zh-CN.md
+++ b/components/drawer/index.zh-CN.md
@@ -19,6 +19,7 @@ cover: https://gw.alipayobjects.com/zos/alicdn/7z8NJQhFb/Drawer.svg
 
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
+| autoFocus | 抽屉展开后是否将焦点切换至其 Dom 节点 | boolean | true | 4.17.0 |
 | afterVisibleChange | 切换抽屉时动画结束后的回调 | function(visible) | - |  |
 | bodyStyle | 可用于设置 Drawer 内容部分的样式 | CSSProperties | - |  |
 | className | 对话框外层容器的类名 | string | - |  |

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "rc-checkbox": "~2.3.0",
     "rc-collapse": "~3.1.0",
     "rc-dialog": "~8.6.0",
-    "rc-drawer": "~4.3.0",
+    "rc-drawer": "~4.4.2",
     "rc-dropdown": "~3.2.0",
     "rc-field-form": "~1.20.0",
     "rc-image": "~5.2.5",


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->
https://github.com/ant-design/ant-design/issues/28097

### 💡 Background and solution
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->
Bring `autoFocus` prop from rc-drawer into ant-design. 

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Add autoFocus prop to Drawer, in order to control whether Drawer should get focused after open |
| 🇨🇳 Chinese | 为 Drawer 添加 autoFocus 属性，用于控制 Drawer 打开时是否自动获取焦点 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
