### PR TITLE
feat: allow input number arrows overrides

### DIFF
--- a/components/input-number/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/input-number/__tests__/__snapshots__/demo.test.js.snap
@@ -736,6 +736,81 @@ exports[`renders ./components/input-number/demo/borderless.md correctly 1`] = `
 </div>
 `;
 
+exports[`renders ./components/input-number/demo/custom-arrows.md correctly 1`] = `
+<div
+  class="ant-space ant-space-vertical"
+>
+  <div
+    class="ant-space-item"
+  >
+    <div
+      class="ant-input-number"
+    >
+      <div
+        class="ant-input-number-handler-wrap"
+      >
+        <span
+          aria-disabled="false"
+          aria-label="Increase Value"
+          class="ant-input-number-handler ant-input-number-handler-up"
+          role="button"
+          unselectable="on"
+        >
+          <span
+            class="ant-input-number-handler-up-inner"
+          >
+            <span
+              aria-label="setting"
+              class="anticon anticon-setting"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="setting"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M924.8 625.7l-65.5-56c3.1-19 4.7-38.4 4.7-57.8s-1.6-38.8-4.7-57.8l65.5-56a32.03 32.03 0 009.3-35.2l-.9-2.6a443.74 443.74 0 00-79.7-137.9l-1.8-2.1a32.12 32.12 0 00-35.1-9.5l-81.3 28.9c-30-24.6-63.5-44-99.7-57.6l-15.7-85a32.05 32.05 0 00-25.8-25.7l-2.7-.5c-52.1-9.4-106.9-9.4-159 0l-2.7.5a32.05 32.05 0 00-25.8 25.7l-15.8 85.4a351.86 351.86 0 00-99 57.4l-81.9-29.1a32 32 0 00-35.1 9.5l-1.8 2.1a446.02 446.02 0 00-79.7 137.9l-.9 2.6c-4.5 12.5-.8 26.5 9.3 35.2l66.3 56.6c-3.1 18.8-4.6 38-4.6 57.1 0 19.2 1.5 38.4 4.6 57.1L99 625.5a32.03 32.03 0 00-9.3 35.2l.9 2.6c18.1 50.4 44.9 96.9 79.7 137.9l1.8 2.1a32.12 32.12 0 0035.1 9.5l81.9-29.1c29.8 24.5 63.1 43.9 99 57.4l15.8 85.4a32.05 32.05 0 0025.8 25.7l2.7.5a449.4 449.4 0 00159 0l2.7-.5a32.05 32.05 0 0025.8-25.7l15.7-85a350 350 0 0099.7-57.6l81.3 28.9a32 32 0 0035.1-9.5l1.8-2.1c34.8-41.1 61.6-87.5 79.7-137.9l.9-2.6c4.5-12.3.8-26.3-9.3-35zM788.3 465.9c2.5 15.1 3.8 30.6 3.8 46.1s-1.3 31-3.8 46.1l-6.6 40.1 74.7 63.9a370.03 370.03 0 01-42.6 73.6L721 702.8l-31.4 25.8c-23.9 19.6-50.5 35-79.3 45.8l-38.1 14.3-17.9 97a377.5 377.5 0 01-85 0l-17.9-97.2-37.8-14.5c-28.5-10.8-55-26.2-78.7-45.7l-31.4-25.9-93.4 33.2c-17-22.9-31.2-47.6-42.6-73.6l75.5-64.5-6.5-40c-2.4-14.9-3.7-30.3-3.7-45.5 0-15.3 1.2-30.6 3.7-45.5l6.5-40-75.5-64.5c11.3-26.1 25.6-50.7 42.6-73.6l93.4 33.2 31.4-25.9c23.7-19.5 50.2-34.9 78.7-45.7l37.9-14.3 17.9-97.2c28.1-3.2 56.8-3.2 85 0l17.9 97 38.1 14.3c28.7 10.8 55.4 26.2 79.3 45.8l31.4 25.8 92.8-32.9c17 22.9 31.2 47.6 42.6 73.6L781.8 426l6.5 39.9zM512 326c-97.2 0-176 78.8-176 176s78.8 176 176 176 176-78.8 176-176-78.8-176-176-176zm79.2 255.2A111.6 111.6 0 01512 614c-29.9 0-58-11.7-79.2-32.8A111.6 111.6 0 01400 502c0-29.9 11.7-58 32.8-79.2C454 401.6 482.1 390 512 390c29.9 0 58 11.6 79.2 32.8A111.6 111.6 0 01624 502c0 29.9-11.7 58-32.8 79.2z"
+                />
+              </svg>
+            </span>
+          </span>
+        </span>
+        <span
+          aria-disabled="false"
+          aria-label="Decrease Value"
+          class="ant-input-number-handler ant-input-number-handler-down"
+          role="button"
+          unselectable="on"
+        >
+          <span
+            class="ant-input-number-handler-up-inner"
+          >
+            $
+          </span>
+        </span>
+      </div>
+      <div
+        class="ant-input-number-input-wrap"
+      >
+        <input
+          aria-valuenow="100"
+          autocomplete="off"
+          class="ant-input-number-input"
+          role="spinbutton"
+          step="1"
+          value="100"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`renders ./components/input-number/demo/digit.md correctly 1`] = `
 <div
   class="ant-input-number"

