### PR TITLE
docs: Fix the explanation typo in the comment for Modal component

### DIFF
--- a/components/modal/index.en-US.md
+++ b/components/modal/index.en-US.md
@@ -154,10 +154,10 @@ const [modal, contextHolder] = Modal.useModal();
 
 return (
   <Context1.Provider value="Ant">
-    {/* contextHolder is in Context1 which mean modal will not get context of Context1 */}
+    {/* contextHolder is in Context1, which means modal will get context of Context1 */}
     {contextHolder}
     <Context2.Provider value="Design">
-      {/* contextHolder is out of Context2 which mean modal will not get context of Context2 */}
+      {/* contextHolder is out of Context2, which means modal will not get context of Context2 */}
     </Context2.Provider>
   </Context1.Provider>
 );


### PR DESCRIPTION
[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

The explanation in the Chinese docs is correct, but incorrect in the English docs. See the codes below.

Chinese:
```
const [modal, contextHolder] = Modal.useModal();

return (
  <Context1.Provider value="Ant">
    {/* contextHolder 在 Context1 内，它可以获得 Context1 的 context */}
    {contextHolder}
    <Context2.Provider value="Design">
      {/* contextHolder 在 Context2 外，因而不会获得 Context2 的 context */}
    </Context2.Provider>
  </Context1.Provider>
);
```

English:
```
const [modal, contextHolder] = Modal.useModal();

// then call modal.confirm instead of Modal.confirm

return (
  <Context1.Provider value="Ant">
    {/* contextHolder is in Context1 which mean modal will not get context of Context1 */}
    {contextHolder}
    <Context2.Provider value="Design">
      {/* contextHolder is out of Context2 which mean modal will not get context of Context2 */}
    </Context2.Provider>
  </Context1.Provider>
);
```

### 📝 Changelog

Fix the typo in the comment to help foreign users better understand the usage of Modal.useModal()

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | docs update |
| 🇨🇳 Chinese | docs update |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed