### PR TITLE
chore: add focus warning for Input

### DIFF
--- a/components/input/Input.tsx
+++ b/components/input/Input.tsx
@@ -158,7 +158,6 @@ const Input = forwardRef<InputRef, InputProps>((props, ref) => {
         'Input',
         `When Input is focused, dynamic add or remove prefix / suffix will make it lose focus caused by dom structure change. Read more: https://ant.design/components/input/#FAQ`,
       );
-      inputRef.current?.focus();
     }
     prevHasPrefixSuffix.current = inputHasPrefixSuffix;
   }, [inputHasPrefixSuffix]);

--- a/components/input/Input.tsx
+++ b/components/input/Input.tsx
@@ -149,7 +149,7 @@ const Input = forwardRef<InputRef, InputProps>((props, ref) => {
   const mergedStatus = getMergedStatus(contextStatus, customStatus);
 
   // ===================== Focus warning =====================
-  const inputHasPrefixSuffix = hasPrefixSuffix(props);
+  const inputHasPrefixSuffix = hasPrefixSuffix(props) || !!hasFeedback;
   const prevHasPrefixSuffix = useRef<boolean>(inputHasPrefixSuffix);
   useEffect(() => {
     if (inputHasPrefixSuffix && !prevHasPrefixSuffix.current) {
@@ -158,6 +158,7 @@ const Input = forwardRef<InputRef, InputProps>((props, ref) => {
         'Input',
         `When Input is focused, dynamic add or remove prefix / suffix will make it lose focus caused by dom structure change. Read more: https://ant.design/components/input/#FAQ`,
       );
+      inputRef.current?.focus();
     }
     prevHasPrefixSuffix.current = inputHasPrefixSuffix;
   }, [inputHasPrefixSuffix]);

--- a/components/input/Input.tsx
+++ b/components/input/Input.tsx
@@ -200,8 +200,6 @@ const Input = forwardRef<InputRef, InputProps>((props, ref) => {
     </>
   );
 
-  const withPrefixSuffix = hasPrefixSuffix(props) || hasFeedback;
-
   // Allow clear
   let mergedAllowClear;
   if (typeof allowClear === 'object' && allowClear?.clearIcon) {
@@ -229,7 +227,7 @@ const Input = forwardRef<InputRef, InputProps>((props, ref) => {
           [`${prefixCls}-rtl`]: direction === 'rtl',
           [`${prefixCls}-borderless`]: !bordered,
         },
-        !withPrefixSuffix && getStatusClassNames(prefixCls, mergedStatus),
+        !inputHasPrefixSuffix && getStatusClassNames(prefixCls, mergedStatus),
       )}
       affixWrapperClassName={classNames(
         {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
close https://github.com/ant-design/ant-design/issues/34458
<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Add warning for Input getting blurred when dynamically add `hasFeedback`.        |
| 🇨🇳 Chinese |  为动态改变 Form.Item 的 `hasFeedback` 时 Input 焦点丢失添加警告。         |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
