### PR TITLE
fix: Clear timer of delayed loading after Button is unmounted

### DIFF
--- a/components/button/__tests__/delay-timer.test.tsx
+++ b/components/button/__tests__/delay-timer.test.tsx
@@ -1,0 +1,93 @@
+import React, { useState } from 'react';
+import { mount } from 'enzyme';
+import { act } from 'react-dom/test-utils';
+import Button from '../button';
+
+const specialDelay = 9529;
+const Content = () => {
+  const [loading, setLoading] = useState(false);
+  const toggleLoading = () => {
+    setLoading(!loading);
+  };
+
+  const [visible, setVisible] = useState(true);
+  const toggleVisible = () => {
+    setVisible(!visible);
+  };
+
+  return (
+    <div>
+      <button type="button" id="toggle_loading" onClick={toggleLoading}>
+        Toggle Loading
+      </button>
+      <button type="button" id="toggle_visible" onClick={toggleVisible}>
+        Toggle Visible
+      </button>
+      {visible && <Button type="text" loading={loading ? { delay: specialDelay } : false} />}
+    </div>
+  );
+};
+
+it('Delay loading timer in Button component', () => {
+  const otherTimer: any = 9528;
+  jest.spyOn(window, 'setTimeout').mockReturnValue(otherTimer);
+  jest.restoreAllMocks();
+
+  const wrapper = mount(<Content />);
+
+  const btnTimer: any = 9527;
+  jest.spyOn(window, 'setTimeout').mockReturnValue(btnTimer);
+  jest.spyOn(window, 'clearTimeout');
+  const setTimeoutMock = window.setTimeout as any as jest.Mock;
+  const clearTimeoutMock = window.clearTimeout as any as jest.Mock;
+
+  // other component may call setTimeout or clearTimeout
+  const setTimeoutCount = () => {
+    const items = setTimeoutMock.mock.calls.filter(item => {
+      return item[1] === specialDelay;
+    });
+    return items.length;
+  };
+  const clearTimeoutCount = () => {
+    const items = clearTimeoutMock.mock.calls.filter(item => {
+      return item[0] === btnTimer;
+    });
+    return items.length;
+  };
+
+  // switch loading state to true
+  wrapper.find('#toggle_loading').at(0).simulate('click');
+  expect(setTimeoutCount()).toBe(1);
+  expect(clearTimeoutCount()).toBe(0);
+
+  // trigger timer handler
+  act(() => {
+    setTimeoutMock.mock.calls[0][0]();
+  });
+  expect(setTimeoutCount()).toBe(1);
+  expect(clearTimeoutCount()).toBe(0);
+
+  // switch loading state to false
+  wrapper.find('#toggle_loading').at(0).simulate('click');
+  expect(setTimeoutCount()).toBe(1);
+  expect(clearTimeoutCount()).toBe(0);
+
+  // switch loading state to true
+  wrapper.find('#toggle_loading').at(0).simulate('click');
+  expect(setTimeoutCount()).toBe(2);
+  expect(clearTimeoutCount()).toBe(0);
+
+  // switch loading state to false
+  wrapper.find('#toggle_loading').at(0).simulate('click');
+  expect(setTimeoutCount()).toBe(2);
+  expect(clearTimeoutCount()).toBe(1);
+
+  // switch loading state to true
+  wrapper.find('#toggle_loading').at(0).simulate('click');
+  // remove Button component
+  wrapper.find('#toggle_visible').at(0).simulate('click');
+  expect(setTimeoutCount()).toBe(3);
+  expect(clearTimeoutCount()).toBe(2);
+
+  jest.restoreAllMocks();
+});

--- a/components/button/__tests__/delay-timer.test.tsx
+++ b/components/button/__tests__/delay-timer.test.tsx
@@ -43,15 +43,11 @@ it('Delay loading timer in Button component', () => {
 
   // other component may call setTimeout or clearTimeout
   const setTimeoutCount = () => {
-    const items = setTimeoutMock.mock.calls.filter(item => {
-      return item[1] === specialDelay;
-    });
+    const items = setTimeoutMock.mock.calls.filter(item => item[1] === specialDelay);
     return items.length;
   };
   const clearTimeoutCount = () => {
-    const items = clearTimeoutMock.mock.calls.filter(item => {
-      return item[0] === btnTimer;
-    });
+    const items = clearTimeoutMock.mock.calls.filter(item => item[0] === btnTimer);
     return items.length;
   };
 

--- a/components/button/button.tsx
+++ b/components/button/button.tsx
@@ -156,7 +156,6 @@ const InternalButton: React.ForwardRefRenderFunction<unknown, ButtonProps> = (pr
   const [hasTwoCNChar, setHasTwoCNChar] = React.useState(false);
   const { getPrefixCls, autoInsertSpaceInButton, direction } = React.useContext(ConfigContext);
   const buttonRef = (ref as any) || React.createRef<HTMLElement>();
-  const delayTimeoutRef = React.useRef<number>();
 
   const isNeedInserted = () =>
     React.Children.count(children) === 1 && !icon && !isUnborderedButtonType(type);
@@ -181,14 +180,25 @@ const InternalButton: React.ForwardRefRenderFunction<unknown, ButtonProps> = (pr
     typeof loading === 'object' && loading.delay ? loading.delay || true : !!loading;
 
   React.useEffect(() => {
-    clearTimeout(delayTimeoutRef.current);
+    let delayTimer: number | null = null;
+
     if (typeof loadingOrDelay === 'number') {
-      delayTimeoutRef.current = window.setTimeout(() => {
+      delayTimer = window.setTimeout(() => {
+        delayTimer = null;
         setLoading(loadingOrDelay);
       }, loadingOrDelay);
     } else {
       setLoading(loadingOrDelay);
     }
+
+    return () => {
+      if (delayTimer) {
+        // in order to not perform a React state update on an unmounted component
+        // and clear timer after 'loadingOrDelay' updated.
+        window.clearTimeout(delayTimer);
+        delayTimer = null;
+      }
+    };
   }, [loadingOrDelay]);
 
   React.useEffect(fixTwoCNChar, [buttonRef]);


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
No related issue.
<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution
If we use property `loading={{ delay: 1000 }}` in a Button component and destroy this component immediately, the timer won't be cleared.  It'll cause a React state update on an unmounted component.

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->
No breaking change.
| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Clear timer of delayed loading after Button is unmounted.    |
| 🇨🇳 Chinese |    Button组件卸载后，清理延迟加载定时器。      |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
