### PR TITLE
feat: ConfigProvider add form colon

### DIFF
--- a/components/config-provider/__tests__/form.test.js
+++ b/components/config-provider/__tests__/form.test.js
@@ -91,4 +91,20 @@ describe('ConfigProvider.Form', () => {
       expect(wrapper).toMatchRenderedSnapshot();
     });
   });
+
+  describe('form colon', () => {
+    it('set colon false', async () => {
+      const wrapper = mount(
+        <ConfigProvider form={{ colon: false }}>
+          <Form>
+            <Form.Item label="没有冒号">
+              <input />
+            </Form.Item>
+          </Form>
+        </ConfigProvider>,
+      );
+
+      expect(wrapper.exists('.ant-form-item-no-colon')).toBeTruthy();
+    });
+  });
 });

--- a/components/config-provider/context.tsx
+++ b/components/config-provider/context.tsx
@@ -43,6 +43,7 @@ export interface ConfigConsumerProps {
   dropdownMatchSelectWidth?: boolean;
   form?: {
     requiredMark?: RequiredMark;
+    colon?: boolean;
   };
 }
 

--- a/components/config-provider/index.tsx
+++ b/components/config-provider/index.tsx
@@ -64,6 +64,7 @@ export interface ConfigProviderProps {
   form?: {
     validateMessages?: ValidateMessages;
     requiredMark?: RequiredMark;
+    colon?: boolean;
   };
   input?: {
     autoComplete?: string;

--- a/components/config-provider/index.zh-CN.md
+++ b/components/config-provider/index.zh-CN.md
@@ -44,7 +44,7 @@ export default () => (
 | csp | 设置 [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) 配置 | { nonce: string } | - |  |
 | direction | 设置文本展示方向。 [示例](#components-config-provider-demo-direction) | `ltr` \| `rtl` | `ltr` |  |
 | dropdownMatchSelectWidth | 下拉菜单和选择器同宽。默认将设置 `min-width`，当值小于选择框宽度时会被忽略。`false` 时会关闭虚拟滚动 | boolean \| number | - | 4.3.0 |
-| form | 设置 Form 组件的通用属性 | { validateMessages?: [ValidateMessages](/components/form/#validateMessages), requiredMark?: boolean \| `optional` } | - | requiredMark: 4.8.0 |
+| form | 设置 Form 组件的通用属性 | { validateMessages?: [ValidateMessages](/components/form/#validateMessages), requiredMark?: boolean \| `optional`, colon?: boolean} | - | requiredMark: 4.8.0; colon: 4.17.0 |
 | getPopupContainer | 弹出框（Select, Tooltip, Menu 等等）渲染父节点，默认渲染到 body 上。 | function(triggerNode) | () => document.body |  |
 | getTargetContainer | 配置 Affix、Anchor 滚动监听容器。 | () => HTMLElement | () => window | 4.2.0 |
 | iconPrefixCls | 设置图标统一样式前缀。注意：需要配合 `less` 变量 [@iconfont-css-prefix](https://github.com/ant-design/ant-design/blob/d943b85a523bdf181dabc12c928226f3b4b893de/components/style/themes/default.less#L106) 使用 | string | `anticon` | 4.11.0 |

--- a/components/form/FormItemLabel.tsx
+++ b/components/form/FormItemLabel.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import classNames from 'classnames';
 import QuestionCircleOutlined from '@ant-design/icons/QuestionCircleOutlined';
 import Col, { ColProps } from '../grid/col';
+import { ConfigContext } from '../config-provider';
 import { FormLabelAlign } from './interface';
 import { FormContext, FormContextProps } from './context';
 import { RequiredMark } from './Form';
@@ -51,6 +52,7 @@ const FormItemLabel: React.FC<FormItemLabelProps & { required?: boolean; prefixC
   tooltip,
 }) => {
   const [formLocale] = useLocaleReceiver('Form');
+  const { form: contextForm } = React.useContext(ConfigContext);
 
   if (!label) return null;
 
@@ -75,7 +77,14 @@ const FormItemLabel: React.FC<FormItemLabelProps & { required?: boolean; prefixC
 
         let labelChildren = label;
         // Keep label is original where there should have no colon
-        const computedColon = colon === true || (contextColon !== false && colon !== false);
+        const computedColon =
+          colon !== undefined
+            ? colon
+            : contextColon !== undefined
+            ? contextColon
+            : contextForm && contextForm.colon !== undefined
+            ? contextForm.colon
+            : true;
         const haveColon = computedColon && !vertical;
         // Remove duplicated user input colon
         if (haveColon && typeof label === 'string' && (label as string).trim() !== '') {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

新特性请提交至 feature 分支，其余可提交至 master 分支。
在维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

[[English Template / 英文模板](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE.md)]

### 🤔 这个变动的性质是？

- [x] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
关闭#32780
### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |    Get the ConfigContext in the FormItemLabel component.Optimized the comparison logic of colon priority of ConfigContext, FormContext and Props.      |
| 🇨🇳 中文 |      在FormItemLabel组件里获取ConfigContext。优化了ConfigContext、FormContext和Props的冒号优先级的比较逻辑。    |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供