### PR TITLE
docs(Spin): fix en-US description of `spinning` prop

### DIFF
--- a/components/spin/index.en-US.md
+++ b/components/spin/index.en-US.md
@@ -18,7 +18,7 @@ When part of the page is waiting for asynchronous data or during a rendering pro
 | delay | Specifies a delay in milliseconds for loading state (prevent flush) | number (milliseconds) | - |
 | indicator | React node of the spinning indicator | ReactNode | - |
 | size | The size of Spin, options: `small`, `default` and `large` | string | `default` |
-| spinning | Whether Spin is spinning | boolean | true |
+| spinning | Whether Spin is visible | boolean | true |
 | tip | Customize description content when Spin has children | ReactNode | - |
 | wrapperClassName | The className of wrapper when Spin has children | string | - |
 


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

新特性请提交至 feature 分支，其余可提交至 master 分支。
在维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

[[English Template / 英文模板](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE.md)]

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [ ] 日常 bug 修复
- [x] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

`Spin` 组件中关于 `spinning` prop 的英文文档描述有问题
* 英文: Whether Spin is spinning
* 中文: 是否为加载中状态

从英文解释来看，`spinning === false` 时 icon 还是看得见，但是不会「转」，与中文描述不一致。实际现象是 `spinning === false` 时 icon 不显示（非加载状态）。

本次 PR 修正了英文文档中的描述，避免误导。

也许这个 prop 命名为 `loading` 更好 🤔  ？

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

<del>
### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |          |
| 🇨🇳 中文 |          |
</del>

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
