### PR TITLE
feat: Expand pl_PL translations to latest translation spec

### DIFF
--- a/components/locale/pl_PL.tsx
+++ b/components/locale/pl_PL.tsx
@@ -1,8 +1,11 @@
+/* eslint-disable no-template-curly-in-string */
 import Pagination from 'rc-pagination/lib/locale/pl_PL';
 import DatePicker from '../date-picker/locale/pl_PL';
 import TimePicker from '../time-picker/locale/pl_PL';
 import Calendar from '../calendar/locale/pl_PL';
 import { Locale } from '../locale-provider';
+
+const typeTemplate = '${label} nie posiada poprawnej wartości dla typu ${type}';
 
 const localeValues: Locale = {
   locale: 'pl',
@@ -10,12 +13,24 @@ const localeValues: Locale = {
   DatePicker,
   TimePicker,
   Calendar,
+  global: {
+    placeholder: 'Wybierz',
+  },
   Table: {
     filterTitle: 'Menu filtra',
     filterConfirm: 'OK',
-    filterReset: 'Wyczyść',
+    filterReset: 'Usuń filtry',
+    filterEmptyText: 'Brak filtrów',
+    filterCheckall: 'Wybierz wszystkie elementy',
+    filterSearchPlaceholder: 'Szukaj w filtrach',
+    emptyText: 'Brak danych',
     selectAll: 'Zaznacz bieżącą stronę',
     selectInvert: 'Odwróć zaznaczenie',
+    selectNone: 'Wyczyść',
+    selectionAll: 'Wybierz wszystkie',
+    sortTitle: 'Sortowanie',
+    expand: 'Rozwiń wiersz',
+    collapse: 'Zwiń wiersz',
     triggerDesc: 'Sortuj malejąco',
     triggerAsc: 'Sortuj rosnąco',
     cancelSort: 'Usuń sortowanie',
@@ -30,9 +45,16 @@ const localeValues: Locale = {
     cancelText: 'Anuluj',
   },
   Transfer: {
+    titles: ['', ''],
     searchPlaceholder: 'Szukaj',
     itemUnit: 'obiekt',
     itemsUnit: 'obiekty',
+    remove: 'Usuń',
+    selectCurrent: 'Wybierz aktualną stronę',
+    removeCurrent: 'Usuń aktualną stronę',
+    selectAll: 'Wybierz wszystkie',
+    removeAll: 'Usuń wszystkie',
+    selectInvert: 'Odwróć wybór',
   },
   Upload: {
     uploading: 'Wysyłanie...',
@@ -43,6 +65,71 @@ const localeValues: Locale = {
   },
   Empty: {
     description: 'Brak danych',
+  },
+  Icon: {
+    icon: 'Ikona',
+  },
+  Text: {
+    edit: 'Edytuj',
+    copy: 'Kopiuj',
+    copied: 'Skopiowany',
+    expand: 'Rozwiń',
+  },
+  PageHeader: {
+    back: 'Wstecz',
+  },
+  Form: {
+    optional: '(opcjonalne)',
+    defaultValidateMessages: {
+      default: 'Błąd walidacji dla pola ${label}',
+      required: 'Pole ${label} jest wymagane',
+      enum: 'Pole ${label} musi posiadać wartość z listy: [${enum}]',
+      whitespace: 'Pole ${label} nie może być puste',
+      date: {
+        format: '${label} posiada zły format daty',
+        parse: '${label} nie może zostać zinterpretowane jako data',
+        invalid: '${label} jest niepoprawną datą',
+      },
+      types: {
+        string: typeTemplate,
+        method: typeTemplate,
+        array: typeTemplate,
+        object: typeTemplate,
+        number: typeTemplate,
+        date: typeTemplate,
+        boolean: typeTemplate,
+        integer: typeTemplate,
+        float: typeTemplate,
+        regexp: typeTemplate,
+        email: typeTemplate,
+        url: typeTemplate,
+        hex: typeTemplate,
+      },
+      string: {
+        len: '${label} musi posiadać ${len} znaków',
+        min: '${label} musi posiadać co namniej ${min} znaków',
+        max: '${label} musi posiadać maksymalnie ${max} znaków',
+        range: '${label} musi posiadać między ${min} a ${max} znaków',
+      },
+      number: {
+        len: '${label} musi mieć wartość o długości ${len}',
+        min: '${label} musi mieć wartość większą lub równą ${min}',
+        max: '${label} musi mieć wartość mniejszą lub równą ${max}',
+        range: '${label} musi mieć wartość pomiędzy ${min} a ${max}',
+      },
+      array: {
+        len: '${label} musi posiadać ${len} elementów',
+        min: '${label} musi posiadać co najmniej ${len} elementów',
+        max: '${label} musi posiadać maksymalnie ${len} elementów',
+        range: '${label} musi posiadać między ${min} a ${max} elementów',
+      },
+      pattern: {
+        mismatch: '${label} nie posiada wartości zgodnej ze wzorem ${pattern}',
+      },
+    },
+  },
+  Image: {
+    preview: 'Podgląd',
   },
 };
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [x] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
N/a
<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution
I've noticed that there aren't polish translations for form validation. When adding this I figured I'll go ahead and add all missing translations (basing them on `default.tsx`).

I haven't seen a place in code where I could see all translations (I've tested this using various components and wrapping them in docs with ConfigProvider). Is there one place where we can see all translations?

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Added missing pl_PL translations |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
