### PR TITLE
fix: useLayoutEffect to useIsomorphicLayoutEffect

### DIFF
--- a/components/typography/Base/Ellipsis.tsx
+++ b/components/typography/Base/Ellipsis.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import toArray from 'rc-util/lib/Children/toArray';
+import useIsomorphicLayoutEffect from '../hooks/useIsomorphicLayoutEffect';
 
 export interface EllipsisProps {
   enabledMeasure?: boolean;
@@ -93,20 +94,20 @@ const Ellipsis = ({ enabledMeasure, children, text, width, rows, onEllipsis }: E
   }, [enabledMeasure, walkingState, children, nodeList, midLen, totalLen]);
 
   // ======================== Walk ========================
-  React.useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     if (enabledMeasure && width && totalLen) {
       setWalkingState(PREPARE);
       setCutLength([0, Math.ceil(totalLen / 2), totalLen]);
     }
   }, [enabledMeasure, width, text, totalLen, rows]);
 
-  React.useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     if (walkingState === PREPARE) {
       setSingleRowHeight(singleRowRef.current?.offsetHeight || 0);
     }
   }, [walkingState]);
 
-  React.useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     if (singleRowHeight) {
       if (walkingState === PREPARE) {
         // Ignore if position is enough

--- a/components/typography/Base/Ellipsis.tsx
+++ b/components/typography/Base/Ellipsis.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import toArray from 'rc-util/lib/Children/toArray';
-import useIsomorphicLayoutEffect from '../hooks/useIsomorphicLayoutEffect';
+import useIsomorphicLayoutEffect from 'rc-util/lib/hooks/useLayoutEffect';
 
 export interface EllipsisProps {
   enabledMeasure?: boolean;

--- a/components/typography/Base/index.tsx
+++ b/components/typography/Base/index.tsx
@@ -21,6 +21,7 @@ import useMergedConfig from '../hooks/useMergedConfig';
 import useUpdatedEffect from '../hooks/useUpdatedEffect';
 import Ellipsis from './Ellipsis';
 import EllipsisTooltip from './EllipsisTooltip';
+import useIsomorphicLayoutEffect from '../hooks/useIsomorphicLayoutEffect';
 
 export type BaseType = 'secondary' | 'success' | 'warning' | 'danger';
 
@@ -243,7 +244,7 @@ const Base = React.forwardRef((props: InternalBlockProps, ref: any) => {
     [mergedEnableEllipsis, ellipsisConfig, enableEdit, enableCopy],
   );
 
-  React.useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     if (enableEllipsis && !needMeasureEllipsis) {
       setIsLineClampSupport(isStyleSupport('webkitLineClamp'));
       setIsTextOverflowSupport(isStyleSupport('textOverflow'));

--- a/components/typography/Base/index.tsx
+++ b/components/typography/Base/index.tsx
@@ -10,6 +10,7 @@ import CheckOutlined from '@ant-design/icons/CheckOutlined';
 import CopyOutlined from '@ant-design/icons/CopyOutlined';
 import ResizeObserver from 'rc-resize-observer';
 import { AutoSizeType } from 'rc-textarea/lib/ResizableTextArea';
+import useIsomorphicLayoutEffect from 'rc-util/lib/hooks/useLayoutEffect';
 import { ConfigContext } from '../../config-provider';
 import { useLocaleReceiver } from '../../locale-provider/LocaleReceiver';
 import TransButton from '../../_util/transButton';
@@ -21,7 +22,6 @@ import useMergedConfig from '../hooks/useMergedConfig';
 import useUpdatedEffect from '../hooks/useUpdatedEffect';
 import Ellipsis from './Ellipsis';
 import EllipsisTooltip from './EllipsisTooltip';
-import useIsomorphicLayoutEffect from '../hooks/useIsomorphicLayoutEffect';
 
 export type BaseType = 'secondary' | 'success' | 'warning' | 'danger';
 

--- a/components/typography/hooks/useIsomorphicLayoutEffect.ts
+++ b/components/typography/hooks/useIsomorphicLayoutEffect.ts
@@ -1,0 +1,3 @@
+import { useEffect, useLayoutEffect } from 'react';
+
+export default typeof document !== 'undefined' ? useLayoutEffect : useEffect;

--- a/components/typography/hooks/useIsomorphicLayoutEffect.ts
+++ b/components/typography/hooks/useIsomorphicLayoutEffect.ts
@@ -1,3 +1,0 @@
-import { useEffect, useLayoutEffect } from 'react';
-
-export default typeof document !== 'undefined' ? useLayoutEffect : useEffect;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

- https://github.com/ant-design/ant-design/issues/30396#issuecomment-1016575065
- https://github.com/ant-design/ant-design/pull/33725/files#r789492314


### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

`useLayoutEffect` generates the following warning in the SSR environment.
👉. [Reproduce link](https://stackblitz.com/edit/nextjs-kz5wby?file=pages/index.js)

```
Warning: useLayoutEffect does nothing on the server, because its effect cannot be encoded into the server renderer's output format.
```

Can you consider the SSR environment without directly using `useLayoutEffect` in the antd and `react-component/*`packages?


### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

Fix `useLayoutEffect` warning in `Typography` (actually, 
I'm not good at Chinese, so please suggest a Chinese Changelog)

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Fix `useLayoutEffect` warning in `Typography`        |
| 🇨🇳 Chinese |   修复`Typography`中的 `useLayoutEffect` 警告        |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
