### PR TITLE
fix: Invalid memoized context value in LocaleProvider

### DIFF
--- a/components/anchor/Anchor.tsx
+++ b/components/anchor/Anchor.tsx
@@ -257,6 +257,16 @@ export default class Anchor extends React.Component<AnchorProps, AnchorState, Co
     }
   };
 
+  getMemoizedContextValue = memoizeOne(
+    (link: AntAnchor['activeLink'], onClickFn: AnchorProps['onClick']): AntAnchor => ({
+      registerLink: this.registerLink,
+      unregisterLink: this.unregisterLink,
+      scrollTo: this.handleScrollTo,
+      activeLink: link,
+      onClick: onClickFn,
+    }),
+  );
+
   render() {
     const { getPrefixCls, direction } = this.context;
     const {
@@ -310,13 +320,7 @@ export default class Anchor extends React.Component<AnchorProps, AnchorState, Co
       </div>
     );
 
-    const contextValue = memoizeOne((link, onClickFn) => ({
-      registerLink: this.registerLink,
-      unregisterLink: this.unregisterLink,
-      scrollTo: this.handleScrollTo,
-      activeLink: link,
-      onClick: onClickFn,
-    }))(activeLink, onClick);
+    const contextValue = this.getMemoizedContextValue(activeLink, onClick);
 
     return (
       <AnchorContext.Provider value={contextValue}>

--- a/components/anchor/__tests__/cached-context.test.tsx
+++ b/components/anchor/__tests__/cached-context.test.tsx
@@ -1,0 +1,51 @@
+import React, { memo, useState, useRef, useContext } from 'react';
+import { mount } from 'enzyme';
+import Anchor from '../Anchor';
+import AnchorContext from '../context';
+
+// we use'memo' here in order to only render inner component while context changed.
+const CacheInner = memo(() => {
+  const countRef = useRef(0);
+  countRef.current++;
+  // subscribe anchor context
+  useContext(AnchorContext);
+  return (
+    <div>
+      Child Rendering Count: <span id="child_count">{countRef.current}</span>
+    </div>
+  );
+});
+
+const CacheOuter = () => {
+  // We use 'useState' here in order to trigger parent component rendering.
+  const [count, setCount] = useState(1);
+  const handleClick = () => {
+    setCount(count + 1);
+  };
+  // During each rendering phase, the cached context value returned from method 'Anchor#getMemoizedContextValue' will take effect.
+  // So 'CacheInner' component won't rerender.
+  return (
+    <div>
+      <button type="button" onClick={handleClick} id="parent_btn">
+        Click
+      </button>
+      Parent Rendering Count: <span id="parent_count">{count}</span>
+      <Anchor affix={false}>
+        <CacheInner />
+      </Anchor>
+    </div>
+  );
+};
+
+it("Rendering on Anchor without changed AnchorContext won't trigger rendering on child component.", () => {
+  const wrapper = mount(<CacheOuter />);
+  const childCount = wrapper.find('#child_count').text();
+  wrapper.find('#parent_btn').at(0).simulate('click');
+  expect(wrapper.find('#parent_count').text()).toBe('2');
+  // child component won't rerender
+  expect(wrapper.find('#child_count').text()).toBe(childCount);
+  wrapper.find('#parent_btn').at(0).simulate('click');
+  expect(wrapper.find('#parent_count').text()).toBe('3');
+  // child component won't rerender
+  expect(wrapper.find('#child_count').text()).toBe(childCount);
+});

--- a/components/locale-provider/__tests__/cached-context.test.tsx
+++ b/components/locale-provider/__tests__/cached-context.test.tsx
@@ -1,0 +1,53 @@
+import React, { memo, useState, useRef, useContext } from 'react';
+import { mount } from 'enzyme';
+import LocaleProvider, { ANT_MARK } from '..';
+import LocaleContext from '../context';
+
+const defaultLocale = {
+  locale: 'locale',
+};
+// we use'memo' here in order to only render inner component while context changed.
+const CacheInner = memo(() => {
+  const countRef = useRef(0);
+  countRef.current++;
+  // subscribe locale context
+  useContext(LocaleContext);
+  return (
+    <div>
+      Child Rendering Count: <span id="child_count">{countRef.current}</span>
+    </div>
+  );
+});
+
+const CacheOuter = () => {
+  // We use 'useState' here in order to trigger parent component rendering.
+  const [count, setCount] = useState(1);
+  const handleClick = () => {
+    setCount(count + 1);
+  };
+  // During each rendering phase, the cached context value returned from method 'LocaleProvider#getMemoizedContextValue' will take effect.
+  // So 'CacheInner' component won't rerender.
+  return (
+    <div>
+      <button onClick={handleClick} id="parent_btn">
+        Click
+      </button>
+      Parent Rendering Count: <span id="parent_count">{count}</span>
+      <LocaleProvider locale={defaultLocale} _ANT_MARK__={ANT_MARK}>
+        <CacheInner />
+      </LocaleProvider>
+    </div>
+  );
+};
+
+it("Rendering on LocaleProvider won't trigger rendering on child component.", () => {
+  const wrapper = mount(<CacheOuter />);
+  wrapper.find('#parent_btn').at(0).simulate('click');
+  expect(wrapper.find('#parent_count').text()).toBe('2');
+  // child component won't rerender
+  expect(wrapper.find('#child_count').text()).toBe('1');
+  wrapper.find('#parent_btn').at(0).simulate('click');
+  expect(wrapper.find('#parent_count').text()).toBe('3');
+  // child component won't rerender
+  expect(wrapper.find('#child_count').text()).toBe('1');
+});

--- a/components/locale-provider/__tests__/cached-context.test.tsx
+++ b/components/locale-provider/__tests__/cached-context.test.tsx
@@ -29,7 +29,7 @@ const CacheOuter = () => {
   // So 'CacheInner' component won't rerender.
   return (
     <div>
-      <button onClick={handleClick} id="parent_btn">
+      <button type="button" onClick={handleClick} id="parent_btn">
         Click
       </button>
       Parent Rendering Count: <span id="parent_count">{count}</span>

--- a/components/locale-provider/index.tsx
+++ b/components/locale-provider/index.tsx
@@ -78,12 +78,14 @@ export default class LocaleProvider extends React.Component<LocaleProviderProps,
     changeConfirmLocale();
   }
 
+  getMemoizedContextValue = memoizeOne((localeValue: Locale): Locale & { exist?: boolean } => ({
+    ...localeValue,
+    exist: true,
+  }));
+
   render() {
     const { locale, children } = this.props;
-    const contextValue = memoizeOne(localeValue => ({
-      ...localeValue,
-      exist: true,
-    }))(locale);
+    const contextValue = this.getMemoizedContextValue(locale);
     return <LocaleContext.Provider value={contextValue}>{children}</LocaleContext.Provider>;
   }
 }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
No related issue.
<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

In order to make use of cache ability from `memoize-one` library, we must store the wrapped function in a variable.

In `LocaleProvider` component, we have created a new wrapped function from `memoize-one` during each rendering phase.
That won't return same object reference even though `locale` property is not changed.  So all child components subscribed `LocaleContext` will render again if `LocaleProvider` in parent components is rendering. 

I have created an online [demo](https://codesandbox.io/s/naughty-bouman-779gc?file=/src/App.js) to test this problem.
If you click 'Click' button, the rendering counts are same. But the expected result is "Child Rendering Count" should always be 1.
![image](https://user-images.githubusercontent.com/15250494/149445928-abe90ec7-0475-4583-979a-c241db4906c9.png)



<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog
No breaking change.
<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix ConfigProvider and Anchor rerender unexpectedly.          |
| 🇨🇳 Chinese | 修复 ConfigProvider 和 Anchor 的渲染函数多次运行的问题。          |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
