### PR TITLE
fix: Steps title height when empty

### DIFF
--- a/components/steps/style/index.less
+++ b/components/steps/style/index.less
@@ -96,6 +96,7 @@
   &-title {
     position: relative;
     display: inline-block;
+    // https://github.com/ant-design/ant-design/issues/33247
     min-height: @steps-title-line-height;
     padding-right: 16px;
     color: @text-color;

--- a/components/steps/style/index.less
+++ b/components/steps/style/index.less
@@ -96,7 +96,7 @@
   &-title {
     position: relative;
     display: inline-block;
-    height: @steps-title-line-height;
+    min-height: @steps-title-line-height;
     padding-right: 16px;
     color: @text-color;
     font-size: @font-size-lg;

--- a/components/steps/style/index.less
+++ b/components/steps/style/index.less
@@ -96,6 +96,7 @@
   &-title {
     position: relative;
     display: inline-block;
+    height: @steps-title-line-height;
     padding-right: 16px;
     color: @text-color;
     font-size: @font-size-lg;

--- a/components/steps/style/progress-dot.less
+++ b/components/steps/style/progress-dot.less
@@ -2,6 +2,7 @@
 .@{steps-prefix-cls}-dot.@{steps-prefix-cls}-small {
   .@{steps-prefix-cls}-item {
     &-title {
+      min-height: unset;
       line-height: @line-height-base;
     }
 

--- a/components/steps/style/small.less
+++ b/components/steps/style/small.less
@@ -17,6 +17,7 @@
     border-radius: @steps-small-icon-size;
   }
   .@{steps-prefix-cls}-item-title {
+    min-height: @steps-small-icon-size;
     padding-right: 12px;
     font-size: @font-size-base;
     line-height: @steps-small-icon-size;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
fix https://github.com/ant-design/ant-design/issues/33247
<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fix the problem with Steps when title is empty.      |
| 🇨🇳 Chinese |  修复 Steps 标题为空时高度异常的问题。         |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
