### PR TITLE
fix(input): cursor should not jump to the end after inputing

### DIFF
--- a/components/input/__tests__/textarea.test.js
+++ b/components/input/__tests__/textarea.test.js
@@ -92,6 +92,8 @@ describe('TextArea', () => {
       };
 
       const wrapper = mount(<Demo />);
+      // textarea should has value, when format with length
+      wrapper.find('textarea').getDOMNode().value = 'light';
       wrapper.find('textarea').simulate('change', { target: { value: 'light' } });
 
       expect(wrapper.find('textarea').props().value).toEqual('l');

--- a/components/input/hooks/useCursor.ts
+++ b/components/input/hooks/useCursor.ts
@@ -20,7 +20,7 @@ export function useCursor(getInputElement: () => HTMLTextAreaElement | undefined
       setEndText(null);
       return;
     }
-    const value = inputElement.value;
+    const {value} = inputElement;
     if (endText && value.endsWith(endText)) {
       const newCursorPosition = value.length - endText.length;
       inputElement.setSelectionRange(newCursorPosition, newCursorPosition);

--- a/components/input/hooks/useCursor.ts
+++ b/components/input/hooks/useCursor.ts
@@ -1,0 +1,32 @@
+// Simplicated version of: https://github.com/react-component/input-number/blob/master/src/hooks/useCursor.ts
+
+import React from 'react';
+export function useCursor(getInputElement: () => HTMLTextAreaElement | undefined) {
+  const [endText, setEndText] = React.useState<string | null>(null);
+
+  function recordCursor() {
+    const inputElement = getInputElement();
+    if (!inputElement) {
+      setEndText(null);
+      return;
+    }
+    const cursorPosition = inputElement.selectionEnd;
+    setEndText(inputElement.value.slice(cursorPosition));
+  }
+
+  function resetCursor() {
+    const inputElement = getInputElement();
+    if (!inputElement) {
+      setEndText(null);
+      return;
+    }
+    const value = inputElement.value;
+    if (endText && value.endsWith(endText)) {
+      const newCursorPosition = value.length - endText.length;
+      inputElement.setSelectionRange(newCursorPosition, newCursorPosition);
+      setEndText(null);
+    }
+  }
+
+  return [recordCursor, resetCursor];
+}


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

https://github.com/ant-design/ant-design/issues/34369
<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution
Antd will set a formatted value  after inputing, this will make browser can't reset cursor's position.

I add a state to store cursor's position and reset it back after back. It's quick like what input-number does: https://github.com/react-component/input-number/blob/master/src/hooks/useCursor.ts



<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      fix  textarea's cursor jumps to the end when inputing     |
| 🇨🇳 Chinese |  修复某些输入情况下，textarea 跳跃到末尾的问题    |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
