### PR TITLE
fix: apply scale transform to disabled star

### DIFF
--- a/components/rate/style/index.less
+++ b/components/rate/style/index.less
@@ -17,8 +17,8 @@
 
   &-disabled &-star {
     cursor: default;
-
-    &:hover {
+    
+    > div:hover {
       transform: scale(1);
     }
   }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

### 💡 Background and solution

<img width="153" alt="image" src="https://user-images.githubusercontent.com/42885087/158718482-fd09a08c-e55d-4e6c-917e-e632c17a4a04.png">

1. The rate in read-only state appears to be intended to prevent scale from being transformed when hovered, but it did not work properly.
2. I modified the code to prevent scale from being transformed when hovering over the rate in read-only state.

### 📝 Changelog

Scale is not transformed when hovering over the rate in read-only state.

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
