### PR TITLE
fix: Avoid mutating Event properties that are supposed to be getters

### DIFF
--- a/components/input/Input.tsx
+++ b/components/input/Input.tsx
@@ -112,7 +112,7 @@ export function resolveOnChange<E extends HTMLInputElement | HTMLTextAreaElement
   if (targetValue !== undefined) {
     event = Object.create(e, {
       target: { value: target },
-      currentTarget: { value: target }
+      currentTarget: { value: target },
     });
 
     target.value = targetValue;

--- a/components/input/Input.tsx
+++ b/components/input/Input.tsx
@@ -83,9 +83,6 @@ export function resolveOnChange<E extends HTMLInputElement | HTMLTextAreaElement
   let event = e;
 
   if (e.type === 'click') {
-    // click clear icon
-    event = Object.create(e);
-
     // Clone a new target for event.
     // Avoid the following usage, the setQuery method gets the original value.
     //
@@ -100,8 +97,11 @@ export function resolveOnChange<E extends HTMLInputElement | HTMLTextAreaElement
 
     const currentTarget = target.cloneNode(true) as E;
 
-    event.target = currentTarget;
-    event.currentTarget = currentTarget;
+    // click clear icon
+    event = Object.create(e, {
+      target: { value: currentTarget },
+      currentTarget: { value: currentTarget }
+    });
 
     currentTarget.value = '';
     onChange(event as React.ChangeEvent<E>);
@@ -110,9 +110,10 @@ export function resolveOnChange<E extends HTMLInputElement | HTMLTextAreaElement
 
   // Trigger by composition event, this means we need force change the input value
   if (targetValue !== undefined) {
-    event = Object.create(e);
-    event.target = target;
-    event.currentTarget = target;
+    event = Object.create(e, {
+      target: { value: target },
+      currentTarget: { value: target }
+    });
 
     target.value = targetValue;
     onChange(event as React.ChangeEvent<E>);

--- a/components/input/Input.tsx
+++ b/components/input/Input.tsx
@@ -100,7 +100,7 @@ export function resolveOnChange<E extends HTMLInputElement | HTMLTextAreaElement
     // click clear icon
     event = Object.create(e, {
       target: { value: currentTarget },
-      currentTarget: { value: currentTarget }
+      currentTarget: { value: currentTarget },
     });
 
     currentTarget.value = '';


### PR DESCRIPTION
React's synthetic Event objects have mutable `target` and `currentTarget` properties. These are an incorrect emulation of the corresponding DOM Event properties, which are _getters_ and cannot be assigned-to. AntD's input handling [attempts to assign to these getters](https://github.com/ant-design/ant-design/blob/a4d139687a6ca5a0abad09ac5cdadce617ccf9ca/components/input/Input.tsx#L114-L115), which fails in Preact because it uses native Event objects. (Note that the `Object.create()` usage here retains the getter property definitions, so they are still not writable).

The solution is to replace the simple property assignments with property definitions. Fortunately, this is likely to be smaller due to the existing use of `Object.create()` to construct a prototypal facade of Event objects.

### 🤔 This is a ...

- [x] Bug fix
- [x] Other (compatibility issue)

### 🔗 Related issue link

No related issue, but this came up in response to a bug report about AntD's `<Input.TextArea>` throwing on change when rendered with Preact (see demo below).

### 💡 Background and solution

**Demo** - attempting to type into the TextArea throws an error:
https://codesandbox.io/s/dry-paper-nz0t9?file=/index.js

**Patched Demo** - a small plugin replaces the `target` and `currentTarget` getters on events with mutable value properties, allowing AntD to assign to them:
https://codesandbox.io/s/aged-cdn-9k4ww?file=/index.js:110-573 

### 📝 Changelog

Fixes an issue where `<Input.TextArea>` throws when rendered with Preact.

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fix Input.Textarea throws error on preact.         |
| 🇨🇳 Chinese |  修复 Input.Textarea 在 preact 下报错的问题。         |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
