### PR TITLE
fix: bad List.Item type (#35454)

### DIFF
--- a/components/list/Item.tsx
+++ b/components/list/Item.tsx
@@ -63,7 +63,7 @@ export const Meta: FC<ListItemMetaProps> = ({
 };
 
 export interface ListItemTypeProps
-  extends ForwardRefExoticComponent<ListItemMetaProps & React.RefAttributes<HTMLElement>> {
+  extends ForwardRefExoticComponent<ListItemProps & React.RefAttributes<HTMLElement>> {
   Meta: typeof Meta;
 }
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

### 🤔 This is a ...

- [x] Bug fix

### 🔗 Related issue link

close https://github.com/ant-design/ant-design/issues/35454

### 💡 Background and solution

The `ListItemTypeProps` incorrectly extends `ListItemMetaProps` instead of `ListItemProps`.

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix broken List.Item type |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
