### PR TITLE
fix: Get ref of Card component #33730

### DIFF
--- a/components/card/__tests__/index.test.js
+++ b/components/card/__tests__/index.test.js
@@ -82,4 +82,22 @@ describe('Card', () => {
     );
     expect(wrapper.find('Tabs').get(0).props.size).toBe('small');
   });
+
+  it('get ref of card', () => {
+    class WrapperComponent extends React.Component {
+      render() {
+        return (
+          <Card
+            // eslint-disable-next-line react/no-string-refs
+            ref="firstRef"
+            title="Card title"
+          >
+            <p>Card content</p>
+          </Card>
+        );
+      }
+    }
+    const wrapper = mount(<WrapperComponent />);
+    expect(wrapper.ref('firstRef').className.includes('ant-card')).toBe(true);
+  });
 });

--- a/components/card/index.tsx
+++ b/components/card/index.tsx
@@ -56,12 +56,12 @@ export interface CardProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 't
   tabProps?: TabsProps;
 }
 
-export interface CardInterface extends React.FC<CardProps> {
+export interface CardInterface extends React.ForwardRefExoticComponent<CardProps> {
   Grid: typeof Grid;
   Meta: typeof Meta;
 }
 
-const Card: CardInterface = props => {
+const Card = React.forwardRef((props: CardProps, ref: React.Ref<HTMLDivElement>) => {
   const { getPrefixCls, direction } = React.useContext(ConfigContext);
   const size = React.useContext(SizeContext);
 
@@ -196,14 +196,14 @@ const Card: CardInterface = props => {
   );
 
   return (
-    <div {...divProps} className={classString}>
+    <div ref={ref} {...divProps} className={classString}>
       {head}
       {coverDom}
       {body}
       {actionDom}
     </div>
   );
-};
+}) as CardInterface;
 
 Card.Grid = Grid;
 Card.Meta = Meta;


### PR DESCRIPTION
[[English Template / 英文模板](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE.md)]

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [x] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [x] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
#33730 
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志
可以传入ref获取正确的实例
Pass in ref to get the correct dom element of card component
<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |    update ref of card      |
| 🇨🇳 中文 |     可以传入ref获取card元素     |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供