### PR TITLE
improve performance of useSelection

### DIFF
--- a/components/table/hooks/useSelection.tsx
+++ b/components/table/hooks/useSelection.tsx
@@ -56,16 +56,13 @@ export type INTERNAL_SELECTION_ITEM =
 function flattenData<RecordType>(
   data: RecordType[] | undefined,
   childrenColumnName: string,
+  list: RecordType[] = [],
 ): RecordType[] {
-  let list: RecordType[] = [];
   (data || []).forEach(record => {
     list.push(record);
 
     if (record && typeof record === 'object' && childrenColumnName in record) {
-      list = [
-        ...list,
-        ...flattenData<RecordType>((record as any)[childrenColumnName], childrenColumnName),
-      ];
+      flattenData((record as any)[childrenColumnName], childrenColumnName, list);
     }
   });
 
@@ -158,8 +155,8 @@ export default function useSelection<RecordType>(
 
   // Get flatten data
   const flattedData = useMemo(
-    () => flattenData(pageData, childrenColumnName),
-    [pageData, childrenColumnName],
+    () => (!rowSelection ? [] : flattenData(pageData, childrenColumnName)),
+    [pageData, childrenColumnName, !rowSelection],
   );
 
   // Get all checkbox props


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [x] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->
We haven't created an issue but profiled bad performance with a large tree to the `flattenData` function that is run even when there is no row selection.

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->
`flattenData` builds the flat list of rows by spreading the recursive results which kills performance. Passing the result list down and pushing onto it improves performance as well as skipping a lot of code if there is no row selection. We are not 100% sure this is correct but the tests pass.

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
