### PR TITLE
fix: typescript error in ConfigProvider.

### DIFF
--- a/components/config-provider/context.tsx
+++ b/components/config-provider/context.tsx
@@ -21,7 +21,7 @@ export type DirectionType = 'ltr' | 'rtl' | undefined;
 
 export interface ConfigConsumerProps {
   getTargetContainer?: () => HTMLElement;
-  getPopupContainer?: (triggerNode: HTMLElement) => HTMLElement;
+  getPopupContainer?: (triggerNode?: HTMLElement) => HTMLElement;
   rootPrefixCls?: string;
   iconPrefixCls?: string;
   getPrefixCls: (suffixCls?: string, customizePrefixCls?: string) => string;

--- a/components/config-provider/index.tsx
+++ b/components/config-provider/index.tsx
@@ -54,7 +54,7 @@ const PASSED_PROPS: Exclude<keyof ConfigConsumerProps, 'rootPrefixCls' | 'getPre
 
 export interface ConfigProviderProps {
   getTargetContainer?: () => HTMLElement;
-  getPopupContainer?: (triggerNode: HTMLElement) => HTMLElement;
+  getPopupContainer?: (triggerNode?: HTMLElement) => HTMLElement;
   prefixCls?: string;
   iconPrefixCls?: string;
   children?: React.ReactNode;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

###  https://github.com/ant-design/ant-design/issues/18797

<!--
1. The above issue was closed, but the description given made it seem like this is the correct typescript definition. 
-->

### 💡 Background and solution

In my project, I was using the `ConfigContext` from AntDesign to pass `getPopupContainer` to an ant design menu item `getContainer` attribute. I was getting an error as the types weren't compatible, notably that `getPopupContainer` required a `triggerNode`. Based on https://github.com/ant-design/ant-design/issues/18797, `triggerNode` is an optional argument.


### 📝 Changelog


| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  getPopupContainer in ConfigContext has optional triggerNode.    |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