--- a/components/input-number/demo/custom-arrows.md
+++ b/components/input-number/demo/custom-arrows.md
@@ -1,0 +1,26 @@
+---
+order: 2
+title:
+  zh-CN: 自定义向上/向下箭头
+  en-US: Custom up / down arrows
+---
+
+## zh-CN
+
+使用上下自定义箭头示例。
+
+## en-US
+
+Using up & down custom arrows example.
+
+```jsx
+import { InputNumber, Space } from 'antd';
+import { SettingOutlined } from '@ant-design/icons';
+
+ReactDOM.render(
+  <Space direction="vertical">
+    <InputNumber customUpIcon={<SettingOutlined />} customDownIcon="$" defaultValue={100} />
+  </Space>,
+  mountNode,
+);
+```

--- a/components/input-number/index.en-US.md
+++ b/components/input-number/index.en-US.md
@@ -20,6 +20,8 @@ When a numeric value needs to be provided.
 | autoFocus | If get focus when component mounted | boolean | false | - |
 | bordered | Whether has border style | boolean | true | 4.12.0 |
 | controls | Whether to show `+-` controls | boolean | true | 4.17.0 |
+| customUpIcon | The custom icon displayed instead of the default up arrow icon | ReactNode | - | 4.17.0 |
+| customDownIcon | The custom icon displayed instead of the default down arrow icon | ReactNode | - | 4.17.0 |
 | decimalSeparator | Decimal separator | string | - | - |
 | defaultValue | The initial value | number | - | - |
 | disabled | If disable the input | boolean | false | - |

--- a/components/input-number/index.tsx
+++ b/components/input-number/index.tsx
@@ -15,6 +15,8 @@ export interface InputNumberProps<T extends ValueType = ValueType>
   prefixCls?: string;
   addonBefore?: React.ReactNode;
   addonAfter?: React.ReactNode;
+  customUpIcon?: React.ReactNode;
+  customDownIcon?: React.ReactNode;
   prefix?: React.ReactNode;
   size?: SizeType;
   bordered?: boolean;
@@ -34,6 +36,8 @@ const InputNumber = React.forwardRef<HTMLInputElement, InputNumberProps>((props,
     prefixCls: customizePrefixCls,
     addonBefore,
     addonAfter,
+    customUpIcon,
+    customDownIcon,
     prefix,
     bordered = true,
     readOnly,
@@ -41,8 +45,16 @@ const InputNumber = React.forwardRef<HTMLInputElement, InputNumberProps>((props,
   } = props;
 
   const prefixCls = getPrefixCls('input-number', customizePrefixCls);
-  const upIcon = <UpOutlined className={`${prefixCls}-handler-up-inner`} />;
-  const downIcon = <DownOutlined className={`${prefixCls}-handler-down-inner`} />;
+  const upIcon = customUpIcon ? (
+    <span className={`${prefixCls}-handler-up-inner`}>{customUpIcon}</span>
+  ) : (
+    <UpOutlined className={`${prefixCls}-handler-up-inner`} />
+  );
+  const downIcon = customDownIcon ? (
+    <span className={`${prefixCls}-handler-up-inner`}>{customDownIcon}</span>
+  ) : (
+    <DownOutlined className={`${prefixCls}-handler-down-inner`} />
+  );
 
   const mergeSize = customizeSize || size;
   const inputNumberClass = classNames(


### PR DESCRIPTION
[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

Our current antd use case requires the default upIcon and downIcon to be modified. That is currently not possible.

### 💡 Background and solution

Solution: Hoist the default icons and allow for overrides.

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | `InputNumber` now support `upIcon` and `downIcon` |
| 🇨🇳 Chinese | `InputNumber` 现在支持 `upIcon` 和 `downIcon` |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
