### PR TITLE
fix #33433: fix DropDown.Button destroyPopupOnHide prop not working

### DIFF
--- a/components/dropdown/dropdown-button.tsx
+++ b/components/dropdown/dropdown-button.tsx
@@ -59,6 +59,7 @@ const DropdownButton: DropdownButtonInterface = props => {
     mouseLeaveDelay,
     overlayClassName,
     overlayStyle,
+    destroyPopupOnHide,
     ...restProps
   } = props;
 
@@ -74,6 +75,7 @@ const DropdownButton: DropdownButtonInterface = props => {
     mouseLeaveDelay,
     overlayClassName,
     overlayStyle,
+    destroyPopupOnHide,
   } as DropDownProps;
 
   if ('visible' in props) {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

#33433 Dropdown button destroyPopupOnHide prop not working
Dropdown.Button destroyPopupOnHide 不生效问题

### 💡 Background and solution

Dropdwon.Button 组件封装时未将 destroyPopupOnHide 取出传入Dropdown，补上了参数的传递

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     The destroyPopupOnHide props can be used normally in the Dropdown.Button component, and the warning will not appear in the browser.      |
| 🇨🇳 Chinese |     可以在Dropdown.Button组件正常使用destroyPopupOnHide Api了，同时浏览器也不会出现相应warning      |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
