### PR TITLE
feat(Typography): copyable text  support format

### DIFF
--- a/components/typography/Base/index.tsx
+++ b/components/typography/Base/index.tsx
@@ -30,6 +30,7 @@ interface CopyConfig {
   onCopy?: (event?: React.MouseEvent<HTMLDivElement>) => void;
   icon?: React.ReactNode;
   tooltips?: boolean | React.ReactNode;
+  format?: 'text/plain' | 'text/html';
 }
 
 interface EditConfig {
@@ -189,6 +190,11 @@ const Base = React.forwardRef((props: InternalBlockProps, ref: any) => {
   const [copied, setCopied] = React.useState(false);
   const copyIdRef = React.useRef<NodeJS.Timeout>();
 
+  const copyOptions: Pick<CopyConfig, 'format'> = {};
+  if (copyConfig.format) {
+    copyOptions.format = copyConfig.format;
+  }
+
   const cleanCopyId = () => {
     clearTimeout(copyIdRef.current!);
   };
@@ -197,7 +203,7 @@ const Base = React.forwardRef((props: InternalBlockProps, ref: any) => {
     e?.preventDefault();
     e?.stopPropagation();
 
-    copy(copyConfig.text || String(children) || '');
+    copy(copyConfig.text || String(children) || '', copyOptions);
 
     setCopied(true);
 

--- a/components/typography/__tests__/index.test.js
+++ b/components/typography/__tests__/index.test.js
@@ -89,12 +89,12 @@ describe('Typography', () => {
 
   describe('Base', () => {
     describe('copyable', () => {
-      function copyTest(name, text, target, icon, tooltips) {
+      function copyTest(name, text, target, icon, tooltips, format) {
         it(name, async () => {
           jest.useFakeTimers();
           const onCopy = jest.fn();
           const wrapper = mount(
-            <Base component="p" copyable={{ text, onCopy, icon, tooltips }}>
+            <Base component="p" copyable={{ text, onCopy, icon, tooltips, format }}>
               test copy
             </Base>,
           );
@@ -132,6 +132,7 @@ describe('Typography', () => {
           }
 
           expect(copy.lastStr).toEqual(target);
+          expect(copy.lastOptions.format).toEqual(format);
           wrapper.update();
           expect(onCopy).toHaveBeenCalled();
 
@@ -173,6 +174,22 @@ describe('Typography', () => {
 
       copyTest('basic copy', undefined, 'test copy');
       copyTest('customize copy', 'bamboo', 'bamboo');
+      copyTest(
+        'costomize copy with plain text',
+        'bamboo',
+        'bamboo',
+        undefined,
+        undefined,
+        'text/plain',
+      );
+      copyTest(
+        'costomize copy with html text',
+        'bamboo',
+        'bamboo',
+        undefined,
+        undefined,
+        'text/html',
+      );
       copyTest('customize copy icon', 'bamboo', 'bamboo', <SmileOutlined />);
       copyTest('customize copy icon by pass array', 'bamboo', 'bamboo', [
         <SmileOutlined key="copy-icon" />,

--- a/components/typography/index.en-US.md
+++ b/components/typography/index.en-US.md
@@ -74,6 +74,7 @@ Basic text writing, including headings, body text, lists, and more.
       onCopy: function(event),
       icon: ReactNode,
       tooltips: false | [ReactNode, ReactNode],
+      format: 'text/plain' | 'text/html',
     }
 
 | Property | Description | Type | Default | Version |
@@ -81,6 +82,7 @@ Basic text writing, including headings, body text, lists, and more.
 | icon | Custom copy icon: \[copyIcon, copiedIcon] | \[ReactNode, ReactNode] | - | 4.6.0 |
 | text | The text to copy | string | - |  |
 | tooltips | Custom tooltip text, hide when it is false | \[ReactNode, ReactNode] | \[`Copy`, `Copied`] | 4.4.0 |
+| format | The Mime Type of the text | 'text/plain' \| 'text/html' | - | |
 | onCopy | Called when copied text | function | - |  |
 
 ### editable

--- a/components/typography/index.zh-CN.md
+++ b/components/typography/index.zh-CN.md
@@ -75,6 +75,7 @@ cover: https://gw.alipayobjects.com/zos/alicdn/GOM1KQ24O/Typography.svg
       onCopy: function(event),
       icon: ReactNode,
       tooltips: false | [ReactNode, ReactNode],
+      format: 'text/plain' | 'text/html',
     }
 
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
@@ -82,6 +83,7 @@ cover: https://gw.alipayobjects.com/zos/alicdn/GOM1KQ24O/Typography.svg
 | icon | 自定义拷贝图标：\[默认图标, 拷贝后的图标] | \[ReactNode, ReactNode] | - | 4.6.0 |
 | text | 拷贝到剪切板里的文本 | string | - |  |
 | tooltips | 自定义提示文案，为 false 时隐藏文案 | \[ReactNode, ReactNode] | \[`复制`, `复制成功`] | 4.4.0 |
+| format | 剪切板数据的 Mime Type | 'text/plain' \| 'text/html' | - | |
 | onCopy | 拷贝成功的回调函数 | function | - |  |
 
 ### editable

--- a/tests/__mocks__/copy-to-clipboard.js
+++ b/tests/__mocks__/copy-to-clipboard.js
@@ -1,5 +1,6 @@
-function copy(str) {
+function copy(str, options = {}) {
   copy.lastStr = str;
+  copy.lastOptions = options;
 }
 
 export default copy;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->
close #35182 
### 💡 Background and solution
use the format of `copy-to-clipboard` to reset clipboardData
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     The `copyable` prop of Typography.Paragraph supports to reset  the mime type of the clipboardData by the `format`   |
| 🇨🇳 Chinese |      Typography.Paragraph 的 copyable 属性支持 format 以重置剪切板数据的 Mime Type     |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
