### PR TITLE
fix: Exception in enter key callback on editable or copyable Paragraph

### DIFF
--- a/components/typography/Base/index.tsx
+++ b/components/typography/Base/index.tsx
@@ -168,8 +168,8 @@ const Base = React.forwardRef((props: InternalBlockProps, ref: any) => {
     }
   }, [editing]);
 
-  const onEditClick = (e: React.MouseEvent<HTMLDivElement>) => {
-    e.preventDefault();
+  const onEditClick = (e?: React.MouseEvent<HTMLDivElement>) => {
+    e?.preventDefault();
     triggerEdit(true);
   };
 
@@ -192,8 +192,8 @@ const Base = React.forwardRef((props: InternalBlockProps, ref: any) => {
     clearTimeout(copyIdRef.current!);
   };
 
-  const onCopyClick = (e: React.MouseEvent<HTMLDivElement>) => {
-    e.preventDefault();
+  const onCopyClick = (e?: React.MouseEvent<HTMLDivElement>) => {
+    e?.preventDefault();
 
     if (copyConfig.text === undefined) {
       copyConfig.text = String(children);

--- a/components/typography/__tests__/enter-key-callback.test.tsx
+++ b/components/typography/__tests__/enter-key-callback.test.tsx
@@ -4,10 +4,6 @@ import KeyCode from 'rc-util/lib/KeyCode';
 import Paragraph from '../Paragraph';
 
 test('Callback on enter key is triggered', () => {
-  const timer: any = null;
-  jest.spyOn(window, 'setTimeout').mockReturnValue(timer);
-  jest.spyOn(window, 'clearTimeout');
-
   const onEditStart = jest.fn();
   const onCopy = jest.fn();
 
@@ -23,6 +19,9 @@ test('Callback on enter key is triggered', () => {
       test
     </Paragraph>,
   );
+  const timer: any = 9527;
+  jest.spyOn(window, 'setTimeout').mockReturnValue(timer);
+  jest.spyOn(window, 'clearTimeout');
   // must copy first, because editing button will hide copy button
   wrapper.find('.ant-typography-copy').at(0).simulate('keyup', { keyCode: KeyCode.ENTER });
   wrapper.find('.anticon-edit').at(0).simulate('keyup', { keyCode: KeyCode.ENTER });

--- a/components/typography/__tests__/enter-key-callback.test.tsx
+++ b/components/typography/__tests__/enter-key-callback.test.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import KeyCode from 'rc-util/lib/KeyCode';
+import Paragraph from '../Paragraph';
+
+test('Callback on enter key is triggered', () => {
+  const timer: any = null;
+  jest.spyOn(window, 'setTimeout').mockReturnValue(timer);
+  jest.spyOn(window, 'clearTimeout');
+
+  const onEditStart = jest.fn();
+  const onCopy = jest.fn();
+
+  const wrapper = mount(
+    <Paragraph
+      copyable={{
+        onCopy,
+      }}
+      editable={{
+        onStart: onEditStart,
+      }}
+    >
+      test
+    </Paragraph>,
+  );
+  // must copy first, because editing button will hide copy button
+  wrapper.find('.ant-typography-copy').at(0).simulate('keyup', { keyCode: KeyCode.ENTER });
+  wrapper.find('.anticon-edit').at(0).simulate('keyup', { keyCode: KeyCode.ENTER });
+
+  expect(onEditStart.mock.calls.length).toBe(1);
+  expect(onCopy.mock.calls.length).toBe(1);
+  jest.restoreAllMocks();
+});


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
No related issue.
<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution
```
<Paragraph
  copyable={{
    onCopy: () => {},
  }}
  editable={{
    onStart: () => {},
  }}
>
   test
</Paragraph>
```

If we trigger an `keyup` event with `Enter` key on editing or copying button, we'll get an error **"Cannot read property 'preventDefault' of undefined"**.
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Fix exception in enter key callback on editable or copyable Paragraph component.     |
| 🇨🇳 Chinese |     修复在Paragraph组件中编辑和拷贝按钮无法响应Enter按键      |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
