### PR TITLE
fix: input onSearch trigger wrongly (#34844)

### DIFF
--- a/components/input/Search.tsx
+++ b/components/input/Search.tsx
@@ -34,11 +34,14 @@ const Search = React.forwardRef<InputRef, SearchProps>((props, ref) => {
     disabled,
     onSearch: customOnSearch,
     onChange: customOnChange,
+    onCompositionStart,
+    onCompositionEnd,
     ...restProps
   } = props;
 
   const { getPrefixCls, direction } = React.useContext(ConfigContext);
   const contextSize = React.useContext(SizeContext);
+  const composedRef = React.useRef<boolean>(false);
 
   const size = customizeSize || contextSize;
 
@@ -63,6 +66,13 @@ const Search = React.forwardRef<InputRef, SearchProps>((props, ref) => {
     if (customOnSearch) {
       customOnSearch(inputRef.current?.input?.value!, e);
     }
+  };
+
+  const onPressEnter = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (composedRef.current) {
+      return;
+    }
+    onSearch(e);
   };
 
   const prefixCls = getPrefixCls('input-search', customizePrefixCls);
@@ -127,12 +137,24 @@ const Search = React.forwardRef<InputRef, SearchProps>((props, ref) => {
     className,
   );
 
+  const handleOnCompositionStart: React.CompositionEventHandler<HTMLInputElement> = e => {
+    composedRef.current = true;
+    onCompositionStart?.(e);
+  };
+
+  const handleOnCompositionEnd: React.CompositionEventHandler<HTMLInputElement> = e => {
+    composedRef.current = false;
+    onCompositionEnd?.(e);
+  };
+
   return (
     <Input
       ref={composeRef<InputRef>(inputRef, ref)}
-      onPressEnter={onSearch}
+      onPressEnter={onPressEnter}
       {...restProps}
       size={size}
+      onCompositionStart={handleOnCompositionStart}
+      onCompositionEnd={handleOnCompositionEnd}
       prefixCls={inputPrefixCls}
       addonAfter={button}
       suffix={suffix}

--- a/components/input/__tests__/Search.test.js
+++ b/components/input/__tests__/Search.test.js
@@ -161,6 +161,26 @@ describe('Input.Search', () => {
     );
   });
 
+  // https://github.com/ant-design/ant-design/issues/34844
+  it('should not trigger onSearch when press enter using chinese inputting method', () => {
+    const onSearch = jest.fn();
+    const wrapper = mount(<Search defaultValue="search text" onSearch={onSearch} />);
+    wrapper.find('input').simulate('compositionStart');
+    wrapper.find('input').simulate('keydown', { key: 'Enter', keyCode: 13 });
+    expect(onSearch).not.toHaveBeenCalled();
+
+    wrapper.find('input').simulate('compositionEnd');
+    wrapper.find('input').simulate('keydown', { key: 'Enter', keyCode: 13 });
+    expect(onSearch).toHaveBeenCalledTimes(1);
+    expect(onSearch).toHaveBeenCalledWith(
+      'search text',
+      expect.objectContaining({
+        type: 'keydown',
+        preventDefault: expect.any(Function),
+      }),
+    );
+  });
+
   // https://github.com/ant-design/ant-design/issues/14785
   it('should support addonAfter', () => {
     const addonAfter = <span>Addon After</span>;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
https://github.com/ant-design/ant-design/issues/34844

### 💡 Background and solution

<strong>问题：</strong>Input.Search组件，在使用中文输入法输入后回车，会触发onSearch事件，这跟旧版本的表现不一致。同时，onSearch事件中使用的值跟input组件内的值也不一致。
<strong>解决：</strong>监听compositionStart和compositionEnd事件，在中文输入法输入状态下，回车不触发onSearch事件。
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      fix Input.Seach component wrongly trigger onSearch method when press enter using chinese inputting method    |
| 🇨🇳 Chinese |   修复Input.Search组件在中文输入法下输入enter键触发了onSearch     |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
