### PR TITLE
fix: Avoid selecting the placeholder of input control on Chrome brows…

### DIFF
--- a/components/style/mixins/compatibility.less
+++ b/components/style/mixins/compatibility.less
@@ -15,4 +15,10 @@
   &:placeholder-shown {
     text-overflow: ellipsis;
   }
+
+  // Chrome
+  /* stylelint-disable-next-line selector-no-vendor-prefix */
+  &::-webkit-input-placeholder {
+    user-select: none;
+  }
 }


### PR DESCRIPTION
fix: Avoid selecting the placeholder of input control on Chrome browser, keep consistent of selection behavior with Firefox browser

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

无

### 💡 需求背景和解决方案

在 Chrome 下，如果选择一个带有 placeholder 的文本框，则会连带选中该文本框内部的 placeholder 文字，与 Firefox 行为不一致

### 📝 更新日志

在 Chrome 下，如果选择一个带有 placeholder 的文本框，则**不会**连带选中该文本框内部的 placeholder 文字
左边页面为修改后的演示效果，右边页面为修改前的演示效果，可以看到左边页面选择文本框时不会选中 placeholder

![antd_fix_placeholder](https://user-images.githubusercontent.com/11588555/138754250-c581d81f-b964-47bb-ad9f-644d74ab599c.gif)

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | Avoid selecting the placeholder text when selecting an Input control on Chrome |
| 🇨🇳 中文 | 在 Chrome 内核浏览器中，选择文本框时避免选择 placeholder 文字 |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
