### PR TITLE
fix: Table selection arrow get covered by fixed column

### DIFF
--- a/components/table/style/index.less
+++ b/components/table/style/index.less
@@ -428,6 +428,7 @@
 
   table tr th&-selection-column,
   table tr td&-selection-column {
+    z-index: 4;
     padding-right: @padding-xs;
     padding-left: @padding-xs;
     text-align: center;

--- a/components/table/style/index.less
+++ b/components/table/style/index.less
@@ -428,7 +428,6 @@
 
   table tr th&-selection-column,
   table tr td&-selection-column {
-    z-index: 4;
     padding-right: @padding-xs;
     padding-left: @padding-xs;
     text-align: center;
@@ -436,6 +435,10 @@
     .@{ant-prefix}-radio-wrapper {
       margin-right: 0;
     }
+  }
+
+  table tr th&-selection-column&-cell-fix-left {
+    z-index: 3;
   }
 
   table tr th&-selection-column::after {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
close #32268

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution
Fixed column and Selection Column had same z-index. That's why the overflowing arrow was partially hidden. 
To fix it I have added a higher z-index to selection column.

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fix Table selection column arrow get covered by fixed column. |
| 🇨🇳 Chinese | 修复 Table 选择框下拉箭头被固定列遮挡的问题。  |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
