### PR TITLE
fix: DatePicker/RangePicker Icon Overrides no effect

### DIFF
--- a/components/date-picker/generatePicker/generateRangePicker.tsx
+++ b/components/date-picker/generatePicker/generateRangePicker.tsx
@@ -46,6 +46,10 @@ export default function generateRangePicker<DateType>(
         size: customizeSize,
         bordered = true,
         placeholder,
+        prevIcon,
+        nextIcon,
+        superPrevIcon,
+        superNextIcon,
         ...restProps
       } = this.props;
       const { format, showTime, picker } = this.props as any;
@@ -76,10 +80,10 @@ export default function generateRangePicker<DateType>(
                 placeholder={getRangePlaceholder(picker, locale, placeholder)}
                 suffixIcon={picker === 'time' ? <ClockCircleOutlined /> : <CalendarOutlined />}
                 clearIcon={<CloseCircleFilled />}
-                prevIcon={<span className={`${prefixCls}-prev-icon`} />}
-                nextIcon={<span className={`${prefixCls}-next-icon`} />}
-                superPrevIcon={<span className={`${prefixCls}-super-prev-icon`} />}
-                superNextIcon={<span className={`${prefixCls}-super-next-icon`} />}
+                prevIcon={prevIcon || <span className={`${prefixCls}-prev-icon`} />}
+                nextIcon={nextIcon || <span className={`${prefixCls}-next-icon`} />}
+                superPrevIcon={superPrevIcon || <span className={`${prefixCls}-super-prev-icon`} />}
+                superNextIcon={superNextIcon || <span className={`${prefixCls}-super-next-icon`} />}
                 allowClear
                 transitionName={`${rootPrefixCls}-slide-up`}
                 {...restProps}

--- a/components/date-picker/generatePicker/generateSinglePicker.tsx
+++ b/components/date-picker/generatePicker/generateSinglePicker.tsx
@@ -69,6 +69,10 @@ export default function generatePicker<DateType>(generateConfig: GenerateConfig<
           size: customizeSize,
           bordered = true,
           placeholder,
+          prevIcon,
+          nextIcon,
+          superPrevIcon,
+          superNextIcon,
           ...restProps
         } = this.props;
         const { format, showTime } = this.props as any;
@@ -106,10 +110,10 @@ export default function generatePicker<DateType>(generateConfig: GenerateConfig<
                     mergedPicker === 'time' ? <ClockCircleOutlined /> : <CalendarOutlined />
                   }
                   clearIcon={<CloseCircleFilled />}
-                  prevIcon={<span className={`${prefixCls}-prev-icon`} />}
-                  nextIcon={<span className={`${prefixCls}-next-icon`} />}
-                  superPrevIcon={<span className={`${prefixCls}-super-prev-icon`} />}
-                  superNextIcon={<span className={`${prefixCls}-super-next-icon`} />}
+                  prevIcon={prevIcon || <span className={`${prefixCls}-prev-icon`} />}
+                  nextIcon={nextIcon || <span className={`${prefixCls}-next-icon`} />}
+                  superPrevIcon={superPrevIcon || <span className={`${prefixCls}-super-prev-icon`} />}
+                  superNextIcon={superNextIcon || <span className={`${prefixCls}-super-next-icon`} />}
                   allowClear
                   transitionName={`${rootPrefixCls}-slide-up`}
                   {...additionalProps}


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 💡 Background and solution

https://github.com/ant-design/ant-design/pull/31703

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    fix DatePicker/RangePicker Icon Overrides no efffect      |
| 🇨🇳 Chinese |    修复 DatePicker/RangePicker 使用 `nextIcon`、`prevIcon`、`superNextIcon`  和 ` superPrevIcon`  属性未生效的问题   |

### ☑️ Self Check before Merge
#### ⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
