### PR TITLE
fix: Table sotring a11y

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -15,6 +15,11 @@ timeline: true
 
 ---
 
+## 4.17.0-alpha.3
+`2021-09-09`
+
+- 🐞 Fix Table sorting a11y. [#32093](https://github.com/ant-design/ant-design/pull/32093)
+
 ## 4.17.0-alpha.2
 
 `2021-09-07`

--- a/components/config-provider/__tests__/__snapshots__/components.test.js.snap
+++ b/components/config-provider/__tests__/__snapshots__/components.test.js.snap
@@ -22945,6 +22945,7 @@ exports[`ConfigProvider components Table configProvider 1`] = `
                 <tr>
                   <th
                     class="config-table-cell config-table-column-has-sorters"
+                    tabindex="0"
                   >
                     <div
                       class="config-table-filter-column"
@@ -22969,8 +22970,7 @@ exports[`ConfigProvider components Table configProvider 1`] = `
                               <span
                                 aria-label="caret-up"
                                 class="anticon anticon-caret-up config-table-column-sorter-up"
-                                role="button"
-                                tabindex="0"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -22989,8 +22989,7 @@ exports[`ConfigProvider components Table configProvider 1`] = `
                               <span
                                 aria-label="caret-down"
                                 class="anticon anticon-caret-down config-table-column-sorter-down"
-                                role="button"
-                                tabindex="0"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -23227,6 +23226,7 @@ exports[`ConfigProvider components Table configProvider componentSize large 1`] 
                 <tr>
                   <th
                     class="config-table-cell config-table-column-has-sorters"
+                    tabindex="0"
                   >
                     <div
                       class="config-table-filter-column"
@@ -23251,8 +23251,7 @@ exports[`ConfigProvider components Table configProvider componentSize large 1`] 
                               <span
                                 aria-label="caret-up"
                                 class="anticon anticon-caret-up config-table-column-sorter-up"
-                                role="button"
-                                tabindex="0"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -23271,8 +23270,7 @@ exports[`ConfigProvider components Table configProvider componentSize large 1`] 
                               <span
                                 aria-label="caret-down"
                                 class="anticon anticon-caret-down config-table-column-sorter-down"
-                                role="button"
-                                tabindex="0"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -23509,6 +23507,7 @@ exports[`ConfigProvider components Table configProvider componentSize middle 1`]
                 <tr>
                   <th
                     class="config-table-cell config-table-column-has-sorters"
+                    tabindex="0"
                   >
                     <div
                       class="config-table-filter-column"
@@ -23533,8 +23532,7 @@ exports[`ConfigProvider components Table configProvider componentSize middle 1`]
                               <span
                                 aria-label="caret-up"
                                 class="anticon anticon-caret-up config-table-column-sorter-up"
-                                role="button"
-                                tabindex="0"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -23553,8 +23551,7 @@ exports[`ConfigProvider components Table configProvider componentSize middle 1`]
                               <span
                                 aria-label="caret-down"
                                 class="anticon anticon-caret-down config-table-column-sorter-down"
-                                role="button"
-                                tabindex="0"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -23791,6 +23788,7 @@ exports[`ConfigProvider components Table configProvider virtual and dropdownMatc
                 <tr>
                   <th
                     class="ant-table-cell ant-table-column-has-sorters"
+                    tabindex="0"
                   >
                     <div
                       class="ant-table-filter-column"
@@ -23815,8 +23813,7 @@ exports[`ConfigProvider components Table configProvider virtual and dropdownMatc
                               <span
                                 aria-label="caret-up"
                                 class="anticon anticon-caret-up ant-table-column-sorter-up"
-                                role="button"
-                                tabindex="0"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -23835,8 +23832,7 @@ exports[`ConfigProvider components Table configProvider virtual and dropdownMatc
                               <span
                                 aria-label="caret-down"
                                 class="anticon anticon-caret-down ant-table-column-sorter-down"
-                                role="button"
-                                tabindex="0"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -24073,6 +24069,7 @@ exports[`ConfigProvider components Table normal 1`] = `
                 <tr>
                   <th
                     class="ant-table-cell ant-table-column-has-sorters"
+                    tabindex="0"
                   >
                     <div
                       class="ant-table-filter-column"
@@ -24097,8 +24094,7 @@ exports[`ConfigProvider components Table normal 1`] = `
                               <span
                                 aria-label="caret-up"
                                 class="anticon anticon-caret-up ant-table-column-sorter-up"
-                                role="button"
-                                tabindex="0"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -24117,8 +24113,7 @@ exports[`ConfigProvider components Table normal 1`] = `
                               <span
                                 aria-label="caret-down"
                                 class="anticon anticon-caret-down ant-table-column-sorter-down"
-                                role="button"
-                                tabindex="0"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -24355,6 +24350,7 @@ exports[`ConfigProvider components Table prefixCls 1`] = `
                 <tr>
                   <th
                     class="prefix-Table-cell prefix-Table-column-has-sorters"
+                    tabindex="0"
                   >
                     <div
                       class="prefix-Table-filter-column"
@@ -24379,8 +24375,7 @@ exports[`ConfigProvider components Table prefixCls 1`] = `
                               <span
                                 aria-label="caret-up"
                                 class="anticon anticon-caret-up prefix-Table-column-sorter-up"
-                                role="button"
-                                tabindex="0"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -24399,8 +24394,7 @@ exports[`ConfigProvider components Table prefixCls 1`] = `
                               <span
                                 aria-label="caret-down"
                                 class="anticon anticon-caret-down prefix-Table-column-sorter-down"
-                                role="button"
-                                tabindex="0"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"

--- a/components/config-provider/__tests__/__snapshots__/components.test.js.snap
+++ b/components/config-provider/__tests__/__snapshots__/components.test.js.snap
@@ -22969,7 +22969,8 @@ exports[`ConfigProvider components Table configProvider 1`] = `
                               <span
                                 aria-label="caret-up"
                                 class="anticon anticon-caret-up config-table-column-sorter-up"
-                                role="img"
+                                role="button"
+                                tabindex="0"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -22988,7 +22989,8 @@ exports[`ConfigProvider components Table configProvider 1`] = `
                               <span
                                 aria-label="caret-down"
                                 class="anticon anticon-caret-down config-table-column-sorter-down"
-                                role="img"
+                                role="button"
+                                tabindex="0"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -23249,7 +23251,8 @@ exports[`ConfigProvider components Table configProvider componentSize large 1`] 
                               <span
                                 aria-label="caret-up"
                                 class="anticon anticon-caret-up config-table-column-sorter-up"
-                                role="img"
+                                role="button"
+                                tabindex="0"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -23268,7 +23271,8 @@ exports[`ConfigProvider components Table configProvider componentSize large 1`] 
                               <span
                                 aria-label="caret-down"
                                 class="anticon anticon-caret-down config-table-column-sorter-down"
-                                role="img"
+                                role="button"
+                                tabindex="0"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -23529,7 +23533,8 @@ exports[`ConfigProvider components Table configProvider componentSize middle 1`]
                               <span
                                 aria-label="caret-up"
                                 class="anticon anticon-caret-up config-table-column-sorter-up"
-                                role="img"
+                                role="button"
+                                tabindex="0"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -23548,7 +23553,8 @@ exports[`ConfigProvider components Table configProvider componentSize middle 1`]
                               <span
                                 aria-label="caret-down"
                                 class="anticon anticon-caret-down config-table-column-sorter-down"
-                                role="img"
+                                role="button"
+                                tabindex="0"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -23809,7 +23815,8 @@ exports[`ConfigProvider components Table configProvider virtual and dropdownMatc
                               <span
                                 aria-label="caret-up"
                                 class="anticon anticon-caret-up ant-table-column-sorter-up"
-                                role="img"
+                                role="button"
+                                tabindex="0"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -23828,7 +23835,8 @@ exports[`ConfigProvider components Table configProvider virtual and dropdownMatc
                               <span
                                 aria-label="caret-down"
                                 class="anticon anticon-caret-down ant-table-column-sorter-down"
-                                role="img"
+                                role="button"
+                                tabindex="0"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -24089,7 +24097,8 @@ exports[`ConfigProvider components Table normal 1`] = `
                               <span
                                 aria-label="caret-up"
                                 class="anticon anticon-caret-up ant-table-column-sorter-up"
-                                role="img"
+                                role="button"
+                                tabindex="0"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -24108,7 +24117,8 @@ exports[`ConfigProvider components Table normal 1`] = `
                               <span
                                 aria-label="caret-down"
                                 class="anticon anticon-caret-down ant-table-column-sorter-down"
-                                role="img"
+                                role="button"
+                                tabindex="0"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -24369,7 +24379,8 @@ exports[`ConfigProvider components Table prefixCls 1`] = `
                               <span
                                 aria-label="caret-up"
                                 class="anticon anticon-caret-up prefix-Table-column-sorter-up"
-                                role="img"
+                                role="button"
+                                tabindex="0"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -24388,7 +24399,8 @@ exports[`ConfigProvider components Table prefixCls 1`] = `
                               <span
                                 aria-label="caret-down"
                                 class="anticon anticon-caret-down prefix-Table-column-sorter-down"
-                                role="img"
+                                role="button"
+                                tabindex="0"
                               >
                                 <svg
                                   aria-hidden="true"

--- a/components/table/__tests__/__snapshots__/Table.sorter.test.js.snap
+++ b/components/table/__tests__/__snapshots__/Table.sorter.test.js.snap
@@ -7,6 +7,7 @@ exports[`Table.sorter renders sorter icon correctly 1`] = `
   <tr>
     <th
       class="ant-table-cell ant-table-column-has-sorters"
+      tabindex="0"
     >
       <div
         class="ant-table-column-sorters"
@@ -25,8 +26,7 @@ exports[`Table.sorter renders sorter icon correctly 1`] = `
             <span
               aria-label="caret-up"
               class="anticon anticon-caret-up ant-table-column-sorter-up"
-              role="button"
-              tabindex="0"
+              role="img"
             >
               <svg
                 aria-hidden="true"
@@ -45,8 +45,7 @@ exports[`Table.sorter renders sorter icon correctly 1`] = `
             <span
               aria-label="caret-down"
               class="anticon anticon-caret-down ant-table-column-sorter-down"
-              role="button"
-              tabindex="0"
+              role="img"
             >
               <svg
                 aria-hidden="true"
@@ -99,6 +98,7 @@ exports[`Table.sorter should support defaultOrder in Column 1`] = `
                 <tr>
                   <th
                     class="ant-table-cell ant-table-column-sort ant-table-column-has-sorters"
+                    tabindex="0"
                   >
                     <div
                       class="ant-table-column-sorters"
@@ -117,8 +117,7 @@ exports[`Table.sorter should support defaultOrder in Column 1`] = `
                           <span
                             aria-label="caret-up"
                             class="anticon anticon-caret-up ant-table-column-sorter-up active"
-                            role="button"
-                            tabindex="0"
+                            role="img"
                           >
                             <svg
                               aria-hidden="true"
@@ -137,8 +136,7 @@ exports[`Table.sorter should support defaultOrder in Column 1`] = `
                           <span
                             aria-label="caret-down"
                             class="anticon anticon-caret-down ant-table-column-sorter-down"
-                            role="button"
-                            tabindex="0"
+                            role="img"
                           >
                             <svg
                               aria-hidden="true"

--- a/components/table/__tests__/__snapshots__/Table.sorter.test.js.snap
+++ b/components/table/__tests__/__snapshots__/Table.sorter.test.js.snap
@@ -25,7 +25,8 @@ exports[`Table.sorter renders sorter icon correctly 1`] = `
             <span
               aria-label="caret-up"
               class="anticon anticon-caret-up ant-table-column-sorter-up"
-              role="img"
+              role="button"
+              tabindex="0"
             >
               <svg
                 aria-hidden="true"
@@ -44,7 +45,8 @@ exports[`Table.sorter renders sorter icon correctly 1`] = `
             <span
               aria-label="caret-down"
               class="anticon anticon-caret-down ant-table-column-sorter-down"
-              role="img"
+              role="button"
+              tabindex="0"
             >
               <svg
                 aria-hidden="true"
@@ -115,7 +117,8 @@ exports[`Table.sorter should support defaultOrder in Column 1`] = `
                           <span
                             aria-label="caret-up"
                             class="anticon anticon-caret-up ant-table-column-sorter-up active"
-                            role="img"
+                            role="button"
+                            tabindex="0"
                           >
                             <svg
                               aria-hidden="true"
@@ -134,7 +137,8 @@ exports[`Table.sorter should support defaultOrder in Column 1`] = `
                           <span
                             aria-label="caret-down"
                             class="anticon anticon-caret-down ant-table-column-sorter-down"
-                            role="img"
+                            role="button"
+                            tabindex="0"
                           >
                             <svg
                               aria-hidden="true"

--- a/components/table/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/table/__tests__/__snapshots__/demo.test.js.snap
@@ -54,7 +54,8 @@ exports[`renders ./components/table/demo/ajax.md correctly 1`] = `
                           <span
                             aria-label="caret-up"
                             class="anticon anticon-caret-up ant-table-column-sorter-up"
-                            role="img"
+                            role="button"
+                            tabindex="0"
                           >
                             <svg
                               aria-hidden="true"
@@ -73,7 +74,8 @@ exports[`renders ./components/table/demo/ajax.md correctly 1`] = `
                           <span
                             aria-label="caret-down"
                             class="anticon anticon-caret-down ant-table-column-sorter-down"
-                            role="img"
+                            role="button"
+                            tabindex="0"
                           >
                             <svg
                               aria-hidden="true"
@@ -1158,7 +1160,8 @@ exports[`renders ./components/table/demo/custom-filter-panel.md correctly 1`] = 
                               <span
                                 aria-label="caret-up"
                                 class="anticon anticon-caret-up ant-table-column-sorter-up"
-                                role="img"
+                                role="button"
+                                tabindex="0"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -1177,7 +1180,8 @@ exports[`renders ./components/table/demo/custom-filter-panel.md correctly 1`] = 
                               <span
                                 aria-label="caret-down"
                                 class="anticon anticon-caret-down ant-table-column-sorter-down"
-                                role="img"
+                                role="button"
+                                tabindex="0"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -2732,7 +2736,8 @@ Array [
                             <span
                               aria-label="caret-up"
                               class="anticon anticon-caret-up ant-table-column-sorter-up"
-                              role="img"
+                              role="button"
+                              tabindex="0"
                             >
                               <svg
                                 aria-hidden="true"
@@ -2751,7 +2756,8 @@ Array [
                             <span
                               aria-label="caret-down"
                               class="anticon anticon-caret-down ant-table-column-sorter-down"
-                              role="img"
+                              role="button"
+                              tabindex="0"
                             >
                               <svg
                                 aria-hidden="true"
@@ -2829,7 +2835,8 @@ Array [
                             <span
                               aria-label="caret-up"
                               class="anticon anticon-caret-up ant-table-column-sorter-up"
-                              role="img"
+                              role="button"
+                              tabindex="0"
                             >
                               <svg
                                 aria-hidden="true"
@@ -2848,7 +2855,8 @@ Array [
                             <span
                               aria-label="caret-down"
                               class="anticon anticon-caret-down ant-table-column-sorter-down"
-                              role="img"
+                              role="button"
+                              tabindex="0"
                             >
                               <svg
                                 aria-hidden="true"
@@ -5678,7 +5686,8 @@ exports[`renders ./components/table/demo/filter-in-tree.md correctly 1`] = `
                           <span
                             aria-label="caret-up"
                             class="anticon anticon-caret-up ant-table-column-sorter-up"
-                            role="img"
+                            role="button"
+                            tabindex="0"
                           >
                             <svg
                               aria-hidden="true"
@@ -5697,7 +5706,8 @@ exports[`renders ./components/table/demo/filter-in-tree.md correctly 1`] = `
                           <span
                             aria-label="caret-down"
                             class="anticon anticon-caret-down ant-table-column-sorter-down"
-                            role="img"
+                            role="button"
+                            tabindex="0"
                           >
                             <svg
                               aria-hidden="true"
@@ -8870,7 +8880,8 @@ exports[`renders ./components/table/demo/grouping-columns.md correctly 1`] = `
                           <span
                             aria-label="caret-up"
                             class="anticon anticon-caret-up ant-table-column-sorter-up"
-                            role="img"
+                            role="button"
+                            tabindex="0"
                           >
                             <svg
                               aria-hidden="true"
@@ -8889,7 +8900,8 @@ exports[`renders ./components/table/demo/grouping-columns.md correctly 1`] = `
                           <span
                             aria-label="caret-down"
                             class="anticon anticon-caret-down ant-table-column-sorter-down"
-                            role="img"
+                            role="button"
+                            tabindex="0"
                           >
                             <svg
                               aria-hidden="true"
@@ -9838,7 +9850,8 @@ exports[`renders ./components/table/demo/head.md correctly 1`] = `
                               <span
                                 aria-label="caret-down"
                                 class="anticon anticon-caret-down ant-table-column-sorter-down"
-                                role="img"
+                                role="button"
+                                tabindex="0"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -9905,7 +9918,8 @@ exports[`renders ./components/table/demo/head.md correctly 1`] = `
                           <span
                             aria-label="caret-up"
                             class="anticon anticon-caret-up ant-table-column-sorter-up"
-                            role="img"
+                            role="button"
+                            tabindex="0"
                           >
                             <svg
                               aria-hidden="true"
@@ -9924,7 +9938,8 @@ exports[`renders ./components/table/demo/head.md correctly 1`] = `
                           <span
                             aria-label="caret-down"
                             class="anticon anticon-caret-down ant-table-column-sorter-down active"
-                            role="img"
+                            role="button"
+                            tabindex="0"
                           >
                             <svg
                               aria-hidden="true"
@@ -10554,7 +10569,8 @@ exports[`renders ./components/table/demo/multiple-sorter.md correctly 1`] = `
                           <span
                             aria-label="caret-up"
                             class="anticon anticon-caret-up ant-table-column-sorter-up"
-                            role="img"
+                            role="button"
+                            tabindex="0"
                           >
                             <svg
                               aria-hidden="true"
@@ -10573,7 +10589,8 @@ exports[`renders ./components/table/demo/multiple-sorter.md correctly 1`] = `
                           <span
                             aria-label="caret-down"
                             class="anticon anticon-caret-down ant-table-column-sorter-down"
-                            role="img"
+                            role="button"
+                            tabindex="0"
                           >
                             <svg
                               aria-hidden="true"
@@ -10613,7 +10630,8 @@ exports[`renders ./components/table/demo/multiple-sorter.md correctly 1`] = `
                           <span
                             aria-label="caret-up"
                             class="anticon anticon-caret-up ant-table-column-sorter-up"
-                            role="img"
+                            role="button"
+                            tabindex="0"
                           >
                             <svg
                               aria-hidden="true"
@@ -10632,7 +10650,8 @@ exports[`renders ./components/table/demo/multiple-sorter.md correctly 1`] = `
                           <span
                             aria-label="caret-down"
                             class="anticon anticon-caret-down ant-table-column-sorter-down"
-                            role="img"
+                            role="button"
+                            tabindex="0"
                           >
                             <svg
                               aria-hidden="true"
@@ -10672,7 +10691,8 @@ exports[`renders ./components/table/demo/multiple-sorter.md correctly 1`] = `
                           <span
                             aria-label="caret-up"
                             class="anticon anticon-caret-up ant-table-column-sorter-up"
-                            role="img"
+                            role="button"
+                            tabindex="0"
                           >
                             <svg
                               aria-hidden="true"
@@ -10691,7 +10711,8 @@ exports[`renders ./components/table/demo/multiple-sorter.md correctly 1`] = `
                           <span
                             aria-label="caret-down"
                             class="anticon anticon-caret-down ant-table-column-sorter-down"
-                            role="img"
+                            role="button"
+                            tabindex="0"
                           >
                             <svg
                               aria-hidden="true"
@@ -12851,7 +12872,8 @@ Array [
                                 <span
                                   aria-label="caret-up"
                                   class="anticon anticon-caret-up ant-table-column-sorter-up"
-                                  role="img"
+                                  role="button"
+                                  tabindex="0"
                                 >
                                   <svg
                                     aria-hidden="true"
@@ -12870,7 +12892,8 @@ Array [
                                 <span
                                   aria-label="caret-down"
                                   class="anticon anticon-caret-down ant-table-column-sorter-down"
-                                  role="img"
+                                  role="button"
+                                  tabindex="0"
                                 >
                                   <svg
                                     aria-hidden="true"
@@ -12937,7 +12960,8 @@ Array [
                             <span
                               aria-label="caret-up"
                               class="anticon anticon-caret-up ant-table-column-sorter-up"
-                              role="img"
+                              role="button"
+                              tabindex="0"
                             >
                               <svg
                                 aria-hidden="true"
@@ -12956,7 +12980,8 @@ Array [
                             <span
                               aria-label="caret-down"
                               class="anticon anticon-caret-down ant-table-column-sorter-down"
-                              role="img"
+                              role="button"
+                              tabindex="0"
                             >
                               <svg
                                 aria-hidden="true"
@@ -13002,7 +13027,8 @@ Array [
                                 <span
                                   aria-label="caret-up"
                                   class="anticon anticon-caret-up ant-table-column-sorter-up"
-                                  role="img"
+                                  role="button"
+                                  tabindex="0"
                                 >
                                   <svg
                                     aria-hidden="true"
@@ -13021,7 +13047,8 @@ Array [
                                 <span
                                   aria-label="caret-down"
                                   class="anticon anticon-caret-down ant-table-column-sorter-down"
-                                  role="img"
+                                  role="button"
+                                  tabindex="0"
                                 >
                                   <svg
                                     aria-hidden="true"
@@ -13324,7 +13351,8 @@ exports[`renders ./components/table/demo/resizable-column.md correctly 1`] = `
                           <span
                             aria-label="caret-up"
                             class="anticon anticon-caret-up ant-table-column-sorter-up"
-                            role="img"
+                            role="button"
+                            tabindex="0"
                           >
                             <svg
                               aria-hidden="true"
@@ -13343,7 +13371,8 @@ exports[`renders ./components/table/demo/resizable-column.md correctly 1`] = `
                           <span
                             aria-label="caret-down"
                             class="anticon anticon-caret-down ant-table-column-sorter-down"
-                            role="img"
+                            role="button"
+                            tabindex="0"
                           >
                             <svg
                               aria-hidden="true"

--- a/components/table/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/table/__tests__/__snapshots__/demo.test.js.snap
@@ -36,6 +36,7 @@ exports[`renders ./components/table/demo/ajax.md correctly 1`] = `
                 <tr>
                   <th
                     class="ant-table-cell ant-table-column-has-sorters"
+                    tabindex="0"
                   >
                     <div
                       class="ant-table-column-sorters"
@@ -54,8 +55,7 @@ exports[`renders ./components/table/demo/ajax.md correctly 1`] = `
                           <span
                             aria-label="caret-up"
                             class="anticon anticon-caret-up ant-table-column-sorter-up"
-                            role="button"
-                            tabindex="0"
+                            role="img"
                           >
                             <svg
                               aria-hidden="true"
@@ -74,8 +74,7 @@ exports[`renders ./components/table/demo/ajax.md correctly 1`] = `
                           <span
                             aria-label="caret-down"
                             class="anticon anticon-caret-down ant-table-column-sorter-down"
-                            role="button"
-                            tabindex="0"
+                            role="img"
                           >
                             <svg
                               aria-hidden="true"
@@ -1136,6 +1135,7 @@ exports[`renders ./components/table/demo/custom-filter-panel.md correctly 1`] = 
                   </th>
                   <th
                     class="ant-table-cell ant-table-column-has-sorters"
+                    tabindex="0"
                   >
                     <div
                       class="ant-table-filter-column"
@@ -1160,8 +1160,7 @@ exports[`renders ./components/table/demo/custom-filter-panel.md correctly 1`] = 
                               <span
                                 aria-label="caret-up"
                                 class="anticon anticon-caret-up ant-table-column-sorter-up"
-                                role="button"
-                                tabindex="0"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -1180,8 +1179,7 @@ exports[`renders ./components/table/demo/custom-filter-panel.md correctly 1`] = 
                               <span
                                 aria-label="caret-down"
                                 class="anticon anticon-caret-down ant-table-column-sorter-down"
-                                role="button"
-                                tabindex="0"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -2718,6 +2716,7 @@ Array [
                     </th>
                     <th
                       class="ant-table-cell ant-table-column-has-sorters"
+                      tabindex="0"
                     >
                       <div
                         class="ant-table-column-sorters"
@@ -2736,8 +2735,7 @@ Array [
                             <span
                               aria-label="caret-up"
                               class="anticon anticon-caret-up ant-table-column-sorter-up"
-                              role="button"
-                              tabindex="0"
+                              role="img"
                             >
                               <svg
                                 aria-hidden="true"
@@ -2756,8 +2754,7 @@ Array [
                             <span
                               aria-label="caret-down"
                               class="anticon anticon-caret-down ant-table-column-sorter-down"
-                              role="button"
-                              tabindex="0"
+                              role="img"
                             >
                               <svg
                                 aria-hidden="true"
@@ -2817,6 +2814,7 @@ Array [
                     </th>
                     <th
                       class="ant-table-cell ant-table-column-has-sorters"
+                      tabindex="0"
                     >
                       <div
                         class="ant-table-column-sorters"
@@ -2835,8 +2833,7 @@ Array [
                             <span
                               aria-label="caret-up"
                               class="anticon anticon-caret-up ant-table-column-sorter-up"
-                              role="button"
-                              tabindex="0"
+                              role="img"
                             >
                               <svg
                                 aria-hidden="true"
@@ -2855,8 +2852,7 @@ Array [
                             <span
                               aria-label="caret-down"
                               class="anticon anticon-caret-down ant-table-column-sorter-down"
-                              role="button"
-                              tabindex="0"
+                              role="img"
                             >
                               <svg
                                 aria-hidden="true"
@@ -5668,6 +5664,7 @@ exports[`renders ./components/table/demo/filter-in-tree.md correctly 1`] = `
                   </th>
                   <th
                     class="ant-table-cell ant-table-column-has-sorters"
+                    tabindex="0"
                   >
                     <div
                       class="ant-table-column-sorters"
@@ -5686,8 +5683,7 @@ exports[`renders ./components/table/demo/filter-in-tree.md correctly 1`] = `
                           <span
                             aria-label="caret-up"
                             class="anticon anticon-caret-up ant-table-column-sorter-up"
-                            role="button"
-                            tabindex="0"
+                            role="img"
                           >
                             <svg
                               aria-hidden="true"
@@ -5706,8 +5702,7 @@ exports[`renders ./components/table/demo/filter-in-tree.md correctly 1`] = `
                           <span
                             aria-label="caret-down"
                             class="anticon anticon-caret-down ant-table-column-sorter-down"
-                            role="button"
-                            tabindex="0"
+                            role="img"
                           >
                             <svg
                               aria-hidden="true"
@@ -8862,6 +8857,7 @@ exports[`renders ./components/table/demo/grouping-columns.md correctly 1`] = `
                   <th
                     class="ant-table-cell ant-table-column-has-sorters"
                     rowspan="3"
+                    tabindex="0"
                   >
                     <div
                       class="ant-table-column-sorters"
@@ -8880,8 +8876,7 @@ exports[`renders ./components/table/demo/grouping-columns.md correctly 1`] = `
                           <span
                             aria-label="caret-up"
                             class="anticon anticon-caret-up ant-table-column-sorter-up"
-                            role="button"
-                            tabindex="0"
+                            role="img"
                           >
                             <svg
                               aria-hidden="true"
@@ -8900,8 +8895,7 @@ exports[`renders ./components/table/demo/grouping-columns.md correctly 1`] = `
                           <span
                             aria-label="caret-down"
                             class="anticon anticon-caret-down ant-table-column-sorter-down"
-                            role="button"
-                            tabindex="0"
+                            role="img"
                           >
                             <svg
                               aria-hidden="true"
@@ -9826,6 +9820,7 @@ exports[`renders ./components/table/demo/head.md correctly 1`] = `
                 <tr>
                   <th
                     class="ant-table-cell ant-table-column-has-sorters"
+                    tabindex="0"
                   >
                     <div
                       class="ant-table-filter-column"
@@ -9850,8 +9845,7 @@ exports[`renders ./components/table/demo/head.md correctly 1`] = `
                               <span
                                 aria-label="caret-down"
                                 class="anticon anticon-caret-down ant-table-column-sorter-down"
-                                role="button"
-                                tabindex="0"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -9900,6 +9894,7 @@ exports[`renders ./components/table/demo/head.md correctly 1`] = `
                   </th>
                   <th
                     class="ant-table-cell ant-table-column-sort ant-table-column-has-sorters"
+                    tabindex="0"
                   >
                     <div
                       class="ant-table-column-sorters"
@@ -9918,8 +9913,7 @@ exports[`renders ./components/table/demo/head.md correctly 1`] = `
                           <span
                             aria-label="caret-up"
                             class="anticon anticon-caret-up ant-table-column-sorter-up"
-                            role="button"
-                            tabindex="0"
+                            role="img"
                           >
                             <svg
                               aria-hidden="true"
@@ -9938,8 +9932,7 @@ exports[`renders ./components/table/demo/head.md correctly 1`] = `
                           <span
                             aria-label="caret-down"
                             class="anticon anticon-caret-down ant-table-column-sorter-down active"
-                            role="button"
-                            tabindex="0"
+                            role="img"
                           >
                             <svg
                               aria-hidden="true"
@@ -10551,6 +10544,7 @@ exports[`renders ./components/table/demo/multiple-sorter.md correctly 1`] = `
                   </th>
                   <th
                     class="ant-table-cell ant-table-column-has-sorters"
+                    tabindex="0"
                   >
                     <div
                       class="ant-table-column-sorters"
@@ -10569,8 +10563,7 @@ exports[`renders ./components/table/demo/multiple-sorter.md correctly 1`] = `
                           <span
                             aria-label="caret-up"
                             class="anticon anticon-caret-up ant-table-column-sorter-up"
-                            role="button"
-                            tabindex="0"
+                            role="img"
                           >
                             <svg
                               aria-hidden="true"
@@ -10589,8 +10582,7 @@ exports[`renders ./components/table/demo/multiple-sorter.md correctly 1`] = `
                           <span
                             aria-label="caret-down"
                             class="anticon anticon-caret-down ant-table-column-sorter-down"
-                            role="button"
-                            tabindex="0"
+                            role="img"
                           >
                             <svg
                               aria-hidden="true"
@@ -10612,6 +10604,7 @@ exports[`renders ./components/table/demo/multiple-sorter.md correctly 1`] = `
                   </th>
                   <th
                     class="ant-table-cell ant-table-column-has-sorters"
+                    tabindex="0"
                   >
                     <div
                       class="ant-table-column-sorters"
@@ -10630,8 +10623,7 @@ exports[`renders ./components/table/demo/multiple-sorter.md correctly 1`] = `
                           <span
                             aria-label="caret-up"
                             class="anticon anticon-caret-up ant-table-column-sorter-up"
-                            role="button"
-                            tabindex="0"
+                            role="img"
                           >
                             <svg
                               aria-hidden="true"
@@ -10650,8 +10642,7 @@ exports[`renders ./components/table/demo/multiple-sorter.md correctly 1`] = `
                           <span
                             aria-label="caret-down"
                             class="anticon anticon-caret-down ant-table-column-sorter-down"
-                            role="button"
-                            tabindex="0"
+                            role="img"
                           >
                             <svg
                               aria-hidden="true"
@@ -10673,6 +10664,7 @@ exports[`renders ./components/table/demo/multiple-sorter.md correctly 1`] = `
                   </th>
                   <th
                     class="ant-table-cell ant-table-column-has-sorters"
+                    tabindex="0"
                   >
                     <div
                       class="ant-table-column-sorters"
@@ -10691,8 +10683,7 @@ exports[`renders ./components/table/demo/multiple-sorter.md correctly 1`] = `
                           <span
                             aria-label="caret-up"
                             class="anticon anticon-caret-up ant-table-column-sorter-up"
-                            role="button"
-                            tabindex="0"
+                            role="img"
                           >
                             <svg
                               aria-hidden="true"
@@ -10711,8 +10702,7 @@ exports[`renders ./components/table/demo/multiple-sorter.md correctly 1`] = `
                           <span
                             aria-label="caret-down"
                             class="anticon anticon-caret-down ant-table-column-sorter-down"
-                            role="button"
-                            tabindex="0"
+                            role="img"
                           >
                             <svg
                               aria-hidden="true"
@@ -12848,6 +12838,7 @@ Array [
                   <tr>
                     <th
                       class="ant-table-cell ant-table-cell-ellipsis ant-table-column-has-sorters"
+                      tabindex="0"
                     >
                       <div
                         class="ant-table-filter-column"
@@ -12872,8 +12863,7 @@ Array [
                                 <span
                                   aria-label="caret-up"
                                   class="anticon anticon-caret-up ant-table-column-sorter-up"
-                                  role="button"
-                                  tabindex="0"
+                                  role="img"
                                 >
                                   <svg
                                     aria-hidden="true"
@@ -12892,8 +12882,7 @@ Array [
                                 <span
                                   aria-label="caret-down"
                                   class="anticon anticon-caret-down ant-table-column-sorter-down"
-                                  role="button"
-                                  tabindex="0"
+                                  role="img"
                                 >
                                   <svg
                                     aria-hidden="true"
@@ -12942,6 +12931,7 @@ Array [
                     </th>
                     <th
                       class="ant-table-cell ant-table-cell-ellipsis ant-table-column-has-sorters"
+                      tabindex="0"
                     >
                       <div
                         class="ant-table-column-sorters"
@@ -12960,8 +12950,7 @@ Array [
                             <span
                               aria-label="caret-up"
                               class="anticon anticon-caret-up ant-table-column-sorter-up"
-                              role="button"
-                              tabindex="0"
+                              role="img"
                             >
                               <svg
                                 aria-hidden="true"
@@ -12980,8 +12969,7 @@ Array [
                             <span
                               aria-label="caret-down"
                               class="anticon anticon-caret-down ant-table-column-sorter-down"
-                              role="button"
-                              tabindex="0"
+                              role="img"
                             >
                               <svg
                                 aria-hidden="true"
@@ -13003,6 +12991,7 @@ Array [
                     </th>
                     <th
                       class="ant-table-cell ant-table-cell-ellipsis ant-table-column-has-sorters"
+                      tabindex="0"
                     >
                       <div
                         class="ant-table-filter-column"
@@ -13027,8 +13016,7 @@ Array [
                                 <span
                                   aria-label="caret-up"
                                   class="anticon anticon-caret-up ant-table-column-sorter-up"
-                                  role="button"
-                                  tabindex="0"
+                                  role="img"
                                 >
                                   <svg
                                     aria-hidden="true"
@@ -13047,8 +13035,7 @@ Array [
                                 <span
                                   aria-label="caret-down"
                                   class="anticon anticon-caret-down ant-table-column-sorter-down"
-                                  role="button"
-                                  tabindex="0"
+                                  role="img"
                                 >
                                   <svg
                                     aria-hidden="true"
@@ -13333,6 +13320,7 @@ exports[`renders ./components/table/demo/resizable-column.md correctly 1`] = `
                   </th>
                   <th
                     class="ant-table-cell ant-table-column-has-sorters react-resizable"
+                    tabindex="0"
                   >
                     <div
                       class="ant-table-column-sorters"
@@ -13351,8 +13339,7 @@ exports[`renders ./components/table/demo/resizable-column.md correctly 1`] = `
                           <span
                             aria-label="caret-up"
                             class="anticon anticon-caret-up ant-table-column-sorter-up"
-                            role="button"
-                            tabindex="0"
+                            role="img"
                           >
                             <svg
                               aria-hidden="true"
@@ -13371,8 +13358,7 @@ exports[`renders ./components/table/demo/resizable-column.md correctly 1`] = `
                           <span
                             aria-label="caret-down"
                             class="anticon anticon-caret-down ant-table-column-sorter-down"
-                            role="button"
-                            tabindex="0"
+                            role="img"
                           >
                             <svg
                               aria-hidden="true"

--- a/components/table/hooks/useSorter.tsx
+++ b/components/table/hooks/useSorter.tsx
@@ -130,6 +130,8 @@ function injectSorter<RecordType>(
           className={classNames(`${prefixCls}-column-sorter-up`, {
             active: sorterOrder === ASCEND,
           })}
+          tabIndex={0}
+          role="button"
         />
       );
       const downNode: React.ReactNode = sortDirections.includes(DESCEND) && (
@@ -137,6 +139,8 @@ function injectSorter<RecordType>(
           className={classNames(`${prefixCls}-column-sorter-down`, {
             active: sorterOrder === DESCEND,
           })}
+          tabIndex={0}
+          role="button"
         />
       );
       const { cancelSort, triggerAsc, triggerDesc } = tableLocale || {};

--- a/components/table/hooks/useSorter.tsx
+++ b/components/table/hooks/useSorter.tsx
@@ -130,8 +130,6 @@ function injectSorter<RecordType>(
           className={classNames(`${prefixCls}-column-sorter-up`, {
             active: sorterOrder === ASCEND,
           })}
-          tabIndex={0}
-          role="button"
         />
       );
       const downNode: React.ReactNode = sortDirections.includes(DESCEND) && (
@@ -139,8 +137,6 @@ function injectSorter<RecordType>(
           className={classNames(`${prefixCls}-column-sorter-down`, {
             active: sorterOrder === DESCEND,
           })}
-          tabIndex={0}
-          role="button"
         />
       );
       const { cancelSort, triggerAsc, triggerDesc } = tableLocale || {};
@@ -183,6 +179,7 @@ function injectSorter<RecordType>(
           const cell: React.HTMLAttributes<HTMLElement> =
             (column.onHeaderCell && column.onHeaderCell(col)) || {};
           const originOnClick = cell.onClick;
+          const keyboardOnClick = cell.onKeyPress;
           cell.onClick = (event: React.MouseEvent<HTMLElement>) => {
             triggerSorter({
               column,
@@ -195,8 +192,24 @@ function injectSorter<RecordType>(
               originOnClick(event);
             }
           };
+          cell.onKeyPress = (event: React.KeyboardEvent<HTMLElement>) => {
+            const { code } = event;
+            if (code === 'Space') {
+              triggerSorter({
+                column,
+                key: columnKey,
+                sortOrder: nextSortOrder,
+                multiplePriority: getMultiplePriority(column),
+              });
+
+              if (keyboardOnClick) {
+                keyboardOnClick(event);
+              }
+            }
+          };
 
           cell.className = classNames(cell.className, `${prefixCls}-column-has-sorters`);
+          cell.tabIndex = 0;
 
           return cell;
         },


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
close https://github.com/ant-design/ant-design/issues/32092
close #31516
### 💡 Background and solution

Add tabindex 
Add roles button

### 📝 Changelog

Change upNode and downNode

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     #      |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
