### PR TITLE
fix textarea maxlength issue

### DIFF
--- a/components/input/TextArea.tsx
+++ b/components/input/TextArea.tsx
@@ -117,8 +117,11 @@ const TextArea = React.forwardRef<TextAreaRef, TextAreaProps>(
         );
       }
       // Patch composition onChange when value changed
-      handleSetValue(triggerValue);
-      resolveOnChange(e.currentTarget, e, onChange, triggerValue);
+      if (triggerValue !== value) {
+        handleSetValue(triggerValue);
+        resolveOnChange(e.currentTarget, e, onChange, triggerValue);
+      }
+
       onCompositionEnd?.(e);
     };
 
@@ -171,7 +174,12 @@ const TextArea = React.forwardRef<TextAreaRef, TextAreaProps>(
       />
     );
 
-    const val = fixControlledValue(value) as string;
+    let val = fixControlledValue(value) as string;
+
+    if (!compositing && hasMaxLength && (props.value === null || props.value === undefined)) {
+      // fix #27612 将value转为数组进行截取，解决 '😂'.length === 2 等emoji表情导致的截取乱码的问题
+      val = fixEmojiLength(val, maxLength!);
+    }
 
     // TextArea
     const textareaNode = (

--- a/components/input/TextArea.tsx
+++ b/components/input/TextArea.tsx
@@ -28,11 +28,11 @@ function setTriggerValue(
     // 光标在尾部，直接截断
     newTriggerValue = fixEmojiLength(triggerValue, maxLength!);
   } else if (
-    [...((preValue || '') as string)].length < triggerValue.length &&
-    [...((triggerValue || '') as string)].length > maxLength!
+    [...(preValue || '')].length < triggerValue.length &&
+    [...(triggerValue || '')].length > maxLength!
   ) {
     // 光标在中间，如果最后的值超过最大值，则采用原先的值
-    newTriggerValue = preValue as string;
+    newTriggerValue = preValue;
   }
   return newTriggerValue;
 }

--- a/components/input/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/input/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -9530,10 +9530,19 @@ Array [
 `;
 
 exports[`renders ./components/input/demo/textarea.md extend context correctly 1`] = `
-<textarea
-  class="ant-input"
-  rows="4"
-/>
+Array [
+  <textarea
+    class="ant-input"
+    rows="4"
+  />,
+  <br />,
+  <br />,
+  <textarea
+    class="ant-input"
+    placeholder="maxLength is 6"
+    rows="4"
+  />,
+]
 `;
 
 exports[`renders ./components/input/demo/textarea-resize.md extend context correctly 1`] = `

--- a/components/input/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/input/__tests__/__snapshots__/demo.test.js.snap
@@ -3304,10 +3304,19 @@ Array [
 `;
 
 exports[`renders ./components/input/demo/textarea.md correctly 1`] = `
-<textarea
-  class="ant-input"
-  rows="4"
-/>
+Array [
+  <textarea
+    class="ant-input"
+    rows="4"
+  />,
+  <br />,
+  <br />,
+  <textarea
+    class="ant-input"
+    placeholder="maxLength is 6"
+    rows="4"
+  />,
+]
 `;
 
 exports[`renders ./components/input/demo/textarea-resize.md correctly 1`] = `

--- a/components/input/demo/textarea.md
+++ b/components/input/demo/textarea.md
@@ -18,5 +18,13 @@ import { Input } from 'antd';
 
 const { TextArea } = Input;
 
-ReactDOM.render(<TextArea rows={4} maxLength={6} />, mountNode);
+ReactDOM.render(
+  <>
+    <TextArea rows={4} />
+    <br />
+    <br />
+    <TextArea rows={4} placeholder="maxLength is 6" maxLength={6} />
+  </>,
+  mountNode,
+);
 ```

--- a/components/input/demo/textarea.md
+++ b/components/input/demo/textarea.md
@@ -18,5 +18,5 @@ import { Input } from 'antd';
 
 const { TextArea } = Input;
 
-ReactDOM.render(<TextArea rows={4} />, mountNode);
+ReactDOM.render(<TextArea rows={4} maxLength={6} />, mountNode);
 ```


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->
#33872
### 💡 Background and solution
背景：当光标不是处于字符的最后位置时，新增字符直到超过maxlength时，会导致原光标后的字符被截断。
解决方法：根据光标的位置来分别进行处理，分字符输入和拼音输入两种情况；
1. 字符输入时，如果光标在最后，直接按照maxLength裁切；如果光标在中间，且最后的值长度超过maxlength，则采用原先的值
2. 拼音输入时，情况同上，但是要在onInternalCompositionStart时保存一份旧值。
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   fix the issue that entering characters causes the character to disappear after the cursor when cursor is not in middle   |
| 🇨🇳 Chinese |    修复光标位于字符中间时，若存在maxlength,输入字符会导致光标后字符被截断的问题       |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
