### PR TITLE
fix: fix the table tree hover error #33453

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "rc-slider": "~9.7.4",
     "rc-steps": "~4.1.0",
     "rc-switch": "~3.2.0",
-    "rc-table": "^7.22.2",
+    "rc-table": "~7.22.2",
     "rc-tabs": "~11.10.0",
     "rc-textarea": "~0.3.0",
     "rc-tooltip": "~5.1.1",

--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "rc-slider": "~9.7.4",
     "rc-steps": "~4.1.0",
     "rc-switch": "~3.2.0",
-    "rc-table": "~7.22.1",
+    "rc-table": "^7.22.2",
     "rc-tabs": "~11.10.0",
     "rc-textarea": "~0.3.0",
     "rc-tooltip": "~5.1.1",


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
 #33453 

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution
出现hover错误的原因是 子cell分配的index出现问题，分配的index应该是对于整个flattenData，而在前面的错误中分配index为每个子数组中相应数据的index
仅仅修改将renderIndex取消传值，测试用例会发生错误。
所以增加一个renderIndex的prop传值，将render传入的index用renderIndex替代，其他的维持正确的index。
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      fix the table of tree data have a hover error     |
| 🇨🇳 Chinese |      修复树形数据展示 hover 高亮异常     |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
