### PR TITLE
refactor: use react.forwardref wrap affix to change it to function co…

### DIFF
--- a/components/affix/__tests__/Affix.test.tsx
+++ b/components/affix/__tests__/Affix.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { mount, ReactWrapper } from 'enzyme';
-import Affix, { AffixProps, AffixState } from '..';
+import Affix, { AffixProps, AffixState, AffixClass } from '..';
 import { getObserverEntities } from '../utils';
 import Button from '../../button';
 import rtlTest from '../../../tests/shared/rtlTest';
@@ -17,7 +17,7 @@ class AffixMounter extends React.Component<{
 }> {
   private container: HTMLDivElement;
 
-  public affix: Affix;
+  public affix: AffixClass;
 
   componentDidMount() {
     this.container.addEventListener = jest
@@ -58,7 +58,7 @@ describe('Affix Render', () => {
 
   const domMock = jest.spyOn(HTMLElement.prototype, 'getBoundingClientRect');
   let affixMounterWrapper: ReactWrapper<unknown, unknown, AffixMounter>;
-  let affixWrapper: ReactWrapper<AffixProps, AffixState, Affix>;
+  let affixWrapper: ReactWrapper<AffixProps, AffixState, AffixClass>;
 
   const classRect: Record<string, DOMRect> = {
     container: {
@@ -155,11 +155,24 @@ describe('Affix Render', () => {
       document.body.innerHTML = '<div id="mounter" />';
       const container = document.querySelector('#id') as HTMLDivElement;
       const getTarget = () => container;
-      affixWrapper = mount(<Affix target={getTarget}>{null}</Affix>);
+      class AffixWrapper extends React.Component {
+        render() {
+          return (
+            // eslint-disable-next-line react/no-string-refs
+            <Affix ref="affixRef" target={getTarget}>
+              {null}
+            </Affix>
+          );
+        }
+      }
+      affixWrapper = mount(<AffixWrapper />);
       affixWrapper.setProps({ target: () => null });
-      expect(affixWrapper.instance().state.status).toBe(0);
-      expect(affixWrapper.instance().state.affixStyle).toBe(undefined);
-      expect(affixWrapper.instance().state.placeholderStyle).toBe(undefined);
+
+      const affixState = affixWrapper.ref('affixRef').state as unknown as AffixState;
+
+      expect(affixState.status).toBe(0);
+      expect(affixState.affixStyle).toBe(undefined);
+      expect(affixState.placeholderStyle).toBe(undefined);
     });
 
     it('instance change', async () => {

--- a/components/affix/index.tsx
+++ b/components/affix/index.tsx
@@ -126,7 +126,7 @@ class Affix extends React.Component<AffixProps, AffixState> {
 
   getOffsetTop = () => {
     const { offsetBottom, offsetTop } = this.props;
-    return (offsetBottom === undefined && offsetTop === undefined) ? 0 : offsetTop;
+    return offsetBottom === undefined && offsetTop === undefined ? 0 : offsetTop;
   };
 
   getOffsetBottom = () => this.props.offsetBottom;
@@ -286,4 +286,6 @@ class Affix extends React.Component<AffixProps, AffixState> {
   }
 }
 
-export default Affix;
+export type AffixClass = Affix;
+
+export default React.forwardRef<Affix, AffixProps>((props, ref) => <Affix {...props} ref={ref} />);


### PR DESCRIPTION
…mponent

<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [x] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
   None
<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution
AntD v5 需要原有组件转化为CssInJs形式，这时候需要用到hook方法，而原来的Affix组件为Class Component，需要将其转化为FunctionComponent，给出的解决方案是用React.forwardRef将组件包裹，将其转化为FunctionComponent。

AntD v5 requires the original components to be converted into CssInJs form. At this time, the hook method needs to be used, and the original Affix component is a Class Component, which needs to be converted into a FunctionComponent. The solution given is to use React.forwardRef to wrap the component and put It is converted to FunctionComponent.
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog
**不再支持的功能！！** 导出的Affix不再为一个Class类型，无法作为类型声明
**no longer supported!！！** The exported Affix is no longer a Class type and cannot be declared as a type
affix: Affix // Type Error
`

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Affix converted to FunctionComponent     |
| 🇨🇳 Chinese |     Affix转化为FunctionComponent      |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
