### PR TITLE
fix: Form should have default validateMessages in en locale

### DIFF
--- a/components/config-provider/index.tsx
+++ b/components/config-provider/index.tsx
@@ -216,7 +216,9 @@ const ProviderChildren: React.FC<ProviderChildrenProps> = props => {
 
   let childNode = children;
   // Additional Form provider
-  let validateMessages: ValidateMessages = {};
+  let validateMessages: ValidateMessages = {
+    ...defaultLocale.Form?.defaultValidateMessages,
+  };
 
   if (locale) {
     validateMessages =

--- a/components/form/__tests__/index.test.js
+++ b/components/form/__tests__/index.test.js
@@ -12,6 +12,7 @@ import Select from '../../select';
 import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
 import { sleep } from '../../../tests/utils';
+import ConfigProvider from '../../config-provider';
 
 jest.mock('scroll-into-view-if-needed');
 
@@ -596,6 +597,25 @@ describe('Form', () => {
     wrapper.update();
     await sleep(100);
     expect(wrapper.find('.ant-form-item-explain').first().text()).toEqual('Bamboo is good!');
+  });
+
+  it('should have default validateMessages in default locale', async () => {
+    const wrapper = mount(
+      // eslint-disable-next-line no-template-curly-in-string
+      <ConfigProvider>
+        <Form>
+          <Form.Item name="test" label="Bamboo" rules={[{ required: true }]}>
+            <input />
+          </Form.Item>
+        </Form>
+      </ConfigProvider>,
+    );
+
+    wrapper.find('form').simulate('submit');
+    await sleep(100);
+    wrapper.update();
+    await sleep(100);
+    expect(wrapper.find('.ant-form-item-explain').first().text()).toEqual('Please enter Bamboo');
   });
 
   it('`name` support template when label is not provided', async () => {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<img width="662" alt="图片" src="https://user-images.githubusercontent.com/507615/147812034-bcfcad37-53d2-4eb1-99a8-e5693288e0d4.png">

默认语言包时应该显示 `Please enter name`。

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fix Form validateMessages is not correct in default locale.         |
| 🇨🇳 Chinese | 修复 Form 在英文语言包下错误提示文案不生效的问题。          |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
