### PR TITLE
fix: Revert "fix: TextArea missing maxLength attr."

### DIFF
--- a/components/form/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/form/__tests__/__snapshots__/demo.test.js.snap
@@ -4017,7 +4017,6 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
             <textarea
               class="ant-input"
               id="register_intro"
-              maxlength="100"
             />
           </div>
         </div>

--- a/components/input/TextArea.tsx
+++ b/components/input/TextArea.tsx
@@ -135,7 +135,6 @@ const TextArea = React.forwardRef<TextAreaRef, TextAreaProps>(
         onChange={handleChange}
         onCompositionEnd={onInternalCompositionEnd}
         ref={innerRef}
-        maxLength={maxLength}
       />
     );
 

--- a/components/input/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/input/__tests__/__snapshots__/demo.test.js.snap
@@ -3336,7 +3336,6 @@ exports[`renders ./components/input/demo/textarea-show-count.md correctly 1`] = 
 >
   <textarea
     class="ant-input"
-    maxlength="100"
   />
 </div>
 `;

--- a/components/input/__tests__/__snapshots__/textarea.test.js.snap
+++ b/components/input/__tests__/__snapshots__/textarea.test.js.snap
@@ -245,7 +245,6 @@ exports[`TextArea allowClear should not show icon if value is undefined, null or
 exports[`TextArea maxLength should support maxLength 1`] = `
 <textarea
   class="ant-input"
-  maxlength="10"
 />
 `;
 


### PR DESCRIPTION
Reverts ant-design/ant-design#32448

Reason: https://github.com/ant-design/ant-design/pull/32448#issuecomment-994769551

<img width="604" alt="图片" src="https://user-images.githubusercontent.com/507615/146191358-932e5934-3ddc-49c2-93c7-756f41a47762.png">
