### PR TITLE
fix: lt_LT locale for typeTemplate

### DIFF
--- a/components/locale/lt_LT.tsx
+++ b/components/locale/lt_LT.tsx
@@ -6,7 +6,7 @@ import TimePicker from '../time-picker/locale/lt_LT';
 import Calendar from '../calendar/locale/lt_LT';
 import { Locale } from '../locale-provider';
 
-const typeTemplate: string = '${label} не является типом ${type}';
+const typeTemplate: string = '${label} neatitinka tipo ${type}';
 
 const localeValues: Locale = {
   locale: 'lt',


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [x] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

Updated text for `typeTemplate` in LT locale, because current text is in Russian

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Updated lt_LT locale for `typeTemplate`  |
| 🇨🇳 Chinese |     更新lt_LT的locale     |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
