### PR TITLE
fix: Input can not be hidden when prefix is set

### DIFF
--- a/components/input/ClearableLabeledInput.tsx
+++ b/components/input/ClearableLabeledInput.tsx
@@ -29,6 +29,7 @@ interface BasicProps {
   focused?: boolean;
   readOnly?: boolean;
   bordered: boolean;
+  hidden?: boolean;
 }
 
 /** This props only for input. */
@@ -104,6 +105,7 @@ class ClearableLabeledInput extends React.Component<ClearableInputProps> {
       style,
       readOnly,
       bordered,
+      hidden,
     } = this.props;
     if (!hasPrefixSuffix(this.props)) {
       return cloneElement(element, {
@@ -132,6 +134,7 @@ class ClearableLabeledInput extends React.Component<ClearableInputProps> {
         className={affixWrapperCls}
         style={style}
         onMouseUp={this.onInputMouseUp}
+        hidden={hidden}
       >
         {prefixNode}
         {cloneElement(element, {

--- a/components/input/__tests__/index.test.js
+++ b/components/input/__tests__/index.test.js
@@ -97,6 +97,18 @@ describe('prefix and suffix', () => {
     expect(wrapper.getDOMNode().className.includes('my-class-name')).toBe(true);
     expect(wrapper.find('input').getDOMNode().className.includes('my-class-name')).toBe(false);
   });
+
+  it('should support hidden when has prefix or suffix', () => {
+    const wrapper = mount(
+      <>
+        <Input prefix="prefix" hidden className="prefix-with-hidden" />
+        <Input suffix="suffix" hidden className="suffix-with-hidden" />
+      </>,
+    );
+
+    expect(wrapper.find('.prefix-with-hidden').at(0).getDOMNode().hidden).toBe(true);
+    expect(wrapper.find('.suffix-with-hidden').at(0).getDOMNode().hidden).toBe(true);
+  });
 });
 
 describe('As Form Control', () => {


### PR DESCRIPTION


[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

#33692 

### 💡 Background and solution

Attribute `hidden` are also passed to the outer `<span>`

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Input can not be hidden when the prefix is set |
| 🇨🇳 Chinese | 修复当前缀被设置时 Input 不能隐藏 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
