### PR TITLE
fix: set requestId to null after fn was cancelled

### DIFF
--- a/components/_util/throttleByAnimationFrame.tsx
+++ b/components/_util/throttleByAnimationFrame.tsx
@@ -1,20 +1,26 @@
 import raf from 'rc-util/lib/raf';
 
-export function throttleByAnimationFrame(fn: (...args: any[]) => void) {
+export function throttleByAnimationFrame<T extends unknown[]>(fn: (...args: T) => void) {
   let requestId: number | null;
 
-  const later = (args: any[]) => () => {
+  const later = (args: T) => () => {
     requestId = null;
     fn(...args);
   };
 
-  const throttled = (...args: any[]) => {
+  const throttled: {
+    (...args: T): void;
+    cancel: () => void;
+  } = (...args: T) => {
     if (requestId == null) {
       requestId = raf(later(args));
     }
   };
 
-  (throttled as any).cancel = () => raf.cancel(requestId!);
+  throttled.cancel = () => {
+    raf.cancel(requestId!);
+    requestId = null;
+  };
 
   return throttled;
 }


### PR DESCRIPTION
### 🤔 This is a ...

- [x] Bug fix

### 🔗 Related issue link

close #34814

### 💡 Background and solution

`handleScroll.cancel` will be invoked once in StrictMode:
https://github.com/ant-design/ant-design/blob/11d09f80dec12b845a629e9c0493e3dd0b5053ec/components/back-top/index.tsx#L57-L65

But `cancel` doesn't clear `requestId`, which makes `fn` will never be triggered any more:
https://github.com/ant-design/ant-design/blob/11d09f80dec12b845a629e9c0493e3dd0b5053ec/components/_util/throttleByAnimationFrame.tsx#L11-L15

---

Conveniently, make `throttleByAnimationFrame` type-safe with generic.

This PR relies on https://github.com/react-component/util/pull/287

### 📝 Changelog

Fix `BackTop` not working in StrictMode.

| Language   | Changelog                                           |
| ---------- | --------------------------------------------------- |
| 🇺🇸 English | Fix `BackTop` not working in StrictMode.            |
| 🇨🇳 Chinese | 修复 `BackTop` 组件在严格模式下不能正常工作的问题。 |



### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
