### PR TITLE
perf: Not wrap Tooltip when menu item no need it

### DIFF
--- a/components/menu/MenuItem.tsx
+++ b/components/menu/MenuItem.tsx
@@ -55,33 +55,42 @@ export default class MenuItem extends React.Component<MenuItemProps> {
       tooltipProps.visible = false;
     }
     const childrenLength = toArray(children).length;
-    return (
-      <Tooltip
-        {...tooltipProps}
-        placement={direction === 'rtl' ? 'left' : 'right'}
-        overlayClassName={`${prefixCls}-inline-collapsed-tooltip`}
+
+    let itemNode = (
+      <Item
+        {...rest}
+        className={classNames(
+          {
+            [`${prefixCls}-item-danger`]: danger,
+            [`${prefixCls}-item-only-child`]: (icon ? childrenLength + 1 : childrenLength) === 1,
+          },
+          className,
+        )}
+        title={typeof title === 'string' ? title : undefined}
       >
-        <Item
-          {...rest}
-          className={classNames(
-            {
-              [`${prefixCls}-item-danger`]: danger,
-              [`${prefixCls}-item-only-child`]: (icon ? childrenLength + 1 : childrenLength) === 1,
-            },
-            className,
-          )}
-          title={typeof title === 'string' ? title : undefined}
-        >
-          {cloneElement(icon, {
-            className: classNames(
-              isValidElement(icon) ? icon.props?.className : '',
-              `${prefixCls}-item-icon`,
-            ),
-          })}
-          {this.renderItemChildren(inlineCollapsed)}
-        </Item>
-      </Tooltip>
+        {cloneElement(icon, {
+          className: classNames(
+            isValidElement(icon) ? icon.props?.className : '',
+            `${prefixCls}-item-icon`,
+          ),
+        })}
+        {this.renderItemChildren(inlineCollapsed)}
+      </Item>
     );
+
+    if (tooltipProps.title) {
+      itemNode = (
+        <Tooltip
+          {...tooltipProps}
+          placement={direction === 'rtl' ? 'left' : 'right'}
+          overlayClassName={`${prefixCls}-inline-collapsed-tooltip`}
+        >
+          {itemNode}
+        </Tooltip>
+      );
+    }
+
+    return itemNode;
   };
 
   render() {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [x] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

resolve #32681

### 💡 Background and solution

调试了一下发现 Menu.Item 并未渲染，但是 Tooltip hover 触发了刷新。移除不必要的 Tooltip 速度就快了。这个改完，`rc-tooltip` 里也看看还有什么可以优化的地方。

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Fix Menu render perf when long menu item.       |
| 🇨🇳 Chinese |    修复 Menu 在长列表下的性能问题。     |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
