### PR TITLE
feat: add support to it_IT locale in forms, images and page headers b…

### DIFF
--- a/components/locale/it_IT.tsx
+++ b/components/locale/it_IT.tsx
@@ -5,7 +5,7 @@ import Calendar from '../calendar/locale/it_IT';
 import { Locale } from '../locale-provider';
 
 /* eslint-disable no-template-curly-in-string */
-var typeTemplate = "Il valore del campo ${label} non è valido per il tipo: ${type}";
+const typeTemplate = "Il valore del campo ${label} non è valido per il tipo: ${type}";
 
 const localeValues: Locale = {
   locale: 'it',
@@ -45,7 +45,7 @@ const localeValues: Locale = {
     removeCurrent: 'Deseleziona la pagina corrente',
     selectAll: 'Seleziona tutto',
     removeAll: 'Deseleziona tutto',
-    selectInvert: 'Inverti selezione'
+    selectInvert: 'Inverti selezione',
   },
   Upload: {
     uploading: 'Caricamento...',
@@ -67,7 +67,7 @@ const localeValues: Locale = {
     expand: 'espandi',
   },
   PageHeader: {
-    back: 'Indietro'
+    back: 'Indietro',
   },
   Form: {
   optional: '(opzionale)',
@@ -79,7 +79,7 @@ const localeValues: Locale = {
     date: {
       format: "Il valore del campo ${label} non è nel formato corretto",
       parse: 'Il valore del campo ${label} non può essere convertito in data',
-      invalid: "Il valore del campo ${label} non è una data valida"
+      invalid: "Il valore del campo ${label} non è una data valida",
     },
     types: {
       string: typeTemplate,
@@ -94,34 +94,34 @@ const localeValues: Locale = {
       regexp: typeTemplate,
       email: typeTemplate,
       url: typeTemplate,
-      hex: typeTemplate
+      hex: typeTemplate,
     },
     string: {
       len: 'La lunghezza del campo ${label} deve essere di ${len} caratteri',
       min: 'La lunghezza del campo ${label} deve essere minimo ${min} caratteri',
       max: 'La lunghezza del campo ${label} deve essere massimo ${max} caratteri',
-      range: 'La lunghezza del campo ${label} deve essere fra ${min} e ${max} caratteri'
+      range: 'La lunghezza del campo ${label} deve essere fra ${min} e ${max} caratteri',
     },
     number: {
       len: 'Il valore del campo ${label} deve essere ${len}',
       min: 'Il valore del campo ${label} deve essere maggiore di ${min}',
       max: 'Il valore del campo ${label} deve essere minore di ${max}',
-      range: 'Il valore del campo ${label} deve essere compreso fra ${min} e ${max}'
+      range: 'Il valore del campo ${label} deve essere compreso fra ${min} e ${max}',
     },
     array: {
       len: 'La lunghezza della lista ${label} deve essere ${len}',
       min: 'La lunghezza della lista ${label} deve essere almeno ${min}',
       max: 'La lunghezza della lista ${label} deve essere al massimo ${max}',
-      range: 'La lunghezza della lista ${label} deve essere ${min}-${max}'
+      range: 'La lunghezza della lista ${label} deve essere ${min}-${max}',
     },
     pattern: {
-      mismatch: 'Il valore del campo ${label} non corrisponde al formato: ${pattern}'
-    }
-  }
+      mismatch: 'Il valore del campo ${label} non corrisponde al formato: ${pattern}',
+    },
+  },
 },
 Image: {
-  preview: 'Anteprima'
-}
+  preview: 'Anteprima',
+},
 };
 
 export default localeValues;

--- a/components/locale/it_IT.tsx
+++ b/components/locale/it_IT.tsx
@@ -4,6 +4,9 @@ import TimePicker from '../time-picker/locale/it_IT';
 import Calendar from '../calendar/locale/it_IT';
 import { Locale } from '../locale-provider';
 
+/* eslint-disable no-template-curly-in-string */
+var typeTemplate = "Il valore del campo ${label} non è valido per il tipo: ${type}";
+
 const localeValues: Locale = {
   locale: 'it',
   Pagination,
@@ -37,6 +40,12 @@ const localeValues: Locale = {
     searchPlaceholder: 'Cerca qui',
     itemUnit: 'elemento',
     itemsUnit: 'elementi',
+    remove: 'Deseleziona',
+    selectCurrent: 'Seleziona la pagina corrente',
+    removeCurrent: 'Deseleziona la pagina corrente',
+    selectAll: 'Seleziona tutto',
+    removeAll: 'Deseleziona tutto',
+    selectInvert: 'Inverti selezione'
   },
   Upload: {
     uploading: 'Caricamento...',
@@ -57,6 +66,62 @@ const localeValues: Locale = {
     copied: 'copia effettuata',
     expand: 'espandi',
   },
+  PageHeader: {
+    back: 'Indietro'
+  },
+  Form: {
+  optional: '(opzionale)',
+  defaultValidateMessages: {
+    "default": 'Errore nel campo ${label}',
+    required: 'Il campo ${label} è obbligatorio',
+    "enum": 'Il valore del campo ${label} deve essere uno dei seguenti: [${enum}]',
+    whitespace: 'Il valore del campo ${label} non può essere vuoto',
+    date: {
+      format: "Il valore del campo ${label} non è nel formato corretto",
+      parse: 'Il valore del campo ${label} non può essere convertito in data',
+      invalid: "Il valore del campo ${label} non è una data valida"
+    },
+    types: {
+      string: typeTemplate,
+      method: typeTemplate,
+      array: typeTemplate,
+      object: typeTemplate,
+      number: typeTemplate,
+      date: typeTemplate,
+      "boolean": typeTemplate,
+      integer: typeTemplate,
+      "float": typeTemplate,
+      regexp: typeTemplate,
+      email: typeTemplate,
+      url: typeTemplate,
+      hex: typeTemplate
+    },
+    string: {
+      len: 'La lunghezza del campo ${label} deve essere di ${len} caratteri',
+      min: 'La lunghezza del campo ${label} deve essere minimo ${min} caratteri',
+      max: 'La lunghezza del campo ${label} deve essere massimo ${max} caratteri',
+      range: 'La lunghezza del campo ${label} deve essere fra ${min} e ${max} caratteri'
+    },
+    number: {
+      len: 'Il valore del campo ${label} deve essere ${len}',
+      min: 'Il valore del campo ${label} deve essere maggiore di ${min}',
+      max: 'Il valore del campo ${label} deve essere minore di ${max}',
+      range: 'Il valore del campo ${label} deve essere compreso fra ${min} e ${max}'
+    },
+    array: {
+      len: 'La lunghezza della lista ${label} deve essere ${len}',
+      min: 'La lunghezza della lista ${label} deve essere almeno ${min}',
+      max: 'La lunghezza della lista ${label} deve essere al massimo ${max}',
+      range: 'La lunghezza della lista ${label} deve essere ${min}-${max}'
+    },
+    pattern: {
+      mismatch: 'Il valore del campo ${label} non corrisponde al formato: ${pattern}'
+    }
+  }
+},
+Image: {
+  preview: 'Anteprima'
+}
 };
 
 export default localeValues;


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [x ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->
I saw that italian translations for form validation were missing (like for example when a field is required)

### 💡 Background and solution
I added them 

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog
Now italian is available for forms, images and page headers components

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     x      |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ x] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
