### PR TITLE
fix: Use latest rc-picker version with defaultPickerValue/showTime fix

### DIFF
--- a/components/date-picker/__tests__/DatePicker.test.js
+++ b/components/date-picker/__tests__/DatePicker.test.js
@@ -183,4 +183,20 @@ describe('DatePicker', () => {
         .length,
     ).toBe(60);
   });
+
+  it('DatePicker.RangePicker with defaultPickerValue and showTime', () => {
+    const startDate = moment('1982-02-12');
+    const endDate = moment('1982-02-22');
+
+    const wrapper = mount(
+      <DatePicker.RangePicker defaultPickerValue={[startDate, endDate]} showTime open />,
+    );
+
+    const month = wrapper.find('.ant-picker-header-view .ant-picker-month-btn').text();
+    const year = wrapper.find('.ant-picker-header-view .ant-picker-year-btn').text();
+
+    expect(month).toBe(startDate.format('MMM'));
+    expect(year).toBe(startDate.format('YYYY'));
+    expect(wrapper.find('.ant-picker-time-panel').length).toBe(1);
+  });
 });

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "rc-motion": "^2.4.4",
     "rc-notification": "~4.5.7",
     "rc-pagination": "~3.1.9",
-    "rc-picker": "~2.5.14",
+    "rc-picker": "~2.5.17",
     "rc-progress": "~3.1.0",
     "rc-rate": "~2.9.0",
     "rc-resize-observer": "^1.0.0",


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close https://github.com/ant-design/ant-design/issues/30005


<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

The `defaultPickerValue` is ignored on DatePicker if the `showTime` option ist set.

This is not a directly bug in Ant Design, but in rc-picker, that was fixed in release version 2.5.17 by [this pull request](https://github.com/react-component/picker/pull/291).

The [Ant Design Issue ](https://github.com/ant-design/ant-design/issues/30005) has been closed, but it still does not work in Ant Design until the rc-picker version is updated in the dependencies.

I did just that :)
... and wrote a test for this case (DatePicker.RangePicker with defaultPickerValue and showTime)

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

There should not be any changes from the user side. 
The `defaultPickerValue` option on DatePicker should just work like documented instead of being ignored when showTime is set.

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fix RangePicker `defaultPickerValue`  not working.   |
| 🇨🇳 Chinese | 修复 RangePicker `defaultPickerValue` 不生效的问题。          |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
