### PR TITLE
fix: if breadcrumbRender return false, breadcrumb will hidden

### DIFF
--- a/components/page-header/__tests__/index.test.js
+++ b/components/page-header/__tests__/index.test.js
@@ -73,6 +73,11 @@ describe('PageHeader', () => {
     expect(wrapper.find('.ant-page-header-back')).toHaveLength(0);
   });
 
+  it('pageHeader support breadcrumbRender return false', () => {
+    const wrapper = mount(<PageHeader title="Page Title" breadcrumbRender={() => false} />);
+    expect(wrapper.find('.ant-page-header-back')).toHaveLength(0);
+  });
+
   it('pageHeader do not has title', () => {
     const routes = [
       {

--- a/components/page-header/index.tsx
+++ b/components/page-header/index.tsx
@@ -159,7 +159,7 @@ const PageHeader: React.FC<PageHeaderProps> = props => {
         const isBreadcrumbComponent = breadcrumb && 'props' in breadcrumb;
         //  support breadcrumbRender function
         const breadcrumbRenderDomFromProps =
-          breadcrumbRender?.(props, defaultBreadcrumbDom) || defaultBreadcrumbDom;
+          breadcrumbRender?.(props, defaultBreadcrumbDom) ?? defaultBreadcrumbDom;
 
         const breadcrumbDom = isBreadcrumbComponent ? breadcrumb : breadcrumbRenderDomFromProps;
 


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

新特性请提交至 feature 分支，其余可提交至 master 分支。
在维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

[[English Template / 英文模板](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE.md)]

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案



<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

需要在某些情况下隐藏 breadcrumb ，现在的解决办法是高阶组件加 pathname 判断的方式来解决问题。

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |   Fix the problem that pageheader 'breadcrumbrender' returns false and still shows dom.     |
| 🇨🇳 中文 |   修复 PageHeader `breadcrumbRender `返回false，仍然展示 dom 的问题。          |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
