### PR TITLE
feat: Support ref for Title, Text, Paragraph

### DIFF
--- a/components/typography/Paragraph.tsx
+++ b/components/typography/Paragraph.tsx
@@ -5,6 +5,8 @@ export interface ParagraphProps extends BlockProps {
   onClick?: (e?: React.MouseEvent<HTMLDivElement>) => void;
 }
 
-const Paragraph: React.FC<ParagraphProps> = props => <Base {...props} component="div" />;
+const Paragraph: React.ForwardRefRenderFunction<HTMLDivElement, ParagraphProps> = (props, ref) => (
+  <Base ref={ref} {...props} component="div" />
+);
 
-export default Paragraph;
+export default React.forwardRef(Paragraph);

--- a/components/typography/Text.tsx
+++ b/components/typography/Text.tsx
@@ -8,7 +8,10 @@ export interface TextProps extends BlockProps {
   onClick?: (e?: React.MouseEvent<HTMLDivElement>) => void;
 }
 
-const Text: React.FC<TextProps> = ({ ellipsis, ...restProps }) => {
+const Text: React.ForwardRefRenderFunction<HTMLSpanElement, TextProps> = (
+  { ellipsis, ...restProps },
+  ref,
+) => {
   const mergedEllipsis = React.useMemo(() => {
     if (ellipsis && typeof ellipsis === 'object') {
       return omit(ellipsis as any, ['expandable', 'rows']);
@@ -25,7 +28,7 @@ const Text: React.FC<TextProps> = ({ ellipsis, ...restProps }) => {
     '`ellipsis` do not support `expandable` or `rows` props.',
   );
 
-  return <Base {...restProps} ellipsis={mergedEllipsis} component="span" />;
+  return <Base ref={ref} {...restProps} ellipsis={mergedEllipsis} component="span" />;
 };
 
-export default Text;
+export default React.forwardRef(Text);

--- a/components/typography/Title.tsx
+++ b/components/typography/Title.tsx
@@ -13,7 +13,7 @@ export type TitleProps = Omit<
   'strong'
 >;
 
-const Title: React.FC<TitleProps> = props => {
+const Title: React.ForwardRefRenderFunction<HTMLHeadingElement, TitleProps> = (props, ref) => {
   const { level = 1, ...restProps } = props;
   let component: string;
 
@@ -28,7 +28,7 @@ const Title: React.FC<TitleProps> = props => {
     component = 'h1';
   }
 
-  return <Base {...restProps} component={component} />;
+  return <Base ref={ref} {...restProps} component={component} />;
 };
 
-export default Title;
+export default React.forwardRef(Title);

--- a/components/typography/__tests__/index.test.js
+++ b/components/typography/__tests__/index.test.js
@@ -402,4 +402,25 @@ describe('Typography', () => {
 
     expect(errorSpy).not.toHaveBeenCalled();
   });
+
+  it('should get HTMLHeadingElement ref from Title', () => {
+    const ref = React.createRef();
+
+    mount(<Title level={1} ref={ref} />);
+    expect(ref.current instanceof HTMLHeadingElement).toBe(true);
+  });
+
+  it('should get HTMLDivElement ref from Paragraph', () => {
+    const ref = React.createRef();
+
+    mount(<Paragraph ref={ref} />);
+    expect(ref.current instanceof HTMLDivElement).toBe(true);
+  });
+
+  it('should get HTMLSpanElement ref from Text', () => {
+    const ref = React.createRef();
+
+    mount(<Text ref={ref} />);
+    expect(ref.current instanceof HTMLSpanElement).toBe(true);
+  });
 });


### PR DESCRIPTION
[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### Ref for Title, Text and Paragraph

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  🐞Fix Title, Text, Paragraph components cannot get ref     |
| 🇨🇳 Chinese |  🐞修复 Title、Text、Paragraph 组件不支持 ref 的问题。    |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
