### PR TITLE
Changed warning color to a darker contrast so it is more easily readable

### DIFF
--- a/components/style/themes/default.less
+++ b/components/style/themes/default.less
@@ -35,7 +35,7 @@
 @success-color-deprecated-border: color(~`colorPalette('@{success-color}', 3) `);
 
 // >>> Warning
-@warning-color: @gold-6;
+@warning-color: @gold-7;
 @warning-color-hover: color(~`colorPalette('@{warning-color}', 5) `);
 @warning-color-active: color(~`colorPalette('@{warning-color}', 7) `);
 @warning-color-outline: fade(@warning-color, @outline-fade);


### PR DESCRIPTION

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [x ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
https://github.com/ant-design/ant-design/issues/32826


### 💡 Background and solution
1. Current color gold-6 was hard to read over the white background as the contrast was low as stated in the issue linked above
2. Changed the color to a darker contrast to make it more easily readable

### 📝 Changelog
None

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x ] Doc is updated/provided or not needed
- [x ] Demo is updated/provided or not needed
- [ x] TypeScript definition is updated/provided or not needed
- [x ] Changelog is provided or not needed
