### PR TITLE
fix: update ConfigProvider context to  use globalConfig 

### DIFF
--- a/components/config-provider/context.tsx
+++ b/components/config-provider/context.tsx
@@ -3,6 +3,7 @@ import defaultRenderEmpty, { RenderEmptyHandler } from './renderEmpty';
 import { Locale } from '../locale-provider';
 import { SizeType } from './SizeContext';
 import { RequiredMark } from '../form/Form';
+import { globalConfig } from './global-config';
 
 export interface Theme {
   primaryColor?: string;
@@ -46,15 +47,9 @@ export interface ConfigConsumerProps {
   };
 }
 
-const defaultGetPrefixCls = (suffixCls?: string, customizePrefixCls?: string) => {
-  if (customizePrefixCls) return customizePrefixCls;
-
-  return suffixCls ? `ant-${suffixCls}` : 'ant';
-};
-
 export const ConfigContext = React.createContext<ConfigConsumerProps>({
   // We provide a default function for Context without provider
-  getPrefixCls: defaultGetPrefixCls,
+  getPrefixCls: globalConfig().getPrefixCls,
 
   renderEmpty: defaultRenderEmpty,
 });

--- a/components/config-provider/global-config.ts
+++ b/components/config-provider/global-config.ts
@@ -1,0 +1,61 @@
+import { Theme } from './context';
+import { registerTheme } from './cssVariables';
+import { ConfigProviderProps } from './type';
+
+export const defaultPrefixCls = 'ant';
+export const defaultIconPrefixCls = 'anticon';
+
+let globalPrefixCls: string;
+let globalIconPrefixCls: string;
+
+function getGlobalPrefixCls() {
+  return globalPrefixCls || defaultPrefixCls;
+}
+
+function getGlobalIconPrefixCls() {
+  return globalIconPrefixCls || defaultIconPrefixCls;
+}
+
+export const setGlobalConfig = ({
+  prefixCls,
+  iconPrefixCls,
+  theme,
+}: Pick<ConfigProviderProps, 'prefixCls' | 'iconPrefixCls'> & { theme?: Theme }) => {
+  if (prefixCls !== undefined) {
+    globalPrefixCls = prefixCls;
+  }
+  if (iconPrefixCls !== undefined) {
+    globalIconPrefixCls = iconPrefixCls;
+  }
+
+  if (theme) {
+    registerTheme(getGlobalPrefixCls(), theme);
+  }
+};
+
+export const globalConfig = () => ({
+  getPrefixCls: (suffixCls?: string, customizePrefixCls?: string) => {
+    if (customizePrefixCls) return customizePrefixCls;
+    return suffixCls ? `${getGlobalPrefixCls()}-${suffixCls}` : getGlobalPrefixCls();
+  },
+  getIconPrefixCls: getGlobalIconPrefixCls,
+  getRootPrefixCls: (rootPrefixCls?: string, customizePrefixCls?: string) => {
+    // Customize rootPrefixCls is first priority
+    if (rootPrefixCls) {
+      return rootPrefixCls;
+    }
+
+    // If Global prefixCls provided, use this
+    if (globalPrefixCls) {
+      return globalPrefixCls;
+    }
+
+    // [Legacy] If customize prefixCls provided, we cut it to get the prefixCls
+    if (customizePrefixCls && customizePrefixCls.includes('-')) {
+      return customizePrefixCls.replace(/^(.*)-[^-]*$/, '$1');
+    }
+
+    // Fallback to default prefixCls
+    return getGlobalPrefixCls();
+  },
+});

--- a/components/config-provider/index.tsx
+++ b/components/config-provider/index.tsx
@@ -12,14 +12,20 @@ import {
   CSPConfig,
   DirectionType,
   ConfigConsumerProps,
-  Theme,
 } from './context';
-import SizeContext, { SizeContextProvider, SizeType } from './SizeContext';
+import SizeContext, { SizeContextProvider } from './SizeContext';
 import message from '../message';
 import notification from '../notification';
-import { RequiredMark } from '../form/Form';
-import { registerTheme } from './cssVariables';
+
+import { ConfigProviderProps } from './type';
+
 import defaultLocale from '../locale/default';
