### PR TITLE
fix: rowSelection preserveSelectedRowKeys false not work for async pagination data

### DIFF
--- a/components/table/Table.tsx
+++ b/components/table/Table.tsx
@@ -314,6 +314,10 @@ function InternalTable<RecordType extends object = any>(
   const [transformTitleColumns] = useTitleColumns(columnTitleProps);
 
   // ========================== Pagination ==========================
+
+  const setSelectedKeysRef = React.useRef<(keys: React.Key[]) => void>();
+  const selectedKeysRef = React.useRef<React.Key[]>([]);
+
   const onPaginationChange = (current: number, pageSize: number) => {
     triggerOnChange(
       {
@@ -321,6 +325,8 @@ function InternalTable<RecordType extends object = any>(
       },
       'paginate',
     );
+    const func = setSelectedKeysRef.current;
+    if (func) func(selectedKeysRef.current);
   };
 
   const [mergedPagination, resetPagination] = usePagination(
@@ -366,18 +372,24 @@ function InternalTable<RecordType extends object = any>(
   ]);
 
   // ========================== Selections ==========================
-  const [transformSelectionColumns, selectedKeySet] = useSelection<RecordType>(rowSelection, {
-    prefixCls,
-    data: mergedData,
-    pageData,
-    getRowKey,
-    getRecordByKey,
-    expandType,
-    childrenColumnName,
-    locale: tableLocale,
-    expandIconColumnIndex: mergedExpandable.expandIconColumnIndex,
-    getPopupContainer,
-  });
+  const [setSelectedKeys, transformSelectionColumns, selectedKeySet] = useSelection<RecordType>(
+    rowSelection,
+    {
+      prefixCls,
+      data: mergedData,
+      pageData,
+      getRowKey,
+      getRecordByKey,
+      expandType,
+      childrenColumnName,
+      locale: tableLocale,
+      expandIconColumnIndex: mergedExpandable.expandIconColumnIndex,
+      getPopupContainer,
+    },
+  );
+
+  setSelectedKeysRef.current = setSelectedKeys;
+  selectedKeysRef.current = Array.from(selectedKeySet);
 
   const internalRowClassName = (record: RecordType, index: number, indent: number) => {
     let mergedRowClassName;

--- a/components/table/__tests__/Table.rowSelection.test.js
+++ b/components/table/__tests__/Table.rowSelection.test.js
@@ -1416,22 +1416,30 @@ describe('Table.rowSelection', () => {
     });
 
     it('set preserveSelectedRowKeys as false works when data changed', () => {
+      const newData = [];
+      for (let i = 0; i < 20; i += 1) {
+        newData.push({
+          name: i.toString(),
+        });
+      }
       const onChange = jest.fn();
       const wrapper = mount(
-        <Table
-          dataSource={[{ name: 'light' }, { name: 'bamboo' }]}
-          rowSelection={{ onChange, preserveSelectedRowKeys: false }}
-          rowKey="name"
-        />,
+        createTable({
+          rowSelection: { preserveSelectedRowKeys: false, onChange },
+          dataSource: newData.slice(0, 10),
+          rowKey: 'name',
+          pagination: { total: 20 },
+        }),
       );
-
       wrapper
         .find('tbody input')
         .first()
         .simulate('change', { target: { checked: true } });
-      expect(onChange).toHaveBeenCalledWith(['light'], [{ name: 'light' }]);
-
-      wrapper.setProps({ dataSource: [{ name: 'bamboo' }] });
+      expect(onChange).toHaveBeenCalledWith(['0'], [{ name: '0' }]);
+      wrapper.setProps({ dataSource: newData.slice(10) });
+      wrapper.find('Pager').at(1).simulate('click');
+      wrapper.setProps({ dataSource: newData.slice(0, 10) });
+      wrapper.find('Pager').at(0).simulate('click');
       expect(onChange).toHaveBeenCalledWith([], []);
     });
 

--- a/components/table/__tests__/Table.rowSelection.test.js
+++ b/components/table/__tests__/Table.rowSelection.test.js
@@ -1415,6 +1415,26 @@ describe('Table.rowSelection', () => {
       );
     });
 
+    it('set preserveSelectedRowKeys as false works when data changed', () => {
+      const onChange = jest.fn();
+      const wrapper = mount(
+        <Table
+          dataSource={[{ name: 'light' }, { name: 'bamboo' }]}
+          rowSelection={{ onChange, preserveSelectedRowKeys: false }}
+          rowKey="name"
+        />,
+      );
+
+      wrapper
+        .find('tbody input')
+        .first()
+        .simulate('change', { target: { checked: true } });
+      expect(onChange).toHaveBeenCalledWith(['light'], [{ name: 'light' }]);
+
+      wrapper.setProps({ dataSource: [{ name: 'bamboo' }] });
+      expect(onChange).toHaveBeenCalledWith([], []);
+    });
+
     it('works with receive selectedRowKeys fron [] to undefined', () => {
       const onChange = jest.fn();
       const dataSource = [{ name: 'Jack' }];

--- a/components/table/hooks/useSelection.tsx
+++ b/components/table/hooks/useSelection.tsx
@@ -253,6 +253,12 @@ export default function useSelection<RecordType>(
     [setMergedSelectedKeys, getRecordByKey, onSelectionChange, preserveSelectedRowKeys],
   );
 
+  React.useEffect(() => {
+    if (preserveSelectedRowKeys === false) {
+      setSelectedKeys(derivedSelectedKeys);
+    }
+  }, [preserveSelectedRowKeys]);
+
   // ====================== Selections ======================
   // Trigger single `onSelect` event
   const triggerSingleSelection = useCallback(

--- a/components/table/hooks/useSelection.tsx
+++ b/components/table/hooks/useSelection.tsx
@@ -75,7 +75,7 @@ function flattenData<RecordType>(
 export default function useSelection<RecordType>(
   rowSelection: TableRowSelection<RecordType> | undefined,
   config: UseSelectionConfig<RecordType>,
-): [TransformColumns<RecordType>, Set<Key>] {
+): [(keys: Key[]) => void, TransformColumns<RecordType>, Set<Key>] {
   const {
     preserveSelectedRowKeys,
     selectedRowKeys,
@@ -252,12 +252,6 @@ export default function useSelection<RecordType>(
     },
     [setMergedSelectedKeys, getRecordByKey, onSelectionChange, preserveSelectedRowKeys],
   );
-
-  React.useEffect(() => {
-    if (preserveSelectedRowKeys === false) {
-      setSelectedKeys(derivedSelectedKeys);
-    }
-  }, [preserveSelectedRowKeys]);
 
   // ====================== Selections ======================
   // Trigger single `onSelect` event
@@ -664,5 +658,5 @@ export default function useSelection<RecordType>(
     ],
   );
 
-  return [transformColumns, derivedSelectedKeySet];
+  return [setSelectedKeys, transformColumns, derivedSelectedKeySet];
 }


### PR DESCRIPTION
fix: rowSelection preserveSelectedRowKeys false not work for async pagination data

<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
[32861](https://github.com/ant-design/ant-design/issues/32861)
<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

##### Background
+ 在preserveSelectedRowKeys设置为false的情况下，切换分页并不会清除上一页选中的选项（此时dataSource已被更新），与文案不符

#### Fix
+ 注意到在issue提出者给出的csb中，如果在切换到分页2后选择任意选项再切换回分页1，则分页1选择的选项已被清除
+ 阅读源代码发现此行为会触发`triggerSingleSelection`函数，此函数中会调用setSelectedKeys函数，在该函数中有如下代码：
```typescript
      if (preserveSelectedRowKeys) {
        availableKeys = keys;
        records = keys.map(key => preserveRecordsRef.current.get(key)!);
      } else {
        // Filter key which not exist in the `dataSource`
        availableKeys = [];
        records = [];

        keys.forEach(key => {
          const record = getRecordByKey(key);
          if (record !== undefined) {
            availableKeys.push(key);
            records.push(record);
          }
        });
      }
```
这里包含了清除不在dataSource内的key的部分
所以新增了一个useEffect用于在数据更新时不需要手动触发即可进行清除工作

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     fix: rowSelection preserveSelectedRowKeys false not work for async pagination data      |
| 🇨🇳 Chinese |    修复了preserveSelectedRowKeys为false时需要触发才会清除数据已被删除的key的bug       |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
