### PR TITLE
fix: del messageInstance when configuring getContainer

### DIFF
--- a/components/message/__tests__/config.test.js
+++ b/components/message/__tests__/config.test.js
@@ -47,27 +47,6 @@ describe('message.config', () => {
     expect(document.querySelectorAll('.custom-container').length).toBe(1);
   });
 
-  it('should be able to config getContainer, although messageInstance already exists', () => {
-    const container1 = document.createElement('div');
-    const container2 = document.createElement('div');
-    document.body.appendChild(container1);
-    document.body.appendChild(container2);
-    expect(container1.querySelector('.ant-message-notice')).toBeFalsy();
-    expect(container2.querySelector('.ant-message-notice')).toBeFalsy();
-    message.config({
-      getContainer: () => container1,
-    });
-    message.info('mounted in container1');
-    expect(container1.querySelector('.ant-message-notice')).toBeTruthy();
-    message.config({
-      getContainer: () => container2,
-    });
-    message.info('mounted in container2');
-    expect(container2.querySelector('.ant-message-notice')).toBeTruthy();
-    document.body.removeChild(container1);
-    document.body.removeChild(container2);
-  });
-
   it('should be able to config maxCount', () => {
     message.config({
       maxCount: 5,
@@ -145,5 +124,36 @@ describe('message.config', () => {
     message.config({
       transitionName: 'ant-move-up',
     });
+  });
+
+  it('should be able to config getContainer, although messageInstance already exists', () => {
+    function createContainer() {
+      const container = document.createElement('div');
+      document.body.appendChild(container);
+      return [
+        container,
+        () => {
+          document.body.removeChild(container);
+        },
+      ];
+    }
+    const [container1, removeContainer1] = createContainer();
+    const [container2, removeContainer2] = createContainer();
+    expect(container1.querySelector('.ant-message-notice')).toBeFalsy();
+    expect(container2.querySelector('.ant-message-notice')).toBeFalsy();
+    message.config({
+      getContainer: () => container1,
+    });
+    const messageText1 = 'mounted in container1';
+    message.info(messageText1);
+    expect(container1.querySelector('.ant-message-notice').textContent).toEqual(messageText1);
+    message.config({
+      getContainer: () => container2,
+    });
+    const messageText2 = 'mounted in container2';
+    message.info(messageText2);
+    expect(container2.querySelector('.ant-message-notice').textContent).toEqual(messageText2);
+    removeContainer1();
+    removeContainer2();
   });
 });

--- a/components/message/__tests__/config.test.js
+++ b/components/message/__tests__/config.test.js
@@ -47,6 +47,27 @@ describe('message.config', () => {
     expect(document.querySelectorAll('.custom-container').length).toBe(1);
   });
 
+  it('should be able to config getContainer, although messageInstance already exists', () => {
+    const container1 = document.createElement('div');
+    const container2 = document.createElement('div');
+    document.body.appendChild(container1);
+    document.body.appendChild(container2);
+    expect(container1.querySelector('.ant-message-notice')).toBeFalsy();
+    expect(container2.querySelector('.ant-message-notice')).toBeFalsy();
+    message.config({
+      getContainer: () => container1,
+    });
+    message.info('mounted in container1');
+    expect(container1.querySelector('.ant-message-notice')).toBeTruthy();
+    message.config({
+      getContainer: () => container2,
+    });
+    message.info('mounted in container2');
+    expect(container2.querySelector('.ant-message-notice')).toBeTruthy();
+    document.body.removeChild(container1);
+    document.body.removeChild(container2);
+  });
+
   it('should be able to config maxCount', () => {
     message.config({
       maxCount: 5,

--- a/components/message/index.tsx
+++ b/components/message/index.tsx
@@ -54,6 +54,7 @@ function setMessageConfig(options: ConfigOptions) {
   }
   if (options.getContainer !== undefined) {
     getContainer = options.getContainer;
+    messageInstance = null; // delete messageInstance for new getContainer
   }
   if (options.transitionName !== undefined) {
     transitionName = options.transitionName;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
#33930 
<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution
Background: see #33930 
Solution: del messageInstance when configuring getContainer
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  del messageInstance when configuring getContainer  |
| 🇨🇳 Chinese |  配置getContainer时，删除messageInstance  |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
