### PR TITLE
feat: crossorigin attribute of Upload

### DIFF
--- a/components/upload/UploadList/ListItem.tsx
+++ b/components/upload/UploadList/ListItem.tsx
@@ -104,6 +104,7 @@ const ListItem = React.forwardRef(
             src={file.thumbUrl || file.url}
             alt={file.name}
             className={`${prefixCls}-list-item-image`}
+            crossOrigin={file.crossOrigin}
           />
         ) : (
           iconNode

--- a/components/upload/__tests__/uploadlist.test.js
+++ b/components/upload/__tests__/uploadlist.test.js
@@ -1240,4 +1240,134 @@ describe('Upload List', () => {
     const wrapper = mount(<Upload fileList={null} />);
     wrapper.unmount();
   });
+
+  it('should not exist crossorigin attribute when does not set file.crossorigin in case of listType="picture"', () => {
+    const list = [
+      {
+        uid: '0',
+        name: 'xxx.png',
+        status: 'done',
+        url: 'https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png',
+        thumbUrl: 'https://zos.alipayobjects.com/rmsportal/IQKRngzUuFzJzGzRJXUs.png',
+      },
+    ];
+
+    const wrapper = mount(
+      <Upload fileList={list} listType="picture">
+        <button type="button">upload</button>
+      </Upload>,
+    );
+    list.forEach((file, i) => {
+      const imgNode = wrapper.find('.ant-upload-list-item-thumbnail img').at(i);
+      expect(imgNode.prop('crossOrigin')).toBe(undefined);
+      expect(imgNode.prop('crossOrigin')).toBe(file.crossOrigin);
+    });
+    wrapper.unmount();
+  });
+
+  it('should exist crossorigin attribute when set file.crossorigin in case of listType="picture"', () => {
+    const list = [
+      {
+        uid: '0',
+        name: 'xxx.png',
+        status: 'done',
+        url: 'https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png',
+        thumbUrl: 'https://zos.alipayobjects.com/rmsportal/IQKRngzUuFzJzGzRJXUs.png',
+        crossOrigin: '',
+      },
+      {
+        uid: '1',
+        name: 'xxx.png',
+        status: 'done',
+        url: 'https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png',
+        thumbUrl: 'https://zos.alipayobjects.com/rmsportal/IQKRngzUuFzJzGzRJXUs.png',
+        crossOrigin: 'anonymous',
+      },
+      {
+        uid: '2',
+        name: 'xxx.png',
+        status: 'done',
+        url: 'https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png',
+        thumbUrl: 'https://zos.alipayobjects.com/rmsportal/IQKRngzUuFzJzGzRJXUs.png',
+        crossOrigin: 'use-credentials',
+      },
+    ];
+
+    const wrapper = mount(
+      <Upload fileList={list} listType="picture">
+        <button type="button">upload</button>
+      </Upload>,
+    );
+    list.forEach((file, i) => {
+      const imgNode = wrapper.find('.ant-upload-list-item-thumbnail img').at(i);
+      expect(imgNode.prop('crossOrigin')).not.toBe(undefined);
+      expect(imgNode.prop('crossOrigin')).toBe(file.crossOrigin);
+    });
+    wrapper.unmount();
+  });
+
+  it('should not exist crossorigin attribute when does not set file.crossorigin in case of listType="picture-card"', () => {
+    const list = [
+      {
+        uid: '0',
+        name: 'xxx.png',
+        status: 'done',
+        url: 'https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png',
+        thumbUrl: 'https://zos.alipayobjects.com/rmsportal/IQKRngzUuFzJzGzRJXUs.png',
+      },
+    ];
+
+    const wrapper = mount(
+      <Upload fileList={list} listType="picture">
+        <button type="button">upload</button>
+      </Upload>,
+    );
+    list.forEach((file, i) => {
+      const imgNode = wrapper.find('.ant-upload-list-item-thumbnail img').at(i);
+      expect(imgNode.prop('crossOrigin')).toBe(undefined);
+      expect(imgNode.prop('crossOrigin')).toBe(file.crossOrigin);
+    });
+    wrapper.unmount();
+  });
+
+  it('should exist crossorigin attribute when set file.crossorigin in case of listType="picture-card"', () => {
+    const list = [
+      {
+        uid: '0',
+        name: 'xxx.png',
+        status: 'done',
+        url: 'https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png',
+        thumbUrl: 'https://zos.alipayobjects.com/rmsportal/IQKRngzUuFzJzGzRJXUs.png',
+        crossOrigin: '',
+      },
+      {
+        uid: '1',
+        name: 'xxx.png',
+        status: 'done',
+        url: 'https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png',
+        thumbUrl: 'https://zos.alipayobjects.com/rmsportal/IQKRngzUuFzJzGzRJXUs.png',
+        crossOrigin: 'anonymous',
+      },
+      {
+        uid: '2',
+        name: 'xxx.png',
+        status: 'done',
+        url: 'https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png',
+        thumbUrl: 'https://zos.alipayobjects.com/rmsportal/IQKRngzUuFzJzGzRJXUs.png',
+        crossOrigin: 'use-credentials',
+      },
+    ];
+
+    const wrapper = mount(
+      <Upload fileList={list} listType="picture">
+        <button type="button">upload</button>
+      </Upload>,
+    );
+    list.forEach((file, i) => {
+      const imgNode = wrapper.find('.ant-upload-list-item-thumbnail img').at(i);
+      expect(imgNode.prop('crossOrigin')).not.toBe(undefined);
+      expect(imgNode.prop('crossOrigin')).toBe(file.crossOrigin);
+    });
+    wrapper.unmount();
+  });
 });

