### PR TITLE
perf: set cell(td/th) border instead of row(tr) [Descriptions]

### DIFF
--- a/components/descriptions/style/index.less
+++ b/components/descriptions/style/index.less
@@ -41,10 +41,14 @@
     > th,
     > td {
       padding-bottom: @descriptions-item-padding-bottom;
+      border-bottom: 1px solid @border-color-split;
     }
 
     &:last-child {
-      border-bottom: none;
+      > th,
+      > td {
+        border-bottom: none;
+      }
     }
   }
 
@@ -149,14 +153,6 @@
 
       &::after {
         display: none;
-      }
-    }
-
-    .@{descriptions-prefix-cls}-row {
-      border-bottom: 1px solid @border-color-split;
-
-      &:last-child {
-        border-bottom: none;
       }
     }
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

#34687

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     set cell(td/th) border instead of row(tr), fix  when DescriptionsItem style.display=none, it's border still show   |
| 🇨🇳 Chinese |    将之前的row的底部border更改到cell上, 解决 DescriptionsItem style display none 时, border仍然显示的问题   |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
