### PR TITLE
remove row and cell aria roles

### DIFF
--- a/components/auto-complete/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/auto-complete/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -522,11 +522,9 @@ exports[`renders ./components/auto-complete/demo/form-debug.md extend context co
 >
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
-      role="cell"
     >
       <label
         class=""
@@ -537,7 +535,6 @@ exports[`renders ./components/auto-complete/demo/form-debug.md extend context co
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -592,11 +589,9 @@ exports[`renders ./components/auto-complete/demo/form-debug.md extend context co
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
-      role="cell"
     >
       <label
         class=""
@@ -607,7 +602,6 @@ exports[`renders ./components/auto-complete/demo/form-debug.md extend context co
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -736,11 +730,9 @@ exports[`renders ./components/auto-complete/demo/form-debug.md extend context co
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
-      role="cell"
     >
       <label
         class=""
@@ -751,7 +743,6 @@ exports[`renders ./components/auto-complete/demo/form-debug.md extend context co
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -926,11 +917,9 @@ exports[`renders ./components/auto-complete/demo/form-debug.md extend context co
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
-      role="cell"
     >
       <label
         class=""
@@ -941,7 +930,6 @@ exports[`renders ./components/auto-complete/demo/form-debug.md extend context co
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -1023,11 +1011,9 @@ exports[`renders ./components/auto-complete/demo/form-debug.md extend context co
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
-      role="cell"
     >
       <label
         class=""
@@ -1038,7 +1024,6 @@ exports[`renders ./components/auto-complete/demo/form-debug.md extend context co
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -1240,11 +1225,9 @@ exports[`renders ./components/auto-complete/demo/form-debug.md extend context co
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
-      role="cell"
     >
       <label
         class=""
@@ -1255,7 +1238,6 @@ exports[`renders ./components/auto-complete/demo/form-debug.md extend context co
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -1466,11 +1448,9 @@ exports[`renders ./components/auto-complete/demo/form-debug.md extend context co
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
-      role="cell"
     >
       <label
         class=""
@@ -1481,7 +1461,6 @@ exports[`renders ./components/auto-complete/demo/form-debug.md extend context co
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"

--- a/components/auto-complete/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/auto-complete/__tests__/__snapshots__/demo.test.js.snap
@@ -174,11 +174,9 @@ exports[`renders ./components/auto-complete/demo/form-debug.md correctly 1`] = `
 >
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
-      role="cell"
     >
       <label
         class=""
@@ -189,7 +187,6 @@ exports[`renders ./components/auto-complete/demo/form-debug.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -230,11 +227,9 @@ exports[`renders ./components/auto-complete/demo/form-debug.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
-      role="cell"
     >
       <label
         class=""
@@ -245,7 +240,6 @@ exports[`renders ./components/auto-complete/demo/form-debug.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -314,11 +308,9 @@ exports[`renders ./components/auto-complete/demo/form-debug.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
-      role="cell"
     >
       <label
         class=""
@@ -329,7 +321,6 @@ exports[`renders ./components/auto-complete/demo/form-debug.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -430,11 +421,9 @@ exports[`renders ./components/auto-complete/demo/form-debug.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
-      role="cell"
     >
       <label
         class=""
@@ -445,7 +434,6 @@ exports[`renders ./components/auto-complete/demo/form-debug.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -513,11 +501,9 @@ exports[`renders ./components/auto-complete/demo/form-debug.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
-      role="cell"
     >
       <label
         class=""
@@ -528,7 +514,6 @@ exports[`renders ./components/auto-complete/demo/form-debug.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -656,11 +641,9 @@ exports[`renders ./components/auto-complete/demo/form-debug.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
-      role="cell"
     >
       <label
         class=""
@@ -671,7 +654,6 @@ exports[`renders ./components/auto-complete/demo/form-debug.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -808,11 +790,9 @@ exports[`renders ./components/auto-complete/demo/form-debug.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
-      role="cell"
     >
       <label
         class=""
@@ -823,7 +803,6 @@ exports[`renders ./components/auto-complete/demo/form-debug.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"

--- a/components/calendar/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/calendar/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -3185,12 +3185,10 @@ exports[`renders ./components/calendar/demo/customize-header.md extend context c
       </h4>
       <div
         class="ant-row"
-        role="row"
         style="margin-left:-4px;margin-right:-4px"
       >
         <div
           class="ant-col"
-          role="cell"
           style="padding-left:4px;padding-right:4px"
         >
           <div
@@ -3239,7 +3237,6 @@ exports[`renders ./components/calendar/demo/customize-header.md extend context c
         </div>
         <div
           class="ant-col"
-          role="cell"
           style="padding-left:4px;padding-right:4px"
         >
           <div
@@ -3690,7 +3687,6 @@ exports[`renders ./components/calendar/demo/customize-header.md extend context c
         </div>
         <div
           class="ant-col"
-          role="cell"
           style="padding-left:4px;padding-right:4px"
         >
           <div

--- a/components/calendar/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/calendar/__tests__/__snapshots__/demo.test.js.snap
@@ -1905,12 +1905,10 @@ exports[`renders ./components/calendar/demo/customize-header.md correctly 1`] = 
       </h4>
       <div
         class="ant-row"
-        role="row"
         style="margin-left:-4px;margin-right:-4px"
       >
         <div
           class="ant-col"
-          role="cell"
           style="padding-left:4px;padding-right:4px"
         >
           <div
@@ -1959,7 +1957,6 @@ exports[`renders ./components/calendar/demo/customize-header.md correctly 1`] = 
         </div>
         <div
           class="ant-col"
-          role="cell"
           style="padding-left:4px;padding-right:4px"
         >
           <div
@@ -2024,7 +2021,6 @@ exports[`renders ./components/calendar/demo/customize-header.md correctly 1`] = 
         </div>
         <div
           class="ant-col"
-          role="cell"
           style="padding-left:4px;padding-right:4px"
         >
           <div

--- a/components/card/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/card/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -233,12 +233,10 @@ exports[`renders ./components/card/demo/in-column.md extend context correctly 1`
 >
   <div
     class="ant-row"
-    role="row"
     style="margin-left:-8px;margin-right:-8px"
   >
     <div
       class="ant-col ant-col-8"
-      role="cell"
       style="padding-left:8px;padding-right:8px"
     >
       <div
@@ -266,7 +264,6 @@ exports[`renders ./components/card/demo/in-column.md extend context correctly 1`
     </div>
     <div
       class="ant-col ant-col-8"
-      role="cell"
       style="padding-left:8px;padding-right:8px"
     >
       <div
@@ -294,7 +291,6 @@ exports[`renders ./components/card/demo/in-column.md extend context correctly 1`
     </div>
     <div
       class="ant-col ant-col-8"
-      role="cell"
       style="padding-left:8px;padding-right:8px"
     >
       <div
@@ -438,12 +434,10 @@ Array [
       >
         <div
           class="ant-row"
-          role="row"
           style="margin-left:-4px;margin-right:-4px"
         >
           <div
             class="ant-col ant-col-22"
-            role="cell"
             style="padding-left:4px;padding-right:4px"
           >
             <div
@@ -453,12 +447,10 @@ Array [
         </div>
         <div
           class="ant-row"
-          role="row"
           style="margin-left:-4px;margin-right:-4px"
         >
           <div
             class="ant-col ant-col-8"
-            role="cell"
             style="padding-left:4px;padding-right:4px"
           >
             <div
@@ -467,7 +459,6 @@ Array [
           </div>
           <div
             class="ant-col ant-col-15"
-            role="cell"
             style="padding-left:4px;padding-right:4px"
           >
             <div
@@ -477,12 +468,10 @@ Array [
         </div>
         <div
           class="ant-row"
-          role="row"
           style="margin-left:-4px;margin-right:-4px"
         >
           <div
             class="ant-col ant-col-6"
-            role="cell"
             style="padding-left:4px;padding-right:4px"
           >
             <div
@@ -491,7 +480,6 @@ Array [
           </div>
           <div
             class="ant-col ant-col-18"
-            role="cell"
             style="padding-left:4px;padding-right:4px"
           >
             <div
@@ -501,12 +489,10 @@ Array [
         </div>
         <div
           class="ant-row"
-          role="row"
           style="margin-left:-4px;margin-right:-4px"
         >
           <div
             class="ant-col ant-col-13"
-            role="cell"
             style="padding-left:4px;padding-right:4px"
           >
             <div
@@ -515,7 +501,6 @@ Array [
           </div>
           <div
             class="ant-col ant-col-9"
-            role="cell"
             style="padding-left:4px;padding-right:4px"
           >
             <div
@@ -525,12 +510,10 @@ Array [
         </div>
         <div
           class="ant-row"
-          role="row"
           style="margin-left:-4px;margin-right:-4px"
         >
           <div
             class="ant-col ant-col-4"
-            role="cell"
             style="padding-left:4px;padding-right:4px"
           >
             <div
@@ -539,7 +522,6 @@ Array [
           </div>
           <div
             class="ant-col ant-col-3"
-            role="cell"
             style="padding-left:4px;padding-right:4px"
           >
             <div
@@ -548,7 +530,6 @@ Array [
           </div>
           <div
             class="ant-col ant-col-16"
-            role="cell"
             style="padding-left:4px;padding-right:4px"
           >
             <div

--- a/components/card/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/card/__tests__/__snapshots__/demo.test.js.snap
@@ -233,12 +233,10 @@ exports[`renders ./components/card/demo/in-column.md correctly 1`] = `
 >
   <div
     class="ant-row"
-    role="row"
     style="margin-left:-8px;margin-right:-8px"
   >
     <div
       class="ant-col ant-col-8"
-      role="cell"
       style="padding-left:8px;padding-right:8px"
     >
       <div
@@ -266,7 +264,6 @@ exports[`renders ./components/card/demo/in-column.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-8"
-      role="cell"
       style="padding-left:8px;padding-right:8px"
     >
       <div
@@ -294,7 +291,6 @@ exports[`renders ./components/card/demo/in-column.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-8"
-      role="cell"
       style="padding-left:8px;padding-right:8px"
     >
       <div
@@ -438,12 +434,10 @@ Array [
       >
         <div
           class="ant-row"
-          role="row"
           style="margin-left:-4px;margin-right:-4px"
         >
           <div
             class="ant-col ant-col-22"
-            role="cell"
             style="padding-left:4px;padding-right:4px"
           >
             <div
@@ -453,12 +447,10 @@ Array [
         </div>
         <div
           class="ant-row"
-          role="row"
           style="margin-left:-4px;margin-right:-4px"
         >
           <div
             class="ant-col ant-col-8"
-            role="cell"
             style="padding-left:4px;padding-right:4px"
           >
             <div
@@ -467,7 +459,6 @@ Array [
           </div>
           <div
             class="ant-col ant-col-15"
-            role="cell"
             style="padding-left:4px;padding-right:4px"
           >
             <div
@@ -477,12 +468,10 @@ Array [
         </div>
         <div
           class="ant-row"
-          role="row"
           style="margin-left:-4px;margin-right:-4px"
         >
           <div
             class="ant-col ant-col-6"
-            role="cell"
             style="padding-left:4px;padding-right:4px"
           >
             <div
@@ -491,7 +480,6 @@ Array [
           </div>
           <div
             class="ant-col ant-col-18"
-            role="cell"
             style="padding-left:4px;padding-right:4px"
           >
             <div
@@ -501,12 +489,10 @@ Array [
         </div>
         <div
           class="ant-row"
-          role="row"
           style="margin-left:-4px;margin-right:-4px"
         >
           <div
             class="ant-col ant-col-13"
-            role="cell"
             style="padding-left:4px;padding-right:4px"
           >
             <div
@@ -515,7 +501,6 @@ Array [
           </div>
           <div
             class="ant-col ant-col-9"
-            role="cell"
             style="padding-left:4px;padding-right:4px"
           >
             <div
@@ -525,12 +510,10 @@ Array [
         </div>
         <div
           class="ant-row"
-          role="row"
           style="margin-left:-4px;margin-right:-4px"
         >
           <div
             class="ant-col ant-col-4"
-            role="cell"
             style="padding-left:4px;padding-right:4px"
           >
             <div
@@ -539,7 +522,6 @@ Array [
           </div>
           <div
             class="ant-col ant-col-3"
-            role="cell"
             style="padding-left:4px;padding-right:4px"
           >
             <div
@@ -548,7 +530,6 @@ Array [
           </div>
           <div
             class="ant-col ant-col-16"
-            role="cell"
             style="padding-left:4px;padding-right:4px"
           >
             <div

--- a/components/card/__tests__/__snapshots__/index.test.js.snap
+++ b/components/card/__tests__/__snapshots__/index.test.js.snap
@@ -24,12 +24,10 @@ exports[`Card should still have padding when card which set padding to 0 is load
     >
       <div
         class="ant-row"
-        role="row"
         style="margin-left: -4px; margin-right: -4px;"
       >
         <div
           class="ant-col ant-col-22"
-          role="cell"
           style="padding-left: 4px; padding-right: 4px;"
         >
           <div
@@ -39,12 +37,10 @@ exports[`Card should still have padding when card which set padding to 0 is load
       </div>
       <div
         class="ant-row"
-        role="row"
         style="margin-left: -4px; margin-right: -4px;"
       >
         <div
           class="ant-col ant-col-8"
-          role="cell"
           style="padding-left: 4px; padding-right: 4px;"
         >
           <div
@@ -53,7 +49,6 @@ exports[`Card should still have padding when card which set padding to 0 is load
         </div>
         <div
           class="ant-col ant-col-15"
-          role="cell"
           style="padding-left: 4px; padding-right: 4px;"
         >
           <div
@@ -63,12 +58,10 @@ exports[`Card should still have padding when card which set padding to 0 is load
       </div>
       <div
         class="ant-row"
-        role="row"
         style="margin-left: -4px; margin-right: -4px;"
       >
         <div
           class="ant-col ant-col-6"
-          role="cell"
           style="padding-left: 4px; padding-right: 4px;"
         >
           <div
@@ -77,7 +70,6 @@ exports[`Card should still have padding when card which set padding to 0 is load
         </div>
         <div
           class="ant-col ant-col-18"
-          role="cell"
           style="padding-left: 4px; padding-right: 4px;"
         >
           <div
@@ -87,12 +79,10 @@ exports[`Card should still have padding when card which set padding to 0 is load
       </div>
       <div
         class="ant-row"
-        role="row"
         style="margin-left: -4px; margin-right: -4px;"
       >
         <div
           class="ant-col ant-col-13"
-          role="cell"
           style="padding-left: 4px; padding-right: 4px;"
         >
           <div
@@ -101,7 +91,6 @@ exports[`Card should still have padding when card which set padding to 0 is load
         </div>
         <div
           class="ant-col ant-col-9"
-          role="cell"
           style="padding-left: 4px; padding-right: 4px;"
         >
           <div
@@ -111,12 +100,10 @@ exports[`Card should still have padding when card which set padding to 0 is load
       </div>
       <div
         class="ant-row"
-        role="row"
         style="margin-left: -4px; margin-right: -4px;"
       >
         <div
           class="ant-col ant-col-4"
-          role="cell"
           style="padding-left: 4px; padding-right: 4px;"
         >
           <div
@@ -125,7 +112,6 @@ exports[`Card should still have padding when card which set padding to 0 is load
         </div>
         <div
           class="ant-col ant-col-3"
-          role="cell"
           style="padding-left: 4px; padding-right: 4px;"
         >
           <div
@@ -134,7 +120,6 @@ exports[`Card should still have padding when card which set padding to 0 is load
         </div>
         <div
           class="ant-col ant-col-16"
-          role="cell"
           style="padding-left: 4px; padding-right: 4px;"
         >
           <div

--- a/components/checkbox/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/checkbox/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -606,11 +606,9 @@ exports[`renders ./components/checkbox/demo/layout.md extend context correctly 1
 >
   <div
     class="ant-row"
-    role="row"
   >
     <div
       class="ant-col ant-col-8"
-      role="cell"
     >
       <label
         class="ant-checkbox-wrapper"
@@ -634,7 +632,6 @@ exports[`renders ./components/checkbox/demo/layout.md extend context correctly 1
     </div>
     <div
       class="ant-col ant-col-8"
-      role="cell"
     >
       <label
         class="ant-checkbox-wrapper"
@@ -658,7 +655,6 @@ exports[`renders ./components/checkbox/demo/layout.md extend context correctly 1
     </div>
     <div
       class="ant-col ant-col-8"
-      role="cell"
     >
       <label
         class="ant-checkbox-wrapper"
@@ -682,7 +678,6 @@ exports[`renders ./components/checkbox/demo/layout.md extend context correctly 1
     </div>
     <div
       class="ant-col ant-col-8"
-      role="cell"
     >
       <label
         class="ant-checkbox-wrapper"
@@ -706,7 +701,6 @@ exports[`renders ./components/checkbox/demo/layout.md extend context correctly 1
     </div>
     <div
       class="ant-col ant-col-8"
-      role="cell"
     >
       <label
         class="ant-checkbox-wrapper"

--- a/components/checkbox/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/checkbox/__tests__/__snapshots__/demo.test.js.snap
@@ -606,11 +606,9 @@ exports[`renders ./components/checkbox/demo/layout.md correctly 1`] = `
 >
   <div
     class="ant-row"
-    role="row"
   >
     <div
       class="ant-col ant-col-8"
-      role="cell"
     >
       <label
         class="ant-checkbox-wrapper"
@@ -634,7 +632,6 @@ exports[`renders ./components/checkbox/demo/layout.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-8"
-      role="cell"
     >
       <label
         class="ant-checkbox-wrapper"
@@ -658,7 +655,6 @@ exports[`renders ./components/checkbox/demo/layout.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-8"
-      role="cell"
     >
       <label
         class="ant-checkbox-wrapper"
@@ -682,7 +678,6 @@ exports[`renders ./components/checkbox/demo/layout.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-8"
-      role="cell"
     >
       <label
         class="ant-checkbox-wrapper"
@@ -706,7 +701,6 @@ exports[`renders ./components/checkbox/demo/layout.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-8"
-      role="cell"
     >
       <label
         class="ant-checkbox-wrapper"

--- a/components/comment/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/comment/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -216,11 +216,9 @@ exports[`renders ./components/comment/demo/editor.md extend context correctly 1`
       >
         <div
           class="ant-row ant-form-item"
-          role="row"
         >
           <div
             class="ant-col ant-form-item-control"
-            role="cell"
           >
             <div
               class="ant-form-item-control-input"
@@ -238,11 +236,9 @@ exports[`renders ./components/comment/demo/editor.md extend context correctly 1`
         </div>
         <div
           class="ant-row ant-form-item"
-          role="row"
         >
           <div
             class="ant-col ant-form-item-control"
-            role="cell"
           >
             <div
               class="ant-form-item-control-input"

--- a/components/comment/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/comment/__tests__/__snapshots__/demo.test.js.snap
@@ -144,11 +144,9 @@ exports[`renders ./components/comment/demo/editor.md correctly 1`] = `
       >
         <div
           class="ant-row ant-form-item"
-          role="row"
         >
           <div
             class="ant-col ant-form-item-control"
-            role="cell"
           >
             <div
               class="ant-form-item-control-input"
@@ -166,11 +164,9 @@ exports[`renders ./components/comment/demo/editor.md correctly 1`] = `
         </div>
         <div
           class="ant-row ant-form-item"
-          role="row"
         >
           <div
             class="ant-col ant-form-item-control"
-            role="cell"
           >
             <div
               class="ant-form-item-control-input"

--- a/components/config-provider/__tests__/__snapshots__/components.test.js.snap
+++ b/components/config-provider/__tests__/__snapshots__/components.test.js.snap
@@ -13368,11 +13368,9 @@ exports[`ConfigProvider components Form configProvider 1`] = `
 >
   <div
     class="config-row config-form-item config-form-item-with-help config-form-item-has-error"
-    role="row"
   >
     <div
       class="config-col config-form-item-control"
-      role="cell"
     >
       <div
         class="config-form-item-control-input"
@@ -13408,11 +13406,9 @@ exports[`ConfigProvider components Form configProvider componentSize large 1`] =
 >
   <div
     class="config-row config-form-item config-form-item-with-help config-form-item-has-error"
-    role="row"
   >
     <div
       class="config-col config-form-item-control"
-      role="cell"
     >
       <div
         class="config-form-item-control-input"
@@ -13448,11 +13444,9 @@ exports[`ConfigProvider components Form configProvider componentSize middle 1`] 
 >
   <div
     class="config-row config-form-item config-form-item-with-help config-form-item-has-error"
-    role="row"
   >
     <div
       class="config-col config-form-item-control"
-      role="cell"
     >
       <div
         class="config-form-item-control-input"
@@ -13488,11 +13482,9 @@ exports[`ConfigProvider components Form configProvider virtual and dropdownMatch
 >
   <div
     class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-error"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -13528,11 +13520,9 @@ exports[`ConfigProvider components Form normal 1`] = `
 >
   <div
     class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-error"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -13568,11 +13558,9 @@ exports[`ConfigProvider components Form prefixCls 1`] = `
 >
   <div
     class="ant-row prefix-Form-item prefix-Form-item-with-help prefix-Form-item-has-error"
-    role="row"
   >
     <div
       class="ant-col prefix-Form-item-control"
-      role="cell"
     >
       <div
         class="prefix-Form-item-control-input"
@@ -13605,11 +13593,9 @@ exports[`ConfigProvider components Form prefixCls 1`] = `
 exports[`ConfigProvider components Grid configProvider 1`] = `
 <div
   class="config-row"
-  role="row"
 >
   <div
     class="config-col config-col-1"
-    role="cell"
   />
 </div>
 `;
@@ -13617,11 +13603,9 @@ exports[`ConfigProvider components Grid configProvider 1`] = `
 exports[`ConfigProvider components Grid configProvider componentSize large 1`] = `
 <div
   class="config-row"
-  role="row"
 >
   <div
     class="config-col config-col-1"
-    role="cell"
   />
 </div>
 `;
@@ -13629,11 +13613,9 @@ exports[`ConfigProvider components Grid configProvider componentSize large 1`] =
 exports[`ConfigProvider components Grid configProvider componentSize middle 1`] = `
 <div
   class="config-row"
-  role="row"
 >
   <div
     class="config-col config-col-1"
-    role="cell"
   />
 </div>
 `;
@@ -13641,11 +13623,9 @@ exports[`ConfigProvider components Grid configProvider componentSize middle 1`] 
 exports[`ConfigProvider components Grid configProvider virtual and dropdownMatchSelectWidth 1`] = `
 <div
   class="ant-row"
-  role="row"
 >
   <div
     class="ant-col ant-col-1"
-    role="cell"
   />
 </div>
 `;
@@ -13653,11 +13633,9 @@ exports[`ConfigProvider components Grid configProvider virtual and dropdownMatch
 exports[`ConfigProvider components Grid normal 1`] = `
 <div
   class="ant-row"
-  role="row"
 >
   <div
     class="ant-col ant-col-1"
-    role="cell"
   />
 </div>
 `;
@@ -13665,11 +13643,9 @@ exports[`ConfigProvider components Grid normal 1`] = `
 exports[`ConfigProvider components Grid prefixCls 1`] = `
 <div
   class="prefix-row"
-  role="row"
 >
   <div
     class="prefix-col prefix-col-1"
-    role="cell"
   />
 </div>
 `;

--- a/components/config-provider/__tests__/__snapshots__/form.test.js.snap
+++ b/components/config-provider/__tests__/__snapshots__/form.test.js.snap
@@ -6,11 +6,9 @@ exports[`ConfigProvider.Form form requiredMark set requiredMark optional 1`] = `
 >
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
-      role="cell"
     >
       <label
         class="ant-form-item-required-mark-optional"
@@ -28,7 +26,6 @@ exports[`ConfigProvider.Form form requiredMark set requiredMark optional 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"

--- a/components/form/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/form/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -8,21 +8,17 @@ exports[`renders ./components/form/demo/advanced-search.md extend context correc
   >
     <div
       class="ant-row"
-      role="row"
       style="margin-left:-12px;margin-right:-12px"
     >
       <div
         class="ant-col ant-col-8"
-        role="cell"
         style="padding-left:12px;padding-right:12px"
       >
         <div
           class="ant-row ant-form-item"
-          role="row"
         >
           <div
             class="ant-col ant-form-item-label"
-            role="cell"
           >
             <label
               class="ant-form-item-required"
@@ -34,7 +30,6 @@ exports[`renders ./components/form/demo/advanced-search.md extend context correc
           </div>
           <div
             class="ant-col ant-form-item-control"
-            role="cell"
           >
             <div
               class="ant-form-item-control-input"
@@ -56,16 +51,13 @@ exports[`renders ./components/form/demo/advanced-search.md extend context correc
       </div>
       <div
         class="ant-col ant-col-8"
-        role="cell"
         style="padding-left:12px;padding-right:12px"
       >
         <div
           class="ant-row ant-form-item"
-          role="row"
         >
           <div
             class="ant-col ant-form-item-label"
-            role="cell"
           >
             <label
               class="ant-form-item-required"
@@ -77,7 +69,6 @@ exports[`renders ./components/form/demo/advanced-search.md extend context correc
           </div>
           <div
             class="ant-col ant-form-item-control"
-            role="cell"
           >
             <div
               class="ant-form-item-control-input"
@@ -234,16 +225,13 @@ exports[`renders ./components/form/demo/advanced-search.md extend context correc
       </div>
       <div
         class="ant-col ant-col-8"
-        role="cell"
         style="padding-left:12px;padding-right:12px"
       >
         <div
           class="ant-row ant-form-item"
-          role="row"
         >
           <div
             class="ant-col ant-form-item-label"
-            role="cell"
           >
             <label
               class="ant-form-item-required"
@@ -255,7 +243,6 @@ exports[`renders ./components/form/demo/advanced-search.md extend context correc
           </div>
           <div
             class="ant-col ant-form-item-control"
-            role="cell"
           >
             <div
               class="ant-form-item-control-input"
@@ -277,16 +264,13 @@ exports[`renders ./components/form/demo/advanced-search.md extend context correc
       </div>
       <div
         class="ant-col ant-col-8"
-        role="cell"
         style="padding-left:12px;padding-right:12px"
       >
         <div
           class="ant-row ant-form-item"
-          role="row"
         >
           <div
             class="ant-col ant-form-item-label"
-            role="cell"
           >
             <label
               class="ant-form-item-required"
@@ -298,7 +282,6 @@ exports[`renders ./components/form/demo/advanced-search.md extend context correc
           </div>
           <div
             class="ant-col ant-form-item-control"
-            role="cell"
           >
             <div
               class="ant-form-item-control-input"
@@ -320,16 +303,13 @@ exports[`renders ./components/form/demo/advanced-search.md extend context correc
       </div>
       <div
         class="ant-col ant-col-8"
-        role="cell"
         style="padding-left:12px;padding-right:12px"
       >
         <div
           class="ant-row ant-form-item"
-          role="row"
         >
           <div
             class="ant-col ant-form-item-label"
-            role="cell"
           >
             <label
               class="ant-form-item-required"
@@ -341,7 +321,6 @@ exports[`renders ./components/form/demo/advanced-search.md extend context correc
           </div>
           <div
             class="ant-col ant-form-item-control"
-            role="cell"
           >
             <div
               class="ant-form-item-control-input"
@@ -498,16 +477,13 @@ exports[`renders ./components/form/demo/advanced-search.md extend context correc
       </div>
       <div
         class="ant-col ant-col-8"
-        role="cell"
         style="padding-left:12px;padding-right:12px"
       >
         <div
           class="ant-row ant-form-item"
-          role="row"
         >
           <div
             class="ant-col ant-form-item-label"
-            role="cell"
           >
             <label
               class="ant-form-item-required"
@@ -519,7 +495,6 @@ exports[`renders ./components/form/demo/advanced-search.md extend context correc
           </div>
           <div
             class="ant-col ant-form-item-control"
-            role="cell"
           >
             <div
               class="ant-form-item-control-input"
@@ -542,11 +517,9 @@ exports[`renders ./components/form/demo/advanced-search.md extend context correc
     </div>
     <div
       class="ant-row"
-      role="row"
     >
       <div
         class="ant-col ant-col-24"
-        role="cell"
         style="text-align:right"
       >
         <button
@@ -609,11 +582,9 @@ exports[`renders ./components/form/demo/basic.md extend context correctly 1`] = 
 >
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-8 ant-form-item-label"
-      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -625,7 +596,6 @@ exports[`renders ./components/form/demo/basic.md extend context correctly 1`] = 
     </div>
     <div
       class="ant-col ant-col-16 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -645,11 +615,9 @@ exports[`renders ./components/form/demo/basic.md extend context correctly 1`] = 
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-8 ant-form-item-label"
-      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -661,7 +629,6 @@ exports[`renders ./components/form/demo/basic.md extend context correctly 1`] = 
     </div>
     <div
       class="ant-col ant-col-16 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -713,11 +680,9 @@ exports[`renders ./components/form/demo/basic.md extend context correctly 1`] = 
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-16 ant-col-offset-8 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -751,11 +716,9 @@ exports[`renders ./components/form/demo/basic.md extend context correctly 1`] = 
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-16 ant-col-offset-8 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -787,11 +750,9 @@ Array [
   >
     <div
       class="ant-row ant-form-item"
-      role="row"
     >
       <div
         class="ant-col ant-col-24 ant-form-item-label"
-        role="cell"
       >
         <label
           class="ant-form-item-required"
@@ -803,7 +764,6 @@ Array [
       </div>
       <div
         class="ant-col ant-col-24 ant-form-item-control"
-        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -823,11 +783,9 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
-      role="row"
     >
       <div
         class="ant-col ant-col-24 ant-form-item-label"
-        role="cell"
       >
         <label
           class="ant-form-item-required"
@@ -839,7 +797,6 @@ Array [
       </div>
       <div
         class="ant-col ant-col-24 ant-form-item-control"
-        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -891,11 +848,9 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
-      role="row"
     >
       <div
         class="ant-col ant-col-24 ant-form-item-control"
-        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -923,11 +878,9 @@ Array [
   >
     <div
       class="ant-row ant-form-item"
-      role="row"
     >
       <div
         class="ant-col ant-form-item-label ant-col-sm-24 ant-col-xl-24"
-        role="cell"
       >
         <label
           class="ant-form-item-required"
@@ -939,7 +892,6 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control ant-col-sm-24 ant-col-xl-24"
-        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -959,11 +911,9 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
-      role="row"
     >
       <div
         class="ant-col ant-form-item-label ant-col-sm-24 ant-col-xl-24"
-        role="cell"
       >
         <label
           class="ant-form-item-required"
@@ -975,7 +925,6 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control ant-col-sm-24 ant-col-xl-24"
-        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -1027,11 +976,9 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
-      role="row"
     >
       <div
         class="ant-col ant-form-item-control ant-col-sm-24 ant-col-xl-24"
-        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -1062,11 +1009,9 @@ exports[`renders ./components/form/demo/control-hooks.md extend context correctl
 >
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-8 ant-form-item-label"
-      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -1078,7 +1023,6 @@ exports[`renders ./components/form/demo/control-hooks.md extend context correctl
     </div>
     <div
       class="ant-col ant-col-16 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -1098,11 +1042,9 @@ exports[`renders ./components/form/demo/control-hooks.md extend context correctl
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-8 ant-form-item-label"
-      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -1114,7 +1056,6 @@ exports[`renders ./components/form/demo/control-hooks.md extend context correctl
     </div>
     <div
       class="ant-col ant-col-16 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -1286,11 +1227,9 @@ exports[`renders ./components/form/demo/control-hooks.md extend context correctl
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-16 ant-col-offset-8 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -1336,11 +1275,9 @@ exports[`renders ./components/form/demo/control-ref.md extend context correctly 
 >
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-8 ant-form-item-label"
-      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -1352,7 +1289,6 @@ exports[`renders ./components/form/demo/control-ref.md extend context correctly 
     </div>
     <div
       class="ant-col ant-col-16 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -1372,11 +1308,9 @@ exports[`renders ./components/form/demo/control-ref.md extend context correctly 
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-8 ant-form-item-label"
-      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -1388,7 +1322,6 @@ exports[`renders ./components/form/demo/control-ref.md extend context correctly 
     </div>
     <div
       class="ant-col ant-col-16 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -1560,11 +1493,9 @@ exports[`renders ./components/form/demo/control-ref.md extend context correctly 
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-16 ant-col-offset-8 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -1610,11 +1541,9 @@ exports[`renders ./components/form/demo/customized-form-controls.md extend conte
 >
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -1626,7 +1555,6 @@ exports[`renders ./components/form/demo/customized-form-controls.md extend conte
     </div>
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -1790,11 +1718,9 @@ exports[`renders ./components/form/demo/customized-form-controls.md extend conte
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -1825,11 +1751,9 @@ exports[`renders ./components/form/demo/dep-debug.md extend context correctly 1`
   0
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -1841,7 +1765,6 @@ exports[`renders ./components/form/demo/dep-debug.md extend context correctly 1`
     </div>
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -1861,11 +1784,9 @@ exports[`renders ./components/form/demo/dep-debug.md extend context correctly 1`
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -1877,7 +1798,6 @@ exports[`renders ./components/form/demo/dep-debug.md extend context correctly 1`
     </div>
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -1904,11 +1824,9 @@ exports[`renders ./components/form/demo/disabled-input-debug.md extend context c
 >
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -1919,7 +1837,6 @@ exports[`renders ./components/form/demo/disabled-input-debug.md extend context c
     </div>
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -1939,11 +1856,9 @@ exports[`renders ./components/form/demo/disabled-input-debug.md extend context c
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-error"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -1954,7 +1869,6 @@ exports[`renders ./components/form/demo/disabled-input-debug.md extend context c
     </div>
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -1984,11 +1898,9 @@ exports[`renders ./components/form/demo/disabled-input-debug.md extend context c
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-error"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -1999,7 +1911,6 @@ exports[`renders ./components/form/demo/disabled-input-debug.md extend context c
     </div>
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -2030,11 +1941,9 @@ exports[`renders ./components/form/demo/disabled-input-debug.md extend context c
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -2045,7 +1954,6 @@ exports[`renders ./components/form/demo/disabled-input-debug.md extend context c
     </div>
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -2065,11 +1973,9 @@ exports[`renders ./components/form/demo/disabled-input-debug.md extend context c
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-error"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -2080,7 +1986,6 @@ exports[`renders ./components/form/demo/disabled-input-debug.md extend context c
     </div>
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -2110,11 +2015,9 @@ exports[`renders ./components/form/demo/disabled-input-debug.md extend context c
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-error"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -2125,7 +2028,6 @@ exports[`renders ./components/form/demo/disabled-input-debug.md extend context c
     </div>
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -2156,11 +2058,9 @@ exports[`renders ./components/form/demo/disabled-input-debug.md extend context c
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -2171,7 +2071,6 @@ exports[`renders ./components/form/demo/disabled-input-debug.md extend context c
     </div>
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -2204,11 +2103,9 @@ exports[`renders ./components/form/demo/disabled-input-debug.md extend context c
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-error"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -2219,7 +2116,6 @@ exports[`renders ./components/form/demo/disabled-input-debug.md extend context c
     </div>
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -2262,11 +2158,9 @@ exports[`renders ./components/form/demo/disabled-input-debug.md extend context c
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-error"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -2277,7 +2171,6 @@ exports[`renders ./components/form/demo/disabled-input-debug.md extend context c
     </div>
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -2321,11 +2214,9 @@ exports[`renders ./components/form/demo/disabled-input-debug.md extend context c
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -2336,7 +2227,6 @@ exports[`renders ./components/form/demo/disabled-input-debug.md extend context c
     </div>
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -2365,11 +2255,9 @@ exports[`renders ./components/form/demo/disabled-input-debug.md extend context c
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-error"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -2380,7 +2268,6 @@ exports[`renders ./components/form/demo/disabled-input-debug.md extend context c
     </div>
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -2419,11 +2306,9 @@ exports[`renders ./components/form/demo/disabled-input-debug.md extend context c
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-error"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -2434,7 +2319,6 @@ exports[`renders ./components/form/demo/disabled-input-debug.md extend context c
     </div>
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -2482,11 +2366,9 @@ exports[`renders ./components/form/demo/dynamic-form-item.md extend context corr
 >
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-xs-offset-0 ant-col-sm-20 ant-col-sm-offset-4"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -2564,11 +2446,9 @@ exports[`renders ./components/form/demo/dynamic-form-item.md extend context corr
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-xs-offset-0 ant-col-sm-20 ant-col-sm-offset-4"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -2599,11 +2479,9 @@ exports[`renders ./components/form/demo/dynamic-form-items.md extend context cor
 >
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -2648,11 +2526,9 @@ exports[`renders ./components/form/demo/dynamic-form-items.md extend context cor
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -2683,11 +2559,9 @@ exports[`renders ./components/form/demo/dynamic-form-items-complex.md extend con
 >
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
-      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -2699,7 +2573,6 @@ exports[`renders ./components/form/demo/dynamic-form-items-complex.md extend con
     </div>
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -2852,11 +2725,9 @@ exports[`renders ./components/form/demo/dynamic-form-items-complex.md extend con
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -2901,11 +2772,9 @@ exports[`renders ./components/form/demo/dynamic-form-items-complex.md extend con
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -2936,11 +2805,9 @@ exports[`renders ./components/form/demo/dynamic-form-items-no-style.md extend co
 >
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -2951,7 +2818,6 @@ exports[`renders ./components/form/demo/dynamic-form-items-no-style.md extend co
     </div>
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -2961,11 +2827,9 @@ exports[`renders ./components/form/demo/dynamic-form-items-no-style.md extend co
         >
           <div
             class="ant-row ant-form-item"
-            role="row"
           >
             <div
               class="ant-col ant-form-item-control"
-              role="cell"
             >
               <div
                 class="ant-form-item-control-input"
@@ -3014,11 +2878,9 @@ exports[`renders ./components/form/demo/dynamic-form-items-no-style.md extend co
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -3048,11 +2910,9 @@ exports[`renders ./components/form/demo/dynamic-rule.md extend context correctly
 >
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-4 ant-form-item-label"
-      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -3064,7 +2924,6 @@ exports[`renders ./components/form/demo/dynamic-rule.md extend context correctly
     </div>
     <div
       class="ant-col ant-col-8 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -3085,11 +2944,9 @@ exports[`renders ./components/form/demo/dynamic-rule.md extend context correctly
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-4 ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -3101,7 +2958,6 @@ exports[`renders ./components/form/demo/dynamic-rule.md extend context correctly
     </div>
     <div
       class="ant-col ant-col-8 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -3122,11 +2978,9 @@ exports[`renders ./components/form/demo/dynamic-rule.md extend context correctly
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-8 ant-col-offset-4 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -3158,11 +3012,9 @@ exports[`renders ./components/form/demo/dynamic-rule.md extend context correctly
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-8 ant-col-offset-4 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -3192,11 +3044,9 @@ exports[`renders ./components/form/demo/form-context.md extend context correctly
 >
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-8 ant-form-item-label"
-      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -3208,7 +3058,6 @@ exports[`renders ./components/form/demo/form-context.md extend context correctly
     </div>
     <div
       class="ant-col ant-col-16 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -3228,11 +3077,9 @@ exports[`renders ./components/form/demo/form-context.md extend context correctly
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-8 ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -3243,7 +3090,6 @@ exports[`renders ./components/form/demo/form-context.md extend context correctly
     </div>
     <div
       class="ant-col ant-col-16 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -3282,11 +3128,9 @@ exports[`renders ./components/form/demo/form-context.md extend context correctly
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-16 ant-col-offset-8 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -3339,11 +3183,9 @@ Array [
   >
     <div
       class="ant-row ant-form-item"
-      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
-        role="cell"
       >
         <label
           class="ant-form-item-required"
@@ -3355,7 +3197,6 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
-        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -3396,11 +3237,9 @@ exports[`renders ./components/form/demo/inline-login.md extend context correctly
 >
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -3448,11 +3287,9 @@ exports[`renders ./components/form/demo/inline-login.md extend context correctly
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -3500,11 +3337,9 @@ exports[`renders ./components/form/demo/inline-login.md extend context correctly
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -3534,11 +3369,9 @@ exports[`renders ./components/form/demo/label-debug.md extend context correctly 
 >
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-8 ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -3571,7 +3404,6 @@ exports[`renders ./components/form/demo/label-debug.md extend context correctly 
     </div>
     <div
       class="ant-col ant-col-16 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -3591,11 +3423,9 @@ exports[`renders ./components/form/demo/label-debug.md extend context correctly 
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-8 ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -3628,7 +3458,6 @@ exports[`renders ./components/form/demo/label-debug.md extend context correctly 
     </div>
     <div
       class="ant-col ant-col-16 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -3687,11 +3516,9 @@ exports[`renders ./components/form/demo/layout.md extend context correctly 1`] =
 >
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-4 ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -3703,7 +3530,6 @@ exports[`renders ./components/form/demo/layout.md extend context correctly 1`] =
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -3780,11 +3606,9 @@ exports[`renders ./components/form/demo/layout.md extend context correctly 1`] =
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-4 ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -3795,7 +3619,6 @@ exports[`renders ./components/form/demo/layout.md extend context correctly 1`] =
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -3815,11 +3638,9 @@ exports[`renders ./components/form/demo/layout.md extend context correctly 1`] =
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-4 ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -3830,7 +3651,6 @@ exports[`renders ./components/form/demo/layout.md extend context correctly 1`] =
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -3850,11 +3670,9 @@ exports[`renders ./components/form/demo/layout.md extend context correctly 1`] =
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-14 ant-col-offset-4 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -3884,11 +3702,9 @@ exports[`renders ./components/form/demo/layout-can-wrap.md extend context correc
 >
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-form-item-label-left ant-form-item-label-wrap"
-      role="cell"
       style="flex:0 0 110px"
     >
       <label
@@ -3901,7 +3717,6 @@ exports[`renders ./components/form/demo/layout-can-wrap.md extend context correc
     </div>
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
       style="flex:1 1 auto"
     >
       <div
@@ -3922,11 +3737,9 @@ exports[`renders ./components/form/demo/layout-can-wrap.md extend context correc
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-form-item-label-left ant-form-item-label-wrap"
-      role="cell"
       style="flex:0 0 110px"
     >
       <label
@@ -3939,7 +3752,6 @@ exports[`renders ./components/form/demo/layout-can-wrap.md extend context correc
     </div>
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
       style="flex:1 1 auto"
     >
       <div
@@ -3960,11 +3772,9 @@ exports[`renders ./components/form/demo/layout-can-wrap.md extend context correc
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-form-item-label-left ant-form-item-label-wrap"
-      role="cell"
       style="flex:0 0 110px"
     >
       <label
@@ -3976,7 +3786,6 @@ exports[`renders ./components/form/demo/layout-can-wrap.md extend context correc
     </div>
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
       style="flex:1 1 auto"
     >
       <div
@@ -4007,11 +3816,9 @@ exports[`renders ./components/form/demo/nest-messages.md extend context correctl
 >
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-8 ant-form-item-label"
-      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -4023,7 +3830,6 @@ exports[`renders ./components/form/demo/nest-messages.md extend context correctl
     </div>
     <div
       class="ant-col ant-col-16 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -4043,11 +3849,9 @@ exports[`renders ./components/form/demo/nest-messages.md extend context correctl
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-8 ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -4059,7 +3863,6 @@ exports[`renders ./components/form/demo/nest-messages.md extend context correctl
     </div>
     <div
       class="ant-col ant-col-16 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -4079,11 +3882,9 @@ exports[`renders ./components/form/demo/nest-messages.md extend context correctl
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-8 ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -4095,7 +3896,6 @@ exports[`renders ./components/form/demo/nest-messages.md extend context correctl
     </div>
     <div
       class="ant-col ant-col-16 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -4183,11 +3983,9 @@ exports[`renders ./components/form/demo/nest-messages.md extend context correctl
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-8 ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -4199,7 +3997,6 @@ exports[`renders ./components/form/demo/nest-messages.md extend context correctl
     </div>
     <div
       class="ant-col ant-col-16 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -4219,11 +4016,9 @@ exports[`renders ./components/form/demo/nest-messages.md extend context correctl
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-8 ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -4235,7 +4030,6 @@ exports[`renders ./components/form/demo/nest-messages.md extend context correctl
     </div>
     <div
       class="ant-col ant-col-16 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -4253,11 +4047,9 @@ exports[`renders ./components/form/demo/nest-messages.md extend context correctl
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-16 ant-col-offset-8 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -4287,11 +4079,9 @@ exports[`renders ./components/form/demo/normal-login.md extend context correctly
 >
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -4339,11 +4129,9 @@ exports[`renders ./components/form/demo/normal-login.md extend context correctly
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -4391,11 +4179,9 @@ exports[`renders ./components/form/demo/normal-login.md extend context correctly
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -4435,11 +4221,9 @@ exports[`renders ./components/form/demo/normal-login.md extend context correctly
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -4474,11 +4258,9 @@ exports[`renders ./components/form/demo/ref-item.md extend context correctly 1`]
 >
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -4490,7 +4272,6 @@ exports[`renders ./components/form/demo/ref-item.md extend context correctly 1`]
     </div>
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -4510,11 +4291,9 @@ exports[`renders ./components/form/demo/ref-item.md extend context correctly 1`]
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -4558,11 +4337,9 @@ exports[`renders ./components/form/demo/register.md extend context correctly 1`]
 >
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
-      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -4574,7 +4351,6 @@ exports[`renders ./components/form/demo/register.md extend context correctly 1`]
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -4594,11 +4370,9 @@ exports[`renders ./components/form/demo/register.md extend context correctly 1`]
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
-      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -4610,7 +4384,6 @@ exports[`renders ./components/form/demo/register.md extend context correctly 1`]
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -4662,11 +4435,9 @@ exports[`renders ./components/form/demo/register.md extend context correctly 1`]
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
-      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -4678,7 +4449,6 @@ exports[`renders ./components/form/demo/register.md extend context correctly 1`]
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -4730,11 +4500,9 @@ exports[`renders ./components/form/demo/register.md extend context correctly 1`]
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
-      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -4793,7 +4561,6 @@ exports[`renders ./components/form/demo/register.md extend context correctly 1`]
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -4813,11 +4580,9 @@ exports[`renders ./components/form/demo/register.md extend context correctly 1`]
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
-      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -4829,7 +4594,6 @@ exports[`renders ./components/form/demo/register.md extend context correctly 1`]
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -5018,11 +4782,9 @@ exports[`renders ./components/form/demo/register.md extend context correctly 1`]
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
-      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -5034,7 +4796,6 @@ exports[`renders ./components/form/demo/register.md extend context correctly 1`]
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -5210,11 +4971,9 @@ exports[`renders ./components/form/demo/register.md extend context correctly 1`]
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
-      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -5226,7 +4985,6 @@ exports[`renders ./components/form/demo/register.md extend context correctly 1`]
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -5467,11 +5225,9 @@ exports[`renders ./components/form/demo/register.md extend context correctly 1`]
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
-      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -5483,7 +5239,6 @@ exports[`renders ./components/form/demo/register.md extend context correctly 1`]
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -5541,11 +5296,9 @@ exports[`renders ./components/form/demo/register.md extend context correctly 1`]
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
-      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -5557,7 +5310,6 @@ exports[`renders ./components/form/demo/register.md extend context correctly 1`]
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -5580,11 +5332,9 @@ exports[`renders ./components/form/demo/register.md extend context correctly 1`]
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
-      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -5596,7 +5346,6 @@ exports[`renders ./components/form/demo/register.md extend context correctly 1`]
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -5768,11 +5517,9 @@ exports[`renders ./components/form/demo/register.md extend context correctly 1`]
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
-      role="cell"
     >
       <label
         class=""
@@ -5783,7 +5530,6 @@ exports[`renders ./components/form/demo/register.md extend context correctly 1`]
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -5793,12 +5539,10 @@ exports[`renders ./components/form/demo/register.md extend context correctly 1`]
         >
           <div
             class="ant-row"
-            role="row"
             style="margin-left:-4px;margin-right:-4px"
           >
             <div
               class="ant-col ant-col-12"
-              role="cell"
               style="padding-left:4px;padding-right:4px"
             >
               <input
@@ -5810,7 +5554,6 @@ exports[`renders ./components/form/demo/register.md extend context correctly 1`]
             </div>
             <div
               class="ant-col ant-col-12"
-              role="cell"
               style="padding-left:4px;padding-right:4px"
             >
               <button
@@ -5834,11 +5577,9 @@ exports[`renders ./components/form/demo/register.md extend context correctly 1`]
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-xs-offset-0 ant-col-sm-16 ant-col-sm-offset-8"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -5876,11 +5617,9 @@ exports[`renders ./components/form/demo/register.md extend context correctly 1`]
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-xs-offset-0 ant-col-sm-16 ant-col-sm-offset-8"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -5909,11 +5648,9 @@ exports[`renders ./components/form/demo/required-mark.md extend context correctl
 >
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
-      role="cell"
     >
       <label
         class="ant-form-item-required-mark-optional"
@@ -5931,7 +5668,6 @@ exports[`renders ./components/form/demo/required-mark.md extend context correctl
     </div>
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -6008,11 +5744,9 @@ exports[`renders ./components/form/demo/required-mark.md extend context correctl
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
-      role="cell"
     >
       <label
         class="ant-form-item-required ant-form-item-required-mark-optional"
@@ -6070,7 +5804,6 @@ exports[`renders ./components/form/demo/required-mark.md extend context correctl
     </div>
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -6090,11 +5823,9 @@ exports[`renders ./components/form/demo/required-mark.md extend context correctl
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
-      role="cell"
     >
       <label
         class="ant-form-item-required-mark-optional"
@@ -6158,7 +5889,6 @@ exports[`renders ./components/form/demo/required-mark.md extend context correctl
     </div>
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -6178,11 +5908,9 @@ exports[`renders ./components/form/demo/required-mark.md extend context correctl
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -6211,11 +5939,9 @@ exports[`renders ./components/form/demo/size.md extend context correctly 1`] = `
 >
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-4 ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -6227,7 +5953,6 @@ exports[`renders ./components/form/demo/size.md extend context correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -6304,11 +6029,9 @@ exports[`renders ./components/form/demo/size.md extend context correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-4 ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -6319,7 +6042,6 @@ exports[`renders ./components/form/demo/size.md extend context correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -6338,11 +6060,9 @@ exports[`renders ./components/form/demo/size.md extend context correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-4 ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -6353,7 +6073,6 @@ exports[`renders ./components/form/demo/size.md extend context correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -6480,11 +6199,9 @@ exports[`renders ./components/form/demo/size.md extend context correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-4 ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -6495,7 +6212,6 @@ exports[`renders ./components/form/demo/size.md extend context correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -6661,11 +6377,9 @@ exports[`renders ./components/form/demo/size.md extend context correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-4 ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -6676,7 +6390,6 @@ exports[`renders ./components/form/demo/size.md extend context correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -6799,11 +6512,9 @@ exports[`renders ./components/form/demo/size.md extend context correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-4 ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -6814,7 +6525,6 @@ exports[`renders ./components/form/demo/size.md extend context correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -7421,11 +7131,9 @@ exports[`renders ./components/form/demo/size.md extend context correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-4 ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -7436,7 +7144,6 @@ exports[`renders ./components/form/demo/size.md extend context correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -7523,11 +7230,9 @@ exports[`renders ./components/form/demo/size.md extend context correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-4 ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -7538,7 +7243,6 @@ exports[`renders ./components/form/demo/size.md extend context correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -7565,11 +7269,9 @@ exports[`renders ./components/form/demo/size.md extend context correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-4 ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -7580,7 +7282,6 @@ exports[`renders ./components/form/demo/size.md extend context correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -7610,11 +7311,9 @@ exports[`renders ./components/form/demo/time-related-controls.md extend context 
 >
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
-      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -7626,7 +7325,6 @@ exports[`renders ./components/form/demo/time-related-controls.md extend context 
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -8234,11 +7932,9 @@ exports[`renders ./components/form/demo/time-related-controls.md extend context 
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
-      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -8250,7 +7946,6 @@ exports[`renders ./components/form/demo/time-related-controls.md extend context 
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -10211,11 +9906,9 @@ exports[`renders ./components/form/demo/time-related-controls.md extend context 
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
-      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -10227,7 +9920,6 @@ exports[`renders ./components/form/demo/time-related-controls.md extend context 
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -10471,11 +10163,9 @@ exports[`renders ./components/form/demo/time-related-controls.md extend context 
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
-      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -10487,7 +10177,6 @@ exports[`renders ./components/form/demo/time-related-controls.md extend context 
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -11680,11 +11369,9 @@ exports[`renders ./components/form/demo/time-related-controls.md extend context 
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
-      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -11696,7 +11383,6 @@ exports[`renders ./components/form/demo/time-related-controls.md extend context 
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -13704,11 +13390,9 @@ exports[`renders ./components/form/demo/time-related-controls.md extend context 
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
-      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -13720,7 +13404,6 @@ exports[`renders ./components/form/demo/time-related-controls.md extend context 
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -15142,11 +14825,9 @@ exports[`renders ./components/form/demo/time-related-controls.md extend context 
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-xs-offset-0 ant-col-sm-16 ant-col-sm-offset-8"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -15177,11 +14858,9 @@ Array [
   >
     <div
       class="ant-row ant-form-item"
-      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
-        role="cell"
       >
         <label
           class=""
@@ -15193,7 +14872,6 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
-        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -15213,11 +14891,9 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
-      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
-        role="cell"
       >
         <label
           class=""
@@ -15229,7 +14905,6 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
-        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -15333,11 +15008,9 @@ exports[`renders ./components/form/demo/validate-other.md extend context correct
 >
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-6 ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -15348,7 +15021,6 @@ exports[`renders ./components/form/demo/validate-other.md extend context correct
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -15367,11 +15039,9 @@ exports[`renders ./components/form/demo/validate-other.md extend context correct
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-6 ant-form-item-label"
-      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -15383,7 +15053,6 @@ exports[`renders ./components/form/demo/validate-other.md extend context correct
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -15538,11 +15207,9 @@ exports[`renders ./components/form/demo/validate-other.md extend context correct
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-6 ant-form-item-label"
-      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -15554,7 +15221,6 @@ exports[`renders ./components/form/demo/validate-other.md extend context correct
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -15698,11 +15364,9 @@ exports[`renders ./components/form/demo/validate-other.md extend context correct
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-6 ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -15713,7 +15377,6 @@ exports[`renders ./components/form/demo/validate-other.md extend context correct
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -15809,11 +15472,9 @@ exports[`renders ./components/form/demo/validate-other.md extend context correct
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-6 ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -15825,7 +15486,6 @@ exports[`renders ./components/form/demo/validate-other.md extend context correct
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -15853,11 +15513,9 @@ exports[`renders ./components/form/demo/validate-other.md extend context correct
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-6 ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -15869,7 +15527,6 @@ exports[`renders ./components/form/demo/validate-other.md extend context correct
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -15996,11 +15653,9 @@ exports[`renders ./components/form/demo/validate-other.md extend context correct
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-6 ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -16012,7 +15667,6 @@ exports[`renders ./components/form/demo/validate-other.md extend context correct
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -16088,11 +15742,9 @@ exports[`renders ./components/form/demo/validate-other.md extend context correct
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-6 ant-form-item-label"
-      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -16104,7 +15756,6 @@ exports[`renders ./components/form/demo/validate-other.md extend context correct
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -16180,11 +15831,9 @@ exports[`renders ./components/form/demo/validate-other.md extend context correct
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-6 ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -16196,7 +15845,6 @@ exports[`renders ./components/form/demo/validate-other.md extend context correct
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -16210,11 +15858,9 @@ exports[`renders ./components/form/demo/validate-other.md extend context correct
           >
             <div
               class="ant-row"
-              role="row"
             >
               <div
                 class="ant-col ant-col-8"
-                role="cell"
               >
                 <label
                   class="ant-checkbox-wrapper ant-checkbox-wrapper-checked ant-checkbox-wrapper-in-form-item"
@@ -16240,7 +15886,6 @@ exports[`renders ./components/form/demo/validate-other.md extend context correct
               </div>
               <div
                 class="ant-col ant-col-8"
-                role="cell"
               >
                 <label
                   class="ant-checkbox-wrapper ant-checkbox-wrapper-checked ant-checkbox-wrapper-disabled ant-checkbox-wrapper-in-form-item"
@@ -16267,7 +15912,6 @@ exports[`renders ./components/form/demo/validate-other.md extend context correct
               </div>
               <div
                 class="ant-col ant-col-8"
-                role="cell"
               >
                 <label
                   class="ant-checkbox-wrapper ant-checkbox-wrapper-in-form-item"
@@ -16292,7 +15936,6 @@ exports[`renders ./components/form/demo/validate-other.md extend context correct
               </div>
               <div
                 class="ant-col ant-col-8"
-                role="cell"
               >
                 <label
                   class="ant-checkbox-wrapper ant-checkbox-wrapper-in-form-item"
@@ -16317,7 +15960,6 @@ exports[`renders ./components/form/demo/validate-other.md extend context correct
               </div>
               <div
                 class="ant-col ant-col-8"
-                role="cell"
               >
                 <label
                   class="ant-checkbox-wrapper ant-checkbox-wrapper-in-form-item"
@@ -16342,7 +15984,6 @@ exports[`renders ./components/form/demo/validate-other.md extend context correct
               </div>
               <div
                 class="ant-col ant-col-8"
-                role="cell"
               >
                 <label
                   class="ant-checkbox-wrapper ant-checkbox-wrapper-in-form-item"
@@ -16373,11 +16014,9 @@ exports[`renders ./components/form/demo/validate-other.md extend context correct
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-6 ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -16389,7 +16028,6 @@ exports[`renders ./components/form/demo/validate-other.md extend context correct
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -16699,11 +16337,9 @@ exports[`renders ./components/form/demo/validate-other.md extend context correct
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-6 ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -16715,7 +16351,6 @@ exports[`renders ./components/form/demo/validate-other.md extend context correct
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -16784,11 +16419,9 @@ exports[`renders ./components/form/demo/validate-other.md extend context correct
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-6 ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -16799,7 +16432,6 @@ exports[`renders ./components/form/demo/validate-other.md extend context correct
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -16871,11 +16503,9 @@ exports[`renders ./components/form/demo/validate-other.md extend context correct
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-12 ant-col-offset-6 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -16904,11 +16534,9 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
 >
   <div
     class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-error"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-6"
-      role="cell"
     >
       <label
         class=""
@@ -16919,7 +16547,6 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-14"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -16950,11 +16577,9 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-has-warning"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-6"
-      role="cell"
     >
       <label
         class=""
@@ -16965,7 +16590,6 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-14"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -17013,11 +16637,9 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-feedback ant-form-item-is-validating"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-6"
-      role="cell"
     >
       <label
         class=""
@@ -17028,7 +16650,6 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-14"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -17090,11 +16711,9 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-has-feedback ant-form-item-has-success"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-6"
-      role="cell"
     >
       <label
         class=""
@@ -17105,7 +16724,6 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-14"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -17157,11 +16775,9 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-has-feedback ant-form-item-has-warning"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-6"
-      role="cell"
     >
       <label
         class=""
@@ -17172,7 +16788,6 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-14"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -17224,11 +16839,9 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-feedback ant-form-item-has-error"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-6"
-      role="cell"
     >
       <label
         class=""
@@ -17239,7 +16852,6 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-14"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -17301,11 +16913,9 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-has-feedback ant-form-item-has-success"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-6"
-      role="cell"
     >
       <label
         class=""
@@ -17316,7 +16926,6 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-14"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -17947,11 +17556,9 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-has-feedback ant-form-item-has-warning"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-6"
-      role="cell"
     >
       <label
         class=""
@@ -17962,7 +17569,6 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-14"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -19407,11 +19013,9 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-has-feedback ant-form-item-has-error"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-6"
-      role="cell"
     >
       <label
         class=""
@@ -19422,7 +19026,6 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-14"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -20638,11 +20241,9 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-has-feedback ant-form-item-has-error"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-6"
-      role="cell"
     >
       <label
         class=""
@@ -20653,7 +20254,6 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-14"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -20847,11 +20447,9 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-feedback ant-form-item-has-error"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-6"
-      role="cell"
     >
       <label
         class=""
@@ -20862,7 +20460,6 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-14"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -20997,11 +20594,9 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-feedback ant-form-item-has-warning"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-6"
-      role="cell"
     >
       <label
         class=""
@@ -21012,7 +20607,6 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-14"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -21193,12 +20787,10 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
     style="margin-bottom:0"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-6"
-      role="cell"
     >
       <label
         class=""
@@ -21209,7 +20801,6 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-14"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -21219,12 +20810,10 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
         >
           <div
             class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-error"
-            role="row"
             style="display:inline-block;width:calc(50% - 12px)"
           >
             <div
               class="ant-col ant-form-item-control"
-              role="cell"
             >
               <div
                 class="ant-form-item-control-input"
@@ -21846,12 +21435,10 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
           </span>
           <div
             class="ant-row ant-form-item"
-            role="row"
             style="display:inline-block;width:calc(50% - 12px)"
           >
             <div
               class="ant-col ant-form-item-control"
-              role="cell"
             >
               <div
                 class="ant-form-item-control-input"
@@ -22462,11 +22049,9 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-has-feedback ant-form-item-has-success"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-6"
-      role="cell"
     >
       <label
         class=""
@@ -22477,7 +22062,6 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-14"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -22596,11 +22180,9 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-has-feedback ant-form-item-has-success"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-6"
-      role="cell"
     >
       <label
         class=""
@@ -22611,7 +22193,6 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-14"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -22687,11 +22268,9 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-has-feedback ant-form-item-has-warning"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-6"
-      role="cell"
     >
       <label
         class=""
@@ -22702,7 +22281,6 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-14"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -22777,11 +22355,9 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-has-feedback ant-form-item-has-error"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-6"
-      role="cell"
     >
       <label
         class=""
@@ -22792,7 +22368,6 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-14"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -22892,11 +22467,9 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-has-feedback ant-form-item-has-error"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-6"
-      role="cell"
     >
       <label
         class=""
@@ -22907,7 +22480,6 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-14"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -22960,11 +22532,9 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-feedback ant-form-item-has-error"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-6"
-      role="cell"
     >
       <label
         class=""
@@ -22975,7 +22545,6 @@ exports[`renders ./components/form/demo/validate-static.md extend context correc
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-14"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -23066,11 +22635,9 @@ exports[`renders ./components/form/demo/warning-only.md extend context correctly
 >
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
-      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -23082,7 +22649,6 @@ exports[`renders ./components/form/demo/warning-only.md extend context correctly
     </div>
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -23103,11 +22669,9 @@ exports[`renders ./components/form/demo/warning-only.md extend context correctly
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -23157,11 +22721,9 @@ exports[`renders ./components/form/demo/without-form-create.md extend context co
 >
   <div
     class="ant-row ant-form-item ant-form-item-with-help"
-    role="row"
   >
     <div
       class="ant-col ant-col-7 ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -23172,7 +22734,6 @@ exports[`renders ./components/form/demo/without-form-create.md extend context co
     </div>
     <div
       class="ant-col ant-col-12 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"

--- a/components/form/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/form/__tests__/__snapshots__/demo.test.js.snap
@@ -8,21 +8,17 @@ exports[`renders ./components/form/demo/advanced-search.md correctly 1`] = `
   >
     <div
       class="ant-row"
-      role="row"
       style="margin-left:-12px;margin-right:-12px"
     >
       <div
         class="ant-col ant-col-8"
-        role="cell"
         style="padding-left:12px;padding-right:12px"
       >
         <div
           class="ant-row ant-form-item"
-          role="row"
         >
           <div
             class="ant-col ant-form-item-label"
-            role="cell"
           >
             <label
               class="ant-form-item-required"
@@ -34,7 +30,6 @@ exports[`renders ./components/form/demo/advanced-search.md correctly 1`] = `
           </div>
           <div
             class="ant-col ant-form-item-control"
-            role="cell"
           >
             <div
               class="ant-form-item-control-input"
@@ -56,16 +51,13 @@ exports[`renders ./components/form/demo/advanced-search.md correctly 1`] = `
       </div>
       <div
         class="ant-col ant-col-8"
-        role="cell"
         style="padding-left:12px;padding-right:12px"
       >
         <div
           class="ant-row ant-form-item"
-          role="row"
         >
           <div
             class="ant-col ant-form-item-label"
-            role="cell"
           >
             <label
               class="ant-form-item-required"
@@ -77,7 +69,6 @@ exports[`renders ./components/form/demo/advanced-search.md correctly 1`] = `
           </div>
           <div
             class="ant-col ant-form-item-control"
-            role="cell"
           >
             <div
               class="ant-form-item-control-input"
@@ -152,16 +143,13 @@ exports[`renders ./components/form/demo/advanced-search.md correctly 1`] = `
       </div>
       <div
         class="ant-col ant-col-8"
-        role="cell"
         style="padding-left:12px;padding-right:12px"
       >
         <div
           class="ant-row ant-form-item"
-          role="row"
         >
           <div
             class="ant-col ant-form-item-label"
-            role="cell"
           >
             <label
               class="ant-form-item-required"
@@ -173,7 +161,6 @@ exports[`renders ./components/form/demo/advanced-search.md correctly 1`] = `
           </div>
           <div
             class="ant-col ant-form-item-control"
-            role="cell"
           >
             <div
               class="ant-form-item-control-input"
@@ -195,16 +182,13 @@ exports[`renders ./components/form/demo/advanced-search.md correctly 1`] = `
       </div>
       <div
         class="ant-col ant-col-8"
-        role="cell"
         style="padding-left:12px;padding-right:12px"
       >
         <div
           class="ant-row ant-form-item"
-          role="row"
         >
           <div
             class="ant-col ant-form-item-label"
-            role="cell"
           >
             <label
               class="ant-form-item-required"
@@ -216,7 +200,6 @@ exports[`renders ./components/form/demo/advanced-search.md correctly 1`] = `
           </div>
           <div
             class="ant-col ant-form-item-control"
-            role="cell"
           >
             <div
               class="ant-form-item-control-input"
@@ -238,16 +221,13 @@ exports[`renders ./components/form/demo/advanced-search.md correctly 1`] = `
       </div>
       <div
         class="ant-col ant-col-8"
-        role="cell"
         style="padding-left:12px;padding-right:12px"
       >
         <div
           class="ant-row ant-form-item"
-          role="row"
         >
           <div
             class="ant-col ant-form-item-label"
-            role="cell"
           >
             <label
               class="ant-form-item-required"
@@ -259,7 +239,6 @@ exports[`renders ./components/form/demo/advanced-search.md correctly 1`] = `
           </div>
           <div
             class="ant-col ant-form-item-control"
-            role="cell"
           >
             <div
               class="ant-form-item-control-input"
@@ -334,16 +313,13 @@ exports[`renders ./components/form/demo/advanced-search.md correctly 1`] = `
       </div>
       <div
         class="ant-col ant-col-8"
-        role="cell"
         style="padding-left:12px;padding-right:12px"
       >
         <div
           class="ant-row ant-form-item"
-          role="row"
         >
           <div
             class="ant-col ant-form-item-label"
-            role="cell"
           >
             <label
               class="ant-form-item-required"
@@ -355,7 +331,6 @@ exports[`renders ./components/form/demo/advanced-search.md correctly 1`] = `
           </div>
           <div
             class="ant-col ant-form-item-control"
-            role="cell"
           >
             <div
               class="ant-form-item-control-input"
@@ -378,11 +353,9 @@ exports[`renders ./components/form/demo/advanced-search.md correctly 1`] = `
     </div>
     <div
       class="ant-row"
-      role="row"
     >
       <div
         class="ant-col ant-col-24"
-        role="cell"
         style="text-align:right"
       >
         <button
@@ -445,11 +418,9 @@ exports[`renders ./components/form/demo/basic.md correctly 1`] = `
 >
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-8 ant-form-item-label"
-      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -461,7 +432,6 @@ exports[`renders ./components/form/demo/basic.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-16 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -481,11 +451,9 @@ exports[`renders ./components/form/demo/basic.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-8 ant-form-item-label"
-      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -497,7 +465,6 @@ exports[`renders ./components/form/demo/basic.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-16 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -549,11 +516,9 @@ exports[`renders ./components/form/demo/basic.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-16 ant-col-offset-8 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -587,11 +552,9 @@ exports[`renders ./components/form/demo/basic.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-16 ant-col-offset-8 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -623,11 +586,9 @@ Array [
   >
     <div
       class="ant-row ant-form-item"
-      role="row"
     >
       <div
         class="ant-col ant-col-24 ant-form-item-label"
-        role="cell"
       >
         <label
           class="ant-form-item-required"
@@ -639,7 +600,6 @@ Array [
       </div>
       <div
         class="ant-col ant-col-24 ant-form-item-control"
-        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -659,11 +619,9 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
-      role="row"
     >
       <div
         class="ant-col ant-col-24 ant-form-item-label"
-        role="cell"
       >
         <label
           class="ant-form-item-required"
@@ -675,7 +633,6 @@ Array [
       </div>
       <div
         class="ant-col ant-col-24 ant-form-item-control"
-        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -727,11 +684,9 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
-      role="row"
     >
       <div
         class="ant-col ant-col-24 ant-form-item-control"
-        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -759,11 +714,9 @@ Array [
   >
     <div
       class="ant-row ant-form-item"
-      role="row"
     >
       <div
         class="ant-col ant-form-item-label ant-col-sm-24 ant-col-xl-24"
-        role="cell"
       >
         <label
           class="ant-form-item-required"
@@ -775,7 +728,6 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control ant-col-sm-24 ant-col-xl-24"
-        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -795,11 +747,9 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
-      role="row"
     >
       <div
         class="ant-col ant-form-item-label ant-col-sm-24 ant-col-xl-24"
-        role="cell"
       >
         <label
           class="ant-form-item-required"
@@ -811,7 +761,6 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control ant-col-sm-24 ant-col-xl-24"
-        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -863,11 +812,9 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
-      role="row"
     >
       <div
         class="ant-col ant-form-item-control ant-col-sm-24 ant-col-xl-24"
-        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -898,11 +845,9 @@ exports[`renders ./components/form/demo/control-hooks.md correctly 1`] = `
 >
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-8 ant-form-item-label"
-      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -914,7 +859,6 @@ exports[`renders ./components/form/demo/control-hooks.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-16 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -934,11 +878,9 @@ exports[`renders ./components/form/demo/control-hooks.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-8 ant-form-item-label"
-      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -950,7 +892,6 @@ exports[`renders ./components/form/demo/control-hooks.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-16 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -1023,11 +964,9 @@ exports[`renders ./components/form/demo/control-hooks.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-16 ant-col-offset-8 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -1073,11 +1012,9 @@ exports[`renders ./components/form/demo/control-ref.md correctly 1`] = `
 >
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-8 ant-form-item-label"
-      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -1089,7 +1026,6 @@ exports[`renders ./components/form/demo/control-ref.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-16 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -1109,11 +1045,9 @@ exports[`renders ./components/form/demo/control-ref.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-8 ant-form-item-label"
-      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -1125,7 +1059,6 @@ exports[`renders ./components/form/demo/control-ref.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-16 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -1198,11 +1131,9 @@ exports[`renders ./components/form/demo/control-ref.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-16 ant-col-offset-8 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -1248,11 +1179,9 @@ exports[`renders ./components/form/demo/customized-form-controls.md correctly 1`
 >
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -1264,7 +1193,6 @@ exports[`renders ./components/form/demo/customized-form-controls.md correctly 1`
     </div>
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -1346,11 +1274,9 @@ exports[`renders ./components/form/demo/customized-form-controls.md correctly 1`
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -1381,11 +1307,9 @@ exports[`renders ./components/form/demo/dep-debug.md correctly 1`] = `
   0
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -1397,7 +1321,6 @@ exports[`renders ./components/form/demo/dep-debug.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -1417,11 +1340,9 @@ exports[`renders ./components/form/demo/dep-debug.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -1433,7 +1354,6 @@ exports[`renders ./components/form/demo/dep-debug.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -1460,11 +1380,9 @@ exports[`renders ./components/form/demo/disabled-input-debug.md correctly 1`] = 
 >
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -1475,7 +1393,6 @@ exports[`renders ./components/form/demo/disabled-input-debug.md correctly 1`] = 
     </div>
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -1495,11 +1412,9 @@ exports[`renders ./components/form/demo/disabled-input-debug.md correctly 1`] = 
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-error"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -1510,7 +1425,6 @@ exports[`renders ./components/form/demo/disabled-input-debug.md correctly 1`] = 
     </div>
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -1540,11 +1454,9 @@ exports[`renders ./components/form/demo/disabled-input-debug.md correctly 1`] = 
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-error"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -1555,7 +1467,6 @@ exports[`renders ./components/form/demo/disabled-input-debug.md correctly 1`] = 
     </div>
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -1586,11 +1497,9 @@ exports[`renders ./components/form/demo/disabled-input-debug.md correctly 1`] = 
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -1601,7 +1510,6 @@ exports[`renders ./components/form/demo/disabled-input-debug.md correctly 1`] = 
     </div>
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -1621,11 +1529,9 @@ exports[`renders ./components/form/demo/disabled-input-debug.md correctly 1`] = 
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-error"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -1636,7 +1542,6 @@ exports[`renders ./components/form/demo/disabled-input-debug.md correctly 1`] = 
     </div>
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -1666,11 +1571,9 @@ exports[`renders ./components/form/demo/disabled-input-debug.md correctly 1`] = 
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-error"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -1681,7 +1584,6 @@ exports[`renders ./components/form/demo/disabled-input-debug.md correctly 1`] = 
     </div>
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -1712,11 +1614,9 @@ exports[`renders ./components/form/demo/disabled-input-debug.md correctly 1`] = 
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -1727,7 +1627,6 @@ exports[`renders ./components/form/demo/disabled-input-debug.md correctly 1`] = 
     </div>
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -1760,11 +1659,9 @@ exports[`renders ./components/form/demo/disabled-input-debug.md correctly 1`] = 
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-error"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -1775,7 +1672,6 @@ exports[`renders ./components/form/demo/disabled-input-debug.md correctly 1`] = 
     </div>
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -1818,11 +1714,9 @@ exports[`renders ./components/form/demo/disabled-input-debug.md correctly 1`] = 
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-error"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -1833,7 +1727,6 @@ exports[`renders ./components/form/demo/disabled-input-debug.md correctly 1`] = 
     </div>
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -1877,11 +1770,9 @@ exports[`renders ./components/form/demo/disabled-input-debug.md correctly 1`] = 
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -1892,7 +1783,6 @@ exports[`renders ./components/form/demo/disabled-input-debug.md correctly 1`] = 
     </div>
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -1921,11 +1811,9 @@ exports[`renders ./components/form/demo/disabled-input-debug.md correctly 1`] = 
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-error"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -1936,7 +1824,6 @@ exports[`renders ./components/form/demo/disabled-input-debug.md correctly 1`] = 
     </div>
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -1975,11 +1862,9 @@ exports[`renders ./components/form/demo/disabled-input-debug.md correctly 1`] = 
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-error"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -1990,7 +1875,6 @@ exports[`renders ./components/form/demo/disabled-input-debug.md correctly 1`] = 
     </div>
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -2038,11 +1922,9 @@ exports[`renders ./components/form/demo/dynamic-form-item.md correctly 1`] = `
 >
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-xs-offset-0 ant-col-sm-20 ant-col-sm-offset-4"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -2120,11 +2002,9 @@ exports[`renders ./components/form/demo/dynamic-form-item.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-xs-offset-0 ant-col-sm-20 ant-col-sm-offset-4"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -2155,11 +2035,9 @@ exports[`renders ./components/form/demo/dynamic-form-items.md correctly 1`] = `
 >
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -2204,11 +2082,9 @@ exports[`renders ./components/form/demo/dynamic-form-items.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -2239,11 +2115,9 @@ exports[`renders ./components/form/demo/dynamic-form-items-complex.md correctly 
 >
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
-      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -2255,7 +2129,6 @@ exports[`renders ./components/form/demo/dynamic-form-items-complex.md correctly 
     </div>
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -2326,11 +2199,9 @@ exports[`renders ./components/form/demo/dynamic-form-items-complex.md correctly 
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -2375,11 +2246,9 @@ exports[`renders ./components/form/demo/dynamic-form-items-complex.md correctly 
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -2410,11 +2279,9 @@ exports[`renders ./components/form/demo/dynamic-form-items-no-style.md correctly
 >
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -2425,7 +2292,6 @@ exports[`renders ./components/form/demo/dynamic-form-items-no-style.md correctly
     </div>
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -2435,11 +2301,9 @@ exports[`renders ./components/form/demo/dynamic-form-items-no-style.md correctly
         >
           <div
             class="ant-row ant-form-item"
-            role="row"
           >
             <div
               class="ant-col ant-form-item-control"
-              role="cell"
             >
               <div
                 class="ant-form-item-control-input"
@@ -2488,11 +2352,9 @@ exports[`renders ./components/form/demo/dynamic-form-items-no-style.md correctly
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -2522,11 +2384,9 @@ exports[`renders ./components/form/demo/dynamic-rule.md correctly 1`] = `
 >
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-4 ant-form-item-label"
-      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -2538,7 +2398,6 @@ exports[`renders ./components/form/demo/dynamic-rule.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-8 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -2559,11 +2418,9 @@ exports[`renders ./components/form/demo/dynamic-rule.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-4 ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -2575,7 +2432,6 @@ exports[`renders ./components/form/demo/dynamic-rule.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-8 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -2596,11 +2452,9 @@ exports[`renders ./components/form/demo/dynamic-rule.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-8 ant-col-offset-4 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -2632,11 +2486,9 @@ exports[`renders ./components/form/demo/dynamic-rule.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-8 ant-col-offset-4 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -2666,11 +2518,9 @@ exports[`renders ./components/form/demo/form-context.md correctly 1`] = `
 >
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-8 ant-form-item-label"
-      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -2682,7 +2532,6 @@ exports[`renders ./components/form/demo/form-context.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-16 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -2702,11 +2551,9 @@ exports[`renders ./components/form/demo/form-context.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-8 ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -2717,7 +2564,6 @@ exports[`renders ./components/form/demo/form-context.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-16 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -2756,11 +2602,9 @@ exports[`renders ./components/form/demo/form-context.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-16 ant-col-offset-8 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -2813,11 +2657,9 @@ Array [
   >
     <div
       class="ant-row ant-form-item"
-      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
-        role="cell"
       >
         <label
           class="ant-form-item-required"
@@ -2829,7 +2671,6 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
-        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -2870,11 +2711,9 @@ exports[`renders ./components/form/demo/inline-login.md correctly 1`] = `
 >
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -2922,11 +2761,9 @@ exports[`renders ./components/form/demo/inline-login.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -2974,11 +2811,9 @@ exports[`renders ./components/form/demo/inline-login.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -3008,11 +2843,9 @@ exports[`renders ./components/form/demo/label-debug.md correctly 1`] = `
 >
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-8 ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -3045,7 +2878,6 @@ exports[`renders ./components/form/demo/label-debug.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-16 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -3065,11 +2897,9 @@ exports[`renders ./components/form/demo/label-debug.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-8 ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -3102,7 +2932,6 @@ exports[`renders ./components/form/demo/label-debug.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-16 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -3161,11 +2990,9 @@ exports[`renders ./components/form/demo/layout.md correctly 1`] = `
 >
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-4 ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -3177,7 +3004,6 @@ exports[`renders ./components/form/demo/layout.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -3254,11 +3080,9 @@ exports[`renders ./components/form/demo/layout.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-4 ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -3269,7 +3093,6 @@ exports[`renders ./components/form/demo/layout.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -3289,11 +3112,9 @@ exports[`renders ./components/form/demo/layout.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-4 ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -3304,7 +3125,6 @@ exports[`renders ./components/form/demo/layout.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -3324,11 +3144,9 @@ exports[`renders ./components/form/demo/layout.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-14 ant-col-offset-4 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -3358,11 +3176,9 @@ exports[`renders ./components/form/demo/layout-can-wrap.md correctly 1`] = `
 >
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-form-item-label-left ant-form-item-label-wrap"
-      role="cell"
       style="flex:0 0 110px"
     >
       <label
@@ -3375,7 +3191,6 @@ exports[`renders ./components/form/demo/layout-can-wrap.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
       style="flex:1 1 auto"
     >
       <div
@@ -3396,11 +3211,9 @@ exports[`renders ./components/form/demo/layout-can-wrap.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-form-item-label-left ant-form-item-label-wrap"
-      role="cell"
       style="flex:0 0 110px"
     >
       <label
@@ -3413,7 +3226,6 @@ exports[`renders ./components/form/demo/layout-can-wrap.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
       style="flex:1 1 auto"
     >
       <div
@@ -3434,11 +3246,9 @@ exports[`renders ./components/form/demo/layout-can-wrap.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-form-item-label-left ant-form-item-label-wrap"
-      role="cell"
       style="flex:0 0 110px"
     >
       <label
@@ -3450,7 +3260,6 @@ exports[`renders ./components/form/demo/layout-can-wrap.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
       style="flex:1 1 auto"
     >
       <div
@@ -3481,11 +3290,9 @@ exports[`renders ./components/form/demo/nest-messages.md correctly 1`] = `
 >
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-8 ant-form-item-label"
-      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -3497,7 +3304,6 @@ exports[`renders ./components/form/demo/nest-messages.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-16 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -3517,11 +3323,9 @@ exports[`renders ./components/form/demo/nest-messages.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-8 ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -3533,7 +3337,6 @@ exports[`renders ./components/form/demo/nest-messages.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-16 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -3553,11 +3356,9 @@ exports[`renders ./components/form/demo/nest-messages.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-8 ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -3569,7 +3370,6 @@ exports[`renders ./components/form/demo/nest-messages.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-16 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -3657,11 +3457,9 @@ exports[`renders ./components/form/demo/nest-messages.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-8 ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -3673,7 +3471,6 @@ exports[`renders ./components/form/demo/nest-messages.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-16 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -3693,11 +3490,9 @@ exports[`renders ./components/form/demo/nest-messages.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-8 ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -3709,7 +3504,6 @@ exports[`renders ./components/form/demo/nest-messages.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-16 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -3727,11 +3521,9 @@ exports[`renders ./components/form/demo/nest-messages.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-16 ant-col-offset-8 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -3761,11 +3553,9 @@ exports[`renders ./components/form/demo/normal-login.md correctly 1`] = `
 >
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -3813,11 +3603,9 @@ exports[`renders ./components/form/demo/normal-login.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -3865,11 +3653,9 @@ exports[`renders ./components/form/demo/normal-login.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -3909,11 +3695,9 @@ exports[`renders ./components/form/demo/normal-login.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -3948,11 +3732,9 @@ exports[`renders ./components/form/demo/ref-item.md correctly 1`] = `
 >
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -3964,7 +3746,6 @@ exports[`renders ./components/form/demo/ref-item.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -3984,11 +3765,9 @@ exports[`renders ./components/form/demo/ref-item.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -4032,11 +3811,9 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
 >
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
-      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -4048,7 +3825,6 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -4068,11 +3844,9 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
-      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -4084,7 +3858,6 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -4136,11 +3909,9 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
-      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -4152,7 +3923,6 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -4204,11 +3974,9 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
-      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -4243,7 +4011,6 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -4263,11 +4030,9 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
-      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -4279,7 +4044,6 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -4378,11 +4142,9 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
-      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -4394,7 +4156,6 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -4488,11 +4249,9 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
-      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -4504,7 +4263,6 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -4663,11 +4421,9 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
-      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -4679,7 +4435,6 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -4723,11 +4478,9 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
-      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -4739,7 +4492,6 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -4762,11 +4514,9 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
-      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -4778,7 +4528,6 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -4851,11 +4600,9 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
-      role="cell"
     >
       <label
         class=""
@@ -4866,7 +4613,6 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -4876,12 +4622,10 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
         >
           <div
             class="ant-row"
-            role="row"
             style="margin-left:-4px;margin-right:-4px"
           >
             <div
               class="ant-col ant-col-12"
-              role="cell"
               style="padding-left:4px;padding-right:4px"
             >
               <input
@@ -4893,7 +4637,6 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
             </div>
             <div
               class="ant-col ant-col-12"
-              role="cell"
               style="padding-left:4px;padding-right:4px"
             >
               <button
@@ -4917,11 +4660,9 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-xs-offset-0 ant-col-sm-16 ant-col-sm-offset-8"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -4959,11 +4700,9 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-xs-offset-0 ant-col-sm-16 ant-col-sm-offset-8"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -4992,11 +4731,9 @@ exports[`renders ./components/form/demo/required-mark.md correctly 1`] = `
 >
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
-      role="cell"
     >
       <label
         class="ant-form-item-required-mark-optional"
@@ -5014,7 +4751,6 @@ exports[`renders ./components/form/demo/required-mark.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -5091,11 +4827,9 @@ exports[`renders ./components/form/demo/required-mark.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
-      role="cell"
     >
       <label
         class="ant-form-item-required ant-form-item-required-mark-optional"
@@ -5129,7 +4863,6 @@ exports[`renders ./components/form/demo/required-mark.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -5149,11 +4882,9 @@ exports[`renders ./components/form/demo/required-mark.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
-      role="cell"
     >
       <label
         class="ant-form-item-required-mark-optional"
@@ -5193,7 +4924,6 @@ exports[`renders ./components/form/demo/required-mark.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -5213,11 +4943,9 @@ exports[`renders ./components/form/demo/required-mark.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -5246,11 +4974,9 @@ exports[`renders ./components/form/demo/size.md correctly 1`] = `
 >
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-4 ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -5262,7 +4988,6 @@ exports[`renders ./components/form/demo/size.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -5339,11 +5064,9 @@ exports[`renders ./components/form/demo/size.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-4 ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -5354,7 +5077,6 @@ exports[`renders ./components/form/demo/size.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -5373,11 +5095,9 @@ exports[`renders ./components/form/demo/size.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-4 ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -5388,7 +5108,6 @@ exports[`renders ./components/form/demo/size.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -5458,11 +5177,9 @@ exports[`renders ./components/form/demo/size.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-4 ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -5473,7 +5190,6 @@ exports[`renders ./components/form/demo/size.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -5542,11 +5258,9 @@ exports[`renders ./components/form/demo/size.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-4 ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -5557,7 +5271,6 @@ exports[`renders ./components/form/demo/size.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -5626,11 +5339,9 @@ exports[`renders ./components/form/demo/size.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-4 ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -5641,7 +5352,6 @@ exports[`renders ./components/form/demo/size.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -5694,11 +5404,9 @@ exports[`renders ./components/form/demo/size.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-4 ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -5709,7 +5417,6 @@ exports[`renders ./components/form/demo/size.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -5796,11 +5503,9 @@ exports[`renders ./components/form/demo/size.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-4 ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -5811,7 +5516,6 @@ exports[`renders ./components/form/demo/size.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -5838,11 +5542,9 @@ exports[`renders ./components/form/demo/size.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-4 ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -5853,7 +5555,6 @@ exports[`renders ./components/form/demo/size.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -5883,11 +5584,9 @@ exports[`renders ./components/form/demo/time-related-controls.md correctly 1`] =
 >
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
-      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -5899,7 +5598,6 @@ exports[`renders ./components/form/demo/time-related-controls.md correctly 1`] =
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -5953,11 +5651,9 @@ exports[`renders ./components/form/demo/time-related-controls.md correctly 1`] =
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
-      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -5969,7 +5665,6 @@ exports[`renders ./components/form/demo/time-related-controls.md correctly 1`] =
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -6023,11 +5718,9 @@ exports[`renders ./components/form/demo/time-related-controls.md correctly 1`] =
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
-      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -6039,7 +5732,6 @@ exports[`renders ./components/form/demo/time-related-controls.md correctly 1`] =
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -6093,11 +5785,9 @@ exports[`renders ./components/form/demo/time-related-controls.md correctly 1`] =
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
-      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -6109,7 +5799,6 @@ exports[`renders ./components/form/demo/time-related-controls.md correctly 1`] =
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -6205,11 +5894,9 @@ exports[`renders ./components/form/demo/time-related-controls.md correctly 1`] =
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
-      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -6221,7 +5908,6 @@ exports[`renders ./components/form/demo/time-related-controls.md correctly 1`] =
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -6317,11 +6003,9 @@ exports[`renders ./components/form/demo/time-related-controls.md correctly 1`] =
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-8"
-      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -6333,7 +6017,6 @@ exports[`renders ./components/form/demo/time-related-controls.md correctly 1`] =
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-16"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -6390,11 +6073,9 @@ exports[`renders ./components/form/demo/time-related-controls.md correctly 1`] =
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-xs-offset-0 ant-col-sm-16 ant-col-sm-offset-8"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -6425,11 +6106,9 @@ Array [
   >
     <div
       class="ant-row ant-form-item"
-      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
-        role="cell"
       >
         <label
           class=""
@@ -6441,7 +6120,6 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
-        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -6461,11 +6139,9 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
-      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
-        role="cell"
       >
         <label
           class=""
@@ -6477,7 +6153,6 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
-        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -6581,11 +6256,9 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
 >
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-6 ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -6596,7 +6269,6 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -6615,11 +6287,9 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-6 ant-form-item-label"
-      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -6631,7 +6301,6 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -6704,11 +6373,9 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-6 ant-form-item-label"
-      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -6720,7 +6387,6 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -6783,11 +6449,9 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-6 ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -6798,7 +6462,6 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -6894,11 +6557,9 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-6 ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -6910,7 +6571,6 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -6938,11 +6598,9 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-6 ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -6954,7 +6612,6 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -7057,11 +6714,9 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-6 ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -7073,7 +6728,6 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -7149,11 +6803,9 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-6 ant-form-item-label"
-      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -7165,7 +6817,6 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -7241,11 +6892,9 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-6 ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -7257,7 +6906,6 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -7271,11 +6919,9 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
           >
             <div
               class="ant-row"
-              role="row"
             >
               <div
                 class="ant-col ant-col-8"
-                role="cell"
               >
                 <label
                   class="ant-checkbox-wrapper ant-checkbox-wrapper-checked ant-checkbox-wrapper-in-form-item"
@@ -7301,7 +6947,6 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
               </div>
               <div
                 class="ant-col ant-col-8"
-                role="cell"
               >
                 <label
                   class="ant-checkbox-wrapper ant-checkbox-wrapper-checked ant-checkbox-wrapper-disabled ant-checkbox-wrapper-in-form-item"
@@ -7328,7 +6973,6 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
               </div>
               <div
                 class="ant-col ant-col-8"
-                role="cell"
               >
                 <label
                   class="ant-checkbox-wrapper ant-checkbox-wrapper-in-form-item"
@@ -7353,7 +6997,6 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
               </div>
               <div
                 class="ant-col ant-col-8"
-                role="cell"
               >
                 <label
                   class="ant-checkbox-wrapper ant-checkbox-wrapper-in-form-item"
@@ -7378,7 +7021,6 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
               </div>
               <div
                 class="ant-col ant-col-8"
-                role="cell"
               >
                 <label
                   class="ant-checkbox-wrapper ant-checkbox-wrapper-in-form-item"
@@ -7403,7 +7045,6 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
               </div>
               <div
                 class="ant-col ant-col-8"
-                role="cell"
               >
                 <label
                   class="ant-checkbox-wrapper ant-checkbox-wrapper-in-form-item"
@@ -7434,11 +7075,9 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-6 ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -7450,7 +7089,6 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -7760,11 +7398,9 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-6 ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -7776,7 +7412,6 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -7845,11 +7480,9 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-6 ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -7860,7 +7493,6 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-14 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -7932,11 +7564,9 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-12 ant-col-offset-6 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -7965,11 +7595,9 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
 >
   <div
     class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-error"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-6"
-      role="cell"
     >
       <label
         class=""
@@ -7980,7 +7608,6 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-14"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -8011,11 +7638,9 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-has-warning"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-6"
-      role="cell"
     >
       <label
         class=""
@@ -8026,7 +7651,6 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-14"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -8074,11 +7698,9 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-feedback ant-form-item-is-validating"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-6"
-      role="cell"
     >
       <label
         class=""
@@ -8089,7 +7711,6 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-14"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -8151,11 +7772,9 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-has-feedback ant-form-item-has-success"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-6"
-      role="cell"
     >
       <label
         class=""
@@ -8166,7 +7785,6 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-14"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -8218,11 +7836,9 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-has-feedback ant-form-item-has-warning"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-6"
-      role="cell"
     >
       <label
         class=""
@@ -8233,7 +7849,6 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-14"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -8285,11 +7900,9 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-feedback ant-form-item-has-error"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-6"
-      role="cell"
     >
       <label
         class=""
@@ -8300,7 +7913,6 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-14"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -8362,11 +7974,9 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-has-feedback ant-form-item-has-success"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-6"
-      role="cell"
     >
       <label
         class=""
@@ -8377,7 +7987,6 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-14"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -8454,11 +8063,9 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-has-feedback ant-form-item-has-warning"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-6"
-      role="cell"
     >
       <label
         class=""
@@ -8469,7 +8076,6 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-14"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -8549,11 +8155,9 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-has-feedback ant-form-item-has-error"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-6"
-      role="cell"
     >
       <label
         class=""
@@ -8564,7 +8168,6 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-14"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -8683,11 +8286,9 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-has-feedback ant-form-item-has-error"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-6"
-      role="cell"
     >
       <label
         class=""
@@ -8698,7 +8299,6 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-14"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -8793,11 +8393,9 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-feedback ant-form-item-has-error"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-6"
-      role="cell"
     >
       <label
         class=""
@@ -8808,7 +8406,6 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-14"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -8912,11 +8509,9 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-feedback ant-form-item-has-warning"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-6"
-      role="cell"
     >
       <label
         class=""
@@ -8927,7 +8522,6 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-14"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -9031,12 +8625,10 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
     style="margin-bottom:0"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-6"
-      role="cell"
     >
       <label
         class=""
@@ -9047,7 +8639,6 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-14"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -9057,12 +8648,10 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
         >
           <div
             class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-error"
-            role="row"
             style="display:inline-block;width:calc(50% - 12px)"
           >
             <div
               class="ant-col ant-form-item-control"
-              role="cell"
             >
               <div
                 class="ant-form-item-control-input"
@@ -9130,12 +8719,10 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
           </span>
           <div
             class="ant-row ant-form-item"
-            role="row"
             style="display:inline-block;width:calc(50% - 12px)"
           >
             <div
               class="ant-col ant-form-item-control"
-              role="cell"
             >
               <div
                 class="ant-form-item-control-input"
@@ -9192,11 +8779,9 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-has-feedback ant-form-item-has-success"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-6"
-      role="cell"
     >
       <label
         class=""
@@ -9207,7 +8792,6 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-14"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -9326,11 +8910,9 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-has-feedback ant-form-item-has-success"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-6"
-      role="cell"
     >
       <label
         class=""
@@ -9341,7 +8923,6 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-14"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -9417,11 +8998,9 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-has-feedback ant-form-item-has-warning"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-6"
-      role="cell"
     >
       <label
         class=""
@@ -9432,7 +9011,6 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-14"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -9507,11 +9085,9 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-has-feedback ant-form-item-has-error"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-6"
-      role="cell"
     >
       <label
         class=""
@@ -9522,7 +9098,6 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-14"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -9622,11 +9197,9 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-has-feedback ant-form-item-has-error"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-6"
-      role="cell"
     >
       <label
         class=""
@@ -9637,7 +9210,6 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-14"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -9690,11 +9262,9 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item ant-form-item-with-help ant-form-item-has-feedback ant-form-item-has-error"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-6"
-      role="cell"
     >
       <label
         class=""
@@ -9705,7 +9275,6 @@ exports[`renders ./components/form/demo/validate-static.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-14"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -9796,11 +9365,9 @@ exports[`renders ./components/form/demo/warning-only.md correctly 1`] = `
 >
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-label"
-      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -9812,7 +9379,6 @@ exports[`renders ./components/form/demo/warning-only.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -9833,11 +9399,9 @@ exports[`renders ./components/form/demo/warning-only.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -9887,11 +9451,9 @@ exports[`renders ./components/form/demo/without-form-create.md correctly 1`] = `
 >
   <div
     class="ant-row ant-form-item ant-form-item-with-help"
-    role="row"
   >
     <div
       class="ant-col ant-col-7 ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -9902,7 +9464,6 @@ exports[`renders ./components/form/demo/without-form-create.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-12 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"

--- a/components/form/__tests__/__snapshots__/index.test.js.snap
+++ b/components/form/__tests__/__snapshots__/index.test.js.snap
@@ -6,11 +6,9 @@ exports[`Form Form item hidden noStyle should not work when hidden 1`] = `
 >
   <div
     class="ant-row ant-form-item ant-form-item-hidden"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -37,11 +35,9 @@ exports[`Form Form item hidden should work 1`] = `
 >
   <div
     class="ant-row ant-form-item ant-form-item-hidden"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -71,11 +67,9 @@ exports[`Form Form.Item should support data-*、aria-* and custom attribute 1`] 
     cccc="bbbb"
     class="ant-row ant-form-item"
     data-text="123"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -100,11 +94,9 @@ exports[`Form rtl render component should be rendered correctly in RTL direction
 exports[`Form rtl render component should be rendered correctly in RTL direction 2`] = `
 <div
   class="ant-row ant-row-rtl ant-form-item"
-  role="row"
 >
   <div
     class="ant-col ant-form-item-control ant-col-rtl"
-    role="cell"
   >
     <div
       class="ant-form-item-control-input"

--- a/components/grid/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/grid/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -4,80 +4,66 @@ exports[`renders ./components/grid/demo/basic.md extend context correctly 1`] = 
 Array [
   <div
     class="ant-row"
-    role="row"
   >
     <div
       class="ant-col ant-col-24"
-      role="cell"
     >
       col
     </div>
   </div>,
   <div
     class="ant-row"
-    role="row"
   >
     <div
       class="ant-col ant-col-12"
-      role="cell"
     >
       col-12
     </div>
     <div
       class="ant-col ant-col-12"
-      role="cell"
     >
       col-12
     </div>
   </div>,
   <div
     class="ant-row"
-    role="row"
   >
     <div
       class="ant-col ant-col-8"
-      role="cell"
     >
       col-8
     </div>
     <div
       class="ant-col ant-col-8"
-      role="cell"
     >
       col-8
     </div>
     <div
       class="ant-col ant-col-8"
-      role="cell"
     >
       col-8
     </div>
   </div>,
   <div
     class="ant-row"
-    role="row"
   >
     <div
       class="ant-col ant-col-6"
-      role="cell"
     >
       col-6
     </div>
     <div
       class="ant-col ant-col-6"
-      role="cell"
     >
       col-6
     </div>
     <div
       class="ant-col ant-col-6"
-      role="cell"
     >
       col-6
     </div>
     <div
       class="ant-col ant-col-6"
-      role="cell"
     >
       col-6
     </div>
@@ -99,29 +85,24 @@ Array [
   </div>,
   <div
     class="ant-row ant-row-start"
-    role="row"
   >
     <div
       class="ant-col ant-col-4"
-      role="cell"
     >
       col-4
     </div>
     <div
       class="ant-col ant-col-4"
-      role="cell"
     >
       col-4
     </div>
     <div
       class="ant-col ant-col-4"
-      role="cell"
     >
       col-4
     </div>
     <div
       class="ant-col ant-col-4"
-      role="cell"
     >
       col-4
     </div>
@@ -138,29 +119,24 @@ Array [
   </div>,
   <div
     class="ant-row ant-row-center"
-    role="row"
   >
     <div
       class="ant-col ant-col-4"
-      role="cell"
     >
       col-4
     </div>
     <div
       class="ant-col ant-col-4"
-      role="cell"
     >
       col-4
     </div>
     <div
       class="ant-col ant-col-4"
-      role="cell"
     >
       col-4
     </div>
     <div
       class="ant-col ant-col-4"
-      role="cell"
     >
       col-4
     </div>
@@ -177,29 +153,24 @@ Array [
   </div>,
   <div
     class="ant-row ant-row-end"
-    role="row"
   >
     <div
       class="ant-col ant-col-4"
-      role="cell"
     >
       col-4
     </div>
     <div
       class="ant-col ant-col-4"
-      role="cell"
     >
       col-4
     </div>
     <div
       class="ant-col ant-col-4"
-      role="cell"
     >
       col-4
     </div>
     <div
       class="ant-col ant-col-4"
-      role="cell"
     >
       col-4
     </div>
@@ -216,29 +187,24 @@ Array [
   </div>,
   <div
     class="ant-row ant-row-space-between"
-    role="row"
   >
     <div
       class="ant-col ant-col-4"
-      role="cell"
     >
       col-4
     </div>
     <div
       class="ant-col ant-col-4"
-      role="cell"
     >
       col-4
     </div>
     <div
       class="ant-col ant-col-4"
-      role="cell"
     >
       col-4
     </div>
     <div
       class="ant-col ant-col-4"
-      role="cell"
     >
       col-4
     </div>
@@ -255,29 +221,24 @@ Array [
   </div>,
   <div
     class="ant-row ant-row-space-around"
-    role="row"
   >
     <div
       class="ant-col ant-col-4"
-      role="cell"
     >
       col-4
     </div>
     <div
       class="ant-col ant-col-4"
-      role="cell"
     >
       col-4
     </div>
     <div
       class="ant-col ant-col-4"
-      role="cell"
     >
       col-4
     </div>
     <div
       class="ant-col ant-col-4"
-      role="cell"
     >
       col-4
     </div>
@@ -294,29 +255,24 @@ Array [
   </div>,
   <div
     class="ant-row ant-row-space-evenly"
-    role="row"
   >
     <div
       class="ant-col ant-col-4"
-      role="cell"
     >
       col-4
     </div>
     <div
       class="ant-col ant-col-4"
-      role="cell"
     >
       col-4
     </div>
     <div
       class="ant-col ant-col-4"
-      role="cell"
     >
       col-4
     </div>
     <div
       class="ant-col ant-col-4"
-      role="cell"
     >
       col-4
     </div>
@@ -338,11 +294,9 @@ Array [
   </div>,
   <div
     class="ant-row ant-row-center ant-row-top"
-    role="row"
   >
     <div
       class="ant-col ant-col-4"
-      role="cell"
     >
       <p
         class="height-100"
@@ -352,7 +306,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-4"
-      role="cell"
     >
       <p
         class="height-50"
@@ -362,7 +315,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-4"
-      role="cell"
     >
       <p
         class="height-120"
@@ -372,7 +324,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-4"
-      role="cell"
     >
       <p
         class="height-80"
@@ -393,11 +344,9 @@ Array [
   </div>,
   <div
     class="ant-row ant-row-space-around ant-row-middle"
-    role="row"
   >
     <div
       class="ant-col ant-col-4"
-      role="cell"
     >
       <p
         class="height-100"
@@ -407,7 +356,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-4"
-      role="cell"
     >
       <p
         class="height-50"
@@ -417,7 +365,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-4"
-      role="cell"
     >
       <p
         class="height-120"
@@ -427,7 +374,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-4"
-      role="cell"
     >
       <p
         class="height-80"
@@ -448,11 +394,9 @@ Array [
   </div>,
   <div
     class="ant-row ant-row-space-between ant-row-bottom"
-    role="row"
   >
     <div
       class="ant-col ant-col-4"
-      role="cell"
     >
       <p
         class="height-100"
@@ -462,7 +406,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-4"
-      role="cell"
     >
       <p
         class="height-50"
@@ -472,7 +415,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-4"
-      role="cell"
     >
       <p
         class="height-120"
@@ -482,7 +424,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-4"
-      role="cell"
     >
       <p
         class="height-80"
@@ -508,29 +449,24 @@ Array [
   </div>,
   <div
     class="ant-row"
-    role="row"
   >
     <div
       class="ant-col ant-col-6 ant-col-order-4"
-      role="cell"
     >
       1 col-order-4
     </div>
     <div
       class="ant-col ant-col-6 ant-col-order-3"
-      role="cell"
     >
       2 col-order-3
     </div>
     <div
       class="ant-col ant-col-6 ant-col-order-2"
-      role="cell"
     >
       3 col-order-2
     </div>
     <div
       class="ant-col ant-col-6 ant-col-order-1"
-      role="cell"
     >
       4 col-order-1
     </div>
@@ -547,29 +483,24 @@ Array [
   </div>,
   <div
     class="ant-row"
-    role="row"
   >
     <div
       class="ant-col ant-col-6 ant-col-xs-order-1 ant-col-sm-order-2 ant-col-md-order-3 ant-col-lg-order-4"
-      role="cell"
     >
       1 col-order-responsive
     </div>
     <div
       class="ant-col ant-col-6 ant-col-xs-order-2 ant-col-sm-order-1 ant-col-md-order-4 ant-col-lg-order-3"
-      role="cell"
     >
       2 col-order-responsive
     </div>
     <div
       class="ant-col ant-col-6 ant-col-xs-order-3 ant-col-sm-order-4 ant-col-md-order-2 ant-col-lg-order-1"
-      role="cell"
     >
       3 col-order-responsive
     </div>
     <div
       class="ant-col ant-col-6 ant-col-xs-order-4 ant-col-sm-order-3 ant-col-md-order-1 ant-col-lg-order-2"
-      role="cell"
     >
       4 col-order-responsive
     </div>
@@ -591,18 +522,15 @@ Array [
   </div>,
   <div
     class="ant-row"
-    role="row"
   >
     <div
       class="ant-col"
-      role="cell"
       style="flex:2 2 auto"
     >
       2 / 5
     </div>
     <div
       class="ant-col"
-      role="cell"
       style="flex:3 3 auto"
     >
       3 / 5
@@ -620,18 +548,15 @@ Array [
   </div>,
   <div
     class="ant-row"
-    role="row"
   >
     <div
       class="ant-col"
-      role="cell"
       style="flex:0 0 100px"
     >
       100px
     </div>
     <div
       class="ant-col"
-      role="cell"
       style="flex:auto"
     >
       Fill Rest
@@ -649,18 +574,15 @@ Array [
   </div>,
   <div
     class="ant-row"
-    role="row"
   >
     <div
       class="ant-col"
-      role="cell"
       style="flex:1 1 200px"
     >
       1 1 200px
     </div>
     <div
       class="ant-col"
-      role="cell"
       style="flex:0 1 300px"
     >
       0 1 300px
@@ -668,11 +590,9 @@ Array [
   </div>,
   <div
     class="ant-row ant-row-no-wrap"
-    role="row"
   >
     <div
       class="ant-col"
-      role="cell"
       style="flex:none;min-width:0"
     >
       <div
@@ -683,7 +603,6 @@ Array [
     </div>
     <div
       class="ant-col"
-      role="cell"
       style="flex:auto;min-width:0"
     >
       auto with no-wrap
@@ -706,12 +625,10 @@ Array [
   </div>,
   <div
     class="ant-row"
-    role="row"
     style="margin-left:-8px;margin-right:-8px"
   >
     <div
       class="ant-col ant-col-6 gutter-row"
-      role="cell"
       style="padding-left:8px;padding-right:8px"
     >
       <div
@@ -722,7 +639,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6 gutter-row"
-      role="cell"
       style="padding-left:8px;padding-right:8px"
     >
       <div
@@ -733,7 +649,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6 gutter-row"
-      role="cell"
       style="padding-left:8px;padding-right:8px"
     >
       <div
@@ -744,7 +659,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6 gutter-row"
-      role="cell"
       style="padding-left:8px;padding-right:8px"
     >
       <div
@@ -766,12 +680,10 @@ Array [
   </div>,
   <div
     class="ant-row"
-    role="row"
     style="margin-left:-16px;margin-right:-16px"
   >
     <div
       class="ant-col ant-col-6 gutter-row"
-      role="cell"
       style="padding-left:16px;padding-right:16px"
     >
       <div
@@ -782,7 +694,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6 gutter-row"
-      role="cell"
       style="padding-left:16px;padding-right:16px"
     >
       <div
@@ -793,7 +704,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6 gutter-row"
-      role="cell"
       style="padding-left:16px;padding-right:16px"
     >
       <div
@@ -804,7 +714,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6 gutter-row"
-      role="cell"
       style="padding-left:16px;padding-right:16px"
     >
       <div
@@ -826,12 +735,10 @@ Array [
   </div>,
   <div
     class="ant-row"
-    role="row"
     style="margin-left:-8px;margin-right:-8px;margin-top:-12px;margin-bottom:-12px"
   >
     <div
       class="ant-col ant-col-6 gutter-row"
-      role="cell"
       style="padding-left:8px;padding-right:8px;padding-top:12px;padding-bottom:12px"
     >
       <div
@@ -842,7 +749,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6 gutter-row"
-      role="cell"
       style="padding-left:8px;padding-right:8px;padding-top:12px;padding-bottom:12px"
     >
       <div
@@ -853,7 +759,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6 gutter-row"
-      role="cell"
       style="padding-left:8px;padding-right:8px;padding-top:12px;padding-bottom:12px"
     >
       <div
@@ -864,7 +769,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6 gutter-row"
-      role="cell"
       style="padding-left:8px;padding-right:8px;padding-top:12px;padding-bottom:12px"
     >
       <div
@@ -875,7 +779,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6 gutter-row"
-      role="cell"
       style="padding-left:8px;padding-right:8px;padding-top:12px;padding-bottom:12px"
     >
       <div
@@ -886,7 +789,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6 gutter-row"
-      role="cell"
       style="padding-left:8px;padding-right:8px;padding-top:12px;padding-bottom:12px"
     >
       <div
@@ -897,7 +799,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6 gutter-row"
-      role="cell"
       style="padding-left:8px;padding-right:8px;padding-top:12px;padding-bottom:12px"
     >
       <div
@@ -908,7 +809,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6 gutter-row"
-      role="cell"
       style="padding-left:8px;padding-right:8px;padding-top:12px;padding-bottom:12px"
     >
       <div
@@ -925,45 +825,37 @@ exports[`renders ./components/grid/demo/offset.md extend context correctly 1`] =
 Array [
   <div
     class="ant-row"
-    role="row"
   >
     <div
       class="ant-col ant-col-8"
-      role="cell"
     >
       col-8
     </div>
     <div
       class="ant-col ant-col-8 ant-col-offset-8"
-      role="cell"
     >
       col-8
     </div>
   </div>,
   <div
     class="ant-row"
-    role="row"
   >
     <div
       class="ant-col ant-col-6 ant-col-offset-6"
-      role="cell"
     >
       col-6 col-offset-6
     </div>
     <div
       class="ant-col ant-col-6 ant-col-offset-6"
-      role="cell"
     >
       col-6 col-offset-6
     </div>
   </div>,
   <div
     class="ant-row"
-    role="row"
   >
     <div
       class="ant-col ant-col-12 ant-col-offset-6"
-      role="cell"
     >
       col-12 col-offset-6
     </div>
@@ -1335,12 +1227,10 @@ Array [
   </div>,
   <div
     class="ant-row"
-    role="row"
     style="margin-left:-8px;margin-right:-8px;margin-top:-8px;margin-bottom:-8px"
   >
     <div
       class="ant-col ant-col-6"
-      role="cell"
       style="padding-left:8px;padding-right:8px;padding-top:8px;padding-bottom:8px"
     >
       <div>
@@ -1349,7 +1239,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6"
-      role="cell"
       style="padding-left:8px;padding-right:8px;padding-top:8px;padding-bottom:8px"
     >
       <div>
@@ -1358,7 +1247,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6"
-      role="cell"
       style="padding-left:8px;padding-right:8px;padding-top:8px;padding-bottom:8px"
     >
       <div>
@@ -1367,7 +1255,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6"
-      role="cell"
       style="padding-left:8px;padding-right:8px;padding-top:8px;padding-bottom:8px"
     >
       <div>
@@ -1376,7 +1263,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6"
-      role="cell"
       style="padding-left:8px;padding-right:8px;padding-top:8px;padding-bottom:8px"
     >
       <div>
@@ -1385,7 +1271,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6"
-      role="cell"
       style="padding-left:8px;padding-right:8px;padding-top:8px;padding-bottom:8px"
     >
       <div>
@@ -1394,7 +1279,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6"
-      role="cell"
       style="padding-left:8px;padding-right:8px;padding-top:8px;padding-bottom:8px"
     >
       <div>
@@ -1403,7 +1287,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6"
-      role="cell"
       style="padding-left:8px;padding-right:8px;padding-top:8px;padding-bottom:8px"
     >
       <div>
@@ -1414,12 +1297,10 @@ Array [
   "Another Row:",
   <div
     class="ant-row"
-    role="row"
     style="margin-left:-8px;margin-right:-8px;margin-top:-8px;margin-bottom:-8px"
   >
     <div
       class="ant-col ant-col-6"
-      role="cell"
       style="padding-left:8px;padding-right:8px;padding-top:8px;padding-bottom:8px"
     >
       <div>
@@ -1428,7 +1309,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6"
-      role="cell"
       style="padding-left:8px;padding-right:8px;padding-top:8px;padding-bottom:8px"
     >
       <div>
@@ -1437,7 +1317,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6"
-      role="cell"
       style="padding-left:8px;padding-right:8px;padding-top:8px;padding-bottom:8px"
     >
       <div>
@@ -1446,7 +1325,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6"
-      role="cell"
       style="padding-left:8px;padding-right:8px;padding-top:8px;padding-bottom:8px"
     >
       <div>
@@ -1485,23 +1363,19 @@ Array [
 exports[`renders ./components/grid/demo/responsive.md extend context correctly 1`] = `
 <div
   class="ant-row"
-  role="row"
 >
   <div
     class="ant-col ant-col-xs-2 ant-col-sm-4 ant-col-md-6 ant-col-lg-8 ant-col-xl-10"
-    role="cell"
   >
     Col
   </div>
   <div
     class="ant-col ant-col-xs-20 ant-col-sm-16 ant-col-md-12 ant-col-lg-8 ant-col-xl-4"
-    role="cell"
   >
     Col
   </div>
   <div
     class="ant-col ant-col-xs-2 ant-col-sm-4 ant-col-md-6 ant-col-lg-8 ant-col-xl-10"
-    role="cell"
   >
     Col
   </div>
@@ -1511,23 +1385,19 @@ exports[`renders ./components/grid/demo/responsive.md extend context correctly 1
 exports[`renders ./components/grid/demo/responsive-more.md extend context correctly 1`] = `
 <div
   class="ant-row"
-  role="row"
 >
   <div
     class="ant-col ant-col-xs-5 ant-col-xs-offset-1 ant-col-lg-6 ant-col-lg-offset-2"
-    role="cell"
   >
     Col
   </div>
   <div
     class="ant-col ant-col-xs-11 ant-col-xs-offset-1 ant-col-lg-6 ant-col-lg-offset-2"
-    role="cell"
   >
     Col
   </div>
   <div
     class="ant-col ant-col-xs-5 ant-col-xs-offset-1 ant-col-lg-6 ant-col-lg-offset-2"
-    role="cell"
   >
     Col
   </div>
@@ -1537,17 +1407,14 @@ exports[`renders ./components/grid/demo/responsive-more.md extend context correc
 exports[`renders ./components/grid/demo/sort.md extend context correctly 1`] = `
 <div
   class="ant-row"
-  role="row"
 >
   <div
     class="ant-col ant-col-18 ant-col-push-6"
-    role="cell"
   >
     col-18 col-push-6
   </div>
   <div
     class="ant-col ant-col-6 ant-col-pull-18"
-    role="cell"
   >
     col-6 col-pull-18
   </div>

--- a/components/grid/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/grid/__tests__/__snapshots__/demo.test.js.snap
@@ -4,80 +4,66 @@ exports[`renders ./components/grid/demo/basic.md correctly 1`] = `
 Array [
   <div
     class="ant-row"
-    role="row"
   >
     <div
       class="ant-col ant-col-24"
-      role="cell"
     >
       col
     </div>
   </div>,
   <div
     class="ant-row"
-    role="row"
   >
     <div
       class="ant-col ant-col-12"
-      role="cell"
     >
       col-12
     </div>
     <div
       class="ant-col ant-col-12"
-      role="cell"
     >
       col-12
     </div>
   </div>,
   <div
     class="ant-row"
-    role="row"
   >
     <div
       class="ant-col ant-col-8"
-      role="cell"
     >
       col-8
     </div>
     <div
       class="ant-col ant-col-8"
-      role="cell"
     >
       col-8
     </div>
     <div
       class="ant-col ant-col-8"
-      role="cell"
     >
       col-8
     </div>
   </div>,
   <div
     class="ant-row"
-    role="row"
   >
     <div
       class="ant-col ant-col-6"
-      role="cell"
     >
       col-6
     </div>
     <div
       class="ant-col ant-col-6"
-      role="cell"
     >
       col-6
     </div>
     <div
       class="ant-col ant-col-6"
-      role="cell"
     >
       col-6
     </div>
     <div
       class="ant-col ant-col-6"
-      role="cell"
     >
       col-6
     </div>
@@ -99,29 +85,24 @@ Array [
   </div>,
   <div
     class="ant-row ant-row-start"
-    role="row"
   >
     <div
       class="ant-col ant-col-4"
-      role="cell"
     >
       col-4
     </div>
     <div
       class="ant-col ant-col-4"
-      role="cell"
     >
       col-4
     </div>
     <div
       class="ant-col ant-col-4"
-      role="cell"
     >
       col-4
     </div>
     <div
       class="ant-col ant-col-4"
-      role="cell"
     >
       col-4
     </div>
@@ -138,29 +119,24 @@ Array [
   </div>,
   <div
     class="ant-row ant-row-center"
-    role="row"
   >
     <div
       class="ant-col ant-col-4"
-      role="cell"
     >
       col-4
     </div>
     <div
       class="ant-col ant-col-4"
-      role="cell"
     >
       col-4
     </div>
     <div
       class="ant-col ant-col-4"
-      role="cell"
     >
       col-4
     </div>
     <div
       class="ant-col ant-col-4"
-      role="cell"
     >
       col-4
     </div>
@@ -177,29 +153,24 @@ Array [
   </div>,
   <div
     class="ant-row ant-row-end"
-    role="row"
   >
     <div
       class="ant-col ant-col-4"
-      role="cell"
     >
       col-4
     </div>
     <div
       class="ant-col ant-col-4"
-      role="cell"
     >
       col-4
     </div>
     <div
       class="ant-col ant-col-4"
-      role="cell"
     >
       col-4
     </div>
     <div
       class="ant-col ant-col-4"
-      role="cell"
     >
       col-4
     </div>
@@ -216,29 +187,24 @@ Array [
   </div>,
   <div
     class="ant-row ant-row-space-between"
-    role="row"
   >
     <div
       class="ant-col ant-col-4"
-      role="cell"
     >
       col-4
     </div>
     <div
       class="ant-col ant-col-4"
-      role="cell"
     >
       col-4
     </div>
     <div
       class="ant-col ant-col-4"
-      role="cell"
     >
       col-4
     </div>
     <div
       class="ant-col ant-col-4"
-      role="cell"
     >
       col-4
     </div>
@@ -255,29 +221,24 @@ Array [
   </div>,
   <div
     class="ant-row ant-row-space-around"
-    role="row"
   >
     <div
       class="ant-col ant-col-4"
-      role="cell"
     >
       col-4
     </div>
     <div
       class="ant-col ant-col-4"
-      role="cell"
     >
       col-4
     </div>
     <div
       class="ant-col ant-col-4"
-      role="cell"
     >
       col-4
     </div>
     <div
       class="ant-col ant-col-4"
-      role="cell"
     >
       col-4
     </div>
@@ -294,29 +255,24 @@ Array [
   </div>,
   <div
     class="ant-row ant-row-space-evenly"
-    role="row"
   >
     <div
       class="ant-col ant-col-4"
-      role="cell"
     >
       col-4
     </div>
     <div
       class="ant-col ant-col-4"
-      role="cell"
     >
       col-4
     </div>
     <div
       class="ant-col ant-col-4"
-      role="cell"
     >
       col-4
     </div>
     <div
       class="ant-col ant-col-4"
-      role="cell"
     >
       col-4
     </div>
@@ -338,11 +294,9 @@ Array [
   </div>,
   <div
     class="ant-row ant-row-center ant-row-top"
-    role="row"
   >
     <div
       class="ant-col ant-col-4"
-      role="cell"
     >
       <p
         class="height-100"
@@ -352,7 +306,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-4"
-      role="cell"
     >
       <p
         class="height-50"
@@ -362,7 +315,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-4"
-      role="cell"
     >
       <p
         class="height-120"
@@ -372,7 +324,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-4"
-      role="cell"
     >
       <p
         class="height-80"
@@ -393,11 +344,9 @@ Array [
   </div>,
   <div
     class="ant-row ant-row-space-around ant-row-middle"
-    role="row"
   >
     <div
       class="ant-col ant-col-4"
-      role="cell"
     >
       <p
         class="height-100"
@@ -407,7 +356,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-4"
-      role="cell"
     >
       <p
         class="height-50"
@@ -417,7 +365,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-4"
-      role="cell"
     >
       <p
         class="height-120"
@@ -427,7 +374,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-4"
-      role="cell"
     >
       <p
         class="height-80"
@@ -448,11 +394,9 @@ Array [
   </div>,
   <div
     class="ant-row ant-row-space-between ant-row-bottom"
-    role="row"
   >
     <div
       class="ant-col ant-col-4"
-      role="cell"
     >
       <p
         class="height-100"
@@ -462,7 +406,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-4"
-      role="cell"
     >
       <p
         class="height-50"
@@ -472,7 +415,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-4"
-      role="cell"
     >
       <p
         class="height-120"
@@ -482,7 +424,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-4"
-      role="cell"
     >
       <p
         class="height-80"
@@ -508,29 +449,24 @@ Array [
   </div>,
   <div
     class="ant-row"
-    role="row"
   >
     <div
       class="ant-col ant-col-6 ant-col-order-4"
-      role="cell"
     >
       1 col-order-4
     </div>
     <div
       class="ant-col ant-col-6 ant-col-order-3"
-      role="cell"
     >
       2 col-order-3
     </div>
     <div
       class="ant-col ant-col-6 ant-col-order-2"
-      role="cell"
     >
       3 col-order-2
     </div>
     <div
       class="ant-col ant-col-6 ant-col-order-1"
-      role="cell"
     >
       4 col-order-1
     </div>
@@ -547,29 +483,24 @@ Array [
   </div>,
   <div
     class="ant-row"
-    role="row"
   >
     <div
       class="ant-col ant-col-6 ant-col-xs-order-1 ant-col-sm-order-2 ant-col-md-order-3 ant-col-lg-order-4"
-      role="cell"
     >
       1 col-order-responsive
     </div>
     <div
       class="ant-col ant-col-6 ant-col-xs-order-2 ant-col-sm-order-1 ant-col-md-order-4 ant-col-lg-order-3"
-      role="cell"
     >
       2 col-order-responsive
     </div>
     <div
       class="ant-col ant-col-6 ant-col-xs-order-3 ant-col-sm-order-4 ant-col-md-order-2 ant-col-lg-order-1"
-      role="cell"
     >
       3 col-order-responsive
     </div>
     <div
       class="ant-col ant-col-6 ant-col-xs-order-4 ant-col-sm-order-3 ant-col-md-order-1 ant-col-lg-order-2"
-      role="cell"
     >
       4 col-order-responsive
     </div>
@@ -591,18 +522,15 @@ Array [
   </div>,
   <div
     class="ant-row"
-    role="row"
   >
     <div
       class="ant-col"
-      role="cell"
       style="flex:2 2 auto"
     >
       2 / 5
     </div>
     <div
       class="ant-col"
-      role="cell"
       style="flex:3 3 auto"
     >
       3 / 5
@@ -620,18 +548,15 @@ Array [
   </div>,
   <div
     class="ant-row"
-    role="row"
   >
     <div
       class="ant-col"
-      role="cell"
       style="flex:0 0 100px"
     >
       100px
     </div>
     <div
       class="ant-col"
-      role="cell"
       style="flex:auto"
     >
       Fill Rest
@@ -649,18 +574,15 @@ Array [
   </div>,
   <div
     class="ant-row"
-    role="row"
   >
     <div
       class="ant-col"
-      role="cell"
       style="flex:1 1 200px"
     >
       1 1 200px
     </div>
     <div
       class="ant-col"
-      role="cell"
       style="flex:0 1 300px"
     >
       0 1 300px
@@ -668,11 +590,9 @@ Array [
   </div>,
   <div
     class="ant-row ant-row-no-wrap"
-    role="row"
   >
     <div
       class="ant-col"
-      role="cell"
       style="flex:none;min-width:0"
     >
       <div
@@ -683,7 +603,6 @@ Array [
     </div>
     <div
       class="ant-col"
-      role="cell"
       style="flex:auto;min-width:0"
     >
       auto with no-wrap
@@ -706,12 +625,10 @@ Array [
   </div>,
   <div
     class="ant-row"
-    role="row"
     style="margin-left:-8px;margin-right:-8px"
   >
     <div
       class="ant-col ant-col-6 gutter-row"
-      role="cell"
       style="padding-left:8px;padding-right:8px"
     >
       <div
@@ -722,7 +639,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6 gutter-row"
-      role="cell"
       style="padding-left:8px;padding-right:8px"
     >
       <div
@@ -733,7 +649,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6 gutter-row"
-      role="cell"
       style="padding-left:8px;padding-right:8px"
     >
       <div
@@ -744,7 +659,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6 gutter-row"
-      role="cell"
       style="padding-left:8px;padding-right:8px"
     >
       <div
@@ -766,12 +680,10 @@ Array [
   </div>,
   <div
     class="ant-row"
-    role="row"
     style="margin-left:-16px;margin-right:-16px"
   >
     <div
       class="ant-col ant-col-6 gutter-row"
-      role="cell"
       style="padding-left:16px;padding-right:16px"
     >
       <div
@@ -782,7 +694,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6 gutter-row"
-      role="cell"
       style="padding-left:16px;padding-right:16px"
     >
       <div
@@ -793,7 +704,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6 gutter-row"
-      role="cell"
       style="padding-left:16px;padding-right:16px"
     >
       <div
@@ -804,7 +714,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6 gutter-row"
-      role="cell"
       style="padding-left:16px;padding-right:16px"
     >
       <div
@@ -826,12 +735,10 @@ Array [
   </div>,
   <div
     class="ant-row"
-    role="row"
     style="margin-left:-8px;margin-right:-8px;margin-top:-12px;margin-bottom:-12px"
   >
     <div
       class="ant-col ant-col-6 gutter-row"
-      role="cell"
       style="padding-left:8px;padding-right:8px;padding-top:12px;padding-bottom:12px"
     >
       <div
@@ -842,7 +749,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6 gutter-row"
-      role="cell"
       style="padding-left:8px;padding-right:8px;padding-top:12px;padding-bottom:12px"
     >
       <div
@@ -853,7 +759,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6 gutter-row"
-      role="cell"
       style="padding-left:8px;padding-right:8px;padding-top:12px;padding-bottom:12px"
     >
       <div
@@ -864,7 +769,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6 gutter-row"
-      role="cell"
       style="padding-left:8px;padding-right:8px;padding-top:12px;padding-bottom:12px"
     >
       <div
@@ -875,7 +779,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6 gutter-row"
-      role="cell"
       style="padding-left:8px;padding-right:8px;padding-top:12px;padding-bottom:12px"
     >
       <div
@@ -886,7 +789,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6 gutter-row"
-      role="cell"
       style="padding-left:8px;padding-right:8px;padding-top:12px;padding-bottom:12px"
     >
       <div
@@ -897,7 +799,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6 gutter-row"
-      role="cell"
       style="padding-left:8px;padding-right:8px;padding-top:12px;padding-bottom:12px"
     >
       <div
@@ -908,7 +809,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6 gutter-row"
-      role="cell"
       style="padding-left:8px;padding-right:8px;padding-top:12px;padding-bottom:12px"
     >
       <div
@@ -925,45 +825,37 @@ exports[`renders ./components/grid/demo/offset.md correctly 1`] = `
 Array [
   <div
     class="ant-row"
-    role="row"
   >
     <div
       class="ant-col ant-col-8"
-      role="cell"
     >
       col-8
     </div>
     <div
       class="ant-col ant-col-8 ant-col-offset-8"
-      role="cell"
     >
       col-8
     </div>
   </div>,
   <div
     class="ant-row"
-    role="row"
   >
     <div
       class="ant-col ant-col-6 ant-col-offset-6"
-      role="cell"
     >
       col-6 col-offset-6
     </div>
     <div
       class="ant-col ant-col-6 ant-col-offset-6"
-      role="cell"
     >
       col-6 col-offset-6
     </div>
   </div>,
   <div
     class="ant-row"
-    role="row"
   >
     <div
       class="ant-col ant-col-12 ant-col-offset-6"
-      role="cell"
     >
       col-12 col-offset-6
     </div>
@@ -1263,12 +1155,10 @@ Array [
   </div>,
   <div
     class="ant-row"
-    role="row"
     style="margin-left:-8px;margin-right:-8px;margin-top:-8px;margin-bottom:-8px"
   >
     <div
       class="ant-col ant-col-6"
-      role="cell"
       style="padding-left:8px;padding-right:8px;padding-top:8px;padding-bottom:8px"
     >
       <div>
@@ -1277,7 +1167,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6"
-      role="cell"
       style="padding-left:8px;padding-right:8px;padding-top:8px;padding-bottom:8px"
     >
       <div>
@@ -1286,7 +1175,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6"
-      role="cell"
       style="padding-left:8px;padding-right:8px;padding-top:8px;padding-bottom:8px"
     >
       <div>
@@ -1295,7 +1183,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6"
-      role="cell"
       style="padding-left:8px;padding-right:8px;padding-top:8px;padding-bottom:8px"
     >
       <div>
@@ -1304,7 +1191,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6"
-      role="cell"
       style="padding-left:8px;padding-right:8px;padding-top:8px;padding-bottom:8px"
     >
       <div>
@@ -1313,7 +1199,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6"
-      role="cell"
       style="padding-left:8px;padding-right:8px;padding-top:8px;padding-bottom:8px"
     >
       <div>
@@ -1322,7 +1207,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6"
-      role="cell"
       style="padding-left:8px;padding-right:8px;padding-top:8px;padding-bottom:8px"
     >
       <div>
@@ -1331,7 +1215,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6"
-      role="cell"
       style="padding-left:8px;padding-right:8px;padding-top:8px;padding-bottom:8px"
     >
       <div>
@@ -1342,12 +1225,10 @@ Array [
   "Another Row:",
   <div
     class="ant-row"
-    role="row"
     style="margin-left:-8px;margin-right:-8px;margin-top:-8px;margin-bottom:-8px"
   >
     <div
       class="ant-col ant-col-6"
-      role="cell"
       style="padding-left:8px;padding-right:8px;padding-top:8px;padding-bottom:8px"
     >
       <div>
@@ -1356,7 +1237,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6"
-      role="cell"
       style="padding-left:8px;padding-right:8px;padding-top:8px;padding-bottom:8px"
     >
       <div>
@@ -1365,7 +1245,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6"
-      role="cell"
       style="padding-left:8px;padding-right:8px;padding-top:8px;padding-bottom:8px"
     >
       <div>
@@ -1374,7 +1253,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6"
-      role="cell"
       style="padding-left:8px;padding-right:8px;padding-top:8px;padding-bottom:8px"
     >
       <div>
@@ -1413,23 +1291,19 @@ Array [
 exports[`renders ./components/grid/demo/responsive.md correctly 1`] = `
 <div
   class="ant-row"
-  role="row"
 >
   <div
     class="ant-col ant-col-xs-2 ant-col-sm-4 ant-col-md-6 ant-col-lg-8 ant-col-xl-10"
-    role="cell"
   >
     Col
   </div>
   <div
     class="ant-col ant-col-xs-20 ant-col-sm-16 ant-col-md-12 ant-col-lg-8 ant-col-xl-4"
-    role="cell"
   >
     Col
   </div>
   <div
     class="ant-col ant-col-xs-2 ant-col-sm-4 ant-col-md-6 ant-col-lg-8 ant-col-xl-10"
-    role="cell"
   >
     Col
   </div>
@@ -1439,23 +1313,19 @@ exports[`renders ./components/grid/demo/responsive.md correctly 1`] = `
 exports[`renders ./components/grid/demo/responsive-more.md correctly 1`] = `
 <div
   class="ant-row"
-  role="row"
 >
   <div
     class="ant-col ant-col-xs-5 ant-col-xs-offset-1 ant-col-lg-6 ant-col-lg-offset-2"
-    role="cell"
   >
     Col
   </div>
   <div
     class="ant-col ant-col-xs-11 ant-col-xs-offset-1 ant-col-lg-6 ant-col-lg-offset-2"
-    role="cell"
   >
     Col
   </div>
   <div
     class="ant-col ant-col-xs-5 ant-col-xs-offset-1 ant-col-lg-6 ant-col-lg-offset-2"
-    role="cell"
   >
     Col
   </div>
@@ -1465,17 +1335,14 @@ exports[`renders ./components/grid/demo/responsive-more.md correctly 1`] = `
 exports[`renders ./components/grid/demo/sort.md correctly 1`] = `
 <div
   class="ant-row"
-  role="row"
 >
   <div
     class="ant-col ant-col-18 ant-col-push-6"
-    role="cell"
   >
     col-18 col-push-6
   </div>
   <div
     class="ant-col ant-col-6 ant-col-pull-18"
-    role="cell"
   >
     col-6 col-pull-18
   </div>

--- a/components/grid/__tests__/__snapshots__/index.test.js.snap
+++ b/components/grid/__tests__/__snapshots__/index.test.js.snap
@@ -3,19 +3,16 @@
 exports[`Grid renders wrapped Col correctly 1`] = `
 <div
   class="ant-row"
-  role="row"
   style="margin-left:-10px;margin-right:-10px"
 >
   <div>
     <div
       class="ant-col ant-col-12"
-      role="cell"
       style="padding-left:10px;padding-right:10px"
     />
   </div>
   <div
     class="ant-col ant-col-12"
-    role="cell"
     style="padding-left:10px;padding-right:10px"
   />
 </div>
@@ -24,35 +21,30 @@ exports[`Grid renders wrapped Col correctly 1`] = `
 exports[`Grid rtl render component should be rendered correctly in RTL direction 1`] = `
 <div
   class="ant-row ant-row-rtl"
-  role="row"
 />
 `;
 
 exports[`Grid rtl render component should be rendered correctly in RTL direction 2`] = `
 <div
   class="ant-col ant-col-rtl"
-  role="cell"
 />
 `;
 
 exports[`Grid should render Col 1`] = `
 <div
   class="ant-col ant-col-2"
-  role="cell"
 />
 `;
 
 exports[`Grid should render Row 1`] = `
 <div
   class="ant-row"
-  role="row"
 />
 `;
 
 exports[`Grid when typeof gutter is object array in large screen 1`] = `
 <div
   class="ant-row"
-  role="row"
   style="margin-left:-20px;margin-right:-20px;margin-top:-200px;margin-bottom:-200px"
 />
 `;

--- a/components/grid/__tests__/gap.test.js
+++ b/components/grid/__tests__/gap.test.js
@@ -15,7 +15,7 @@ jest.mock('../../_util/styleChecker', () => ({
 describe('Grid.Gap', () => {
   it('should not have `row-gap: 0px` style', () => {
     render(
-      <Row>
+      <Row role="row">
         <Col />
       </Row>,
     );

--- a/components/grid/col.tsx
+++ b/components/grid/col.tsx
@@ -128,7 +128,7 @@ const Col = React.forwardRef<HTMLDivElement, ColProps>((props, ref) => {
   }
 
   return (
-    <div role="cell" {...others} style={{ ...mergedStyle, ...style }} className={classes} ref={ref}>
+    <div {...others} style={{ ...mergedStyle, ...style }} className={classes} ref={ref}>
       {children}
     </div>
   );

--- a/components/grid/row.tsx
+++ b/components/grid/row.tsx
@@ -124,7 +124,7 @@ const Row = React.forwardRef<HTMLDivElement, RowProps>((props, ref) => {
 
   return (
     <RowContext.Provider value={rowContext}>
-      <div role="row" {...others} className={classes} style={{ ...rowStyle, ...style }} ref={ref}>
+      <div {...others} className={classes} style={{ ...rowStyle, ...style }} ref={ref}>
         {children}
       </div>
     </RowContext.Provider>

--- a/components/input/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/input/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -5201,12 +5201,10 @@ exports[`renders ./components/input/demo/group.md extend context correctly 1`] =
   >
     <div
       class="ant-row"
-      role="row"
       style="margin-left:-4px;margin-right:-4px"
     >
       <div
         class="ant-col ant-col-5"
-        role="cell"
         style="padding-left:4px;padding-right:4px"
       >
         <input
@@ -5217,7 +5215,6 @@ exports[`renders ./components/input/demo/group.md extend context correctly 1`] =
       </div>
       <div
         class="ant-col ant-col-8"
-        role="cell"
         style="padding-left:4px;padding-right:4px"
       >
         <input

--- a/components/input/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/input/__tests__/__snapshots__/demo.test.js.snap
@@ -1418,12 +1418,10 @@ exports[`renders ./components/input/demo/group.md correctly 1`] = `
   >
     <div
       class="ant-row"
-      role="row"
       style="margin-left:-4px;margin-right:-4px"
     >
       <div
         class="ant-col ant-col-5"
-        role="cell"
         style="padding-left:4px;padding-right:4px"
       >
         <input
@@ -1434,7 +1432,6 @@ exports[`renders ./components/input/demo/group.md correctly 1`] = `
       </div>
       <div
         class="ant-col ant-col-8"
-        role="cell"
         style="padding-left:4px;padding-right:4px"
       >
         <input

--- a/components/input/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/input/__tests__/__snapshots__/index.test.tsx.snap
@@ -365,11 +365,9 @@ exports[`Input should support size in form 1`] = `
 >
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"

--- a/components/list/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/list/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -179,7 +179,6 @@ exports[`renders ./components/list/demo/grid.md extend context correctly 1`] = `
     >
       <div
         class="ant-row"
-        role="row"
         style="margin-left:-8px;margin-right:-8px"
       >
         <div
@@ -187,7 +186,6 @@ exports[`renders ./components/list/demo/grid.md extend context correctly 1`] = `
         >
           <div
             class="ant-col"
-            role="cell"
             style="padding-left:8px;padding-right:8px;flex:1 1 auto"
           >
             <div
@@ -223,7 +221,6 @@ exports[`renders ./components/list/demo/grid.md extend context correctly 1`] = `
         >
           <div
             class="ant-col"
-            role="cell"
             style="padding-left:8px;padding-right:8px;flex:1 1 auto"
           >
             <div
@@ -259,7 +256,6 @@ exports[`renders ./components/list/demo/grid.md extend context correctly 1`] = `
         >
           <div
             class="ant-col"
-            role="cell"
             style="padding-left:8px;padding-right:8px;flex:1 1 auto"
           >
             <div
@@ -295,7 +291,6 @@ exports[`renders ./components/list/demo/grid.md extend context correctly 1`] = `
         >
           <div
             class="ant-col"
-            role="cell"
             style="padding-left:8px;padding-right:8px;flex:1 1 auto"
           >
             <div
@@ -345,7 +340,6 @@ Array [
       >
         <div
           class="ant-row"
-          role="row"
           style="margin-left:-8px;margin-right:-8px"
         >
           <div
@@ -353,7 +347,6 @@ Array [
           >
             <div
               class="ant-col"
-              role="cell"
               style="padding-left:8px;padding-right:8px;flex:1 1 auto"
             >
               <div
@@ -389,7 +382,6 @@ Array [
           >
             <div
               class="ant-col"
-              role="cell"
               style="padding-left:8px;padding-right:8px;flex:1 1 auto"
             >
               <div
@@ -425,7 +417,6 @@ Array [
           >
             <div
               class="ant-col"
-              role="cell"
               style="padding-left:8px;padding-right:8px;flex:1 1 auto"
             >
               <div
@@ -461,7 +452,6 @@ Array [
           >
             <div
               class="ant-col"
-              role="cell"
               style="padding-left:8px;padding-right:8px;flex:1 1 auto"
             >
               <div
@@ -497,7 +487,6 @@ Array [
           >
             <div
               class="ant-col"
-              role="cell"
               style="padding-left:8px;padding-right:8px;flex:1 1 auto"
             >
               <div
@@ -533,7 +522,6 @@ Array [
           >
             <div
               class="ant-col"
-              role="cell"
               style="padding-left:8px;padding-right:8px;flex:1 1 auto"
             >
               <div
@@ -579,7 +567,6 @@ Array [
       >
         <div
           class="ant-row"
-          role="row"
           style="margin-left:-8px;margin-right:-8px"
         >
           <div
@@ -587,7 +574,6 @@ Array [
           >
             <div
               class="ant-col"
-              role="cell"
               style="padding-left:8px;padding-right:8px;flex:1 1 auto"
             >
               <div
@@ -623,7 +609,6 @@ Array [
           >
             <div
               class="ant-col"
-              role="cell"
               style="padding-left:8px;padding-right:8px;flex:1 1 auto"
             >
               <div
@@ -659,7 +644,6 @@ Array [
           >
             <div
               class="ant-col"
-              role="cell"
               style="padding-left:8px;padding-right:8px;flex:1 1 auto"
             >
               <div
@@ -695,7 +679,6 @@ Array [
           >
             <div
               class="ant-col"
-              role="cell"
               style="padding-left:8px;padding-right:8px;flex:1 1 auto"
             >
               <div
@@ -731,7 +714,6 @@ Array [
           >
             <div
               class="ant-col"
-              role="cell"
               style="padding-left:8px;padding-right:8px;flex:1 1 auto"
             >
               <div
@@ -767,7 +749,6 @@ Array [
           >
             <div
               class="ant-col"
-              role="cell"
               style="padding-left:8px;padding-right:8px;flex:1 1 auto"
             >
               <div
@@ -813,7 +794,6 @@ Array [
       >
         <div
           class="ant-row"
-          role="row"
           style="margin-left:-8px;margin-right:-8px"
         >
           <div
@@ -821,7 +801,6 @@ Array [
           >
             <div
               class="ant-col"
-              role="cell"
               style="padding-left:8px;padding-right:8px;flex:1 1 auto"
             >
               <div
@@ -858,7 +837,6 @@ Array [
           >
             <div
               class="ant-col"
-              role="cell"
               style="padding-left:8px;padding-right:8px;flex:1 1 auto"
             >
               <div
@@ -895,7 +873,6 @@ Array [
           >
             <div
               class="ant-col"
-              role="cell"
               style="padding-left:8px;padding-right:8px;flex:1 1 auto"
             >
               <div
@@ -932,7 +909,6 @@ Array [
           >
             <div
               class="ant-col"
-              role="cell"
               style="padding-left:8px;padding-right:8px;flex:1 1 auto"
             >
               <div
@@ -969,7 +945,6 @@ Array [
           >
             <div
               class="ant-col"
-              role="cell"
               style="padding-left:8px;padding-right:8px;flex:1 1 auto"
             >
               <div
@@ -1006,7 +981,6 @@ Array [
           >
             <div
               class="ant-col"
-              role="cell"
               style="padding-left:8px;padding-right:8px;flex:1 1 auto"
             >
               <div
@@ -1202,13 +1176,11 @@ exports[`renders ./components/list/demo/responsive.md extend context correctly 1
     >
       <div
         class="ant-row"
-        role="row"
         style="margin-left:-8px;margin-right:-8px"
       >
         <div>
           <div
             class="ant-col"
-            role="cell"
             style="padding-left:8px;padding-right:8px;flex:1 1 auto"
           >
             <div
@@ -1242,7 +1214,6 @@ exports[`renders ./components/list/demo/responsive.md extend context correctly 1
         <div>
           <div
             class="ant-col"
-            role="cell"
             style="padding-left:8px;padding-right:8px;flex:1 1 auto"
           >
             <div
@@ -1276,7 +1247,6 @@ exports[`renders ./components/list/demo/responsive.md extend context correctly 1
         <div>
           <div
             class="ant-col"
-            role="cell"
             style="padding-left:8px;padding-right:8px;flex:1 1 auto"
           >
             <div
@@ -1310,7 +1280,6 @@ exports[`renders ./components/list/demo/responsive.md extend context correctly 1
         <div>
           <div
             class="ant-col"
-            role="cell"
             style="padding-left:8px;padding-right:8px;flex:1 1 auto"
           >
             <div
@@ -1344,7 +1313,6 @@ exports[`renders ./components/list/demo/responsive.md extend context correctly 1
         <div>
           <div
             class="ant-col"
-            role="cell"
             style="padding-left:8px;padding-right:8px;flex:1 1 auto"
           >
             <div
@@ -1378,7 +1346,6 @@ exports[`renders ./components/list/demo/responsive.md extend context correctly 1
         <div>
           <div
             class="ant-col"
-            role="cell"
             style="padding-left:8px;padding-right:8px;flex:1 1 auto"
           >
             <div

--- a/components/list/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/list/__tests__/__snapshots__/demo.test.js.snap
@@ -179,7 +179,6 @@ exports[`renders ./components/list/demo/grid.md correctly 1`] = `
     >
       <div
         class="ant-row"
-        role="row"
         style="margin-left:-8px;margin-right:-8px"
       >
         <div
@@ -187,7 +186,6 @@ exports[`renders ./components/list/demo/grid.md correctly 1`] = `
         >
           <div
             class="ant-col"
-            role="cell"
             style="padding-left:8px;padding-right:8px;flex:1 1 auto"
           >
             <div
@@ -223,7 +221,6 @@ exports[`renders ./components/list/demo/grid.md correctly 1`] = `
         >
           <div
             class="ant-col"
-            role="cell"
             style="padding-left:8px;padding-right:8px;flex:1 1 auto"
           >
             <div
@@ -259,7 +256,6 @@ exports[`renders ./components/list/demo/grid.md correctly 1`] = `
         >
           <div
             class="ant-col"
-            role="cell"
             style="padding-left:8px;padding-right:8px;flex:1 1 auto"
           >
             <div
@@ -295,7 +291,6 @@ exports[`renders ./components/list/demo/grid.md correctly 1`] = `
         >
           <div
             class="ant-col"
-            role="cell"
             style="padding-left:8px;padding-right:8px;flex:1 1 auto"
           >
             <div
@@ -345,7 +340,6 @@ Array [
       >
         <div
           class="ant-row"
-          role="row"
           style="margin-left:-8px;margin-right:-8px"
         >
           <div
@@ -353,7 +347,6 @@ Array [
           >
             <div
               class="ant-col"
-              role="cell"
               style="padding-left:8px;padding-right:8px;flex:1 1 auto"
             >
               <div
@@ -389,7 +382,6 @@ Array [
           >
             <div
               class="ant-col"
-              role="cell"
               style="padding-left:8px;padding-right:8px;flex:1 1 auto"
             >
               <div
@@ -425,7 +417,6 @@ Array [
           >
             <div
               class="ant-col"
-              role="cell"
               style="padding-left:8px;padding-right:8px;flex:1 1 auto"
             >
               <div
@@ -461,7 +452,6 @@ Array [
           >
             <div
               class="ant-col"
-              role="cell"
               style="padding-left:8px;padding-right:8px;flex:1 1 auto"
             >
               <div
@@ -497,7 +487,6 @@ Array [
           >
             <div
               class="ant-col"
-              role="cell"
               style="padding-left:8px;padding-right:8px;flex:1 1 auto"
             >
               <div
@@ -533,7 +522,6 @@ Array [
           >
             <div
               class="ant-col"
-              role="cell"
               style="padding-left:8px;padding-right:8px;flex:1 1 auto"
             >
               <div
@@ -579,7 +567,6 @@ Array [
       >
         <div
           class="ant-row"
-          role="row"
           style="margin-left:-8px;margin-right:-8px"
         >
           <div
@@ -587,7 +574,6 @@ Array [
           >
             <div
               class="ant-col"
-              role="cell"
               style="padding-left:8px;padding-right:8px;flex:1 1 auto"
             >
               <div
@@ -623,7 +609,6 @@ Array [
           >
             <div
               class="ant-col"
-              role="cell"
               style="padding-left:8px;padding-right:8px;flex:1 1 auto"
             >
               <div
@@ -659,7 +644,6 @@ Array [
           >
             <div
               class="ant-col"
-              role="cell"
               style="padding-left:8px;padding-right:8px;flex:1 1 auto"
             >
               <div
@@ -695,7 +679,6 @@ Array [
           >
             <div
               class="ant-col"
-              role="cell"
               style="padding-left:8px;padding-right:8px;flex:1 1 auto"
             >
               <div
@@ -731,7 +714,6 @@ Array [
           >
             <div
               class="ant-col"
-              role="cell"
               style="padding-left:8px;padding-right:8px;flex:1 1 auto"
             >
               <div
@@ -767,7 +749,6 @@ Array [
           >
             <div
               class="ant-col"
-              role="cell"
               style="padding-left:8px;padding-right:8px;flex:1 1 auto"
             >
               <div
@@ -813,7 +794,6 @@ Array [
       >
         <div
           class="ant-row"
-          role="row"
           style="margin-left:-8px;margin-right:-8px"
         >
           <div
@@ -821,7 +801,6 @@ Array [
           >
             <div
               class="ant-col"
-              role="cell"
               style="padding-left:8px;padding-right:8px;flex:1 1 auto"
             >
               <div
@@ -858,7 +837,6 @@ Array [
           >
             <div
               class="ant-col"
-              role="cell"
               style="padding-left:8px;padding-right:8px;flex:1 1 auto"
             >
               <div
@@ -895,7 +873,6 @@ Array [
           >
             <div
               class="ant-col"
-              role="cell"
               style="padding-left:8px;padding-right:8px;flex:1 1 auto"
             >
               <div
@@ -932,7 +909,6 @@ Array [
           >
             <div
               class="ant-col"
-              role="cell"
               style="padding-left:8px;padding-right:8px;flex:1 1 auto"
             >
               <div
@@ -969,7 +945,6 @@ Array [
           >
             <div
               class="ant-col"
-              role="cell"
               style="padding-left:8px;padding-right:8px;flex:1 1 auto"
             >
               <div
@@ -1006,7 +981,6 @@ Array [
           >
             <div
               class="ant-col"
-              role="cell"
               style="padding-left:8px;padding-right:8px;flex:1 1 auto"
             >
               <div
@@ -1202,13 +1176,11 @@ exports[`renders ./components/list/demo/responsive.md correctly 1`] = `
     >
       <div
         class="ant-row"
-        role="row"
         style="margin-left:-8px;margin-right:-8px"
       >
         <div>
           <div
             class="ant-col"
-            role="cell"
             style="padding-left:8px;padding-right:8px;flex:1 1 auto"
           >
             <div
@@ -1242,7 +1214,6 @@ exports[`renders ./components/list/demo/responsive.md correctly 1`] = `
         <div>
           <div
             class="ant-col"
-            role="cell"
             style="padding-left:8px;padding-right:8px;flex:1 1 auto"
           >
             <div
@@ -1276,7 +1247,6 @@ exports[`renders ./components/list/demo/responsive.md correctly 1`] = `
         <div>
           <div
             class="ant-col"
-            role="cell"
             style="padding-left:8px;padding-right:8px;flex:1 1 auto"
           >
             <div
@@ -1310,7 +1280,6 @@ exports[`renders ./components/list/demo/responsive.md correctly 1`] = `
         <div>
           <div
             class="ant-col"
-            role="cell"
             style="padding-left:8px;padding-right:8px;flex:1 1 auto"
           >
             <div
@@ -1344,7 +1313,6 @@ exports[`renders ./components/list/demo/responsive.md correctly 1`] = `
         <div>
           <div
             class="ant-col"
-            role="cell"
             style="padding-left:8px;padding-right:8px;flex:1 1 auto"
           >
             <div
@@ -1378,7 +1346,6 @@ exports[`renders ./components/list/demo/responsive.md correctly 1`] = `
         <div>
           <div
             class="ant-col"
-            role="cell"
             style="padding-left:8px;padding-right:8px;flex:1 1 auto"
           >
             <div

--- a/components/mentions/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/mentions/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -44,11 +44,9 @@ exports[`renders ./components/mentions/demo/form.md extend context correctly 1`]
 >
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-6 ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -60,7 +58,6 @@ exports[`renders ./components/mentions/demo/form.md extend context correctly 1`]
     </div>
     <div
       class="ant-col ant-col-16 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -83,11 +80,9 @@ exports[`renders ./components/mentions/demo/form.md extend context correctly 1`]
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-6 ant-form-item-label"
-      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -99,7 +94,6 @@ exports[`renders ./components/mentions/demo/form.md extend context correctly 1`]
     </div>
     <div
       class="ant-col ant-col-16 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -123,11 +117,9 @@ exports[`renders ./components/mentions/demo/form.md extend context correctly 1`]
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-14 ant-col-offset-6 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"

--- a/components/mentions/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/mentions/__tests__/__snapshots__/demo.test.js.snap
@@ -44,11 +44,9 @@ exports[`renders ./components/mentions/demo/form.md correctly 1`] = `
 >
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-6 ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -60,7 +58,6 @@ exports[`renders ./components/mentions/demo/form.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-16 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -83,11 +80,9 @@ exports[`renders ./components/mentions/demo/form.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-6 ant-form-item-label"
-      role="cell"
     >
       <label
         class="ant-form-item-required"
@@ -99,7 +94,6 @@ exports[`renders ./components/mentions/demo/form.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-16 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"
@@ -123,11 +117,9 @@ exports[`renders ./components/mentions/demo/form.md correctly 1`] = `
   </div>
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-14 ant-col-offset-6 ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"

--- a/components/page-header/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/page-header/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -339,7 +339,6 @@ Array [
     >
       <div
         class="ant-row"
-        role="row"
       >
         <div
           class="ant-statistic"
@@ -943,7 +942,6 @@ exports[`renders ./components/page-header/demo/content.md extend context correct
   >
     <div
       class="ant-row"
-      role="row"
     >
       <div
         style="flex:1"

--- a/components/page-header/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/page-header/__tests__/__snapshots__/demo.test.js.snap
@@ -339,7 +339,6 @@ Array [
     >
       <div
         class="ant-row"
-        role="row"
       >
         <div
           class="ant-statistic"
@@ -740,7 +739,6 @@ exports[`renders ./components/page-header/demo/content.md correctly 1`] = `
   >
     <div
       class="ant-row"
-      role="row"
     >
       <div
         style="flex:1"

--- a/components/skeleton/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/skeleton/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -190,11 +190,9 @@ Array [
   >
     <div
       class="ant-row ant-form-item"
-      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
-        role="cell"
       >
         <label
           class=""
@@ -205,7 +203,6 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
-        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -232,11 +229,9 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
-      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
-        role="cell"
       >
         <label
           class=""
@@ -247,7 +242,6 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
-        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -274,11 +268,9 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
-      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
-        role="cell"
       >
         <label
           class=""
@@ -289,7 +281,6 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
-        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -365,11 +356,9 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
-      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
-        role="cell"
       >
         <label
           class=""
@@ -380,7 +369,6 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
-        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -456,11 +444,9 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
-      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
-        role="cell"
       >
         <label
           class=""
@@ -471,7 +457,6 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
-        role="cell"
       >
         <div
           class="ant-form-item-control-input"

--- a/components/skeleton/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/skeleton/__tests__/__snapshots__/demo.test.js.snap
@@ -190,11 +190,9 @@ Array [
   >
     <div
       class="ant-row ant-form-item"
-      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
-        role="cell"
       >
         <label
           class=""
@@ -205,7 +203,6 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
-        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -232,11 +229,9 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
-      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
-        role="cell"
       >
         <label
           class=""
@@ -247,7 +242,6 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
-        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -274,11 +268,9 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
-      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
-        role="cell"
       >
         <label
           class=""
@@ -289,7 +281,6 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
-        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -365,11 +356,9 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
-      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
-        role="cell"
       >
         <label
           class=""
@@ -380,7 +369,6 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
-        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -456,11 +444,9 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
-      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
-        role="cell"
       >
         <label
           class=""
@@ -471,7 +457,6 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
-        role="cell"
       >
         <div
           class="ant-form-item-control-input"

--- a/components/slider/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/slider/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -466,11 +466,9 @@ exports[`renders ./components/slider/demo/input-number.md extend context correct
 <div>
   <div
     class="ant-row"
-    role="row"
   >
     <div
       class="ant-col ant-col-12"
-      role="cell"
     >
       <div
         class="ant-slider ant-slider-horizontal"
@@ -523,7 +521,6 @@ exports[`renders ./components/slider/demo/input-number.md extend context correct
     </div>
     <div
       class="ant-col ant-col-4"
-      role="cell"
     >
       <div
         class="ant-input-number"
@@ -606,11 +603,9 @@ exports[`renders ./components/slider/demo/input-number.md extend context correct
   </div>
   <div
     class="ant-row"
-    role="row"
   >
     <div
       class="ant-col ant-col-12"
-      role="cell"
     >
       <div
         class="ant-slider ant-slider-horizontal"
@@ -663,7 +658,6 @@ exports[`renders ./components/slider/demo/input-number.md extend context correct
     </div>
     <div
       class="ant-col ant-col-4"
-      role="cell"
     >
       <div
         class="ant-input-number"

--- a/components/slider/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/slider/__tests__/__snapshots__/demo.test.js.snap
@@ -250,11 +250,9 @@ exports[`renders ./components/slider/demo/input-number.md correctly 1`] = `
 <div>
   <div
     class="ant-row"
-    role="row"
   >
     <div
       class="ant-col ant-col-12"
-      role="cell"
     >
       <div
         class="ant-slider ant-slider-horizontal"
@@ -283,7 +281,6 @@ exports[`renders ./components/slider/demo/input-number.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-4"
-      role="cell"
     >
       <div
         class="ant-input-number"
@@ -366,11 +363,9 @@ exports[`renders ./components/slider/demo/input-number.md correctly 1`] = `
   </div>
   <div
     class="ant-row"
-    role="row"
   >
     <div
       class="ant-col ant-col-12"
-      role="cell"
     >
       <div
         class="ant-slider ant-slider-horizontal"
@@ -399,7 +394,6 @@ exports[`renders ./components/slider/demo/input-number.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-4"
-      role="cell"
     >
       <div
         class="ant-input-number"

--- a/components/statistic/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/statistic/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -3,12 +3,10 @@
 exports[`renders ./components/statistic/demo/basic.md extend context correctly 1`] = `
 <div
   class="ant-row"
-  role="row"
   style="margin-left:-8px;margin-right:-8px"
 >
   <div
     class="ant-col ant-col-12"
-    role="cell"
     style="padding-left:8px;padding-right:8px"
   >
     <div
@@ -36,7 +34,6 @@ exports[`renders ./components/statistic/demo/basic.md extend context correctly 1
   </div>
   <div
     class="ant-col ant-col-12"
-    role="cell"
     style="padding-left:8px;padding-right:8px"
   >
     <div
@@ -78,7 +75,6 @@ exports[`renders ./components/statistic/demo/basic.md extend context correctly 1
   </div>
   <div
     class="ant-col ant-col-12"
-    role="cell"
     style="padding-left:8px;padding-right:8px"
   >
     <div
@@ -111,12 +107,10 @@ exports[`renders ./components/statistic/demo/card.md extend context correctly 1`
 >
   <div
     class="ant-row"
-    role="row"
     style="margin-left:-8px;margin-right:-8px"
   >
     <div
       class="ant-col ant-col-12"
-      role="cell"
       style="padding-left:8px;padding-right:8px"
     >
       <div
@@ -186,7 +180,6 @@ exports[`renders ./components/statistic/demo/card.md extend context correctly 1`
     </div>
     <div
       class="ant-col ant-col-12"
-      role="cell"
       style="padding-left:8px;padding-right:8px"
     >
       <div
@@ -261,12 +254,10 @@ exports[`renders ./components/statistic/demo/card.md extend context correctly 1`
 exports[`renders ./components/statistic/demo/countdown.md extend context correctly 1`] = `
 <div
   class="ant-row"
-  role="row"
   style="margin-left:-8px;margin-right:-8px"
 >
   <div
     class="ant-col ant-col-12"
-    role="cell"
     style="padding-left:8px;padding-right:8px"
   >
     <div
@@ -290,7 +281,6 @@ exports[`renders ./components/statistic/demo/countdown.md extend context correct
   </div>
   <div
     class="ant-col ant-col-12"
-    role="cell"
     style="padding-left:8px;padding-right:8px"
   >
     <div
@@ -314,7 +304,6 @@ exports[`renders ./components/statistic/demo/countdown.md extend context correct
   </div>
   <div
     class="ant-col ant-col-24"
-    role="cell"
     style="padding-left:8px;padding-right:8px;margin-top:32px"
   >
     <div
@@ -338,7 +327,6 @@ exports[`renders ./components/statistic/demo/countdown.md extend context correct
   </div>
   <div
     class="ant-col ant-col-12"
-    role="cell"
     style="padding-left:8px;padding-right:8px"
   >
     <div
@@ -366,12 +354,10 @@ exports[`renders ./components/statistic/demo/countdown.md extend context correct
 exports[`renders ./components/statistic/demo/unit.md extend context correctly 1`] = `
 <div
   class="ant-row"
-  role="row"
   style="margin-left:-8px;margin-right:-8px"
 >
   <div
     class="ant-col ant-col-12"
-    role="cell"
     style="padding-left:8px;padding-right:8px"
   >
     <div
@@ -422,7 +408,6 @@ exports[`renders ./components/statistic/demo/unit.md extend context correctly 1`
   </div>
   <div
     class="ant-col ant-col-12"
-    role="cell"
     style="padding-left:8px;padding-right:8px"
   >
     <div

--- a/components/statistic/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/statistic/__tests__/__snapshots__/demo.test.js.snap
@@ -3,12 +3,10 @@
 exports[`renders ./components/statistic/demo/basic.md correctly 1`] = `
 <div
   class="ant-row"
-  role="row"
   style="margin-left:-8px;margin-right:-8px"
 >
   <div
     class="ant-col ant-col-12"
-    role="cell"
     style="padding-left:8px;padding-right:8px"
   >
     <div
@@ -36,7 +34,6 @@ exports[`renders ./components/statistic/demo/basic.md correctly 1`] = `
   </div>
   <div
     class="ant-col ant-col-12"
-    role="cell"
     style="padding-left:8px;padding-right:8px"
   >
     <div
@@ -78,7 +75,6 @@ exports[`renders ./components/statistic/demo/basic.md correctly 1`] = `
   </div>
   <div
     class="ant-col ant-col-12"
-    role="cell"
     style="padding-left:8px;padding-right:8px"
   >
     <div
@@ -111,12 +107,10 @@ exports[`renders ./components/statistic/demo/card.md correctly 1`] = `
 >
   <div
     class="ant-row"
-    role="row"
     style="margin-left:-8px;margin-right:-8px"
   >
     <div
       class="ant-col ant-col-12"
-      role="cell"
       style="padding-left:8px;padding-right:8px"
     >
       <div
@@ -186,7 +180,6 @@ exports[`renders ./components/statistic/demo/card.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-12"
-      role="cell"
       style="padding-left:8px;padding-right:8px"
     >
       <div
@@ -261,12 +254,10 @@ exports[`renders ./components/statistic/demo/card.md correctly 1`] = `
 exports[`renders ./components/statistic/demo/countdown.md correctly 1`] = `
 <div
   class="ant-row"
-  role="row"
   style="margin-left:-8px;margin-right:-8px"
 >
   <div
     class="ant-col ant-col-12"
-    role="cell"
     style="padding-left:8px;padding-right:8px"
   >
     <div
@@ -290,7 +281,6 @@ exports[`renders ./components/statistic/demo/countdown.md correctly 1`] = `
   </div>
   <div
     class="ant-col ant-col-12"
-    role="cell"
     style="padding-left:8px;padding-right:8px"
   >
     <div
@@ -314,7 +304,6 @@ exports[`renders ./components/statistic/demo/countdown.md correctly 1`] = `
   </div>
   <div
     class="ant-col ant-col-24"
-    role="cell"
     style="padding-left:8px;padding-right:8px;margin-top:32px"
   >
     <div
@@ -338,7 +327,6 @@ exports[`renders ./components/statistic/demo/countdown.md correctly 1`] = `
   </div>
   <div
     class="ant-col ant-col-12"
-    role="cell"
     style="padding-left:8px;padding-right:8px"
   >
     <div
@@ -366,12 +354,10 @@ exports[`renders ./components/statistic/demo/countdown.md correctly 1`] = `
 exports[`renders ./components/statistic/demo/unit.md correctly 1`] = `
 <div
   class="ant-row"
-  role="row"
   style="margin-left:-8px;margin-right:-8px"
 >
   <div
     class="ant-col ant-col-12"
-    role="cell"
     style="padding-left:8px;padding-right:8px"
   >
     <div
@@ -422,7 +408,6 @@ exports[`renders ./components/statistic/demo/unit.md correctly 1`] = `
   </div>
   <div
     class="ant-col ant-col-12"
-    role="cell"
     style="padding-left:8px;padding-right:8px"
   >
     <div

--- a/components/table/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/table/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -2295,11 +2295,9 @@ Array [
   >
     <div
       class="ant-row ant-form-item"
-      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
-        role="cell"
       >
         <label
           class=""
@@ -2310,7 +2308,6 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
-        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -2337,11 +2334,9 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
-      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
-        role="cell"
       >
         <label
           class=""
@@ -2352,7 +2347,6 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
-        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -2379,11 +2373,9 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
-      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
-        role="cell"
       >
         <label
           class=""
@@ -2394,7 +2386,6 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
-        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -2421,11 +2412,9 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
-      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
-        role="cell"
       >
         <label
           class=""
@@ -2436,7 +2425,6 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
-        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -2463,11 +2451,9 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
-      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
-        role="cell"
       >
         <label
           class=""
@@ -2478,7 +2464,6 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
-        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -2505,11 +2490,9 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
-      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
-        role="cell"
       >
         <label
           class=""
@@ -2520,7 +2503,6 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
-        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -2547,11 +2529,9 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
-      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
-        role="cell"
       >
         <label
           class=""
@@ -2562,7 +2542,6 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
-        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -2589,11 +2568,9 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
-      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
-        role="cell"
       >
         <label
           class=""
@@ -2604,7 +2581,6 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
-        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -2631,11 +2607,9 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
-      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
-        role="cell"
       >
         <label
           class=""
@@ -2646,7 +2620,6 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
-        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -2673,11 +2646,9 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
-      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
-        role="cell"
       >
         <label
           class=""
@@ -2688,7 +2659,6 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
-        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -2715,11 +2685,9 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
-      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
-        role="cell"
       >
         <label
           class=""
@@ -2730,7 +2698,6 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
-        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -2806,11 +2773,9 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
-      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
-        role="cell"
       >
         <label
           class=""
@@ -2821,7 +2786,6 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
-        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -2896,11 +2860,9 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
-      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
-        role="cell"
       >
         <label
           class=""
@@ -2911,7 +2873,6 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
-        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -2967,11 +2928,9 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
-      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
-        role="cell"
       >
         <label
           class=""
@@ -2982,7 +2941,6 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
-        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -3077,11 +3035,9 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
-      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
-        role="cell"
       >
         <label
           class=""
@@ -3092,7 +3048,6 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
-        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -15746,11 +15701,9 @@ Array [
   >
     <div
       class="ant-row ant-form-item"
-      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
-        role="cell"
       >
         <label
           class=""
@@ -15761,7 +15714,6 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
-        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -15788,11 +15740,9 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
-      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
-        role="cell"
       >
         <label
           class=""
@@ -15803,7 +15753,6 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
-        role="cell"
       >
         <div
           class="ant-form-item-control-input"

--- a/components/table/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/table/__tests__/__snapshots__/demo.test.js.snap
@@ -1804,11 +1804,9 @@ Array [
   >
     <div
       class="ant-row ant-form-item"
-      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
-        role="cell"
       >
         <label
           class=""
@@ -1819,7 +1817,6 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
-        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -1846,11 +1843,9 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
-      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
-        role="cell"
       >
         <label
           class=""
@@ -1861,7 +1856,6 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
-        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -1888,11 +1882,9 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
-      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
-        role="cell"
       >
         <label
           class=""
@@ -1903,7 +1895,6 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
-        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -1930,11 +1921,9 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
-      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
-        role="cell"
       >
         <label
           class=""
@@ -1945,7 +1934,6 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
-        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -1972,11 +1960,9 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
-      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
-        role="cell"
       >
         <label
           class=""
@@ -1987,7 +1973,6 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
-        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -2014,11 +1999,9 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
-      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
-        role="cell"
       >
         <label
           class=""
@@ -2029,7 +2012,6 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
-        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -2056,11 +2038,9 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
-      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
-        role="cell"
       >
         <label
           class=""
@@ -2071,7 +2051,6 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
-        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -2098,11 +2077,9 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
-      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
-        role="cell"
       >
         <label
           class=""
@@ -2113,7 +2090,6 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
-        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -2140,11 +2116,9 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
-      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
-        role="cell"
       >
         <label
           class=""
@@ -2155,7 +2129,6 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
-        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -2182,11 +2155,9 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
-      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
-        role="cell"
       >
         <label
           class=""
@@ -2197,7 +2168,6 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
-        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -2224,11 +2194,9 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
-      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
-        role="cell"
       >
         <label
           class=""
@@ -2239,7 +2207,6 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
-        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -2315,11 +2282,9 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
-      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
-        role="cell"
       >
         <label
           class=""
@@ -2330,7 +2295,6 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
-        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -2405,11 +2369,9 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
-      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
-        role="cell"
       >
         <label
           class=""
@@ -2420,7 +2382,6 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
-        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -2476,11 +2437,9 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
-      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
-        role="cell"
       >
         <label
           class=""
@@ -2491,7 +2450,6 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
-        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -2586,11 +2544,9 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
-      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
-        role="cell"
       >
         <label
           class=""
@@ -2601,7 +2557,6 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
-        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -11988,11 +11943,9 @@ Array [
   >
     <div
       class="ant-row ant-form-item"
-      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
-        role="cell"
       >
         <label
           class=""
@@ -12003,7 +11956,6 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
-        role="cell"
       >
         <div
           class="ant-form-item-control-input"
@@ -12030,11 +11982,9 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
-      role="row"
     >
       <div
         class="ant-col ant-form-item-label"
-        role="cell"
       >
         <label
           class=""
@@ -12045,7 +11995,6 @@ Array [
       </div>
       <div
         class="ant-col ant-form-item-control"
-        role="cell"
       >
         <div
           class="ant-form-item-control-input"

--- a/components/upload/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/upload/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -3781,11 +3781,9 @@ exports[`renders ./components/upload/demo/upload-with-aliyun-oss.md extend conte
 >
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-4 ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -3797,7 +3795,6 @@ exports[`renders ./components/upload/demo/upload-with-aliyun-oss.md extend conte
     </div>
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"

--- a/components/upload/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/upload/__tests__/__snapshots__/demo.test.js.snap
@@ -3565,11 +3565,9 @@ exports[`renders ./components/upload/demo/upload-with-aliyun-oss.md correctly 1`
 >
   <div
     class="ant-row ant-form-item"
-    role="row"
   >
     <div
       class="ant-col ant-col-4 ant-form-item-label"
-      role="cell"
     >
       <label
         class=""
@@ -3581,7 +3579,6 @@ exports[`renders ./components/upload/demo/upload-with-aliyun-oss.md correctly 1`
     </div>
     <div
       class="ant-col ant-form-item-control"
-      role="cell"
     >
       <div
         class="ant-form-item-control-input"


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

#35549

### 💡 Background and solution

The `row` and `cell` aria roles on `Row` and `Col` make it difficult to comply with [aria-required-parent](https://accessibilityinsights.io/info-examples/web/aria-required-parent/). [Docs](https://www.w3.org/TR/wai-aria-1.1/#row) state:

> Authors MUST ensure elements with role `row` are contained in, or owned by, an element with the role `table`, `grid`, `rowgroup`, or `treegrid`.

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | In the prior state, `Row` and `Col` supply `row` and `cell` aria roles (respectively) by default. In the new state, `Row` and `Col` don't supply any aria role by default. If such roles are desired, they will have to be specified manually, ex. ```<Row role="row" />```. |
| 🇨🇳 Chinese | 在之前的状态中，`Row` 和 `Col` 默认提供 `row` 和 `cell` 咏叹调角色（分别）。 在新状态下，`Row` 和 `Col` 默认不提供任何 aria 角色。 如果需要此类角色，则必须手动指定它们。 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
