### PR TITLE
chore:  code style optimization

### DIFF
--- a/components/message/hooks/useMessage.tsx
+++ b/components/message/hooks/useMessage.tsx
@@ -12,7 +12,7 @@ import {
   attachTypeApi,
   ThenableArgument,
   getKeyThenIncreaseKey,
-  NoticeType,
+  typeList,
 } from '..';
 
 export default function createUseMessage(
@@ -78,9 +78,7 @@ export default function createUseMessage(
 
     hookApiRef.current.open = notify;
 
-    (['success', 'info', 'warning', 'error', 'loading'] as NoticeType[]).forEach(type =>
-      attachTypeApi(hookApiRef.current, type),
-    );
+    typeList.forEach(type => attachTypeApi(hookApiRef.current, type));
 
     return [
       hookApiRef.current,

--- a/components/message/index.tsx
+++ b/components/message/index.tsx
@@ -13,8 +13,6 @@ import InfoCircleFilled from '@ant-design/icons/InfoCircleFilled';
 import createUseMessage from './hooks/useMessage';
 import ConfigProvider, { globalConfig } from '../config-provider';
 
-export type NoticeType = 'info' | 'success' | 'error' | 'warning' | 'loading';
-
 let messageInstance: RCNotificationInstance | null;
 let defaultDuration = 3;
 let defaultTop: number;
@@ -128,6 +126,11 @@ const typeToIcon = {
   warning: ExclamationCircleFilled,
   loading: LoadingOutlined,
 };
+
+export type NoticeType = keyof typeof typeToIcon;
+
+export const typeList = Object.keys(typeToIcon) as NoticeType[];
+
 export interface ArgsProps {
   content: React.ReactNode;
   duration?: number;
@@ -247,9 +250,7 @@ export function attachTypeApi(originalApi: MessageApi, type: NoticeType) {
   };
 }
 
-(['success', 'info', 'warning', 'error', 'loading'] as NoticeType[]).forEach(type =>
-  attachTypeApi(api, type),
-);
+typeList.forEach(type => attachTypeApi(api, type));
 
 api.warn = api.warning;
 api.useMessage = createUseMessage(getRCNotificationInstance, getRCNoticeProps);


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

新特性请提交至 feature 分支，其余可提交至 master 分支。
在维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

[[English Template / 英文模板](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE.md)]

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [x] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [x] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->
没必要把 'info', 'success' , 'error' , 'warning' , 'loading', 五种type到处都写一遍，不管是定义类型还是数组变量。
都可以通过`typeToIcon`字面量对象推导出来。以后有type增加也只需要维护`typeToIcon`即可。
```TS
const typeToIcon = {
  info: InfoCircleFilled,
  success: CheckCircleFilled,
  error: CloseCircleFilled,
  warning: ExclamationCircleFilled,
  loading: LoadingOutlined,
};
type NoticeType = keyof typeof typeToIcon;
const typeList = Object.keys(typeToIcon) as NoticeType[]
```
| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |  1. declare  type ` NoticeType`  use `keyof` type operator 2. typeList use `Object.keys`  |
| 🇨🇳 中文 |    1. 使用keyof操作符声明类型， 2.  `Object.keys`来生成类型数组      |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供