### PR TITLE
refactor: Move part mixins less to theme instead

### DIFF
--- a/components/style/core/motion.less
+++ b/components/style/core/motion.less
@@ -1,4 +1,4 @@
-@import '../mixins/motion';
+// @import '../mixins/motion'; This has moved to theme/xxx inside
 @import 'motion/fade';
 @import 'motion/move';
 @import 'motion/other';

--- a/components/style/core/motion.less
+++ b/components/style/core/motion.less
@@ -1,4 +1,4 @@
-// @import '../mixins/motion'; This has moved to theme/xxx inside
+// @import '../mixins/motion'; This has moved to theme/xxx inside.
 @import 'motion/fade';
 @import 'motion/move';
 @import 'motion/other';

--- a/components/style/mixins/index.less
+++ b/components/style/mixins/index.less
@@ -4,10 +4,12 @@
 @import 'compatibility';
 @import 'clearfix';
 @import 'iconfont';
-@import 'motion';
-@import 'reset';
 @import 'operation-unit';
 @import 'typography';
 @import 'customize';
 @import 'box';
 @import 'modal-mask';
+
+// Note: These mixins require theme variables. Let's move to theme file instead:
+// @import 'motion';
+// @import 'reset';

--- a/components/style/mixins/index.less
+++ b/components/style/mixins/index.less
@@ -4,6 +4,8 @@
 @import 'compatibility';
 @import 'clearfix';
 @import 'iconfont';
+@import 'motion';
+@import 'reset';
 @import 'operation-unit';
 @import 'typography';
 @import 'customize';
@@ -11,5 +13,3 @@
 @import 'modal-mask';
 
 // We should move this to theme folder instead
-@import 'motion';
-@import 'reset';

--- a/components/style/mixins/index.less
+++ b/components/style/mixins/index.less
@@ -4,10 +4,12 @@
 @import 'compatibility';
 @import 'clearfix';
 @import 'iconfont';
-@import 'motion';
-@import 'reset';
 @import 'operation-unit';
 @import 'typography';
 @import 'customize';
 @import 'box';
 @import 'modal-mask';
+
+// We should move this to theme folder instead
+@import 'motion';
+@import 'reset';

--- a/components/style/themes/default.less
+++ b/components/style/themes/default.less
@@ -1,5 +1,6 @@
 /* stylelint-disable at-rule-empty-line-before,at-rule-name-space-after,at-rule-no-unknown */
 @import '../color/colors';
+@import './mixins/index';
 
 @theme: default;
 

--- a/components/style/themes/mixins/index.less
+++ b/components/style/themes/mixins/index.less
@@ -1,0 +1,2 @@
+@import 'motion';
+@import 'reset';

--- a/components/style/themes/mixins/motion.less
+++ b/components/style/themes/mixins/motion.less
@@ -1,5 +1,3 @@
-@import '../themes/index';
-
 .motion-common(@duration: @animation-duration-base) {
   animation-duration: @duration;
   animation-fill-mode: both;

--- a/components/style/themes/mixins/reset.less
+++ b/components/style/themes/mixins/reset.less
@@ -1,5 +1,3 @@
-@import '../themes/index';
-
 .reset-component() {
   box-sizing: border-box;
   margin: 0;

--- a/components/style/themes/variable.less
+++ b/components/style/themes/variable.less
@@ -1,5 +1,6 @@
 /* stylelint-disable at-rule-empty-line-before,at-rule-name-space-after,at-rule-no-unknown */
 @import '../color/colors';
+@import './mixins/index';
 
 @theme: variable;
 

--- a/docs/react/customize-theme-variable.en-US.md
+++ b/docs/react/customize-theme-variable.en-US.md
@@ -72,3 +72,9 @@ Since prefix modified. Origin `antd.variable.css` should also be replaced:
 ```bash
 lessc --modify-var="ant-prefix=custom" antd/dist/antd.variable.less modified.css
 ```
+
+### Related changes
+
+In order to implement CSS Variable and maintain original usage compatibility, we added `@root-entry-name: xxx;` entry injection to the `dist/antd.xxx.less` file to support less dynamic loading of the corresponding less file. Under normal circumstances, you do not need to pay attention to this change. However, if your project directly references the less file in the `lib|es` directory. You need to configure `@root-entry-name: default;` (or `@root-entry-name: variable;`) at the entry of less so that less can find the correct entry.
+
+In addition, we migrated `@import'motion'` and `@import'reset'` in `lib|es/style/minxins/index.less` to `lib|es/style/themes/xxx.less` In, because these two files rely on theme-related variables. If you use the relevant internal method, please adjust it yourself. Of course, we still recommend using the `antd.less` files in the `dist` directory directly instead of calling internal files, because they are often affected by refactoring.

--- a/docs/react/customize-theme-variable.zh-CN.md
+++ b/docs/react/customize-theme-variable.zh-CN.md
@@ -72,3 +72,9 @@ ConfigProvider.config({
 ```bash
 lessc --modify-var="ant-prefix=custom" antd/dist/antd.variable.less modified.css
 ```
+
+### 相关变更
+
+为了实现 CSS Variable 并保持原始用法兼容性，我们于 `dist/antd.xxx.less` 文件中添加了 `@root-entry-name: xxx;` 入口注入以支持 less 动态加载对应的 less 文件。一般情况下，你不需要关注该变化。但是，如果你的项目中直接引用了 `lib|es` 目录下的 less 文件。你需要在 less 入口处配置 `@root-entry-name: default;` （或者 `@root-entry-name: variable;`）以使 less 可以找到正确的入口。
+
+此外，我们将 `lib|es/style/minxins/index.less` 中的 `@import 'motion'` 和 `@import 'reset'` 迁移至了 `lib|es/style/themes/xxx.less` 中，因为这两个文件依赖了主题相关变量。如果你使用了相关内部方法，请自行调整。当然，我们还是建议直接使用 `dist` 目录下的 `antd.less` 文件而非调用内部文件，因为它们经常会受重构影响。


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [x] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Move part `mixins` related less file to `themes` instead since it requires theme variable. We do not recommend use internal file but please note this if you already use it.        |
| 🇨🇳 Chinese |   移动部分 `mixins` less 文件到 `themes` 文件下，因为它们依赖于主题相关变量。我们不推荐直接引用底层 less 文件，但是如果你使用了请注意这部分变更。        |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
