### PR TITLE
fix: ellipsis should display tooltip if rows larger than 1

### DIFF
--- a/components/typography/Base/index.tsx
+++ b/components/typography/Base/index.tsx
@@ -293,12 +293,14 @@ const Base = React.forwardRef((props: InternalBlockProps, ref: any) => {
     const textEle = typographyRef.current;
 
     if (enableEllipsis && cssEllipsis && textEle) {
-      const currentEllipsis = textEle.offsetWidth < textEle.scrollWidth;
+      const currentEllipsis = cssLineClamp
+        ? textEle.offsetHeight < textEle.scrollHeight
+        : textEle.offsetWidth < textEle.scrollWidth;
       if (isNativeEllipsis !== currentEllipsis) {
         setIsNativeEllipsis(currentEllipsis);
       }
     }
-  }, [enableEllipsis, cssEllipsis, children]);
+  }, [enableEllipsis, cssEllipsis, children, cssLineClamp]);
 
   // ========================== Tooltip ===========================
   const tooltipTitle = ellipsisConfig.tooltip === true ? children : ellipsisConfig.tooltip;

--- a/components/typography/__tests__/ellipsis.test.js
+++ b/components/typography/__tests__/ellipsis.test.js
@@ -277,4 +277,34 @@ describe('Typography.Ellipsis', () => {
     const tooltipWrapper = mount(<Base ellipsis={{ expandable: true, tooltip: 'little' }} />);
     expect(tooltipWrapper.find('.ant-typography').prop('aria-label')).toEqual('little');
   });
+
+  it('should display tooltip if line clamp', () => {
+    mockRectSpy = spyElementPrototypes(HTMLElement, {
+      scrollHeight: {
+        get() {
+          let html = this.innerHTML;
+          html = html.replace(/<[^>]*>/g, '');
+          const lines = Math.ceil(html.length / LINE_STR_COUNT);
+          return lines * 16;
+        },
+      },
+      offsetHeight: {
+        get: () => 32,
+      },
+      offsetWidth: {
+        get: () => 100,
+      },
+      scrollWidth: {
+        get: () => 100,
+      },
+    });
+
+    const wrapper = mount(
+      <Base ellipsis={{ tooltip: 'This is tooltip', rows: 2 }}>
+        Ant Design, a design language for background applications, is refined by Ant UED Team.
+      </Base>,
+    );
+    expect(wrapper.find('EllipsisTooltip').prop('isEllipsis')).toBeTruthy();
+    mockRectSpy.mockRestore();
+  });
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->
close https://github.com/ant-design/ant-design/issues/33855

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |Fix the problem that tooltip didn't show on ellipsis with rows larger than 1|
| 🇨🇳 Chinese |修复 Typography ellipsis 行数大于 1 时 Tooltip 不显示的问题|

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
