### PR TITLE
fix: exporting RefSelectProps from select

### DIFF
--- a/components/index.tsx
+++ b/components/index.tsx
@@ -156,7 +156,7 @@ export { default as Result } from './result';
 export type { RowProps } from './row';
 export { default as Row } from './row';
 
-export type { SelectProps } from './select';
+export type { SelectProps, RefSelectProps } from './select';
 export { default as Select } from './select';
 
 export type { SegmentedProps } from './segmented';


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 💡 Background and solution

`RefSelectProps` type is needed in the following usecase:

```ts
import type { SelectProps, RefSelectProps } from 'antd';
import { Select } from 'antd';
import type { Ref } from 'react';
import { forwardRef } from 'react';

const MySelect = forwardRef(
  (props: SelectProps<string>, ref: Ref<RefSelectProps>) => {
    return <Select ref={ref} {...props} />;
  }
);
```

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  exporting `RefSelectProps` from `Select` |
| 🇨🇳 Chinese |  从 `Select` 导出类型 `RefSelectProps`         |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
