### PR TITLE
feat: triggerType prop for editable paragraph

### DIFF
--- a/components/typography/Base.tsx
+++ b/components/typography/Base.tsx
@@ -41,6 +41,7 @@ interface EditConfig {
   onEnd?: () => void;
   maxLength?: number;
   autoSize?: boolean | AutoSizeType;
+  triggerType?: ('icon' | 'text')[];
 }
 
 export interface EllipsisConfig {
@@ -372,12 +373,12 @@ class Base extends React.Component<InternalBlockProps, BaseState> {
     const { editable } = this.props;
     if (!editable) return;
 
-    const { icon, tooltip } = editable as EditConfig;
+    const { icon, tooltip, triggerType = ['icon'] } = editable as EditConfig;
 
     const title = toArray(tooltip)[0] || this.editStr;
     const ariaLabel = typeof title === 'string' ? title : '';
 
-    return (
+    return triggerType.indexOf('icon') !== -1 ? (
       <Tooltip key="edit" title={tooltip === false ? '' : title}>
         <TransButton
           ref={this.setEditRef}
@@ -388,7 +389,7 @@ class Base extends React.Component<InternalBlockProps, BaseState> {
           {icon || <EditOutlined role="button" />}
         </TransButton>
       </Tooltip>
-    );
+    ) : null;
   }
 
   renderCopy() {
@@ -455,6 +456,7 @@ class Base extends React.Component<InternalBlockProps, BaseState> {
     const { component, children, className, type, disabled, style, ...restProps } = this.props;
     const { direction } = this.context;
     const { rows, suffix, tooltip } = this.getEllipsis();
+    const { triggerType = ['icon'] } = this.getEditable() as EditConfig;
 
     const prefixCls = this.getPrefixCls();
 
@@ -549,6 +551,7 @@ class Base extends React.Component<InternalBlockProps, BaseState> {
                 component={component}
                 ref={this.contentRef}
                 direction={direction}
+                onClick={triggerType.indexOf('text') !== -1 ? this.onEditClick : () => {}}
                 {...textProps}
               >
                 {textNode}

--- a/components/typography/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/typography/__tests__/__snapshots__/demo.test.js.snap
@@ -436,6 +436,101 @@ Array [
       </span>
     </div>
   </div>,
+  "Trigger edit with: ",
+  <div
+    class="ant-radio-group ant-radio-group-outline"
+  >
+    <label
+      class="ant-radio-wrapper ant-radio-wrapper-checked"
+    >
+      <span
+        class="ant-radio ant-radio-checked"
+      >
+        <input
+          checked=""
+          class="ant-radio-input"
+          type="radio"
+          value="icon"
+        />
+        <span
+          class="ant-radio-inner"
+        />
+      </span>
+      <span>
+        icon
+      </span>
+    </label>
+    <label
+      class="ant-radio-wrapper"
+    >
+      <span
+        class="ant-radio"
+      >
+        <input
+          class="ant-radio-input"
+          type="radio"
+          value="text"
+        />
+        <span
+          class="ant-radio-inner"
+        />
+      </span>
+      <span>
+        text
+      </span>
+    </label>
+    <label
+      class="ant-radio-wrapper"
+    >
+      <span
+        class="ant-radio"
+      >
+        <input
+          class="ant-radio-input"
+          type="radio"
+          value="both"
+        />
+        <span
+          class="ant-radio-inner"
+        />
+      </span>
+      <span>
+        both
+      </span>
+    </label>
+  </div>,
+  <div
+    class="ant-typography"
+  >
+    Text or icon as trigger - click to start editing.
+    <div
+      aria-label="click to edit text"
+      class="ant-typography-edit"
+      role="button"
+      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-block"
+      tabindex="0"
+    >
+      <span
+        aria-label="edit"
+        class="anticon anticon-edit"
+        role="button"
+      >
+        <svg
+          aria-hidden="true"
+          data-icon="edit"
+          fill="currentColor"
+          focusable="false"
+          height="1em"
+          viewBox="64 64 896 896"
+          width="1em"
+        >
+          <path
+            d="M257.7 752c2 0 4-.2 6-.5L431.9 722c2-.4 3.9-1.3 5.3-2.8l423.9-423.9a9.96 9.96 0 000-14.1L694.9 114.9c-1.9-1.9-4.4-2.9-7.1-2.9s-5.2 1-7.1 2.9L256.8 538.8c-1.5 1.5-2.4 3.3-2.8 5.3l-29.5 168.2a33.5 33.5 0 009.4 29.8c6.6 6.4 14.9 9.9 23.8 9.9zm67.4-174.4L687.8 215l73.3 73.3-362.7 362.6-88.9 15.7 15.6-89zM880 836H144c-17.7 0-32 14.3-32 32v36c0 4.4 3.6 8 8 8h784c4.4 0 8-3.6 8-8v-36c0-17.7-14.3-32-32-32z"
+          />
+        </svg>
+      </span>
+    </div>
+  </div>,
   <div
     class="ant-typography"
   >

--- a/components/typography/__tests__/index.test.js
+++ b/components/typography/__tests__/index.test.js
@@ -395,7 +395,7 @@ describe('Typography', () => {
     });
 
     describe('editable', () => {
-      function testStep({ name = '', icon, tooltip } = {}, submitFunc, expectFunc) {
+      function testStep({ name = '', icon, tooltip, triggerType } = {}, submitFunc, expectFunc) {
         it(name, () => {
           jest.useFakeTimers();
           const onStart = jest.fn();
@@ -406,7 +406,7 @@ describe('Typography', () => {
 
           const wrapper = mount(
             <Paragraph
-              editable={{ onChange, onStart, icon, tooltip }}
+              editable={{ onChange, onStart, icon, tooltip, triggerType }}
               className={className}
               style={style}
             >
@@ -414,27 +414,47 @@ describe('Typography', () => {
             </Paragraph>,
           );
 
-          if (icon) {
-            expect(wrapper.find('.anticon-highlight').length).toBeTruthy();
-          } else {
-            expect(wrapper.find('.anticon-edit').length).toBeTruthy();
+          if (triggerType === undefined || triggerType.indexOf('icon') !== -1) {
+            if (icon) {
+              expect(wrapper.find('.anticon-highlight').length).toBeTruthy();
+            } else {
+              expect(wrapper.find('.anticon-edit').length).toBeTruthy();
+            }
+
+            if (triggerType === undefined || triggerType.indexOf('text') === -1) {
+              wrapper.simulate('click');
+              expect(onStart).not.toHaveBeenCalled();
+            }
+            wrapper.find('.ant-typography-edit').first().simulate('mouseenter');
+            jest.runAllTimers();
+            wrapper.update();
+
+            if (tooltip === undefined || tooltip === true) {
+              expect(wrapper.find('.ant-tooltip-inner').text()).toBe('Edit');
+            } else if (tooltip === false) {
+              expect(wrapper.find('.ant-tooltip-inner').length).toBeFalsy();
+            } else {
+              expect(wrapper.find('.ant-tooltip-inner').text()).toBe(tooltip);
+            }
+
+            wrapper.find('.ant-typography-edit').first().simulate('click');
+
+            expect(onStart).toHaveBeenCalled();
+            if (triggerType !== undefined && triggerType.indexOf('text') !== -1) {
+              wrapper.find('textarea').simulate('keyDown', { keyCode: KeyCode.ESC });
+              wrapper.find('textarea').simulate('keyUp', { keyCode: KeyCode.ESC });
+              expect(onChange).not.toHaveBeenCalled();
+            }
           }
 
-          wrapper.find('.ant-typography-edit').first().simulate('mouseenter');
-          jest.runAllTimers();
-          wrapper.update();
-
-          if (tooltip === undefined || tooltip === true) {
-            expect(wrapper.find('.ant-tooltip-inner').text()).toBe('Edit');
-          } else if (tooltip === false) {
-            expect(wrapper.find('.ant-tooltip-inner').length).toBeFalsy();
-          } else {
-            expect(wrapper.find('.ant-tooltip-inner').text()).toBe(tooltip);
+          if (triggerType !== undefined && triggerType.indexOf('text') !== -1) {
+            if (triggerType.indexOf('icon') === -1) {
+              expect(wrapper.find('.anticon-highlight').length).toBeFalsy();
+              expect(wrapper.find('.anticon-edit').length).toBeFalsy();
+            }
+            wrapper.simulate('click');
+            expect(onStart).toHaveBeenCalled();
           }
-
-          wrapper.find('.ant-typography-edit').first().simulate('click');
-
-          expect(onStart).toHaveBeenCalled();
 
           // Should have className
           const props = wrapper.find('div').first().props();
@@ -492,6 +512,10 @@ describe('Typography', () => {
       testStep({ name: 'customize edit show tooltip', tooltip: true });
       testStep({ name: 'customize edit hide tooltip', tooltip: false });
       testStep({ name: 'customize edit tooltip text', tooltip: 'click to edit text' });
+
+      testStep({ name: 'trigger by icon', triggerType: ['icon'] });
+      testStep({ name: 'trigger by text', triggerType: ['text'] });
+      testStep({ name: 'trigger by both icon and text', triggerType: ['icon', 'text'] });
 
       it('should trigger onEnd when type Enter', () => {
         const onEnd = jest.fn();

--- a/components/typography/demo/interactive.md
+++ b/components/typography/demo/interactive.md
@@ -16,7 +16,7 @@ Provide additional interactive capacity of editable and copyable.
 ```jsx
 import React, { useState } from 'react';
 import { Checkbox, Radio, Typography } from 'antd';
-import { HighlightOutlined, SmileOutlined, SmileFilled } from '@ant-design/icons';
+import { CheckOutlined, HighlightOutlined, SmileOutlined, SmileFilled } from '@ant-design/icons';
 
 const { Paragraph } = Typography;
 
@@ -86,6 +86,7 @@ const Demo = () => {
         }}
       >
         {clickTriggerStr}
+      </Paragraph>
       <Paragraph
         editable={{
           icon: <HighlightOutlined />,

--- a/components/typography/demo/interactive.md
+++ b/components/typography/demo/interactive.md
@@ -15,7 +15,7 @@ Provide additional interactive capacity of editable and copyable.
 
 ```jsx
 import React, { useState } from 'react';
-import { Typography } from 'antd';
+import { Checkbox, Radio, Typography } from 'antd';
 import { HighlightOutlined, SmileOutlined, SmileFilled } from '@ant-design/icons';
 
 const { Paragraph } = Typography;
@@ -23,10 +23,33 @@ const { Paragraph } = Typography;
 const Demo = () => {
   const [editableStr, setEditableStr] = useState('This is an editable text.');
   const [customIconStr, setCustomIconStr] = useState('Custom Edit icon and replace tooltip text.');
+  const [clickTriggerStr, setClickTriggerStr] = useState(
+    'Text or icon as trigger - click to start editing.',
+  );
+  const [chooseTrigger, setChooseTrigger] = useState('icon');
   const [hideTooltipStr, setHideTooltipStr] = useState('Hide Edit tooltip.');
   const [lengthLimitedStr, setLengthLimitedStr] = useState(
     'This is an editable text with limited length.',
   );
+
+  const radioToState = input => {
+    switch (input) {
+      case 'text':
+        return ['text'];
+      case 'both':
+        return ['icon', 'text'];
+      case 'icon':
+      default:
+        return ['icon'];
+    }
+  };
+
+  const stateToRadio = () => {
+    if (chooseTrigger.indexOf('text') !== -1) {
+      return chooseTrigger.indexOf('icon') !== -1 ? 'both' : 'text';
+    }
+    return 'icon';
+  };
 
   return (
     <>
@@ -39,6 +62,24 @@ const Demo = () => {
         }}
       >
         {customIconStr}
+      </Paragraph>
+      Trigger edit with:{' '}
+      <Radio.Group
+        onChange={e => setChooseTrigger(radioToState(e.target.value))}
+        value={stateToRadio()}
+      >
+        <Radio value="icon">icon</Radio>
+        <Radio value="text">text</Radio>
+        <Radio value="both">both</Radio>
+      </Radio.Group>
+      <Paragraph
+        editable={{
+          tooltip: 'click to edit text',
+          onChange: setClickTriggerStr,
+          triggerType: chooseTrigger,
+        }}
+      >
+        {clickTriggerStr}
       </Paragraph>
       <Paragraph editable={{ tooltip: false, onChange: setHideTooltipStr }}>
         {hideTooltipStr}

--- a/components/typography/index.en-US.md
+++ b/components/typography/index.en-US.md
@@ -95,6 +95,7 @@ Basic text writing, including headings, body text, lists, and more.
       onChange: function(string),
       onCancel: function,
       onEnd: function,
+      triggerType: ('icon' | 'text')[],
     }
 
 | Property | Description | Type | Default | Version |
@@ -104,11 +105,11 @@ Basic text writing, including headings, body text, lists, and more.
 | icon | Custom editable icon | ReactNode | &lt;EditOutlined /> | 4.6.0 |
 | maxLength | `maxLength` attribute of textarea | number | - | 4.4.0 |
 | tooltip | Custom tooltip text, hide when it is false | boolean \| ReactNode | `Edit` | 4.6.0 |
-| onCancel | Called when type ESC to exit editable state | function | - |  |
-| onChange | Called when input at textarea | function(event) | - |  |
-| onEnd | Called when type ENTER to exit editable state | function | - | 4.14.0 |
 | onStart | Called when enter editable state | function | - |  |
-
+| onChange | Called when input at textarea | function(event) | - |  |
+| onCancel | Called when type ESC to exit editable state | function | - |  |
+| onEnd | Called when type ENTER to exit editable state | function | - | 4.14.0 |
+| triggerType | Edit mode trigger - icon, text or both (not specifying icon as trigger hides it) | Array&lt;`icon`\|`text`> | \[`icon`] |  |
 
 ### ellipsis
 

--- a/components/typography/index.zh-CN.md
+++ b/components/typography/index.zh-CN.md
@@ -106,10 +106,10 @@ cover: https://gw.alipayobjects.com/zos/alicdn/GOM1KQ24O/Typography.svg
 | icon | 自定义编辑图标 | ReactNode | &lt;EditOutlined /> | 4.6.0 |
 | maxLength | 编辑中文本域最大长度 | number | - | 4.4.0 |
 | tooltip | 自定义提示文本，为 false 时关闭 | boolean \| ReactNode | `编辑` | 4.6.0 |
-| onStart | 进入编辑中状态时触发 | function | - |  |
-| onChange | 文本域编辑时触发 | function(event) | - |  |
 | onCancel | 按 ESC 退出编辑状态时触发 | function | - |  |
+| onChange | 文本域编辑时触发 | function(event) | - |  |
 | onEnd | 按 ENTER 结束编辑状态时触发 | function | - | 4.14.0 |
+| onStart | 进入编辑中状态时触发 | function | - |  |
 | triggerType | Edit mode trigger - icon, text or both (not specifying icon as trigger hides it) | Array&lt;`icon`\|`text`> | \[`icon`] |  |
 
 ### ellipsis

--- a/components/typography/index.zh-CN.md
+++ b/components/typography/index.zh-CN.md
@@ -96,6 +96,7 @@ cover: https://gw.alipayobjects.com/zos/alicdn/GOM1KQ24O/Typography.svg
       onChange: function(string),
       onCancel: function,
       onEnd: function,
+      triggerType: ('icon' | 'text')[],
     }
 
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
@@ -105,11 +106,11 @@ cover: https://gw.alipayobjects.com/zos/alicdn/GOM1KQ24O/Typography.svg
 | icon | 自定义编辑图标 | ReactNode | &lt;EditOutlined /> | 4.6.0 |
 | maxLength | 编辑中文本域最大长度 | number | - | 4.4.0 |
 | tooltip | 自定义提示文本，为 false 时关闭 | boolean \| ReactNode | `编辑` | 4.6.0 |
-| onCancel | 按 ESC 退出编辑状态时触发 | function | - |  |
-| onChange | 文本域编辑时触发 | function(event) | - |  |
-| onEnd | 按 ENTER 结束编辑状态时触发 | function | - | 4.14.0 |
 | onStart | 进入编辑中状态时触发 | function | - |  |
-| onCancel | 按 ESC 退出编辑状态时触发 | function | - |  | 
+| onChange | 文本域编辑时触发 | function(event) | - |  |
+| onCancel | 按 ESC 退出编辑状态时触发 | function | - |  |
+| onEnd | 按 ENTER 结束编辑状态时触发 | function | - | 4.14.0 |
+| triggerType | Edit mode trigger - icon, text or both (not specifying icon as trigger hides it) | Array&lt;`icon`\|`text`> | \[`icon`] |  |
 
 ### ellipsis
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [X] Site / documentation update
- [X] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [X] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution
in order to be able to use Paragraph as true inline edit (with no extra elements), it may be useful to hide the icon and use the value itself as edit trigger.
NOTE: this is a follow-up to a declined PRs #31537 and #32214

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | for editable Paragraph, edit can be triggered by clicking the icon or the value itself (or both) |
| 🇨🇳 Chinese | 对于可编辑段落，可以通过点击图标或值本身（或两者都有）来触发进入编辑状态。 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [X] Doc is updated/provided or not needed
- [X] Demo is updated/provided or not needed
- [X] TypeScript definition is updated/provided or not needed
- [X] Changelog is provided or not needed
