### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/components/_util/getDataOrAriaProps.ts
+++ b/components/_util/getDataOrAriaProps.ts
@@ -1,8 +1,8 @@
 export default function getDataOrAriaProps(props: any) {
   return Object.keys(props).reduce((prev: any, key: string) => {
     if (
-      (key.substr(0, 5) === 'data-' || key.substr(0, 5) === 'aria-' || key === 'role') &&
-      key.substr(0, 7) !== 'data-__'
+      (key.startsWith('data-') || key.startsWith('aria-') || key === 'role') &&
+      !key.startsWith('data-__')
     ) {
       prev[key] = props[key];
     }

--- a/components/tree/demo/search.md
+++ b/components/tree/demo/search.md
@@ -110,8 +110,8 @@ class SearchTree extends React.Component {
     const loop = data =>
       data.map(item => {
         const index = item.title.indexOf(searchValue);
-        const beforeStr = item.title.substr(0, index);
-        const afterStr = item.title.substr(index + searchValue.length);
+        const beforeStr = item.title.substring(0, index);
+        const afterStr = item.title.slice(index + searchValue.length);
         const title =
           index > -1 ? (
             <span>

--- a/components/upload/demo/file-type.md
+++ b/components/upload/demo/file-type.md
@@ -102,7 +102,7 @@ class PicturesWall extends React.Component {
         icon = <LoadingOutlined />; // or icon = 'uploading...';
       } else {
         fileSufIconList.forEach(item => {
-          if (item.suf.includes(file.name.substr(file.name.lastIndexOf('.')))) {
+          if (item.suf.includes(file.name.slice(file.name.lastIndexOf('.')))) {
             icon = item.type;
           }
         });

--- a/site/theme/template/Layout/Header/index.tsx
+++ b/site/theme/template/Layout/Header/index.tsx
@@ -192,7 +192,7 @@ class Header extends React.Component<HeaderProps, HeaderState> {
       location: { pathname, query },
     } = this.props;
     const currentProtocol = `${window.location.protocol}//`;
-    const currentHref = window.location.href.substr(currentProtocol.length);
+    const currentHref = window.location.href.slice(currentProtocol.length);
 
     if (utils.isLocalStorageNameSupported()) {
       localStorage.setItem('locale', utils.isZhCN(pathname) ? 'en-US' : 'zh-CN');


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it functions which works similarily but aren't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)


### 💡 Background and solution

[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated which means we should switch to different methods which do the same or similar thing but aren't deprecated.


### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Change all uses of `substr()` to functions which aren't deprecated |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
