### PR TITLE
docs: delete duplicated property

### DIFF
--- a/components/typography/index.zh-CN.md
+++ b/components/typography/index.zh-CN.md
@@ -109,7 +109,6 @@ cover: https://gw.alipayobjects.com/zos/alicdn/GOM1KQ24O/Typography.svg
 | onChange | 文本域编辑时触发 | function(event) | - |  |
 | onEnd | 按 ENTER 结束编辑状态时触发 | function | - | 4.14.0 |
 | onStart | 进入编辑中状态时触发 | function | - |  |
-| onCancel | 按 ESC 退出编辑状态时触发 | function | - |  | 
 
 ### ellipsis
 


### PR DESCRIPTION
[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

no need

### 💡 Background and solution
Removing duplicated property of `Editable` to make the Chinese version same as the English version.

### 📝 Changelog

no need

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      no need     |
| 🇨🇳 Chinese |     no need      |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
