### PR TITLE
fix: incorrect position of picker popup

### DIFF
--- a/components/date-picker/style/index.less
+++ b/components/date-picker/style/index.less
@@ -220,6 +220,10 @@
   &-dropdown {
     .reset-component();
     position: absolute;
+    // Fix incorrect position of picker popup
+    // https://github.com/ant-design/ant-design/issues/35590
+    top: -9999px;
+    left: -9999px;
     z-index: @zindex-picker;
 
     &-hidden {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
https://github.com/ant-design/ant-design/issues/35590#issue-1238095083

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution
把初始位置设为负数
https://github.com/yiminghe/dom-align/blob/7110744d1b4d2f0e76d8f9e120127787c260ba71/README.md?plain=1#L49
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fix DatePicker placeholder flush when open first time.  |
| 🇨🇳 Chinese |  修复 DatePicker 初次打开时 placeholder 闪烁的问题。  |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
