### PR TITLE
fix menu collapsed props order

### DIFF
--- a/components/menu/__tests__/index.test.js
+++ b/components/menu/__tests__/index.test.js
@@ -6,10 +6,13 @@ import {
   AppstoreOutlined,
   PieChartOutlined,
   UserOutlined,
+  MenuUnfoldOutlined,
+  MenuFoldOutlined,
 } from '@ant-design/icons';
 import { act } from 'react-dom/test-utils';
 import Menu from '..';
 import Layout from '../../layout';
+import Button from '../../button';
 import Tooltip from '../../tooltip';
 import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
@@ -613,6 +616,60 @@ describe('Menu', () => {
     wrapper.find(Menu).simulate('mouseenter');
     expect(wrapper.find(Menu).getDOMNode().classList.contains('ant-menu-inline')).toBe(false);
     expect(wrapper.find(Menu).getDOMNode().classList.contains('ant-menu-vertical')).toBe(true);
+  });
+
+  it('should controlled collapse work when using with Layout.Sider', () => {
+    class Demo extends React.Component {
+      state = {
+        collapsed: false,
+      };
+
+      toggleCollapsed = () => {
+        this.setState(prev => ({ ...prev, collapsed: !prev.collapsed }));
+      };
+
+      render() {
+        const { collapsed } = this.state;
+        return (
+          <Layout style={{ minHeight: '100vh' }}>
+            <Layout.Sider collapsed={false}>
+              <Button type="primary" onClick={this.toggleCollapsed}>
+                {collapsed ? <MenuUnfoldOutlined /> : <MenuFoldOutlined />}
+              </Button>
+              <Menu
+                theme="dark"
+                inlineCollapsed={collapsed}
+                defaultSelectedKeys={['1']}
+                mode="inline"
+              >
+                <SubMenu key="sub1" icon={<UserOutlined />} title="User">
+                  <Menu.Item key="3">Tom</Menu.Item>
+                  <Menu.Item key="4">Bill</Menu.Item>
+                  <Menu.Item key="5">Alex</Menu.Item>
+                </SubMenu>
+              </Menu>
+            </Layout.Sider>
+          </Layout>
+        );
+      }
+    }
+
+    const wrapper = mount(<Demo />);
+    expect(wrapper.find(Menu).at(0).getDOMNode().classList.contains('ant-menu-inline')).toBe(true);
+
+    wrapper.find(Button).simulate('click');
+    act(() => {
+      jest.runAllTimers();
+    });
+    wrapper.update();
+    expect(wrapper.find(Menu).getDOMNode().classList.contains('ant-menu-inline-collapsed')).toBe(
+      true,
+    );
+
+    wrapper.find(Button).simulate('click');
+    expect(wrapper.find(Menu).getDOMNode().classList.contains('ant-menu-inline-collapsed')).toBe(
+      false,
+    );
   });
 
   it('onMouseEnter should work', () => {

--- a/components/menu/index.tsx
+++ b/components/menu/index.tsx
@@ -52,10 +52,10 @@ class InternalMenu extends React.Component<InternalMenuProps> {
 
   getInlineCollapsed() {
     const { inlineCollapsed, siderCollapsed } = this.props;
-    if (siderCollapsed !== undefined) {
-      return siderCollapsed;
+    if (inlineCollapsed !== undefined) {
+      return inlineCollapsed;
     }
-    return inlineCollapsed;
+    return siderCollapsed;
   }
 
   renderMenu = ({ getPopupContainer, getPrefixCls, direction }: ConfigConsumerProps) => {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->
For #32240

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    The `inlineCollapsed` props is used preferentially to control the `collapsed` state of the `Menu` under the `Layout.Sider`  component         |
| 🇨🇳 Chinese |   优先使用 `inlineCollapsed` 道具是了能够在 `Layout.Sider` 组件下控制菜单的 `collapsed` 状态  |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
