### PR TITLE
style: Switch loading icon style been covered in office website

### DIFF
--- a/components/switch/style/index.less
+++ b/components/switch/style/index.less
@@ -110,11 +110,11 @@
     position: relative;
     top: ((@switch-pin-size - @font-size-base) / 2);
     color: rgba(0, 0, 0, 0.65);
-    vertical-align: top;
   }
 
   &-checked &-loading-icon {
     color: @switch-color;
+    vertical-align: top;
   }
 
   // ========================== Size ==========================
@@ -136,6 +136,7 @@
     .@{switch-prefix-cls}-loading-icon {
       top: ((@switch-sm-pin-size - 9px) / 2);
       font-size: 9px;
+      vertical-align: top;
     }
 
     &.@{switch-prefix-cls}-checked {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
[#32215](https://github.com/ant-design/ant-design/issues/32215)
<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Switch loading icon style been covered in office website |
| 🇨🇳 Chinese | ant design 官网中 Switch 组件的 loading icon 样式被覆盖 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
