### PR TITLE
test: transfer part of tooltip test case to testing library

### DIFF
--- a/components/tooltip/__tests__/tooltip.test.js
+++ b/components/tooltip/__tests__/tooltip.test.js
@@ -26,7 +26,7 @@ describe('Tooltip', () => {
     const onVisibleChange = jest.fn();
     const ref = React.createRef();
 
-    const wrapper = mount(
+    const { container, rerender } = render(
       <Tooltip
         title=""
         mouseEnterDelay={0}
@@ -39,34 +39,55 @@ describe('Tooltip', () => {
     );
 
     // `title` is empty.
-    const div = wrapper.find('#hello').at(0);
-    div.simulate('mouseenter');
+    const divElement = container.querySelector('#hello');
+    fireEvent.mouseEnter(divElement);
     expect(onVisibleChange).not.toHaveBeenCalled();
     expect(ref.current.props.visible).toBe(false);
 
-    div.simulate('mouseleave');
+    fireEvent.mouseLeave(divElement);
     expect(onVisibleChange).not.toHaveBeenCalled();
     expect(ref.current.props.visible).toBe(false);
 
     // update `title` value.
-    wrapper.setProps({ title: 'Have a nice day!' });
-    wrapper.find('#hello').simulate('mouseenter');
+    rerender(
+      <Tooltip
+        title="Have a nice day!"
+        mouseEnterDelay={0}
+        mouseLeaveDelay={0}
+        onVisibleChange={onVisibleChange}
+        ref={ref}
+      >
+        <div id="hello">Hello world!</div>
+      </Tooltip>,
+    );
+    fireEvent.mouseEnter(divElement);
     expect(onVisibleChange).toHaveBeenLastCalledWith(true);
     expect(ref.current.props.visible).toBe(true);
 
-    wrapper.find('#hello').simulate('mouseleave');
+    fireEvent.mouseLeave(divElement);
     expect(onVisibleChange).toHaveBeenLastCalledWith(false);
     expect(ref.current.props.visible).toBe(false);
 
     // add `visible` props.
-    wrapper.setProps({ visible: false });
-    wrapper.find('#hello').simulate('mouseenter');
+    rerender(
+      <Tooltip
+        title="Have a nice day!"
+        mouseEnterDelay={0}
+        mouseLeaveDelay={0}
+        onVisibleChange={onVisibleChange}
+        ref={ref}
+        visible={false}
+      >
+        <div id="hello">Hello world!</div>
+      </Tooltip>,
+    );
+    fireEvent.mouseEnter(divElement);
     expect(onVisibleChange).toHaveBeenLastCalledWith(true);
     const lastCount = onVisibleChange.mock.calls.length;
     expect(ref.current.props.visible).toBe(false);
 
     // always trigger onVisibleChange
-    wrapper.simulate('mouseleave');
+    fireEvent.mouseLeave(divElement);
     expect(onVisibleChange.mock.calls.length).toBe(lastCount); // no change with lastCount
     expect(ref.current.props.visible).toBe(false);
   });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

![image](https://user-images.githubusercontent.com/15316908/166384252-e3b58e54-8b49-4c7a-aeab-5281fa9f3795.png)
在组件 `tooltip` 的 `cssinjs` 重构中, 发现测试出现错误, 转换挂掉的`test case` , 使用`testing library` 即可恢复正常, 测试报错如上图, 修改仅涉及挂掉的case, 未改动其他部分.
### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      transfer part of tooltip test case to testing library     |
| 🇨🇳 Chinese |       转换tooltip的部分测试为testing library   |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
