### PR TITLE
fix: when fullscreen is false, the element returned by dateFullCellRender cannot be interactive

### DIFF
--- a/components/calendar/__tests__/index.test.js
+++ b/components/calendar/__tests__/index.test.js
@@ -403,4 +403,20 @@ describe('Calendar', () => {
     );
     expect(wrapper.find('.bamboo').first().text()).toEqual('Light');
   });
+
+  it('when fullscreen is false, the element returned by dateFullCellRender should be interactive', () => {
+    const onClick = jest.fn();
+    const wrapper = mount(
+      <Calendar
+        fullscreen={false}
+        dateFullCellRender={() => (
+          <div className="bamboo" onClick={onClick}>
+            Light
+          </div>
+        )}
+      />,
+    );
+    wrapper.find('.bamboo').first().simulate('click');
+    expect(onClick).toBeCalled();
+  });
 });

--- a/components/calendar/style/index.less
+++ b/components/calendar/style/index.less
@@ -70,6 +70,10 @@
         line-height: 18px;
       }
     }
+
+    .@{calendar-picker-prefix-cls}-cell::before {
+      pointer-events: none;
+    }
   }
 
   // ========================== Full ==========================


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
fix #34553

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution
当 fullscreen = false，[ant-picker-calendar-mini](https://github.com/ant-design/ant-design/blob/07b8fb12a66c79e454cb09009585ba647499f6ae/components/calendar/generateCalendar.tsx#L241) 下 ant-picker-cell::before 挡住了子元素，ant-picker-cell::before 会给禁用的时间提供背景色，不能直接隐藏，所以加了 pointer-events: none

当 fullscreen = true，[ant-picker-calendar-full](https://github.com/ant-design/ant-design/blob/07b8fb12a66c79e454cb09009585ba647499f6ae/components/calendar/generateCalendar.tsx#L240) 下 [ant-picker-cell::before display: none](https://github.com/ant-design/ant-design/blob/07b8fb12a66c79e454cb09009585ba647499f6ae/components/calendar/style/index.less#L99-L101)，所以不会影响。

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fix when the fullscreen of the Calendar is false, the element returned by dateFullCellRender cannot be interactive.      |
| 🇨🇳 Chinese |    修复当 Calendar 的 fullscreen 为 false 时，dateFullCellRender 返回的元素不可交互 。      |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
