### PR TITLE
fix(Grid): let Grid.useBreakpoint hook return screen breakpoint info in first render

### DIFF
--- a/components/_util/responsiveObserve.ts
+++ b/components/_util/responsiveObserve.ts
@@ -26,6 +26,17 @@ const responsiveObserve = {
       listener: ((this: MediaQueryList, ev: MediaQueryListEvent) => any) | null;
     };
   },
+  evaluateResponsiveMap(callback: (mqlRes: { mql: MediaQueryList; screen: Breakpoint }) => void) {
+    Object.keys(responsiveMap).forEach((screen: Breakpoint) => {
+      const matchMediaQuery = responsiveMap[screen];
+      const mql = window.matchMedia(matchMediaQuery);
+
+      callback({
+        mql,
+        screen,
+      });
+    });
+  },
   dispatch(pointMap: ScreenMap) {
     screens = pointMap;
     subscribers.forEach(func => func(screens));
@@ -51,7 +62,7 @@ const responsiveObserve = {
     subscribers.clear();
   },
   register() {
-    Object.keys(responsiveMap).forEach((screen: Breakpoint) => {
+    this.evaluateResponsiveMap(({ mql, screen }: { mql: MediaQueryList; screen: Breakpoint }) => {
       const matchMediaQuery = responsiveMap[screen];
       const listener = ({ matches }: { matches: boolean }) => {
         this.dispatch({
@@ -59,7 +70,6 @@ const responsiveObserve = {
           [screen]: matches,
         });
       };
-      const mql = window.matchMedia(matchMediaQuery);
       mql.addListener(listener);
       this.matchHandlers[matchMediaQuery] = {
         mql,
@@ -69,6 +79,14 @@ const responsiveObserve = {
       listener(mql);
     });
   },
+};
+
+export const getScreenMap = (): ScreenMap => {
+  const screenMap: ScreenMap = {};
+  responsiveObserve.evaluateResponsiveMap(({ mql, screen }) => {
+    screenMap[screen] = mql.matches;
+  });
+  return screenMap;
 };
 
 export default responsiveObserve;

--- a/components/grid/hooks/useBreakpoint.tsx
+++ b/components/grid/hooks/useBreakpoint.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useState } from 'react';
-import ResponsiveObserve, { ScreenMap } from '../../_util/responsiveObserve';
+import ResponsiveObserve, { ScreenMap, getScreenMap } from '../../_util/responsiveObserve';
 
 function useBreakpoint(): ScreenMap {
-  const [screens, setScreens] = useState<ScreenMap>({});
+  const [screens, setScreens] = useState<ScreenMap>(() => getScreenMap());
 
   useEffect(() => {
     const token = ResponsiveObserve.subscribe(supportScreens => {


### PR DESCRIPTION
… when first render. (#32533)

<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

https://github.com/ant-design/ant-design/issues/32533

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

1. The problem is Grid.useBreakpoint hook returned empty object in the first render. because it uses responsiveObserve.subscribe to get breakpoint info in the callback. 
2. I think manual evaluation breakpoint, and return its result in useState's lazy callback function in the first render is a good idea. Because window.matchMedia can be executed independently.
3. As a result, I change responsiveObserve's code and add a util function named getScreenMap

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Grid.useBreakpoint will return media query result instead of return an empty object in the first render.      |
| 🇨🇳 Chinese |  Grid.useBreakpoint 在组件首次渲染的时候，将会返回媒体查询的结果，而不是返回空对象。         |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
