### PR TITLE
feat: Exposes additional props for pagination component on transfer

### DIFF
--- a/components/transfer/ListBody.tsx
+++ b/components/transfer/ListBody.tsx
@@ -24,6 +24,9 @@ function parsePagination(pagination?: PaginationType) {
 
   const defaultPagination = {
     pageSize: 10,
+    simple: true,
+    showSizeChanger: false,
+    showLessItems: false,
   };
 
   if (typeof pagination === 'object') {
@@ -116,7 +119,9 @@ class ListBody<RecordType extends KeyWiseTransferItem> extends React.Component<
     if (mergedPagination) {
       paginationNode = (
         <Pagination
-          simple
+          simple={mergedPagination.simple}
+          showSizeChanger={mergedPagination.showSizeChanger}
+          showLessItems={mergedPagination.showLessItems}
           size="small"
           disabled={globalDisabled}
           className={`${prefixCls}-pagination`}

--- a/components/transfer/ListBody.tsx
+++ b/components/transfer/ListBody.tsx
@@ -24,9 +24,6 @@ function parsePagination(pagination?: PaginationType) {
 
   const defaultPagination = {
     pageSize: 10,
-    simple: true,
-    showSizeChanger: false,
-    showLessItems: false,
   };
 
   if (typeof pagination === 'object') {
@@ -119,9 +116,7 @@ class ListBody<RecordType extends KeyWiseTransferItem> extends React.Component<
     if (mergedPagination) {
       paginationNode = (
         <Pagination
-          simple={mergedPagination.simple}
-          showSizeChanger={mergedPagination.showSizeChanger}
-          showLessItems={mergedPagination.showLessItems}
+          simple
           size="small"
           disabled={globalDisabled}
           className={`${prefixCls}-pagination`}

--- a/components/transfer/index.en-US.md
+++ b/components/transfer/index.en-US.md
@@ -30,7 +30,7 @@ One or more elements can be selected from either column, one click on the proper
 | oneWay | Display as single direction style | boolean | false | 4.3.0 |
 | operations | A set of operations that are sorted from top to bottom | string\[] | \[`>`, `<`] |  |
 | operationStyle | A custom CSS style used for rendering the operations column | object | - |  |
-| pagination | Use pagination. Not work in render props | boolean \| { pageSize: number } | false | 4.3.0 |
+| pagination | Use pagination. Not work in render props | boolean \| { pageSize: number, simple: boolean, showSizeChanger?: boolean, showLessItems?: boolean } | false | 4.3.0 |
 | render | The function to generate the item shown on a column. Based on an record (element of the dataSource array), this function should return a React element which is generated from that record. Also, it can return a plain object with `value` and `label`, `label` is a React element and `value` is for title | (record) => ReactNode | - |  |
 | selectAllLabels | A set of customized labels for select all checkboxs on the header | (ReactNode \| (info: { selectedCount: number, totalCount: number }) => ReactNode)\[] | - |  |
 | selectedKeys | A set of keys of selected items | string\[] | \[] |  |

--- a/components/transfer/index.en-US.md
+++ b/components/transfer/index.en-US.md
@@ -30,7 +30,7 @@ One or more elements can be selected from either column, one click on the proper
 | oneWay | Display as single direction style | boolean | false | 4.3.0 |
 | operations | A set of operations that are sorted from top to bottom | string\[] | \[`>`, `<`] |  |
 | operationStyle | A custom CSS style used for rendering the operations column | object | - |  |
-| pagination | Use pagination. Not work in render props | boolean \| { pageSize: number, simple: boolean, showSizeChanger?: boolean, showLessItems?: boolean } | false | 4.3.0 |
+| pagination | Use pagination. Not work in render props | boolean \| { pageSize: number } | false | 4.3.0 |
 | render | The function to generate the item shown on a column. Based on an record (element of the dataSource array), this function should return a React element which is generated from that record. Also, it can return a plain object with `value` and `label`, `label` is a React element and `value` is for title | (record) => ReactNode | - |  |
 | selectAllLabels | A set of customized labels for select all checkboxs on the header | (ReactNode \| (info: { selectedCount: number, totalCount: number }) => ReactNode)\[] | - |  |
 | selectedKeys | A set of keys of selected items | string\[] | \[] |  |

--- a/components/transfer/index.zh-CN.md
+++ b/components/transfer/index.zh-CN.md
@@ -33,7 +33,7 @@ cover: https://gw.alipayobjects.com/zos/alicdn/QAXskNI4G/Transfer.svg
 | oneWay | 展示为单向样式 | boolean | false | 4.3.0 |
 | operations | 操作文案集合，顺序从上至下 | string\[] | \[`>`, `<`] |  |
 | operationStyle | 操作栏的自定义样式 | CSSProperties | - |  |
-| pagination | 使用分页样式，自定义渲染列表下无效 | boolean \| { pageSize: number } | false | 4.3.0 |
+| pagination | 使用分页样式，自定义渲染列表下无效 | boolean \| { pageSize: number, simple: boolean, showSizeChanger?: boolean, showLessItems?: boolean } | false | 4.3.0 |
 | render | 每行数据渲染函数，该函数的入参为 `dataSource` 中的项，返回值为 ReactElement。或者返回一个普通对象，其中 `label` 字段为 ReactElement，`value` 字段为 title | (record) => ReactNode | - |  |
 | selectAllLabels | 自定义顶部多选框标题的集合 | (ReactNode \| (info: { selectedCount: number, totalCount: number }) => ReactNode)\[] | - |  |
 | selectedKeys | 设置哪些项应该被选中 | string\[] | \[] |  |

--- a/components/transfer/index.zh-CN.md
+++ b/components/transfer/index.zh-CN.md
@@ -33,7 +33,7 @@ cover: https://gw.alipayobjects.com/zos/alicdn/QAXskNI4G/Transfer.svg
 | oneWay | 展示为单向样式 | boolean | false | 4.3.0 |
 | operations | 操作文案集合，顺序从上至下 | string\[] | \[`>`, `<`] |  |
 | operationStyle | 操作栏的自定义样式 | CSSProperties | - |  |
-| pagination | 使用分页样式，自定义渲染列表下无效 | boolean \| { pageSize: number, simple: boolean, showSizeChanger?: boolean, showLessItems?: boolean } | false | 4.3.0 |
+| pagination | 使用分页样式，自定义渲染列表下无效 | boolean \| { pageSize: number } | false | 4.3.0 |
 | render | 每行数据渲染函数，该函数的入参为 `dataSource` 中的项，返回值为 ReactElement。或者返回一个普通对象，其中 `label` 字段为 ReactElement，`value` 字段为 title | (record) => ReactNode | - |  |
 | selectAllLabels | 自定义顶部多选框标题的集合 | (ReactNode \| (info: { selectedCount: number, totalCount: number }) => ReactNode)\[] | - |  |
 | selectedKeys | 设置哪些项应该被选中 | string\[] | \[] |  |

--- a/components/transfer/interface.ts
+++ b/components/transfer/interface.ts
@@ -2,4 +2,7 @@ export type PaginationType =
   | boolean
   | {
       pageSize?: number;
+      simple?: boolean;
+      showSizeChanger?: boolean;
+      showLessItems?: boolean;
     };

--- a/components/transfer/interface.ts
+++ b/components/transfer/interface.ts
@@ -2,7 +2,4 @@ export type PaginationType =
   | boolean
   | {
       pageSize?: number;
-      simple?: boolean;
-      showSizeChanger?: boolean;
-      showLessItems?: boolean;
     };


### PR DESCRIPTION
[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 💡 Background and solution

Pagination on the transfer component is currently locked down, wanted to increase users ability to customize look and feel of the pagination component by exposing a few additional props.

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Pagination props: [simple showSizeChanger showLessItems] are now exposed via the pagination config object in transfer |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
