### PR TITLE
fix: drawer can not ref form instance when open

### DIFF
--- a/components/drawer/__tests__/DrawerEvent.test.js
+++ b/components/drawer/__tests__/DrawerEvent.test.js
@@ -1,7 +1,28 @@
 import React from 'react';
 import Drawer from '..';
-import { render, fireEvent } from '../../../tests/utils';
+import { render, fireEvent, screen } from '../../../tests/utils';
 import Form from '../../form';
+import Button from '../../button';
+
+const RefDemo = ({ fn }) => {
+  const formRef = React.useRef();
+  const [visible, setVisible] = React.useState(false);
+
+  React.useEffect(() => {
+    if (visible) {
+      fn(formRef.current);
+    }
+  }, [visible]);
+
+  return (
+    <>
+      <Button onClick={() => setVisible(true)}>open</Button>
+      <Drawer visible={visible}>
+        <Form ref={formRef} />
+      </Drawer>
+    </>
+  );
+};
 
 describe('Drawer', () => {
   const getDrawer = props => (
@@ -79,12 +100,10 @@ describe('Drawer', () => {
     expect(afterVisibleChange).toBeCalledTimes(1);
   });
   it('should support form ref', () => {
-    const formRef = React.createRef();
-    render(
-      <Drawer visible>
-        <Form ref={formRef} />
-      </Drawer>,
-    );
-    expect(typeof formRef.current).toBe('object');
+    const fn = formRef => {
+      expect(typeof formRef).toBe('object');
+    };
+    render(<RefDemo fn={fn} />);
+    fireEvent.click(screen.getByText('open'));
   });
 });

--- a/components/drawer/__tests__/DrawerEvent.test.js
+++ b/components/drawer/__tests__/DrawerEvent.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import Drawer from '..';
 import { render, fireEvent } from '../../../tests/utils';
+import Form from '../../form';
 
 describe('Drawer', () => {
   const getDrawer = props => (
@@ -76,5 +77,14 @@ describe('Drawer', () => {
     ev.propertyName = 'transform';
     fireEvent(document.querySelector('.ant-drawer-content-wrapper'), ev);
     expect(afterVisibleChange).toBeCalledTimes(1);
+  });
+  it('should support form ref', () => {
+    const formRef = React.createRef();
+    render(
+      <Drawer visible>
+        <Form ref={formRef} />
+      </Drawer>,
+    );
+    expect(typeof formRef.current).toBe('object');
   });
 });

--- a/components/drawer/__tests__/DrawerEvent.test.js
+++ b/components/drawer/__tests__/DrawerEvent.test.js
@@ -1,16 +1,15 @@
 import React from 'react';
 import Drawer from '..';
 import { render, fireEvent, screen } from '../../../tests/utils';
-import Form from '../../form';
 import Button from '../../button';
 
 const RefDemo = ({ fn }) => {
-  const formRef = React.useRef();
+  const ref = React.useRef();
   const [visible, setVisible] = React.useState(false);
 
   React.useEffect(() => {
     if (visible) {
-      fn(formRef.current);
+      fn(ref.current);
     }
   }, [visible]);
 
@@ -18,7 +17,7 @@ const RefDemo = ({ fn }) => {
     <>
       <Button onClick={() => setVisible(true)}>open</Button>
       <Drawer visible={visible}>
-        <Form ref={formRef} />
+        <div ref={ref} />
       </Drawer>
     </>
   );
@@ -99,9 +98,9 @@ describe('Drawer', () => {
     fireEvent(document.querySelector('.ant-drawer-content-wrapper'), ev);
     expect(afterVisibleChange).toBeCalledTimes(1);
   });
-  it('should support form ref', () => {
-    const fn = formRef => {
-      expect(typeof formRef).toBe('object');
+  it('should support children ref', () => {
+    const fn = ref => {
+      expect(typeof ref).toBe('object');
     };
     render(<RefDemo fn={fn} />);
     fireEvent.click(screen.getByText('open'));

--- a/components/drawer/__tests__/DrawerEvent.test.js
+++ b/components/drawer/__tests__/DrawerEvent.test.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import Drawer from '..';
 import { render, fireEvent } from '../../../tests/utils';
-import Button from '../../button';
 
 describe('Drawer', () => {
   const getDrawer = props => (
@@ -98,7 +97,7 @@ describe('Drawer', () => {
 
       return (
         <>
-          <Button onClick={() => setVisible(true)}>open</Button>
+          <a onClick={() => setVisible(true)}>open</a>
           <Drawer visible={visible}>
             <div ref={ref} />
           </Drawer>
@@ -106,7 +105,7 @@ describe('Drawer', () => {
       );
     };
     const { container } = render(<RefDemo />);
-    fireEvent.click(container.querySelector('button'));
+    fireEvent.click(container.querySelector('a'));
     expect(fn).toBeCalled();
   });
 });

--- a/components/drawer/__tests__/DrawerEvent.test.js
+++ b/components/drawer/__tests__/DrawerEvent.test.js
@@ -3,26 +3,6 @@ import Drawer from '..';
 import { render, fireEvent, screen } from '../../../tests/utils';
 import Button from '../../button';
 
-const RefDemo = ({ fn }) => {
-  const ref = React.useRef();
-  const [visible, setVisible] = React.useState(false);
-
-  React.useEffect(() => {
-    if (visible) {
-      fn(ref.current);
-    }
-  }, [visible]);
-
-  return (
-    <>
-      <Button onClick={() => setVisible(true)}>open</Button>
-      <Drawer visible={visible}>
-        <div ref={ref} />
-      </Drawer>
-    </>
-  );
-};
-
 describe('Drawer', () => {
   const getDrawer = props => (
     <Drawer visible getContainer={false} {...props}>
@@ -102,7 +82,26 @@ describe('Drawer', () => {
     const fn = ref => {
       expect(typeof ref).toBe('object');
     };
-    render(<RefDemo fn={fn} />);
+    const RefDemo = () => {
+      const ref = React.useRef();
+      const [visible, setVisible] = React.useState(false);
+
+      React.useEffect(() => {
+        if (visible) {
+          fn(ref.current);
+        }
+      }, [visible]);
+
+      return (
+        <>
+          <Button onClick={() => setVisible(true)}>open</Button>
+          <Drawer visible={visible}>
+            <div ref={ref} />
+          </Drawer>
+        </>
+      );
+    };
+    render(<RefDemo />);
     fireEvent.click(screen.getByText('open'));
   });
 });

--- a/components/drawer/__tests__/DrawerEvent.test.js
+++ b/components/drawer/__tests__/DrawerEvent.test.js
@@ -79,16 +79,20 @@ describe('Drawer', () => {
     expect(afterVisibleChange).toBeCalledTimes(1);
   });
   it('should support children ref', () => {
-    const fn = ref => {
+    const fn = jest.fn();
+
+    const refCallback = ref => {
       expect(typeof ref).toBe('object');
+      fn();
     };
+
     const RefDemo = () => {
       const ref = React.useRef();
       const [visible, setVisible] = React.useState(false);
 
       React.useEffect(() => {
         if (visible) {
-          fn(ref.current);
+          refCallback(ref.current);
         }
       }, [visible]);
 
@@ -103,5 +107,6 @@ describe('Drawer', () => {
     };
     render(<RefDemo />);
     fireEvent.click(screen.getByText('open'));
+    expect(fn).toBeCalled();
   });
 });

--- a/components/drawer/__tests__/DrawerEvent.test.js
+++ b/components/drawer/__tests__/DrawerEvent.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import Drawer from '..';
-import { render, fireEvent, screen } from '../../../tests/utils';
+import { render, fireEvent } from '../../../tests/utils';
 import Button from '../../button';
 
 describe('Drawer', () => {
@@ -105,8 +105,8 @@ describe('Drawer', () => {
         </>
       );
     };
-    render(<RefDemo />);
-    fireEvent.click(screen.getByText('open'));
+    const { container } = render(<RefDemo />);
+    fireEvent.click(container.querySelector('button'));
     expect(fn).toBeCalled();
   });
 });

--- a/components/drawer/index.tsx
+++ b/components/drawer/index.tsx
@@ -266,7 +266,7 @@ const Drawer = React.forwardRef<DrawerRef, DrawerProps>(
     // render drawer body dom
     const renderBody = () => {
       // destroyCloseRef.current =false Load the body only once by default
-      if (destroyCloseRef.current && !forceRender && !load) {
+      if (destroyCloseRef.current && !forceRender && !propsVisible) {
         return null;
       }
 

--- a/components/drawer/index.tsx
+++ b/components/drawer/index.tsx
@@ -306,7 +306,7 @@ const Drawer = React.forwardRef<DrawerRef, DrawerProps>(
             ...rest,
           }}
           {...offsetStyle}
-          open={visible}
+          open={visible || propsVisible}
           showMask={mask}
           style={getRcDrawerStyle()}
           className={drawerClassName}


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

resolve #35703

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   fix drawer can not ref form instance when open     |
| 🇨🇳 Chinese |      修复抽屉打开时 form 实例  为 null  |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