+import {
+  setGlobalConfig,
+  globalConfig,
+  defaultPrefixCls,
+  defaultIconPrefixCls,
+} from './global-config';
 
 export {
   RenderEmptyHandler,
@@ -28,6 +34,10 @@ export {
   CSPConfig,
   DirectionType,
   ConfigConsumerProps,
+  ConfigProviderProps,
+  globalConfig,
+  defaultPrefixCls,
+  defaultIconPrefixCls,
 };
 
 export const configConsumerProps = [
@@ -52,96 +62,10 @@ const PASSED_PROPS: Exclude<keyof ConfigConsumerProps, 'rootPrefixCls' | 'getPre
   'form',
 ];
 
-export interface ConfigProviderProps {
-  getTargetContainer?: () => HTMLElement;
-  getPopupContainer?: (triggerNode?: HTMLElement) => HTMLElement;
-  prefixCls?: string;
-  iconPrefixCls?: string;
-  children?: React.ReactNode;
-  renderEmpty?: RenderEmptyHandler;
-  csp?: CSPConfig;
-  autoInsertSpaceInButton?: boolean;
-  form?: {
-    validateMessages?: ValidateMessages;
-    requiredMark?: RequiredMark;
-  };
-  input?: {
-    autoComplete?: string;
-  };
-  locale?: Locale;
-  pageHeader?: {
-    ghost: boolean;
-  };
-  componentSize?: SizeType;
-  direction?: DirectionType;
-  space?: {
-    size?: SizeType | number;
-  };
-  virtual?: boolean;
-  dropdownMatchSelectWidth?: boolean;
-}
-
 interface ProviderChildrenProps extends ConfigProviderProps {
   parentContext: ConfigConsumerProps;
   legacyLocale: Locale;
 }
-
-export const defaultPrefixCls = 'ant';
-export const defaultIconPrefixCls = 'anticon';
-let globalPrefixCls: string;
-let globalIconPrefixCls: string;
-
-function getGlobalPrefixCls() {
-  return globalPrefixCls || defaultPrefixCls;
-}
-
-function getGlobalIconPrefixCls() {
-  return globalIconPrefixCls || defaultIconPrefixCls;
-}
-
-const setGlobalConfig = ({
-  prefixCls,
-  iconPrefixCls,
-  theme,
-}: Pick<ConfigProviderProps, 'prefixCls' | 'iconPrefixCls'> & { theme?: Theme }) => {
-  if (prefixCls !== undefined) {
-    globalPrefixCls = prefixCls;
-  }
-  if (iconPrefixCls !== undefined) {
-    globalIconPrefixCls = iconPrefixCls;
-  }
-
-  if (theme) {
-    registerTheme(getGlobalPrefixCls(), theme);
-  }
-};
-
-export const globalConfig = () => ({
-  getPrefixCls: (suffixCls?: string, customizePrefixCls?: string) => {
-    if (customizePrefixCls) return customizePrefixCls;
-    return suffixCls ? `${getGlobalPrefixCls()}-${suffixCls}` : getGlobalPrefixCls();
-  },
-  getIconPrefixCls: getGlobalIconPrefixCls,
-  getRootPrefixCls: (rootPrefixCls?: string, customizePrefixCls?: string) => {
-    // Customize rootPrefixCls is first priority
-    if (rootPrefixCls) {
-      return rootPrefixCls;
-    }
-
-    // If Global prefixCls provided, use this
-    if (globalPrefixCls) {
-      return globalPrefixCls;
-    }
-
-    // [Legacy] If customize prefixCls provided, we cut it to get the prefixCls
-    if (customizePrefixCls && customizePrefixCls.includes('-')) {
-      return customizePrefixCls.replace(/^(.*)-[^-]*$/, '$1');
-    }
-
-    // Fallback to default prefixCls
-    return getGlobalPrefixCls();
-  },
-});
 
 const ProviderChildren: React.FC<ProviderChildrenProps> = props => {
   const {

--- a/components/config-provider/type.ts
+++ b/components/config-provider/type.ts
@@ -1,0 +1,35 @@
+import { ValidateMessages } from 'rc-field-form/lib/interface';
+import { RenderEmptyHandler } from './renderEmpty';
+import { CSPConfig, DirectionType } from './context';
+import { RequiredMark } from '../form/Form';
+import { Locale } from '../locale-provider';
+import { SizeType } from './SizeContext';
+
+export interface ConfigProviderProps {
+  getTargetContainer?: () => HTMLElement;
+  getPopupContainer?: (triggerNode?: HTMLElement) => HTMLElement;
+  prefixCls?: string;
+  iconPrefixCls?: string;
+  children?: React.ReactNode;
+  renderEmpty?: RenderEmptyHandler;
+  csp?: CSPConfig;
+  autoInsertSpaceInButton?: boolean;
+  form?: {
+    validateMessages?: ValidateMessages;
+    requiredMark?: RequiredMark;
+  };
+  input?: {
+    autoComplete?: string;
+  };
+  locale?: Locale;
+  pageHeader?: {
+    ghost: boolean;
+  };
+  componentSize?: SizeType;
+  direction?: DirectionType;
+  space?: {
+    size?: SizeType | number;
+  };
+  virtual?: boolean;
+  dropdownMatchSelectWidth?: boolean;
+}


### PR DESCRIPTION
- Move global config functions to seperate file
- Reuse global config prefixCls for the context
- Move types to seperate file

<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [x] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->
- https://github.com/ant-design/ant-design/issues/32961

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | `ConfigProvider.config({...})` can now be used to globally set the `prefixCls` for the components.  |
| 🇨🇳 Chinese | # Need help in translation 🙂 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
