### PR TITLE
fix: Form validateMessages in nested ConfigProvider

### DIFF
--- a/components/config-provider/index.tsx
+++ b/components/config-provider/index.tsx
@@ -216,9 +216,7 @@ const ProviderChildren: React.FC<ProviderChildrenProps> = props => {
 
   let childNode = children;
   // Additional Form provider
-  let validateMessages: ValidateMessages = {
-    ...defaultLocale.Form?.defaultValidateMessages,
-  };
+  let validateMessages: ValidateMessages = {};
 
   if (locale) {
     validateMessages =

--- a/components/form/__tests__/index.test.js
+++ b/components/form/__tests__/index.test.js
@@ -13,6 +13,7 @@ import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
 import { sleep } from '../../../tests/utils';
 import ConfigProvider from '../../config-provider';
+import zhCN from '../../locale/zh_CN';
 
 jest.mock('scroll-into-view-if-needed');
 
@@ -613,15 +614,17 @@ describe('Form', () => {
     expect(wrapper.find('.ant-form-item-explain').first().text()).toEqual('Bamboo is good!');
   });
 
-  it('should have default validateMessages in default locale', async () => {
+  // https://github.com/ant-design/ant-design/issues/33691
+  it('should keep upper locale in nested ConfigProvider', async () => {
     const wrapper = mount(
-      // eslint-disable-next-line no-template-curly-in-string
-      <ConfigProvider>
-        <Form>
-          <Form.Item name="test" label="Bamboo" rules={[{ required: true }]}>
-            <input />
-          </Form.Item>
-        </Form>
+      <ConfigProvider locale={zhCN}>
+        <ConfigProvider>
+          <Form>
+            <Form.Item name="test" label="Bamboo" rules={[{ required: true }]}>
+              <input />
+            </Form.Item>
+          </Form>
+        </ConfigProvider>
       </ConfigProvider>,
     );
 
@@ -629,7 +632,7 @@ describe('Form', () => {
     await sleep(100);
     wrapper.update();
     await sleep(100);
-    expect(wrapper.find('.ant-form-item-explain').first().text()).toEqual('Please enter Bamboo');
+    expect(wrapper.find('.ant-form-item-explain').first().text()).toEqual('请输入Bamboo');
   });
 
   it('`name` support template when label is not provided', async () => {


### PR DESCRIPTION


<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close #33691

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->
Revert https://github.com/ant-design/ant-design/pull/33511, need a better solution.

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Form `validateMessages` bug in multiple ConfigProvider.         |
| 🇨🇳 Chinese |  修复 Form `validateMessages` 在多个 ConfigProvider 内错乱的问题。       |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
