### PR TITLE
fix: Typography copyable in clipboard incorrect

### DIFF
--- a/components/typography/Base/index.tsx
+++ b/components/typography/Base/index.tsx
@@ -196,10 +196,7 @@ const Base = React.forwardRef((props: InternalBlockProps, ref: any) => {
     e?.preventDefault();
     e?.stopPropagation();
 
-    if (copyConfig.text === undefined) {
-      copyConfig.text = String(children);
-    }
-    copy(copyConfig.text || '');
+    copy(copyConfig.text || String(children) || '');
 
     setCopied(true);
 

--- a/components/typography/__tests__/copy.test.tsx
+++ b/components/typography/__tests__/copy.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import { SmileOutlined, LikeOutlined } from '@ant-design/icons';
+import * as copyObj from 'copy-to-clipboard';
 
 import Base from '../Base';
 
@@ -205,6 +206,35 @@ describe('Typography copy', () => {
       );
       wrapper.find('.ant-typography-copy').first().simulate('click');
       expect(onDivClick).not.toBeCalled();
+    });
+
+    it('copy to clipboard', done => {
+      const spy = jest.spyOn(copyObj, 'default');
+      const originText = 'origin text.';
+      const nextText = 'next text.';
+      const Test = () => {
+        const [dynamicText, setDynamicText] = React.useState(originText);
+        React.useEffect(() => {
+          setTimeout(() => {
+            setDynamicText(nextText);
+          }, 500);
+        });
+        return (
+          <Base component="p" copyable>
+            {dynamicText}
+          </Base>
+        );
+      };
+      const wrapper = mount(<Test />);
+      const copyBtn = wrapper.find('.ant-typography-copy').first();
+      copyBtn.simulate('click');
+      expect(spy.mock.calls[0][0]).toEqual(originText);
+      setTimeout(() => {
+        spy.mockReset();
+        copyBtn.simulate('click');
+        expect(spy.mock.calls[0][0]).toEqual(nextText);
+        done();
+      }, 500);
     });
   });
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution
https://codesandbox.io/s/sleepy-dawn-qedrs?file=/src/App.js
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Fix Typography `copyable` incorrect copy text after children is updated.      |
| 🇨🇳 Chinese |  修复  Typography `copyable` 时 `children` 内容变化后复制内容没变的问题。      |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
