### PR TITLE
fix: Image 图片底部空白 #30825

### DIFF
--- a/components/image/style/index.less
+++ b/components/image/style/index.less
@@ -9,9 +9,9 @@
   display: inline-block;
 
   &-img {
-    display: block;
     width: 100%;
     height: auto;
+    vertical-align: middle;
 
     &-placeholder {
       background-color: @image-bg;


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

Image 图片底部空白 #30825

### 💡 需求背景和解决方案

移除元素 .ant-imaga 的 display: block; 样式
添加 img 元素 vertical-align: middle;


### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |    Fix the white space at the bottom of the image component      |
| 🇨🇳 中文 |    修复Image底部留白      |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
