### PR TITLE
fix: Upload types for pass generic

### DIFF
--- a/components/upload/Upload.tsx
+++ b/components/upload/Upload.tsx
@@ -422,15 +422,20 @@ const InternalUpload: React.ForwardRefRenderFunction<unknown, UploadProps> = (pr
   );
 };
 
-interface CompoundedComponent
-  extends React.ForwardRefExoticComponent<
-    React.PropsWithChildren<UploadProps> & React.RefAttributes<any>
-  > {
+const ForwardUpload = React.forwardRef<unknown, UploadProps>(InternalUpload) as <T>(
+  props: React.PropsWithChildren<UploadProps<T>> & React.RefAttributes<any>,
+) => React.ReactElement;
+
+type InternalUploadType = typeof ForwardUpload;
+
+interface UploadInterface extends InternalUploadType {
+  defaultProps?: Partial<UploadProps>;
+  displayName?: string;
   Dragger: typeof Dragger;
   LIST_IGNORE: string;
 }
 
-const Upload = React.forwardRef<unknown, UploadProps>(InternalUpload) as CompoundedComponent;
+const Upload = ForwardUpload as UploadInterface;
 
 Upload.Dragger = Dragger;
 

--- a/components/upload/__tests__/type.test.tsx
+++ b/components/upload/__tests__/type.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Upload from '..';
+import Upload, { UploadProps } from '..';
 
 describe('Upload.typescript', () => {
   it('Upload', () => {
@@ -8,6 +8,29 @@ describe('Upload.typescript', () => {
         <span>click to upload</span>
       </Upload>
     );
+    expect(upload).toBeTruthy();
+  });
+
+  it('onChange', () => {
+    const upload = (
+      <Upload<File> onChange={({ file }) => file}>
+        <span>click to upload</span>
+      </Upload>
+    );
+
+    expect(upload).toBeTruthy();
+  });
+
+  it('onChange in UploadProps', () => {
+    const uploadProps: UploadProps<File> = {
+      onChange: ({ file }) => file,
+    };
+    const upload = (
+      <Upload {...uploadProps}>
+        <span>click to upload</span>
+      </Upload>
+    );
+
     expect(upload).toBeTruthy();
   });
 

--- a/components/upload/interface.tsx
+++ b/components/upload/interface.tsx
@@ -40,7 +40,7 @@ export interface InternalUploadFile<T = any> extends UploadFile<T> {
   originFileObj: RcFile;
 }
 
-export interface UploadChangeParam<T extends object = UploadFile> {
+export interface UploadChangeParam<T = UploadFile> {
   // https://github.com/ant-design/ant-design/issues/14420
   file: T;
   fileList: UploadFile[];

--- a/components/upload/interface.tsx
+++ b/components/upload/interface.tsx
@@ -104,7 +104,7 @@ export interface UploadProps<T = any> extends Pick<RcUploadProps, 'capture'> {
     file: RcFile,
     FileList: RcFile[],
   ) => BeforeUploadValueType | Promise<BeforeUploadValueType>;
-  onChange?: (info: UploadChangeParam) => void;
+  onChange?: (info: UploadChangeParam<T>) => void;
   onDrop?: (event: React.DragEvent<HTMLDivElement>) => void;
   listType?: UploadListType;
   className?: string;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

Merged. https://github.com/ant-design/ant-design/pull/16360

I think, should pass generic to `UploadChangeParam` in `UploadProps`

https://codesandbox.io/s/antd-typescript-forked-2fr1u?file=/index.tsx

![image](https://user-images.githubusercontent.com/48552260/148036763-fe0deb1f-62b1-44f3-860f-77797f8e7c00.png)




### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
