### PR TITLE
fix: Typography ellipsis height error

### DIFF
--- a/components/typography/util.tsx
+++ b/components/typography/util.tsx
@@ -25,14 +25,6 @@ const wrapperStyle: React.CSSProperties = {
   lineHeight: 'inherit',
 };
 
-function pxToNumber(value: string | null): number {
-  if (!value) {
-    return 0;
-  }
-  const match = value.match(/^\d*(\.\d*)?/);
-  return match ? Number(match[0]) : 0;
-}
-
 function styleToString(style: CSSStyleDeclaration) {
   // There are some different behavior between Firefox & Chrome.
   // We have to handle this ourself.
@@ -66,6 +58,10 @@ function resetDomStyles(target: HTMLElement, origin: HTMLElement) {
   target.style.height = 'auto';
   target.style.minHeight = 'auto';
   target.style.maxHeight = 'auto';
+  target.style.paddingTop = '0';
+  target.style.paddingBottom = '0';
+  target.style.borderTopWidth = '0';
+  target.style.borderBottomWidth = '0';
   target.style.top = '-999999px';
   target.style.zIndex = '-1000';
   // clean up css overflow
@@ -79,10 +75,11 @@ function getRealLineHeight(originElement: HTMLElement) {
   resetDomStyles(heightContainer, originElement);
   heightContainer.appendChild(document.createTextNode('text'));
   document.body.appendChild(heightContainer);
-  const { offsetHeight } = heightContainer;
-  const lineHeight = pxToNumber(window.getComputedStyle(originElement).lineHeight);
+  // The element real height is always less than multiple of line-height
+  // Use getBoundingClientRect to get actual single row height of the element
+  const realHeight = heightContainer.getBoundingClientRect().height;
   document.body.removeChild(heightContainer);
-  return offsetHeight > lineHeight ? offsetHeight : lineHeight;
+  return realHeight;
 }
 
 export default (
@@ -103,14 +100,8 @@ export default (
   }
 
   const { rows, suffix = '' } = option;
-  // Get origin style
-  const originStyle = window.getComputedStyle(originElement);
   const lineHeight = getRealLineHeight(originElement);
-  const overflowRows = rows + 1;
-  const oneRowMaxHeight =
-    Math.floor(lineHeight) +
-    pxToNumber(originStyle.paddingTop) +
-    pxToNumber(originStyle.paddingBottom);
+  const maxHeight = Math.round(lineHeight * rows * 100 ) / 100;
 
   resetDomStyles(ellipsisContainer, originElement);
 
@@ -129,9 +120,9 @@ export default (
 
   // Check if ellipsis in measure div is height enough for content
   function inRange() {
-    return (
-      Math.ceil(ellipsisContainer.getBoundingClientRect().height / overflowRows) < oneRowMaxHeight
-    );
+    const currentHeight =
+      Math.round(ellipsisContainer.getBoundingClientRect().height * 100) / 100
+    return currentHeight - .1 <= maxHeight; // -.1 for firefox
   }
 
   // Skip ellipsis if already match


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

Fix [#32266](https://github.com/ant-design/ant-design/issues/32266)
<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->
Background:
Element `height` is always less than the multiple of `line-height`, which will cause errors when comparing heights.
![image](https://user-images.githubusercontent.com/649260/134507760-4670b0e4-7261-4284-8956-11a9e3d0228d.png)

Solution:
* Modify function `getRealLineHeight` to make it get the correct value without `Math.ceil`.
* Modify function `inRange` to make it can correctly determine the text overflow when the page is zoomed.

### 📝 Changelog


<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Fix `Typography` `ellipsis` error when page zoomed.     |
| 🇨🇳 Chinese |       修复   `Typography` `ellipsis` 在缩放下的文本溢出  |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
