### PR TITLE
fix: Steps tail shouldn't show when type is navigation and labelPlacement is vertical (fix #33681)

### DIFF
--- a/components/steps/style/nav.less
+++ b/components/steps/style/nav.less
@@ -124,3 +124,11 @@
     }
   }
 }
+
+.@{steps-prefix-cls}-navigation.@{steps-prefix-cls}-horizontal {
+  > .@{steps-prefix-cls}-item
+    > .@{steps-prefix-cls}-item-container
+    > .@{steps-prefix-cls}-item-tail {
+    visibility: hidden;
+  }
+}

--- a/components/steps/style/nav.less
+++ b/components/steps/style/nav.less
@@ -124,11 +124,3 @@
     }
   }
 }
-
-.@{steps-prefix-cls}-navigation.@{steps-prefix-cls}-horizontal {
-  > .@{steps-prefix-cls}-item
-    > .@{steps-prefix-cls}-item-container
-    > .@{steps-prefix-cls}-item-tail {
-    visibility: hidden;
-  }
-}


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->
close #33681
### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->
the `ant-steps-item-tail` element should be hidden when type is navigation and labelPlacement is vertical

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fix Steps. tail will be hidden when type is navigation and labelPlacement is vertical         |
| 🇨🇳 Chinese | 修复 Steps 组件, tail 在 type = navigation 和 labelPlacement = vertical 的时候不会显示     |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
