### PR TITLE
refactor: modal confirm button style

### DIFF
--- a/components/modal/style/confirm.less
+++ b/components/modal/style/confirm.less
@@ -46,12 +46,12 @@
   }
 
   .@{confirm-prefix-cls}-btns {
-    float: right;
     margin-top: 24px;
+    text-align: end;
 
     .@{ant-prefix}-btn + .@{ant-prefix}-btn {
+      margin-right: 8px;
       margin-bottom: 0;
-      margin-left: 8px;
     }
   }
 

--- a/components/modal/style/confirm.less
+++ b/components/modal/style/confirm.less
@@ -47,11 +47,11 @@
 
   .@{confirm-prefix-cls}-btns {
     margin-top: 24px;
-    text-align: end;
+    text-align: right;
 
     .@{ant-prefix}-btn + .@{ant-prefix}-btn {
-      margin-right: 8px;
       margin-bottom: 0;
+      margin-left: 8px;
     }
   }
 

--- a/components/modal/style/rtl.less
+++ b/components/modal/style/rtl.less
@@ -53,7 +53,7 @@
 
     &-btns {
       .@{dialog-wrap-rtl-cls} & {
-        float: left;
+        text-align: left;
       }
       .@{ant-prefix}-btn + .@{ant-prefix}-btn {
         .@{dialog-wrap-rtl-cls} & {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

- 用 `text-align` 替换原来的 `float` 方式实现 modal confirm 底部按钮布局，便于 V5 css-in-js  改造。
- `ant-modal-confirm-btns` 里面的变成 block，而不是原来 float 布局下的 content width

改造前：
<img width="827" alt="D49C3468-76CC-4748-AF08-B90C896017BF" src="https://user-images.githubusercontent.com/8649233/168217596-0662c34e-b8cf-40d3-8f58-58c0a8b001fb.png">

改造后：
<img width="824" alt="5F8BD3A8-D91E-4CEA-A6F7-CB9C2F7A17A6" src="https://user-images.githubusercontent.com/8649233/168217610-8ed339ab-5902-4161-bf33-df03981be484.png">

- 用户侧无感知

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Change the implementation of the bottom button layout of the Modal confirm component      |
| 🇨🇳 Chinese |  改变 Modal confirm 组件底部按钮布局实现方式       |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
