### PR TITLE
fix: fix input value as number can not used es6 extended operator

### DIFF
--- a/components/input/Input.tsx
+++ b/components/input/Input.tsx
@@ -65,7 +65,7 @@ export function fixControlledValue<T>(value: T) {
   if (typeof value === 'undefined' || value === null) {
     return '';
   }
-  if(typeof value === 'number') {
+  if (typeof value === 'number') {
     return `${value}`;
   }
   return value;

--- a/components/input/Input.tsx
+++ b/components/input/Input.tsx
@@ -65,6 +65,9 @@ export function fixControlledValue<T>(value: T) {
   if (typeof value === 'undefined' || value === null) {
     return '';
   }
+  if(typeof value === 'number') {
+    return `${value}`;
+  }
   return value;
 }
 

--- a/components/input/__tests__/index.test.js
+++ b/components/input/__tests__/index.test.js
@@ -146,6 +146,12 @@ describe('should support showCount', () => {
     expect(wrapper.find('.ant-input-show-count-suffix').getDOMNode().innerHTML).toBe('8 / 5');
   });
 
+  it('value is a number', () => {
+    const wrapper = mount(<Input maxLength={5} showCount value={12345} />);
+    expect(wrapper.find('input').prop('value')).toBe('12345');
+    expect(wrapper.find('.ant-input-show-count-suffix').getDOMNode().innerHTML).toBe('5 / 5');
+  });
+
   describe('emoji', () => {
     it('should minimize value between emoji length and maxLength', () => {
       const wrapper = mount(<Input maxLength={1} showCount value="👀" />);


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [X] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

解决 input 组件中 renderShowCountSuffix 执行时使用 fixControlledValue 函数来处理 value 值忽略了数字的判断，导致 renderShowCountSuffix 中使用扩展运算符时类型报错

![image](https://user-images.githubusercontent.com/26181170/147564226-0eba4124-1aa4-4e71-891d-3ce8852f8c43.png)


### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
