### PR TITLE
fix: Cascader typescript

### DIFF
--- a/components/cascader/__tests__/type.test.tsx
+++ b/components/cascader/__tests__/type.test.tsx
@@ -1,6 +1,6 @@
 import { mount } from 'enzyme';
 import * as React from 'react';
-import Cascader from '..';
+import Cascader, { BasicDataNode } from '..';
 
 describe('Cascader.typescript', () => {
   it('options value', () => {
@@ -46,6 +46,32 @@ describe('Cascader.typescript', () => {
 
   it('suffixIcon', () => {
     const wrapper = mount(<Cascader suffixIcon={<span />} />);
+    expect(wrapper).toBeTruthy();
+  });
+
+  it('Generic', () => {
+    interface MyOptionData extends BasicDataNode {
+      customizeLabel: string;
+      customizeValue: string;
+      customizeChildren?: MyOptionData[];
+    }
+
+    const wrapper = mount(
+      <Cascader<MyOptionData>
+        options={[
+          {
+            customizeLabel: 'Bamboo',
+            customizeValue: 'bamboo',
+            customizeChildren: [
+              {
+                customizeLabel: 'Little',
+                customizeValue: 'little',
+              },
+            ],
+          },
+        ]}
+      />,
+    );
     expect(wrapper).toBeTruthy();
   });
 });

--- a/components/cascader/__tests__/type.test.tsx
+++ b/components/cascader/__tests__/type.test.tsx
@@ -1,3 +1,4 @@
+import { mount } from 'enzyme';
 import * as React from 'react';
 import Cascader from '..';
 
@@ -41,5 +42,10 @@ describe('Cascader.typescript', () => {
     const result = <Cascader options={options} defaultValue={[1, 'hangzhou']} />;
 
     expect(result).toBeTruthy();
+  });
+
+  it('suffixIcon', () => {
+    const wrapper = mount(<Cascader suffixIcon={<span />} />);
+    expect(wrapper).toBeTruthy();
   });
 });

--- a/components/cascader/index.tsx
+++ b/components/cascader/index.tsx
@@ -80,7 +80,7 @@ export interface CascaderProps extends Omit<RcCascaderProps, 'checkable'> {
   suffixIcon?: React.ReactNode;
 }
 
-interface CascaderRef {
+export interface CascaderRef {
   focus: () => void;
   blur: () => void;
 }

--- a/components/cascader/index.tsx
+++ b/components/cascader/index.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import classNames from 'classnames';
 import RcCascader from 'rc-cascader';
 import type { CascaderProps as RcCascaderProps } from 'rc-cascader';
-import type { ShowSearchType, FieldNames } from 'rc-cascader/lib/interface';
+import type { ShowSearchType, FieldNames, DataNode } from 'rc-cascader/lib/interface';
 import omit from 'rc-util/lib/omit';
 import RightOutlined from '@ant-design/icons/RightOutlined';
 import RedoOutlined from '@ant-design/icons/RedoOutlined';
@@ -18,6 +18,8 @@ import { getTransitionName } from '../_util/motion';
 // - List search content will show all content
 // - Hover opacity style
 // - Search filter match case
+
+export type BasicDataNode = Omit<DataNode, 'label' | 'value' | 'children'>;
 
 export type FieldNamesType = FieldNames;
 
@@ -72,12 +74,14 @@ const defaultSearchRender: ShowSearchType['render'] = (inputValue, path, prefixC
   return optionList;
 };
 
-export interface CascaderProps extends Omit<RcCascaderProps, 'checkable'> {
+export interface CascaderProps<DataNodeType>
+  extends Omit<RcCascaderProps, 'checkable' | 'options'> {
   multiple?: boolean;
   size?: SizeType;
   bordered?: boolean;
 
   suffixIcon?: React.ReactNode;
+  options?: DataNodeType[];
 }
 
 export interface CascaderRef {
@@ -85,7 +89,7 @@ export interface CascaderRef {
   blur: () => void;
 }
 
-const Cascader = React.forwardRef((props: CascaderProps, ref: React.Ref<CascaderRef>) => {
+const Cascader = React.forwardRef((props: CascaderProps<any>, ref: React.Ref<CascaderRef>) => {
   const {
     prefixCls: customizePrefixCls,
     size: customizeSize,
@@ -227,7 +231,11 @@ const Cascader = React.forwardRef((props: CascaderProps, ref: React.Ref<Cascader
       ref={ref}
     />
   );
-});
+}) as (<DataNodeType extends BasicDataNode | DataNode = DataNode>(
+  props: React.PropsWithChildren<CascaderProps<DataNodeType>> & { ref?: React.Ref<CascaderRef> },
+) => React.ReactElement) & {
+  displayName: string;
+};
 
 Cascader.displayName = 'Cascader';
 

--- a/components/cascader/index.tsx
+++ b/components/cascader/index.tsx
@@ -76,6 +76,8 @@ export interface CascaderProps extends Omit<RcCascaderProps, 'checkable'> {
   multiple?: boolean;
   size?: SizeType;
   bordered?: boolean;
+
+  suffixIcon?: React.ReactNode;
 }
 
 interface CascaderRef {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Cascader typescript fix definition missing `suffixIcon` and support generic of `options` type.      |
| 🇨🇳 Chinese |    Cascader 丢失 `suffixIcon` 定义问题并且支持 `options` 泛型定义。     |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
