### PR TITLE
fix: HierarchyRequestError: Failed to execute 'appendChild' on 'Node': This node type does not support this method.

### DIFF
--- a/components/_util/wave.tsx
+++ b/components/_util/wave.tsx
@@ -97,7 +97,8 @@ export default class Wave extends React.Component<WaveProps> {
 
       const nodeRoot = node.getRootNode?.() || node.ownerDocument;
       const nodeBody: Element =
-        nodeRoot instanceof Document ? nodeRoot.body : (nodeRoot.firstChild as Element) ?? nodeRoot;
+        nodeRoot instanceof Document || nodeRoot instanceof HTMLDocument ?
+        nodeRoot.body : (nodeRoot.firstChild as Element) ?? nodeRoot;
 
       styleForPseudo = updateCSS(
         `


### PR DESCRIPTION
### 🤔 This is a Bug fix

### 💡 Background and solution

点击页面的按钮组件，会报以下错误：
HierarchyRequestError: Failed to execute 'appendChild' on 'Node': This node type does not support this method.

原因是逻辑错误，导致了 html 结点错误地调用了 appendChild 方法。

修复逻辑后，html 会变为 body，body 可以调用 appendChild 方法。


### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   fix a error that append dom to html        |
| 🇨🇳 Chinese |   修复了一个问题，dom 被绑定到 html 上       |
