### PR TITLE
fix: Notification placement = 'top' bug

### DIFF
--- a/components/notification/style/index.less
+++ b/components/notification/style/index.less
@@ -35,6 +35,11 @@
     margin-left: auto;
   }
 
+  // fix: https://github.com/ant-design/ant-design/issues/34700
+  &-top > div {
+    height: 0;
+  }
+
   &-close-icon {
     font-size: @font-size-base;
     cursor: pointer;


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

新特性请提交至 feature 分支，其余可提交至 master 分支。
在维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

[[English Template / 英文模板](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE.md)]

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue
Notification通知提醒框placement=‘top’时好像有个蒙层，阻挡了点击Notification同高度的其他东西 #34700
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志
当 Notification placement为top时，设置notice contianer div的高为0 
<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |    when Notification placement is 'top', set notice contianer div height  = 0    |
| 🇨🇳 中文 |   当 Notification placement为top时，设置notice contianer div的高为0     |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
