### PR TITLE
Resolve Ant Design Notification component TypeScript error via adding…

### DIFF
--- a/components/notification/index.tsx
+++ b/components/notification/index.tsx
@@ -206,6 +206,7 @@ export interface ArgsProps {
   duration?: number | null;
   icon?: React.ReactNode;
   placement?: NotificationPlacement;
+  maxCount?: number;
   style?: React.CSSProperties;
   prefixCls?: string;
   className?: string;


### PR DESCRIPTION
Resolve Ant Design Notification component TypeScript error via adding maxCount as an ArgsProps property.

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [✓] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

https://github.com/ant-design/ant-design/issues/16107 - "Being able to provide all config options with method 2 would be nice"

### 💡 Background and solution

Per the below screenshot, at present TypeScript issues an error when a maxCount value is passed as a notification argument. 

![Pasted Graphic 6](https://user-images.githubusercontent.com/10634609/166440716-a94dcbfc-e098-46ca-a783-fef036eb2196.png)

For reference, the error: "Argument of type '{ message: string; description: string; duration: number; placement: NotificationPlacement | undefined; maxCount: number; }' is not assignable to parameter of type 'ArgsProps'.

Object literal may only specify known properties, and 'maxCount' does not exist in type 'ArgsProps'.ts(2345)"

The error is resolved via adding maxCount as a Notification component ArgsProps property.

### 📝 Changelog

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [✓] Doc is updated/provided or not needed
- [✓] Demo is updated/provided or not needed
- [✓] TypeScript definition is updated/provided or not needed
- [✓] Changelog is provided or not needed
