### PR TITLE
fix: missing `default.css`

### DIFF
--- a/.antd-tools.config.js
+++ b/.antd-tools.config.js
@@ -136,6 +136,7 @@ function needTransformStyle(content) {
 
 module.exports = {
   compile: {
+    includeLessFile: [/(\/|\\)components(\/|\\)style(\/|\\)default.less$/],
     transformTSFile(file) {
       if (isComponentStyleEntry(file)) {
         let content = file.contents.toString();

--- a/.antd-tools.config.js
+++ b/.antd-tools.config.js
@@ -35,24 +35,6 @@ function finalizeCompile() {
       );
     });
   }
-
-  // Create entry for babel plugin import
-  function patchEntry(styleEntry) {
-    if (fs.existsSync(styleEntry)) {
-      fs.writeFileSync(
-        path.join(styleEntry, 'style', 'index-default.less'),
-        [
-          // Inject variable
-          '@root-entry-name: default;',
-          // Point to origin file
-          "@import './index';",
-        ].join('\n'),
-      );
-    }
-  }
-
-  patchEntry(path.join(process.cwd(), 'lib'));
-  patchEntry(path.join(process.cwd(), 'es'));
 }
 
 function buildThemeFile(theme, vars) {
@@ -162,8 +144,7 @@ module.exports = {
           const cloneFile = file.clone();
 
           // Origin
-          content = content.replace('../../style/index.less', '../../style/index-default.less');
-          // content = content.replace('./index.less', './index-default.less');
+          content = content.replace('../../style/index.less', '../../style/default.less');
           cloneFile.contents = Buffer.from(content);
 
           return cloneFile;

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -454,3 +454,43 @@ jobs:
         env:
           LIB_DIR: dist
     needs: setup
+
+  style:
+    name: style compile
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@master
+
+      - name: restore cache from package-lock.json
+        uses: actions/cache@v2
+        with:
+          path: package-temp-dir
+          key: lock-${{ github.sha }}
+
+      - name: restore cache from node_modules
+        uses: actions/cache@v2
+        with:
+          path: node_modules
+          key: node_modules-${{ hashFiles('**/package-temp-dir/package-lock.json') }}
+
+      - name: compile
+        run: npm run compile
+
+      - name: dist
+        run: npm run dist
+        env:
+          NODE_OPTIONS: --max_old_space_size=4096
+
+      - name: lessc default
+        run: npx lessc --js ./dist/antd.less
+
+      - name: lessc dark
+        run: npx lessc --js ./dist/antd.dark.less
+
+      - name: lessc variable
+        run: npx lessc --js ./dist/antd.variable.less
+
+      - name: lessc component
+        run: npx lessc --js ./es/button/style/index.less
+    needs: setup

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
   "devDependencies": {
     "@ant-design/bisheng-plugin": "^2.3.0",
     "@ant-design/hitu": "^0.0.0-alpha.13",
-    "@ant-design/tools": "^14.0.0-alpha.2",
+    "@ant-design/tools": "^14.0.0-alpha.3",
     "@docsearch/css": "^3.0.0-alpha.39",
     "@docsearch/react": "^3.0.0-alpha.39",
     "@qixian.cs/github-contributors-list": "^1.0.3",

--- a/tests/dekko/lib.test.js
+++ b/tests/dekko/lib.test.js
@@ -8,6 +8,8 @@ function getFileName(filePath) {
 
 $('lib').isDirectory().hasFile('index.js').hasFile('index.d.ts');
 
+$('lib/style').isDirectory().hasFile('index.css').hasFile('default.css');
+
 $('lib/*')
   .filter(
     filename =>


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

resolve #32108

### 💡 Background and solution

`antd-tools` 只会编译 `/style/index.less` 文件，导致其余文件没有编译。加了一个 include 把丢失文件加上。

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Fix antd compile file miss `/style/default.css`.     |
| 🇨🇳 Chinese |      修复 antd 编译产物缺失 `/style/default.css` 文件的问题。     |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
