### PR TITLE
fix: DirectoryTree keyboard error

### DIFF
--- a/components/tree/DirectoryTree.tsx
+++ b/components/tree/DirectoryTree.tsx
@@ -161,8 +161,8 @@ const DirectoryTree: React.ForwardRefRenderFunction<RcTree, DirectoryTreeProps> 
     };
 
     // Windows / Mac single pick
-    const ctrlPick: boolean = nativeEvent.ctrlKey || nativeEvent.metaKey;
-    const shiftPick: boolean = nativeEvent.shiftKey;
+    const ctrlPick: boolean = nativeEvent?.ctrlKey || nativeEvent?.metaKey;
+    const shiftPick: boolean = nativeEvent?.shiftKey;
 
     // Generate new selected keys
     let newSelectedKeys: Key[];


### PR DESCRIPTION
When selecting a DirectoryTree node using the keyboard (pressing spacebar), an error was logged to the console and the selection was not changed. Keyboard navigation was not possible because of this error. This PR fixes this bug by testing whether the nativeEvent received by onSelect is defined before accessing its child properties.

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close #32550

### 💡 Background and solution

As described in #32550, keyboard navigation is not possible with the Directory Tree component at the moment. This is because onSelect expects a MouseEvent, and that MouseEvent is undefined when selection is made using the keyboard. The fix is to test whether the MouseEvent (nativeEvent variable) is defined before trying to access any child property.

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Tree.DirectoryTree throws `TypeError:nativeEvent is undefined`. |
| 🇨🇳 Chinese |  修复 Tree.DirectoryTree 键盘操作时抛出 `TypeError:nativeEvent is undefined`。        |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
