### PR TITLE
fix: Radio dot offset when zooming

### DIFF
--- a/components/radio/style/index.less
+++ b/components/radio/style/index.less
@@ -81,15 +81,17 @@
   &-inner {
     &::after {
       position: absolute;
-      top: ((@radio-size - @radio-dot-size) / 2) - @radio-border-width;
-      left: ((@radio-size - @radio-dot-size) / 2) - @radio-border-width;
+      top: 50%;
+      left: 50%;
       display: block;
-      width: @radio-dot-size;
-      height: @radio-dot-size;
+      width: @radio-size;
+      height: @radio-size;
+      margin-top: -(@radio-size / 2);
+      margin-left: -(@radio-size / 2);
       background-color: @radio-dot-color;
       border-top: 0;
       border-left: 0;
-      border-radius: @radio-dot-size;
+      border-radius: @radio-size;
       transform: scale(0);
       opacity: 0;
       transition: all @radio-duration @ease-in-out-circ;
@@ -128,7 +130,7 @@
     border-color: @radio-dot-color;
 
     &::after {
-      transform: scale(1);
+      transform: scale((unit(@radio-dot-size) / unit(@radio-size)));
       opacity: 1;
       transition: all @radio-duration @ease-in-out-circ;
     }


### PR DESCRIPTION

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [x] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

1. 修复当 windows 桌面分辨率缩放 125%，firefox 出现的单选圆点偏移
2. 修复 #33036

修改了单选选中圆点样式，改用先定位到中心，再缩放的方式实现。原有变量 @radio-size @radio-dot-size 用法不变
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |   Fix Radio dot offset when zooming       |
| 🇨🇳 中文 |   修复单选选中圆点缩放时偏移的问题  |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
