### PR TITLE
fix: Notification closeIcon don't update (#32351)

### DIFF
--- a/components/notification/__tests__/index.test.js
+++ b/components/notification/__tests__/index.test.js
@@ -191,6 +191,21 @@ describe('notification', () => {
     expect(document.querySelectorAll('.test-customize-icon').length).toBe(1);
   });
 
+  it('closeIcon should be update', async () => {
+    const openNotificationWithCloseIcon = async type => {
+      notification.open({
+        message: 'Notification Title',
+        closeIcon: <span className={`test-customize-icon-${type}`} />,
+      });
+      await Promise.resolve();
+      expect(document.querySelectorAll(`.test-customize-icon-${type}`).length).toBe(1);
+    };
+
+    const promises = ['1', '2'].map(type => openNotificationWithCloseIcon(type));
+
+    await Promise.all(promises);
+  });
+
   it('support config duration', () => {
     notification.config({
       duration: 0,

--- a/components/notification/index.tsx
+++ b/components/notification/index.tsx
@@ -124,7 +124,6 @@ function getNotificationInstance(
     top,
     bottom,
     getContainer = defaultGetContainer,
-    closeIcon = defaultCloseIcon,
     prefixCls: customizePrefixCls,
   } = args;
   const { getPrefixCls, getIconPrefixCls } = globalConfig();
@@ -141,12 +140,6 @@ function getNotificationInstance(
     return;
   }
 
-  const closeIconToRender = (
-    <span className={`${prefixCls}-close-x`}>
-      {closeIcon || <CloseOutlined className={`${prefixCls}-close-icon`} />}
-    </span>
-  );
-
   const notificationClass = classNames(`${prefixCls}-${placement}`, {
     [`${prefixCls}-rtl`]: rtl === true,
   });
@@ -158,7 +151,6 @@ function getNotificationInstance(
         className: notificationClass,
         style: getPlacementStyle(placement, top, bottom),
         getContainer,
-        closeIcon: closeIconToRender,
         maxCount,
       },
       notification => {
@@ -213,6 +205,7 @@ function getRCNoticeProps(args: ArgsProps, prefixCls: string, iconPrefixCls?: st
     key,
     style,
     className,
+    closeIcon = defaultCloseIcon,
   } = args;
 
   const duration = durationArg === undefined ? defaultDuration : durationArg;
@@ -225,6 +218,12 @@ function getRCNoticeProps(args: ArgsProps, prefixCls: string, iconPrefixCls?: st
       className: `${prefixCls}-icon ${prefixCls}-icon-${type}`,
     });
   }
+
+  const closeIconToRender = (
+    <span className={`${prefixCls}-close-x`}>
+      {closeIcon || <CloseOutlined className={`${prefixCls}-close-icon`} />}
+    </span>
+  );
 
   const autoMarginTag =
     !description && iconNode ? (
@@ -247,6 +246,7 @@ function getRCNoticeProps(args: ArgsProps, prefixCls: string, iconPrefixCls?: st
     ),
     duration,
     closable: true,
+    closeIcon: closeIconToRender,
     onClose,
     onClick,
     key,


### PR DESCRIPTION
[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
[#32351](https://github.com/ant-design/ant-design/issues/32351)

### 💡 Background and solution
when notification.open({ closeIcon }) time after time, the closeIcon don't update.

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    🐞 Fix  `closeIcon` don't update    |
| 🇨🇳 Chinese |   🐞 多次调用组件，closeIcon 未更新   |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
