### PR TITLE
fix: Collapse style issue when expandIconPosition is right

### DIFF
--- a/components/collapse/style/index.less
+++ b/components/collapse/style/index.less
@@ -69,6 +69,7 @@
   &-icon-position-right {
     & > .@{collapse-prefix-cls}-item {
       > .@{collapse-prefix-cls}-header {
+        position: relative;
         padding: @collapse-header-padding;
         padding-right: @collapse-header-padding-extra;
 


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

#32599

### 💡 Background and solution

There's a style issue when `expandIconPosition` is set to `right`, it can be reproduced by [official documents](https://ant.design/components/collapse-cn/#components-collapse-demo-extra).

Fix by setting` position: relative` on the parent node.

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fix the style issue when `expandIconPosition` is `right` |
| 🇨🇳 Chinese | 修复 Collapse 设置 `expandIconPosition` 为 `right` 后的样式问题 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
