### PR TITLE
fix: input classname in affix wrapper

### DIFF
--- a/components/config-provider/__tests__/__snapshots__/components.test.js.snap
+++ b/components/config-provider/__tests__/__snapshots__/components.test.js.snap
@@ -13790,7 +13790,7 @@ exports[`ConfigProvider components Input configProvider componentSize large 1`] 
   >
     <input
       action="click"
-      class="config-input"
+      class="config-input config-input-lg"
       type="password"
       value=""
     />

--- a/components/input/Input.tsx
+++ b/components/input/Input.tsx
@@ -223,7 +223,7 @@ const Input = forwardRef<InputRef, InputProps>((props, ref) => {
       addonAfter={addonAfter && <NoFormStatus>{addonAfter}</NoFormStatus>}
       addonBefore={addonBefore && <NoFormStatus>{addonBefore}</NoFormStatus>}
       inputClassName={classNames(
-        !withPrefixSuffix && {
+        {
           [`${prefixCls}-sm`]: mergedSize === 'small',
           [`${prefixCls}-lg`]: mergedSize === 'large',
           [`${prefixCls}-rtl`]: direction === 'rtl',

--- a/components/input/__tests__/__snapshots__/Password.test.js.snap
+++ b/components/input/__tests__/__snapshots__/Password.test.js.snap
@@ -6,7 +6,7 @@ exports[`Input.Password rtl render component should be rendered correctly in RTL
 >
   <input
     action="click"
-    class="ant-input"
+    class="ant-input ant-input-rtl"
     type="password"
     value=""
   />
@@ -163,7 +163,7 @@ exports[`Input.Password should support size 1`] = `
 >
   <input
     action="click"
-    class="ant-input"
+    class="ant-input ant-input-lg"
     type="password"
     value=""
   />

--- a/components/input/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/input/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -5009,7 +5009,7 @@ exports[`renders ./components/input/demo/borderless-debug.md extend context corr
     class="ant-input-affix-wrapper ant-input-affix-wrapper-borderless"
   >
     <input
-      class="ant-input"
+      class="ant-input ant-input-borderless"
       placeholder="Unbordered"
       type="text"
       value=""
@@ -5053,7 +5053,7 @@ exports[`renders ./components/input/demo/borderless-debug.md extend context corr
       ￥
     </span>
     <input
-      class="ant-input"
+      class="ant-input ant-input-borderless"
       type="text"
       value=""
     />
@@ -5072,7 +5072,7 @@ exports[`renders ./components/input/demo/borderless-debug.md extend context corr
       ￥
     </span>
     <input
-      class="ant-input ant-input-disabled"
+      class="ant-input ant-input-disabled ant-input-borderless"
       disabled=""
       type="text"
       value=""
@@ -9161,7 +9161,7 @@ exports[`renders ./components/input/demo/search-input.md extend context correctl
           class="ant-input-affix-wrapper ant-input-affix-wrapper-lg"
         >
           <input
-            class="ant-input"
+            class="ant-input ant-input-lg"
             placeholder="input search text"
             type="text"
             value=""
@@ -9224,7 +9224,7 @@ exports[`renders ./components/input/demo/search-input.md extend context correctl
           class="ant-input-affix-wrapper ant-input-affix-wrapper-lg"
         >
           <input
-            class="ant-input"
+            class="ant-input ant-input-lg"
             placeholder="input search text"
             type="text"
             value=""
@@ -9485,7 +9485,7 @@ Array [
       </span>
     </span>
     <input
-      class="ant-input"
+      class="ant-input ant-input-lg"
       placeholder="large size"
       type="text"
       value=""
@@ -9555,7 +9555,7 @@ Array [
       </span>
     </span>
     <input
-      class="ant-input"
+      class="ant-input ant-input-sm"
       placeholder="small size"
       type="text"
       value=""

--- a/components/input/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/input/__tests__/__snapshots__/demo.test.js.snap
@@ -1226,7 +1226,7 @@ exports[`renders ./components/input/demo/borderless-debug.md correctly 1`] = `
     class="ant-input-affix-wrapper ant-input-affix-wrapper-borderless"
   >
     <input
-      class="ant-input"
+      class="ant-input ant-input-borderless"
       placeholder="Unbordered"
       type="text"
       value=""
@@ -1270,7 +1270,7 @@ exports[`renders ./components/input/demo/borderless-debug.md correctly 1`] = `
       ￥
     </span>
     <input
-      class="ant-input"
+      class="ant-input ant-input-borderless"
       type="text"
       value=""
     />
@@ -1289,7 +1289,7 @@ exports[`renders ./components/input/demo/borderless-debug.md correctly 1`] = `
       ￥
     </span>
     <input
-      class="ant-input ant-input-disabled"
+      class="ant-input ant-input-disabled ant-input-borderless"
       disabled=""
       type="text"
       value=""
@@ -2935,7 +2935,7 @@ exports[`renders ./components/input/demo/search-input.md correctly 1`] = `
           class="ant-input-affix-wrapper ant-input-affix-wrapper-lg"
         >
           <input
-            class="ant-input"
+            class="ant-input ant-input-lg"
             placeholder="input search text"
             type="text"
             value=""
@@ -2998,7 +2998,7 @@ exports[`renders ./components/input/demo/search-input.md correctly 1`] = `
           class="ant-input-affix-wrapper ant-input-affix-wrapper-lg"
         >
           <input
-            class="ant-input"
+            class="ant-input ant-input-lg"
             placeholder="input search text"
             type="text"
             value=""
@@ -3259,7 +3259,7 @@ Array [
       </span>
     </span>
     <input
-      class="ant-input"
+      class="ant-input ant-input-lg"
       placeholder="large size"
       type="text"
       value=""
@@ -3329,7 +3329,7 @@ Array [
       </span>
     </span>
     <input
-      class="ant-input"
+      class="ant-input ant-input-sm"
       placeholder="small size"
       type="text"
       value=""

--- a/components/input/style/mixin.less
+++ b/components/input/style/mixin.less
@@ -7,10 +7,6 @@
 .input-lg() {
   padding: @input-padding-vertical-lg @input-padding-horizontal-lg;
   font-size: @font-size-lg;
-
-  input {
-    font-size: @font-size-lg;
-  }
 }
 
 .input-sm() {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix missing classname in input when Input has `prefix` or `suffix`          |
| 🇨🇳 Chinese | 修复 Input 有 `prefix` 或者 `suffix` 时 input 缺少某些 className 的问题          |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
