### PR TITLE
fix(checkbox): disabled checkboxGroup should works well with tooltip

### DIFF
--- a/components/checkbox/style/mixin.less
+++ b/components/checkbox/style/mixin.less
@@ -122,6 +122,7 @@
 
     .@{checkbox-prefix-cls}-input {
       cursor: not-allowed;
+      pointer-events: none;
     }
 
     .@{checkbox-inner-prefix-cls} {

--- a/components/tooltip/__tests__/__snapshots__/tooltip.test.js.snap
+++ b/components/tooltip/__tests__/__snapshots__/tooltip.test.js.snap
@@ -16,32 +16,6 @@ exports[`Tooltip should hide when mouse leave antd disabled component Button 1`]
 </span>
 `;
 
-exports[`Tooltip should hide when mouse leave antd disabled component Checkbox 1`] = `
-<span
-  class="ant-tooltip-disabled-compatible-wrapper"
-  style="display: inline-block; cursor: not-allowed;"
->
-  <label
-    class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled"
-    style="pointer-events: none;"
-  >
-    <span
-      class="ant-checkbox ant-checkbox-disabled"
-    >
-      <input
-        class="ant-checkbox-input"
-        disabled=""
-        type="checkbox"
-        value=""
-      />
-      <span
-        class="ant-checkbox-inner"
-      />
-    </span>
-  </label>
-</span>
-`;
-
 exports[`Tooltip should hide when mouse leave antd disabled component Switch 1`] = `
 <span
   class="ant-tooltip-disabled-compatible-wrapper"

--- a/components/tooltip/__tests__/tooltip.test.js
+++ b/components/tooltip/__tests__/tooltip.test.js
@@ -4,7 +4,6 @@ import { spyElementPrototype } from 'rc-util/lib/test/domHook';
 import Tooltip from '..';
 import Button from '../../button';
 import Switch from '../../switch';
-import Checkbox from '../../checkbox';
 import DatePicker from '../../date-picker';
 import Input from '../../input';
 import Group from '../../input/Group';
@@ -131,7 +130,6 @@ describe('Tooltip', () => {
 
     testComponent('Button', Button);
     testComponent('Switch', Switch);
-    testComponent('Checkbox', Checkbox);
   });
 
   it('should render disabled Button style properly', () => {

--- a/components/tooltip/index.tsx
+++ b/components/tooltip/index.tsx
@@ -87,7 +87,6 @@ function getDisabledCompatibleChildren(element: React.ReactElement<any>, prefixC
   if (
     (elementType.__ANT_BUTTON === true ||
       elementType.__ANT_SWITCH === true ||
-      elementType.__ANT_CHECKBOX === true ||
       element.type === 'button') &&
     element.props.disabled
   ) {
@@ -130,9 +129,11 @@ function getDisabledCompatibleChildren(element: React.ReactElement<any>, prefixC
 }
 
 const Tooltip = React.forwardRef<unknown, TooltipProps>((props, ref) => {
-  const { getPopupContainer: getContextPopupContainer, getPrefixCls, direction } = React.useContext(
-    ConfigContext,
-  );
+  const {
+    getPopupContainer: getContextPopupContainer,
+    getPrefixCls,
+    direction,
+  } = React.useContext(ConfigContext);
 
   const [visible, setVisible] = useMergedState(false, {
     value: props.visible,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
As we all known, mouseEnter/MouseLeave events may not triggered on disabled form elements in chromium. 
So Tooltip add an extra wrapper for Input/Button/Checkbox. But for checkbox, it already has a `span` wrapper, so don't need tooltip to do such works.
So this pr is to solve #20940, and  others issues like:
+ checkboxGroup
+ layout/style error caused by extra wrapper
+ checkbox is not the direct children of tooltip

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->
Tooltip won't  add wrapper for Checkbox anymore.

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   disabled checkbox should works well with tooltip  |
| 🇨🇳 Chinese |  修复 tooltip 的子元素含有禁用态的 CheckBox 时，可能引起的行为和样式异常  |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
