### PR TITLE
fix(<Row/>): wipe out unnecessary prop

### DIFF
--- a/components/auto-complete/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/auto-complete/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -522,9 +522,11 @@ exports[`renders ./components/auto-complete/demo/form-debug.md extend context co
 >
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
+      role="cell"
     >
       <label
         class=""
@@ -535,6 +537,7 @@ exports[`renders ./components/auto-complete/demo/form-debug.md extend context co
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -589,9 +592,11 @@ exports[`renders ./components/auto-complete/demo/form-debug.md extend context co
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
+      role="cell"
     >
       <label
         class=""
@@ -602,6 +607,7 @@ exports[`renders ./components/auto-complete/demo/form-debug.md extend context co
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -730,9 +736,11 @@ exports[`renders ./components/auto-complete/demo/form-debug.md extend context co
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
+      role="cell"
     >
       <label
         class=""
@@ -743,6 +751,7 @@ exports[`renders ./components/auto-complete/demo/form-debug.md extend context co
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -917,9 +926,11 @@ exports[`renders ./components/auto-complete/demo/form-debug.md extend context co
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
+      role="cell"
     >
       <label
         class=""
@@ -930,6 +941,7 @@ exports[`renders ./components/auto-complete/demo/form-debug.md extend context co
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -1011,9 +1023,11 @@ exports[`renders ./components/auto-complete/demo/form-debug.md extend context co
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
+      role="cell"
     >
       <label
         class=""
@@ -1024,6 +1038,7 @@ exports[`renders ./components/auto-complete/demo/form-debug.md extend context co
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -1225,9 +1240,11 @@ exports[`renders ./components/auto-complete/demo/form-debug.md extend context co
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
+      role="cell"
     >
       <label
         class=""
@@ -1238,6 +1255,7 @@ exports[`renders ./components/auto-complete/demo/form-debug.md extend context co
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -1448,9 +1466,11 @@ exports[`renders ./components/auto-complete/demo/form-debug.md extend context co
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
+      role="cell"
     >
       <label
         class=""
@@ -1461,6 +1481,7 @@ exports[`renders ./components/auto-complete/demo/form-debug.md extend context co
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"

--- a/components/auto-complete/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/auto-complete/__tests__/__snapshots__/demo.test.js.snap
@@ -174,9 +174,11 @@ exports[`renders ./components/auto-complete/demo/form-debug.md correctly 1`] = `
 >
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
+      role="cell"
     >
       <label
         class=""
@@ -187,6 +189,7 @@ exports[`renders ./components/auto-complete/demo/form-debug.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -227,9 +230,11 @@ exports[`renders ./components/auto-complete/demo/form-debug.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
+      role="cell"
     >
       <label
         class=""
@@ -240,6 +245,7 @@ exports[`renders ./components/auto-complete/demo/form-debug.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -308,9 +314,11 @@ exports[`renders ./components/auto-complete/demo/form-debug.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
+      role="cell"
     >
       <label
         class=""
@@ -321,6 +329,7 @@ exports[`renders ./components/auto-complete/demo/form-debug.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -421,9 +430,11 @@ exports[`renders ./components/auto-complete/demo/form-debug.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
+      role="cell"
     >
       <label
         class=""
@@ -434,6 +445,7 @@ exports[`renders ./components/auto-complete/demo/form-debug.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -501,9 +513,11 @@ exports[`renders ./components/auto-complete/demo/form-debug.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
+      role="cell"
     >
       <label
         class=""
@@ -514,6 +528,7 @@ exports[`renders ./components/auto-complete/demo/form-debug.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -641,9 +656,11 @@ exports[`renders ./components/auto-complete/demo/form-debug.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
+      role="cell"
     >
       <label
         class=""
@@ -654,6 +671,7 @@ exports[`renders ./components/auto-complete/demo/form-debug.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -790,9 +808,11 @@ exports[`renders ./components/auto-complete/demo/form-debug.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
+      role="cell"
     >
       <label
         class=""
@@ -803,6 +823,7 @@ exports[`renders ./components/auto-complete/demo/form-debug.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"

--- a/components/calendar/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/calendar/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -3185,10 +3185,12 @@ exports[`renders ./components/calendar/demo/customize-header.md extend context c
       </h4>
       <div
         class="ant-row"
+        role="row"
         style="margin-left:-4px;margin-right:-4px"
       >
         <div
           class="ant-col"
+          role="cell"
           style="padding-left:4px;padding-right:4px"
         >
           <div
@@ -3237,6 +3239,7 @@ exports[`renders ./components/calendar/demo/customize-header.md extend context c
         </div>
         <div
           class="ant-col"
+          role="cell"
           style="padding-left:4px;padding-right:4px"
         >
           <div
@@ -3687,6 +3690,7 @@ exports[`renders ./components/calendar/demo/customize-header.md extend context c
         </div>
         <div
           class="ant-col"
+          role="cell"
           style="padding-left:4px;padding-right:4px"
         >
           <div

--- a/components/calendar/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/calendar/__tests__/__snapshots__/demo.test.js.snap
@@ -1905,10 +1905,12 @@ exports[`renders ./components/calendar/demo/customize-header.md correctly 1`] = 
       </h4>
       <div
         class="ant-row"
+        role="row"
         style="margin-left:-4px;margin-right:-4px"
       >
         <div
           class="ant-col"
+          role="cell"
           style="padding-left:4px;padding-right:4px"
         >
           <div
@@ -1957,6 +1959,7 @@ exports[`renders ./components/calendar/demo/customize-header.md correctly 1`] = 
         </div>
         <div
           class="ant-col"
+          role="cell"
           style="padding-left:4px;padding-right:4px"
         >
           <div
@@ -2021,6 +2024,7 @@ exports[`renders ./components/calendar/demo/customize-header.md correctly 1`] = 
         </div>
         <div
           class="ant-col"
+          role="cell"
           style="padding-left:4px;padding-right:4px"
         >
           <div

--- a/components/card/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/card/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -931,7 +931,7 @@ Array [
             <div>
               <div
                 class="ant-tabs-dropdown"
-                style="opacity:0;pointer-events:none"
+                style="opacity:0"
               >
                 <ul
                   aria-label="expanded dropdown"
@@ -1085,7 +1085,7 @@ Array [
             <div>
               <div
                 class="ant-tabs-dropdown"
-                style="opacity:0;pointer-events:none"
+                style="opacity:0"
               >
                 <ul
                   aria-label="expanded dropdown"

--- a/components/card/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/card/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -233,10 +233,12 @@ exports[`renders ./components/card/demo/in-column.md extend context correctly 1`
 >
   <div
     class="ant-row"
+    role="row"
     style="margin-left:-8px;margin-right:-8px"
   >
     <div
       class="ant-col ant-col-8"
+      role="cell"
       style="padding-left:8px;padding-right:8px"
     >
       <div
@@ -264,6 +266,7 @@ exports[`renders ./components/card/demo/in-column.md extend context correctly 1`
     </div>
     <div
       class="ant-col ant-col-8"
+      role="cell"
       style="padding-left:8px;padding-right:8px"
     >
       <div
@@ -291,6 +294,7 @@ exports[`renders ./components/card/demo/in-column.md extend context correctly 1`
     </div>
     <div
       class="ant-col ant-col-8"
+      role="cell"
       style="padding-left:8px;padding-right:8px"
     >
       <div
@@ -434,10 +438,12 @@ Array [
       >
         <div
           class="ant-row"
+          role="row"
           style="margin-left:-4px;margin-right:-4px"
         >
           <div
             class="ant-col ant-col-22"
+            role="cell"
             style="padding-left:4px;padding-right:4px"
           >
             <div
@@ -447,10 +453,12 @@ Array [
         </div>
         <div
           class="ant-row"
+          role="row"
           style="margin-left:-4px;margin-right:-4px"
         >
           <div
             class="ant-col ant-col-8"
+            role="cell"
             style="padding-left:4px;padding-right:4px"
           >
             <div
@@ -459,6 +467,7 @@ Array [
           </div>
           <div
             class="ant-col ant-col-15"
+            role="cell"
             style="padding-left:4px;padding-right:4px"
           >
             <div
@@ -468,10 +477,12 @@ Array [
         </div>
         <div
           class="ant-row"
+          role="row"
           style="margin-left:-4px;margin-right:-4px"
         >
           <div
             class="ant-col ant-col-6"
+            role="cell"
             style="padding-left:4px;padding-right:4px"
           >
             <div
@@ -480,6 +491,7 @@ Array [
           </div>
           <div
             class="ant-col ant-col-18"
+            role="cell"
             style="padding-left:4px;padding-right:4px"
           >
             <div
@@ -489,10 +501,12 @@ Array [
         </div>
         <div
           class="ant-row"
+          role="row"
           style="margin-left:-4px;margin-right:-4px"
         >
           <div
             class="ant-col ant-col-13"
+            role="cell"
             style="padding-left:4px;padding-right:4px"
           >
             <div
@@ -501,6 +515,7 @@ Array [
           </div>
           <div
             class="ant-col ant-col-9"
+            role="cell"
             style="padding-left:4px;padding-right:4px"
           >
             <div
@@ -510,10 +525,12 @@ Array [
         </div>
         <div
           class="ant-row"
+          role="row"
           style="margin-left:-4px;margin-right:-4px"
         >
           <div
             class="ant-col ant-col-4"
+            role="cell"
             style="padding-left:4px;padding-right:4px"
           >
             <div
@@ -522,6 +539,7 @@ Array [
           </div>
           <div
             class="ant-col ant-col-3"
+            role="cell"
             style="padding-left:4px;padding-right:4px"
           >
             <div
@@ -530,6 +548,7 @@ Array [
           </div>
           <div
             class="ant-col ant-col-16"
+            role="cell"
             style="padding-left:4px;padding-right:4px"
           >
             <div
@@ -912,7 +931,7 @@ Array [
             <div>
               <div
                 class="ant-tabs-dropdown"
-                style="opacity:0"
+                style="opacity:0;pointer-events:none"
               >
                 <ul
                   aria-label="expanded dropdown"
@@ -1066,7 +1085,7 @@ Array [
             <div>
               <div
                 class="ant-tabs-dropdown"
-                style="opacity:0"
+                style="opacity:0;pointer-events:none"
               >
                 <ul
                   aria-label="expanded dropdown"

--- a/components/card/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/card/__tests__/__snapshots__/demo.test.js.snap
@@ -233,10 +233,12 @@ exports[`renders ./components/card/demo/in-column.md correctly 1`] = `
 >
   <div
     class="ant-row"
+    role="row"
     style="margin-left:-8px;margin-right:-8px"
   >
     <div
       class="ant-col ant-col-8"
+      role="cell"
       style="padding-left:8px;padding-right:8px"
     >
       <div
@@ -264,6 +266,7 @@ exports[`renders ./components/card/demo/in-column.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-8"
+      role="cell"
       style="padding-left:8px;padding-right:8px"
     >
       <div
@@ -291,6 +294,7 @@ exports[`renders ./components/card/demo/in-column.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-8"
+      role="cell"
       style="padding-left:8px;padding-right:8px"
     >
       <div
@@ -434,10 +438,12 @@ Array [
       >
         <div
           class="ant-row"
+          role="row"
           style="margin-left:-4px;margin-right:-4px"
         >
           <div
             class="ant-col ant-col-22"
+            role="cell"
             style="padding-left:4px;padding-right:4px"
           >
             <div
@@ -447,10 +453,12 @@ Array [
         </div>
         <div
           class="ant-row"
+          role="row"
           style="margin-left:-4px;margin-right:-4px"
         >
           <div
             class="ant-col ant-col-8"
+            role="cell"
             style="padding-left:4px;padding-right:4px"
           >
             <div
@@ -459,6 +467,7 @@ Array [
           </div>
           <div
             class="ant-col ant-col-15"
+            role="cell"
             style="padding-left:4px;padding-right:4px"
           >
             <div
@@ -468,10 +477,12 @@ Array [
         </div>
         <div
           class="ant-row"
+          role="row"
           style="margin-left:-4px;margin-right:-4px"
         >
           <div
             class="ant-col ant-col-6"
+            role="cell"
             style="padding-left:4px;padding-right:4px"
           >
             <div
@@ -480,6 +491,7 @@ Array [
           </div>
           <div
             class="ant-col ant-col-18"
+            role="cell"
             style="padding-left:4px;padding-right:4px"
           >
             <div
@@ -489,10 +501,12 @@ Array [
         </div>
         <div
           class="ant-row"
+          role="row"
           style="margin-left:-4px;margin-right:-4px"
         >
           <div
             class="ant-col ant-col-13"
+            role="cell"
             style="padding-left:4px;padding-right:4px"
           >
             <div
@@ -501,6 +515,7 @@ Array [
           </div>
           <div
             class="ant-col ant-col-9"
+            role="cell"
             style="padding-left:4px;padding-right:4px"
           >
             <div
@@ -510,10 +525,12 @@ Array [
         </div>
         <div
           class="ant-row"
+          role="row"
           style="margin-left:-4px;margin-right:-4px"
         >
           <div
             class="ant-col ant-col-4"
+            role="cell"
             style="padding-left:4px;padding-right:4px"
           >
             <div
@@ -522,6 +539,7 @@ Array [
           </div>
           <div
             class="ant-col ant-col-3"
+            role="cell"
             style="padding-left:4px;padding-right:4px"
           >
             <div
@@ -530,6 +548,7 @@ Array [
           </div>
           <div
             class="ant-col ant-col-16"
+            role="cell"
             style="padding-left:4px;padding-right:4px"
           >
             <div

--- a/components/card/__tests__/__snapshots__/index.test.js.snap
+++ b/components/card/__tests__/__snapshots__/index.test.js.snap
@@ -24,10 +24,12 @@ exports[`Card should still have padding when card which set padding to 0 is load
     >
       <div
         class="ant-row"
+        role="row"
         style="margin-left: -4px; margin-right: -4px;"
       >
         <div
           class="ant-col ant-col-22"
+          role="cell"
           style="padding-left: 4px; padding-right: 4px;"
         >
           <div
@@ -37,10 +39,12 @@ exports[`Card should still have padding when card which set padding to 0 is load
       </div>
       <div
         class="ant-row"
+        role="row"
         style="margin-left: -4px; margin-right: -4px;"
       >
         <div
           class="ant-col ant-col-8"
+          role="cell"
           style="padding-left: 4px; padding-right: 4px;"
         >
           <div
@@ -49,6 +53,7 @@ exports[`Card should still have padding when card which set padding to 0 is load
         </div>
         <div
           class="ant-col ant-col-15"
+          role="cell"
           style="padding-left: 4px; padding-right: 4px;"
         >
           <div
@@ -58,10 +63,12 @@ exports[`Card should still have padding when card which set padding to 0 is load
       </div>
       <div
         class="ant-row"
+        role="row"
         style="margin-left: -4px; margin-right: -4px;"
       >
         <div
           class="ant-col ant-col-6"
+          role="cell"
           style="padding-left: 4px; padding-right: 4px;"
         >
           <div
@@ -70,6 +77,7 @@ exports[`Card should still have padding when card which set padding to 0 is load
         </div>
         <div
           class="ant-col ant-col-18"
+          role="cell"
           style="padding-left: 4px; padding-right: 4px;"
         >
           <div
@@ -79,10 +87,12 @@ exports[`Card should still have padding when card which set padding to 0 is load
       </div>
       <div
         class="ant-row"
+        role="row"
         style="margin-left: -4px; margin-right: -4px;"
       >
         <div
           class="ant-col ant-col-13"
+          role="cell"
           style="padding-left: 4px; padding-right: 4px;"
         >
           <div
@@ -91,6 +101,7 @@ exports[`Card should still have padding when card which set padding to 0 is load
         </div>
         <div
           class="ant-col ant-col-9"
+          role="cell"
           style="padding-left: 4px; padding-right: 4px;"
         >
           <div
@@ -100,10 +111,12 @@ exports[`Card should still have padding when card which set padding to 0 is load
       </div>
       <div
         class="ant-row"
+        role="row"
         style="margin-left: -4px; margin-right: -4px;"
       >
         <div
           class="ant-col ant-col-4"
+          role="cell"
           style="padding-left: 4px; padding-right: 4px;"
         >
           <div
@@ -112,6 +125,7 @@ exports[`Card should still have padding when card which set padding to 0 is load
         </div>
         <div
           class="ant-col ant-col-3"
+          role="cell"
           style="padding-left: 4px; padding-right: 4px;"
         >
           <div
@@ -120,6 +134,7 @@ exports[`Card should still have padding when card which set padding to 0 is load
         </div>
         <div
           class="ant-col ant-col-16"
+          role="cell"
           style="padding-left: 4px; padding-right: 4px;"
         >
           <div

--- a/components/checkbox/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/checkbox/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -606,9 +606,11 @@ exports[`renders ./components/checkbox/demo/layout.md extend context correctly 1
 >
   <div
     class="ant-row"
+    role="row"
   >
     <div
       class="ant-col ant-col-8"
+      role="cell"
     >
       <label
         class="ant-checkbox-wrapper"
@@ -632,6 +634,7 @@ exports[`renders ./components/checkbox/demo/layout.md extend context correctly 1
     </div>
     <div
       class="ant-col ant-col-8"
+      role="cell"
     >
       <label
         class="ant-checkbox-wrapper"
@@ -655,6 +658,7 @@ exports[`renders ./components/checkbox/demo/layout.md extend context correctly 1
     </div>
     <div
       class="ant-col ant-col-8"
+      role="cell"
     >
       <label
         class="ant-checkbox-wrapper"
@@ -678,6 +682,7 @@ exports[`renders ./components/checkbox/demo/layout.md extend context correctly 1
     </div>
     <div
       class="ant-col ant-col-8"
+      role="cell"
     >
       <label
         class="ant-checkbox-wrapper"
@@ -701,6 +706,7 @@ exports[`renders ./components/checkbox/demo/layout.md extend context correctly 1
     </div>
     <div
       class="ant-col ant-col-8"
+      role="cell"
     >
       <label
         class="ant-checkbox-wrapper"

--- a/components/checkbox/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/checkbox/__tests__/__snapshots__/demo.test.js.snap
@@ -606,9 +606,11 @@ exports[`renders ./components/checkbox/demo/layout.md correctly 1`] = `
 >
   <div
     class="ant-row"
+    role="row"
   >
     <div
       class="ant-col ant-col-8"
+      role="cell"
     >
       <label
         class="ant-checkbox-wrapper"
@@ -632,6 +634,7 @@ exports[`renders ./components/checkbox/demo/layout.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-8"
+      role="cell"
     >
       <label
         class="ant-checkbox-wrapper"
@@ -655,6 +658,7 @@ exports[`renders ./components/checkbox/demo/layout.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-8"
+      role="cell"
     >
       <label
         class="ant-checkbox-wrapper"
@@ -678,6 +682,7 @@ exports[`renders ./components/checkbox/demo/layout.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-8"
+      role="cell"
     >
       <label
         class="ant-checkbox-wrapper"
@@ -701,6 +706,7 @@ exports[`renders ./components/checkbox/demo/layout.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-8"
+      role="cell"
     >
       <label
         class="ant-checkbox-wrapper"

--- a/components/comment/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/comment/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -216,9 +216,11 @@ exports[`renders ./components/comment/demo/editor.md extend context correctly 1`
       >
         <div
           class="ant-row ant-form-item"
+          role="row"
         >
           <div
             class="ant-col ant-form-item-control"
+            role="cell"
           >
             <div
               class="ant-form-item-control-input"
@@ -236,9 +238,11 @@ exports[`renders ./components/comment/demo/editor.md extend context correctly 1`
         </div>
         <div
           class="ant-row ant-form-item"
+          role="row"
         >
           <div
             class="ant-col ant-form-item-control"
+            role="cell"
           >
             <div
               class="ant-form-item-control-input"

--- a/components/comment/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/comment/__tests__/__snapshots__/demo.test.js.snap
@@ -144,9 +144,11 @@ exports[`renders ./components/comment/demo/editor.md correctly 1`] = `
       >
         <div
           class="ant-row ant-form-item"
+          role="row"
         >
           <div
             class="ant-col ant-form-item-control"
+            role="cell"
           >
             <div
               class="ant-form-item-control-input"
@@ -164,9 +166,11 @@ exports[`renders ./components/comment/demo/editor.md correctly 1`] = `
         </div>
         <div
           class="ant-row ant-form-item"
+          role="row"
         >
           <div
             class="ant-col ant-form-item-control"
+            role="cell"
           >
             <div
               class="ant-form-item-control-input"

--- a/components/config-provider/__tests__/__snapshots__/components.test.js.snap
+++ b/components/config-provider/__tests__/__snapshots__/components.test.js.snap
@@ -13368,9 +13368,11 @@ exports[`ConfigProvider components Form configProvider 1`] = `
 >
   <div
     class="config-row config-form-item config-form-item-with-help config-form-item-has-error"
+    role="row"
   >
     <div
       class="config-col config-form-item-control"
+      role="cell"
     >
       <div
         class="config-form-item-control-input"
@@ -13406,9 +13408,11 @@ exports[`ConfigProvider components Form configProvider componentSize large 1`] =
 >
   <div
     class="config-row config-form-item config-form-item-with-help config-form-item-has-error"
+    role="row"
   >
     <div
       class="config-col config-form-item-control"
+      role="cell"
     >
       <div
         class="config-form-item-control-input"
@@ -13444,9 +13448,11 @@ exports[`ConfigProvider components Form configProvider componentSize middle 1`] 
 >
   <div
     class="config-row config-form-item config-form-item-with-help config-form-item-has-error"
+    role="row"
   >
     <div
       class="config-col config-form-item-control"
+      role="cell"
     >
       <div
         class="config-form-item-control-input"
@@ -13482,9 +13488,11 @@ exports[`ConfigProvider components Form configProvider virtual and dropdownMatch
 >
   <div
     class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-error"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -13520,9 +13528,11 @@ exports[`ConfigProvider components Form normal 1`] = `
 >
   <div
     class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-error"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -13558,9 +13568,11 @@ exports[`ConfigProvider components Form prefixCls 1`] = `
 >
   <div
     class="ant-row prefix-Form-item prefix-Form-item-with-help prefix-Form-item-has-error"
+    role="row"
   >
     <div
       class="ant-col prefix-Form-item-control"
+      role="cell"
     >
       <div
         class="prefix-Form-item-control-input"
@@ -13593,9 +13605,11 @@ exports[`ConfigProvider components Form prefixCls 1`] = `
 exports[`ConfigProvider components Grid configProvider 1`] = `
 <div
   class="config-row"
+  role="row"
 >
   <div
     class="config-col config-col-1"
+    role="cell"
   />
 </div>
 `;
@@ -13603,9 +13617,11 @@ exports[`ConfigProvider components Grid configProvider 1`] = `
 exports[`ConfigProvider components Grid configProvider componentSize large 1`] = `
 <div
   class="config-row"
+  role="row"
 >
   <div
     class="config-col config-col-1"
+    role="cell"
   />
 </div>
 `;
@@ -13613,9 +13629,11 @@ exports[`ConfigProvider components Grid configProvider componentSize large 1`] =
 exports[`ConfigProvider components Grid configProvider componentSize middle 1`] = `
 <div
   class="config-row"
+  role="row"
 >
   <div
     class="config-col config-col-1"
+    role="cell"
   />
 </div>
 `;
@@ -13623,9 +13641,11 @@ exports[`ConfigProvider components Grid configProvider componentSize middle 1`] 
 exports[`ConfigProvider components Grid configProvider virtual and dropdownMatchSelectWidth 1`] = `
 <div
   class="ant-row"
+  role="row"
 >
   <div
     class="ant-col ant-col-1"
+    role="cell"
   />
 </div>
 `;
@@ -13633,9 +13653,11 @@ exports[`ConfigProvider components Grid configProvider virtual and dropdownMatch
 exports[`ConfigProvider components Grid normal 1`] = `
 <div
   class="ant-row"
+  role="row"
 >
   <div
     class="ant-col ant-col-1"
+    role="cell"
   />
 </div>
 `;
@@ -13643,9 +13665,11 @@ exports[`ConfigProvider components Grid normal 1`] = `
 exports[`ConfigProvider components Grid prefixCls 1`] = `
 <div
   class="prefix-row"
+  role="row"
 >
   <div
     class="prefix-col prefix-col-1"
+    role="cell"
   />
 </div>
 `;

--- a/components/config-provider/__tests__/__snapshots__/form.test.js.snap
+++ b/components/config-provider/__tests__/__snapshots__/form.test.js.snap
@@ -6,9 +6,11 @@ exports[`ConfigProvider.Form form requiredMark set requiredMark optional 1`] = `
 >
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
+      role="cell"
     >
       <label
         class="ant-form-item-required-mark-optional"
@@ -26,6 +28,7 @@ exports[`ConfigProvider.Form form requiredMark set requiredMark optional 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"

--- a/components/form/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/form/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -121,7 +121,7 @@ exports[`renders ./components/form/demo/advanced-search.md extend context correc
                   <div>
                     <div
                       class="ant-select-dropdown"
-                      style="opacity:0;pointer-events:none"
+                      style="opacity:0"
                     >
                       <div>
                         <div
@@ -385,7 +385,7 @@ exports[`renders ./components/form/demo/advanced-search.md extend context correc
                   <div>
                     <div
                       class="ant-select-dropdown"
-                      style="opacity:0;pointer-events:none"
+                      style="opacity:0"
                     >
                       <div>
                         <div
@@ -1157,7 +1157,7 @@ exports[`renders ./components/form/demo/control-hooks.md extend context correctl
             <div>
               <div
                 class="ant-select-dropdown"
-                style="opacity:0;pointer-events:none"
+                style="opacity:0"
               >
                 <div>
                   <div
@@ -1431,7 +1431,7 @@ exports[`renders ./components/form/demo/control-ref.md extend context correctly 
             <div>
               <div
                 class="ant-select-dropdown"
-                style="opacity:0;pointer-events:none"
+                style="opacity:0"
               >
                 <div>
                   <div
@@ -1677,7 +1677,7 @@ exports[`renders ./components/form/demo/customized-form-controls.md extend conte
               <div>
                 <div
                   class="ant-select-dropdown"
-                  style="opacity:0;pointer-events:none"
+                  style="opacity:0"
                 >
                   <div>
                     <div
@@ -2740,7 +2740,7 @@ exports[`renders ./components/form/demo/dynamic-form-items-complex.md extend con
             <div>
               <div
                 class="ant-select-dropdown"
-                style="opacity:0;pointer-events:none"
+                style="opacity:0"
               >
                 <div>
                   <div
@@ -4768,7 +4768,7 @@ exports[`renders ./components/form/demo/register.md extend context correctly 1`]
         <div>
           <div
             class="ant-tooltip"
-            style="opacity:0;pointer-events:none"
+            style="opacity:0"
           >
             <div
               class="ant-tooltip-content"
@@ -4872,7 +4872,7 @@ exports[`renders ./components/form/demo/register.md extend context correctly 1`]
             <div>
               <div
                 class="ant-select-dropdown ant-cascader-dropdown"
-                style="opacity:0;pointer-events:none;min-width:auto"
+                style="opacity:0;min-width:auto"
               >
                 <div>
                   <div
@@ -5089,7 +5089,7 @@ exports[`renders ./components/form/demo/register.md extend context correctly 1`]
                   <div>
                     <div
                       class="ant-select-dropdown"
-                      style="opacity:0;pointer-events:none"
+                      style="opacity:0"
                     >
                       <div>
                         <div
@@ -5352,7 +5352,7 @@ exports[`renders ./components/form/demo/register.md extend context correctly 1`]
                   <div>
                     <div
                       class="ant-select-dropdown"
-                      style="opacity:0;pointer-events:none"
+                      style="opacity:0"
                     >
                       <div>
                         <div
@@ -5523,7 +5523,7 @@ exports[`renders ./components/form/demo/register.md extend context correctly 1`]
             <div>
               <div
                 class="ant-select-dropdown ant-select-dropdown-empty"
-                style="opacity:0;pointer-events:none"
+                style="opacity:0"
               >
                 <div>
                   <div
@@ -5639,7 +5639,7 @@ exports[`renders ./components/form/demo/register.md extend context correctly 1`]
             <div>
               <div
                 class="ant-select-dropdown"
-                style="opacity:0;pointer-events:none"
+                style="opacity:0"
               >
                 <div>
                   <div
@@ -6045,7 +6045,7 @@ exports[`renders ./components/form/demo/required-mark.md extend context correctl
         <div>
           <div
             class="ant-tooltip"
-            style="opacity:0;pointer-events:none"
+            style="opacity:0"
           >
             <div
               class="ant-tooltip-content"
@@ -6127,7 +6127,7 @@ exports[`renders ./components/form/demo/required-mark.md extend context correctl
         <div>
           <div
             class="ant-tooltip"
-            style="opacity:0;pointer-events:none"
+            style="opacity:0"
           >
             <div
               class="ant-tooltip-content"
@@ -6393,7 +6393,7 @@ exports[`renders ./components/form/demo/size.md extend context correctly 1`] = `
             <div>
               <div
                 class="ant-select-dropdown"
-                style="opacity:0;pointer-events:none"
+                style="opacity:0"
               >
                 <div>
                   <div
@@ -6534,7 +6534,7 @@ exports[`renders ./components/form/demo/size.md extend context correctly 1`] = `
             <div>
               <div
                 class="ant-select-dropdown ant-tree-select-dropdown"
-                style="opacity:0;pointer-events:none"
+                style="opacity:0"
               >
                 <div>
                   <div>
@@ -6715,7 +6715,7 @@ exports[`renders ./components/form/demo/size.md extend context correctly 1`] = `
             <div>
               <div
                 class="ant-select-dropdown ant-cascader-dropdown"
-                style="opacity:0;pointer-events:none;min-width:auto"
+                style="opacity:0;min-width:auto"
               >
                 <div>
                   <div
@@ -6864,7 +6864,7 @@ exports[`renders ./components/form/demo/size.md extend context correctly 1`] = `
           <div>
             <div
               class="ant-picker-dropdown"
-              style="opacity:0;pointer-events:none"
+              style="opacity:0"
             >
               <div
                 class="ant-picker-panel-container"
@@ -7677,7 +7677,7 @@ exports[`renders ./components/form/demo/time-related-controls.md extend context 
           <div>
             <div
               class="ant-picker-dropdown"
-              style="opacity:0;pointer-events:none"
+              style="opacity:0"
             >
               <div
                 class="ant-picker-panel-container"
@@ -8301,7 +8301,7 @@ exports[`renders ./components/form/demo/time-related-controls.md extend context 
           <div>
             <div
               class="ant-picker-dropdown"
-              style="opacity:0;pointer-events:none"
+              style="opacity:0"
             >
               <div
                 class="ant-picker-panel-container"
@@ -10278,7 +10278,7 @@ exports[`renders ./components/form/demo/time-related-controls.md extend context 
           <div>
             <div
               class="ant-picker-dropdown"
-              style="opacity:0;pointer-events:none"
+              style="opacity:0"
             >
               <div
                 class="ant-picker-panel-container"
@@ -10580,7 +10580,7 @@ exports[`renders ./components/form/demo/time-related-controls.md extend context 
           <div>
             <div
               class="ant-picker-dropdown ant-picker-dropdown-range"
-              style="opacity:0;pointer-events:none"
+              style="opacity:0"
             >
               <div
                 class="ant-picker-range-wrapper ant-picker-date-range-wrapper"
@@ -11789,7 +11789,7 @@ exports[`renders ./components/form/demo/time-related-controls.md extend context 
           <div>
             <div
               class="ant-picker-dropdown ant-picker-dropdown-range"
-              style="opacity:0;pointer-events:none"
+              style="opacity:0"
             >
               <div
                 class="ant-picker-range-wrapper ant-picker-date-range-wrapper"
@@ -13774,7 +13774,7 @@ exports[`renders ./components/form/demo/time-related-controls.md extend context 
           <div>
             <div
               class="ant-picker-dropdown"
-              style="opacity:0;pointer-events:none"
+              style="opacity:0"
             >
               <div
                 class="ant-picker-panel-container"
@@ -15426,7 +15426,7 @@ exports[`renders ./components/form/demo/validate-other.md extend context correct
             <div>
               <div
                 class="ant-select-dropdown"
-                style="opacity:0;pointer-events:none"
+                style="opacity:0"
               >
                 <div>
                   <div
@@ -15613,7 +15613,7 @@ exports[`renders ./components/form/demo/validate-other.md extend context correct
             <div>
               <div
                 class="ant-select-dropdown"
-                style="opacity:0;pointer-events:none"
+                style="opacity:0"
               >
                 <div>
                   <div
@@ -15928,7 +15928,7 @@ exports[`renders ./components/form/demo/validate-other.md extend context correct
             <div>
               <div
                 class="ant-tooltip ant-slider-tooltip"
-                style="opacity:0;pointer-events:none"
+                style="opacity:0"
               >
                 <div
                   class="ant-tooltip-content"
@@ -17390,7 +17390,7 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
           <div>
             <div
               class="ant-picker-dropdown"
-              style="opacity:0;pointer-events:none"
+              style="opacity:0"
             >
               <div
                 class="ant-picker-panel-container"
@@ -18039,7 +18039,7 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
           <div>
             <div
               class="ant-picker-dropdown"
-              style="opacity:0;pointer-events:none"
+              style="opacity:0"
             >
               <div
                 class="ant-picker-panel-container"
@@ -19538,7 +19538,7 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
           <div>
             <div
               class="ant-picker-dropdown ant-picker-dropdown-range"
-              style="opacity:0;pointer-events:none"
+              style="opacity:0"
             >
               <div
                 class="ant-picker-range-wrapper ant-picker-date-range-wrapper"
@@ -20695,7 +20695,7 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
             <div>
               <div
                 class="ant-select-dropdown"
-                style="opacity:0;pointer-events:none"
+                style="opacity:0"
               >
                 <div>
                   <div
@@ -20903,7 +20903,7 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
             <div>
               <div
                 class="ant-select-dropdown ant-cascader-dropdown"
-                style="opacity:0;pointer-events:none;min-width:auto"
+                style="opacity:0;min-width:auto"
               >
                 <div>
                   <div
@@ -21053,7 +21053,7 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
             <div>
               <div
                 class="ant-select-dropdown ant-tree-select-dropdown"
-                style="opacity:0;pointer-events:none"
+                style="opacity:0"
               >
                 <div>
                   <div>
@@ -21274,7 +21274,7 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
                   <div>
                     <div
                       class="ant-picker-dropdown"
-                      style="opacity:0;pointer-events:none"
+                      style="opacity:0"
                     >
                       <div
                         class="ant-picker-panel-container"
@@ -21901,7 +21901,7 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
                   <div>
                     <div
                       class="ant-picker-dropdown"
-                      style="opacity:0;pointer-events:none"
+                      style="opacity:0"
                     >
                       <div
                         class="ant-picker-panel-container"

--- a/components/form/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/form/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -8,17 +8,21 @@ exports[`renders ./components/form/demo/advanced-search.md extend context correc
   >
     <div
       class="ant-row"
+      role="row"
       style="margin-left:-12px;margin-right:-12px"
     >
       <div
         class="ant-col ant-col-8"
+        role="cell"
         style="padding-left:12px;padding-right:12px"
       >
         <div
           class="ant-row ant-form-item"
+          role="row"
         >
           <div
             class="ant-col ant-form-item-label"
+            role="cell"
           >
             <label
               class="ant-form-item-required"
@@ -30,6 +34,7 @@ exports[`renders ./components/form/demo/advanced-search.md extend context correc
           </div>
           <div
             class="ant-col ant-form-item-control"
+            role="cell"
           >
             <div
               class="ant-form-item-control-input"
@@ -51,13 +56,16 @@ exports[`renders ./components/form/demo/advanced-search.md extend context correc
       </div>
       <div
         class="ant-col ant-col-8"
+        role="cell"
         style="padding-left:12px;padding-right:12px"
       >
         <div
           class="ant-row ant-form-item"
+          role="row"
         >
           <div
             class="ant-col ant-form-item-label"
+            role="cell"
           >
             <label
               class="ant-form-item-required"
@@ -69,6 +77,7 @@ exports[`renders ./components/form/demo/advanced-search.md extend context correc
           </div>
           <div
             class="ant-col ant-form-item-control"
+            role="cell"
           >
             <div
               class="ant-form-item-control-input"
@@ -112,7 +121,7 @@ exports[`renders ./components/form/demo/advanced-search.md extend context correc
                   <div>
                     <div
                       class="ant-select-dropdown"
-                      style="opacity:0"
+                      style="opacity:0;pointer-events:none"
                     >
                       <div>
                         <div
@@ -225,13 +234,16 @@ exports[`renders ./components/form/demo/advanced-search.md extend context correc
       </div>
       <div
         class="ant-col ant-col-8"
+        role="cell"
         style="padding-left:12px;padding-right:12px"
       >
         <div
           class="ant-row ant-form-item"
+          role="row"
         >
           <div
             class="ant-col ant-form-item-label"
+            role="cell"
           >
             <label
               class="ant-form-item-required"
@@ -243,6 +255,7 @@ exports[`renders ./components/form/demo/advanced-search.md extend context correc
           </div>
           <div
             class="ant-col ant-form-item-control"
+            role="cell"
           >
             <div
               class="ant-form-item-control-input"
@@ -264,13 +277,16 @@ exports[`renders ./components/form/demo/advanced-search.md extend context correc
       </div>
       <div
         class="ant-col ant-col-8"
+        role="cell"
         style="padding-left:12px;padding-right:12px"
       >
         <div
           class="ant-row ant-form-item"
+          role="row"
         >
           <div
             class="ant-col ant-form-item-label"
+            role="cell"
           >
             <label
               class="ant-form-item-required"
@@ -282,6 +298,7 @@ exports[`renders ./components/form/demo/advanced-search.md extend context correc
           </div>
           <div
             class="ant-col ant-form-item-control"
+            role="cell"
           >
             <div
               class="ant-form-item-control-input"
@@ -303,13 +320,16 @@ exports[`renders ./components/form/demo/advanced-search.md extend context correc
       </div>
       <div
         class="ant-col ant-col-8"
+        role="cell"
         style="padding-left:12px;padding-right:12px"
       >
         <div
           class="ant-row ant-form-item"
+          role="row"
         >
           <div
             class="ant-col ant-form-item-label"
+            role="cell"
           >
             <label
               class="ant-form-item-required"
@@ -321,6 +341,7 @@ exports[`renders ./components/form/demo/advanced-search.md extend context correc
           </div>
           <div
             class="ant-col ant-form-item-control"
+            role="cell"
           >
             <div
               class="ant-form-item-control-input"
@@ -364,7 +385,7 @@ exports[`renders ./components/form/demo/advanced-search.md extend context correc
                   <div>
                     <div
                       class="ant-select-dropdown"
-                      style="opacity:0"
+                      style="opacity:0;pointer-events:none"
                     >
                       <div>
                         <div
@@ -477,13 +498,16 @@ exports[`renders ./components/form/demo/advanced-search.md extend context correc
       </div>
       <div
         class="ant-col ant-col-8"
+        role="cell"
         style="padding-left:12px;padding-right:12px"
       >
         <div
           class="ant-row ant-form-item"
+          role="row"
         >
           <div
             class="ant-col ant-form-item-label"
+            role="cell"
           >
             <label
               class="ant-form-item-required"
@@ -495,6 +519,7 @@ exports[`renders ./components/form/demo/advanced-search.md extend context correc
           </div>
           <div
             class="ant-col ant-form-item-control"
+            role="cell"
           >
             <div
               class="ant-form-item-control-input"
@@ -517,9 +542,11 @@ exports[`renders ./components/form/demo/advanced-search.md extend context correc
     </div>
     <div
       class="ant-row"
+      role="row"
     >
       <div
         class="ant-col ant-col-24"
+        role="cell"
         style="text-align:right"
       >
         <button
@@ -582,9 +609,11 @@ exports[`renders ./components/form/demo/basic.md extend context correctly 1`] = 
 >
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-8 ant-form-item-label"
+      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -596,6 +625,7 @@ exports[`renders ./components/form/demo/basic.md extend context correctly 1`] = 
     </div>
     <div
       class="ant-col ant-col-16 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -615,9 +645,11 @@ exports[`renders ./components/form/demo/basic.md extend context correctly 1`] = 
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-8 ant-form-item-label"
+      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -629,6 +661,7 @@ exports[`renders ./components/form/demo/basic.md extend context correctly 1`] = 
     </div>
     <div
       class="ant-col ant-col-16 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -680,9 +713,11 @@ exports[`renders ./components/form/demo/basic.md extend context correctly 1`] = 
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-16 ant-col-offset-8 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -716,9 +751,11 @@ exports[`renders ./components/form/demo/basic.md extend context correctly 1`] = 
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-16 ant-col-offset-8 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -750,9 +787,11 @@ Array [
   >
     <div
       class="ant-row ant-form-item"
+      role="row"
     >
       <div
         class="ant-col ant-col-24 ant-form-item-label"
+        role="cell"
       >
         <label
           class="ant-form-item-required"
@@ -764,6 +803,7 @@ Array [
       </div>
       <div
         class="ant-col ant-col-24 ant-form-item-control"
+        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -783,9 +823,11 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
+      role="row"
     >
       <div
         class="ant-col ant-col-24 ant-form-item-label"
+        role="cell"
       >
         <label
           class="ant-form-item-required"
@@ -797,6 +839,7 @@ Array [
       </div>
       <div
         class="ant-col ant-col-24 ant-form-item-control"
+        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -848,9 +891,11 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
+      role="row"
     >
       <div
         class="ant-col ant-col-24 ant-form-item-control"
+        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -878,9 +923,11 @@ Array [
   >
     <div
       class="ant-row ant-form-item"
+      role="row"
     >
       <div
         class="ant-col ant-form-item-label ant-col-sm-24 ant-col-xl-24"
+        role="cell"
       >
         <label
           class="ant-form-item-required"
@@ -892,6 +939,7 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control ant-col-sm-24 ant-col-xl-24"
+        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -911,9 +959,11 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
+      role="row"
     >
       <div
         class="ant-col ant-form-item-label ant-col-sm-24 ant-col-xl-24"
+        role="cell"
       >
         <label
           class="ant-form-item-required"
@@ -925,6 +975,7 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control ant-col-sm-24 ant-col-xl-24"
+        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -976,9 +1027,11 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
+      role="row"
     >
       <div
         class="ant-col ant-form-item-control ant-col-sm-24 ant-col-xl-24"
+        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -1009,9 +1062,11 @@ exports[`renders ./components/form/demo/control-hooks.md extend context correctl
 >
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-8 ant-form-item-label"
+      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -1023,6 +1078,7 @@ exports[`renders ./components/form/demo/control-hooks.md extend context correctl
     </div>
     <div
       class="ant-col ant-col-16 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -1042,9 +1098,11 @@ exports[`renders ./components/form/demo/control-hooks.md extend context correctl
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-8 ant-form-item-label"
+      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -1056,6 +1114,7 @@ exports[`renders ./components/form/demo/control-hooks.md extend context correctl
     </div>
     <div
       class="ant-col ant-col-16 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -1098,7 +1157,7 @@ exports[`renders ./components/form/demo/control-hooks.md extend context correctl
             <div>
               <div
                 class="ant-select-dropdown"
-                style="opacity:0"
+                style="opacity:0;pointer-events:none"
               >
                 <div>
                   <div
@@ -1227,9 +1286,11 @@ exports[`renders ./components/form/demo/control-hooks.md extend context correctl
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-16 ant-col-offset-8 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -1275,9 +1336,11 @@ exports[`renders ./components/form/demo/control-ref.md extend context correctly 
 >
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-8 ant-form-item-label"
+      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -1289,6 +1352,7 @@ exports[`renders ./components/form/demo/control-ref.md extend context correctly 
     </div>
     <div
       class="ant-col ant-col-16 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -1308,9 +1372,11 @@ exports[`renders ./components/form/demo/control-ref.md extend context correctly 
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-8 ant-form-item-label"
+      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -1322,6 +1388,7 @@ exports[`renders ./components/form/demo/control-ref.md extend context correctly 
     </div>
     <div
       class="ant-col ant-col-16 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -1364,7 +1431,7 @@ exports[`renders ./components/form/demo/control-ref.md extend context correctly 
             <div>
               <div
                 class="ant-select-dropdown"
-                style="opacity:0"
+                style="opacity:0;pointer-events:none"
               >
                 <div>
                   <div
@@ -1493,9 +1560,11 @@ exports[`renders ./components/form/demo/control-ref.md extend context correctly 
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-16 ant-col-offset-8 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -1541,9 +1610,11 @@ exports[`renders ./components/form/demo/customized-form-controls.md extend conte
 >
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -1555,6 +1626,7 @@ exports[`renders ./components/form/demo/customized-form-controls.md extend conte
     </div>
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -1605,7 +1677,7 @@ exports[`renders ./components/form/demo/customized-form-controls.md extend conte
               <div>
                 <div
                   class="ant-select-dropdown"
-                  style="opacity:0"
+                  style="opacity:0;pointer-events:none"
                 >
                   <div>
                     <div
@@ -1718,9 +1790,11 @@ exports[`renders ./components/form/demo/customized-form-controls.md extend conte
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -1751,9 +1825,11 @@ exports[`renders ./components/form/demo/dep-debug.md extend context correctly 1`
   0
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -1765,6 +1841,7 @@ exports[`renders ./components/form/demo/dep-debug.md extend context correctly 1`
     </div>
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -1784,9 +1861,11 @@ exports[`renders ./components/form/demo/dep-debug.md extend context correctly 1`
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -1798,6 +1877,7 @@ exports[`renders ./components/form/demo/dep-debug.md extend context correctly 1`
     </div>
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -1824,9 +1904,11 @@ exports[`renders ./components/form/demo/disabled-input-debug.md extend context c
 >
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -1837,6 +1919,7 @@ exports[`renders ./components/form/demo/disabled-input-debug.md extend context c
     </div>
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -1856,9 +1939,11 @@ exports[`renders ./components/form/demo/disabled-input-debug.md extend context c
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-error"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -1869,6 +1954,7 @@ exports[`renders ./components/form/demo/disabled-input-debug.md extend context c
     </div>
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -1898,9 +1984,11 @@ exports[`renders ./components/form/demo/disabled-input-debug.md extend context c
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-error"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -1911,6 +1999,7 @@ exports[`renders ./components/form/demo/disabled-input-debug.md extend context c
     </div>
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -1941,9 +2030,11 @@ exports[`renders ./components/form/demo/disabled-input-debug.md extend context c
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -1954,6 +2045,7 @@ exports[`renders ./components/form/demo/disabled-input-debug.md extend context c
     </div>
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -1973,9 +2065,11 @@ exports[`renders ./components/form/demo/disabled-input-debug.md extend context c
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-error"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -1986,6 +2080,7 @@ exports[`renders ./components/form/demo/disabled-input-debug.md extend context c
     </div>
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -2015,9 +2110,11 @@ exports[`renders ./components/form/demo/disabled-input-debug.md extend context c
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-error"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -2028,6 +2125,7 @@ exports[`renders ./components/form/demo/disabled-input-debug.md extend context c
     </div>
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -2058,9 +2156,11 @@ exports[`renders ./components/form/demo/disabled-input-debug.md extend context c
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -2071,6 +2171,7 @@ exports[`renders ./components/form/demo/disabled-input-debug.md extend context c
     </div>
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -2103,9 +2204,11 @@ exports[`renders ./components/form/demo/disabled-input-debug.md extend context c
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-error"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -2116,6 +2219,7 @@ exports[`renders ./components/form/demo/disabled-input-debug.md extend context c
     </div>
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -2158,9 +2262,11 @@ exports[`renders ./components/form/demo/disabled-input-debug.md extend context c
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-error"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -2171,6 +2277,7 @@ exports[`renders ./components/form/demo/disabled-input-debug.md extend context c
     </div>
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -2214,9 +2321,11 @@ exports[`renders ./components/form/demo/disabled-input-debug.md extend context c
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -2227,6 +2336,7 @@ exports[`renders ./components/form/demo/disabled-input-debug.md extend context c
     </div>
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -2255,9 +2365,11 @@ exports[`renders ./components/form/demo/disabled-input-debug.md extend context c
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-error"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -2268,6 +2380,7 @@ exports[`renders ./components/form/demo/disabled-input-debug.md extend context c
     </div>
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -2306,9 +2419,11 @@ exports[`renders ./components/form/demo/disabled-input-debug.md extend context c
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-error"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -2319,6 +2434,7 @@ exports[`renders ./components/form/demo/disabled-input-debug.md extend context c
     </div>
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -2366,9 +2482,11 @@ exports[`renders ./components/form/demo/dynamic-form-item.md extend context corr
 >
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-xs-offset-0 ant-col-sm-20 ant-col-sm-offset-4"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -2446,9 +2564,11 @@ exports[`renders ./components/form/demo/dynamic-form-item.md extend context corr
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-xs-offset-0 ant-col-sm-20 ant-col-sm-offset-4"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -2479,9 +2599,11 @@ exports[`renders ./components/form/demo/dynamic-form-items.md extend context cor
 >
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -2526,9 +2648,11 @@ exports[`renders ./components/form/demo/dynamic-form-items.md extend context cor
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -2559,9 +2683,11 @@ exports[`renders ./components/form/demo/dynamic-form-items-complex.md extend con
 >
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
+      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -2573,6 +2699,7 @@ exports[`renders ./components/form/demo/dynamic-form-items-complex.md extend con
     </div>
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -2613,7 +2740,7 @@ exports[`renders ./components/form/demo/dynamic-form-items-complex.md extend con
             <div>
               <div
                 class="ant-select-dropdown"
-                style="opacity:0"
+                style="opacity:0;pointer-events:none"
               >
                 <div>
                   <div
@@ -2725,9 +2852,11 @@ exports[`renders ./components/form/demo/dynamic-form-items-complex.md extend con
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -2772,9 +2901,11 @@ exports[`renders ./components/form/demo/dynamic-form-items-complex.md extend con
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -2805,9 +2936,11 @@ exports[`renders ./components/form/demo/dynamic-form-items-no-style.md extend co
 >
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -2818,6 +2951,7 @@ exports[`renders ./components/form/demo/dynamic-form-items-no-style.md extend co
     </div>
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -2827,9 +2961,11 @@ exports[`renders ./components/form/demo/dynamic-form-items-no-style.md extend co
         >
           <div
             class="ant-row ant-form-item"
+            role="row"
           >
             <div
               class="ant-col ant-form-item-control"
+              role="cell"
             >
               <div
                 class="ant-form-item-control-input"
@@ -2878,9 +3014,11 @@ exports[`renders ./components/form/demo/dynamic-form-items-no-style.md extend co
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -2910,9 +3048,11 @@ exports[`renders ./components/form/demo/dynamic-rule.md extend context correctly
 >
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-4 ant-form-item-label"
+      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -2924,6 +3064,7 @@ exports[`renders ./components/form/demo/dynamic-rule.md extend context correctly
     </div>
     <div
       class="ant-col ant-col-8 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -2944,9 +3085,11 @@ exports[`renders ./components/form/demo/dynamic-rule.md extend context correctly
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-4 ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -2958,6 +3101,7 @@ exports[`renders ./components/form/demo/dynamic-rule.md extend context correctly
     </div>
     <div
       class="ant-col ant-col-8 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -2978,9 +3122,11 @@ exports[`renders ./components/form/demo/dynamic-rule.md extend context correctly
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-8 ant-col-offset-4 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -3012,9 +3158,11 @@ exports[`renders ./components/form/demo/dynamic-rule.md extend context correctly
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-8 ant-col-offset-4 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -3044,9 +3192,11 @@ exports[`renders ./components/form/demo/form-context.md extend context correctly
 >
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-8 ant-form-item-label"
+      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -3058,6 +3208,7 @@ exports[`renders ./components/form/demo/form-context.md extend context correctly
     </div>
     <div
       class="ant-col ant-col-16 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -3077,9 +3228,11 @@ exports[`renders ./components/form/demo/form-context.md extend context correctly
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-8 ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -3090,6 +3243,7 @@ exports[`renders ./components/form/demo/form-context.md extend context correctly
     </div>
     <div
       class="ant-col ant-col-16 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -3128,9 +3282,11 @@ exports[`renders ./components/form/demo/form-context.md extend context correctly
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-16 ant-col-offset-8 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -3183,9 +3339,11 @@ Array [
   >
     <div
       class="ant-row ant-form-item"
+      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
+        role="cell"
       >
         <label
           class="ant-form-item-required"
@@ -3197,6 +3355,7 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
+        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -3237,9 +3396,11 @@ exports[`renders ./components/form/demo/inline-login.md extend context correctly
 >
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -3287,9 +3448,11 @@ exports[`renders ./components/form/demo/inline-login.md extend context correctly
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -3337,9 +3500,11 @@ exports[`renders ./components/form/demo/inline-login.md extend context correctly
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -3369,9 +3534,11 @@ exports[`renders ./components/form/demo/label-debug.md extend context correctly 
 >
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-8 ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -3404,6 +3571,7 @@ exports[`renders ./components/form/demo/label-debug.md extend context correctly 
     </div>
     <div
       class="ant-col ant-col-16 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -3423,9 +3591,11 @@ exports[`renders ./components/form/demo/label-debug.md extend context correctly 
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-8 ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -3458,6 +3628,7 @@ exports[`renders ./components/form/demo/label-debug.md extend context correctly 
     </div>
     <div
       class="ant-col ant-col-16 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -3516,9 +3687,11 @@ exports[`renders ./components/form/demo/layout.md extend context correctly 1`] =
 >
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-4 ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -3530,6 +3703,7 @@ exports[`renders ./components/form/demo/layout.md extend context correctly 1`] =
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -3606,9 +3780,11 @@ exports[`renders ./components/form/demo/layout.md extend context correctly 1`] =
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-4 ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -3619,6 +3795,7 @@ exports[`renders ./components/form/demo/layout.md extend context correctly 1`] =
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -3638,9 +3815,11 @@ exports[`renders ./components/form/demo/layout.md extend context correctly 1`] =
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-4 ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -3651,6 +3830,7 @@ exports[`renders ./components/form/demo/layout.md extend context correctly 1`] =
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -3670,9 +3850,11 @@ exports[`renders ./components/form/demo/layout.md extend context correctly 1`] =
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-14 ant-col-offset-4 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -3702,9 +3884,11 @@ exports[`renders ./components/form/demo/layout-can-wrap.md extend context correc
 >
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-form-item-label-left ant-form-item-label-wrap"
+      role="cell"
       style="flex:0 0 110px"
     >
       <label
@@ -3717,6 +3901,7 @@ exports[`renders ./components/form/demo/layout-can-wrap.md extend context correc
     </div>
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
       style="flex:1 1 auto"
     >
       <div
@@ -3737,9 +3922,11 @@ exports[`renders ./components/form/demo/layout-can-wrap.md extend context correc
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-form-item-label-left ant-form-item-label-wrap"
+      role="cell"
       style="flex:0 0 110px"
     >
       <label
@@ -3752,6 +3939,7 @@ exports[`renders ./components/form/demo/layout-can-wrap.md extend context correc
     </div>
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
       style="flex:1 1 auto"
     >
       <div
@@ -3772,9 +3960,11 @@ exports[`renders ./components/form/demo/layout-can-wrap.md extend context correc
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-form-item-label-left ant-form-item-label-wrap"
+      role="cell"
       style="flex:0 0 110px"
     >
       <label
@@ -3786,6 +3976,7 @@ exports[`renders ./components/form/demo/layout-can-wrap.md extend context correc
     </div>
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
       style="flex:1 1 auto"
     >
       <div
@@ -3816,9 +4007,11 @@ exports[`renders ./components/form/demo/nest-messages.md extend context correctl
 >
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-8 ant-form-item-label"
+      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -3830,6 +4023,7 @@ exports[`renders ./components/form/demo/nest-messages.md extend context correctl
     </div>
     <div
       class="ant-col ant-col-16 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -3849,9 +4043,11 @@ exports[`renders ./components/form/demo/nest-messages.md extend context correctl
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-8 ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -3863,6 +4059,7 @@ exports[`renders ./components/form/demo/nest-messages.md extend context correctl
     </div>
     <div
       class="ant-col ant-col-16 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -3882,9 +4079,11 @@ exports[`renders ./components/form/demo/nest-messages.md extend context correctl
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-8 ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -3896,6 +4095,7 @@ exports[`renders ./components/form/demo/nest-messages.md extend context correctl
     </div>
     <div
       class="ant-col ant-col-16 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -3983,9 +4183,11 @@ exports[`renders ./components/form/demo/nest-messages.md extend context correctl
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-8 ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -3997,6 +4199,7 @@ exports[`renders ./components/form/demo/nest-messages.md extend context correctl
     </div>
     <div
       class="ant-col ant-col-16 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -4016,9 +4219,11 @@ exports[`renders ./components/form/demo/nest-messages.md extend context correctl
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-8 ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -4030,6 +4235,7 @@ exports[`renders ./components/form/demo/nest-messages.md extend context correctl
     </div>
     <div
       class="ant-col ant-col-16 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -4047,9 +4253,11 @@ exports[`renders ./components/form/demo/nest-messages.md extend context correctl
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-16 ant-col-offset-8 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -4079,9 +4287,11 @@ exports[`renders ./components/form/demo/normal-login.md extend context correctly
 >
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -4129,9 +4339,11 @@ exports[`renders ./components/form/demo/normal-login.md extend context correctly
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -4179,9 +4391,11 @@ exports[`renders ./components/form/demo/normal-login.md extend context correctly
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -4221,9 +4435,11 @@ exports[`renders ./components/form/demo/normal-login.md extend context correctly
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -4258,9 +4474,11 @@ exports[`renders ./components/form/demo/ref-item.md extend context correctly 1`]
 >
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -4272,6 +4490,7 @@ exports[`renders ./components/form/demo/ref-item.md extend context correctly 1`]
     </div>
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -4291,9 +4510,11 @@ exports[`renders ./components/form/demo/ref-item.md extend context correctly 1`]
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -4337,9 +4558,11 @@ exports[`renders ./components/form/demo/register.md extend context correctly 1`]
 >
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
+      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -4351,6 +4574,7 @@ exports[`renders ./components/form/demo/register.md extend context correctly 1`]
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -4370,9 +4594,11 @@ exports[`renders ./components/form/demo/register.md extend context correctly 1`]
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
+      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -4384,6 +4610,7 @@ exports[`renders ./components/form/demo/register.md extend context correctly 1`]
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -4435,9 +4662,11 @@ exports[`renders ./components/form/demo/register.md extend context correctly 1`]
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
+      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -4449,6 +4678,7 @@ exports[`renders ./components/form/demo/register.md extend context correctly 1`]
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -4500,9 +4730,11 @@ exports[`renders ./components/form/demo/register.md extend context correctly 1`]
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
+      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -4536,7 +4768,7 @@ exports[`renders ./components/form/demo/register.md extend context correctly 1`]
         <div>
           <div
             class="ant-tooltip"
-            style="opacity:0"
+            style="opacity:0;pointer-events:none"
           >
             <div
               class="ant-tooltip-content"
@@ -4561,6 +4793,7 @@ exports[`renders ./components/form/demo/register.md extend context correctly 1`]
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -4580,9 +4813,11 @@ exports[`renders ./components/form/demo/register.md extend context correctly 1`]
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
+      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -4594,6 +4829,7 @@ exports[`renders ./components/form/demo/register.md extend context correctly 1`]
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -4636,7 +4872,7 @@ exports[`renders ./components/form/demo/register.md extend context correctly 1`]
             <div>
               <div
                 class="ant-select-dropdown ant-cascader-dropdown"
-                style="opacity:0;min-width:auto"
+                style="opacity:0;pointer-events:none;min-width:auto"
               >
                 <div>
                   <div
@@ -4782,9 +5018,11 @@ exports[`renders ./components/form/demo/register.md extend context correctly 1`]
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
+      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -4796,6 +5034,7 @@ exports[`renders ./components/form/demo/register.md extend context correctly 1`]
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -4850,7 +5089,7 @@ exports[`renders ./components/form/demo/register.md extend context correctly 1`]
                   <div>
                     <div
                       class="ant-select-dropdown"
-                      style="opacity:0"
+                      style="opacity:0;pointer-events:none"
                     >
                       <div>
                         <div
@@ -4971,9 +5210,11 @@ exports[`renders ./components/form/demo/register.md extend context correctly 1`]
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
+      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -4985,6 +5226,7 @@ exports[`renders ./components/form/demo/register.md extend context correctly 1`]
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -5110,7 +5352,7 @@ exports[`renders ./components/form/demo/register.md extend context correctly 1`]
                   <div>
                     <div
                       class="ant-select-dropdown"
-                      style="opacity:0"
+                      style="opacity:0;pointer-events:none"
                     >
                       <div>
                         <div
@@ -5225,9 +5467,11 @@ exports[`renders ./components/form/demo/register.md extend context correctly 1`]
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
+      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -5239,6 +5483,7 @@ exports[`renders ./components/form/demo/register.md extend context correctly 1`]
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -5278,7 +5523,7 @@ exports[`renders ./components/form/demo/register.md extend context correctly 1`]
             <div>
               <div
                 class="ant-select-dropdown ant-select-dropdown-empty"
-                style="opacity:0"
+                style="opacity:0;pointer-events:none"
               >
                 <div>
                   <div
@@ -5296,9 +5541,11 @@ exports[`renders ./components/form/demo/register.md extend context correctly 1`]
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
+      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -5310,6 +5557,7 @@ exports[`renders ./components/form/demo/register.md extend context correctly 1`]
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -5332,9 +5580,11 @@ exports[`renders ./components/form/demo/register.md extend context correctly 1`]
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
+      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -5346,6 +5596,7 @@ exports[`renders ./components/form/demo/register.md extend context correctly 1`]
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -5388,7 +5639,7 @@ exports[`renders ./components/form/demo/register.md extend context correctly 1`]
             <div>
               <div
                 class="ant-select-dropdown"
-                style="opacity:0"
+                style="opacity:0;pointer-events:none"
               >
                 <div>
                   <div
@@ -5517,9 +5768,11 @@ exports[`renders ./components/form/demo/register.md extend context correctly 1`]
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
+      role="cell"
     >
       <label
         class=""
@@ -5530,6 +5783,7 @@ exports[`renders ./components/form/demo/register.md extend context correctly 1`]
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -5539,10 +5793,12 @@ exports[`renders ./components/form/demo/register.md extend context correctly 1`]
         >
           <div
             class="ant-row"
+            role="row"
             style="margin-left:-4px;margin-right:-4px"
           >
             <div
               class="ant-col ant-col-12"
+              role="cell"
               style="padding-left:4px;padding-right:4px"
             >
               <input
@@ -5554,6 +5810,7 @@ exports[`renders ./components/form/demo/register.md extend context correctly 1`]
             </div>
             <div
               class="ant-col ant-col-12"
+              role="cell"
               style="padding-left:4px;padding-right:4px"
             >
               <button
@@ -5577,9 +5834,11 @@ exports[`renders ./components/form/demo/register.md extend context correctly 1`]
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-xs-offset-0 ant-col-sm-16 ant-col-sm-offset-8"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -5617,9 +5876,11 @@ exports[`renders ./components/form/demo/register.md extend context correctly 1`]
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-xs-offset-0 ant-col-sm-16 ant-col-sm-offset-8"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -5648,9 +5909,11 @@ exports[`renders ./components/form/demo/required-mark.md extend context correctl
 >
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
+      role="cell"
     >
       <label
         class="ant-form-item-required-mark-optional"
@@ -5668,6 +5931,7 @@ exports[`renders ./components/form/demo/required-mark.md extend context correctl
     </div>
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -5744,9 +6008,11 @@ exports[`renders ./components/form/demo/required-mark.md extend context correctl
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
+      role="cell"
     >
       <label
         class="ant-form-item-required ant-form-item-required-mark-optional"
@@ -5779,7 +6045,7 @@ exports[`renders ./components/form/demo/required-mark.md extend context correctl
         <div>
           <div
             class="ant-tooltip"
-            style="opacity:0"
+            style="opacity:0;pointer-events:none"
           >
             <div
               class="ant-tooltip-content"
@@ -5804,6 +6070,7 @@ exports[`renders ./components/form/demo/required-mark.md extend context correctl
     </div>
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -5823,9 +6090,11 @@ exports[`renders ./components/form/demo/required-mark.md extend context correctl
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
+      role="cell"
     >
       <label
         class="ant-form-item-required-mark-optional"
@@ -5858,7 +6127,7 @@ exports[`renders ./components/form/demo/required-mark.md extend context correctl
         <div>
           <div
             class="ant-tooltip"
-            style="opacity:0"
+            style="opacity:0;pointer-events:none"
           >
             <div
               class="ant-tooltip-content"
@@ -5889,6 +6158,7 @@ exports[`renders ./components/form/demo/required-mark.md extend context correctl
     </div>
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -5908,9 +6178,11 @@ exports[`renders ./components/form/demo/required-mark.md extend context correctl
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -5939,9 +6211,11 @@ exports[`renders ./components/form/demo/size.md extend context correctly 1`] = `
 >
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-4 ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -5953,6 +6227,7 @@ exports[`renders ./components/form/demo/size.md extend context correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -6029,9 +6304,11 @@ exports[`renders ./components/form/demo/size.md extend context correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-4 ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -6042,6 +6319,7 @@ exports[`renders ./components/form/demo/size.md extend context correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -6060,9 +6338,11 @@ exports[`renders ./components/form/demo/size.md extend context correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-4 ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -6073,6 +6353,7 @@ exports[`renders ./components/form/demo/size.md extend context correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -6112,7 +6393,7 @@ exports[`renders ./components/form/demo/size.md extend context correctly 1`] = `
             <div>
               <div
                 class="ant-select-dropdown"
-                style="opacity:0"
+                style="opacity:0;pointer-events:none"
               >
                 <div>
                   <div
@@ -6199,9 +6480,11 @@ exports[`renders ./components/form/demo/size.md extend context correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-4 ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -6212,6 +6495,7 @@ exports[`renders ./components/form/demo/size.md extend context correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -6250,7 +6534,7 @@ exports[`renders ./components/form/demo/size.md extend context correctly 1`] = `
             <div>
               <div
                 class="ant-select-dropdown ant-tree-select-dropdown"
-                style="opacity:0"
+                style="opacity:0;pointer-events:none"
               >
                 <div>
                   <div>
@@ -6377,9 +6661,11 @@ exports[`renders ./components/form/demo/size.md extend context correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-4 ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -6390,6 +6676,7 @@ exports[`renders ./components/form/demo/size.md extend context correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -6428,7 +6715,7 @@ exports[`renders ./components/form/demo/size.md extend context correctly 1`] = `
             <div>
               <div
                 class="ant-select-dropdown ant-cascader-dropdown"
-                style="opacity:0;min-width:auto"
+                style="opacity:0;pointer-events:none;min-width:auto"
               >
                 <div>
                   <div
@@ -6512,9 +6799,11 @@ exports[`renders ./components/form/demo/size.md extend context correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-4 ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -6525,6 +6814,7 @@ exports[`renders ./components/form/demo/size.md extend context correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -6574,7 +6864,7 @@ exports[`renders ./components/form/demo/size.md extend context correctly 1`] = `
           <div>
             <div
               class="ant-picker-dropdown"
-              style="opacity:0"
+              style="opacity:0;pointer-events:none"
             >
               <div
                 class="ant-picker-panel-container"
@@ -7131,9 +7421,11 @@ exports[`renders ./components/form/demo/size.md extend context correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-4 ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -7144,6 +7436,7 @@ exports[`renders ./components/form/demo/size.md extend context correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -7230,9 +7523,11 @@ exports[`renders ./components/form/demo/size.md extend context correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-4 ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -7243,6 +7538,7 @@ exports[`renders ./components/form/demo/size.md extend context correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -7269,9 +7565,11 @@ exports[`renders ./components/form/demo/size.md extend context correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-4 ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -7282,6 +7580,7 @@ exports[`renders ./components/form/demo/size.md extend context correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -7311,9 +7610,11 @@ exports[`renders ./components/form/demo/time-related-controls.md extend context 
 >
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
+      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -7325,6 +7626,7 @@ exports[`renders ./components/form/demo/time-related-controls.md extend context 
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -7375,7 +7677,7 @@ exports[`renders ./components/form/demo/time-related-controls.md extend context 
           <div>
             <div
               class="ant-picker-dropdown"
-              style="opacity:0"
+              style="opacity:0;pointer-events:none"
             >
               <div
                 class="ant-picker-panel-container"
@@ -7932,9 +8234,11 @@ exports[`renders ./components/form/demo/time-related-controls.md extend context 
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
+      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -7946,6 +8250,7 @@ exports[`renders ./components/form/demo/time-related-controls.md extend context 
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -7996,7 +8301,7 @@ exports[`renders ./components/form/demo/time-related-controls.md extend context 
           <div>
             <div
               class="ant-picker-dropdown"
-              style="opacity:0"
+              style="opacity:0;pointer-events:none"
             >
               <div
                 class="ant-picker-panel-container"
@@ -9906,9 +10211,11 @@ exports[`renders ./components/form/demo/time-related-controls.md extend context 
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
+      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -9920,6 +10227,7 @@ exports[`renders ./components/form/demo/time-related-controls.md extend context 
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -9970,7 +10278,7 @@ exports[`renders ./components/form/demo/time-related-controls.md extend context 
           <div>
             <div
               class="ant-picker-dropdown"
-              style="opacity:0"
+              style="opacity:0;pointer-events:none"
             >
               <div
                 class="ant-picker-panel-container"
@@ -10163,9 +10471,11 @@ exports[`renders ./components/form/demo/time-related-controls.md extend context 
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
+      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -10177,6 +10487,7 @@ exports[`renders ./components/form/demo/time-related-controls.md extend context 
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -10269,7 +10580,7 @@ exports[`renders ./components/form/demo/time-related-controls.md extend context 
           <div>
             <div
               class="ant-picker-dropdown ant-picker-dropdown-range"
-              style="opacity:0"
+              style="opacity:0;pointer-events:none"
             >
               <div
                 class="ant-picker-range-wrapper ant-picker-date-range-wrapper"
@@ -11369,9 +11680,11 @@ exports[`renders ./components/form/demo/time-related-controls.md extend context 
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
+      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -11383,6 +11696,7 @@ exports[`renders ./components/form/demo/time-related-controls.md extend context 
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -11475,7 +11789,7 @@ exports[`renders ./components/form/demo/time-related-controls.md extend context 
           <div>
             <div
               class="ant-picker-dropdown ant-picker-dropdown-range"
-              style="opacity:0"
+              style="opacity:0;pointer-events:none"
             >
               <div
                 class="ant-picker-range-wrapper ant-picker-date-range-wrapper"
@@ -13390,9 +13704,11 @@ exports[`renders ./components/form/demo/time-related-controls.md extend context 
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
+      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -13404,6 +13720,7 @@ exports[`renders ./components/form/demo/time-related-controls.md extend context 
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -13457,7 +13774,7 @@ exports[`renders ./components/form/demo/time-related-controls.md extend context 
           <div>
             <div
               class="ant-picker-dropdown"
-              style="opacity:0"
+              style="opacity:0;pointer-events:none"
             >
               <div
                 class="ant-picker-panel-container"
@@ -14825,9 +15142,11 @@ exports[`renders ./components/form/demo/time-related-controls.md extend context 
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-xs-offset-0 ant-col-sm-16 ant-col-sm-offset-8"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -14858,9 +15177,11 @@ Array [
   >
     <div
       class="ant-row ant-form-item"
+      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
+        role="cell"
       >
         <label
           class=""
@@ -14872,6 +15193,7 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
+        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -14891,9 +15213,11 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
+      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
+        role="cell"
       >
         <label
           class=""
@@ -14905,6 +15229,7 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
+        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -15008,9 +15333,11 @@ exports[`renders ./components/form/demo/validate-other.md extend context correct
 >
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-6 ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -15021,6 +15348,7 @@ exports[`renders ./components/form/demo/validate-other.md extend context correct
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -15039,9 +15367,11 @@ exports[`renders ./components/form/demo/validate-other.md extend context correct
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-6 ant-form-item-label"
+      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -15053,6 +15383,7 @@ exports[`renders ./components/form/demo/validate-other.md extend context correct
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -15095,7 +15426,7 @@ exports[`renders ./components/form/demo/validate-other.md extend context correct
             <div>
               <div
                 class="ant-select-dropdown"
-                style="opacity:0"
+                style="opacity:0;pointer-events:none"
               >
                 <div>
                   <div
@@ -15207,9 +15538,11 @@ exports[`renders ./components/form/demo/validate-other.md extend context correct
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-6 ant-form-item-label"
+      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -15221,6 +15554,7 @@ exports[`renders ./components/form/demo/validate-other.md extend context correct
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -15279,7 +15613,7 @@ exports[`renders ./components/form/demo/validate-other.md extend context correct
             <div>
               <div
                 class="ant-select-dropdown"
-                style="opacity:0"
+                style="opacity:0;pointer-events:none"
               >
                 <div>
                   <div
@@ -15364,9 +15698,11 @@ exports[`renders ./components/form/demo/validate-other.md extend context correct
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-6 ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -15377,6 +15713,7 @@ exports[`renders ./components/form/demo/validate-other.md extend context correct
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -15472,9 +15809,11 @@ exports[`renders ./components/form/demo/validate-other.md extend context correct
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-6 ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -15486,6 +15825,7 @@ exports[`renders ./components/form/demo/validate-other.md extend context correct
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -15513,9 +15853,11 @@ exports[`renders ./components/form/demo/validate-other.md extend context correct
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-6 ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -15527,6 +15869,7 @@ exports[`renders ./components/form/demo/validate-other.md extend context correct
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -15585,7 +15928,7 @@ exports[`renders ./components/form/demo/validate-other.md extend context correct
             <div>
               <div
                 class="ant-tooltip ant-slider-tooltip"
-                style="opacity:0"
+                style="opacity:0;pointer-events:none"
               >
                 <div
                   class="ant-tooltip-content"
@@ -15653,9 +15996,11 @@ exports[`renders ./components/form/demo/validate-other.md extend context correct
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-6 ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -15667,6 +16012,7 @@ exports[`renders ./components/form/demo/validate-other.md extend context correct
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -15742,9 +16088,11 @@ exports[`renders ./components/form/demo/validate-other.md extend context correct
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-6 ant-form-item-label"
+      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -15756,6 +16104,7 @@ exports[`renders ./components/form/demo/validate-other.md extend context correct
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -15831,9 +16180,11 @@ exports[`renders ./components/form/demo/validate-other.md extend context correct
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-6 ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -15845,6 +16196,7 @@ exports[`renders ./components/form/demo/validate-other.md extend context correct
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -15858,9 +16210,11 @@ exports[`renders ./components/form/demo/validate-other.md extend context correct
           >
             <div
               class="ant-row"
+              role="row"
             >
               <div
                 class="ant-col ant-col-8"
+                role="cell"
               >
                 <label
                   class="ant-checkbox-wrapper ant-checkbox-wrapper-checked ant-checkbox-wrapper-in-form-item"
@@ -15886,6 +16240,7 @@ exports[`renders ./components/form/demo/validate-other.md extend context correct
               </div>
               <div
                 class="ant-col ant-col-8"
+                role="cell"
               >
                 <label
                   class="ant-checkbox-wrapper ant-checkbox-wrapper-checked ant-checkbox-wrapper-disabled ant-checkbox-wrapper-in-form-item"
@@ -15912,6 +16267,7 @@ exports[`renders ./components/form/demo/validate-other.md extend context correct
               </div>
               <div
                 class="ant-col ant-col-8"
+                role="cell"
               >
                 <label
                   class="ant-checkbox-wrapper ant-checkbox-wrapper-in-form-item"
@@ -15936,6 +16292,7 @@ exports[`renders ./components/form/demo/validate-other.md extend context correct
               </div>
               <div
                 class="ant-col ant-col-8"
+                role="cell"
               >
                 <label
                   class="ant-checkbox-wrapper ant-checkbox-wrapper-in-form-item"
@@ -15960,6 +16317,7 @@ exports[`renders ./components/form/demo/validate-other.md extend context correct
               </div>
               <div
                 class="ant-col ant-col-8"
+                role="cell"
               >
                 <label
                   class="ant-checkbox-wrapper ant-checkbox-wrapper-in-form-item"
@@ -15984,6 +16342,7 @@ exports[`renders ./components/form/demo/validate-other.md extend context correct
               </div>
               <div
                 class="ant-col ant-col-8"
+                role="cell"
               >
                 <label
                   class="ant-checkbox-wrapper ant-checkbox-wrapper-in-form-item"
@@ -16014,9 +16373,11 @@ exports[`renders ./components/form/demo/validate-other.md extend context correct
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-6 ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -16028,6 +16389,7 @@ exports[`renders ./components/form/demo/validate-other.md extend context correct
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -16337,9 +16699,11 @@ exports[`renders ./components/form/demo/validate-other.md extend context correct
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-6 ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -16351,6 +16715,7 @@ exports[`renders ./components/form/demo/validate-other.md extend context correct
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -16419,9 +16784,11 @@ exports[`renders ./components/form/demo/validate-other.md extend context correct
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-6 ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -16432,6 +16799,7 @@ exports[`renders ./components/form/demo/validate-other.md extend context correct
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -16503,9 +16871,11 @@ exports[`renders ./components/form/demo/validate-other.md extend context correct
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-12 ant-col-offset-6 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -16534,9 +16904,11 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
 >
   <div
     class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-error"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-6"
+      role="cell"
     >
       <label
         class=""
@@ -16547,6 +16919,7 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-14"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -16577,9 +16950,11 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-has-warning"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-6"
+      role="cell"
     >
       <label
         class=""
@@ -16590,6 +16965,7 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-14"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -16637,9 +17013,11 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-feedback ant-form-item-is-validating"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-6"
+      role="cell"
     >
       <label
         class=""
@@ -16650,6 +17028,7 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-14"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -16711,9 +17090,11 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-has-feedback ant-form-item-has-success"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-6"
+      role="cell"
     >
       <label
         class=""
@@ -16724,6 +17105,7 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-14"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -16775,9 +17157,11 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-has-feedback ant-form-item-has-warning"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-6"
+      role="cell"
     >
       <label
         class=""
@@ -16788,6 +17172,7 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-14"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -16839,9 +17224,11 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-feedback ant-form-item-has-error"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-6"
+      role="cell"
     >
       <label
         class=""
@@ -16852,6 +17239,7 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-14"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -16913,9 +17301,11 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-has-feedback ant-form-item-has-success"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-6"
+      role="cell"
     >
       <label
         class=""
@@ -16926,6 +17316,7 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-14"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -16999,7 +17390,7 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
           <div>
             <div
               class="ant-picker-dropdown"
-              style="opacity:0"
+              style="opacity:0;pointer-events:none"
             >
               <div
                 class="ant-picker-panel-container"
@@ -17556,9 +17947,11 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-has-feedback ant-form-item-has-warning"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-6"
+      role="cell"
     >
       <label
         class=""
@@ -17569,6 +17962,7 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-14"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -17645,7 +18039,7 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
           <div>
             <div
               class="ant-picker-dropdown"
-              style="opacity:0"
+              style="opacity:0;pointer-events:none"
             >
               <div
                 class="ant-picker-panel-container"
@@ -19013,9 +19407,11 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-has-feedback ant-form-item-has-error"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-6"
+      role="cell"
     >
       <label
         class=""
@@ -19026,6 +19422,7 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-14"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -19141,7 +19538,7 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
           <div>
             <div
               class="ant-picker-dropdown ant-picker-dropdown-range"
-              style="opacity:0"
+              style="opacity:0;pointer-events:none"
             >
               <div
                 class="ant-picker-range-wrapper ant-picker-date-range-wrapper"
@@ -20241,9 +20638,11 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-has-feedback ant-form-item-has-error"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-6"
+      role="cell"
     >
       <label
         class=""
@@ -20254,6 +20653,7 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-14"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -20295,7 +20695,7 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
             <div>
               <div
                 class="ant-select-dropdown"
-                style="opacity:0"
+                style="opacity:0;pointer-events:none"
               >
                 <div>
                   <div
@@ -20447,9 +20847,11 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-feedback ant-form-item-has-error"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-6"
+      role="cell"
     >
       <label
         class=""
@@ -20460,6 +20862,7 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-14"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -20500,7 +20903,7 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
             <div>
               <div
                 class="ant-select-dropdown ant-cascader-dropdown"
-                style="opacity:0;min-width:auto"
+                style="opacity:0;pointer-events:none;min-width:auto"
               >
                 <div>
                   <div
@@ -20594,9 +20997,11 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-feedback ant-form-item-has-warning"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-6"
+      role="cell"
     >
       <label
         class=""
@@ -20607,6 +21012,7 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-14"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -20647,7 +21053,7 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
             <div>
               <div
                 class="ant-select-dropdown ant-tree-select-dropdown"
-                style="opacity:0"
+                style="opacity:0;pointer-events:none"
               >
                 <div>
                   <div>
@@ -20787,10 +21193,12 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
     style="margin-bottom:0"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-6"
+      role="cell"
     >
       <label
         class=""
@@ -20801,6 +21209,7 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-14"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -20810,10 +21219,12 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
         >
           <div
             class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-error"
+            role="row"
             style="display:inline-block;width:calc(50% - 12px)"
           >
             <div
               class="ant-col ant-form-item-control"
+              role="cell"
             >
               <div
                 class="ant-form-item-control-input"
@@ -20863,7 +21274,7 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
                   <div>
                     <div
                       class="ant-picker-dropdown"
-                      style="opacity:0"
+                      style="opacity:0;pointer-events:none"
                     >
                       <div
                         class="ant-picker-panel-container"
@@ -21435,10 +21846,12 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
           </span>
           <div
             class="ant-row ant-form-item"
+            role="row"
             style="display:inline-block;width:calc(50% - 12px)"
           >
             <div
               class="ant-col ant-form-item-control"
+              role="cell"
             >
               <div
                 class="ant-form-item-control-input"
@@ -21488,7 +21901,7 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
                   <div>
                     <div
                       class="ant-picker-dropdown"
-                      style="opacity:0"
+                      style="opacity:0;pointer-events:none"
                     >
                       <div
                         class="ant-picker-panel-container"
@@ -22049,9 +22462,11 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-has-feedback ant-form-item-has-success"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-6"
+      role="cell"
     >
       <label
         class=""
@@ -22062,6 +22477,7 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-14"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -22180,9 +22596,11 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-has-feedback ant-form-item-has-success"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-6"
+      role="cell"
     >
       <label
         class=""
@@ -22193,6 +22611,7 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-14"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -22268,9 +22687,11 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-has-feedback ant-form-item-has-warning"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-6"
+      role="cell"
     >
       <label
         class=""
@@ -22281,6 +22702,7 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-14"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -22355,9 +22777,11 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-has-feedback ant-form-item-has-error"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-6"
+      role="cell"
     >
       <label
         class=""
@@ -22368,6 +22792,7 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-14"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -22467,9 +22892,11 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-has-feedback ant-form-item-has-error"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-6"
+      role="cell"
     >
       <label
         class=""
@@ -22480,6 +22907,7 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-14"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -22532,9 +22960,11 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-feedback ant-form-item-has-error"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-6"
+      role="cell"
     >
       <label
         class=""
@@ -22545,6 +22975,7 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-14"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -22635,9 +23066,11 @@ exports[`renders ./components/form/demo/warning-only.md extend context correctly
 >
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
+      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -22649,6 +23082,7 @@ exports[`renders ./components/form/demo/warning-only.md extend context correctly
     </div>
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -22669,9 +23103,11 @@ exports[`renders ./components/form/demo/warning-only.md extend context correctly
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -22721,9 +23157,11 @@ exports[`renders ./components/form/demo/without-form-create.md extend context co
 >
   <div
     class="ant-row ant-form-item ant-form-item-with-help"
+    role="row"
   >
     <div
       class="ant-col ant-col-7 ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -22734,6 +23172,7 @@ exports[`renders ./components/form/demo/without-form-create.md extend context co
     </div>
     <div
       class="ant-col ant-col-12 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"

--- a/components/form/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/form/__tests__/__snapshots__/demo.test.js.snap
@@ -8,17 +8,21 @@ exports[`renders ./components/form/demo/advanced-search.md correctly 1`] = `
   >
     <div
       class="ant-row"
+      role="row"
       style="margin-left:-12px;margin-right:-12px"
     >
       <div
         class="ant-col ant-col-8"
+        role="cell"
         style="padding-left:12px;padding-right:12px"
       >
         <div
           class="ant-row ant-form-item"
+          role="row"
         >
           <div
             class="ant-col ant-form-item-label"
+            role="cell"
           >
             <label
               class="ant-form-item-required"
@@ -30,6 +34,7 @@ exports[`renders ./components/form/demo/advanced-search.md correctly 1`] = `
           </div>
           <div
             class="ant-col ant-form-item-control"
+            role="cell"
           >
             <div
               class="ant-form-item-control-input"
@@ -51,13 +56,16 @@ exports[`renders ./components/form/demo/advanced-search.md correctly 1`] = `
       </div>
       <div
         class="ant-col ant-col-8"
+        role="cell"
         style="padding-left:12px;padding-right:12px"
       >
         <div
           class="ant-row ant-form-item"
+          role="row"
         >
           <div
             class="ant-col ant-form-item-label"
+            role="cell"
           >
             <label
               class="ant-form-item-required"
@@ -69,6 +77,7 @@ exports[`renders ./components/form/demo/advanced-search.md correctly 1`] = `
           </div>
           <div
             class="ant-col ant-form-item-control"
+            role="cell"
           >
             <div
               class="ant-form-item-control-input"
@@ -143,13 +152,16 @@ exports[`renders ./components/form/demo/advanced-search.md correctly 1`] = `
       </div>
       <div
         class="ant-col ant-col-8"
+        role="cell"
         style="padding-left:12px;padding-right:12px"
       >
         <div
           class="ant-row ant-form-item"
+          role="row"
         >
           <div
             class="ant-col ant-form-item-label"
+            role="cell"
           >
             <label
               class="ant-form-item-required"
@@ -161,6 +173,7 @@ exports[`renders ./components/form/demo/advanced-search.md correctly 1`] = `
           </div>
           <div
             class="ant-col ant-form-item-control"
+            role="cell"
           >
             <div
               class="ant-form-item-control-input"
@@ -182,13 +195,16 @@ exports[`renders ./components/form/demo/advanced-search.md correctly 1`] = `
       </div>
       <div
         class="ant-col ant-col-8"
+        role="cell"
         style="padding-left:12px;padding-right:12px"
       >
         <div
           class="ant-row ant-form-item"
+          role="row"
         >
           <div
             class="ant-col ant-form-item-label"
+            role="cell"
           >
             <label
               class="ant-form-item-required"
@@ -200,6 +216,7 @@ exports[`renders ./components/form/demo/advanced-search.md correctly 1`] = `
           </div>
           <div
             class="ant-col ant-form-item-control"
+            role="cell"
           >
             <div
               class="ant-form-item-control-input"
@@ -221,13 +238,16 @@ exports[`renders ./components/form/demo/advanced-search.md correctly 1`] = `
       </div>
       <div
         class="ant-col ant-col-8"
+        role="cell"
         style="padding-left:12px;padding-right:12px"
       >
         <div
           class="ant-row ant-form-item"
+          role="row"
         >
           <div
             class="ant-col ant-form-item-label"
+            role="cell"
           >
             <label
               class="ant-form-item-required"
@@ -239,6 +259,7 @@ exports[`renders ./components/form/demo/advanced-search.md correctly 1`] = `
           </div>
           <div
             class="ant-col ant-form-item-control"
+            role="cell"
           >
             <div
               class="ant-form-item-control-input"
@@ -313,13 +334,16 @@ exports[`renders ./components/form/demo/advanced-search.md correctly 1`] = `
       </div>
       <div
         class="ant-col ant-col-8"
+        role="cell"
         style="padding-left:12px;padding-right:12px"
       >
         <div
           class="ant-row ant-form-item"
+          role="row"
         >
           <div
             class="ant-col ant-form-item-label"
+            role="cell"
           >
             <label
               class="ant-form-item-required"
@@ -331,6 +355,7 @@ exports[`renders ./components/form/demo/advanced-search.md correctly 1`] = `
           </div>
           <div
             class="ant-col ant-form-item-control"
+            role="cell"
           >
             <div
               class="ant-form-item-control-input"
@@ -353,9 +378,11 @@ exports[`renders ./components/form/demo/advanced-search.md correctly 1`] = `
     </div>
     <div
       class="ant-row"
+      role="row"
     >
       <div
         class="ant-col ant-col-24"
+        role="cell"
         style="text-align:right"
       >
         <button
@@ -418,9 +445,11 @@ exports[`renders ./components/form/demo/basic.md correctly 1`] = `
 >
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-8 ant-form-item-label"
+      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -432,6 +461,7 @@ exports[`renders ./components/form/demo/basic.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-16 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -451,9 +481,11 @@ exports[`renders ./components/form/demo/basic.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-8 ant-form-item-label"
+      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -465,6 +497,7 @@ exports[`renders ./components/form/demo/basic.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-16 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -516,9 +549,11 @@ exports[`renders ./components/form/demo/basic.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-16 ant-col-offset-8 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -552,9 +587,11 @@ exports[`renders ./components/form/demo/basic.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-16 ant-col-offset-8 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -586,9 +623,11 @@ Array [
   >
     <div
       class="ant-row ant-form-item"
+      role="row"
     >
       <div
         class="ant-col ant-col-24 ant-form-item-label"
+        role="cell"
       >
         <label
           class="ant-form-item-required"
@@ -600,6 +639,7 @@ Array [
       </div>
       <div
         class="ant-col ant-col-24 ant-form-item-control"
+        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -619,9 +659,11 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
+      role="row"
     >
       <div
         class="ant-col ant-col-24 ant-form-item-label"
+        role="cell"
       >
         <label
           class="ant-form-item-required"
@@ -633,6 +675,7 @@ Array [
       </div>
       <div
         class="ant-col ant-col-24 ant-form-item-control"
+        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -684,9 +727,11 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
+      role="row"
     >
       <div
         class="ant-col ant-col-24 ant-form-item-control"
+        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -714,9 +759,11 @@ Array [
   >
     <div
       class="ant-row ant-form-item"
+      role="row"
     >
       <div
         class="ant-col ant-form-item-label ant-col-sm-24 ant-col-xl-24"
+        role="cell"
       >
         <label
           class="ant-form-item-required"
@@ -728,6 +775,7 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control ant-col-sm-24 ant-col-xl-24"
+        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -747,9 +795,11 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
+      role="row"
     >
       <div
         class="ant-col ant-form-item-label ant-col-sm-24 ant-col-xl-24"
+        role="cell"
       >
         <label
           class="ant-form-item-required"
@@ -761,6 +811,7 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control ant-col-sm-24 ant-col-xl-24"
+        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -812,9 +863,11 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
+      role="row"
     >
       <div
         class="ant-col ant-form-item-control ant-col-sm-24 ant-col-xl-24"
+        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -845,9 +898,11 @@ exports[`renders ./components/form/demo/control-hooks.md correctly 1`] = `
 >
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-8 ant-form-item-label"
+      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -859,6 +914,7 @@ exports[`renders ./components/form/demo/control-hooks.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-16 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -878,9 +934,11 @@ exports[`renders ./components/form/demo/control-hooks.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-8 ant-form-item-label"
+      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -892,6 +950,7 @@ exports[`renders ./components/form/demo/control-hooks.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-16 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -964,9 +1023,11 @@ exports[`renders ./components/form/demo/control-hooks.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-16 ant-col-offset-8 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -1012,9 +1073,11 @@ exports[`renders ./components/form/demo/control-ref.md correctly 1`] = `
 >
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-8 ant-form-item-label"
+      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -1026,6 +1089,7 @@ exports[`renders ./components/form/demo/control-ref.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-16 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -1045,9 +1109,11 @@ exports[`renders ./components/form/demo/control-ref.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-8 ant-form-item-label"
+      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -1059,6 +1125,7 @@ exports[`renders ./components/form/demo/control-ref.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-16 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -1131,9 +1198,11 @@ exports[`renders ./components/form/demo/control-ref.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-16 ant-col-offset-8 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -1179,9 +1248,11 @@ exports[`renders ./components/form/demo/customized-form-controls.md correctly 1`
 >
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -1193,6 +1264,7 @@ exports[`renders ./components/form/demo/customized-form-controls.md correctly 1`
     </div>
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -1274,9 +1346,11 @@ exports[`renders ./components/form/demo/customized-form-controls.md correctly 1`
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -1307,9 +1381,11 @@ exports[`renders ./components/form/demo/dep-debug.md correctly 1`] = `
   0
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -1321,6 +1397,7 @@ exports[`renders ./components/form/demo/dep-debug.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -1340,9 +1417,11 @@ exports[`renders ./components/form/demo/dep-debug.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -1354,6 +1433,7 @@ exports[`renders ./components/form/demo/dep-debug.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -1380,9 +1460,11 @@ exports[`renders ./components/form/demo/disabled-input-debug.md correctly 1`] = 
 >
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -1393,6 +1475,7 @@ exports[`renders ./components/form/demo/disabled-input-debug.md correctly 1`] = 
     </div>
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -1412,9 +1495,11 @@ exports[`renders ./components/form/demo/disabled-input-debug.md correctly 1`] = 
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-error"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -1425,6 +1510,7 @@ exports[`renders ./components/form/demo/disabled-input-debug.md correctly 1`] = 
     </div>
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -1454,9 +1540,11 @@ exports[`renders ./components/form/demo/disabled-input-debug.md correctly 1`] = 
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-error"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -1467,6 +1555,7 @@ exports[`renders ./components/form/demo/disabled-input-debug.md correctly 1`] = 
     </div>
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -1497,9 +1586,11 @@ exports[`renders ./components/form/demo/disabled-input-debug.md correctly 1`] = 
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -1510,6 +1601,7 @@ exports[`renders ./components/form/demo/disabled-input-debug.md correctly 1`] = 
     </div>
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -1529,9 +1621,11 @@ exports[`renders ./components/form/demo/disabled-input-debug.md correctly 1`] = 
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-error"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -1542,6 +1636,7 @@ exports[`renders ./components/form/demo/disabled-input-debug.md correctly 1`] = 
     </div>
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -1571,9 +1666,11 @@ exports[`renders ./components/form/demo/disabled-input-debug.md correctly 1`] = 
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-error"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -1584,6 +1681,7 @@ exports[`renders ./components/form/demo/disabled-input-debug.md correctly 1`] = 
     </div>
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -1614,9 +1712,11 @@ exports[`renders ./components/form/demo/disabled-input-debug.md correctly 1`] = 
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -1627,6 +1727,7 @@ exports[`renders ./components/form/demo/disabled-input-debug.md correctly 1`] = 
     </div>
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -1659,9 +1760,11 @@ exports[`renders ./components/form/demo/disabled-input-debug.md correctly 1`] = 
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-error"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -1672,6 +1775,7 @@ exports[`renders ./components/form/demo/disabled-input-debug.md correctly 1`] = 
     </div>
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -1714,9 +1818,11 @@ exports[`renders ./components/form/demo/disabled-input-debug.md correctly 1`] = 
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-error"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -1727,6 +1833,7 @@ exports[`renders ./components/form/demo/disabled-input-debug.md correctly 1`] = 
     </div>
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -1770,9 +1877,11 @@ exports[`renders ./components/form/demo/disabled-input-debug.md correctly 1`] = 
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -1783,6 +1892,7 @@ exports[`renders ./components/form/demo/disabled-input-debug.md correctly 1`] = 
     </div>
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -1811,9 +1921,11 @@ exports[`renders ./components/form/demo/disabled-input-debug.md correctly 1`] = 
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-error"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -1824,6 +1936,7 @@ exports[`renders ./components/form/demo/disabled-input-debug.md correctly 1`] = 
     </div>
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -1862,9 +1975,11 @@ exports[`renders ./components/form/demo/disabled-input-debug.md correctly 1`] = 
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-error"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -1875,6 +1990,7 @@ exports[`renders ./components/form/demo/disabled-input-debug.md correctly 1`] = 
     </div>
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -1922,9 +2038,11 @@ exports[`renders ./components/form/demo/dynamic-form-item.md correctly 1`] = `
 >
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-xs-offset-0 ant-col-sm-20 ant-col-sm-offset-4"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -2002,9 +2120,11 @@ exports[`renders ./components/form/demo/dynamic-form-item.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-xs-offset-0 ant-col-sm-20 ant-col-sm-offset-4"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -2035,9 +2155,11 @@ exports[`renders ./components/form/demo/dynamic-form-items.md correctly 1`] = `
 >
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -2082,9 +2204,11 @@ exports[`renders ./components/form/demo/dynamic-form-items.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -2115,9 +2239,11 @@ exports[`renders ./components/form/demo/dynamic-form-items-complex.md correctly 
 >
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
+      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -2129,6 +2255,7 @@ exports[`renders ./components/form/demo/dynamic-form-items-complex.md correctly 
     </div>
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -2199,9 +2326,11 @@ exports[`renders ./components/form/demo/dynamic-form-items-complex.md correctly 
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -2246,9 +2375,11 @@ exports[`renders ./components/form/demo/dynamic-form-items-complex.md correctly 
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -2279,9 +2410,11 @@ exports[`renders ./components/form/demo/dynamic-form-items-no-style.md correctly
 >
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -2292,6 +2425,7 @@ exports[`renders ./components/form/demo/dynamic-form-items-no-style.md correctly
     </div>
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -2301,9 +2435,11 @@ exports[`renders ./components/form/demo/dynamic-form-items-no-style.md correctly
         >
           <div
             class="ant-row ant-form-item"
+            role="row"
           >
             <div
               class="ant-col ant-form-item-control"
+              role="cell"
             >
               <div
                 class="ant-form-item-control-input"
@@ -2352,9 +2488,11 @@ exports[`renders ./components/form/demo/dynamic-form-items-no-style.md correctly
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -2384,9 +2522,11 @@ exports[`renders ./components/form/demo/dynamic-rule.md correctly 1`] = `
 >
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-4 ant-form-item-label"
+      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -2398,6 +2538,7 @@ exports[`renders ./components/form/demo/dynamic-rule.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-8 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -2418,9 +2559,11 @@ exports[`renders ./components/form/demo/dynamic-rule.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-4 ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -2432,6 +2575,7 @@ exports[`renders ./components/form/demo/dynamic-rule.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-8 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -2452,9 +2596,11 @@ exports[`renders ./components/form/demo/dynamic-rule.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-8 ant-col-offset-4 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -2486,9 +2632,11 @@ exports[`renders ./components/form/demo/dynamic-rule.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-8 ant-col-offset-4 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -2518,9 +2666,11 @@ exports[`renders ./components/form/demo/form-context.md correctly 1`] = `
 >
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-8 ant-form-item-label"
+      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -2532,6 +2682,7 @@ exports[`renders ./components/form/demo/form-context.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-16 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -2551,9 +2702,11 @@ exports[`renders ./components/form/demo/form-context.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-8 ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -2564,6 +2717,7 @@ exports[`renders ./components/form/demo/form-context.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-16 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -2602,9 +2756,11 @@ exports[`renders ./components/form/demo/form-context.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-16 ant-col-offset-8 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -2657,9 +2813,11 @@ Array [
   >
     <div
       class="ant-row ant-form-item"
+      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
+        role="cell"
       >
         <label
           class="ant-form-item-required"
@@ -2671,6 +2829,7 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
+        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -2711,9 +2870,11 @@ exports[`renders ./components/form/demo/inline-login.md correctly 1`] = `
 >
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -2761,9 +2922,11 @@ exports[`renders ./components/form/demo/inline-login.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -2811,9 +2974,11 @@ exports[`renders ./components/form/demo/inline-login.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -2843,9 +3008,11 @@ exports[`renders ./components/form/demo/label-debug.md correctly 1`] = `
 >
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-8 ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -2878,6 +3045,7 @@ exports[`renders ./components/form/demo/label-debug.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-16 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -2897,9 +3065,11 @@ exports[`renders ./components/form/demo/label-debug.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-8 ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -2932,6 +3102,7 @@ exports[`renders ./components/form/demo/label-debug.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-16 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -2990,9 +3161,11 @@ exports[`renders ./components/form/demo/layout.md correctly 1`] = `
 >
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-4 ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -3004,6 +3177,7 @@ exports[`renders ./components/form/demo/layout.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -3080,9 +3254,11 @@ exports[`renders ./components/form/demo/layout.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-4 ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -3093,6 +3269,7 @@ exports[`renders ./components/form/demo/layout.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -3112,9 +3289,11 @@ exports[`renders ./components/form/demo/layout.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-4 ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -3125,6 +3304,7 @@ exports[`renders ./components/form/demo/layout.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -3144,9 +3324,11 @@ exports[`renders ./components/form/demo/layout.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-14 ant-col-offset-4 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -3176,9 +3358,11 @@ exports[`renders ./components/form/demo/layout-can-wrap.md correctly 1`] = `
 >
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-form-item-label-left ant-form-item-label-wrap"
+      role="cell"
       style="flex:0 0 110px"
     >
       <label
@@ -3191,6 +3375,7 @@ exports[`renders ./components/form/demo/layout-can-wrap.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
       style="flex:1 1 auto"
     >
       <div
@@ -3211,9 +3396,11 @@ exports[`renders ./components/form/demo/layout-can-wrap.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-form-item-label-left ant-form-item-label-wrap"
+      role="cell"
       style="flex:0 0 110px"
     >
       <label
@@ -3226,6 +3413,7 @@ exports[`renders ./components/form/demo/layout-can-wrap.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
       style="flex:1 1 auto"
     >
       <div
@@ -3246,9 +3434,11 @@ exports[`renders ./components/form/demo/layout-can-wrap.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-form-item-label-left ant-form-item-label-wrap"
+      role="cell"
       style="flex:0 0 110px"
     >
       <label
@@ -3260,6 +3450,7 @@ exports[`renders ./components/form/demo/layout-can-wrap.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
       style="flex:1 1 auto"
     >
       <div
@@ -3290,9 +3481,11 @@ exports[`renders ./components/form/demo/nest-messages.md correctly 1`] = `
 >
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-8 ant-form-item-label"
+      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -3304,6 +3497,7 @@ exports[`renders ./components/form/demo/nest-messages.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-16 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -3323,9 +3517,11 @@ exports[`renders ./components/form/demo/nest-messages.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-8 ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -3337,6 +3533,7 @@ exports[`renders ./components/form/demo/nest-messages.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-16 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -3356,9 +3553,11 @@ exports[`renders ./components/form/demo/nest-messages.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-8 ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -3370,6 +3569,7 @@ exports[`renders ./components/form/demo/nest-messages.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-16 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -3457,9 +3657,11 @@ exports[`renders ./components/form/demo/nest-messages.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-8 ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -3471,6 +3673,7 @@ exports[`renders ./components/form/demo/nest-messages.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-16 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -3490,9 +3693,11 @@ exports[`renders ./components/form/demo/nest-messages.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-8 ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -3504,6 +3709,7 @@ exports[`renders ./components/form/demo/nest-messages.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-16 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -3521,9 +3727,11 @@ exports[`renders ./components/form/demo/nest-messages.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-16 ant-col-offset-8 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -3553,9 +3761,11 @@ exports[`renders ./components/form/demo/normal-login.md correctly 1`] = `
 >
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -3603,9 +3813,11 @@ exports[`renders ./components/form/demo/normal-login.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -3653,9 +3865,11 @@ exports[`renders ./components/form/demo/normal-login.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -3695,9 +3909,11 @@ exports[`renders ./components/form/demo/normal-login.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -3732,9 +3948,11 @@ exports[`renders ./components/form/demo/ref-item.md correctly 1`] = `
 >
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -3746,6 +3964,7 @@ exports[`renders ./components/form/demo/ref-item.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -3765,9 +3984,11 @@ exports[`renders ./components/form/demo/ref-item.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -3811,9 +4032,11 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
 >
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
+      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -3825,6 +4048,7 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -3844,9 +4068,11 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
+      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -3858,6 +4084,7 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -3909,9 +4136,11 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
+      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -3923,6 +4152,7 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -3974,9 +4204,11 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
+      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -4011,6 +4243,7 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -4030,9 +4263,11 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
+      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -4044,6 +4279,7 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -4142,9 +4378,11 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
+      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -4156,6 +4394,7 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -4249,9 +4488,11 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
+      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -4263,6 +4504,7 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -4421,9 +4663,11 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
+      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -4435,6 +4679,7 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -4478,9 +4723,11 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
+      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -4492,6 +4739,7 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -4514,9 +4762,11 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
+      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -4528,6 +4778,7 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -4600,9 +4851,11 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
+      role="cell"
     >
       <label
         class=""
@@ -4613,6 +4866,7 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -4622,10 +4876,12 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
         >
           <div
             class="ant-row"
+            role="row"
             style="margin-left:-4px;margin-right:-4px"
           >
             <div
               class="ant-col ant-col-12"
+              role="cell"
               style="padding-left:4px;padding-right:4px"
             >
               <input
@@ -4637,6 +4893,7 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
             </div>
             <div
               class="ant-col ant-col-12"
+              role="cell"
               style="padding-left:4px;padding-right:4px"
             >
               <button
@@ -4660,9 +4917,11 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-xs-offset-0 ant-col-sm-16 ant-col-sm-offset-8"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -4700,9 +4959,11 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-xs-offset-0 ant-col-sm-16 ant-col-sm-offset-8"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -4731,9 +4992,11 @@ exports[`renders ./components/form/demo/required-mark.md correctly 1`] = `
 >
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
+      role="cell"
     >
       <label
         class="ant-form-item-required-mark-optional"
@@ -4751,6 +5014,7 @@ exports[`renders ./components/form/demo/required-mark.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -4827,9 +5091,11 @@ exports[`renders ./components/form/demo/required-mark.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
+      role="cell"
     >
       <label
         class="ant-form-item-required ant-form-item-required-mark-optional"
@@ -4863,6 +5129,7 @@ exports[`renders ./components/form/demo/required-mark.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -4882,9 +5149,11 @@ exports[`renders ./components/form/demo/required-mark.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
+      role="cell"
     >
       <label
         class="ant-form-item-required-mark-optional"
@@ -4924,6 +5193,7 @@ exports[`renders ./components/form/demo/required-mark.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -4943,9 +5213,11 @@ exports[`renders ./components/form/demo/required-mark.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -4974,9 +5246,11 @@ exports[`renders ./components/form/demo/size.md correctly 1`] = `
 >
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-4 ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -4988,6 +5262,7 @@ exports[`renders ./components/form/demo/size.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -5064,9 +5339,11 @@ exports[`renders ./components/form/demo/size.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-4 ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -5077,6 +5354,7 @@ exports[`renders ./components/form/demo/size.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -5095,9 +5373,11 @@ exports[`renders ./components/form/demo/size.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-4 ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -5108,6 +5388,7 @@ exports[`renders ./components/form/demo/size.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -5177,9 +5458,11 @@ exports[`renders ./components/form/demo/size.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-4 ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -5190,6 +5473,7 @@ exports[`renders ./components/form/demo/size.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -5258,9 +5542,11 @@ exports[`renders ./components/form/demo/size.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-4 ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -5271,6 +5557,7 @@ exports[`renders ./components/form/demo/size.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -5339,9 +5626,11 @@ exports[`renders ./components/form/demo/size.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-4 ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -5352,6 +5641,7 @@ exports[`renders ./components/form/demo/size.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -5404,9 +5694,11 @@ exports[`renders ./components/form/demo/size.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-4 ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -5417,6 +5709,7 @@ exports[`renders ./components/form/demo/size.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -5503,9 +5796,11 @@ exports[`renders ./components/form/demo/size.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-4 ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -5516,6 +5811,7 @@ exports[`renders ./components/form/demo/size.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -5542,9 +5838,11 @@ exports[`renders ./components/form/demo/size.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-4 ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -5555,6 +5853,7 @@ exports[`renders ./components/form/demo/size.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -5584,9 +5883,11 @@ exports[`renders ./components/form/demo/time-related-controls.md correctly 1`] =
 >
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
+      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -5598,6 +5899,7 @@ exports[`renders ./components/form/demo/time-related-controls.md correctly 1`] =
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -5651,9 +5953,11 @@ exports[`renders ./components/form/demo/time-related-controls.md correctly 1`] =
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
+      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -5665,6 +5969,7 @@ exports[`renders ./components/form/demo/time-related-controls.md correctly 1`] =
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -5718,9 +6023,11 @@ exports[`renders ./components/form/demo/time-related-controls.md correctly 1`] =
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
+      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -5732,6 +6039,7 @@ exports[`renders ./components/form/demo/time-related-controls.md correctly 1`] =
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -5785,9 +6093,11 @@ exports[`renders ./components/form/demo/time-related-controls.md correctly 1`] =
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
+      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -5799,6 +6109,7 @@ exports[`renders ./components/form/demo/time-related-controls.md correctly 1`] =
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -5894,9 +6205,11 @@ exports[`renders ./components/form/demo/time-related-controls.md correctly 1`] =
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
+      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -5908,6 +6221,7 @@ exports[`renders ./components/form/demo/time-related-controls.md correctly 1`] =
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -6003,9 +6317,11 @@ exports[`renders ./components/form/demo/time-related-controls.md correctly 1`] =
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
+      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -6017,6 +6333,7 @@ exports[`renders ./components/form/demo/time-related-controls.md correctly 1`] =
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -6073,9 +6390,11 @@ exports[`renders ./components/form/demo/time-related-controls.md correctly 1`] =
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-xs-offset-0 ant-col-sm-16 ant-col-sm-offset-8"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -6106,9 +6425,11 @@ Array [
   >
     <div
       class="ant-row ant-form-item"
+      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
+        role="cell"
       >
         <label
           class=""
@@ -6120,6 +6441,7 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
+        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -6139,9 +6461,11 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
+      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
+        role="cell"
       >
         <label
           class=""
@@ -6153,6 +6477,7 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
+        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -6256,9 +6581,11 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
 >
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-6 ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -6269,6 +6596,7 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -6287,9 +6615,11 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-6 ant-form-item-label"
+      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -6301,6 +6631,7 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -6373,9 +6704,11 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-6 ant-form-item-label"
+      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -6387,6 +6720,7 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -6449,9 +6783,11 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-6 ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -6462,6 +6798,7 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -6557,9 +6894,11 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-6 ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -6571,6 +6910,7 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -6598,9 +6938,11 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-6 ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -6612,6 +6954,7 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -6714,9 +7057,11 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-6 ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -6728,6 +7073,7 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -6803,9 +7149,11 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-6 ant-form-item-label"
+      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -6817,6 +7165,7 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -6892,9 +7241,11 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-6 ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -6906,6 +7257,7 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -6919,9 +7271,11 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
           >
             <div
               class="ant-row"
+              role="row"
             >
               <div
                 class="ant-col ant-col-8"
+                role="cell"
               >
                 <label
                   class="ant-checkbox-wrapper ant-checkbox-wrapper-checked ant-checkbox-wrapper-in-form-item"
@@ -6947,6 +7301,7 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
               </div>
               <div
                 class="ant-col ant-col-8"
+                role="cell"
               >
                 <label
                   class="ant-checkbox-wrapper ant-checkbox-wrapper-checked ant-checkbox-wrapper-disabled ant-checkbox-wrapper-in-form-item"
@@ -6973,6 +7328,7 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
               </div>
               <div
                 class="ant-col ant-col-8"
+                role="cell"
               >
                 <label
                   class="ant-checkbox-wrapper ant-checkbox-wrapper-in-form-item"
@@ -6997,6 +7353,7 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
               </div>
               <div
                 class="ant-col ant-col-8"
+                role="cell"
               >
                 <label
                   class="ant-checkbox-wrapper ant-checkbox-wrapper-in-form-item"
@@ -7021,6 +7378,7 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
               </div>
               <div
                 class="ant-col ant-col-8"
+                role="cell"
               >
                 <label
                   class="ant-checkbox-wrapper ant-checkbox-wrapper-in-form-item"
@@ -7045,6 +7403,7 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
               </div>
               <div
                 class="ant-col ant-col-8"
+                role="cell"
               >
                 <label
                   class="ant-checkbox-wrapper ant-checkbox-wrapper-in-form-item"
@@ -7075,9 +7434,11 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-6 ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -7089,6 +7450,7 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -7398,9 +7760,11 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-6 ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -7412,6 +7776,7 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -7480,9 +7845,11 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-6 ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -7493,6 +7860,7 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -7564,9 +7932,11 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-12 ant-col-offset-6 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -7595,9 +7965,11 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
 >
   <div
     class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-error"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-6"
+      role="cell"
     >
       <label
         class=""
@@ -7608,6 +7980,7 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-14"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -7638,9 +8011,11 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-has-warning"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-6"
+      role="cell"
     >
       <label
         class=""
@@ -7651,6 +8026,7 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-14"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -7698,9 +8074,11 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-feedback ant-form-item-is-validating"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-6"
+      role="cell"
     >
       <label
         class=""
@@ -7711,6 +8089,7 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-14"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -7772,9 +8151,11 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-has-feedback ant-form-item-has-success"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-6"
+      role="cell"
     >
       <label
         class=""
@@ -7785,6 +8166,7 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-14"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -7836,9 +8218,11 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-has-feedback ant-form-item-has-warning"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-6"
+      role="cell"
     >
       <label
         class=""
@@ -7849,6 +8233,7 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-14"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -7900,9 +8285,11 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-feedback ant-form-item-has-error"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-6"
+      role="cell"
     >
       <label
         class=""
@@ -7913,6 +8300,7 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-14"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -7974,9 +8362,11 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-has-feedback ant-form-item-has-success"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-6"
+      role="cell"
     >
       <label
         class=""
@@ -7987,6 +8377,7 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-14"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -8063,9 +8454,11 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-has-feedback ant-form-item-has-warning"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-6"
+      role="cell"
     >
       <label
         class=""
@@ -8076,6 +8469,7 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-14"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -8155,9 +8549,11 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-has-feedback ant-form-item-has-error"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-6"
+      role="cell"
     >
       <label
         class=""
@@ -8168,6 +8564,7 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-14"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -8286,9 +8683,11 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-has-feedback ant-form-item-has-error"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-6"
+      role="cell"
     >
       <label
         class=""
@@ -8299,6 +8698,7 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-14"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -8393,9 +8793,11 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-feedback ant-form-item-has-error"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-6"
+      role="cell"
     >
       <label
         class=""
@@ -8406,6 +8808,7 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-14"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -8509,9 +8912,11 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-feedback ant-form-item-has-warning"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-6"
+      role="cell"
     >
       <label
         class=""
@@ -8522,6 +8927,7 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-14"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -8625,10 +9031,12 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
     style="margin-bottom:0"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-6"
+      role="cell"
     >
       <label
         class=""
@@ -8639,6 +9047,7 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-14"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -8648,10 +9057,12 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
         >
           <div
             class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-error"
+            role="row"
             style="display:inline-block;width:calc(50% - 12px)"
           >
             <div
               class="ant-col ant-form-item-control"
+              role="cell"
             >
               <div
                 class="ant-form-item-control-input"
@@ -8719,10 +9130,12 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
           </span>
           <div
             class="ant-row ant-form-item"
+            role="row"
             style="display:inline-block;width:calc(50% - 12px)"
           >
             <div
               class="ant-col ant-form-item-control"
+              role="cell"
             >
               <div
                 class="ant-form-item-control-input"
@@ -8779,9 +9192,11 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-has-feedback ant-form-item-has-success"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-6"
+      role="cell"
     >
       <label
         class=""
@@ -8792,6 +9207,7 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-14"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -8910,9 +9326,11 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-has-feedback ant-form-item-has-success"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-6"
+      role="cell"
     >
       <label
         class=""
@@ -8923,6 +9341,7 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-14"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -8998,9 +9417,11 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-has-feedback ant-form-item-has-warning"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-6"
+      role="cell"
     >
       <label
         class=""
@@ -9011,6 +9432,7 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-14"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -9085,9 +9507,11 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-has-feedback ant-form-item-has-error"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-6"
+      role="cell"
     >
       <label
         class=""
@@ -9098,6 +9522,7 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-14"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -9197,9 +9622,11 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-has-feedback ant-form-item-has-error"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-6"
+      role="cell"
     >
       <label
         class=""
@@ -9210,6 +9637,7 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-14"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -9262,9 +9690,11 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-feedback ant-form-item-has-error"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-6"
+      role="cell"
     >
       <label
         class=""
@@ -9275,6 +9705,7 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-14"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -9365,9 +9796,11 @@ exports[`renders ./components/form/demo/warning-only.md correctly 1`] = `
 >
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
+      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -9379,6 +9812,7 @@ exports[`renders ./components/form/demo/warning-only.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -9399,9 +9833,11 @@ exports[`renders ./components/form/demo/warning-only.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -9451,9 +9887,11 @@ exports[`renders ./components/form/demo/without-form-create.md correctly 1`] = `
 >
   <div
     class="ant-row ant-form-item ant-form-item-with-help"
+    role="row"
   >
     <div
       class="ant-col ant-col-7 ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -9464,6 +9902,7 @@ exports[`renders ./components/form/demo/without-form-create.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-12 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"

--- a/components/form/__tests__/__snapshots__/index.test.js.snap
+++ b/components/form/__tests__/__snapshots__/index.test.js.snap
@@ -6,9 +6,11 @@ exports[`Form Form item hidden noStyle should not work when hidden 1`] = `
 >
   <div
     class="ant-row ant-form-item ant-form-item-hidden"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -35,9 +37,11 @@ exports[`Form Form item hidden should work 1`] = `
 >
   <div
     class="ant-row ant-form-item ant-form-item-hidden"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -67,9 +71,11 @@ exports[`Form Form.Item should support data-*、aria-* and custom attribute 1`] 
     cccc="bbbb"
     class="ant-row ant-form-item"
     data-text="123"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -94,9 +100,11 @@ exports[`Form rtl render component should be rendered correctly in RTL direction
 exports[`Form rtl render component should be rendered correctly in RTL direction 2`] = `
 <div
   class="ant-row ant-row-rtl ant-form-item"
+  role="row"
 >
   <div
     class="ant-col ant-form-item-control ant-col-rtl"
+    role="cell"
   >
     <div
       class="ant-form-item-control-input"

--- a/components/grid/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/grid/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -4,66 +4,80 @@ exports[`renders ./components/grid/demo/basic.md extend context correctly 1`] = 
 Array [
   <div
     class="ant-row"
+    role="row"
   >
     <div
       class="ant-col ant-col-24"
+      role="cell"
     >
       col
     </div>
   </div>,
   <div
     class="ant-row"
+    role="row"
   >
     <div
       class="ant-col ant-col-12"
+      role="cell"
     >
       col-12
     </div>
     <div
       class="ant-col ant-col-12"
+      role="cell"
     >
       col-12
     </div>
   </div>,
   <div
     class="ant-row"
+    role="row"
   >
     <div
       class="ant-col ant-col-8"
+      role="cell"
     >
       col-8
     </div>
     <div
       class="ant-col ant-col-8"
+      role="cell"
     >
       col-8
     </div>
     <div
       class="ant-col ant-col-8"
+      role="cell"
     >
       col-8
     </div>
   </div>,
   <div
     class="ant-row"
+    role="row"
   >
     <div
       class="ant-col ant-col-6"
+      role="cell"
     >
       col-6
     </div>
     <div
       class="ant-col ant-col-6"
+      role="cell"
     >
       col-6
     </div>
     <div
       class="ant-col ant-col-6"
+      role="cell"
     >
       col-6
     </div>
     <div
       class="ant-col ant-col-6"
+      role="cell"
     >
       col-6
     </div>
@@ -85,24 +99,29 @@ Array [
   </div>,
   <div
     class="ant-row ant-row-start"
+    role="row"
   >
     <div
       class="ant-col ant-col-4"
+      role="cell"
     >
       col-4
     </div>
     <div
       class="ant-col ant-col-4"
+      role="cell"
     >
       col-4
     </div>
     <div
       class="ant-col ant-col-4"
+      role="cell"
     >
       col-4
     </div>
     <div
       class="ant-col ant-col-4"
+      role="cell"
     >
       col-4
     </div>
@@ -119,24 +138,29 @@ Array [
   </div>,
   <div
     class="ant-row ant-row-center"
+    role="row"
   >
     <div
       class="ant-col ant-col-4"
+      role="cell"
     >
       col-4
     </div>
     <div
       class="ant-col ant-col-4"
+      role="cell"
     >
       col-4
     </div>
     <div
       class="ant-col ant-col-4"
+      role="cell"
     >
       col-4
     </div>
     <div
       class="ant-col ant-col-4"
+      role="cell"
     >
       col-4
     </div>
@@ -153,24 +177,29 @@ Array [
   </div>,
   <div
     class="ant-row ant-row-end"
+    role="row"
   >
     <div
       class="ant-col ant-col-4"
+      role="cell"
     >
       col-4
     </div>
     <div
       class="ant-col ant-col-4"
+      role="cell"
     >
       col-4
     </div>
     <div
       class="ant-col ant-col-4"
+      role="cell"
     >
       col-4
     </div>
     <div
       class="ant-col ant-col-4"
+      role="cell"
     >
       col-4
     </div>
@@ -187,24 +216,29 @@ Array [
   </div>,
   <div
     class="ant-row ant-row-space-between"
+    role="row"
   >
     <div
       class="ant-col ant-col-4"
+      role="cell"
     >
       col-4
     </div>
     <div
       class="ant-col ant-col-4"
+      role="cell"
     >
       col-4
     </div>
     <div
       class="ant-col ant-col-4"
+      role="cell"
     >
       col-4
     </div>
     <div
       class="ant-col ant-col-4"
+      role="cell"
     >
       col-4
     </div>
@@ -221,24 +255,29 @@ Array [
   </div>,
   <div
     class="ant-row ant-row-space-around"
+    role="row"
   >
     <div
       class="ant-col ant-col-4"
+      role="cell"
     >
       col-4
     </div>
     <div
       class="ant-col ant-col-4"
+      role="cell"
     >
       col-4
     </div>
     <div
       class="ant-col ant-col-4"
+      role="cell"
     >
       col-4
     </div>
     <div
       class="ant-col ant-col-4"
+      role="cell"
     >
       col-4
     </div>
@@ -255,24 +294,29 @@ Array [
   </div>,
   <div
     class="ant-row ant-row-space-evenly"
+    role="row"
   >
     <div
       class="ant-col ant-col-4"
+      role="cell"
     >
       col-4
     </div>
     <div
       class="ant-col ant-col-4"
+      role="cell"
     >
       col-4
     </div>
     <div
       class="ant-col ant-col-4"
+      role="cell"
     >
       col-4
     </div>
     <div
       class="ant-col ant-col-4"
+      role="cell"
     >
       col-4
     </div>
@@ -294,9 +338,11 @@ Array [
   </div>,
   <div
     class="ant-row ant-row-center ant-row-top"
+    role="row"
   >
     <div
       class="ant-col ant-col-4"
+      role="cell"
     >
       <p
         class="height-100"
@@ -306,6 +352,7 @@ Array [
     </div>
     <div
       class="ant-col ant-col-4"
+      role="cell"
     >
       <p
         class="height-50"
@@ -315,6 +362,7 @@ Array [
     </div>
     <div
       class="ant-col ant-col-4"
+      role="cell"
     >
       <p
         class="height-120"
@@ -324,6 +372,7 @@ Array [
     </div>
     <div
       class="ant-col ant-col-4"
+      role="cell"
     >
       <p
         class="height-80"
@@ -344,9 +393,11 @@ Array [
   </div>,
   <div
     class="ant-row ant-row-space-around ant-row-middle"
+    role="row"
   >
     <div
       class="ant-col ant-col-4"
+      role="cell"
     >
       <p
         class="height-100"
@@ -356,6 +407,7 @@ Array [
     </div>
     <div
       class="ant-col ant-col-4"
+      role="cell"
     >
       <p
         class="height-50"
@@ -365,6 +417,7 @@ Array [
     </div>
     <div
       class="ant-col ant-col-4"
+      role="cell"
     >
       <p
         class="height-120"
@@ -374,6 +427,7 @@ Array [
     </div>
     <div
       class="ant-col ant-col-4"
+      role="cell"
     >
       <p
         class="height-80"
@@ -394,9 +448,11 @@ Array [
   </div>,
   <div
     class="ant-row ant-row-space-between ant-row-bottom"
+    role="row"
   >
     <div
       class="ant-col ant-col-4"
+      role="cell"
     >
       <p
         class="height-100"
@@ -406,6 +462,7 @@ Array [
     </div>
     <div
       class="ant-col ant-col-4"
+      role="cell"
     >
       <p
         class="height-50"
@@ -415,6 +472,7 @@ Array [
     </div>
     <div
       class="ant-col ant-col-4"
+      role="cell"
     >
       <p
         class="height-120"
@@ -424,6 +482,7 @@ Array [
     </div>
     <div
       class="ant-col ant-col-4"
+      role="cell"
     >
       <p
         class="height-80"
@@ -449,24 +508,29 @@ Array [
   </div>,
   <div
     class="ant-row"
+    role="row"
   >
     <div
       class="ant-col ant-col-6 ant-col-order-4"
+      role="cell"
     >
       1 col-order-4
     </div>
     <div
       class="ant-col ant-col-6 ant-col-order-3"
+      role="cell"
     >
       2 col-order-3
     </div>
     <div
       class="ant-col ant-col-6 ant-col-order-2"
+      role="cell"
     >
       3 col-order-2
     </div>
     <div
       class="ant-col ant-col-6 ant-col-order-1"
+      role="cell"
     >
       4 col-order-1
     </div>
@@ -483,24 +547,29 @@ Array [
   </div>,
   <div
     class="ant-row"
+    role="row"
   >
     <div
       class="ant-col ant-col-6 ant-col-xs-order-1 ant-col-sm-order-2 ant-col-md-order-3 ant-col-lg-order-4"
+      role="cell"
     >
       1 col-order-responsive
     </div>
     <div
       class="ant-col ant-col-6 ant-col-xs-order-2 ant-col-sm-order-1 ant-col-md-order-4 ant-col-lg-order-3"
+      role="cell"
     >
       2 col-order-responsive
     </div>
     <div
       class="ant-col ant-col-6 ant-col-xs-order-3 ant-col-sm-order-4 ant-col-md-order-2 ant-col-lg-order-1"
+      role="cell"
     >
       3 col-order-responsive
     </div>
     <div
       class="ant-col ant-col-6 ant-col-xs-order-4 ant-col-sm-order-3 ant-col-md-order-1 ant-col-lg-order-2"
+      role="cell"
     >
       4 col-order-responsive
     </div>
@@ -522,15 +591,18 @@ Array [
   </div>,
   <div
     class="ant-row"
+    role="row"
   >
     <div
       class="ant-col"
+      role="cell"
       style="flex:2 2 auto"
     >
       2 / 5
     </div>
     <div
       class="ant-col"
+      role="cell"
       style="flex:3 3 auto"
     >
       3 / 5
@@ -548,15 +620,18 @@ Array [
   </div>,
   <div
     class="ant-row"
+    role="row"
   >
     <div
       class="ant-col"
+      role="cell"
       style="flex:0 0 100px"
     >
       100px
     </div>
     <div
       class="ant-col"
+      role="cell"
       style="flex:auto"
     >
       Fill Rest
@@ -574,15 +649,18 @@ Array [
   </div>,
   <div
     class="ant-row"
+    role="row"
   >
     <div
       class="ant-col"
+      role="cell"
       style="flex:1 1 200px"
     >
       1 1 200px
     </div>
     <div
       class="ant-col"
+      role="cell"
       style="flex:0 1 300px"
     >
       0 1 300px
@@ -590,9 +668,11 @@ Array [
   </div>,
   <div
     class="ant-row ant-row-no-wrap"
+    role="row"
   >
     <div
       class="ant-col"
+      role="cell"
       style="flex:none;min-width:0"
     >
       <div
@@ -603,6 +683,7 @@ Array [
     </div>
     <div
       class="ant-col"
+      role="cell"
       style="flex:auto;min-width:0"
     >
       auto with no-wrap
@@ -625,10 +706,12 @@ Array [
   </div>,
   <div
     class="ant-row"
+    role="row"
     style="margin-left:-8px;margin-right:-8px"
   >
     <div
       class="ant-col ant-col-6 gutter-row"
+      role="cell"
       style="padding-left:8px;padding-right:8px"
     >
       <div
@@ -639,6 +722,7 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6 gutter-row"
+      role="cell"
       style="padding-left:8px;padding-right:8px"
     >
       <div
@@ -649,6 +733,7 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6 gutter-row"
+      role="cell"
       style="padding-left:8px;padding-right:8px"
     >
       <div
@@ -659,6 +744,7 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6 gutter-row"
+      role="cell"
       style="padding-left:8px;padding-right:8px"
     >
       <div
@@ -680,10 +766,12 @@ Array [
   </div>,
   <div
     class="ant-row"
+    role="row"
     style="margin-left:-16px;margin-right:-16px"
   >
     <div
       class="ant-col ant-col-6 gutter-row"
+      role="cell"
       style="padding-left:16px;padding-right:16px"
     >
       <div
@@ -694,6 +782,7 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6 gutter-row"
+      role="cell"
       style="padding-left:16px;padding-right:16px"
     >
       <div
@@ -704,6 +793,7 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6 gutter-row"
+      role="cell"
       style="padding-left:16px;padding-right:16px"
     >
       <div
@@ -714,6 +804,7 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6 gutter-row"
+      role="cell"
       style="padding-left:16px;padding-right:16px"
     >
       <div
@@ -735,10 +826,12 @@ Array [
   </div>,
   <div
     class="ant-row"
+    role="row"
     style="margin-left:-8px;margin-right:-8px;margin-top:-12px;margin-bottom:-12px"
   >
     <div
       class="ant-col ant-col-6 gutter-row"
+      role="cell"
       style="padding-left:8px;padding-right:8px;padding-top:12px;padding-bottom:12px"
     >
       <div
@@ -749,6 +842,7 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6 gutter-row"
+      role="cell"
       style="padding-left:8px;padding-right:8px;padding-top:12px;padding-bottom:12px"
     >
       <div
@@ -759,6 +853,7 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6 gutter-row"
+      role="cell"
       style="padding-left:8px;padding-right:8px;padding-top:12px;padding-bottom:12px"
     >
       <div
@@ -769,6 +864,7 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6 gutter-row"
+      role="cell"
       style="padding-left:8px;padding-right:8px;padding-top:12px;padding-bottom:12px"
     >
       <div
@@ -779,6 +875,7 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6 gutter-row"
+      role="cell"
       style="padding-left:8px;padding-right:8px;padding-top:12px;padding-bottom:12px"
     >
       <div
@@ -789,6 +886,7 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6 gutter-row"
+      role="cell"
       style="padding-left:8px;padding-right:8px;padding-top:12px;padding-bottom:12px"
     >
       <div
@@ -799,6 +897,7 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6 gutter-row"
+      role="cell"
       style="padding-left:8px;padding-right:8px;padding-top:12px;padding-bottom:12px"
     >
       <div
@@ -809,6 +908,7 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6 gutter-row"
+      role="cell"
       style="padding-left:8px;padding-right:8px;padding-top:12px;padding-bottom:12px"
     >
       <div
@@ -825,37 +925,45 @@ exports[`renders ./components/grid/demo/offset.md extend context correctly 1`] =
 Array [
   <div
     class="ant-row"
+    role="row"
   >
     <div
       class="ant-col ant-col-8"
+      role="cell"
     >
       col-8
     </div>
     <div
       class="ant-col ant-col-8 ant-col-offset-8"
+      role="cell"
     >
       col-8
     </div>
   </div>,
   <div
     class="ant-row"
+    role="row"
   >
     <div
       class="ant-col ant-col-6 ant-col-offset-6"
+      role="cell"
     >
       col-6 col-offset-6
     </div>
     <div
       class="ant-col ant-col-6 ant-col-offset-6"
+      role="cell"
     >
       col-6 col-offset-6
     </div>
   </div>,
   <div
     class="ant-row"
+    role="row"
   >
     <div
       class="ant-col ant-col-12 ant-col-offset-6"
+      role="cell"
     >
       col-12 col-offset-6
     </div>
@@ -922,7 +1030,7 @@ Array [
       <div>
         <div
           class="ant-tooltip ant-slider-tooltip"
-          style="opacity:0"
+          style="opacity:0;pointer-events:none"
         >
           <div
             class="ant-tooltip-content"
@@ -1042,7 +1150,7 @@ Array [
       <div>
         <div
           class="ant-tooltip ant-slider-tooltip"
-          style="opacity:0"
+          style="opacity:0;pointer-events:none"
         >
           <div
             class="ant-tooltip-content"
@@ -1162,7 +1270,7 @@ Array [
       <div>
         <div
           class="ant-tooltip ant-slider-tooltip"
-          style="opacity:0"
+          style="opacity:0;pointer-events:none"
         >
           <div
             class="ant-tooltip-content"
@@ -1227,10 +1335,12 @@ Array [
   </div>,
   <div
     class="ant-row"
+    role="row"
     style="margin-left:-8px;margin-right:-8px;margin-top:-8px;margin-bottom:-8px"
   >
     <div
       class="ant-col ant-col-6"
+      role="cell"
       style="padding-left:8px;padding-right:8px;padding-top:8px;padding-bottom:8px"
     >
       <div>
@@ -1239,6 +1349,7 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6"
+      role="cell"
       style="padding-left:8px;padding-right:8px;padding-top:8px;padding-bottom:8px"
     >
       <div>
@@ -1247,6 +1358,7 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6"
+      role="cell"
       style="padding-left:8px;padding-right:8px;padding-top:8px;padding-bottom:8px"
     >
       <div>
@@ -1255,6 +1367,7 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6"
+      role="cell"
       style="padding-left:8px;padding-right:8px;padding-top:8px;padding-bottom:8px"
     >
       <div>
@@ -1263,6 +1376,7 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6"
+      role="cell"
       style="padding-left:8px;padding-right:8px;padding-top:8px;padding-bottom:8px"
     >
       <div>
@@ -1271,6 +1385,7 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6"
+      role="cell"
       style="padding-left:8px;padding-right:8px;padding-top:8px;padding-bottom:8px"
     >
       <div>
@@ -1279,6 +1394,7 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6"
+      role="cell"
       style="padding-left:8px;padding-right:8px;padding-top:8px;padding-bottom:8px"
     >
       <div>
@@ -1287,6 +1403,7 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6"
+      role="cell"
       style="padding-left:8px;padding-right:8px;padding-top:8px;padding-bottom:8px"
     >
       <div>
@@ -1297,10 +1414,12 @@ Array [
   "Another Row:",
   <div
     class="ant-row"
+    role="row"
     style="margin-left:-8px;margin-right:-8px;margin-top:-8px;margin-bottom:-8px"
   >
     <div
       class="ant-col ant-col-6"
+      role="cell"
       style="padding-left:8px;padding-right:8px;padding-top:8px;padding-bottom:8px"
     >
       <div>
@@ -1309,6 +1428,7 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6"
+      role="cell"
       style="padding-left:8px;padding-right:8px;padding-top:8px;padding-bottom:8px"
     >
       <div>
@@ -1317,6 +1437,7 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6"
+      role="cell"
       style="padding-left:8px;padding-right:8px;padding-top:8px;padding-bottom:8px"
     >
       <div>
@@ -1325,6 +1446,7 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6"
+      role="cell"
       style="padding-left:8px;padding-right:8px;padding-top:8px;padding-bottom:8px"
     >
       <div>
@@ -1363,19 +1485,23 @@ Array [
 exports[`renders ./components/grid/demo/responsive.md extend context correctly 1`] = `
 <div
   class="ant-row"
+  role="row"
 >
   <div
     class="ant-col ant-col-xs-2 ant-col-sm-4 ant-col-md-6 ant-col-lg-8 ant-col-xl-10"
+    role="cell"
   >
     Col
   </div>
   <div
     class="ant-col ant-col-xs-20 ant-col-sm-16 ant-col-md-12 ant-col-lg-8 ant-col-xl-4"
+    role="cell"
   >
     Col
   </div>
   <div
     class="ant-col ant-col-xs-2 ant-col-sm-4 ant-col-md-6 ant-col-lg-8 ant-col-xl-10"
+    role="cell"
   >
     Col
   </div>
@@ -1385,19 +1511,23 @@ exports[`renders ./components/grid/demo/responsive.md extend context correctly 1
 exports[`renders ./components/grid/demo/responsive-more.md extend context correctly 1`] = `
 <div
   class="ant-row"
+  role="row"
 >
   <div
     class="ant-col ant-col-xs-5 ant-col-xs-offset-1 ant-col-lg-6 ant-col-lg-offset-2"
+    role="cell"
   >
     Col
   </div>
   <div
     class="ant-col ant-col-xs-11 ant-col-xs-offset-1 ant-col-lg-6 ant-col-lg-offset-2"
+    role="cell"
   >
     Col
   </div>
   <div
     class="ant-col ant-col-xs-5 ant-col-xs-offset-1 ant-col-lg-6 ant-col-lg-offset-2"
+    role="cell"
   >
     Col
   </div>
@@ -1407,14 +1537,17 @@ exports[`renders ./components/grid/demo/responsive-more.md extend context correc
 exports[`renders ./components/grid/demo/sort.md extend context correctly 1`] = `
 <div
   class="ant-row"
+  role="row"
 >
   <div
     class="ant-col ant-col-18 ant-col-push-6"
+    role="cell"
   >
     col-18 col-push-6
   </div>
   <div
     class="ant-col ant-col-6 ant-col-pull-18"
+    role="cell"
   >
     col-6 col-pull-18
   </div>

--- a/components/grid/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/grid/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -1030,7 +1030,7 @@ Array [
       <div>
         <div
           class="ant-tooltip ant-slider-tooltip"
-          style="opacity:0;pointer-events:none"
+          style="opacity:0"
         >
           <div
             class="ant-tooltip-content"
@@ -1150,7 +1150,7 @@ Array [
       <div>
         <div
           class="ant-tooltip ant-slider-tooltip"
-          style="opacity:0;pointer-events:none"
+          style="opacity:0"
         >
           <div
             class="ant-tooltip-content"
@@ -1270,7 +1270,7 @@ Array [
       <div>
         <div
           class="ant-tooltip ant-slider-tooltip"
-          style="opacity:0;pointer-events:none"
+          style="opacity:0"
         >
           <div
             class="ant-tooltip-content"

--- a/components/grid/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/grid/__tests__/__snapshots__/demo.test.js.snap
@@ -4,66 +4,80 @@ exports[`renders ./components/grid/demo/basic.md correctly 1`] = `
 Array [
   <div
     class="ant-row"
+    role="row"
   >
     <div
       class="ant-col ant-col-24"
+      role="cell"
     >
       col
     </div>
   </div>,
   <div
     class="ant-row"
+    role="row"
   >
     <div
       class="ant-col ant-col-12"
+      role="cell"
     >
       col-12
     </div>
     <div
       class="ant-col ant-col-12"
+      role="cell"
     >
       col-12
     </div>
   </div>,
   <div
     class="ant-row"
+    role="row"
   >
     <div
       class="ant-col ant-col-8"
+      role="cell"
     >
       col-8
     </div>
     <div
       class="ant-col ant-col-8"
+      role="cell"
     >
       col-8
     </div>
     <div
       class="ant-col ant-col-8"
+      role="cell"
     >
       col-8
     </div>
   </div>,
   <div
     class="ant-row"
+    role="row"
   >
     <div
       class="ant-col ant-col-6"
+      role="cell"
     >
       col-6
     </div>
     <div
       class="ant-col ant-col-6"
+      role="cell"
     >
       col-6
     </div>
     <div
       class="ant-col ant-col-6"
+      role="cell"
     >
       col-6
     </div>
     <div
       class="ant-col ant-col-6"
+      role="cell"
     >
       col-6
     </div>
@@ -85,24 +99,29 @@ Array [
   </div>,
   <div
     class="ant-row ant-row-start"
+    role="row"
   >
     <div
       class="ant-col ant-col-4"
+      role="cell"
     >
       col-4
     </div>
     <div
       class="ant-col ant-col-4"
+      role="cell"
     >
       col-4
     </div>
     <div
       class="ant-col ant-col-4"
+      role="cell"
     >
       col-4
     </div>
     <div
       class="ant-col ant-col-4"
+      role="cell"
     >
       col-4
     </div>
@@ -119,24 +138,29 @@ Array [
   </div>,
   <div
     class="ant-row ant-row-center"
+    role="row"
   >
     <div
       class="ant-col ant-col-4"
+      role="cell"
     >
       col-4
     </div>
     <div
       class="ant-col ant-col-4"
+      role="cell"
     >
       col-4
     </div>
     <div
       class="ant-col ant-col-4"
+      role="cell"
     >
       col-4
     </div>
     <div
       class="ant-col ant-col-4"
+      role="cell"
     >
       col-4
     </div>
@@ -153,24 +177,29 @@ Array [
   </div>,
   <div
     class="ant-row ant-row-end"
+    role="row"
   >
     <div
       class="ant-col ant-col-4"
+      role="cell"
     >
       col-4
     </div>
     <div
       class="ant-col ant-col-4"
+      role="cell"
     >
       col-4
     </div>
     <div
       class="ant-col ant-col-4"
+      role="cell"
     >
       col-4
     </div>
     <div
       class="ant-col ant-col-4"
+      role="cell"
     >
       col-4
     </div>
@@ -187,24 +216,29 @@ Array [
   </div>,
   <div
     class="ant-row ant-row-space-between"
+    role="row"
   >
     <div
       class="ant-col ant-col-4"
+      role="cell"
     >
       col-4
     </div>
     <div
       class="ant-col ant-col-4"
+      role="cell"
     >
       col-4
     </div>
     <div
       class="ant-col ant-col-4"
+      role="cell"
     >
       col-4
     </div>
     <div
       class="ant-col ant-col-4"
+      role="cell"
     >
       col-4
     </div>
@@ -221,24 +255,29 @@ Array [
   </div>,
   <div
     class="ant-row ant-row-space-around"
+    role="row"
   >
     <div
       class="ant-col ant-col-4"
+      role="cell"
     >
       col-4
     </div>
     <div
       class="ant-col ant-col-4"
+      role="cell"
     >
       col-4
     </div>
     <div
       class="ant-col ant-col-4"
+      role="cell"
     >
       col-4
     </div>
     <div
       class="ant-col ant-col-4"
+      role="cell"
     >
       col-4
     </div>
@@ -255,24 +294,29 @@ Array [
   </div>,
   <div
     class="ant-row ant-row-space-evenly"
+    role="row"
   >
     <div
       class="ant-col ant-col-4"
+      role="cell"
     >
       col-4
     </div>
     <div
       class="ant-col ant-col-4"
+      role="cell"
     >
       col-4
     </div>
     <div
       class="ant-col ant-col-4"
+      role="cell"
     >
       col-4
     </div>
     <div
       class="ant-col ant-col-4"
+      role="cell"
     >
       col-4
     </div>
@@ -294,9 +338,11 @@ Array [
   </div>,
   <div
     class="ant-row ant-row-center ant-row-top"
+    role="row"
   >
     <div
       class="ant-col ant-col-4"
+      role="cell"
     >
       <p
         class="height-100"
@@ -306,6 +352,7 @@ Array [
     </div>
     <div
       class="ant-col ant-col-4"
+      role="cell"
     >
       <p
         class="height-50"
@@ -315,6 +362,7 @@ Array [
     </div>
     <div
       class="ant-col ant-col-4"
+      role="cell"
     >
       <p
         class="height-120"
@@ -324,6 +372,7 @@ Array [
     </div>
     <div
       class="ant-col ant-col-4"
+      role="cell"
     >
       <p
         class="height-80"
@@ -344,9 +393,11 @@ Array [
   </div>,
   <div
     class="ant-row ant-row-space-around ant-row-middle"
+    role="row"
   >
     <div
       class="ant-col ant-col-4"
+      role="cell"
     >
       <p
         class="height-100"
@@ -356,6 +407,7 @@ Array [
     </div>
     <div
       class="ant-col ant-col-4"
+      role="cell"
     >
       <p
         class="height-50"
@@ -365,6 +417,7 @@ Array [
     </div>
     <div
       class="ant-col ant-col-4"
+      role="cell"
     >
       <p
         class="height-120"
@@ -374,6 +427,7 @@ Array [
     </div>
     <div
       class="ant-col ant-col-4"
+      role="cell"
     >
       <p
         class="height-80"
@@ -394,9 +448,11 @@ Array [
   </div>,
   <div
     class="ant-row ant-row-space-between ant-row-bottom"
+    role="row"
   >
     <div
       class="ant-col ant-col-4"
+      role="cell"
     >
       <p
         class="height-100"
@@ -406,6 +462,7 @@ Array [
     </div>
     <div
       class="ant-col ant-col-4"
+      role="cell"
     >
       <p
         class="height-50"
@@ -415,6 +472,7 @@ Array [
     </div>
     <div
       class="ant-col ant-col-4"
+      role="cell"
     >
       <p
         class="height-120"
@@ -424,6 +482,7 @@ Array [
     </div>
     <div
       class="ant-col ant-col-4"
+      role="cell"
     >
       <p
         class="height-80"
@@ -449,24 +508,29 @@ Array [
   </div>,
   <div
     class="ant-row"
+    role="row"
   >
     <div
       class="ant-col ant-col-6 ant-col-order-4"
+      role="cell"
     >
       1 col-order-4
     </div>
     <div
       class="ant-col ant-col-6 ant-col-order-3"
+      role="cell"
     >
       2 col-order-3
     </div>
     <div
       class="ant-col ant-col-6 ant-col-order-2"
+      role="cell"
     >
       3 col-order-2
     </div>
     <div
       class="ant-col ant-col-6 ant-col-order-1"
+      role="cell"
     >
       4 col-order-1
     </div>
@@ -483,24 +547,29 @@ Array [
   </div>,
   <div
     class="ant-row"
+    role="row"
   >
     <div
       class="ant-col ant-col-6 ant-col-xs-order-1 ant-col-sm-order-2 ant-col-md-order-3 ant-col-lg-order-4"
+      role="cell"
     >
       1 col-order-responsive
     </div>
     <div
       class="ant-col ant-col-6 ant-col-xs-order-2 ant-col-sm-order-1 ant-col-md-order-4 ant-col-lg-order-3"
+      role="cell"
     >
       2 col-order-responsive
     </div>
     <div
       class="ant-col ant-col-6 ant-col-xs-order-3 ant-col-sm-order-4 ant-col-md-order-2 ant-col-lg-order-1"
+      role="cell"
     >
       3 col-order-responsive
     </div>
     <div
       class="ant-col ant-col-6 ant-col-xs-order-4 ant-col-sm-order-3 ant-col-md-order-1 ant-col-lg-order-2"
+      role="cell"
     >
       4 col-order-responsive
     </div>
@@ -522,15 +591,18 @@ Array [
   </div>,
   <div
     class="ant-row"
+    role="row"
   >
     <div
       class="ant-col"
+      role="cell"
       style="flex:2 2 auto"
     >
       2 / 5
     </div>
     <div
       class="ant-col"
+      role="cell"
       style="flex:3 3 auto"
     >
       3 / 5
@@ -548,15 +620,18 @@ Array [
   </div>,
   <div
     class="ant-row"
+    role="row"
   >
     <div
       class="ant-col"
+      role="cell"
       style="flex:0 0 100px"
     >
       100px
     </div>
     <div
       class="ant-col"
+      role="cell"
       style="flex:auto"
     >
       Fill Rest
@@ -574,15 +649,18 @@ Array [
   </div>,
   <div
     class="ant-row"
+    role="row"
   >
     <div
       class="ant-col"
+      role="cell"
       style="flex:1 1 200px"
     >
       1 1 200px
     </div>
     <div
       class="ant-col"
+      role="cell"
       style="flex:0 1 300px"
     >
       0 1 300px
@@ -590,9 +668,11 @@ Array [
   </div>,
   <div
     class="ant-row ant-row-no-wrap"
+    role="row"
   >
     <div
       class="ant-col"
+      role="cell"
       style="flex:none;min-width:0"
     >
       <div
@@ -603,6 +683,7 @@ Array [
     </div>
     <div
       class="ant-col"
+      role="cell"
       style="flex:auto;min-width:0"
     >
       auto with no-wrap
@@ -625,10 +706,12 @@ Array [
   </div>,
   <div
     class="ant-row"
+    role="row"
     style="margin-left:-8px;margin-right:-8px"
   >
     <div
       class="ant-col ant-col-6 gutter-row"
+      role="cell"
       style="padding-left:8px;padding-right:8px"
     >
       <div
@@ -639,6 +722,7 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6 gutter-row"
+      role="cell"
       style="padding-left:8px;padding-right:8px"
     >
       <div
@@ -649,6 +733,7 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6 gutter-row"
+      role="cell"
       style="padding-left:8px;padding-right:8px"
     >
       <div
@@ -659,6 +744,7 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6 gutter-row"
+      role="cell"
       style="padding-left:8px;padding-right:8px"
     >
       <div
@@ -680,10 +766,12 @@ Array [
   </div>,
   <div
     class="ant-row"
+    role="row"
     style="margin-left:-16px;margin-right:-16px"
   >
     <div
       class="ant-col ant-col-6 gutter-row"
+      role="cell"
       style="padding-left:16px;padding-right:16px"
     >
       <div
@@ -694,6 +782,7 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6 gutter-row"
+      role="cell"
       style="padding-left:16px;padding-right:16px"
     >
       <div
@@ -704,6 +793,7 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6 gutter-row"
+      role="cell"
       style="padding-left:16px;padding-right:16px"
     >
       <div
@@ -714,6 +804,7 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6 gutter-row"
+      role="cell"
       style="padding-left:16px;padding-right:16px"
     >
       <div
@@ -735,10 +826,12 @@ Array [
   </div>,
   <div
     class="ant-row"
+    role="row"
     style="margin-left:-8px;margin-right:-8px;margin-top:-12px;margin-bottom:-12px"
   >
     <div
       class="ant-col ant-col-6 gutter-row"
+      role="cell"
       style="padding-left:8px;padding-right:8px;padding-top:12px;padding-bottom:12px"
     >
       <div
@@ -749,6 +842,7 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6 gutter-row"
+      role="cell"
       style="padding-left:8px;padding-right:8px;padding-top:12px;padding-bottom:12px"
     >
       <div
@@ -759,6 +853,7 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6 gutter-row"
+      role="cell"
       style="padding-left:8px;padding-right:8px;padding-top:12px;padding-bottom:12px"
     >
       <div
@@ -769,6 +864,7 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6 gutter-row"
+      role="cell"
       style="padding-left:8px;padding-right:8px;padding-top:12px;padding-bottom:12px"
     >
       <div
@@ -779,6 +875,7 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6 gutter-row"
+      role="cell"
       style="padding-left:8px;padding-right:8px;padding-top:12px;padding-bottom:12px"
     >
       <div
@@ -789,6 +886,7 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6 gutter-row"
+      role="cell"
       style="padding-left:8px;padding-right:8px;padding-top:12px;padding-bottom:12px"
     >
       <div
@@ -799,6 +897,7 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6 gutter-row"
+      role="cell"
       style="padding-left:8px;padding-right:8px;padding-top:12px;padding-bottom:12px"
     >
       <div
@@ -809,6 +908,7 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6 gutter-row"
+      role="cell"
       style="padding-left:8px;padding-right:8px;padding-top:12px;padding-bottom:12px"
     >
       <div
@@ -825,37 +925,45 @@ exports[`renders ./components/grid/demo/offset.md correctly 1`] = `
 Array [
   <div
     class="ant-row"
+    role="row"
   >
     <div
       class="ant-col ant-col-8"
+      role="cell"
     >
       col-8
     </div>
     <div
       class="ant-col ant-col-8 ant-col-offset-8"
+      role="cell"
     >
       col-8
     </div>
   </div>,
   <div
     class="ant-row"
+    role="row"
   >
     <div
       class="ant-col ant-col-6 ant-col-offset-6"
+      role="cell"
     >
       col-6 col-offset-6
     </div>
     <div
       class="ant-col ant-col-6 ant-col-offset-6"
+      role="cell"
     >
       col-6 col-offset-6
     </div>
   </div>,
   <div
     class="ant-row"
+    role="row"
   >
     <div
       class="ant-col ant-col-12 ant-col-offset-6"
+      role="cell"
     >
       col-12 col-offset-6
     </div>
@@ -1155,10 +1263,12 @@ Array [
   </div>,
   <div
     class="ant-row"
+    role="row"
     style="margin-left:-8px;margin-right:-8px;margin-top:-8px;margin-bottom:-8px"
   >
     <div
       class="ant-col ant-col-6"
+      role="cell"
       style="padding-left:8px;padding-right:8px;padding-top:8px;padding-bottom:8px"
     >
       <div>
@@ -1167,6 +1277,7 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6"
+      role="cell"
       style="padding-left:8px;padding-right:8px;padding-top:8px;padding-bottom:8px"
     >
       <div>
@@ -1175,6 +1286,7 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6"
+      role="cell"
       style="padding-left:8px;padding-right:8px;padding-top:8px;padding-bottom:8px"
     >
       <div>
@@ -1183,6 +1295,7 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6"
+      role="cell"
       style="padding-left:8px;padding-right:8px;padding-top:8px;padding-bottom:8px"
     >
       <div>
@@ -1191,6 +1304,7 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6"
+      role="cell"
       style="padding-left:8px;padding-right:8px;padding-top:8px;padding-bottom:8px"
     >
       <div>
@@ -1199,6 +1313,7 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6"
+      role="cell"
       style="padding-left:8px;padding-right:8px;padding-top:8px;padding-bottom:8px"
     >
       <div>
@@ -1207,6 +1322,7 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6"
+      role="cell"
       style="padding-left:8px;padding-right:8px;padding-top:8px;padding-bottom:8px"
     >
       <div>
@@ -1215,6 +1331,7 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6"
+      role="cell"
       style="padding-left:8px;padding-right:8px;padding-top:8px;padding-bottom:8px"
     >
       <div>
@@ -1225,10 +1342,12 @@ Array [
   "Another Row:",
   <div
     class="ant-row"
+    role="row"
     style="margin-left:-8px;margin-right:-8px;margin-top:-8px;margin-bottom:-8px"
   >
     <div
       class="ant-col ant-col-6"
+      role="cell"
       style="padding-left:8px;padding-right:8px;padding-top:8px;padding-bottom:8px"
     >
       <div>
@@ -1237,6 +1356,7 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6"
+      role="cell"
       style="padding-left:8px;padding-right:8px;padding-top:8px;padding-bottom:8px"
     >
       <div>
@@ -1245,6 +1365,7 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6"
+      role="cell"
       style="padding-left:8px;padding-right:8px;padding-top:8px;padding-bottom:8px"
     >
       <div>
@@ -1253,6 +1374,7 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6"
+      role="cell"
       style="padding-left:8px;padding-right:8px;padding-top:8px;padding-bottom:8px"
     >
       <div>
@@ -1291,19 +1413,23 @@ Array [
 exports[`renders ./components/grid/demo/responsive.md correctly 1`] = `
 <div
   class="ant-row"
+  role="row"
 >
   <div
     class="ant-col ant-col-xs-2 ant-col-sm-4 ant-col-md-6 ant-col-lg-8 ant-col-xl-10"
+    role="cell"
   >
     Col
   </div>
   <div
     class="ant-col ant-col-xs-20 ant-col-sm-16 ant-col-md-12 ant-col-lg-8 ant-col-xl-4"
+    role="cell"
   >
     Col
   </div>
   <div
     class="ant-col ant-col-xs-2 ant-col-sm-4 ant-col-md-6 ant-col-lg-8 ant-col-xl-10"
+    role="cell"
   >
     Col
   </div>
@@ -1313,19 +1439,23 @@ exports[`renders ./components/grid/demo/responsive.md correctly 1`] = `
 exports[`renders ./components/grid/demo/responsive-more.md correctly 1`] = `
 <div
   class="ant-row"
+  role="row"
 >
   <div
     class="ant-col ant-col-xs-5 ant-col-xs-offset-1 ant-col-lg-6 ant-col-lg-offset-2"
+    role="cell"
   >
     Col
   </div>
   <div
     class="ant-col ant-col-xs-11 ant-col-xs-offset-1 ant-col-lg-6 ant-col-lg-offset-2"
+    role="cell"
   >
     Col
   </div>
   <div
     class="ant-col ant-col-xs-5 ant-col-xs-offset-1 ant-col-lg-6 ant-col-lg-offset-2"
+    role="cell"
   >
     Col
   </div>
@@ -1335,14 +1465,17 @@ exports[`renders ./components/grid/demo/responsive-more.md correctly 1`] = `
 exports[`renders ./components/grid/demo/sort.md correctly 1`] = `
 <div
   class="ant-row"
+  role="row"
 >
   <div
     class="ant-col ant-col-18 ant-col-push-6"
+    role="cell"
   >
     col-18 col-push-6
   </div>
   <div
     class="ant-col ant-col-6 ant-col-pull-18"
+    role="cell"
   >
     col-6 col-pull-18
   </div>

--- a/components/grid/__tests__/__snapshots__/index.test.js.snap
+++ b/components/grid/__tests__/__snapshots__/index.test.js.snap
@@ -3,16 +3,19 @@
 exports[`Grid renders wrapped Col correctly 1`] = `
 <div
   class="ant-row"
+  role="row"
   style="margin-left:-10px;margin-right:-10px"
 >
   <div>
     <div
       class="ant-col ant-col-12"
+      role="cell"
       style="padding-left:10px;padding-right:10px"
     />
   </div>
   <div
     class="ant-col ant-col-12"
+    role="cell"
     style="padding-left:10px;padding-right:10px"
   />
 </div>
@@ -21,30 +24,35 @@ exports[`Grid renders wrapped Col correctly 1`] = `
 exports[`Grid rtl render component should be rendered correctly in RTL direction 1`] = `
 <div
   class="ant-row ant-row-rtl"
+  role="row"
 />
 `;
 
 exports[`Grid rtl render component should be rendered correctly in RTL direction 2`] = `
 <div
   class="ant-col ant-col-rtl"
+  role="cell"
 />
 `;
 
 exports[`Grid should render Col 1`] = `
 <div
   class="ant-col ant-col-2"
+  role="cell"
 />
 `;
 
 exports[`Grid should render Row 1`] = `
 <div
   class="ant-row"
+  role="row"
 />
 `;
 
 exports[`Grid when typeof gutter is object array in large screen 1`] = `
 <div
   class="ant-row"
+  role="row"
   style="margin-left:-20px;margin-right:-20px;margin-top:-200px;margin-bottom:-200px"
 />
 `;

--- a/components/grid/__tests__/gap.test.js
+++ b/components/grid/__tests__/gap.test.js
@@ -3,7 +3,6 @@ import ReactDOMServer from 'react-dom/server';
 import { mount } from 'enzyme';
 import { render } from '../../../tests/utils';
 import { Col, Row } from '..';
-import '@testing-library/jest-dom';
 // eslint-disable-next-line no-unused-vars
 import * as styleChecker from '../../_util/styleChecker';
 

--- a/components/grid/__tests__/gap.test.js
+++ b/components/grid/__tests__/gap.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOMServer from 'react-dom/server';
 import { mount } from 'enzyme';
-import { render } from '../../../tests/utils';
+import { render, screen } from '../../../tests/utils';
 import { Col, Row } from '..';
 // eslint-disable-next-line no-unused-vars
 import * as styleChecker from '../../_util/styleChecker';
@@ -20,7 +20,7 @@ describe('Grid.Gap', () => {
       </Row>,
     );
 
-    expect(document.querySelector('.ant-row').style.rowGap).toBe('');
+    expect(screen.getByRole('row').style.rowGap).toBe('');
   });
 
   it('should use gap', () => {

--- a/components/grid/__tests__/gap.test.js
+++ b/components/grid/__tests__/gap.test.js
@@ -3,6 +3,7 @@ import ReactDOMServer from 'react-dom/server';
 import { mount } from 'enzyme';
 import { render } from '../../../tests/utils';
 import { Col, Row } from '..';
+import '@testing-library/jest-dom';
 // eslint-disable-next-line no-unused-vars
 import * as styleChecker from '../../_util/styleChecker';
 
@@ -13,6 +14,16 @@ jest.mock('../../_util/styleChecker', () => ({
 }));
 
 describe('Grid.Gap', () => {
+  it('should not have `row-gap: 0px` style', () => {
+    render(
+      <Row>
+        <Col />
+      </Row>,
+    );
+
+    expect(document.querySelector('.ant-row').style.rowGap).toBe('');
+  });
+
   it('should use gap', () => {
     const wrapper = mount(
       <Row gutter={[16, 8]}>

--- a/components/grid/col.tsx
+++ b/components/grid/col.tsx
@@ -128,7 +128,7 @@ const Col = React.forwardRef<HTMLDivElement, ColProps>((props, ref) => {
   }
 
   return (
-    <div {...others} style={{ ...mergedStyle, ...style }} className={classes} ref={ref}>
+    <div {...others} style={{ ...mergedStyle, ...style }} className={classes} ref={ref} role="cell">
       {children}
     </div>
   );

--- a/components/grid/col.tsx
+++ b/components/grid/col.tsx
@@ -128,7 +128,7 @@ const Col = React.forwardRef<HTMLDivElement, ColProps>((props, ref) => {
   }
 
   return (
-    <div {...others} style={{ ...mergedStyle, ...style }} className={classes} ref={ref} role="cell">
+    <div role="cell" {...others} style={{ ...mergedStyle, ...style }} className={classes} ref={ref}>
       {children}
     </div>
   );

--- a/components/grid/row.tsx
+++ b/components/grid/row.tsx
@@ -127,7 +127,7 @@ const Row = React.forwardRef<HTMLDivElement, RowProps>((props, ref) => {
 
   return (
     <RowContext.Provider value={rowContext}>
-      <div {...others} className={classes} style={{ ...rowStyle, ...style }} ref={ref}>
+      <div {...others} className={classes} style={{ ...rowStyle, ...style }} ref={ref} role="row">
         {children}
       </div>
     </RowContext.Provider>

--- a/components/grid/row.tsx
+++ b/components/grid/row.tsx
@@ -13,7 +13,8 @@ import useFlexGapSupport from '../_util/hooks/useFlexGapSupport';
 const RowAligns = tuple('top', 'middle', 'bottom', 'stretch');
 const RowJustify = tuple('start', 'end', 'center', 'space-around', 'space-between', 'space-evenly');
 
-export type Gutter = number | Partial<Record<Breakpoint, number>>;
+type Gap = number | undefined;
+export type Gutter = number | undefined | Partial<Record<Breakpoint, number>>;
 export interface RowProps extends React.HTMLAttributes<HTMLDivElement> {
   gutter?: Gutter | [Gutter, Gutter];
   align?: typeof RowAligns[number];
@@ -66,9 +67,9 @@ const Row = React.forwardRef<HTMLDivElement, RowProps>((props, ref) => {
   }, []);
 
   // ================================== Render ==================================
-  const getGutter = (): [number, number] => {
-    const results: [number, number] = [0, 0];
-    const normalizedGutter = Array.isArray(gutter) ? gutter : [gutter, 0];
+  const getGutter = (): [Gap, Gap] => {
+    const results: [Gap, Gap] = [undefined, undefined];
+    const normalizedGutter = Array.isArray(gutter) ? gutter : [gutter, undefined];
     normalizedGutter.forEach((g, index) => {
       if (typeof g === 'object') {
         for (let i = 0; i < responsiveArray.length; i++) {
@@ -79,7 +80,7 @@ const Row = React.forwardRef<HTMLDivElement, RowProps>((props, ref) => {
           }
         }
       } else {
-        results[index] = g || 0;
+        results[index] = g;
       }
     });
     return results;
@@ -100,8 +101,8 @@ const Row = React.forwardRef<HTMLDivElement, RowProps>((props, ref) => {
 
   // Add gutter related style
   const rowStyle: React.CSSProperties = {};
-  const horizontalGutter = gutters[0] > 0 ? gutters[0] / -2 : undefined;
-  const verticalGutter = gutters[1] > 0 ? gutters[1] / -2 : undefined;
+  const horizontalGutter = gutters[0] != null && gutters[0] > 0 ? gutters[0] / -2 : undefined;
+  const verticalGutter = gutters[1] != null && gutters[1] > 0 ? gutters[1] / -2 : undefined;
 
   if (horizontalGutter) {
     rowStyle.marginLeft = horizontalGutter;

--- a/components/grid/row.tsx
+++ b/components/grid/row.tsx
@@ -127,7 +127,7 @@ const Row = React.forwardRef<HTMLDivElement, RowProps>((props, ref) => {
 
   return (
     <RowContext.Provider value={rowContext}>
-      <div {...others} className={classes} style={{ ...rowStyle, ...style }} ref={ref} role="row">
+      <div role="row" {...others} className={classes} style={{ ...rowStyle, ...style }} ref={ref}>
         {children}
       </div>
     </RowContext.Provider>

--- a/components/input/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/input/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -5201,10 +5201,12 @@ exports[`renders ./components/input/demo/group.md extend context correctly 1`] =
   >
     <div
       class="ant-row"
+      role="row"
       style="margin-left:-4px;margin-right:-4px"
     >
       <div
         class="ant-col ant-col-5"
+        role="cell"
         style="padding-left:4px;padding-right:4px"
       >
         <input
@@ -5215,6 +5217,7 @@ exports[`renders ./components/input/demo/group.md extend context correctly 1`] =
       </div>
       <div
         class="ant-col ant-col-8"
+        role="cell"
         style="padding-left:4px;padding-right:4px"
       >
         <input

--- a/components/input/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/input/__tests__/__snapshots__/demo.test.js.snap
@@ -1418,10 +1418,12 @@ exports[`renders ./components/input/demo/group.md correctly 1`] = `
   >
     <div
       class="ant-row"
+      role="row"
       style="margin-left:-4px;margin-right:-4px"
     >
       <div
         class="ant-col ant-col-5"
+        role="cell"
         style="padding-left:4px;padding-right:4px"
       >
         <input
@@ -1432,6 +1434,7 @@ exports[`renders ./components/input/demo/group.md correctly 1`] = `
       </div>
       <div
         class="ant-col ant-col-8"
+        role="cell"
         style="padding-left:4px;padding-right:4px"
       >
         <input

--- a/components/input/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/input/__tests__/__snapshots__/index.test.tsx.snap
@@ -365,9 +365,11 @@ exports[`Input should support size in form 1`] = `
 >
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"

--- a/components/list/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/list/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -179,6 +179,7 @@ exports[`renders ./components/list/demo/grid.md extend context correctly 1`] = `
     >
       <div
         class="ant-row"
+        role="row"
         style="margin-left:-8px;margin-right:-8px"
       >
         <div
@@ -186,6 +187,7 @@ exports[`renders ./components/list/demo/grid.md extend context correctly 1`] = `
         >
           <div
             class="ant-col"
+            role="cell"
             style="padding-left:8px;padding-right:8px;flex:1 1 auto"
           >
             <div
@@ -221,6 +223,7 @@ exports[`renders ./components/list/demo/grid.md extend context correctly 1`] = `
         >
           <div
             class="ant-col"
+            role="cell"
             style="padding-left:8px;padding-right:8px;flex:1 1 auto"
           >
             <div
@@ -256,6 +259,7 @@ exports[`renders ./components/list/demo/grid.md extend context correctly 1`] = `
         >
           <div
             class="ant-col"
+            role="cell"
             style="padding-left:8px;padding-right:8px;flex:1 1 auto"
           >
             <div
@@ -291,6 +295,7 @@ exports[`renders ./components/list/demo/grid.md extend context correctly 1`] = `
         >
           <div
             class="ant-col"
+            role="cell"
             style="padding-left:8px;padding-right:8px;flex:1 1 auto"
           >
             <div
@@ -340,6 +345,7 @@ Array [
       >
         <div
           class="ant-row"
+          role="row"
           style="margin-left:-8px;margin-right:-8px"
         >
           <div
@@ -347,6 +353,7 @@ Array [
           >
             <div
               class="ant-col"
+              role="cell"
               style="padding-left:8px;padding-right:8px;flex:1 1 auto"
             >
               <div
@@ -382,6 +389,7 @@ Array [
           >
             <div
               class="ant-col"
+              role="cell"
               style="padding-left:8px;padding-right:8px;flex:1 1 auto"
             >
               <div
@@ -417,6 +425,7 @@ Array [
           >
             <div
               class="ant-col"
+              role="cell"
               style="padding-left:8px;padding-right:8px;flex:1 1 auto"
             >
               <div
@@ -452,6 +461,7 @@ Array [
           >
             <div
               class="ant-col"
+              role="cell"
               style="padding-left:8px;padding-right:8px;flex:1 1 auto"
             >
               <div
@@ -487,6 +497,7 @@ Array [
           >
             <div
               class="ant-col"
+              role="cell"
               style="padding-left:8px;padding-right:8px;flex:1 1 auto"
             >
               <div
@@ -522,6 +533,7 @@ Array [
           >
             <div
               class="ant-col"
+              role="cell"
               style="padding-left:8px;padding-right:8px;flex:1 1 auto"
             >
               <div
@@ -567,6 +579,7 @@ Array [
       >
         <div
           class="ant-row"
+          role="row"
           style="margin-left:-8px;margin-right:-8px"
         >
           <div
@@ -574,6 +587,7 @@ Array [
           >
             <div
               class="ant-col"
+              role="cell"
               style="padding-left:8px;padding-right:8px;flex:1 1 auto"
             >
               <div
@@ -609,6 +623,7 @@ Array [
           >
             <div
               class="ant-col"
+              role="cell"
               style="padding-left:8px;padding-right:8px;flex:1 1 auto"
             >
               <div
@@ -644,6 +659,7 @@ Array [
           >
             <div
               class="ant-col"
+              role="cell"
               style="padding-left:8px;padding-right:8px;flex:1 1 auto"
             >
               <div
@@ -679,6 +695,7 @@ Array [
           >
             <div
               class="ant-col"
+              role="cell"
               style="padding-left:8px;padding-right:8px;flex:1 1 auto"
             >
               <div
@@ -714,6 +731,7 @@ Array [
           >
             <div
               class="ant-col"
+              role="cell"
               style="padding-left:8px;padding-right:8px;flex:1 1 auto"
             >
               <div
@@ -749,6 +767,7 @@ Array [
           >
             <div
               class="ant-col"
+              role="cell"
               style="padding-left:8px;padding-right:8px;flex:1 1 auto"
             >
               <div
@@ -794,6 +813,7 @@ Array [
       >
         <div
           class="ant-row"
+          role="row"
           style="margin-left:-8px;margin-right:-8px"
         >
           <div
@@ -801,6 +821,7 @@ Array [
           >
             <div
               class="ant-col"
+              role="cell"
               style="padding-left:8px;padding-right:8px;flex:1 1 auto"
             >
               <div
@@ -837,6 +858,7 @@ Array [
           >
             <div
               class="ant-col"
+              role="cell"
               style="padding-left:8px;padding-right:8px;flex:1 1 auto"
             >
               <div
@@ -873,6 +895,7 @@ Array [
           >
             <div
               class="ant-col"
+              role="cell"
               style="padding-left:8px;padding-right:8px;flex:1 1 auto"
             >
               <div
@@ -909,6 +932,7 @@ Array [
           >
             <div
               class="ant-col"
+              role="cell"
               style="padding-left:8px;padding-right:8px;flex:1 1 auto"
             >
               <div
@@ -945,6 +969,7 @@ Array [
           >
             <div
               class="ant-col"
+              role="cell"
               style="padding-left:8px;padding-right:8px;flex:1 1 auto"
             >
               <div
@@ -981,6 +1006,7 @@ Array [
           >
             <div
               class="ant-col"
+              role="cell"
               style="padding-left:8px;padding-right:8px;flex:1 1 auto"
             >
               <div
@@ -1176,11 +1202,13 @@ exports[`renders ./components/list/demo/responsive.md extend context correctly 1
     >
       <div
         class="ant-row"
+        role="row"
         style="margin-left:-8px;margin-right:-8px"
       >
         <div>
           <div
             class="ant-col"
+            role="cell"
             style="padding-left:8px;padding-right:8px;flex:1 1 auto"
           >
             <div
@@ -1214,6 +1242,7 @@ exports[`renders ./components/list/demo/responsive.md extend context correctly 1
         <div>
           <div
             class="ant-col"
+            role="cell"
             style="padding-left:8px;padding-right:8px;flex:1 1 auto"
           >
             <div
@@ -1247,6 +1276,7 @@ exports[`renders ./components/list/demo/responsive.md extend context correctly 1
         <div>
           <div
             class="ant-col"
+            role="cell"
             style="padding-left:8px;padding-right:8px;flex:1 1 auto"
           >
             <div
@@ -1280,6 +1310,7 @@ exports[`renders ./components/list/demo/responsive.md extend context correctly 1
         <div>
           <div
             class="ant-col"
+            role="cell"
             style="padding-left:8px;padding-right:8px;flex:1 1 auto"
           >
             <div
@@ -1313,6 +1344,7 @@ exports[`renders ./components/list/demo/responsive.md extend context correctly 1
         <div>
           <div
             class="ant-col"
+            role="cell"
             style="padding-left:8px;padding-right:8px;flex:1 1 auto"
           >
             <div
@@ -1346,6 +1378,7 @@ exports[`renders ./components/list/demo/responsive.md extend context correctly 1
         <div>
           <div
             class="ant-col"
+            role="cell"
             style="padding-left:8px;padding-right:8px;flex:1 1 auto"
           >
             <div

--- a/components/list/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/list/__tests__/__snapshots__/demo.test.js.snap
@@ -179,6 +179,7 @@ exports[`renders ./components/list/demo/grid.md correctly 1`] = `
     >
       <div
         class="ant-row"
+        role="row"
         style="margin-left:-8px;margin-right:-8px"
       >
         <div
@@ -186,6 +187,7 @@ exports[`renders ./components/list/demo/grid.md correctly 1`] = `
         >
           <div
             class="ant-col"
+            role="cell"
             style="padding-left:8px;padding-right:8px;flex:1 1 auto"
           >
             <div
@@ -221,6 +223,7 @@ exports[`renders ./components/list/demo/grid.md correctly 1`] = `
         >
           <div
             class="ant-col"
+            role="cell"
             style="padding-left:8px;padding-right:8px;flex:1 1 auto"
           >
             <div
@@ -256,6 +259,7 @@ exports[`renders ./components/list/demo/grid.md correctly 1`] = `
         >
           <div
             class="ant-col"
+            role="cell"
             style="padding-left:8px;padding-right:8px;flex:1 1 auto"
           >
             <div
@@ -291,6 +295,7 @@ exports[`renders ./components/list/demo/grid.md correctly 1`] = `
         >
           <div
             class="ant-col"
+            role="cell"
             style="padding-left:8px;padding-right:8px;flex:1 1 auto"
           >
             <div
@@ -340,6 +345,7 @@ Array [
       >
         <div
           class="ant-row"
+          role="row"
           style="margin-left:-8px;margin-right:-8px"
         >
           <div
@@ -347,6 +353,7 @@ Array [
           >
             <div
               class="ant-col"
+              role="cell"
               style="padding-left:8px;padding-right:8px;flex:1 1 auto"
             >
               <div
@@ -382,6 +389,7 @@ Array [
           >
             <div
               class="ant-col"
+              role="cell"
               style="padding-left:8px;padding-right:8px;flex:1 1 auto"
             >
               <div
@@ -417,6 +425,7 @@ Array [
           >
             <div
               class="ant-col"
+              role="cell"
               style="padding-left:8px;padding-right:8px;flex:1 1 auto"
             >
               <div
@@ -452,6 +461,7 @@ Array [
           >
             <div
               class="ant-col"
+              role="cell"
               style="padding-left:8px;padding-right:8px;flex:1 1 auto"
             >
               <div
@@ -487,6 +497,7 @@ Array [
           >
             <div
               class="ant-col"
+              role="cell"
               style="padding-left:8px;padding-right:8px;flex:1 1 auto"
             >
               <div
@@ -522,6 +533,7 @@ Array [
           >
             <div
               class="ant-col"
+              role="cell"
               style="padding-left:8px;padding-right:8px;flex:1 1 auto"
             >
               <div
@@ -567,6 +579,7 @@ Array [
       >
         <div
           class="ant-row"
+          role="row"
           style="margin-left:-8px;margin-right:-8px"
         >
           <div
@@ -574,6 +587,7 @@ Array [
           >
             <div
               class="ant-col"
+              role="cell"
               style="padding-left:8px;padding-right:8px;flex:1 1 auto"
             >
               <div
@@ -609,6 +623,7 @@ Array [
           >
             <div
               class="ant-col"
+              role="cell"
               style="padding-left:8px;padding-right:8px;flex:1 1 auto"
             >
               <div
@@ -644,6 +659,7 @@ Array [
           >
             <div
               class="ant-col"
+              role="cell"
               style="padding-left:8px;padding-right:8px;flex:1 1 auto"
             >
               <div
@@ -679,6 +695,7 @@ Array [
           >
             <div
               class="ant-col"
+              role="cell"
               style="padding-left:8px;padding-right:8px;flex:1 1 auto"
             >
               <div
@@ -714,6 +731,7 @@ Array [
           >
             <div
               class="ant-col"
+              role="cell"
               style="padding-left:8px;padding-right:8px;flex:1 1 auto"
             >
               <div
@@ -749,6 +767,7 @@ Array [
           >
             <div
               class="ant-col"
+              role="cell"
               style="padding-left:8px;padding-right:8px;flex:1 1 auto"
             >
               <div
@@ -794,6 +813,7 @@ Array [
       >
         <div
           class="ant-row"
+          role="row"
           style="margin-left:-8px;margin-right:-8px"
         >
           <div
@@ -801,6 +821,7 @@ Array [
           >
             <div
               class="ant-col"
+              role="cell"
               style="padding-left:8px;padding-right:8px;flex:1 1 auto"
             >
               <div
@@ -837,6 +858,7 @@ Array [
           >
             <div
               class="ant-col"
+              role="cell"
               style="padding-left:8px;padding-right:8px;flex:1 1 auto"
             >
               <div
@@ -873,6 +895,7 @@ Array [
           >
             <div
               class="ant-col"
+              role="cell"
               style="padding-left:8px;padding-right:8px;flex:1 1 auto"
             >
               <div
@@ -909,6 +932,7 @@ Array [
           >
             <div
               class="ant-col"
+              role="cell"
               style="padding-left:8px;padding-right:8px;flex:1 1 auto"
             >
               <div
@@ -945,6 +969,7 @@ Array [
           >
             <div
               class="ant-col"
+              role="cell"
               style="padding-left:8px;padding-right:8px;flex:1 1 auto"
             >
               <div
@@ -981,6 +1006,7 @@ Array [
           >
             <div
               class="ant-col"
+              role="cell"
               style="padding-left:8px;padding-right:8px;flex:1 1 auto"
             >
               <div
@@ -1176,11 +1202,13 @@ exports[`renders ./components/list/demo/responsive.md correctly 1`] = `
     >
       <div
         class="ant-row"
+        role="row"
         style="margin-left:-8px;margin-right:-8px"
       >
         <div>
           <div
             class="ant-col"
+            role="cell"
             style="padding-left:8px;padding-right:8px;flex:1 1 auto"
           >
             <div
@@ -1214,6 +1242,7 @@ exports[`renders ./components/list/demo/responsive.md correctly 1`] = `
         <div>
           <div
             class="ant-col"
+            role="cell"
             style="padding-left:8px;padding-right:8px;flex:1 1 auto"
           >
             <div
@@ -1247,6 +1276,7 @@ exports[`renders ./components/list/demo/responsive.md correctly 1`] = `
         <div>
           <div
             class="ant-col"
+            role="cell"
             style="padding-left:8px;padding-right:8px;flex:1 1 auto"
           >
             <div
@@ -1280,6 +1310,7 @@ exports[`renders ./components/list/demo/responsive.md correctly 1`] = `
         <div>
           <div
             class="ant-col"
+            role="cell"
             style="padding-left:8px;padding-right:8px;flex:1 1 auto"
           >
             <div
@@ -1313,6 +1344,7 @@ exports[`renders ./components/list/demo/responsive.md correctly 1`] = `
         <div>
           <div
             class="ant-col"
+            role="cell"
             style="padding-left:8px;padding-right:8px;flex:1 1 auto"
           >
             <div
@@ -1346,6 +1378,7 @@ exports[`renders ./components/list/demo/responsive.md correctly 1`] = `
         <div>
           <div
             class="ant-col"
+            role="cell"
             style="padding-left:8px;padding-right:8px;flex:1 1 auto"
           >
             <div

--- a/components/mentions/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/mentions/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -44,9 +44,11 @@ exports[`renders ./components/mentions/demo/form.md extend context correctly 1`]
 >
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-6 ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -58,6 +60,7 @@ exports[`renders ./components/mentions/demo/form.md extend context correctly 1`]
     </div>
     <div
       class="ant-col ant-col-16 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -80,9 +83,11 @@ exports[`renders ./components/mentions/demo/form.md extend context correctly 1`]
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-6 ant-form-item-label"
+      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -94,6 +99,7 @@ exports[`renders ./components/mentions/demo/form.md extend context correctly 1`]
     </div>
     <div
       class="ant-col ant-col-16 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -117,9 +123,11 @@ exports[`renders ./components/mentions/demo/form.md extend context correctly 1`]
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-14 ant-col-offset-6 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"

--- a/components/mentions/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/mentions/__tests__/__snapshots__/demo.test.js.snap
@@ -44,9 +44,11 @@ exports[`renders ./components/mentions/demo/form.md correctly 1`] = `
 >
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-6 ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -58,6 +60,7 @@ exports[`renders ./components/mentions/demo/form.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-16 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -80,9 +83,11 @@ exports[`renders ./components/mentions/demo/form.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-6 ant-form-item-label"
+      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -94,6 +99,7 @@ exports[`renders ./components/mentions/demo/form.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-16 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -117,9 +123,11 @@ exports[`renders ./components/mentions/demo/form.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-14 ant-col-offset-6 ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"

--- a/components/page-header/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/page-header/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -339,6 +339,7 @@ Array [
     >
       <div
         class="ant-row"
+        role="row"
       >
         <div
           class="ant-statistic"
@@ -942,6 +943,7 @@ exports[`renders ./components/page-header/demo/content.md extend context correct
   >
     <div
       class="ant-row"
+      role="row"
     >
       <div
         style="flex:1"

--- a/components/page-header/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/page-header/__tests__/__snapshots__/demo.test.js.snap
@@ -339,6 +339,7 @@ Array [
     >
       <div
         class="ant-row"
+        role="row"
       >
         <div
           class="ant-statistic"
@@ -739,6 +740,7 @@ exports[`renders ./components/page-header/demo/content.md correctly 1`] = `
   >
     <div
       class="ant-row"
+      role="row"
     >
       <div
         style="flex:1"

--- a/components/skeleton/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/skeleton/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -190,9 +190,11 @@ Array [
   >
     <div
       class="ant-row ant-form-item"
+      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
+        role="cell"
       >
         <label
           class=""
@@ -203,6 +205,7 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
+        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -229,9 +232,11 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
+      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
+        role="cell"
       >
         <label
           class=""
@@ -242,6 +247,7 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
+        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -268,9 +274,11 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
+      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
+        role="cell"
       >
         <label
           class=""
@@ -281,6 +289,7 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
+        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -356,9 +365,11 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
+      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
+        role="cell"
       >
         <label
           class=""
@@ -369,6 +380,7 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
+        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -444,9 +456,11 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
+      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
+        role="cell"
       >
         <label
           class=""
@@ -457,6 +471,7 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
+        role="cell"
       >
         <div
           class="ant-form-item-control-input"

--- a/components/skeleton/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/skeleton/__tests__/__snapshots__/demo.test.js.snap
@@ -190,9 +190,11 @@ Array [
   >
     <div
       class="ant-row ant-form-item"
+      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
+        role="cell"
       >
         <label
           class=""
@@ -203,6 +205,7 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
+        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -229,9 +232,11 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
+      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
+        role="cell"
       >
         <label
           class=""
@@ -242,6 +247,7 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
+        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -268,9 +274,11 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
+      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
+        role="cell"
       >
         <label
           class=""
@@ -281,6 +289,7 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
+        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -356,9 +365,11 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
+      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
+        role="cell"
       >
         <label
           class=""
@@ -369,6 +380,7 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
+        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -444,9 +456,11 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
+      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
+        role="cell"
       >
         <label
           class=""
@@ -457,6 +471,7 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
+        role="cell"
       >
         <div
           class="ant-form-item-control-input"

--- a/components/slider/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/slider/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -466,9 +466,11 @@ exports[`renders ./components/slider/demo/input-number.md extend context correct
 <div>
   <div
     class="ant-row"
+    role="row"
   >
     <div
       class="ant-col ant-col-12"
+      role="cell"
     >
       <div
         class="ant-slider ant-slider-horizontal"
@@ -521,6 +523,7 @@ exports[`renders ./components/slider/demo/input-number.md extend context correct
     </div>
     <div
       class="ant-col ant-col-4"
+      role="cell"
     >
       <div
         class="ant-input-number"
@@ -603,9 +606,11 @@ exports[`renders ./components/slider/demo/input-number.md extend context correct
   </div>
   <div
     class="ant-row"
+    role="row"
   >
     <div
       class="ant-col ant-col-12"
+      role="cell"
     >
       <div
         class="ant-slider ant-slider-horizontal"
@@ -658,6 +663,7 @@ exports[`renders ./components/slider/demo/input-number.md extend context correct
     </div>
     <div
       class="ant-col ant-col-4"
+      role="cell"
     >
       <div
         class="ant-input-number"

--- a/components/slider/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/slider/__tests__/__snapshots__/demo.test.js.snap
@@ -250,9 +250,11 @@ exports[`renders ./components/slider/demo/input-number.md correctly 1`] = `
 <div>
   <div
     class="ant-row"
+    role="row"
   >
     <div
       class="ant-col ant-col-12"
+      role="cell"
     >
       <div
         class="ant-slider ant-slider-horizontal"
@@ -281,6 +283,7 @@ exports[`renders ./components/slider/demo/input-number.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-4"
+      role="cell"
     >
       <div
         class="ant-input-number"
@@ -363,9 +366,11 @@ exports[`renders ./components/slider/demo/input-number.md correctly 1`] = `
   </div>
   <div
     class="ant-row"
+    role="row"
   >
     <div
       class="ant-col ant-col-12"
+      role="cell"
     >
       <div
         class="ant-slider ant-slider-horizontal"
@@ -394,6 +399,7 @@ exports[`renders ./components/slider/demo/input-number.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-4"
+      role="cell"
     >
       <div
         class="ant-input-number"

--- a/components/statistic/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/statistic/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -3,10 +3,12 @@
 exports[`renders ./components/statistic/demo/basic.md extend context correctly 1`] = `
 <div
   class="ant-row"
+  role="row"
   style="margin-left:-8px;margin-right:-8px"
 >
   <div
     class="ant-col ant-col-12"
+    role="cell"
     style="padding-left:8px;padding-right:8px"
   >
     <div
@@ -34,6 +36,7 @@ exports[`renders ./components/statistic/demo/basic.md extend context correctly 1
   </div>
   <div
     class="ant-col ant-col-12"
+    role="cell"
     style="padding-left:8px;padding-right:8px"
   >
     <div
@@ -75,6 +78,7 @@ exports[`renders ./components/statistic/demo/basic.md extend context correctly 1
   </div>
   <div
     class="ant-col ant-col-12"
+    role="cell"
     style="padding-left:8px;padding-right:8px"
   >
     <div
@@ -107,10 +111,12 @@ exports[`renders ./components/statistic/demo/card.md extend context correctly 1`
 >
   <div
     class="ant-row"
+    role="row"
     style="margin-left:-8px;margin-right:-8px"
   >
     <div
       class="ant-col ant-col-12"
+      role="cell"
       style="padding-left:8px;padding-right:8px"
     >
       <div
@@ -180,6 +186,7 @@ exports[`renders ./components/statistic/demo/card.md extend context correctly 1`
     </div>
     <div
       class="ant-col ant-col-12"
+      role="cell"
       style="padding-left:8px;padding-right:8px"
     >
       <div
@@ -254,10 +261,12 @@ exports[`renders ./components/statistic/demo/card.md extend context correctly 1`
 exports[`renders ./components/statistic/demo/countdown.md extend context correctly 1`] = `
 <div
   class="ant-row"
+  role="row"
   style="margin-left:-8px;margin-right:-8px"
 >
   <div
     class="ant-col ant-col-12"
+    role="cell"
     style="padding-left:8px;padding-right:8px"
   >
     <div
@@ -281,6 +290,7 @@ exports[`renders ./components/statistic/demo/countdown.md extend context correct
   </div>
   <div
     class="ant-col ant-col-12"
+    role="cell"
     style="padding-left:8px;padding-right:8px"
   >
     <div
@@ -304,6 +314,7 @@ exports[`renders ./components/statistic/demo/countdown.md extend context correct
   </div>
   <div
     class="ant-col ant-col-24"
+    role="cell"
     style="padding-left:8px;padding-right:8px;margin-top:32px"
   >
     <div
@@ -327,6 +338,7 @@ exports[`renders ./components/statistic/demo/countdown.md extend context correct
   </div>
   <div
     class="ant-col ant-col-12"
+    role="cell"
     style="padding-left:8px;padding-right:8px"
   >
     <div
@@ -354,10 +366,12 @@ exports[`renders ./components/statistic/demo/countdown.md extend context correct
 exports[`renders ./components/statistic/demo/unit.md extend context correctly 1`] = `
 <div
   class="ant-row"
+  role="row"
   style="margin-left:-8px;margin-right:-8px"
 >
   <div
     class="ant-col ant-col-12"
+    role="cell"
     style="padding-left:8px;padding-right:8px"
   >
     <div
@@ -408,6 +422,7 @@ exports[`renders ./components/statistic/demo/unit.md extend context correctly 1`
   </div>
   <div
     class="ant-col ant-col-12"
+    role="cell"
     style="padding-left:8px;padding-right:8px"
   >
     <div

--- a/components/statistic/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/statistic/__tests__/__snapshots__/demo.test.js.snap
@@ -3,10 +3,12 @@
 exports[`renders ./components/statistic/demo/basic.md correctly 1`] = `
 <div
   class="ant-row"
+  role="row"
   style="margin-left:-8px;margin-right:-8px"
 >
   <div
     class="ant-col ant-col-12"
+    role="cell"
     style="padding-left:8px;padding-right:8px"
   >
     <div
@@ -34,6 +36,7 @@ exports[`renders ./components/statistic/demo/basic.md correctly 1`] = `
   </div>
   <div
     class="ant-col ant-col-12"
+    role="cell"
     style="padding-left:8px;padding-right:8px"
   >
     <div
@@ -75,6 +78,7 @@ exports[`renders ./components/statistic/demo/basic.md correctly 1`] = `
   </div>
   <div
     class="ant-col ant-col-12"
+    role="cell"
     style="padding-left:8px;padding-right:8px"
   >
     <div
@@ -107,10 +111,12 @@ exports[`renders ./components/statistic/demo/card.md correctly 1`] = `
 >
   <div
     class="ant-row"
+    role="row"
     style="margin-left:-8px;margin-right:-8px"
   >
     <div
       class="ant-col ant-col-12"
+      role="cell"
       style="padding-left:8px;padding-right:8px"
     >
       <div
@@ -180,6 +186,7 @@ exports[`renders ./components/statistic/demo/card.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-12"
+      role="cell"
       style="padding-left:8px;padding-right:8px"
     >
       <div
@@ -254,10 +261,12 @@ exports[`renders ./components/statistic/demo/card.md correctly 1`] = `
 exports[`renders ./components/statistic/demo/countdown.md correctly 1`] = `
 <div
   class="ant-row"
+  role="row"
   style="margin-left:-8px;margin-right:-8px"
 >
   <div
     class="ant-col ant-col-12"
+    role="cell"
     style="padding-left:8px;padding-right:8px"
   >
     <div
@@ -281,6 +290,7 @@ exports[`renders ./components/statistic/demo/countdown.md correctly 1`] = `
   </div>
   <div
     class="ant-col ant-col-12"
+    role="cell"
     style="padding-left:8px;padding-right:8px"
   >
     <div
@@ -304,6 +314,7 @@ exports[`renders ./components/statistic/demo/countdown.md correctly 1`] = `
   </div>
   <div
     class="ant-col ant-col-24"
+    role="cell"
     style="padding-left:8px;padding-right:8px;margin-top:32px"
   >
     <div
@@ -327,6 +338,7 @@ exports[`renders ./components/statistic/demo/countdown.md correctly 1`] = `
   </div>
   <div
     class="ant-col ant-col-12"
+    role="cell"
     style="padding-left:8px;padding-right:8px"
   >
     <div
@@ -354,10 +366,12 @@ exports[`renders ./components/statistic/demo/countdown.md correctly 1`] = `
 exports[`renders ./components/statistic/demo/unit.md correctly 1`] = `
 <div
   class="ant-row"
+  role="row"
   style="margin-left:-8px;margin-right:-8px"
 >
   <div
     class="ant-col ant-col-12"
+    role="cell"
     style="padding-left:8px;padding-right:8px"
   >
     <div
@@ -408,6 +422,7 @@ exports[`renders ./components/statistic/demo/unit.md correctly 1`] = `
   </div>
   <div
     class="ant-col ant-col-12"
+    role="cell"
     style="padding-left:8px;padding-right:8px"
   >
     <div

--- a/components/table/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/table/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -2295,9 +2295,11 @@ Array [
   >
     <div
       class="ant-row ant-form-item"
+      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
+        role="cell"
       >
         <label
           class=""
@@ -2308,6 +2310,7 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
+        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -2334,9 +2337,11 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
+      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
+        role="cell"
       >
         <label
           class=""
@@ -2347,6 +2352,7 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
+        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -2373,9 +2379,11 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
+      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
+        role="cell"
       >
         <label
           class=""
@@ -2386,6 +2394,7 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
+        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -2412,9 +2421,11 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
+      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
+        role="cell"
       >
         <label
           class=""
@@ -2425,6 +2436,7 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
+        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -2451,9 +2463,11 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
+      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
+        role="cell"
       >
         <label
           class=""
@@ -2464,6 +2478,7 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
+        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -2490,9 +2505,11 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
+      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
+        role="cell"
       >
         <label
           class=""
@@ -2503,6 +2520,7 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
+        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -2529,9 +2547,11 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
+      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
+        role="cell"
       >
         <label
           class=""
@@ -2542,6 +2562,7 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
+        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -2568,9 +2589,11 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
+      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
+        role="cell"
       >
         <label
           class=""
@@ -2581,6 +2604,7 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
+        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -2607,9 +2631,11 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
+      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
+        role="cell"
       >
         <label
           class=""
@@ -2620,6 +2646,7 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
+        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -2646,9 +2673,11 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
+      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
+        role="cell"
       >
         <label
           class=""
@@ -2659,6 +2688,7 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
+        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -2685,9 +2715,11 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
+      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
+        role="cell"
       >
         <label
           class=""
@@ -2698,6 +2730,7 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
+        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -2773,9 +2806,11 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
+      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
+        role="cell"
       >
         <label
           class=""
@@ -2786,6 +2821,7 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
+        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -2860,9 +2896,11 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
+      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
+        role="cell"
       >
         <label
           class=""
@@ -2873,6 +2911,7 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
+        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -2928,9 +2967,11 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
+      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
+        role="cell"
       >
         <label
           class=""
@@ -2941,6 +2982,7 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
+        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -3035,9 +3077,11 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
+      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
+        role="cell"
       >
         <label
           class=""
@@ -3048,6 +3092,7 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
+        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -15701,9 +15746,11 @@ Array [
   >
     <div
       class="ant-row ant-form-item"
+      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
+        role="cell"
       >
         <label
           class=""
@@ -15714,6 +15761,7 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
+        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -15740,9 +15788,11 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
+      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
+        role="cell"
       >
         <label
           class=""
@@ -15753,6 +15803,7 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
+        role="cell"
       >
         <div
           class="ant-form-item-control-input"

--- a/components/table/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/table/__tests__/__snapshots__/demo.test.js.snap
@@ -1804,9 +1804,11 @@ Array [
   >
     <div
       class="ant-row ant-form-item"
+      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
+        role="cell"
       >
         <label
           class=""
@@ -1817,6 +1819,7 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
+        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -1843,9 +1846,11 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
+      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
+        role="cell"
       >
         <label
           class=""
@@ -1856,6 +1861,7 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
+        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -1882,9 +1888,11 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
+      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
+        role="cell"
       >
         <label
           class=""
@@ -1895,6 +1903,7 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
+        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -1921,9 +1930,11 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
+      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
+        role="cell"
       >
         <label
           class=""
@@ -1934,6 +1945,7 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
+        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -1960,9 +1972,11 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
+      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
+        role="cell"
       >
         <label
           class=""
@@ -1973,6 +1987,7 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
+        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -1999,9 +2014,11 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
+      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
+        role="cell"
       >
         <label
           class=""
@@ -2012,6 +2029,7 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
+        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -2038,9 +2056,11 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
+      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
+        role="cell"
       >
         <label
           class=""
@@ -2051,6 +2071,7 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
+        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -2077,9 +2098,11 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
+      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
+        role="cell"
       >
         <label
           class=""
@@ -2090,6 +2113,7 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
+        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -2116,9 +2140,11 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
+      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
+        role="cell"
       >
         <label
           class=""
@@ -2129,6 +2155,7 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
+        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -2155,9 +2182,11 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
+      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
+        role="cell"
       >
         <label
           class=""
@@ -2168,6 +2197,7 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
+        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -2194,9 +2224,11 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
+      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
+        role="cell"
       >
         <label
           class=""
@@ -2207,6 +2239,7 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
+        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -2282,9 +2315,11 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
+      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
+        role="cell"
       >
         <label
           class=""
@@ -2295,6 +2330,7 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
+        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -2369,9 +2405,11 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
+      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
+        role="cell"
       >
         <label
           class=""
@@ -2382,6 +2420,7 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
+        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -2437,9 +2476,11 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
+      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
+        role="cell"
       >
         <label
           class=""
@@ -2450,6 +2491,7 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
+        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -2544,9 +2586,11 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
+      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
+        role="cell"
       >
         <label
           class=""
@@ -2557,6 +2601,7 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
+        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -11943,9 +11988,11 @@ Array [
   >
     <div
       class="ant-row ant-form-item"
+      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
+        role="cell"
       >
         <label
           class=""
@@ -11956,6 +12003,7 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
+        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -11982,9 +12030,11 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
+      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
+        role="cell"
       >
         <label
           class=""
@@ -11995,6 +12045,7 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
+        role="cell"
       >
         <div
           class="ant-form-item-control-input"

--- a/components/upload/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/upload/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -3781,9 +3781,11 @@ exports[`renders ./components/upload/demo/upload-with-aliyun-oss.md extend conte
 >
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-4 ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -3795,6 +3797,7 @@ exports[`renders ./components/upload/demo/upload-with-aliyun-oss.md extend conte
     </div>
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"

--- a/components/upload/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/upload/__tests__/__snapshots__/demo.test.js.snap
@@ -3565,9 +3565,11 @@ exports[`renders ./components/upload/demo/upload-with-aliyun-oss.md correctly 1`
 >
   <div
     class="ant-row ant-form-item"
+    role="row"
   >
     <div
       class="ant-col ant-col-4 ant-form-item-label"
+      role="cell"
     >
       <label
         class=""
@@ -3579,6 +3581,7 @@ exports[`renders ./components/upload/demo/upload-with-aliyun-oss.md correctly 1`
     </div>
     <div
       class="ant-col ant-form-item-control"
+      role="cell"
     >
       <div
         class="ant-form-item-control-input"


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

无链接

### 💡 Background and solution

`Row` 组件默认自带 `row-gap: 0px` 样式定义，这是不必要的，默认浏览器就会设置为 0。
![167110774-83ff9c64-511d-45c9-ad0b-215a9d02dd43](https://user-images.githubusercontent.com/21054747/167234198-c7817ccf-d035-4541-b522-9308a2f905bf.jpeg)
解决方案：允许内部 gutter 值为 undefined, 只有值不为 0 和 undefined 才增加到属性上

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Wipe out Row unnecessary style value of `rowGap: 0`. |
| 🇨🇳 Chinese | 修复 Row 里不必要的 `rowGap: 0` style 属性。 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
