### PR TITLE
fix: Exporting component interfaces

### DIFF
--- a/components/alert/index.tsx
+++ b/components/alert/index.tsx
@@ -60,7 +60,7 @@ const iconMapOutlined = {
   warning: ExclamationCircleOutlined,
 };
 
-interface AlertInterface extends React.FC<AlertProps> {
+export interface AlertInterface extends React.FC<AlertProps> {
   ErrorBoundary: typeof ErrorBoundary;
 }
 

--- a/components/auto-complete/index.tsx
+++ b/components/auto-complete/index.tsx
@@ -131,10 +131,10 @@ const AutoComplete: React.ForwardRefRenderFunction<RefSelectProps, AutoCompleteP
 
 const RefAutoComplete = React.forwardRef<RefSelectProps, AutoCompleteProps>(AutoComplete);
 
-type RefAutoCompleteWithOption = typeof RefAutoComplete & {
+export type RefAutoCompleteInterface = typeof RefAutoComplete & {
   Option: OptionType;
 };
 
-(RefAutoComplete as RefAutoCompleteWithOption).Option = Option;
+(RefAutoComplete as RefAutoCompleteInterface).Option = Option;
 
-export default RefAutoComplete as RefAutoCompleteWithOption;
+export default RefAutoComplete as RefAutoCompleteInterface;

--- a/components/avatar/index.tsx
+++ b/components/avatar/index.tsx
@@ -5,12 +5,12 @@ import Group from './group';
 export { AvatarProps } from './avatar';
 export { GroupProps } from './group';
 
-interface CompoundedComponent
+export interface AvatarInterface
   extends React.ForwardRefExoticComponent<AvatarProps & React.RefAttributes<HTMLElement>> {
   Group: typeof Group;
 }
 
-const Avatar = InternalAvatar as CompoundedComponent;
+const Avatar = InternalAvatar as AvatarInterface;
 Avatar.Group = Group;
 
 export { Group };

--- a/components/badge/index.tsx
+++ b/components/badge/index.tsx
@@ -12,7 +12,7 @@ import { isPresetColor } from './utils';
 
 export { ScrollNumberProps } from './ScrollNumber';
 
-interface CompoundedComponent extends React.FC<BadgeProps> {
+export interface BadgeInterface extends React.FC<BadgeProps> {
   Ribbon: typeof Ribbon;
 }
 
@@ -36,7 +36,7 @@ export interface BadgeProps {
   title?: string;
 }
 
-const Badge: CompoundedComponent = ({
+const Badge: BadgeInterface = ({
   prefixCls: customizePrefixCls,
   scrollNumberPrefixCls: customizeScrollNumberPrefixCls,
   children,

--- a/components/breadcrumb/Breadcrumb.tsx
+++ b/components/breadcrumb/Breadcrumb.tsx
@@ -8,6 +8,9 @@ import { ConfigContext } from '../config-provider';
 import devWarning from '../_util/devWarning';
 import { cloneElement } from '../_util/reactNode';
 
+export { BreadcrumbItemInterface } from './BreadcrumbItem';
+export { BreadcrumbSeparatorInterface } from './BreadcrumbSeparator';
+
 export interface Route {
   path: string;
   breadcrumbName: string;
@@ -64,7 +67,7 @@ const addChildPath = (paths: string[], childPath: string, params: any) => {
   return originalPaths;
 };
 
-interface BreadcrumbInterface extends React.FC<BreadcrumbProps> {
+export interface BreadcrumbInterface extends React.FC<BreadcrumbProps> {
   Item: typeof BreadcrumbItem;
   Separator: typeof BreadcrumbSeparator;
 }

--- a/components/breadcrumb/BreadcrumbItem.tsx
+++ b/components/breadcrumb/BreadcrumbItem.tsx
@@ -13,7 +13,7 @@ export interface BreadcrumbItemProps {
   onClick?: React.MouseEventHandler<HTMLAnchorElement | HTMLSpanElement>;
   className?: string;
 }
-interface BreadcrumbItemInterface extends React.FC<BreadcrumbItemProps> {
+export interface BreadcrumbItemInterface extends React.FC<BreadcrumbItemProps> {
   __ANT_BREADCRUMB_ITEM: boolean;
 }
 const BreadcrumbItem: BreadcrumbItemInterface = ({
@@ -62,9 +62,7 @@ const BreadcrumbItem: BreadcrumbItemInterface = ({
     return (
       <span>
         {link}
-        {separator && (
-          <span className={`${prefixCls}-separator`}>{separator}</span>
-        )}
+        {separator && <span className={`${prefixCls}-separator`}>{separator}</span>}
       </span>
     );
   }

--- a/components/breadcrumb/BreadcrumbSeparator.tsx
+++ b/components/breadcrumb/BreadcrumbSeparator.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { ConfigContext } from '../config-provider';
 
-interface BreadcrumbSeparatorInterface extends React.FC {
+export interface BreadcrumbSeparatorInterface extends React.FC {
   __ANT_BREADCRUMB_SEPARATOR: boolean;
 }
 

--- a/components/button/button.tsx
+++ b/components/button/button.tsx
@@ -124,7 +124,7 @@ export type NativeButtonProps = {
 
 export type ButtonProps = Partial<AnchorButtonProps & NativeButtonProps>;
 
-interface CompoundedComponent
+export interface ButtonInterface
   extends React.ForwardRefExoticComponent<ButtonProps & React.RefAttributes<HTMLElement>> {
   Group: typeof Group;
   __ANT_BUTTON: boolean;
@@ -297,7 +297,7 @@ const InternalButton: React.ForwardRefRenderFunction<unknown, ButtonProps> = (pr
   return <Wave disabled={!!innerLoading}>{buttonNode}</Wave>;
 };
 
-const Button = React.forwardRef<unknown, ButtonProps>(InternalButton) as CompoundedComponent;
+const Button = React.forwardRef<unknown, ButtonProps>(InternalButton) as ButtonInterface;
 
 Button.displayName = 'Button';
 

--- a/components/button/index.tsx
+++ b/components/button/index.tsx
@@ -1,6 +1,6 @@
 import Button from './button';
 
-export { ButtonProps, ButtonShape, ButtonType } from './button';
+export { ButtonProps, ButtonShape, ButtonType, ButtonInterface } from './button';
 export { ButtonGroupProps } from './button-group';
 export { SizeType as ButtonSize } from '../config-provider/SizeContext';
 

--- a/components/checkbox/index.tsx
+++ b/components/checkbox/index.tsx
@@ -5,13 +5,13 @@ import Group from './Group';
 export { CheckboxProps, CheckboxChangeEvent } from './Checkbox';
 export { CheckboxGroupProps, CheckboxOptionType } from './Group';
 
-interface CompoundedComponent
+export interface CheckboxInterface
   extends React.ForwardRefExoticComponent<CheckboxProps & React.RefAttributes<HTMLInputElement>> {
   Group: typeof Group;
   __ANT_CHECKBOX: boolean;
 }
 
-const Checkbox = InternalCheckbox as CompoundedComponent;
+const Checkbox = InternalCheckbox as CheckboxInterface;
 
 Checkbox.Group = Group;
 Checkbox.__ANT_CHECKBOX = true;

--- a/components/collapse/Collapse.tsx
+++ b/components/collapse/Collapse.tsx
@@ -43,7 +43,7 @@ interface PanelProps {
   collapsible?: CollapsibleType;
 }
 
-interface CollapseInterface extends React.FC<CollapseProps> {
+export interface CollapseInterface extends React.FC<CollapseProps> {
   Panel: typeof CollapsePanel;
 }
 

--- a/components/collapse/index.tsx
+++ b/components/collapse/index.tsx
@@ -1,6 +1,6 @@
 import Collapse from './Collapse';
 
-export { CollapseProps } from './Collapse';
+export { CollapseProps, CollapseInterface } from './Collapse';
 export { CollapsePanelProps } from './CollapsePanel';
 
 export default Collapse;

--- a/components/dropdown/dropdown-button.tsx
+++ b/components/dropdown/dropdown-button.tsx
@@ -23,7 +23,7 @@ export interface DropdownButtonProps extends ButtonGroupProps, DropDownProps {
   buttonsRender?: (buttons: React.ReactNode[]) => React.ReactNode[];
 }
 
-interface DropdownButtonInterface extends React.FC<DropdownButtonProps> {
+export interface DropdownButtonInterface extends React.FC<DropdownButtonProps> {
   __ANT_BUTTON: boolean;
 }
 

--- a/components/dropdown/dropdown.tsx
+++ b/components/dropdown/dropdown.tsx
@@ -56,7 +56,7 @@ export interface DropDownProps {
   openClassName?: string;
 }
 
-interface DropdownInterface extends React.FC<DropDownProps> {
+export interface DropdownInterface extends React.FC<DropDownProps> {
   Button: typeof DropdownButton;
 }
 

--- a/components/dropdown/index.tsx
+++ b/components/dropdown/index.tsx
@@ -1,5 +1,9 @@
 import Dropdown from './dropdown';
 
-export { DropDownProps } from './dropdown';
-export { DropdownButtonProps, DropdownButtonType } from './dropdown-button';
+export { DropDownProps, DropdownInterface } from './dropdown';
+export {
+  DropdownButtonProps,
+  DropdownButtonType,
+  DropdownButtonInterface,
+} from './dropdown-button';
 export default Dropdown;

--- a/components/empty/index.tsx
+++ b/components/empty/index.tsx
@@ -23,12 +23,12 @@ export interface EmptyProps {
   children?: React.ReactNode;
 }
 
-interface EmptyType extends React.FC<EmptyProps> {
+export interface EmptyInterface extends React.FC<EmptyProps> {
   PRESENTED_IMAGE_DEFAULT: React.ReactNode;
   PRESENTED_IMAGE_SIMPLE: React.ReactNode;
 }
 
-const Empty: EmptyType = ({
+const Empty: EmptyInterface = ({
   className,
   prefixCls: customizePrefixCls,
   image = defaultEmptyImg,

--- a/components/form/index.tsx
+++ b/components/form/index.tsx
@@ -35,6 +35,7 @@ Form.create = () => {
 };
 
 export {
+  FormInterface,
   FormInstance,
   FormProps,
   FormItemProps,

--- a/components/layout/index.tsx
+++ b/components/layout/index.tsx
@@ -4,14 +4,14 @@ import Sider from './Sider';
 export { BasicProps as LayoutProps } from './layout';
 export { SiderProps } from './Sider';
 
-interface LayoutType extends React.FC<BasicProps> {
+export interface LayoutInterface extends React.FC<BasicProps> {
   Header: typeof Header;
   Footer: typeof Footer;
   Content: typeof Content;
   Sider: typeof Sider;
 }
 
-const Layout = InternalLayout as LayoutType;
+const Layout = InternalLayout as LayoutInterface;
 
 Layout.Header = Header;
 Layout.Footer = Footer;

--- a/components/list/Item.tsx
+++ b/components/list/Item.tsx
@@ -54,11 +54,11 @@ export const Meta: React.FC<ListItemMetaProps> = ({
   );
 };
 
-export interface ListItemTypeProps extends React.FC<ListItemProps> {
+export interface ListItemInterface extends React.FC<ListItemProps> {
   Meta: typeof Meta;
 }
 
-const Item: ListItemTypeProps = ({
+const Item: ListItemInterface = ({
   prefixCls: customizePrefixCls,
   children,
   actions,

--- a/components/list/index.tsx
+++ b/components/list/index.tsx
@@ -8,7 +8,7 @@ import Pagination, { PaginationConfig } from '../pagination';
 import { Row } from '../grid';
 import Item from './Item';
 
-export { ListItemProps, ListItemMetaProps } from './Item';
+export { ListItemProps, ListItemMetaProps, ListItemInterface } from './Item';
 
 export type ColumnCount = number;
 

--- a/components/mentions/index.tsx
+++ b/components/mentions/index.tsx
@@ -38,7 +38,7 @@ interface MentionsEntity {
   value: string;
 }
 
-interface CompoundedComponent
+export interface MentionsInterface
   extends React.ForwardRefExoticComponent<MentionProps & React.RefAttributes<HTMLElement>> {
   Option: typeof Option;
   getMentions: (value: string, config?: MentionsConfig) => MentionsEntity[];
@@ -133,7 +133,7 @@ const InternalMentions: React.ForwardRefRenderFunction<unknown, MentionProps> = 
   );
 };
 
-const Mentions = React.forwardRef<unknown, MentionProps>(InternalMentions) as CompoundedComponent;
+const Mentions = React.forwardRef<unknown, MentionProps>(InternalMentions) as MentionsInterface;
 Mentions.displayName = 'Mentions';
 Mentions.Option = Option;
 

--- a/components/modal/index.tsx
+++ b/components/modal/index.tsx
@@ -17,14 +17,14 @@ function modalWarn(props: ModalFuncProps) {
   return confirm(withWarn(props));
 }
 
-type ModalType = typeof OriginModal &
+type ModalInterface = typeof OriginModal &
   ModalStaticFunctions & {
     useModal: typeof useModal;
     destroyAll: () => void;
     config: typeof modalGlobalConfig;
   };
 
-const Modal = OriginModal as ModalType;
+const Modal = OriginModal as ModalInterface;
 
 Modal.useModal = useModal;
 

--- a/components/radio/index.tsx
+++ b/components/radio/index.tsx
@@ -13,13 +13,13 @@ export {
   RadioChangeEventTarget,
   RadioChangeEvent,
 } from './interface';
-interface CompoundedComponent
+export interface RadioInterface
   extends React.ForwardRefExoticComponent<RadioProps & React.RefAttributes<HTMLElement>> {
   Group: typeof Group;
   Button: typeof Button;
 }
 
-const Radio = InternalRadio as CompoundedComponent;
+const Radio = InternalRadio as RadioInterface;
 Radio.Button = Button;
 Radio.Group = Group;
 export { Button, Group };

--- a/components/select/index.tsx
+++ b/components/select/index.tsx
@@ -154,7 +154,7 @@ const SelectRef = React.forwardRef(InternalSelect) as <VT extends SelectValue = 
 
 type InternalSelectType = typeof SelectRef;
 
-interface SelectInterface extends InternalSelectType {
+export interface SelectInterface extends InternalSelectType {
   SECRET_COMBOBOX_MODE_DO_NOT_USE: string;
   Option: typeof Option;
   OptGroup: typeof OptGroup;

--- a/components/steps/index.tsx
+++ b/components/steps/index.tsx
@@ -39,11 +39,11 @@ export interface StepProps {
   style?: React.CSSProperties;
 }
 
-interface StepsType extends React.FC<StepsProps> {
+export interface StepsInterface extends React.FC<StepsProps> {
   Step: typeof RcSteps.Step;
 }
 
-const Steps: StepsType = props => {
+const Steps: StepsInterface = props => {
   const { percent, size, className, direction, responsive } = props;
   const { xs } = useBreakpoint();
   const { getPrefixCls, direction: rtlDirection } = React.useContext(ConfigContext);

--- a/components/switch/index.tsx
+++ b/components/switch/index.tsx
@@ -31,7 +31,7 @@ export interface SwitchProps {
   id?: string;
 }
 
-interface CompoundedComponent
+export interface SwitchInterface
   extends React.ForwardRefExoticComponent<SwitchProps & React.RefAttributes<HTMLElement>> {
   __ANT_SWITCH: boolean;
 }
@@ -85,7 +85,7 @@ const Switch = React.forwardRef<unknown, SwitchProps>(
       </Wave>
     );
   },
-) as CompoundedComponent;
+) as SwitchInterface;
 
 Switch.__ANT_SWITCH = true;
 Switch.displayName = 'Switch';

--- a/components/table/Table.tsx
+++ b/components/table/Table.tsx
@@ -522,7 +522,7 @@ const ForwardTable = React.forwardRef(InternalTable) as <RecordType extends obje
 
 type InternalTableType = typeof ForwardTable;
 
-interface TableInterface extends InternalTableType {
+export interface TableInterface extends InternalTableType {
   defaultProps?: Partial<TableProps<any>>;
   SELECTION_ALL: 'SELECT_ALL';
   SELECTION_INVERT: 'SELECT_INVERT';

--- a/components/time-picker/index.tsx
+++ b/components/time-picker/index.tsx
@@ -61,10 +61,10 @@ const TimePicker = React.forwardRef<any, TimePickerProps>(
 
 TimePicker.displayName = 'TimePicker';
 
-type MergedTimePicker = typeof TimePicker & {
+export type MergedTimePickerInterface = typeof TimePicker & {
   RangePicker: typeof RangePicker;
 };
 
-(TimePicker as MergedTimePicker).RangePicker = RangePicker;
+(TimePicker as MergedTimePickerInterface).RangePicker = RangePicker;
 
-export default TimePicker as MergedTimePicker;
+export default TimePicker as MergedTimePickerInterface;

--- a/components/timeline/Timeline.tsx
+++ b/components/timeline/Timeline.tsx
@@ -17,11 +17,11 @@ export interface TimelineProps {
   mode?: 'left' | 'alternate' | 'right';
 }
 
-interface TimelineType extends React.FC<TimelineProps> {
+export interface TimelineInterface extends React.FC<TimelineProps> {
   Item: React.FC<TimelineItemProps>;
 }
 
-const Timeline: TimelineType = props => {
+const Timeline: TimelineInterface = props => {
   const { getPrefixCls, direction } = React.useContext(ConfigContext);
   const {
     prefixCls: customizePrefixCls,

--- a/components/tree-select/index.tsx
+++ b/components/tree-select/index.tsx
@@ -172,7 +172,7 @@ const TreeSelectRef = React.forwardRef(InternalTreeSelect) as <T extends Default
 
 type InternalTreeSelectType = typeof TreeSelectRef;
 
-interface TreeSelectInterface extends InternalTreeSelectType {
+export interface TreeSelectInterface extends InternalTreeSelectType {
   TreeNode: typeof TreeNode;
   SHOW_ALL: typeof SHOW_ALL;
   SHOW_PARENT: typeof SHOW_PARENT;

--- a/components/tree/Tree.tsx
+++ b/components/tree/Tree.tsx
@@ -143,7 +143,7 @@ export interface TreeProps<T extends BasicDataNode = DataNode>
   blockNode?: boolean;
 }
 
-type CompoundedComponent = (<T extends BasicDataNode | DataNode = DataNode>(
+export type TreeInterface = (<T extends BasicDataNode | DataNode = DataNode>(
   props: React.PropsWithChildren<TreeProps<T>> & { ref?: React.Ref<RcTree> },
 ) => React.ReactElement) & {
   defaultProps: Partial<React.PropsWithChildren<TreeProps<any>>>;
@@ -225,7 +225,7 @@ const Tree = React.forwardRef<RcTree, TreeProps>((props, ref) => {
       {children}
     </RcTree>
   );
-}) as unknown as CompoundedComponent;
+}) as unknown as TreeInterface;
 
 Tree.TreeNode = TreeNode;
 

--- a/components/upload/Upload.tsx
+++ b/components/upload/Upload.tsx
@@ -174,13 +174,13 @@ const InternalUpload: React.ForwardRefRenderFunction<unknown, UploadProps> = (pr
         let clone;
 
         try {
-          clone = (new File([originFileObj], originFileObj.name, {
+          clone = new File([originFileObj], originFileObj.name, {
             type: originFileObj.type,
-          }) as any) as UploadFile;
+          }) as any as UploadFile;
         } catch (e) {
-          clone = (new Blob([originFileObj], {
+          clone = new Blob([originFileObj], {
             type: originFileObj.type,
-          }) as any) as UploadFile;
+          }) as any as UploadFile;
           clone.name = originFileObj.name;
           clone.lastModifiedDate = new Date();
           clone.lastModified = new Date().getTime();
@@ -414,7 +414,7 @@ const InternalUpload: React.ForwardRefRenderFunction<unknown, UploadProps> = (pr
   );
 };
 
-interface CompoundedComponent
+export interface UploadInterface
   extends React.ForwardRefExoticComponent<
     React.PropsWithChildren<UploadProps> & React.RefAttributes<any>
   > {
@@ -422,7 +422,7 @@ interface CompoundedComponent
   LIST_IGNORE: string;
 }
 
-const Upload = React.forwardRef<unknown, UploadProps>(InternalUpload) as CompoundedComponent;
+const Upload = React.forwardRef<unknown, UploadProps>(InternalUpload) as UploadInterface;
 
 Upload.Dragger = Dragger;
 


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

https://github.com/ant-design/ant-design/issues/33091

### 💡 Background and solution

Typescript complains about non exported interfaces when extending the components, for instance when using styled components.

### 📝 Changelog

 I exported the missing interfaces and renamed them where possible without introducing breaking changes to get a common naming pattern like `<Component>Interface`

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Exporting missing component interfaces  |
| 🇨🇳 Chinese |  导出缺失的组件接口  |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
