### PR TITLE
fix(statistic): ignore the decimal part when the precision is negative

### DIFF
--- a/components/statistic/Number.tsx
+++ b/components/statistic/Number.tsx
@@ -30,7 +30,7 @@ const StatisticNumber: React.FC<NumberProps> = props => {
       int = int.replace(/\B(?=(\d{3})+(?!\d))/g, groupSeparator);
 
       if (typeof precision === 'number') {
-        decimal = padEnd(decimal, precision, '0').slice(0, precision);
+        decimal = padEnd(decimal, precision, '0').slice(0, precision > 0 ? precision : 0);
       }
 
       if (decimal) {

--- a/components/statistic/__tests__/index.test.js
+++ b/components/statistic/__tests__/index.test.js
@@ -51,6 +51,20 @@ describe('Statistic', () => {
     expect(wrapper.render()).toMatchSnapshot();
   });
 
+  it('allow negetive precision', () => {
+    [
+      [-1, -1112893.1212, '-1,112,893'],
+      [-2, -1112893.1212, '-1,112,893'],
+      [-3,  -1112893.1212, '-1,112,893'],
+      [-1, -1112893,  '-1,112,893'],
+      [-1, 1112893,  '1,112,893'],
+    ].forEach(([precision, value, expectValue]) => {
+      const wrapper = mount(<Statistic precision={precision} value={value} />);
+      expect(wrapper.find('.ant-statistic-content-value-int').text()).toEqual(expectValue);
+      expect(wrapper.find('.ant-statistic-content-value-decimal').length).toBe(0);
+    })
+  });
+
   it('loading with skeleton', async () => {
     let loading = false;
     const wrapper = mount(<Statistic title="Active Users" value={112112} loading={loading} />);


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
close #35450 

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution
Ignore the decimal part when the precision is negative

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Ignore the decimal part when the precision is negative      |
| 🇨🇳 Chinese |     当精度为负数时忽略小数部分      |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
