### PR TITLE
chore: Internal mark dropdown menu

### DIFF
--- a/components/dropdown/dropdown.tsx
+++ b/components/dropdown/dropdown.tsx
@@ -8,6 +8,7 @@ import devWarning from '../_util/devWarning';
 import { tuple } from '../_util/type';
 import { cloneElement } from '../_util/reactNode';
 import getPlacements from '../_util/placements';
+import { NestContext } from '../menu/MenuContext';
 
 const Placements = tuple(
   'topLeft',
@@ -132,7 +133,7 @@ const Dropdown: DropdownInterface = props => {
             expandIcon: overlayNodeExpandIcon,
           });
 
-    return fixedModeOverlay as React.ReactElement;
+    return <NestContext.Provider value>{fixedModeOverlay}</NestContext.Provider>;
   };
 
   const getPlacement = () => {

--- a/components/dropdown/style/index.tsx
+++ b/components/dropdown/style/index.tsx
@@ -2,4 +2,5 @@ import '../../style/index.less';
 import './index.less';
 
 // style dependencies
+// deps-lint-skip: menu
 import '../../button/style';

--- a/components/menu/MenuContext.tsx
+++ b/components/menu/MenuContext.tsx
@@ -20,3 +20,12 @@ const MenuContext = createContext<MenuContextProps>({
 });
 
 export default MenuContext;
+
+/**
+ * @private Internal Usage, do not use!!!
+ *
+ *   Tell Menu that it's created in a nest content. Currently only the Dropdown use this.
+ *   `rc-dropdown` will modify Menu component `prefixCls` which should affect cssinjs logic, we need
+ *   tell Menu that do not inject style since Dropdown will handle it self.
+ */
+export const NestContext = createContext(false);


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [x] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

`rc-dropdown` 会注入 `overlay` 的 `prefixCls` 属性，在 less 下没有问题，但是在 cssinjs 下还会生成一份 `ant-dropdown-menu` 的样式导致和 `ant-dropdown` 的样式冲突。加一个 context 告诉 Menu 如果是被注入的就不要添加 cssinjs 样式。

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |       -    |
| 🇨🇳 Chinese |      -     |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
