### PR TITLE
fix: skeleton cannot dispaly without children and loading props : Skeleton(...) return nothing

### DIFF
--- a/components/skeleton/Skeleton.tsx
+++ b/components/skeleton/Skeleton.tsx
@@ -161,7 +161,7 @@ const Skeleton = (props: SkeletonProps) => {
       </div>
     );
   }
-  return children as React.ReactElement;
+  return children ? children as React.ReactElement : null;
 };
 
 Skeleton.defaultProps = {

--- a/components/skeleton/Skeleton.tsx
+++ b/components/skeleton/Skeleton.tsx
@@ -161,7 +161,7 @@ const Skeleton = (props: SkeletonProps) => {
       </div>
     );
   }
-  return children ? children as React.ReactElement : null;
+  return typeof children !== 'undefined' ? (children as React.ReactElement) : null;
 };
 
 Skeleton.defaultProps = {

--- a/components/skeleton/__tests__/__snapshots__/index.test.js.snap
+++ b/components/skeleton/__tests__/__snapshots__/index.test.js.snap
@@ -481,6 +481,8 @@ exports[`Skeleton rtl render component should be rendered correctly in RTL direc
 </div>
 `;
 
+exports[`Skeleton should display without children and falsy loading props 1`] = `null`;
+
 exports[`Skeleton should round title and paragraph 1`] = `
 <div
   class="ant-skeleton ant-skeleton-round"

--- a/components/skeleton/__tests__/index.test.js
+++ b/components/skeleton/__tests__/index.test.js
@@ -35,7 +35,7 @@ describe('Skeleton', () => {
   });
 
   it('should display without children', () => {
-    const wrapper = mount(<Skeleton loading={false}></Skeleton>);
+    const wrapper = mount(<Skeleton loading={false} />);
     expect(wrapper.render()).toMatchSnapshot();
   });
 

--- a/components/skeleton/__tests__/index.test.js
+++ b/components/skeleton/__tests__/index.test.js
@@ -34,6 +34,11 @@ describe('Skeleton', () => {
     expect(wrapperSmall.render()).toMatchSnapshot();
   });
 
+  it('should display without children', () => {
+    const wrapper = mount(<Skeleton loading={false}></Skeleton>);
+    expect(wrapper.render()).toMatchSnapshot();
+  });
+
   it('should display children', () => {
     const wrapper = mount(<Skeleton loading={false}>{[1, 2, 3]}</Skeleton>);
     expect(wrapper.text()).toBe('123');

--- a/components/skeleton/__tests__/index.test.js
+++ b/components/skeleton/__tests__/index.test.js
@@ -34,9 +34,14 @@ describe('Skeleton', () => {
     expect(wrapperSmall.render()).toMatchSnapshot();
   });
 
-  it('should display without children', () => {
+  it('should display without children and falsy loading props', () => {
     const wrapper = mount(<Skeleton loading={false} />);
     expect(wrapper.render()).toMatchSnapshot();
+  });
+
+  it('should display with empty children and falsy loading props', () => {
+    const wrapper = mount(<Skeleton loading={false}>{0}</Skeleton>);
+    expect(wrapper.text()).toBe('0');
   });
 
   it('should display children', () => {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
related issue: https://github.com/ant-design/ant-design/issues/34871
I think `Skeleton(...)`  should return something or return null, instead of nothing.

Seems that related with pr: https://github.com/ant-design/ant-design/pull/34751

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Fix error `Nothing was returned from render` when skeleton use falsy loading props without children    |
| 🇨🇳 Chinese | 修复 skeleton 在没有 children 并设置 loading 为 false 时提示  `Nothing was returned from render` 错误         |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
