### PR TITLE
fix: clear status in input addon

### DIFF
--- a/components/form/context.tsx
+++ b/components/form/context.tsx
@@ -3,6 +3,7 @@ import omit from 'rc-util/lib/omit';
 import { Meta } from 'rc-field-form/lib/interface';
 import { FormProvider as RcFormProvider } from 'rc-field-form';
 import { FormProviderProps as RcFormProviderProps } from 'rc-field-form/lib/FormContext';
+import { FC, PropsWithChildren, useMemo } from 'react';
 import { ColProps } from '../grid/col';
 import { FormLabelAlign } from './interface';
 import { RequiredMark } from './Form';
@@ -57,3 +58,11 @@ export interface FormItemStatusContextProps {
 }
 
 export const FormItemStatusContext = React.createContext<FormItemStatusContextProps>({});
+
+export const NoFormStatus: FC<PropsWithChildren<{}>> = ({ children }: PropsWithChildren<{}>) => {
+  const emptyContext = useMemo(() => ({}), []);
+
+  return (
+    <FormItemStatusContext.Provider value={emptyContext}>{children}</FormItemStatusContext.Provider>
+  );
+};

--- a/components/input-number/index.tsx
+++ b/components/input-number/index.tsx
@@ -6,7 +6,7 @@ import * as React from 'react';
 import { useContext } from 'react';
 import { ConfigContext } from '../config-provider';
 import SizeContext, { SizeType } from '../config-provider/SizeContext';
-import { FormItemStatusContext } from '../form/context';
+import { FormItemStatusContext, NoFormStatus } from '../form/context';
 import { cloneElement } from '../_util/reactNode';
 import {
   getFeedbackIcon,
@@ -168,9 +168,9 @@ const InputNumber = React.forwardRef<HTMLInputElement, InputNumberProps>((props,
     element = (
       <div className={mergedGroupClassName} style={props.style}>
         <div className={mergedWrapperClassName}>
-          {addonBeforeNode}
+          {addonBeforeNode && <NoFormStatus>{addonBeforeNode}</NoFormStatus>}
           {cloneElement(element, { style: null })}
-          {addonAfterNode}
+          {addonAfterNode && <NoFormStatus>{addonAfterNode}</NoFormStatus>}
         </div>
       </div>
     );

--- a/components/input/Input.tsx
+++ b/components/input/Input.tsx
@@ -11,7 +11,7 @@ import {
   InputStatus,
 } from '../_util/statusUtils';
 import { ConfigContext } from '../config-provider';
-import { FormItemStatusContext } from '../form/context';
+import { FormItemStatusContext, NoFormStatus } from '../form/context';
 import { hasPrefixSuffix } from './utils';
 import devWarning from '../_util/devWarning';
 
@@ -130,6 +130,8 @@ const Input = forwardRef<InputRef, InputProps>((props, ref) => {
     onFocus,
     suffix,
     allowClear,
+    addonAfter,
+    addonBefore,
     ...rest
   } = props;
   const { getPrefixCls, direction, input } = React.useContext(ConfigContext);
@@ -217,6 +219,8 @@ const Input = forwardRef<InputRef, InputProps>((props, ref) => {
       onFocus={handleFocus}
       suffix={suffixNode}
       allowClear={mergedAllowClear}
+      addonAfter={addonAfter && <NoFormStatus>{addonAfter}</NoFormStatus>}
+      addonBefore={addonBefore && <NoFormStatus>{addonBefore}</NoFormStatus>}
       inputClassName={classNames(
         !withPrefixSuffix && {
           [`${prefixCls}-sm`]: mergedSize === 'small',


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

Before:
![image](https://user-images.githubusercontent.com/27722486/157619251-44812b3d-94ac-4405-b016-f3248cdcb6cd.png)
After:
![image](https://user-images.githubusercontent.com/27722486/157619364-ff9050a3-ef85-4bb3-a2c8-99ed55bbc10d.png)


### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Clear status in Input `addon`.          |
| 🇨🇳 Chinese | 清除 Input 组件 `addon` 下的校验状态    |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
