### PR TITLE
docs: indicate that menu items require `key`s

### DIFF
--- a/components/menu/index.en-US.md
+++ b/components/menu/index.en-US.md
@@ -29,11 +29,12 @@ ReactDOM.render(<Alert message="After version 4.20.0, we provide a simpler usage
 ```jsx
 // works when >=4.20.0, recommended ✅
 const items = [
-  { label: 'item 1' },
-  { label: 'item 2' },
+  { label: 'item 1', key: 'item-1' }, // remember to pass the key prop
+  { label: 'item 2', key: 'item-2' }, // which is required
   {
     label: 'sub menu',
-    children: [{ label: 'item 3' }],
+    key: 'submenu'
+    children: [{ label: 'item 3', key: 'submenu-item-1' }],
   },
 ];
 return <Menu items={items} />;

--- a/components/menu/index.zh-CN.md
+++ b/components/menu/index.zh-CN.md
@@ -30,11 +30,12 @@ ReactDOM.render(<Alert message="在 4.20.0 版本后，我们提供了 <Menu ite
 ```jsx
 // >=4.20.0 可用，推荐的写法 ✅
 const items = [
-  { label: '菜单项一' },
-  { label: '菜单项二' },
+  { label: '菜单项一', key: 'item-1' }, // 菜单项务必填写 key
+  { label: '菜单项二', key: 'item-2' },
   {
     label: '子菜单',
-    children: [{ label: '子菜单项' }],
+    key: 'submenu',
+    children: [{ label: '子菜单项', key: 'submenu-item-1' }],
   },
 ];
 return <Menu items={items} />;


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

See #35473

### 💡 Background and solution

The updated `<Menu>` component accepts a new way of specifying menu items, but the example in the documentation doesn't make it clear that the "key" property is still required.

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Updated the "Usage upgrade" section in `Menu` docs to reflect `key` is still required in the new API |
| 🇨🇳 Chinese | 更新 `Menu` 文档的 4.20.0 版本过渡示例，注明菜单项需要 keys |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
