### PR TITLE
fix: Input disabled should not keep focus style

### DIFF
--- a/components/input/Input.tsx
+++ b/components/input/Input.tsx
@@ -188,6 +188,9 @@ class Input extends React.Component<InputProps, InputState> {
     if (nextProps.value !== undefined || prevValue !== nextProps.value) {
       newState.value = nextProps.value;
     }
+    if (nextProps.disabled) {
+      newState.focused = false;
+    }
     return newState;
   }
 

--- a/components/input/__tests__/focus.test.tsx
+++ b/components/input/__tests__/focus.test.tsx
@@ -55,4 +55,13 @@ describe('Input.Focus', () => {
     expect(focus).toHaveBeenCalled();
     expect(setSelectionRange).toHaveBeenCalledWith(expect.anything(), 0, 5);
   });
+
+  it('disabled should reset focus', () => {
+    const wrapper = mount(<Input allowClear />);
+    wrapper.find('input').simulate('focus');
+    expect(wrapper.exists('.ant-input-affix-wrapper-focused')).toBeTruthy();
+
+    wrapper.setProps({ disabled: true });
+    expect(wrapper.exists('.ant-input-affix-wrapper-focused')).toBeFalsy();
+  });
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

fix #32715

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Fix Input set to `disabled` still keep focused style.       |
| 🇨🇳 Chinese |  修复 Input 设置 `disabled` 时仍然保留聚焦样式的问题。        |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
