### PR TITLE
refactor: change usecontext of divider prepare for v5

### DIFF
--- a/components/divider/index.tsx
+++ b/components/divider/index.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import classNames from 'classnames';
-import { ConfigConsumer, ConfigConsumerProps } from '../config-provider';
+import { ConfigContext } from '../config-provider';
 
 export interface DividerProps {
   prefixCls?: string;
@@ -14,56 +14,54 @@ export interface DividerProps {
   plain?: boolean;
 }
 
-const Divider: React.FC<DividerProps> = props => (
-  <ConfigConsumer>
-    {({ getPrefixCls, direction }: ConfigConsumerProps) => {
-      const {
-        prefixCls: customizePrefixCls,
-        type = 'horizontal',
-        orientation = 'center',
-        orientationMargin,
-        className,
-        children,
-        dashed,
-        plain,
-        ...restProps
-      } = props;
-      const prefixCls = getPrefixCls('divider', customizePrefixCls);
-      const orientationPrefix = orientation.length > 0 ? `-${orientation}` : orientation;
-      const hasChildren = !!children;
-      const hasCustomMarginLeft = orientation === 'left' && orientationMargin != null;
-      const hasCustomMarginRight = orientation === 'right' && orientationMargin != null;
-      const classString = classNames(
-        prefixCls,
-        `${prefixCls}-${type}`,
-        {
-          [`${prefixCls}-with-text`]: hasChildren,
-          [`${prefixCls}-with-text${orientationPrefix}`]: hasChildren,
-          [`${prefixCls}-dashed`]: !!dashed,
-          [`${prefixCls}-plain`]: !!plain,
-          [`${prefixCls}-rtl`]: direction === 'rtl',
-          [`${prefixCls}-no-default-orientation-margin-left`]: hasCustomMarginLeft,
-          [`${prefixCls}-no-default-orientation-margin-right`]: hasCustomMarginRight,
-        },
-        className,
-      );
+const Divider: React.FC<DividerProps> = props => {
+  const { getPrefixCls, direction } = React.useContext(ConfigContext);
 
-      const innerStyle = {
-        ...(hasCustomMarginLeft && { marginLeft: orientationMargin }),
-        ...(hasCustomMarginRight && { marginRight: orientationMargin }),
-      };
+  const {
+    prefixCls: customizePrefixCls,
+    type = 'horizontal',
+    orientation = 'center',
+    orientationMargin,
+    className,
+    children,
+    dashed,
+    plain,
+    ...restProps
+  } = props;
+  const prefixCls = getPrefixCls('divider', customizePrefixCls);
+  const orientationPrefix = orientation.length > 0 ? `-${orientation}` : orientation;
+  const hasChildren = !!children;
+  const hasCustomMarginLeft = orientation === 'left' && orientationMargin != null;
+  const hasCustomMarginRight = orientation === 'right' && orientationMargin != null;
+  const classString = classNames(
+    prefixCls,
+    `${prefixCls}-${type}`,
+    {
+      [`${prefixCls}-with-text`]: hasChildren,
+      [`${prefixCls}-with-text${orientationPrefix}`]: hasChildren,
+      [`${prefixCls}-dashed`]: !!dashed,
+      [`${prefixCls}-plain`]: !!plain,
+      [`${prefixCls}-rtl`]: direction === 'rtl',
+      [`${prefixCls}-no-default-orientation-margin-left`]: hasCustomMarginLeft,
+      [`${prefixCls}-no-default-orientation-margin-right`]: hasCustomMarginRight,
+    },
+    className,
+  );
 
-      return (
-        <div className={classString} {...restProps} role="separator">
-          {children && (
-            <span className={`${prefixCls}-inner-text`} style={innerStyle}>
-              {children}
-            </span>
-          )}
-        </div>
-      );
-    }}
-  </ConfigConsumer>
-);
+  const innerStyle = {
+    ...(hasCustomMarginLeft && { marginLeft: orientationMargin }),
+    ...(hasCustomMarginRight && { marginRight: orientationMargin }),
+  };
+
+  return (
+    <div className={classString} {...restProps} role="separator">
+      {children && (
+        <span className={`${prefixCls}-inner-text`} style={innerStyle}>
+          {children}
+        </span>
+      )}
+    </div>
+  );
+};
 
 export default Divider;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [x] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
 None
<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution
Divider组件改进css in js中hook需要再组件内部使用，所以需要将原先context使用转化为useContext
Divider component improvement css in js hook needs to be used inside the component, so it is necessary to convert the original context to useContext
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Improve the divider structure to prepare for cssinjs      |
| 🇨🇳 Chinese |       改进divider结构为cssinjs做准备    |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
