### PR TITLE
fix: Tooltip width in safari

### DIFF
--- a/components/tooltip/style/index.less
+++ b/components/tooltip/style/index.less
@@ -19,6 +19,7 @@
   z-index: @zindex-tooltip;
   display: block;
   width: max-content;
+  width: intrinsic;
   max-width: @tooltip-max-width;
   visibility: visible;
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

`width: max-content`在Safari是非标准的前缀
[MDN width](https://developer.mozilla.org/en-US/docs/Web/CSS/width)

### 📝 Changelog

![image](https://user-images.githubusercontent.com/16009933/157625717-4abab2a5-9be0-4376-a3f2-cda17bdb82bb.png)
![image](https://user-images.githubusercontent.com/16009933/157625819-0c0938d2-bec2-4013-92fc-61e7f4f5f443.png)


| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Adapt to Safari, add `width: intrinsic`      |
| 🇨🇳 Chinese |    适配Safari，增加`width: intrinsic`       |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
