### PR TITLE
feat: add onOpen prop for modal

### DIFF
--- a/components/modal/ConfirmDialog.tsx
+++ b/components/modal/ConfirmDialog.tsx
@@ -7,6 +7,7 @@ import ConfigProvider from '../config-provider';
 import { getTransitionName } from '../_util/motion';
 
 interface ConfirmDialogProps extends ModalFuncProps {
+  onOpen?: () => void;
   afterClose?: () => void;
   close: (...args: any[]) => void;
   autoFocusButton?: null | 'ok' | 'cancel';
@@ -19,6 +20,7 @@ const ConfirmDialog = (props: ConfirmDialogProps) => {
     icon,
     onCancel,
     onOk,
+    onOpen,
     close,
     zIndex,
     afterClose,
@@ -86,6 +88,7 @@ const ConfirmDialog = (props: ConfirmDialogProps) => {
         className={classString}
         wrapClassName={classNames({ [`${contentPrefixCls}-centered`]: !!props.centered })}
         onCancel={() => close({ triggerCancel: true })}
+        onOpen={onOpen}
         visible={visible}
         title=""
         footer=""

--- a/components/modal/Modal.tsx
+++ b/components/modal/Modal.tsx
@@ -45,6 +45,7 @@ export interface ModalProps {
   onOk?: (e: React.MouseEvent<HTMLElement>) => void;
   /** 点击模态框右上角叉、取消按钮、Props.maskClosable 值为 true 时的遮罩层或键盘按下 Esc 时的回调 */
   onCancel?: (e: React.MouseEvent<HTMLElement>) => void;
+  onOpen?: () => void;
   afterClose?: () => void;
   /** 垂直居中 */
   centered?: boolean;
@@ -95,6 +96,7 @@ export interface ModalFuncProps {
   // TODO: find out exact types
   onOk?: (...args: any[]) => any;
   onCancel?: (...args: any[]) => any;
+  onOpen?: () => void;
   afterClose?: () => void;
   okButtonProps?: ButtonProps;
   cancelButtonProps?: ButtonProps;
@@ -135,6 +137,13 @@ const Modal: React.FC<ModalProps> = props => {
     getPrefixCls,
     direction,
   } = React.useContext(ConfigContext);
+
+  React.useEffect(() => {
+    if (props.visible) {
+      const { onOpen } = props;
+      onOpen?.();
+    }
+  }, [props.visible]);
 
   const handleCancel = (e: React.MouseEvent<HTMLButtonElement>) => {
     const { onCancel } = props;

--- a/components/modal/index.en-US.md
+++ b/components/modal/index.en-US.md
@@ -44,6 +44,7 @@ When requiring users to interact with the application, but without jumping to a 
 | zIndex | The `z-index` of the Modal | number | 1000 |  |
 | onCancel | Specify a function that will be called when a user clicks mask, close button on top right or Cancel button | function(e) | - |  |
 | onOk | Specify a function that will be called when a user clicks the OK button | function(e) | - |  |
+| onOpen | Specify a function that will be called when modal is opened | function | - |  |
 
 #### Note
 
@@ -90,6 +91,7 @@ The items listed above are all functions, expecting a settings object as paramet
 | zIndex | The `z-index` of the Modal | number | 1000 |  |
 | onCancel | Specify a function that will be called when the user clicks the Cancel button. The parameter of this function is a function whose execution should include closing the dialog. If the function does not take any parameter (`!onCancel.length`) then modal dialog will be closed unless returned value is `true` (`!!onCancel()`). You can also just return a promise and when the promise is resolved, the modal dialog will also be closed | function(close) | - |  |
 | onOk | Specify a function that will be called when the user clicks the OK button. The parameter of this function is a function whose execution should include closing the dialog. If the function does not take any parameter (`!onOk.length`) then modal dialog will be closed unless returned value is `true` (`!!onOk()`). You can also just return a promise and when the promise is resolved, the modal dialog will also be closed | function(close) | - |  |
+| onOpen | Specify a function that will be called when modal is opened | function | - |  |
 
 All the `Modal.method`s will return a reference, and then we can update and close the modal dialog by the reference.
 
@@ -171,4 +173,4 @@ You can config `transitionName=""` and `maskTransitionName=""` to remove motion 
 
 ### How to set static methods prefixCls ？
 
-You can config with [`ConfigProvider.config`](/components/config-provider/#ConfigProvider.config()-4.13.0+)
+You can config with [`ConfigProvider.config`](</components/config-provider/#ConfigProvider.config()-4.13.0+>)

--- a/components/modal/index.zh-CN.md
+++ b/components/modal/index.zh-CN.md
@@ -47,6 +47,7 @@ cover: https://gw.alipayobjects.com/zos/alicdn/3StSdUlSH/Modal.svg
 | zIndex | 设置 Modal 的 `z-index` | number | 1000 |  |
 | onCancel | 点击遮罩层或右上角叉或取消按钮的回调 | function(e) | - |  |
 | onOk | 点击确定回调 | function(e) | - |  |
+| onOpen | 指定打开模态时将调用的函数 | function | - |  |
 
 #### 注意
 
@@ -93,6 +94,7 @@ cover: https://gw.alipayobjects.com/zos/alicdn/3StSdUlSH/Modal.svg
 | zIndex | 设置 Modal 的 `z-index` | number | 1000 |  |
 | onCancel | 取消回调，参数为关闭函数，返回 promise 时 resolve 后自动关闭 | function(close) | - |  |
 | onOk | 点击确定回调，参数为关闭函数，返回 promise 时 resolve 后自动关闭 | function(close) | - |  |
+| onOpen | 指定打开模态时将调用的函数 | function | - |  |
 
 以上函数调用后，会返回一个引用，可以通过该引用更新和关闭弹窗。
 
@@ -128,7 +130,7 @@ browserHistory.listen(() => {
 
 ### Modal.useModal()
 
-当你需要使用 Context 时，可以通过 `Modal.useModal` 创建一个 `contextHolder` 插入子节点中。通过 hooks 创建的临时 Modal 将会得到 `contextHolder` 所在位置的所有上下文。创建的 `modal` 对象拥有与 [`Modal.method`](#Modal.method()) 相同的创建通知方法。
+当你需要使用 Context 时，可以通过 `Modal.useModal` 创建一个 `contextHolder` 插入子节点中。通过 hooks 创建的临时 Modal 将会得到 `contextHolder` 所在位置的所有上下文。创建的 `modal` 对象拥有与 [`Modal.method`](<#Modal.method()>) 相同的创建通知方法。
 
 ```jsx
 const [modal, contextHolder] = Modal.useModal();
@@ -172,4 +174,4 @@ return (
 
 ### 静态方法如何设置 prefixCls ？
 
-你可以通过 [`ConfigProvider.config`](/components/config-provider/#ConfigProvider.config()-4.13.0+) 进行设置。
+你可以通过 [`ConfigProvider.config`](</components/config-provider/#ConfigProvider.config()-4.13.0+>) 进行设置。


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

There are many scenarios when some specific tasks should be done when the modal is opened. Let's use an example.

When a user opens up a modal, an API request should be made to fetch the product list. But while browsing the page, the user may or may not open the modal. So it would be ideal to call the API only after the user clicks to open the modal, not before. Also, every time the user opens the modal, the latest product list should be shown. So we would need to call the API every time the modal is opened. Currently, there is no function to trigger when the modal is opened. 

To solve the above issue, '`onOpen`' prop(optional) is added.

```jsx
<Modal title="Modal" visible={isModalVisible} onOpen={makeApiRequest}>
        ..........
</Modal>
```
Some UI libraries e.g. [reactstrap](https://reactstrap.github.io/?path=/docs/components-modal--modal) have this option.

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | add onOpen prop for modal |
| 🇨🇳 Chinese | 为模态添加 onOpen 道具 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
