### PR TITLE
feat: Add ability to overwrite Menu theme at Menu.SubMenu level.

### DIFF
--- a/components/menu/SubMenu.tsx
+++ b/components/menu/SubMenu.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { SubMenu as RcSubMenu, useFullPath } from 'rc-menu';
 import classNames from 'classnames';
 import omit from 'rc-util/lib/omit';
-import MenuContext from './MenuContext';
+import MenuContext, { MenuTheme } from './MenuContext';
 import { isValidElement, cloneElement } from '../_util/reactNode';
 
 interface TitleEventEntity {
@@ -23,10 +23,11 @@ export interface SubMenuProps {
   popupOffset?: [number, number];
   popupClassName?: string;
   children?: React.ReactNode;
+  theme?: MenuTheme;
 }
 
 function SubMenu(props: SubMenuProps) {
-  const { popupClassName, icon, title } = props;
+  const { popupClassName, icon, title, theme } = props;
   const context = React.useContext(MenuContext);
   const { prefixCls, inlineCollapsed, antdMenuTheme } = context;
 
@@ -71,7 +72,11 @@ function SubMenu(props: SubMenuProps) {
       <RcSubMenu
         {...omit(props, ['icon'])}
         title={titleNode}
-        popupClassName={classNames(prefixCls, `${prefixCls}-${antdMenuTheme}`, popupClassName)}
+        popupClassName={classNames(
+          prefixCls,
+          `${prefixCls}-${theme || antdMenuTheme}`,
+          popupClassName,
+        )}
       />
     </MenuContext.Provider>
   );

--- a/components/menu/__tests__/index.test.js
+++ b/components/menu/__tests__/index.test.js
@@ -291,7 +291,7 @@ describe('Menu', () => {
     const menuModesWithPopupSubMenu = ['horizontal', 'vertical'];
 
     menuModesWithPopupSubMenu.forEach(menuMode => {
-      it(`when submenu is mode ${menuMode}`, () => {
+      it(`when menu is mode ${menuMode}`, () => {
         const wrapper = mount(
           <Menu mode={menuMode} openKeys={['1']} theme="dark">
             <SubMenu key="1" title="submenu1" theme="light">

--- a/components/menu/__tests__/index.test.js
+++ b/components/menu/__tests__/index.test.js
@@ -287,6 +287,32 @@ describe('Menu', () => {
     );
   });
 
+  describe('allows the overriding of theme at the popup submenu level', () => {
+    const menuModesWithPopupSubMenu = ['horizontal', 'vertical'];
+
+    menuModesWithPopupSubMenu.forEach(menuMode => {
+      it(`when submenu is mode ${menuMode}`, () => {
+        const wrapper = mount(
+          <Menu mode={menuMode} openKeys={['1']} theme="dark">
+            <SubMenu key="1" title="submenu1" theme="light">
+              <Menu.Item key="submenu1">Option 1</Menu.Item>
+              <Menu.Item key="submenu2">Option 2</Menu.Item>
+            </SubMenu>
+            <Menu.Item key="2">menu2</Menu.Item>
+          </Menu>,
+        );
+
+        act(() => {
+          jest.runAllTimers();
+          wrapper.update();
+        });
+
+        expect(wrapper.find('ul.ant-menu-root').hasClass('ant-menu-dark')).toBeTruthy();
+        expect(wrapper.find('div.ant-menu-submenu-popup').hasClass('ant-menu-light')).toBeTruthy();
+      });
+    });
+  });
+
   // https://github.com/ant-design/ant-design/pulls/4677
   // https://github.com/ant-design/ant-design/issues/4692
   // TypeError: Cannot read property 'indexOf' of undefined

--- a/components/menu/demo/submenu-theme.md
+++ b/components/menu/demo/submenu-theme.md
@@ -1,7 +1,7 @@
 ---
 order: 5
 title:
-  zh-CN: 主题
+  zh-CN: 子菜单主题
   en-US: Sub-menu theme
 ---
 

--- a/components/menu/demo/submenu-theme.md
+++ b/components/menu/demo/submenu-theme.md
@@ -15,65 +15,51 @@ The Sub-menu will inherit the theme of `Menu`, but you can override this at the 
 
 ```jsx
 import { Menu, Switch } from 'antd';
-import { MailOutlined, AppstoreOutlined, SettingOutlined } from '@ant-design/icons';
+import { MailOutlined } from '@ant-design/icons';
 
 const { SubMenu } = Menu;
 
-class Sider extends React.Component {
-  state = {
-    theme: 'light',
-    current: '1',
+const SubMenuTheme = () => {
+  const [theme, setTheme] = React.useState('light');
+  const [current, setCurrent] = React.useState('1');
+
+  const changeTheme = value => {
+    setTheme(value ? 'dark' : 'light');
   };
 
-  changeTheme = value => {
-    this.setState({
-      theme: value ? 'dark' : 'light',
-    });
+  const handleClick = e => {
+    setCurrent(e.key);
   };
 
-  handleClick = e => {
-    console.log('click ', e);
-    this.setState({
-      current: e.key,
-    });
-  };
+  return (
+    <>
+      <Switch
+        checked={theme === 'dark'}
+        onChange={changeTheme}
+        checkedChildren="Dark"
+        unCheckedChildren="Light"
+      />
+      <br />
+      <br />
+      <Menu
+        onClick={handleClick}
+        style={{ width: 256 }}
+        defaultOpenKeys={['sub1']}
+        selectedKeys={[current]}
+        mode="vertical"
+        theme="dark"
+      >
+        <SubMenu key="sub1" icon={<MailOutlined />} title="Navigation One" theme={theme}>
+          <Menu.Item key="1">Option 1</Menu.Item>
+          <Menu.Item key="2">Option 2</Menu.Item>
+          <Menu.Item key="3">Option 3</Menu.Item>
+        </SubMenu>
+        <Menu.Item key="5">Option 5</Menu.Item>
+        <Menu.Item key="6">Option 6</Menu.Item>
+      </Menu>
+    </>
+  );
+};
 
-  render() {
-    return (
-      <>
-        <Switch
-          checked={this.state.theme === 'dark'}
-          onChange={this.changeTheme}
-          checkedChildren="Dark"
-          unCheckedChildren="Light"
-        />
-        <br />
-        <br />
-        <Menu
-          onClick={this.handleClick}
-          style={{ width: 256 }}
-          defaultOpenKeys={['sub1']}
-          selectedKeys={[this.state.current]}
-          mode="vertical"
-          theme="dark"
-        >
-          <SubMenu
-            key="sub1"
-            icon={<MailOutlined />}
-            title="Navigation One"
-            theme={this.state.theme}
-          >
-            <Menu.Item key="1">Option 1</Menu.Item>
-            <Menu.Item key="2">Option 2</Menu.Item>
-            <Menu.Item key="3">Option 3</Menu.Item>
-          </SubMenu>
-          <Menu.Item key="5">Option 5</Menu.Item>
-          <Menu.Item key="6">Option 6</Menu.Item>
-        </Menu>
-      </>
-    );
-  }
-}
-
-ReactDOM.render(<Sider />, mountNode);
+ReactDOM.render(<SubMenuTheme />, mountNode);
 ```

--- a/components/menu/demo/submenu-theme.md
+++ b/components/menu/demo/submenu-theme.md
@@ -54,7 +54,7 @@ class Sider extends React.Component {
           style={{ width: 256 }}
           defaultOpenKeys={['sub1']}
           selectedKeys={[this.state.current]}
-          mode="horizontal"
+          mode="vertical"
           theme="dark"
         >
           <SubMenu
@@ -66,7 +66,6 @@ class Sider extends React.Component {
             <Menu.Item key="1">Option 1</Menu.Item>
             <Menu.Item key="2">Option 2</Menu.Item>
             <Menu.Item key="3">Option 3</Menu.Item>
-            <Menu.Item key="4">Option 4</Menu.Item>
           </SubMenu>
           <Menu.Item key="5">Option 5</Menu.Item>
           <Menu.Item key="6">Option 6</Menu.Item>

--- a/components/menu/demo/submenu-theme.md
+++ b/components/menu/demo/submenu-theme.md
@@ -1,0 +1,80 @@
+---
+order: 5
+title:
+  zh-CN: 主题
+  en-US: Sub-menu theme
+---
+
+## zh-CN
+
+内建了两套主题 `light` 和 `dark`，默认 `light`。
+
+## en-US
+
+The Sub-menu will inherit the theme of `Menu`, but you can override this at the `SubMenu` level via the `theme` prop.
+
+```jsx
+import { Menu, Switch } from 'antd';
+import { MailOutlined, AppstoreOutlined, SettingOutlined } from '@ant-design/icons';
+
+const { SubMenu } = Menu;
+
+class Sider extends React.Component {
+  state = {
+    theme: 'light',
+    current: '1',
+  };
+
+  changeTheme = value => {
+    this.setState({
+      theme: value ? 'dark' : 'light',
+    });
+  };
+
+  handleClick = e => {
+    console.log('click ', e);
+    this.setState({
+      current: e.key,
+    });
+  };
+
+  render() {
+    return (
+      <>
+        <Switch
+          checked={this.state.theme === 'dark'}
+          onChange={this.changeTheme}
+          checkedChildren="Dark"
+          unCheckedChildren="Light"
+        />
+        <br />
+        <br />
+        <Menu
+          onClick={this.handleClick}
+          style={{ width: 256 }}
+          defaultOpenKeys={['sub1']}
+          selectedKeys={[this.state.current]}
+          mode="horizontal"
+          theme="dark"
+        >
+          <SubMenu
+            key="sub1"
+            icon={<MailOutlined />}
+            title="Navigation One"
+            theme={this.state.theme}
+          >
+            <Menu.Item key="1">Option 1</Menu.Item>
+            <Menu.Item key="2">Option 2</Menu.Item>
+            <Menu.Item key="3">Option 3</Menu.Item>
+            <Menu.Item key="4">Option 4</Menu.Item>
+          </SubMenu>
+          <Menu.Item key="5">Option 5</Menu.Item>
+          <Menu.Item key="6">Option 6</Menu.Item>
+        </Menu>
+      </>
+    );
+  }
+}
+
+ReactDOM.render(<Sider />, mountNode);
+```

--- a/components/menu/demo/switch-mode.md
+++ b/components/menu/demo/switch-mode.md
@@ -1,5 +1,5 @@
 ---
-order: 5
+order: 6
 title:
   zh-CN: 切换菜单类型
   en-US: Switch the menu type

--- a/components/menu/demo/theme.md
+++ b/components/menu/demo/theme.md
@@ -11,7 +11,7 @@ title:
 
 ## en-US
 
-There are two built-in themes: `light` and `dark`. The default value is `light`.
+There are two built-in themes: `light` and `dark`. The default value is `light`. They can be applied to the `Menu`, and the Sub-menu will inherit this, or you can override at the `SubMenu` level
 
 ```jsx
 import { Menu, Switch } from 'antd';
@@ -21,13 +21,20 @@ const { SubMenu } = Menu;
 
 class Sider extends React.Component {
   state = {
-    theme: 'dark',
+    menuTheme: 'dark',
+    subMenuTheme: 'dark',
     current: '1',
   };
 
-  changeTheme = value => {
+  changeMenuTheme = value => {
     this.setState({
-      theme: value ? 'dark' : 'light',
+      menuTheme: value ? 'dark' : 'light',
+    });
+  };
+
+  changeSubMenuTheme = value => {
+    this.setState({
+      subMenuTheme: value ? 'dark' : 'light',
     });
   };
 
@@ -41,23 +48,37 @@ class Sider extends React.Component {
   render() {
     return (
       <>
+        Menu Theme:{' '}
         <Switch
-          checked={this.state.theme === 'dark'}
-          onChange={this.changeTheme}
+          checked={this.state.menuTheme === 'dark'}
+          onChange={this.changeMenuTheme}
+          checkedChildren="Dark"
+          unCheckedChildren="Light"
+        />
+        <br />
+        <br />
+        Sub-Menu Theme: <Switch
+          checked={this.state.subMenuTheme === 'dark'}
+          onChange={this.changeSubMenuTheme}
           checkedChildren="Dark"
           unCheckedChildren="Light"
         />
         <br />
         <br />
         <Menu
-          theme={this.state.theme}
+          theme={this.state.menuTheme}
           onClick={this.handleClick}
           style={{ width: 256 }}
           defaultOpenKeys={['sub1']}
           selectedKeys={[this.state.current]}
           mode="inline"
         >
-          <SubMenu key="sub1" icon={<MailOutlined />} title="Navigation One">
+          <SubMenu
+            key="sub1"
+            icon={<MailOutlined />}
+            title="Navigation One"
+            theme={this.state.subMenuTheme}
+          >
             <Menu.Item key="1">Option 1</Menu.Item>
             <Menu.Item key="2">Option 2</Menu.Item>
             <Menu.Item key="3">Option 3</Menu.Item>

--- a/components/menu/demo/theme.md
+++ b/components/menu/demo/theme.md
@@ -11,7 +11,7 @@ title:
 
 ## en-US
 
-There are two built-in themes: `light` and `dark`. The default value is `light`. They can be applied to the `Menu`, and the Sub-menu will inherit this, or you can override at the `SubMenu` level
+There are two built-in themes: `light` and `dark`. The default value is `light`.
 
 ```jsx
 import { Menu, Switch } from 'antd';
@@ -21,20 +21,13 @@ const { SubMenu } = Menu;
 
 class Sider extends React.Component {
   state = {
-    menuTheme: 'dark',
-    subMenuTheme: 'dark',
+    theme: 'dark',
     current: '1',
   };
 
-  changeMenuTheme = value => {
+  changeTheme = value => {
     this.setState({
-      menuTheme: value ? 'dark' : 'light',
-    });
-  };
-
-  changeSubMenuTheme = value => {
-    this.setState({
-      subMenuTheme: value ? 'dark' : 'light',
+      theme: value ? 'dark' : 'light',
     });
   };
 
@@ -48,37 +41,23 @@ class Sider extends React.Component {
   render() {
     return (
       <>
-        Menu Theme:{' '}
         <Switch
-          checked={this.state.menuTheme === 'dark'}
-          onChange={this.changeMenuTheme}
-          checkedChildren="Dark"
-          unCheckedChildren="Light"
-        />
-        <br />
-        <br />
-        Sub-Menu Theme: <Switch
-          checked={this.state.subMenuTheme === 'dark'}
-          onChange={this.changeSubMenuTheme}
+          checked={this.state.theme === 'dark'}
+          onChange={this.changeTheme}
           checkedChildren="Dark"
           unCheckedChildren="Light"
         />
         <br />
         <br />
         <Menu
-          theme={this.state.menuTheme}
+          theme={this.state.theme}
           onClick={this.handleClick}
           style={{ width: 256 }}
           defaultOpenKeys={['sub1']}
           selectedKeys={[this.state.current]}
           mode="inline"
         >
-          <SubMenu
-            key="sub1"
-            icon={<MailOutlined />}
-            title="Navigation One"
-            theme={this.state.subMenuTheme}
-          >
+          <SubMenu key="sub1" icon={<MailOutlined />} title="Navigation One">
             <Menu.Item key="1">Option 1</Menu.Item>
             <Menu.Item key="2">Option 2</Menu.Item>
             <Menu.Item key="3">Option 3</Menu.Item>

--- a/components/menu/index.en-US.md
+++ b/components/menu/index.en-US.md
@@ -98,7 +98,7 @@ More layouts with navigation: [Layout](/components/layout).
 | popupClassName | Sub-menu class name, not working when `mode="inline"` | string | - |  |
 | popupOffset | Sub-menu offset, not working when `mode="inline"` | \[number, number] | - |  |
 | title | Title of sub menu | ReactNode | - |  |
-| theme | Color theme of the sub-menu (inherits from `Menu`) |  | `light` \| `dark` | - | 4.19.0 |
+| theme | Color theme of the SubMenu (inherits from Menu by default) |  | `light` \| `dark` | - | 4.19.0 |
 | onTitleClick | Callback executed when the sub-menu title is clicked | function({ key, domEvent }) | - |  |
 
 ### Menu.ItemGroup

--- a/components/menu/index.en-US.md
+++ b/components/menu/index.en-US.md
@@ -98,7 +98,7 @@ More layouts with navigation: [Layout](/components/layout).
 | popupClassName | Sub-menu class name, not working when `mode="inline"` | string | - |  |
 | popupOffset | Sub-menu offset, not working when `mode="inline"` | \[number, number] | - |  |
 | title | Title of sub menu | ReactNode | - |  |
-| theme | Color theme of the sub-menu (inherits from `Menu`) |  | `light` \| `dark` | - | 4.18 |
+| theme | Color theme of the sub-menu (inherits from `Menu`) |  | `light` \| `dark` | - | 4.19.0 |
 | onTitleClick | Callback executed when the sub-menu title is clicked | function({ key, domEvent }) | - |  |
 
 ### Menu.ItemGroup

--- a/components/menu/index.en-US.md
+++ b/components/menu/index.en-US.md
@@ -90,7 +90,7 @@ More layouts with navigation: [Layout](/components/layout).
 ### Menu.SubMenu
 
 | Param | Description | Type | Default value | Version |
-| --- | --- | --- | --- | --- |
+| --- | --- | --- | --- | --- | --- |
 | children | Sub-menus or sub-menu items | Array&lt;MenuItem \| SubMenu> | - |  |
 | disabled | Whether sub-menu is disabled | boolean | false |  |
 | icon | Icon of sub menu | ReactNode | - | 4.2.0 |
@@ -98,6 +98,7 @@ More layouts with navigation: [Layout](/components/layout).
 | popupClassName | Sub-menu class name, not working when `mode="inline"` | string | - |  |
 | popupOffset | Sub-menu offset, not working when `mode="inline"` | \[number, number] | - |  |
 | title | Title of sub menu | ReactNode | - |  |
+| theme | Color theme of the sub menu (inherits from `Menu`) |  | `light` \| `dark` | - | 4.18 |
 | onTitleClick | Callback executed when the sub-menu title is clicked | function({ key, domEvent }) | - |  |
 
 ### Menu.ItemGroup

--- a/components/menu/index.en-US.md
+++ b/components/menu/index.en-US.md
@@ -98,7 +98,7 @@ More layouts with navigation: [Layout](/components/layout).
 | popupClassName | Sub-menu class name, not working when `mode="inline"` | string | - |  |
 | popupOffset | Sub-menu offset, not working when `mode="inline"` | \[number, number] | - |  |
 | title | Title of sub menu | ReactNode | - |  |
-| theme | Color theme of the sub menu (inherits from `Menu`) |  | `light` \| `dark` | - | 4.18 |
+| theme | Color theme of the sub-menu (inherits from `Menu`) |  | `light` \| `dark` | - | 4.18 |
 | onTitleClick | Callback executed when the sub-menu title is clicked | function({ key, domEvent }) | - |  |
 
 ### Menu.ItemGroup

--- a/components/menu/index.zh-CN.md
+++ b/components/menu/index.zh-CN.md
@@ -100,7 +100,7 @@ cover: https://gw.alipayobjects.com/zos/alicdn/3XZcjGpvK/Menu.svg
 | popupOffset | 子菜单偏移量，`mode="inline"` 时无效 | \[number, number] | - |  |
 | title | 子菜单项值 | ReactNode | - |  |
 | onTitleClick | 点击子菜单标题 | function({ key, domEvent }) | - |  |
-| theme | Color theme of the sub-menu (inherits from `Menu`) |  | `light` \| `dark` | - | 4.19.0 |
+| theme | 设置子菜单的主题，默认从 Menu 上继承 |  | `light` \| `dark` | - | 4.19.0 |
 
 ### Menu.ItemGroup
 

--- a/components/menu/index.zh-CN.md
+++ b/components/menu/index.zh-CN.md
@@ -91,7 +91,7 @@ cover: https://gw.alipayobjects.com/zos/alicdn/3XZcjGpvK/Menu.svg
 ### Menu.SubMenu
 
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
-| --- | --- | --- | --- | --- |
+| --- | --- | --- | --- | --- | --- |
 | children | 子菜单的菜单项 | Array&lt;MenuItem \| SubMenu> | - |  |
 | disabled | 是否禁用 | boolean | false |  |
 | icon | 菜单图标 | ReactNode | - | 4.2.0 |
@@ -100,6 +100,7 @@ cover: https://gw.alipayobjects.com/zos/alicdn/3XZcjGpvK/Menu.svg
 | popupOffset | 子菜单偏移量，`mode="inline"` 时无效 | \[number, number] | - |  |
 | title | 子菜单项值 | ReactNode | - |  |
 | onTitleClick | 点击子菜单标题 | function({ key, domEvent }) | - |  |
+| theme | Color theme of the sub-menu (inherits from `Menu`) |  | `light` \| `dark` | - | 4.19.0 |
 
 ### Menu.ItemGroup
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [x] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
close #33970


### 💡 Background and solution
We are now able to have a dark themed menu with light themed popup SubMenus, (or vice-versa)

Have implemented the existing `theme` prop and applied optionally to Submenu, it will fallback to parent menu theme.

**Before:**
![image](https://user-images.githubusercontent.com/97387061/153070215-162a0ea8-bbf2-43b0-ac74-ac968385d1e1.png)


**After:**
![image](https://user-images.githubusercontent.com/97387061/153070317-66a3ed0d-93f2-45b2-91c7-9028dffdb395.png)



### 📝 Changelog

Adding theme prop to `Menu.SubMenu` to be able to overwrite theme at SubMenu level.

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     x      |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
