### PR TITLE
fix: tooltip should work with loading switch

### DIFF
--- a/components/tooltip/__tests__/tooltip.test.js
+++ b/components/tooltip/__tests__/tooltip.test.js
@@ -346,4 +346,22 @@ describe('Tooltip', () => {
     );
     expect(wrapper.find('.ant-tooltip-inner').getDOMNode().style.color).toBe('red');
   });
+
+  it('should work with loading switch', () => {
+    const onVisibleChange = jest.fn();
+    const wrapper = mount(
+      <Tooltip
+        title="loading tips"
+        mouseEnterDelay={0}
+        mouseLeaveDelay={0}
+        onVisibleChange={onVisibleChange}
+      >
+        <Switch loading defaultChecked />
+      </Tooltip>,
+    );
+    const wrapperEl = wrapper.find('.ant-tooltip-disabled-compatible-wrapper');
+    expect(wrapperEl).toHaveLength(1);
+    wrapper.find('span').first().simulate('mouseenter');
+    expect(onVisibleChange).toHaveBeenLastCalledWith(true);
+  });
 });

--- a/components/tooltip/demo/colorful.md
+++ b/components/tooltip/demo/colorful.md
@@ -14,7 +14,7 @@ title:
 We preset a series of colorful Tooltip styles for use in different situations.
 
 ```jsx
-import { Tooltip, Button, Divider } from 'antd';
+import { Tooltip, Button, Divider, Switch } from 'antd';
 
 const colors = [
   'pink',
@@ -35,6 +35,9 @@ const customColors = ['#f50', '#2db7f5', '#87d068', '#108ee9'];
 
 ReactDOM.render(
   <>
+    <Tooltip title="loading tips">
+      <Switch loading defaultChecked />
+    </Tooltip>
     <Divider orientation="left">Presets</Divider>
     <div>
       {colors.map(color => (

--- a/components/tooltip/demo/colorful.md
+++ b/components/tooltip/demo/colorful.md
@@ -14,7 +14,7 @@ title:
 We preset a series of colorful Tooltip styles for use in different situations.
 
 ```jsx
-import { Tooltip, Button, Divider, Switch } from 'antd';
+import { Tooltip, Button, Divider } from 'antd';
 
 const colors = [
   'pink',
@@ -35,9 +35,6 @@ const customColors = ['#f50', '#2db7f5', '#87d068', '#108ee9'];
 
 ReactDOM.render(
   <>
-    <Tooltip title="loading tips">
-      <Switch loading defaultChecked />
-    </Tooltip>
     <Divider orientation="left">Presets</Divider>
     <div>
       {colors.map(color => (

--- a/components/tooltip/index.tsx
+++ b/components/tooltip/index.tsx
@@ -88,7 +88,7 @@ function getDisabledCompatibleChildren(element: React.ReactElement<any>, prefixC
     (elementType.__ANT_BUTTON === true ||
       elementType.__ANT_SWITCH === true ||
       element.type === 'button') &&
-    element.props.disabled
+    (element.props.disabled || element.props.loading)
   ) {
     // Pick some layout related style properties up to span
     // Prevent layout bugs like https://github.com/ant-design/ant-design/issues/5254

--- a/components/tooltip/index.tsx
+++ b/components/tooltip/index.tsx
@@ -85,10 +85,8 @@ const PresetColorRegex = new RegExp(`^(${PresetColorTypes.join('|')})(-inverse)?
 function getDisabledCompatibleChildren(element: React.ReactElement<any>, prefixCls: string) {
   const elementType = element.type as any;
   if (
-    (elementType.__ANT_BUTTON === true ||
-      elementType.__ANT_SWITCH === true ||
-      element.type === 'button') &&
-    (element.props.disabled || element.props.loading)
+    ((elementType.__ANT_BUTTON === true || element.type === 'button') && element.props.disabled) ||
+    (elementType.__ANT_SWITCH === true && (element.props.disabled || element.props.loading))
   ) {
     // Pick some layout related style properties up to span
     // Prevent layout bugs like https://github.com/ant-design/ant-design/issues/5254


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->
https://github.com/ant-design/ant-design/issues/33857
### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |Fix the problem that Tooltip cannot be displayed when it is used with switch in loading state|
| 🇨🇳 Chinese |修复 Tooltip 套在 loading 状态的 switch 上时无法正常显示的问题|

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
