### PR TITLE
fix: limit input class due to rc-input won't override input class

### DIFF
--- a/components/input/Input.tsx
+++ b/components/input/Input.tsx
@@ -196,6 +196,8 @@ const Input = forwardRef<InputRef, InputProps>((props, ref) => {
     </>
   );
 
+  const withPrefixSuffix = hasPrefixSuffix(props);
+
   return (
     <RcInput
       ref={composeRef(ref, inputRef)}
@@ -207,13 +209,13 @@ const Input = forwardRef<InputRef, InputProps>((props, ref) => {
       suffix={suffixNode}
       clearIcon={<CloseCircleFilled />}
       inputClassName={classNames(
-        {
+        !withPrefixSuffix && {
           [`${prefixCls}-sm`]: mergedSize === 'small',
           [`${prefixCls}-lg`]: mergedSize === 'large',
           [`${prefixCls}-rtl`]: direction === 'rtl',
           [`${prefixCls}-borderless`]: !bordered,
         },
-        getStatusClassNames(prefixCls, mergedStatus),
+        !withPrefixSuffix && getStatusClassNames(prefixCls, mergedStatus),
       )}
       affixWrapperClassName={classNames(
         {

--- a/components/input/Input.tsx
+++ b/components/input/Input.tsx
@@ -196,7 +196,7 @@ const Input = forwardRef<InputRef, InputProps>((props, ref) => {
     </>
   );
 
-  const withPrefixSuffix = hasPrefixSuffix(props);
+  const withPrefixSuffix = hasPrefixSuffix(props) || hasFeedback;
 
   return (
     <RcInput

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "rc-dropdown": "~3.3.2",
     "rc-field-form": "~1.23.0",
     "rc-image": "~5.2.5",
-    "rc-input": "^0.0.1-alpha.3",
+    "rc-input": "^0.0.1-alpha.4",
     "rc-input-number": "~7.3.0",
     "rc-mentions": "~1.6.1",
     "rc-menu": "~9.2.1",


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [x] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Limit input class when has affix          |
| 🇨🇳 Chinese | 有 affix 时控制 input class |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
