### PR TITLE
fix: directory tree expand when defaultExpandParent is false (#34991)

### DIFF
--- a/components/tree/DirectoryTree.tsx
+++ b/components/tree/DirectoryTree.tsx
@@ -57,10 +57,12 @@ const DirectoryTree: React.ForwardRefRenderFunction<RcTree, DirectoryTreeProps> 
 
   React.useImperativeHandle(ref, () => treeRef.current!);
 
+  const hasDefaultExpandSetting = defaultExpandAll ?? defaultExpandParent ?? null;
+
   const getInitExpandedKeys = () => {
     const { keyEntities } = convertDataToEntities(getTreeData(props));
 
-    let initExpandedKeys: Key[];
+    let initExpandedKeys: Key[] = [];
 
     // Expanded keys
     if (defaultExpandAll) {
@@ -70,7 +72,7 @@ const DirectoryTree: React.ForwardRefRenderFunction<RcTree, DirectoryTreeProps> 
         props.expandedKeys || defaultExpandedKeys || [],
         keyEntities,
       );
-    } else {
+    } else if (hasDefaultExpandSetting === null) {
       initExpandedKeys = (props.expandedKeys || defaultExpandedKeys)!;
     }
     return initExpandedKeys;

--- a/components/tree/__tests__/__snapshots__/directory.test.tsx.snap
+++ b/components/tree/__tests__/__snapshots__/directory.test.tsx.snap
@@ -2605,3 +2605,180 @@ exports[`Directory Tree selectedKeys update 1`] = `
   </div>
 </div>
 `;
+
+exports[`Directory Tree should not expand when defaultExpandParent and defaultExpandAll is false 1`] = `
+<div
+  class="ant-tree ant-tree-block-node ant-tree-directory"
+  role="tree"
+>
+  <div>
+    <input
+      aria-label="for screen reader"
+      style="width:0;height:0;display:flex;overflow:hidden;opacity:0;border:0;padding:0;margin:0"
+      tabindex="0"
+      value=""
+    />
+  </div>
+  <div
+    aria-hidden="true"
+    class="ant-tree-treenode"
+    style="position:absolute;pointer-events:none;visibility:hidden;height:0;overflow:hidden"
+  >
+    <div
+      class="ant-tree-indent"
+    >
+      <div
+        class="ant-tree-indent-unit"
+      />
+    </div>
+  </div>
+  <div
+    class="ant-tree-list"
+    style="position:relative"
+  >
+    <div
+      class="ant-tree-list-holder"
+    >
+      <div>
+        <div
+          class="ant-tree-list-holder-inner"
+          style="display:flex;flex-direction:column"
+        >
+          <div
+            aria-grabbed="false"
+            class="ant-tree-treenode ant-tree-treenode-switcher-close"
+            draggable="false"
+          >
+            <span
+              aria-hidden="true"
+              class="ant-tree-indent"
+            />
+            <span
+              class="ant-tree-switcher ant-tree-switcher_close"
+            >
+              <span
+                aria-label="caret-down"
+                class="anticon anticon-caret-down ant-tree-switcher-icon"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-icon="caret-down"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="0 0 1024 1024"
+                  width="1em"
+                >
+                  <path
+                    d="M840.4 300H183.6c-19.7 0-30.7 20.8-18.5 35l328.4 380.8c9.4 10.9 27.5 10.9 37 0L858.9 335c12.2-14.2 1.2-35-18.5-35z"
+                  />
+                </svg>
+              </span>
+            </span>
+            <span
+              class="ant-tree-node-content-wrapper ant-tree-node-content-wrapper-close"
+              title="---"
+            >
+              <span
+                class="ant-tree-iconEle ant-tree-icon__customize"
+              >
+                <span
+                  aria-label="folder"
+                  class="anticon anticon-folder"
+                  role="img"
+                >
+                  <svg
+                    aria-hidden="true"
+                    data-icon="folder"
+                    fill="currentColor"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M880 298.4H521L403.7 186.2a8.15 8.15 0 00-5.5-2.2H144c-17.7 0-32 14.3-32 32v592c0 17.7 14.3 32 32 32h736c17.7 0 32-14.3 32-32V330.4c0-17.7-14.3-32-32-32zM840 768H184V256h188.5l119.6 114.4H840V768z"
+                    />
+                  </svg>
+                </span>
+              </span>
+              <span
+                class="ant-tree-title"
+              >
+                ---
+              </span>
+            </span>
+          </div>
+          <div
+            aria-grabbed="false"
+            class="ant-tree-treenode ant-tree-treenode-switcher-close ant-tree-treenode-leaf-last"
+            draggable="false"
+          >
+            <span
+              aria-hidden="true"
+              class="ant-tree-indent"
+            />
+            <span
+              class="ant-tree-switcher ant-tree-switcher_close"
+            >
+              <span
+                aria-label="caret-down"
+                class="anticon anticon-caret-down ant-tree-switcher-icon"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-icon="caret-down"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="0 0 1024 1024"
+                  width="1em"
+                >
+                  <path
+                    d="M840.4 300H183.6c-19.7 0-30.7 20.8-18.5 35l328.4 380.8c9.4 10.9 27.5 10.9 37 0L858.9 335c12.2-14.2 1.2-35-18.5-35z"
+                  />
+                </svg>
+              </span>
+            </span>
+            <span
+              class="ant-tree-node-content-wrapper ant-tree-node-content-wrapper-close"
+              title="---"
+            >
+              <span
+                class="ant-tree-iconEle ant-tree-icon__customize"
+              >
+                <span
+                  aria-label="folder"
+                  class="anticon anticon-folder"
+                  role="img"
+                >
+                  <svg
+                    aria-hidden="true"
+                    data-icon="folder"
+                    fill="currentColor"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M880 298.4H521L403.7 186.2a8.15 8.15 0 00-5.5-2.2H144c-17.7 0-32 14.3-32 32v592c0 17.7 14.3 32 32 32h736c17.7 0 32-14.3 32-32V330.4c0-17.7-14.3-32-32-32zM840 768H184V256h188.5l119.6 114.4H840V768z"
+                    />
+                  </svg>
+                </span>
+              </span>
+              <span
+                class="ant-tree-title"
+              >
+                ---
+              </span>
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/components/tree/__tests__/__snapshots__/directory.test.tsx.snap
+++ b/components/tree/__tests__/__snapshots__/directory.test.tsx.snap
@@ -2606,7 +2606,7 @@ exports[`Directory Tree selectedKeys update 1`] = `
 </div>
 `;
 
-exports[`Directory Tree should not expand when defaultExpandParent and defaultExpandAll is false 1`] = `
+exports[`Directory Tree should not expand when defaultExpandAll is false 1`] = `
 <div
   class="ant-tree ant-tree-block-node ant-tree-directory"
   role="tree"
@@ -2678,7 +2678,7 @@ exports[`Directory Tree should not expand when defaultExpandParent and defaultEx
             </span>
             <span
               class="ant-tree-node-content-wrapper ant-tree-node-content-wrapper-close"
-              title="---"
+              title="0-0"
             >
               <span
                 class="ant-tree-iconEle ant-tree-icon__customize"
@@ -2706,7 +2706,7 @@ exports[`Directory Tree should not expand when defaultExpandParent and defaultEx
               <span
                 class="ant-tree-title"
               >
-                ---
+                0-0
               </span>
             </span>
           </div>
@@ -2744,7 +2744,7 @@ exports[`Directory Tree should not expand when defaultExpandParent and defaultEx
             </span>
             <span
               class="ant-tree-node-content-wrapper ant-tree-node-content-wrapper-close"
-              title="---"
+              title="0-1"
             >
               <span
                 class="ant-tree-iconEle ant-tree-icon__customize"
@@ -2772,7 +2772,184 @@ exports[`Directory Tree should not expand when defaultExpandParent and defaultEx
               <span
                 class="ant-tree-title"
               >
-                ---
+                0-1
+              </span>
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Directory Tree should not expand when defaultExpandParent is false 1`] = `
+<div
+  class="ant-tree ant-tree-block-node ant-tree-directory"
+  role="tree"
+>
+  <div>
+    <input
+      aria-label="for screen reader"
+      style="width:0;height:0;display:flex;overflow:hidden;opacity:0;border:0;padding:0;margin:0"
+      tabindex="0"
+      value=""
+    />
+  </div>
+  <div
+    aria-hidden="true"
+    class="ant-tree-treenode"
+    style="position:absolute;pointer-events:none;visibility:hidden;height:0;overflow:hidden"
+  >
+    <div
+      class="ant-tree-indent"
+    >
+      <div
+        class="ant-tree-indent-unit"
+      />
+    </div>
+  </div>
+  <div
+    class="ant-tree-list"
+    style="position:relative"
+  >
+    <div
+      class="ant-tree-list-holder"
+    >
+      <div>
+        <div
+          class="ant-tree-list-holder-inner"
+          style="display:flex;flex-direction:column"
+        >
+          <div
+            aria-grabbed="false"
+            class="ant-tree-treenode ant-tree-treenode-switcher-close"
+            draggable="false"
+          >
+            <span
+              aria-hidden="true"
+              class="ant-tree-indent"
+            />
+            <span
+              class="ant-tree-switcher ant-tree-switcher_close"
+            >
+              <span
+                aria-label="caret-down"
+                class="anticon anticon-caret-down ant-tree-switcher-icon"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-icon="caret-down"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="0 0 1024 1024"
+                  width="1em"
+                >
+                  <path
+                    d="M840.4 300H183.6c-19.7 0-30.7 20.8-18.5 35l328.4 380.8c9.4 10.9 27.5 10.9 37 0L858.9 335c12.2-14.2 1.2-35-18.5-35z"
+                  />
+                </svg>
+              </span>
+            </span>
+            <span
+              class="ant-tree-node-content-wrapper ant-tree-node-content-wrapper-close"
+              title="0-0"
+            >
+              <span
+                class="ant-tree-iconEle ant-tree-icon__customize"
+              >
+                <span
+                  aria-label="folder"
+                  class="anticon anticon-folder"
+                  role="img"
+                >
+                  <svg
+                    aria-hidden="true"
+                    data-icon="folder"
+                    fill="currentColor"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M880 298.4H521L403.7 186.2a8.15 8.15 0 00-5.5-2.2H144c-17.7 0-32 14.3-32 32v592c0 17.7 14.3 32 32 32h736c17.7 0 32-14.3 32-32V330.4c0-17.7-14.3-32-32-32zM840 768H184V256h188.5l119.6 114.4H840V768z"
+                    />
+                  </svg>
+                </span>
+              </span>
+              <span
+                class="ant-tree-title"
+              >
+                0-0
+              </span>
+            </span>
+          </div>
+          <div
+            aria-grabbed="false"
+            class="ant-tree-treenode ant-tree-treenode-switcher-close ant-tree-treenode-leaf-last"
+            draggable="false"
+          >
+            <span
+              aria-hidden="true"
+              class="ant-tree-indent"
+            />
+            <span
+              class="ant-tree-switcher ant-tree-switcher_close"
+            >
+              <span
+                aria-label="caret-down"
+                class="anticon anticon-caret-down ant-tree-switcher-icon"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-icon="caret-down"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="0 0 1024 1024"
+                  width="1em"
+                >
+                  <path
+                    d="M840.4 300H183.6c-19.7 0-30.7 20.8-18.5 35l328.4 380.8c9.4 10.9 27.5 10.9 37 0L858.9 335c12.2-14.2 1.2-35-18.5-35z"
+                  />
+                </svg>
+              </span>
+            </span>
+            <span
+              class="ant-tree-node-content-wrapper ant-tree-node-content-wrapper-close"
+              title="0-1"
+            >
+              <span
+                class="ant-tree-iconEle ant-tree-icon__customize"
+              >
+                <span
+                  aria-label="folder"
+                  class="anticon anticon-folder"
+                  role="img"
+                >
+                  <svg
+                    aria-hidden="true"
+                    data-icon="folder"
+                    fill="currentColor"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M880 298.4H521L403.7 186.2a8.15 8.15 0 00-5.5-2.2H144c-17.7 0-32 14.3-32 32v592c0 17.7 14.3 32 32 32h736c17.7 0 32-14.3 32-32V330.4c0-17.7-14.3-32-32-32zM840 768H184V256h188.5l119.6 114.4H840V768z"
+                    />
+                  </svg>
+                </span>
+              </span>
+              <span
+                class="ant-tree-title"
+              >
+                0-1
               </span>
             </span>
           </div>

--- a/components/tree/__tests__/directory.test.tsx
+++ b/components/tree/__tests__/directory.test.tsx
@@ -162,12 +162,83 @@ describe('Directory Tree', () => {
     expect(asFragment().firstChild).toMatchSnapshot();
   });
 
-  it('should not expand when defaultExpandParent and defaultExpandAll is false', () => {
+  it('should not expand when defaultExpandParent is false', () => {
+    const treeData = [
+      {
+        key: '0-0',
+        title: '0-0',
+        children: [
+          {
+            key: '0-0-0',
+            title: '0-0-0',
+          },
+          {
+            key: '0-0-1',
+            title: '0-0-1',
+          },
+        ],
+      },
+      {
+        key: '0-1',
+        title: '0-1',
+        children: [
+          {
+            key: '0-1-0',
+            title: '0-1-0',
+          },
+          {
+            key: '0-1-1',
+            title: '0-1-1',
+          },
+        ],
+      },
+    ];
+    const wrapper = render(
+      createTree({
+        defaultExpandParent: false,
+        expandedKeys: ['0-0-0', '0-1-1'],
+        treeData,
+      }),
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should not expand when defaultExpandAll is false', () => {
+    const treeData = [
+      {
+        key: '0-0',
+        title: '0-0',
+        children: [
+          {
+            key: '0-0-0',
+            title: '0-0-0',
+          },
+          {
+            key: '0-0-1',
+            title: '0-0-1',
+          },
+        ],
+      },
+      {
+        key: '0-1',
+        title: '0-1',
+        children: [
+          {
+            key: '0-1-0',
+            title: '0-1-0',
+          },
+          {
+            key: '0-1-1',
+            title: '0-1-1',
+          },
+        ],
+      },
+    ];
     const wrapper = render(
       createTree({
         defaultExpandAll: false,
-        defaultExpandParent: false,
-        expandedKeys: ['0-0', '0-1'],
+        expandedKeys: ['0-0-0', '0-1-1'],
+        treeData,
       }),
     );
     expect(wrapper).toMatchSnapshot();

--- a/components/tree/__tests__/directory.test.tsx
+++ b/components/tree/__tests__/directory.test.tsx
@@ -162,6 +162,17 @@ describe('Directory Tree', () => {
     expect(asFragment().firstChild).toMatchSnapshot();
   });
 
+  it('should not expand when defaultExpandParent and defaultExpandAll is false', () => {
+    const wrapper = render(
+      createTree({
+        defaultExpandAll: false,
+        defaultExpandParent: false,
+        expandedKeys: ['0-0', '0-1'],
+      }),
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
+
   it('expandedKeys update', () => {
     const { rerender, asFragment } = render(createTree());
     rerender(createTree({ expandedKeys: ['0-1'] }));


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

#34991 

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     set not to expand at first mount if defaultExpandParent is false      |
| 🇨🇳 Chinese |     设置 defaultExpandParent 为 false 那么首次加载就不展开     |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
