### PR TITLE
fix: export FormInterface

### DIFF
--- a/components/form/index.tsx
+++ b/components/form/index.tsx
@@ -34,6 +34,7 @@ Form.create = () => {
   );
 };
 
+
 export {
   FormInstance,
   FormProps,

--- a/components/form/index.tsx
+++ b/components/form/index.tsx
@@ -43,6 +43,7 @@ export {
   RuleObject,
   RuleRender,
   FormListProps,
+  FormInterface,
 };
 
 export default Form;

--- a/components/form/index.tsx
+++ b/components/form/index.tsx
@@ -34,7 +34,6 @@ Form.create = () => {
   );
 };
 
-
 export {
   FormInstance,
   FormProps,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 💡 Background and solution

1. Describe the problem and the scenario.
    * When extending the Form component in a project containing `declaration: true` in `tsconfig.json`, you get the following error: `TS4023: Exported variable 'Form' has or is using name 'FormInterface' from external module "/Users/cadinmcqueen/repos/tendo-ui-library/node_modules/antd/lib/form/index" but cannot be named.` 
2. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
    * Export `FormInterface` from components/form/index.tsx

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Export missing interface from Form component     |
| 🇨🇳 Chinese |      从 Form 组件导出缺少的界面     |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
