### PR TITLE
fix: Input.Search enterButton don't trigger click event

### DIFF
--- a/components/input/Search.tsx
+++ b/components/input/Search.tsx
@@ -68,10 +68,7 @@ const Search = React.forwardRef<Input, SearchProps>((props, ref) => {
   const prefixCls = getPrefixCls('input-search', customizePrefixCls);
   const inputPrefixCls = getPrefixCls('input', customizeInputPrefixCls);
 
-  const searchIcon =
-    typeof enterButton === 'boolean' ? (
-      <SearchOutlined />
-    ) : null;
+  const searchIcon = typeof enterButton === 'boolean' ? <SearchOutlined /> : null;
   const btnClassName = `${prefixCls}-button`;
 
   let button: React.ReactNode;
@@ -81,7 +78,10 @@ const Search = React.forwardRef<Input, SearchProps>((props, ref) => {
   if (isAntdButton || enterButtonAsElement.type === 'button') {
     button = cloneElement(enterButtonAsElement, {
       onMouseDown,
-      onClick: onSearch,
+      onClick: (e: React.MouseEvent<HTMLButtonElement>) => {
+        enterButtonAsElement?.props?.onClick?.(e);
+        onSearch(e);
+      },
       key: 'enterButton',
       ...(isAntdButton
         ? {

--- a/components/input/__tests__/Search.test.js
+++ b/components/input/__tests__/Search.test.js
@@ -110,10 +110,15 @@ describe('Input.Search', () => {
 
   it('should trigger onSearch when click search button of native', () => {
     const onSearch = jest.fn();
+    const onButtonClick = jest.fn();
     const wrapper = mount(
       <Search
         defaultValue="search text"
-        enterButton={<button type="button">antd button</button>}
+        enterButton={
+          <button type="button" onClick={onButtonClick}>
+            antd button
+          </button>
+        }
         onSearch={onSearch}
       />,
     );
@@ -126,6 +131,7 @@ describe('Input.Search', () => {
         preventDefault: expect.any(Function),
       }),
     );
+    expect(onButtonClick).toHaveBeenCalledTimes(1);
   });
 
   it('should trigger onSearch when press enter', () => {


### PR DESCRIPTION


<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->
close #32993

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fix Input.Search don't trigger click event on element inside `enterButton`.       |
| 🇨🇳 Chinese |  修复 Input.Search 下 `enterButton` 内元素上的 `onClick` 未被触发的问题。         |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
