### PR TITLE
docs: update sentence structure in the Upload Component FAQ section

### DIFF
--- a/components/upload/index.en-US.md
+++ b/components/upload/index.en-US.md
@@ -94,7 +94,7 @@ When uploading state change, it returns:
 
 ## FAQ
 
-### How to implement upload server side?
+### How do I implement upload server side?
 
 - You can consult [jQuery-File-Upload](https://github.com/blueimp/jQuery-File-Upload/wiki#server-side) about how to implement server side upload interface.
 - There is a mock example of [express](https://github.com/react-component/upload/blob/master/server.js) in rc-upload.
@@ -107,10 +107,10 @@ Please set property `url` of each item in `fileList` to control content of link.
 
 See <https://github.com/react-component/upload#customrequest>.
 
-### Why `fileList` in control will not trigger `onChange` `status` update when file not in the list?
+### Why will the `fileList` that's in control not trigger `onChange` `status` update when the file is not in the list?
 
-`onChange` only trigger when file in the list, it will ignore left events when removed from the list. Please note that there exist bug which makes event still trigger even the file is not in the list before `4.13.0`.
+`onChange` will only trigger when the file is in the list, it will ignore any events removed from the list. Please note that there does exist a bug which makes an event still trigger even when the file is not in the list before `4.13.0`.
 
-### Why sometime `onChange` return File object and sometime return { originFileObj: File }?
+### Why does `onChange` sometimes return File object and other times return { originFileObj: File }?
 
 For compatible case, we return File object when `beforeUpload` return `false`. It will merge to `{ originFileObj: File }` in next major version. Current version is compatible to get origin file by `info.file.originFileObj`. You can change this before major release.


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [x] Other (Documentation)

### 🔗 Related issue link

No related issue to link

### 💡 Background and solution

Reading the Upload Component documentation, I discovered the phrasing was choppy in the FAQ section, so I suggest these changes to better explain what is being asked.

### 📝 Changelog

A markdown change that has no breaking changes

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Update docs for Upload Component         |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
