### PR TITLE
fix:use dropdownMatchSelectWidth instead of matchInputWidth

### DIFF
--- a/components/cascader/index.tsx
+++ b/components/cascader/index.tsx
@@ -112,6 +112,7 @@ const Cascader = React.forwardRef((props: CascaderProps<any>, ref: React.Ref<Cas
     notFoundContent,
     direction,
     getPopupContainer,
+    dropdownMatchSelectWidth,
     ...rest
   } = props;
 
@@ -123,7 +124,6 @@ const Cascader = React.forwardRef((props: CascaderProps<any>, ref: React.Ref<Cas
     renderEmpty,
     direction: rootDirection,
     // virtual,
-    // dropdownMatchSelectWidth,
   } = React.useContext(ConfigContext);
 
   const mergedDirection = direction || rootDirection;
@@ -226,6 +226,7 @@ const Cascader = React.forwardRef((props: CascaderProps<any>, ref: React.Ref<Cas
       )}
       {...(restProps as any)}
       direction={mergedDirection}
+      dropdownMatchSelectWidth={dropdownMatchSelectWidth}
       notFoundContent={mergedNotFoundContent}
       allowClear={allowClear}
       showSearch={mergedShowSearch}


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

新特性请提交至 feature 分支，其余可提交至 master 分支。
在维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

[[English Template / 英文模板](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE.md)]

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [X] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

[Cascader matchInputWidth not yet working as expected #33297](https://github.com/ant-design/ant-design/issues/33297)

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
1. 解决matchInputWidth 使用后,不能达到预期效果


### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->
1. 该功能涉及r-cascader功能,dropdownMatchSelectWidth有预留功能
2. 将dropdownMatchSelectWidth由false 改为 由父组件传参(默认flase)
3. 可能影响其他使用 r-cascader的业务
4. https://github.com/react-component/cascader/pull/237

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |          |
| 🇨🇳 中文 |          |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

以下希望方案通过后提供:

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
