### PR TITLE
style: remove overriding !important from input border right width styles

### DIFF
--- a/components/input/style/mixin.less
+++ b/components/input/style/mixin.less
@@ -30,14 +30,14 @@
     border-color: @hoverBorderColor;
     box-shadow: @input-outline-offset @outline-blur-size @outline-width @outlineColor;
   }
-  border-right-width: @border-width-base !important;
+  border-right-width: @border-width-base;
   outline: 0;
 }
 
 // == when hover
 .hover(@color: @input-hover-border-color) {
   border-color: @color;
-  border-right-width: @border-width-base !important;
+  border-right-width: @border-width-base;
 }
 
 .disabled() {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

There is actually no issue for it, but I left a comment on this PR: https://github.com/ant-design/ant-design/pull/10492#issuecomment-1041154579

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

This is actually a fix on a style that is merged in a PR: https://github.com/ant-design/ant-design/pull/10492

This `!important` added here to `border-right-width` of input causes problems with our styling. We can't easily override it without having `!important`. And if we add `!important` to our input styling, it will mess up our application as it should be configurable by some settings.

I believe we should not specify border-width for hover state of an element at all. because it won't happen usually that in hover/focus state somebody wants to change right-border-width specifically; unless in animations, which they will face this `border-base-width 1px !important` that they need to override.

I tried to demonstrate the problem in this video:


https://user-images.githubusercontent.com/5755214/154209194-0d81d02e-6746-4dc8-8a0d-477f0ac82096.mp4


I will just mention the people contributed to the PR, so that they make sure if my changes break anything or not: 

@tfwww 
@afc163 
@morenyang 

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

I don't know if any part of the app is actually dependent heavily on this border-right-width. So I don't know if this is a breaking change or not.

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Remove Input `!important` style.  |
| 🇨🇳 Chinese | 移除 Input 一处 `!important` 样式。    |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed (**Not Needed**)
- [x] Demo is updated/provided or not needed (**Not Needed**, instead the thing I did in the video will work correctly after this fix)
- [x] TypeScript definition is updated/provided or not needed (**Not Needed**)
- [x] Changelog is provided or not needed (**Not Needed**)
