### PR TITLE
style: Switch background should not be transparent

### DIFF
--- a/components/switch/style/index.less
+++ b/components/switch/style/index.less
@@ -17,7 +17,8 @@
   height: @switch-height;
   line-height: @switch-height;
   vertical-align: middle;
-  background-color: @disabled-color;
+  background-image: linear-gradient(to right, @disabled-color, @disabled-color),
+    linear-gradient(to right, @white, @white);
   border: 0;
   border-radius: 100px;
   cursor: pointer;
@@ -38,7 +39,7 @@
   }
 
   &-checked {
-    background-color: @switch-color;
+    background: @switch-color;
   }
 
   &-loading,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

<img width="249" alt="图片" src="https://user-images.githubusercontent.com/507615/164036517-725ea612-1352-49d0-92e8-fbb3c80e098e.png">

Switch 禁用状态下背景是灰色透明的，所以放蓝底会很奇怪。应该改成实色背景。

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Optimize Switch disabled color to fit colorful background          |
| 🇨🇳 Chinese |  优化 Switch 禁用色以更好适应非白底背景。         |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
