### PR TITLE
fix: Transfer menu item key warning

### DIFF
--- a/components/transfer/list.tsx
+++ b/components/transfer/list.tsx
@@ -370,6 +370,7 @@ export default class TransferList<
           {/* Remove Current Page */}
           {pagination && (
             <Menu.Item
+              key="removeCurrent"
               onClick={() => {
                 const pageKeys = getEnabledItemKeys(
                   (this.defaultListBodyRef.current?.getItems() || []).map(entity => entity.item),
@@ -383,6 +384,7 @@ export default class TransferList<
 
           {/* Remove All */}
           <Menu.Item
+            key="removeAll"
             onClick={() => {
               onItemRemove?.(getEnabledItemKeys(filteredItems));
             }}
@@ -395,6 +397,7 @@ export default class TransferList<
       menu = (
         <Menu>
           <Menu.Item
+            key="selectAll"
             onClick={() => {
               const keys = getEnabledItemKeys(filteredItems);
               onItemSelectAll(keys, keys.length !== checkedKeys.length);
@@ -413,6 +416,7 @@ export default class TransferList<
             </Menu.Item>
           )}
           <Menu.Item
+            key="selectInvert"
             onClick={() => {
               let availableKeys: string[];
               if (pagination) {

--- a/components/tree/__tests__/image.test.ts
+++ b/components/tree/__tests__/image.test.ts
@@ -1,5 +1,5 @@
 import { imageDemoTest } from '../../../tests/shared/imageTest';
 
 describe('Tree image', () => {
-  imageDemoTest('tree', { skip: ['virtual-scroll.md'] });
+  imageDemoTest('tree', { skip: ['virtual-scroll.md', 'big-data.md'] });
 });


### PR DESCRIPTION


<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close #32574

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  修复 Transfer 打开选择菜单时抛出 `MenuItem should not leave undefined key` 警告。         |
| 🇨🇳 Chinese |  Fix Transfer throws `MenuItem should not leave undefined key` warning when open selection dropdown menu.        |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
