### PR TITLE
chore: Compatible for @types/react@18

### DIFF
--- a/components/collapse/CollapsePanel.tsx
+++ b/components/collapse/CollapsePanel.tsx
@@ -19,6 +19,7 @@ export interface CollapsePanelProps {
   id?: string;
   extra?: React.ReactNode;
   collapsible?: CollapsibleType;
+  children?: React.ReactNode;
 }
 
 const CollapsePanel: React.FC<CollapsePanelProps> = props => {

--- a/components/descriptions/Row.tsx
+++ b/components/descriptions/Row.tsx
@@ -92,6 +92,7 @@ export interface RowProps {
   bordered?: boolean;
   colon: boolean;
   index: number;
+  children?: React.ReactNode;
 }
 
 const Row: React.FC<RowProps> = props => {

--- a/components/steps/index.tsx
+++ b/components/steps/index.tsx
@@ -24,6 +24,7 @@ export interface StepsProps {
   style?: React.CSSProperties;
   percent?: number;
   onChange?: (current: number) => void;
+  children?: React.ReactNode;
 }
 
 export interface StepProps {

--- a/components/tag/CheckableTag.tsx
+++ b/components/tag/CheckableTag.tsx
@@ -12,6 +12,7 @@ export interface CheckableTagProps {
    * .zh-cn 该组件为完全受控组件，不支持非受控用法。
    */
   checked: boolean;
+  children?: React.ReactNode;
   onChange?: (checked: boolean) => void;
   onClick?: (e: React.MouseEvent<HTMLSpanElement, MouseEvent>) => void;
 }


### PR DESCRIPTION
[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

### 💡 Background and solution

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Update TypeScript definition for @types/react@18 compatible. |
| 🇨🇳 Chinese | 更新 TypeScript 定义以兼容 @types/react@18   |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
