### PR TITLE
fix: cascader's onChange ts adapts to single and multiple

### DIFF
--- a/components/cascader/__tests__/type.test.tsx
+++ b/components/cascader/__tests__/type.test.tsx
@@ -75,19 +75,17 @@ describe('Cascader.typescript', () => {
     expect(wrapper).toBeTruthy();
   });
 
-  it('onChange', () => {
-    test('single', () => {
-      const wrapper = mount(
-        <Cascader multiple={false} onChange={(values: (string | number)[]) => values} />,
-      );
-      expect(wrapper).toBeTruthy();
-    });
+  it('single onChange', () => {
+    const wrapper = mount(
+      <Cascader multiple={false} onChange={(values: (string | number)[]) => values} />,
+    );
+    expect(wrapper).toBeTruthy();
+  });
 
-    test('multiple', () => {
-      const wrapper = mount(
-        <Cascader multiple onChange={(values: (string | number)[][]) => values} />,
-      );
-      expect(wrapper).toBeTruthy();
-    });
+  it('multiple onChange', () => {
+    const wrapper = mount(
+      <Cascader multiple onChange={(values: (string | number)[][]) => values} />,
+    );
+    expect(wrapper).toBeTruthy();
   });
 });

--- a/components/cascader/__tests__/type.test.tsx
+++ b/components/cascader/__tests__/type.test.tsx
@@ -74,4 +74,20 @@ describe('Cascader.typescript', () => {
     );
     expect(wrapper).toBeTruthy();
   });
+
+  it('onChange', () => {
+    test('single', () => {
+      const wrapper = mount(
+        <Cascader multiple={false} onChange={(values: (string | number)[]) => values} />,
+      );
+      expect(wrapper).toBeTruthy();
+    });
+
+    test('multiple', () => {
+      const wrapper = mount(
+        <Cascader multiple onChange={(values: (string | number)[][]) => values} />,
+      );
+      expect(wrapper).toBeTruthy();
+    });
+  });
 });

--- a/components/cascader/index.tsx
+++ b/components/cascader/index.tsx
@@ -2,7 +2,8 @@ import * as React from 'react';
 import classNames from 'classnames';
 import RcCascader from 'rc-cascader';
 import type {
-  CascaderProps as RcCascaderProps,
+  SingleCascaderProps as RcSingleCascaderProps,
+  MultipleCascaderProps as RcMultipleCascaderProps,
   ShowSearchType,
   FieldNames,
   BaseOptionType,
@@ -80,8 +81,16 @@ const defaultSearchRender: ShowSearchType['render'] = (inputValue, path, prefixC
   return optionList;
 };
 
-export interface CascaderProps<DataNodeType>
-  extends Omit<RcCascaderProps, 'checkable' | 'options'> {
+type SingleCascaderProps = Omit<RcSingleCascaderProps, 'checkable' | 'options'> & {
+  multiple?: false;
+};
+type MultipleCascaderProps = Omit<RcMultipleCascaderProps, 'checkable' | 'options'> & {
+  multiple: true;
+};
+
+type UnionCascaderProps = SingleCascaderProps | MultipleCascaderProps;
+
+export type CascaderProps<DataNodeType> = UnionCascaderProps & {
   multiple?: boolean;
   size?: SizeType;
   bordered?: boolean;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
#33153 
<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | cascader's multiple determines the declaration of onChange |
| 🇨🇳 Chinese | cascader组件的multiple属性决定onChange的声明类型 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
