### PR TITLE
style: anchor text is overwritten

### DIFF
--- a/components/anchor/style/index.less
+++ b/components/anchor/style/index.less
@@ -56,12 +56,11 @@
 
   &-link {
     padding: @anchor-link-padding;
-    line-height: 1.143;
 
     &-title {
       position: relative;
       display: block;
-      margin-bottom: 6px;
+      margin-bottom: 3px;
       overflow: hidden;
       color: @text-color;
       white-space: nowrap;
@@ -79,8 +78,8 @@
   }
 
   &-link &-link {
-    padding-top: 5px;
-    padding-bottom: 5px;
+    padding-top: 2px;
+    padding-bottom: 2px;
   }
 }
 

--- a/components/style/themes/default.less
+++ b/components/style/themes/default.less
@@ -509,7 +509,7 @@
 // ---
 @anchor-bg: transparent;
 @anchor-border-color: @border-color-split;
-@anchor-link-top: 7px;
+@anchor-link-top: 4px;
 @anchor-link-left: 16px;
 @anchor-link-padding: @anchor-link-top 0 @anchor-link-top @anchor-link-left;
 

--- a/components/style/themes/variable.less
+++ b/components/style/themes/variable.less
@@ -564,7 +564,7 @@
 // ---
 @anchor-bg: transparent;
 @anchor-border-color: @border-color-split;
-@anchor-link-top: 7px;
+@anchor-link-top: 4px;
 @anchor-link-left: 16px;
 @anchor-link-padding: @anchor-link-top 0 @anchor-link-top @anchor-link-left;
 


### PR DESCRIPTION

|before|after|
|- |-|
| ![image](https://user-images.githubusercontent.com/26833520/169002767-1501e1c7-08c2-4f5b-acf5-ce24f1d6cf64.png) | ![image](https://user-images.githubusercontent.com/26833520/169002597-e768e2d4-0e40-4bf4-932d-e9d4daea3aac.png)|


<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
#35608 
<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |       Because line-height is now used, some browsers or zoomed pages have incomplete text display, so I use padding instead of line-height    |
| 🇨🇳 Chinese |     因为现在使用line-height，有些浏览器或者缩放的页面文字显示不全，所以我用padding代替line-height      |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