--- a/components/upload/index.en-US.md
+++ b/components/upload/index.en-US.md
@@ -60,6 +60,7 @@ Extends File with additional props.
 | thumbUrl | Thumb image url | string | - |
 | uid | unique id. Will auto generate when not provided | string | - |
 | url | Download url | string | - |
+| crossOrigin | CORS settings attributes | `'anonymous'` \| `'use-credentials'` \| `''` | - |
 
 ### onChange
 

--- a/components/upload/index.zh-CN.md
+++ b/components/upload/index.zh-CN.md
@@ -61,6 +61,7 @@ cover: https://gw.alipayobjects.com/zos/alicdn/QaeBt_ZMg/Upload.svg
 | thumbUrl | 缩略图地址 | string | - |
 | uid | 唯一标识符，不设置时会自动生成 | string | - |
 | url | 下载地址 | string | - |
+| crossOrigin | CORS 属性设置 | `'anonymous'` \| `'use-credentials'` \| `''` | - |
 
 ### onChange
 

--- a/components/upload/interface.tsx
+++ b/components/upload/interface.tsx
@@ -27,6 +27,7 @@ export interface UploadFile<T = any> {
   status?: UploadFileStatus;
   percent?: number;
   thumbUrl?: string;
+  crossOrigin?: '' | 'anonymous' | 'use-credentials';
   originFileObj?: RcFile;
   response?: T;
   error?: any;

--- a/components/upload/interface.tsx
+++ b/components/upload/interface.tsx
@@ -27,7 +27,7 @@ export interface UploadFile<T = any> {
   status?: UploadFileStatus;
   percent?: number;
   thumbUrl?: string;
-  crossOrigin?: '' | 'anonymous' | 'use-credentials';
+  crossOrigin?: React.ImgHTMLAttributes<HTMLImageElement>['crossOrigin'];
   originFileObj?: RcFile;
   response?: T;
   error?: any;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

https://github.com/ant-design/ant-design/issues/30932

### 💡 Background and solution

I'm faced with crossorigin issue while using Upload component in my project, and I found https://github.com/ant-design/ant-design/issues/30932 issue is a very similar case.
I added 'crossOrigin' property to UploadFile interface, and wrote test cases about that issue.

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Upload support `crossOrigin` for images in `picture-card` mode. |
| 🇨🇳 Chinese | Upload `picture-card` 模式支持配置图片的 `crossOrigin` 属性。 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
