### PR TITLE
docs: add changelog 4.18.9

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -19,14 +19,14 @@ timeline: true
 
 `2022-02-28`
 
-- 🆕 New Theme
+- 🆕 New theme less variable
   - Add variable for aliyun theme of Radio. [#34194](https://github.com/ant-design/ant-design/pull/34194) [@qdzhaoxiaodao](https://github.com/qdzhaoxiaodao)
   - Add variable for aliyun theme of Divider. [#34187](https://github.com/ant-design/ant-design/pull/34187) [@qdzhaoxiaodao](https://github.com/qdzhaoxiaodao)
   - Add variable for aliyun theme of Modal. [#34191](https://github.com/ant-design/ant-design/pull/34191) [@qdzhaoxiaodao](https://github.com/qdzhaoxiaodao)
   - Add variable for aliyun theme of Dropdown. [#34189](https://github.com/ant-design/ant-design/pull/34189) [@qdzhaoxiaodao](https://github.com/qdzhaoxiaodao)
   - Add variable for aliyun theme of Drawer. [#34188](https://github.com/ant-design/ant-design/pull/34188) [@qdzhaoxiaodao](https://github.com/qdzhaoxiaodao)
 - 🐞 Fix to Form that `initialValues` would change if `preserve` is `false`. [#34153](https://github.com/ant-design/ant-design/pull/34153)
-- 💄 Fix Dropdown item wrap style when text is long. [#34177](https://github.com/ant-design/ant-design/pull/34177)
+- 💄 Fix Dropdown item wrap style when text is too long. [#34177](https://github.com/ant-design/ant-design/pull/34177)
 - TypeScript
   - 🐞 Fix Upload `onChange` parameter generic passing. [#34161](https://github.com/ant-design/ant-design/pull/34161) [@wangcch](https://github.com/wangcch)
 

--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -15,6 +15,21 @@ timeline: true
 
 ---
 
+## 4.18.9
+
+`2022-02-28`
+
+- 🆕 New Theme
+  - Add variable for aliyun theme of Radio. [#34194](https://github.com/ant-design/ant-design/pull/34194) [@qdzhaoxiaodao](https://github.com/qdzhaoxiaodao)
+  - Add variable for aliyun theme of Divider. [#34187](https://github.com/ant-design/ant-design/pull/34187) [@qdzhaoxiaodao](https://github.com/qdzhaoxiaodao)
+  - Add variable for aliyun theme of Modal. [#34191](https://github.com/ant-design/ant-design/pull/34191) [@qdzhaoxiaodao](https://github.com/qdzhaoxiaodao)
+  - Add variable for aliyun theme of Dropdown. [#34189](https://github.com/ant-design/ant-design/pull/34189) [@qdzhaoxiaodao](https://github.com/qdzhaoxiaodao)
+  - Add variable for aliyun theme of Drawer. [#34188](https://github.com/ant-design/ant-design/pull/34188) [@qdzhaoxiaodao](https://github.com/qdzhaoxiaodao)
+- 🐞 Fix to Form that `initialValues` would change if `preserve` is `false`. [#34153](https://github.com/ant-design/ant-design/pull/34153)
+- 💄 Fix Dropdown item wrap style when text is long. [#34177](https://github.com/ant-design/ant-design/pull/34177)
+- TypeScript
+  - 🐞 Fix Upload `onChange` parameter generic passing. [#34161](https://github.com/ant-design/ant-design/pull/34161) [@wangcch](https://github.com/wangcch)
+
 ## 4.18.8
 
 `2022-02-21`

--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -19,13 +19,7 @@ timeline: true
 
 `2022-02-28`
 
-- 🆕 New theme less variable
-  - Add variable for aliyun theme of Radio. [#34194](https://github.com/ant-design/ant-design/pull/34194) [@qdzhaoxiaodao](https://github.com/qdzhaoxiaodao)
-  - Add variable for aliyun theme of Divider. [#34187](https://github.com/ant-design/ant-design/pull/34187) [@qdzhaoxiaodao](https://github.com/qdzhaoxiaodao)
-  - Add variable for aliyun theme of Modal. [#34191](https://github.com/ant-design/ant-design/pull/34191) [@qdzhaoxiaodao](https://github.com/qdzhaoxiaodao)
-  - Add variable for aliyun theme of Dropdown. [#34189](https://github.com/ant-design/ant-design/pull/34189) [@qdzhaoxiaodao](https://github.com/qdzhaoxiaodao)
-  - Add variable for aliyun theme of Drawer. [#34188](https://github.com/ant-design/ant-design/pull/34188) [@qdzhaoxiaodao](https://github.com/qdzhaoxiaodao)
-- 🐞 Fix to Form that `initialValues` would change if `preserve` is `false`. [#34153](https://github.com/ant-design/ant-design/pull/34153)
+- 🆕 New theme less variable for Radio, Divider, Modal, Dropdown, Drawer. [#34194](https://github.com/ant-design/ant-design/pull/34194) [#34187](https://github.com/ant-design/ant-design/pull/34187) [#34191](https://github.com/ant-design/ant-design/pull/34191) [#34189](https://github.com/ant-design/ant-design/pull/34189) [#34188](https://github.com/ant-design/ant-design/pull/34188) [@qdzhaoxiaodao](https://github.com/qdzhaoxiaodao)
 - 💄 Fix Dropdown item wrap style when text is too long. [#34177](https://github.com/ant-design/ant-design/pull/34177)
 - TypeScript
   - 🐞 Fix Upload `onChange` parameter generic passing. [#34161](https://github.com/ant-design/ant-design/pull/34161) [@wangcch](https://github.com/wangcch)

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -15,6 +15,21 @@ timeline: true
 
 ---
 
+## 4.18.9
+
+`2022-02-28`
+
+- 🆕 新主题
+  - 为 Radio 组件添加阿里云主题变量。[#34194](https://github.com/ant-design/ant-design/pull/34194) [@qdzhaoxiaodao](https://github.com/qdzhaoxiaodao)
+  - 为 Divider 组件添加阿里云主题变量。[#34187](https://github.com/ant-design/ant-design/pull/34187) [@qdzhaoxiaodao](https://github.com/qdzhaoxiaodao)
+  - 为 Modal 组件添加阿里云主题变量。[#34191](https://github.com/ant-design/ant-design/pull/34191) [@qdzhaoxiaodao](https://github.com/qdzhaoxiaodao)
+  - 为 Dropdown 组件添加阿里云主题变量。[#34189](https://github.com/ant-design/ant-design/pull/34189) [@qdzhaoxiaodao](https://github.com/qdzhaoxiaodao)
+  - 为 Drawer 组件添加阿里云主题变量。[#34188](https://github.com/ant-design/ant-design/pull/34188) [@qdzhaoxiaodao](https://github.com/qdzhaoxiaodao)
+- 🐞 修复 Form 组件当 `preserve` 为 `false` 时 `initialValues` 会被更改的问题。[#34153](https://github.com/ant-design/ant-design/pull/34153)
+- 💄 修复 Dropdown 菜单项文本太长没有换行的问题。[#34177](https://github.com/ant-design/ant-design/pull/3417)
+- TypeScript
+  - 🐞 修复 Upload `onChange` 参数泛型传递。[#34161](https://github.com/ant-design/ant-design/pull/34161) [@wangcch](https://github.com/wangcch)
+
 ## 4.18.8
 
 `2022-02-21`

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -19,7 +19,7 @@ timeline: true
 
 `2022-02-28`
 
-- 🆕 新增 Radio、Divider、Modal、Dropdown、Drawer 新主题变量。[#34194](https://github.com/ant-design/ant-design/pull/34194) [#34187](https://github.com/ant-design/ant-design/pull/34187) [#34191](https://github.com/ant-design/ant-design/pull/34191) [#34189](https://github.com/ant-design/ant-design/pull/34189) [#34188](https://github.com/ant-design/ant-design/pull/34188) [@qdzhaoxiaodao](https://github.com/qdzhaoxiaodao)
+- 🆕 新增 Radio、Divider、Modal、Dropdown、Drawer 主题变量。[#34194](https://github.com/ant-design/ant-design/pull/34194) [#34187](https://github.com/ant-design/ant-design/pull/34187) [#34191](https://github.com/ant-design/ant-design/pull/34191) [#34189](https://github.com/ant-design/ant-design/pull/34189) [#34188](https://github.com/ant-design/ant-design/pull/34188) [@qdzhaoxiaodao](https://github.com/qdzhaoxiaodao)
 - 🐞 修复 Form 组件当 `preserve` 为 `false` 时 `initialValues` 会被更改的问题。[#34153](https://github.com/ant-design/ant-design/pull/34153)
 - 💄 修复 Dropdown 菜单项文本太长没有换行的问题。[#34177](https://github.com/ant-design/ant-design/pull/3417)
 - TypeScript

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -19,7 +19,7 @@ timeline: true
 
 `2022-02-28`
 
-- 🆕 新主题
+- 🆕 新主题变量
   - 为 Radio 组件添加阿里云主题变量。[#34194](https://github.com/ant-design/ant-design/pull/34194) [@qdzhaoxiaodao](https://github.com/qdzhaoxiaodao)
   - 为 Divider 组件添加阿里云主题变量。[#34187](https://github.com/ant-design/ant-design/pull/34187) [@qdzhaoxiaodao](https://github.com/qdzhaoxiaodao)
   - 为 Modal 组件添加阿里云主题变量。[#34191](https://github.com/ant-design/ant-design/pull/34191) [@qdzhaoxiaodao](https://github.com/qdzhaoxiaodao)

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -19,12 +19,7 @@ timeline: true
 
 `2022-02-28`
 
-- 🆕 新主题变量
-  - 为 Radio 组件添加阿里云主题变量。[#34194](https://github.com/ant-design/ant-design/pull/34194) [@qdzhaoxiaodao](https://github.com/qdzhaoxiaodao)
-  - 为 Divider 组件添加阿里云主题变量。[#34187](https://github.com/ant-design/ant-design/pull/34187) [@qdzhaoxiaodao](https://github.com/qdzhaoxiaodao)
-  - 为 Modal 组件添加阿里云主题变量。[#34191](https://github.com/ant-design/ant-design/pull/34191) [@qdzhaoxiaodao](https://github.com/qdzhaoxiaodao)
-  - 为 Dropdown 组件添加阿里云主题变量。[#34189](https://github.com/ant-design/ant-design/pull/34189) [@qdzhaoxiaodao](https://github.com/qdzhaoxiaodao)
-  - 为 Drawer 组件添加阿里云主题变量。[#34188](https://github.com/ant-design/ant-design/pull/34188) [@qdzhaoxiaodao](https://github.com/qdzhaoxiaodao)
+- 🆕 新增 Radio、Divider、Modal、Dropdown、Drawer 新主题变量。[#34194](https://github.com/ant-design/ant-design/pull/34194) [#34187](https://github.com/ant-design/ant-design/pull/34187) [#34191](https://github.com/ant-design/ant-design/pull/34191) [#34189](https://github.com/ant-design/ant-design/pull/34189) [#34188](https://github.com/ant-design/ant-design/pull/34188) [@qdzhaoxiaodao](https://github.com/qdzhaoxiaodao)
 - 🐞 修复 Form 组件当 `preserve` 为 `false` 时 `initialValues` 会被更改的问题。[#34153](https://github.com/ant-design/ant-design/pull/34153)
 - 💄 修复 Dropdown 菜单项文本太长没有换行的问题。[#34177](https://github.com/ant-design/ant-design/pull/3417)
 - TypeScript

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "antd",
-  "version": "4.18.8",
+  "version": "4.18.9",
   "description": "An enterprise-class UI design language and React components implementation",
   "title": "Ant Design",
   "keywords": [


### PR DESCRIPTION
- 🆕 新增 Radio、Divider、Modal、Dropdown、Drawer 新主题变量。[#34194](https://github.com/ant-design/ant-design/pull/34194) [#34187](https://github.com/ant-design/ant-design/pull/34187) [#34191](https://github.com/ant-design/ant-design/pull/34191) [#34189](https://github.com/ant-design/ant-design/pull/34189) [#34188](https://github.com/ant-design/ant-design/pull/34188) [@qdzhaoxiaodao](https://github.com/qdzhaoxiaodao)
- 🐞 修复 Form 组件当 `preserve` 为 `false` 时 `initialValues` 会被更改的问题。[#34153](https://github.com/ant-design/ant-design/pull/34153)
- 💄 修复 Dropdown 菜单项文本太长没有换行的问题。[#34177](https://github.com/ant-design/ant-design/pull/3417)
- TypeScript
  - 🐞 修复 Upload `onChange` 参数泛型传递。[#34161](https://github.com/ant-design/ant-design/pull/34161) [@wangcch](https://github.com/wangcch)

---

- 🆕 New theme less variable for Radio, Divider, Modal, Dropdown, Drawer. [#34194](https://github.com/ant-design/ant-design/pull/34194) [#34187](https://github.com/ant-design/ant-design/pull/34187) [#34191](https://github.com/ant-design/ant-design/pull/34191) [#34189](https://github.com/ant-design/ant-design/pull/34189) [#34188](https://github.com/ant-design/ant-design/pull/34188) [@qdzhaoxiaodao](https://github.com/qdzhaoxiaodao)
- 💄 Fix Dropdown item wrap style when text is too long. [#34177](https://github.com/ant-design/ant-design/pull/34177)
- TypeScript
  - 🐞 Fix Upload `onChange` parameter generic passing. [#34161](https://github.com/ant-design/ant-design/pull/34161) [@wangcch](https://github.com/wangcch)