### PR TITLE
fix: checkbox group support options other than string

### DIFF
--- a/components/checkbox/Group.tsx
+++ b/components/checkbox/Group.tsx
@@ -17,7 +17,7 @@ export interface CheckboxOptionType {
 export interface AbstractCheckboxGroupProps {
   prefixCls?: string;
   className?: string;
-  options?: Array<CheckboxOptionType | string>;
+  options?: Array<CheckboxOptionType | CheckboxValueType>;
   disabled?: boolean;
   style?: React.CSSProperties;
 }
@@ -69,7 +69,7 @@ const InternalCheckboxGroup: React.ForwardRefRenderFunction<HTMLDivElement, Chec
 
   const getOptions = () =>
     options.map(option => {
-      if (typeof option === 'string') {
+      if (typeof option !== 'object') {
         return {
           label: option,
           value: option,

--- a/components/checkbox/Group.tsx
+++ b/components/checkbox/Group.tsx
@@ -17,7 +17,7 @@ export interface CheckboxOptionType {
 export interface AbstractCheckboxGroupProps {
   prefixCls?: string;
   className?: string;
-  options?: Array<CheckboxOptionType | CheckboxValueType>;
+  options?: Array<CheckboxOptionType | string | number>;
   disabled?: boolean;
   style?: React.CSSProperties;
 }
@@ -69,7 +69,7 @@ const InternalCheckboxGroup: React.ForwardRefRenderFunction<HTMLDivElement, Chec
 
   const getOptions = () =>
     options.map(option => {
-      if (typeof option !== 'object') {
+      if (typeof option === 'string' || typeof option === 'number') {
         return {
           label: option,
           value: option,

--- a/components/checkbox/__tests__/group.test.js
+++ b/components/checkbox/__tests__/group.test.js
@@ -213,4 +213,13 @@ describe('CheckboxGroup', () => {
       />,
     );
   });
+
+  it('should support number option', () => {
+    const onChange = jest.fn();
+
+    const wrapper = mount(<Checkbox.Group options={[1, 'Pear', 'Orange']} onChange={onChange} />);
+
+    wrapper.find('.ant-checkbox-input').at(0).simulate('change');
+    expect(onChange).toHaveBeenCalledWith([1]);
+  });
 });

--- a/components/checkbox/index.en-US.md
+++ b/components/checkbox/index.en-US.md
@@ -34,7 +34,7 @@ Checkbox component.
 | defaultValue | Default selected value | string\[] | \[] |  |
 | disabled | If disable all checkboxes | boolean | false |  |
 | name | The `name` property of all `input[type="checkbox"]` children | string | - |  |
-| options | Specifies options | string\[] \| Option\[] | \[] |  |
+| options | Specifies options | string\[] \| number\[] \| boolean\[] \| Option\[] | \[] |  |
 | value | Used for setting the currently selected value | string\[] | \[] |  |
 | onChange | The callback function that is triggered when the state changes | function(checkedValue) | - |  |
 
@@ -42,7 +42,7 @@ Checkbox component.
 
 #### Checkbox
 
-| Name | Description | Version |
-| --- | --- | --- |
-| blur() | Remove focus |  |
-| focus() | Get focus |  |
+| Name    | Description  | Version |
+| ------- | ------------ | ------- |
+| blur()  | Remove focus |         |
+| focus() | Get focus    |         |

--- a/components/checkbox/index.en-US.md
+++ b/components/checkbox/index.en-US.md
@@ -34,7 +34,7 @@ Checkbox component.
 | defaultValue | Default selected value | string\[] | \[] |  |
 | disabled | If disable all checkboxes | boolean | false |  |
 | name | The `name` property of all `input[type="checkbox"]` children | string | - |  |
-| options | Specifies options | string\[] \| number\[] \| boolean\[] \| Option\[] | \[] |  |
+| options | Specifies options | string\[] \| number\[] \| Option\[] | \[] |  |
 | value | Used for setting the currently selected value | string\[] | \[] |  |
 | onChange | The callback function that is triggered when the state changes | function(checkedValue) | - |  |
 

--- a/components/checkbox/index.zh-CN.md
+++ b/components/checkbox/index.zh-CN.md
@@ -35,7 +35,7 @@ cover: https://gw.alipayobjects.com/zos/alicdn/8nbVbHEm_/CheckBox.svg
 | defaultValue | 默认选中的选项 | string\[] | \[] |  |
 | disabled | 整组失效 | boolean | false |  |
 | name | CheckboxGroup 下所有 `input[type="checkbox"]` 的 `name` 属性 | string | - |  |
-| options | 指定可选项 | string\[] \| number\[] \| boolean\[] \| Option\[] | \[] |  |
+| options | 指定可选项 | string\[] \| number\[] \| Option\[] | \[] |  |
 | value | 指定选中的选项 | string\[] | \[] |  |
 | onChange | 变化时回调函数 | function(checkedValue) | - |  |
 

--- a/components/checkbox/index.zh-CN.md
+++ b/components/checkbox/index.zh-CN.md
@@ -19,14 +19,14 @@ cover: https://gw.alipayobjects.com/zos/alicdn/8nbVbHEm_/CheckBox.svg
 
 #### Checkbox
 
-| 参数 | 说明 | 类型 | 默认值 | 版本 |
-| --- | --- | --- | --- | --- |
-| autoFocus | 自动获取焦点 | boolean | false |  |
-| checked | 指定当前是否选中 | boolean | false |  |
-| defaultChecked | 初始是否选中 | boolean | false |  |
-| disabled | 失效状态 | boolean | false |  |
-| indeterminate | 设置 indeterminate 状态，只负责样式控制 | boolean | false |  |
-| onChange | 变化时回调函数 | function(e:Event) | - |  |
+| 参数           | 说明                                    | 类型              | 默认值 | 版本 |
+| -------------- | --------------------------------------- | ----------------- | ------ | ---- |
+| autoFocus      | 自动获取焦点                            | boolean           | false  |      |
+| checked        | 指定当前是否选中                        | boolean           | false  |      |
+| defaultChecked | 初始是否选中                            | boolean           | false  |      |
+| disabled       | 失效状态                                | boolean           | false  |      |
+| indeterminate  | 设置 indeterminate 状态，只负责样式控制 | boolean           | false  |      |
+| onChange       | 变化时回调函数                          | function(e:Event) | -      |      |
 
 #### Checkbox Group
 
@@ -35,7 +35,7 @@ cover: https://gw.alipayobjects.com/zos/alicdn/8nbVbHEm_/CheckBox.svg
 | defaultValue | 默认选中的选项 | string\[] | \[] |  |
 | disabled | 整组失效 | boolean | false |  |
 | name | CheckboxGroup 下所有 `input[type="checkbox"]` 的 `name` 属性 | string | - |  |
-| options | 指定可选项 | string\[] \| Option\[] | \[] |  |
+| options | 指定可选项 | string\[] \| number\[] \| boolean\[] \| Option\[] | \[] |  |
 | value | 指定选中的选项 | string\[] | \[] |  |
 | onChange | 变化时回调函数 | function(checkedValue) | - |  |
 
@@ -53,7 +53,7 @@ interface Option {
 
 #### Checkbox
 
-| 名称 | 描述 | 版本 |
-| --- | --- | --- |
-| blur() | 移除焦点 |  |
-| focus() | 获取焦点 |  |
+| 名称    | 描述     | 版本 |
+| ------- | -------- | ---- |
+| blur()  | 移除焦点 |      |
+| focus() | 获取焦点 |      |

--- a/components/radio/group.tsx
+++ b/components/radio/group.tsx
@@ -50,11 +50,11 @@ const RadioGroup = React.forwardRef<HTMLDivElement, RadioGroupProps>((props, ref
     if (options && options.length > 0) {
       const optionsPrefixCls = optionType === 'button' ? `${prefixCls}-button` : prefixCls;
       childrenToRender = options.map(option => {
-        if (typeof option === 'string') {
+        if (typeof option !== 'object') {
           // 此处类型自动推导为 string
           return (
             <Radio
-              key={option}
+              key={option.toString()}
               prefixCls={optionsPrefixCls}
               disabled={disabled}
               value={option}

--- a/components/radio/group.tsx
+++ b/components/radio/group.tsx
@@ -50,7 +50,7 @@ const RadioGroup = React.forwardRef<HTMLDivElement, RadioGroupProps>((props, ref
     if (options && options.length > 0) {
       const optionsPrefixCls = optionType === 'button' ? `${prefixCls}-button` : prefixCls;
       childrenToRender = options.map(option => {
-        if (typeof option !== 'object') {
+        if (typeof option === 'string' || typeof option === 'number') {
           // 此处类型自动推导为 string
           return (
             <Radio

--- a/components/radio/index.en-US.md
+++ b/components/radio/index.en-US.md
@@ -34,7 +34,7 @@ Radio group can wrap a group of `Radio`。
 | defaultValue | Default selected value | any | - |  |
 | disabled | Disable all radio buttons | boolean | false |  |
 | name | The `name` property of all `input[type="radio"]` children | string | - |  |
-| options | Set children optional | string\[] \| Array&lt;{ label: string value: string disabled?: boolean }> | - |  |
+| options | Set children optional | string\[] \| number\[] \| Array&lt;{ label: string value: string disabled?: boolean }> | - |  |
 | optionType | Set Radio optionType | `default` \| `button` | `default` | 4.4.0 |
 | size | The size of radio button style | `large` \| `middle` \| `small` | - |  |
 | value | Used for setting the currently selected value | any | - |  |
@@ -44,7 +44,7 @@ Radio group can wrap a group of `Radio`。
 
 ### Radio
 
-| Name | Description |
-| --- | --- |
-| blur() | Remove focus |
-| focus() | Get focus |
+| Name    | Description  |
+| ------- | ------------ |
+| blur()  | Remove focus |
+| focus() | Get focus    |

--- a/components/radio/index.zh-CN.md
+++ b/components/radio/index.zh-CN.md
@@ -17,13 +17,13 @@ cover: https://gw.alipayobjects.com/zos/alicdn/8cYb5seNB/Radio.svg
 
 ### Radio/Radio.Button
 
-| 参数 | 说明 | 类型 | 默认值 |
-| --- | --- | --- | --- |
-| autoFocus | 自动获取焦点 | boolean | false |
-| checked | 指定当前是否选中 | boolean | false |
-| defaultChecked | 初始是否选中 | boolean | false |
-| disabled | 禁用 Radio | boolean | false |
-| value | 根据 value 进行比较，判断是否选中 | any | - |
+| 参数           | 说明                              | 类型    | 默认值 |
+| -------------- | --------------------------------- | ------- | ------ |
+| autoFocus      | 自动获取焦点                      | boolean | false  |
+| checked        | 指定当前是否选中                  | boolean | false  |
+| defaultChecked | 初始是否选中                      | boolean | false  |
+| disabled       | 禁用 Radio                        | boolean | false  |
+| value          | 根据 value 进行比较，判断是否选中 | any     | -      |
 
 ### RadioGroup
 
@@ -35,7 +35,7 @@ cover: https://gw.alipayobjects.com/zos/alicdn/8cYb5seNB/Radio.svg
 | defaultValue | 默认选中的值 | any | - |  |  |
 | disabled | 禁选所有子单选器 | boolean | false |  |  |
 | name | RadioGroup 下所有 `input[type="radio"]` 的 `name` 属性 | string | - |  |  |
-| options | 以配置形式设置子元素 | string\[] \| Array&lt;{ label: string value: string disabled?: boolean }> | - |  |  |
+| options | 以配置形式设置子元素 | string\[] \| number\[] \| Array&lt;{ label: string value: string disabled?: boolean }> | - |  |  |
 | optionType | 用于设置 Radio `options` 类型 | `default` \| `button` | `default` | 4.4.0 |  |
 | size | 大小，只对按钮样式生效 | `large` \| `middle` \| `small` | - |  |  |
 | value | 用于设置当前选中的值 | any | - |  |  |
@@ -45,7 +45,7 @@ cover: https://gw.alipayobjects.com/zos/alicdn/8cYb5seNB/Radio.svg
 
 ### Radio
 
-| 名称 | 描述 |
-| --- | --- |
-| blur() | 移除焦点 |
+| 名称    | 描述     |
+| ------- | -------- |
+| blur()  | 移除焦点 |
 | focus() | 获取焦点 |


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

新特性请提交至 feature 分支，其余可提交至 master 分支。
在维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

[[English Template / 英文模板](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE.md)]

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
https://github.com/ant-design/ant-design/issues/33663
### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |`Checkbox.Group` support number and boolean as options element|
| 🇨🇳 中文 |`Checkbox.Group` 的 options 支持数组中直接传入 number 和 boolean 类型|

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
