### PR TITLE
fix: Warning: Encountered two children with the same key, 'seperator'

### DIFF
--- a/components/cascader/index.tsx
+++ b/components/cascader/index.tsx
@@ -45,7 +45,7 @@ function highlightKeyword(str: string, lowerKeyword: string, prefixCls: string |
 
     if (index % 2 === 1) {
       originWorld = (
-        <span className={`${prefixCls}-menu-item-keyword`} key="seperator">
+        <span className={`${prefixCls}-menu-item-keyword`} key={`seperator-${index}`}>
           {originWorld}
         </span>
       );

--- a/components/cascader/index.tsx
+++ b/components/cascader/index.tsx
@@ -45,6 +45,7 @@ function highlightKeyword(str: string, lowerKeyword: string, prefixCls: string |
 
     if (index % 2 === 1) {
       originWorld = (
+        // eslint-disable-next-line react/no-array-index-key
         <span className={`${prefixCls}-menu-item-keyword`} key={`seperator-${index}`}>
           {originWorld}
         </span>


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [X] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
#33183
<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

> Warning: Encountered two children with the same key, 'seperator'. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.

Append index to seperator key
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog
No breaking changes
<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [X] Changelog is provided or not needed
