### PR TITLE
Fix: row style conflict error

### DIFF
--- a/components/_util/__tests__/styleChecker.test.js
+++ b/components/_util/__tests__/styleChecker.test.js
@@ -1,0 +1,14 @@
+/**
+ * @jest-environment node
+ */
+import * as styleChecker from '../styleChecker';
+
+describe('test styleChecker.js in node', () => {
+  it('can not use dom', () => {
+    expect(!!styleChecker.canUseDocElement()).toBe(false);
+  });
+
+  it('can not use flex', () => {
+    expect(styleChecker.detectFlexGapSupported()).toBe(false);
+  });
+});

--- a/components/calendar/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/calendar/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -3185,11 +3185,10 @@ exports[`renders ./components/calendar/demo/customize-header.md extend context c
       </h4>
       <div
         class="ant-row"
-        style="margin-left:-4px;margin-right:-4px"
+        style="--row-gutter-x:8px"
       >
         <div
           class="ant-col"
-          style="padding-left:4px;padding-right:4px"
         >
           <div
             class="ant-radio-group ant-radio-group-outline ant-radio-group-small"
@@ -3237,7 +3236,6 @@ exports[`renders ./components/calendar/demo/customize-header.md extend context c
         </div>
         <div
           class="ant-col"
-          style="padding-left:4px;padding-right:4px"
         >
           <div
             class="ant-select ant-select-sm my-year-select ant-select-single ant-select-show-arrow"
@@ -3687,7 +3685,6 @@ exports[`renders ./components/calendar/demo/customize-header.md extend context c
         </div>
         <div
           class="ant-col"
-          style="padding-left:4px;padding-right:4px"
         >
           <div
             class="ant-select ant-select-sm ant-select-single ant-select-show-arrow"

--- a/components/calendar/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/calendar/__tests__/__snapshots__/demo.test.js.snap
@@ -1905,11 +1905,10 @@ exports[`renders ./components/calendar/demo/customize-header.md correctly 1`] = 
       </h4>
       <div
         class="ant-row"
-        style="margin-left:-4px;margin-right:-4px"
+        style="--row-gutter-x:8px"
       >
         <div
           class="ant-col"
-          style="padding-left:4px;padding-right:4px"
         >
           <div
             class="ant-radio-group ant-radio-group-outline ant-radio-group-small"
@@ -1957,7 +1956,6 @@ exports[`renders ./components/calendar/demo/customize-header.md correctly 1`] = 
         </div>
         <div
           class="ant-col"
-          style="padding-left:4px;padding-right:4px"
         >
           <div
             class="ant-select ant-select-sm my-year-select ant-select-single ant-select-show-arrow"
@@ -2021,7 +2019,6 @@ exports[`renders ./components/calendar/demo/customize-header.md correctly 1`] = 
         </div>
         <div
           class="ant-col"
-          style="padding-left:4px;padding-right:4px"
         >
           <div
             class="ant-select ant-select-sm ant-select-single ant-select-show-arrow"

--- a/components/card/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/card/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -233,11 +233,10 @@ exports[`renders ./components/card/demo/in-column.md extend context correctly 1`
 >
   <div
     class="ant-row"
-    style="margin-left:-8px;margin-right:-8px"
+    style="--row-gutter-x:16px"
   >
     <div
       class="ant-col ant-col-8"
-      style="padding-left:8px;padding-right:8px"
     >
       <div
         class="ant-card"
@@ -264,7 +263,6 @@ exports[`renders ./components/card/demo/in-column.md extend context correctly 1`
     </div>
     <div
       class="ant-col ant-col-8"
-      style="padding-left:8px;padding-right:8px"
     >
       <div
         class="ant-card"
@@ -291,7 +289,6 @@ exports[`renders ./components/card/demo/in-column.md extend context correctly 1`
     </div>
     <div
       class="ant-col ant-col-8"
-      style="padding-left:8px;padding-right:8px"
     >
       <div
         class="ant-card"
@@ -433,10 +430,11 @@ Array [
         class="ant-skeleton ant-skeleton-active"
       >
         <div
-          class="ant-skeleton-content"
+          class="ant-row"
+          style="--row-gutter-x:8px"
         >
-          <ul
-            class="ant-skeleton-paragraph"
+          <div
+            class="ant-col ant-col-22"
           >
             <li />
             <li />
@@ -444,7 +442,90 @@ Array [
             <li
               style="width:61%"
             />
-          </ul>
+          </div>
+        </div>
+        <div
+          class="ant-row"
+          style="--row-gutter-x:8px"
+        >
+          <div
+            class="ant-col ant-col-8"
+          >
+            <div
+              class="ant-card-loading-block"
+            />
+          </div>
+          <div
+            class="ant-col ant-col-15"
+          >
+            <div
+              class="ant-card-loading-block"
+            />
+          </div>
+        </div>
+        <div
+          class="ant-row"
+          style="--row-gutter-x:8px"
+        >
+          <div
+            class="ant-col ant-col-6"
+          >
+            <div
+              class="ant-card-loading-block"
+            />
+          </div>
+          <div
+            class="ant-col ant-col-18"
+          >
+            <div
+              class="ant-card-loading-block"
+            />
+          </div>
+        </div>
+        <div
+          class="ant-row"
+          style="--row-gutter-x:8px"
+        >
+          <div
+            class="ant-col ant-col-13"
+          >
+            <div
+              class="ant-card-loading-block"
+            />
+          </div>
+          <div
+            class="ant-col ant-col-9"
+          >
+            <div
+              class="ant-card-loading-block"
+            />
+          </div>
+        </div>
+        <div
+          class="ant-row"
+          style="--row-gutter-x:8px"
+        >
+          <div
+            class="ant-col ant-col-4"
+          >
+            <div
+              class="ant-card-loading-block"
+            />
+          </div>
+          <div
+            class="ant-col ant-col-3"
+          >
+            <div
+              class="ant-card-loading-block"
+            />
+          </div>
+          <div
+            class="ant-col ant-col-16"
+          >
+            <div
+              class="ant-card-loading-block"
+            />
+          </div>
         </div>
       </div>
     </div>

--- a/components/card/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/card/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -430,11 +430,10 @@ Array [
         class="ant-skeleton ant-skeleton-active"
       >
         <div
-          class="ant-row"
-          style="--row-gutter-x:8px"
+          class="ant-skeleton-content"
         >
-          <div
-            class="ant-col ant-col-22"
+          <ul
+            class="ant-skeleton-paragraph"
           >
             <li />
             <li />
@@ -442,90 +441,7 @@ Array [
             <li
               style="width:61%"
             />
-          </div>
-        </div>
-        <div
-          class="ant-row"
-          style="--row-gutter-x:8px"
-        >
-          <div
-            class="ant-col ant-col-8"
-          >
-            <div
-              class="ant-card-loading-block"
-            />
-          </div>
-          <div
-            class="ant-col ant-col-15"
-          >
-            <div
-              class="ant-card-loading-block"
-            />
-          </div>
-        </div>
-        <div
-          class="ant-row"
-          style="--row-gutter-x:8px"
-        >
-          <div
-            class="ant-col ant-col-6"
-          >
-            <div
-              class="ant-card-loading-block"
-            />
-          </div>
-          <div
-            class="ant-col ant-col-18"
-          >
-            <div
-              class="ant-card-loading-block"
-            />
-          </div>
-        </div>
-        <div
-          class="ant-row"
-          style="--row-gutter-x:8px"
-        >
-          <div
-            class="ant-col ant-col-13"
-          >
-            <div
-              class="ant-card-loading-block"
-            />
-          </div>
-          <div
-            class="ant-col ant-col-9"
-          >
-            <div
-              class="ant-card-loading-block"
-            />
-          </div>
-        </div>
-        <div
-          class="ant-row"
-          style="--row-gutter-x:8px"
-        >
-          <div
-            class="ant-col ant-col-4"
-          >
-            <div
-              class="ant-card-loading-block"
-            />
-          </div>
-          <div
-            class="ant-col ant-col-3"
-          >
-            <div
-              class="ant-card-loading-block"
-            />
-          </div>
-          <div
-            class="ant-col ant-col-16"
-          >
-            <div
-              class="ant-card-loading-block"
-            />
-          </div>
+          </ul>
         </div>
       </div>
     </div>

--- a/components/card/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/card/__tests__/__snapshots__/demo.test.js.snap
@@ -233,11 +233,10 @@ exports[`renders ./components/card/demo/in-column.md correctly 1`] = `
 >
   <div
     class="ant-row"
-    style="margin-left:-8px;margin-right:-8px"
+    style="--row-gutter-x:16px"
   >
     <div
       class="ant-col ant-col-8"
-      style="padding-left:8px;padding-right:8px"
     >
       <div
         class="ant-card"
@@ -264,7 +263,6 @@ exports[`renders ./components/card/demo/in-column.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-8"
-      style="padding-left:8px;padding-right:8px"
     >
       <div
         class="ant-card"
@@ -291,7 +289,6 @@ exports[`renders ./components/card/demo/in-column.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-8"
-      style="padding-left:8px;padding-right:8px"
     >
       <div
         class="ant-card"
@@ -433,10 +430,11 @@ Array [
         class="ant-skeleton ant-skeleton-active"
       >
         <div
-          class="ant-skeleton-content"
+          class="ant-row"
+          style="--row-gutter-x:8px"
         >
-          <ul
-            class="ant-skeleton-paragraph"
+          <div
+            class="ant-col ant-col-22"
           >
             <li />
             <li />
@@ -444,7 +442,90 @@ Array [
             <li
               style="width:61%"
             />
-          </ul>
+          </div>
+        </div>
+        <div
+          class="ant-row"
+          style="--row-gutter-x:8px"
+        >
+          <div
+            class="ant-col ant-col-8"
+          >
+            <div
+              class="ant-card-loading-block"
+            />
+          </div>
+          <div
+            class="ant-col ant-col-15"
+          >
+            <div
+              class="ant-card-loading-block"
+            />
+          </div>
+        </div>
+        <div
+          class="ant-row"
+          style="--row-gutter-x:8px"
+        >
+          <div
+            class="ant-col ant-col-6"
+          >
+            <div
+              class="ant-card-loading-block"
+            />
+          </div>
+          <div
+            class="ant-col ant-col-18"
+          >
+            <div
+              class="ant-card-loading-block"
+            />
+          </div>
+        </div>
+        <div
+          class="ant-row"
+          style="--row-gutter-x:8px"
+        >
+          <div
+            class="ant-col ant-col-13"
+          >
+            <div
+              class="ant-card-loading-block"
+            />
+          </div>
+          <div
+            class="ant-col ant-col-9"
+          >
+            <div
+              class="ant-card-loading-block"
+            />
+          </div>
+        </div>
+        <div
+          class="ant-row"
+          style="--row-gutter-x:8px"
+        >
+          <div
+            class="ant-col ant-col-4"
+          >
+            <div
+              class="ant-card-loading-block"
+            />
+          </div>
+          <div
+            class="ant-col ant-col-3"
+          >
+            <div
+              class="ant-card-loading-block"
+            />
+          </div>
+          <div
+            class="ant-col ant-col-16"
+          >
+            <div
+              class="ant-card-loading-block"
+            />
+          </div>
         </div>
       </div>
     </div>

--- a/components/card/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/card/__tests__/__snapshots__/demo.test.js.snap
@@ -430,11 +430,10 @@ Array [
         class="ant-skeleton ant-skeleton-active"
       >
         <div
-          class="ant-row"
-          style="--row-gutter-x:8px"
+          class="ant-skeleton-content"
         >
-          <div
-            class="ant-col ant-col-22"
+          <ul
+            class="ant-skeleton-paragraph"
           >
             <li />
             <li />
@@ -442,90 +441,7 @@ Array [
             <li
               style="width:61%"
             />
-          </div>
-        </div>
-        <div
-          class="ant-row"
-          style="--row-gutter-x:8px"
-        >
-          <div
-            class="ant-col ant-col-8"
-          >
-            <div
-              class="ant-card-loading-block"
-            />
-          </div>
-          <div
-            class="ant-col ant-col-15"
-          >
-            <div
-              class="ant-card-loading-block"
-            />
-          </div>
-        </div>
-        <div
-          class="ant-row"
-          style="--row-gutter-x:8px"
-        >
-          <div
-            class="ant-col ant-col-6"
-          >
-            <div
-              class="ant-card-loading-block"
-            />
-          </div>
-          <div
-            class="ant-col ant-col-18"
-          >
-            <div
-              class="ant-card-loading-block"
-            />
-          </div>
-        </div>
-        <div
-          class="ant-row"
-          style="--row-gutter-x:8px"
-        >
-          <div
-            class="ant-col ant-col-13"
-          >
-            <div
-              class="ant-card-loading-block"
-            />
-          </div>
-          <div
-            class="ant-col ant-col-9"
-          >
-            <div
-              class="ant-card-loading-block"
-            />
-          </div>
-        </div>
-        <div
-          class="ant-row"
-          style="--row-gutter-x:8px"
-        >
-          <div
-            class="ant-col ant-col-4"
-          >
-            <div
-              class="ant-card-loading-block"
-            />
-          </div>
-          <div
-            class="ant-col ant-col-3"
-          >
-            <div
-              class="ant-card-loading-block"
-            />
-          </div>
-          <div
-            class="ant-col ant-col-16"
-          >
-            <div
-              class="ant-card-loading-block"
-            />
-          </div>
+          </ul>
         </div>
       </div>
     </div>

--- a/components/card/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/card/__tests__/__snapshots__/index.test.tsx.snap
@@ -22,11 +22,10 @@ exports[`Card should still have padding when card which set padding to 0 is load
       class="ant-skeleton ant-skeleton-active"
     >
       <div
-        class="ant-row"
-        style="--row-gutter-x: 8px;"
+        class="ant-skeleton-content"
       >
-        <div
-          class="ant-col ant-col-22"
+        <ul
+          class="ant-skeleton-paragraph"
         >
           <li />
           <li />
@@ -34,90 +33,7 @@ exports[`Card should still have padding when card which set padding to 0 is load
           <li
             style="width: 61%;"
           />
-        </div>
-      </div>
-      <div
-        class="ant-row"
-        style="--row-gutter-x: 8px;"
-      >
-        <div
-          class="ant-col ant-col-8"
-        >
-          <div
-            class="ant-card-loading-block"
-          />
-        </div>
-        <div
-          class="ant-col ant-col-15"
-        >
-          <div
-            class="ant-card-loading-block"
-          />
-        </div>
-      </div>
-      <div
-        class="ant-row"
-        style="--row-gutter-x: 8px;"
-      >
-        <div
-          class="ant-col ant-col-6"
-        >
-          <div
-            class="ant-card-loading-block"
-          />
-        </div>
-        <div
-          class="ant-col ant-col-18"
-        >
-          <div
-            class="ant-card-loading-block"
-          />
-        </div>
-      </div>
-      <div
-        class="ant-row"
-        style="--row-gutter-x: 8px;"
-      >
-        <div
-          class="ant-col ant-col-13"
-        >
-          <div
-            class="ant-card-loading-block"
-          />
-        </div>
-        <div
-          class="ant-col ant-col-9"
-        >
-          <div
-            class="ant-card-loading-block"
-          />
-        </div>
-      </div>
-      <div
-        class="ant-row"
-        style="--row-gutter-x: 8px;"
-      >
-        <div
-          class="ant-col ant-col-4"
-        >
-          <div
-            class="ant-card-loading-block"
-          />
-        </div>
-        <div
-          class="ant-col ant-col-3"
-        >
-          <div
-            class="ant-card-loading-block"
-          />
-        </div>
-        <div
-          class="ant-col ant-col-16"
-        >
-          <div
-            class="ant-card-loading-block"
-          />
-        </div>
+        </ul>
       </div>
     </div>
   </div>

--- a/components/card/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/card/__tests__/__snapshots__/index.test.tsx.snap
@@ -22,10 +22,11 @@ exports[`Card should still have padding when card which set padding to 0 is load
       class="ant-skeleton ant-skeleton-active"
     >
       <div
-        class="ant-skeleton-content"
+        class="ant-row"
+        style="--row-gutter-x: 8px;"
       >
-        <ul
-          class="ant-skeleton-paragraph"
+        <div
+          class="ant-col ant-col-22"
         >
           <li />
           <li />
@@ -33,7 +34,90 @@ exports[`Card should still have padding when card which set padding to 0 is load
           <li
             style="width: 61%;"
           />
-        </ul>
+        </div>
+      </div>
+      <div
+        class="ant-row"
+        style="--row-gutter-x: 8px;"
+      >
+        <div
+          class="ant-col ant-col-8"
+        >
+          <div
+            class="ant-card-loading-block"
+          />
+        </div>
+        <div
+          class="ant-col ant-col-15"
+        >
+          <div
+            class="ant-card-loading-block"
+          />
+        </div>
+      </div>
+      <div
+        class="ant-row"
+        style="--row-gutter-x: 8px;"
+      >
+        <div
+          class="ant-col ant-col-6"
+        >
+          <div
+            class="ant-card-loading-block"
+          />
+        </div>
+        <div
+          class="ant-col ant-col-18"
+        >
+          <div
+            class="ant-card-loading-block"
+          />
+        </div>
+      </div>
+      <div
+        class="ant-row"
+        style="--row-gutter-x: 8px;"
+      >
+        <div
+          class="ant-col ant-col-13"
+        >
+          <div
+            class="ant-card-loading-block"
+          />
+        </div>
+        <div
+          class="ant-col ant-col-9"
+        >
+          <div
+            class="ant-card-loading-block"
+          />
+        </div>
+      </div>
+      <div
+        class="ant-row"
+        style="--row-gutter-x: 8px;"
+      >
+        <div
+          class="ant-col ant-col-4"
+        >
+          <div
+            class="ant-card-loading-block"
+          />
+        </div>
+        <div
+          class="ant-col ant-col-3"
+        >
+          <div
+            class="ant-card-loading-block"
+          />
+        </div>
+        <div
+          class="ant-col ant-col-16"
+        >
+          <div
+            class="ant-card-loading-block"
+          />
+        </div>
       </div>
     </div>
   </div>

--- a/components/form/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/form/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -8,11 +8,10 @@ exports[`renders ./components/form/demo/advanced-search.md extend context correc
   >
     <div
       class="ant-row"
-      style="margin-left:-12px;margin-right:-12px"
+      style="--row-gutter-x:24px"
     >
       <div
         class="ant-col ant-col-8"
-        style="padding-left:12px;padding-right:12px"
       >
         <div
           class="ant-row ant-form-item"
@@ -51,7 +50,6 @@ exports[`renders ./components/form/demo/advanced-search.md extend context correc
       </div>
       <div
         class="ant-col ant-col-8"
-        style="padding-left:12px;padding-right:12px"
       >
         <div
           class="ant-row ant-form-item"
@@ -225,7 +223,6 @@ exports[`renders ./components/form/demo/advanced-search.md extend context correc
       </div>
       <div
         class="ant-col ant-col-8"
-        style="padding-left:12px;padding-right:12px"
       >
         <div
           class="ant-row ant-form-item"
@@ -264,7 +261,6 @@ exports[`renders ./components/form/demo/advanced-search.md extend context correc
       </div>
       <div
         class="ant-col ant-col-8"
-        style="padding-left:12px;padding-right:12px"
       >
         <div
           class="ant-row ant-form-item"
@@ -303,7 +299,6 @@ exports[`renders ./components/form/demo/advanced-search.md extend context correc
       </div>
       <div
         class="ant-col ant-col-8"
-        style="padding-left:12px;padding-right:12px"
       >
         <div
           class="ant-row ant-form-item"
@@ -477,7 +472,6 @@ exports[`renders ./components/form/demo/advanced-search.md extend context correc
       </div>
       <div
         class="ant-col ant-col-8"
-        style="padding-left:12px;padding-right:12px"
       >
         <div
           class="ant-row ant-form-item"
@@ -8185,11 +8179,10 @@ exports[`renders ./components/form/demo/register.md extend context correctly 1`]
         >
           <div
             class="ant-row"
-            style="margin-left:-4px;margin-right:-4px"
+            style="--row-gutter-x:8px"
           >
             <div
               class="ant-col ant-col-12"
-              style="padding-left:4px;padding-right:4px"
             >
               <input
                 class="ant-input"
@@ -8200,7 +8193,6 @@ exports[`renders ./components/form/demo/register.md extend context correctly 1`]
             </div>
             <div
               class="ant-col ant-col-12"
-              style="padding-left:4px;padding-right:4px"
             >
               <button
                 class="ant-btn ant-btn-default"

--- a/components/form/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/form/__tests__/__snapshots__/demo.test.js.snap
@@ -8,11 +8,10 @@ exports[`renders ./components/form/demo/advanced-search.md correctly 1`] = `
   >
     <div
       class="ant-row"
-      style="margin-left:-12px;margin-right:-12px"
+      style="--row-gutter-x:24px"
     >
       <div
         class="ant-col ant-col-8"
-        style="padding-left:12px;padding-right:12px"
       >
         <div
           class="ant-row ant-form-item"
@@ -51,7 +50,6 @@ exports[`renders ./components/form/demo/advanced-search.md correctly 1`] = `
       </div>
       <div
         class="ant-col ant-col-8"
-        style="padding-left:12px;padding-right:12px"
       >
         <div
           class="ant-row ant-form-item"
@@ -143,7 +141,6 @@ exports[`renders ./components/form/demo/advanced-search.md correctly 1`] = `
       </div>
       <div
         class="ant-col ant-col-8"
-        style="padding-left:12px;padding-right:12px"
       >
         <div
           class="ant-row ant-form-item"
@@ -182,7 +179,6 @@ exports[`renders ./components/form/demo/advanced-search.md correctly 1`] = `
       </div>
       <div
         class="ant-col ant-col-8"
-        style="padding-left:12px;padding-right:12px"
       >
         <div
           class="ant-row ant-form-item"
@@ -221,7 +217,6 @@ exports[`renders ./components/form/demo/advanced-search.md correctly 1`] = `
       </div>
       <div
         class="ant-col ant-col-8"
-        style="padding-left:12px;padding-right:12px"
       >
         <div
           class="ant-row ant-form-item"
@@ -313,7 +308,6 @@ exports[`renders ./components/form/demo/advanced-search.md correctly 1`] = `
       </div>
       <div
         class="ant-col ant-col-8"
-        style="padding-left:12px;padding-right:12px"
       >
         <div
           class="ant-row ant-form-item"
@@ -5409,11 +5403,10 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
         >
           <div
             class="ant-row"
-            style="margin-left:-4px;margin-right:-4px"
+            style="--row-gutter-x:8px"
           >
             <div
               class="ant-col ant-col-12"
-              style="padding-left:4px;padding-right:4px"
             >
               <input
                 class="ant-input"
@@ -5424,7 +5417,6 @@ exports[`renders ./components/form/demo/register.md correctly 1`] = `
             </div>
             <div
               class="ant-col ant-col-12"
-              style="padding-left:4px;padding-right:4px"
             >
               <button
                 class="ant-btn ant-btn-default"

--- a/components/grid/RowContext.tsx
+++ b/components/grid/RowContext.tsx
@@ -2,9 +2,7 @@ import type { Context } from 'react';
 import { createContext } from 'react';
 
 export interface RowContextState {
-  gutter?: [number, number];
   wrap?: boolean;
-  supportFlexGap?: boolean;
 }
 
 const RowContext: Context<RowContextState> = createContext({});

--- a/components/grid/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/grid/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -625,11 +625,10 @@ Array [
   </div>,
   <div
     class="ant-row"
-    style="margin-left:-8px;margin-right:-8px"
+    style="--row-gutter-x:16px"
   >
     <div
       class="ant-col ant-col-6 gutter-row"
-      style="padding-left:8px;padding-right:8px"
     >
       <div
         style="background:#0092ff;padding:8px 0"
@@ -639,7 +638,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6 gutter-row"
-      style="padding-left:8px;padding-right:8px"
     >
       <div
         style="background:#0092ff;padding:8px 0"
@@ -649,7 +647,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6 gutter-row"
-      style="padding-left:8px;padding-right:8px"
     >
       <div
         style="background:#0092ff;padding:8px 0"
@@ -659,7 +656,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6 gutter-row"
-      style="padding-left:8px;padding-right:8px"
     >
       <div
         style="background:#0092ff;padding:8px 0"
@@ -680,11 +676,10 @@ Array [
   </div>,
   <div
     class="ant-row"
-    style="margin-left:-16px;margin-right:-16px"
+    style="--row-gutter-x:32px"
   >
     <div
       class="ant-col ant-col-6 gutter-row"
-      style="padding-left:16px;padding-right:16px"
     >
       <div
         style="background:#0092ff;padding:8px 0"
@@ -694,7 +689,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6 gutter-row"
-      style="padding-left:16px;padding-right:16px"
     >
       <div
         style="background:#0092ff;padding:8px 0"
@@ -704,7 +698,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6 gutter-row"
-      style="padding-left:16px;padding-right:16px"
     >
       <div
         style="background:#0092ff;padding:8px 0"
@@ -714,7 +707,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6 gutter-row"
-      style="padding-left:16px;padding-right:16px"
     >
       <div
         style="background:#0092ff;padding:8px 0"
@@ -735,11 +727,10 @@ Array [
   </div>,
   <div
     class="ant-row"
-    style="margin-left:-8px;margin-right:-8px;margin-top:-12px;margin-bottom:-12px"
+    style="--row-gutter-x:16px;--row-gutter-y:24px"
   >
     <div
       class="ant-col ant-col-6 gutter-row"
-      style="padding-left:8px;padding-right:8px;padding-top:12px;padding-bottom:12px"
     >
       <div
         style="background:#0092ff;padding:8px 0"
@@ -749,7 +740,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6 gutter-row"
-      style="padding-left:8px;padding-right:8px;padding-top:12px;padding-bottom:12px"
     >
       <div
         style="background:#0092ff;padding:8px 0"
@@ -759,7 +749,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6 gutter-row"
-      style="padding-left:8px;padding-right:8px;padding-top:12px;padding-bottom:12px"
     >
       <div
         style="background:#0092ff;padding:8px 0"
@@ -769,7 +758,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6 gutter-row"
-      style="padding-left:8px;padding-right:8px;padding-top:12px;padding-bottom:12px"
     >
       <div
         style="background:#0092ff;padding:8px 0"
@@ -779,7 +767,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6 gutter-row"
-      style="padding-left:8px;padding-right:8px;padding-top:12px;padding-bottom:12px"
     >
       <div
         style="background:#0092ff;padding:8px 0"
@@ -789,7 +776,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6 gutter-row"
-      style="padding-left:8px;padding-right:8px;padding-top:12px;padding-bottom:12px"
     >
       <div
         style="background:#0092ff;padding:8px 0"
@@ -799,7 +785,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6 gutter-row"
-      style="padding-left:8px;padding-right:8px;padding-top:12px;padding-bottom:12px"
     >
       <div
         style="background:#0092ff;padding:8px 0"
@@ -809,7 +794,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6 gutter-row"
-      style="padding-left:8px;padding-right:8px;padding-top:12px;padding-bottom:12px"
     >
       <div
         style="background:#0092ff;padding:8px 0"
@@ -1227,11 +1211,10 @@ Array [
   </div>,
   <div
     class="ant-row"
-    style="margin-left:-8px;margin-right:-8px;margin-top:-8px;margin-bottom:-8px"
+    style="--row-gutter-x:16px;--row-gutter-y:16px"
   >
     <div
       class="ant-col ant-col-6"
-      style="padding-left:8px;padding-right:8px;padding-top:8px;padding-bottom:8px"
     >
       <div>
         Column
@@ -1239,7 +1222,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6"
-      style="padding-left:8px;padding-right:8px;padding-top:8px;padding-bottom:8px"
     >
       <div>
         Column
@@ -1247,7 +1229,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6"
-      style="padding-left:8px;padding-right:8px;padding-top:8px;padding-bottom:8px"
     >
       <div>
         Column
@@ -1255,7 +1236,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6"
-      style="padding-left:8px;padding-right:8px;padding-top:8px;padding-bottom:8px"
     >
       <div>
         Column
@@ -1263,7 +1243,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6"
-      style="padding-left:8px;padding-right:8px;padding-top:8px;padding-bottom:8px"
     >
       <div>
         Column
@@ -1271,7 +1250,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6"
-      style="padding-left:8px;padding-right:8px;padding-top:8px;padding-bottom:8px"
     >
       <div>
         Column
@@ -1279,7 +1257,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6"
-      style="padding-left:8px;padding-right:8px;padding-top:8px;padding-bottom:8px"
     >
       <div>
         Column
@@ -1287,7 +1264,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6"
-      style="padding-left:8px;padding-right:8px;padding-top:8px;padding-bottom:8px"
     >
       <div>
         Column
@@ -1297,11 +1273,10 @@ Array [
   "Another Row:",
   <div
     class="ant-row"
-    style="margin-left:-8px;margin-right:-8px;margin-top:-8px;margin-bottom:-8px"
+    style="--row-gutter-x:16px;--row-gutter-y:16px"
   >
     <div
       class="ant-col ant-col-6"
-      style="padding-left:8px;padding-right:8px;padding-top:8px;padding-bottom:8px"
     >
       <div>
         Column
@@ -1309,7 +1284,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6"
-      style="padding-left:8px;padding-right:8px;padding-top:8px;padding-bottom:8px"
     >
       <div>
         Column
@@ -1317,7 +1291,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6"
-      style="padding-left:8px;padding-right:8px;padding-top:8px;padding-bottom:8px"
     >
       <div>
         Column
@@ -1325,7 +1298,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6"
-      style="padding-left:8px;padding-right:8px;padding-top:8px;padding-bottom:8px"
     >
       <div>
         Column

--- a/components/grid/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/grid/__tests__/__snapshots__/demo.test.js.snap
@@ -625,11 +625,10 @@ Array [
   </div>,
   <div
     class="ant-row"
-    style="margin-left:-8px;margin-right:-8px"
+    style="--row-gutter-x:16px"
   >
     <div
       class="ant-col ant-col-6 gutter-row"
-      style="padding-left:8px;padding-right:8px"
     >
       <div
         style="background:#0092ff;padding:8px 0"
@@ -639,7 +638,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6 gutter-row"
-      style="padding-left:8px;padding-right:8px"
     >
       <div
         style="background:#0092ff;padding:8px 0"
@@ -649,7 +647,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6 gutter-row"
-      style="padding-left:8px;padding-right:8px"
     >
       <div
         style="background:#0092ff;padding:8px 0"
@@ -659,7 +656,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6 gutter-row"
-      style="padding-left:8px;padding-right:8px"
     >
       <div
         style="background:#0092ff;padding:8px 0"
@@ -680,11 +676,10 @@ Array [
   </div>,
   <div
     class="ant-row"
-    style="margin-left:-16px;margin-right:-16px"
+    style="--row-gutter-x:32px"
   >
     <div
       class="ant-col ant-col-6 gutter-row"
-      style="padding-left:16px;padding-right:16px"
     >
       <div
         style="background:#0092ff;padding:8px 0"
@@ -694,7 +689,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6 gutter-row"
-      style="padding-left:16px;padding-right:16px"
     >
       <div
         style="background:#0092ff;padding:8px 0"
@@ -704,7 +698,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6 gutter-row"
-      style="padding-left:16px;padding-right:16px"
     >
       <div
         style="background:#0092ff;padding:8px 0"
@@ -714,7 +707,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6 gutter-row"
-      style="padding-left:16px;padding-right:16px"
     >
       <div
         style="background:#0092ff;padding:8px 0"
@@ -735,11 +727,10 @@ Array [
   </div>,
   <div
     class="ant-row"
-    style="margin-left:-8px;margin-right:-8px;margin-top:-12px;margin-bottom:-12px"
+    style="--row-gutter-x:16px;--row-gutter-y:24px"
   >
     <div
       class="ant-col ant-col-6 gutter-row"
-      style="padding-left:8px;padding-right:8px;padding-top:12px;padding-bottom:12px"
     >
       <div
         style="background:#0092ff;padding:8px 0"
@@ -749,7 +740,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6 gutter-row"
-      style="padding-left:8px;padding-right:8px;padding-top:12px;padding-bottom:12px"
     >
       <div
         style="background:#0092ff;padding:8px 0"
@@ -759,7 +749,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6 gutter-row"
-      style="padding-left:8px;padding-right:8px;padding-top:12px;padding-bottom:12px"
     >
       <div
         style="background:#0092ff;padding:8px 0"
@@ -769,7 +758,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6 gutter-row"
-      style="padding-left:8px;padding-right:8px;padding-top:12px;padding-bottom:12px"
     >
       <div
         style="background:#0092ff;padding:8px 0"
@@ -779,7 +767,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6 gutter-row"
-      style="padding-left:8px;padding-right:8px;padding-top:12px;padding-bottom:12px"
     >
       <div
         style="background:#0092ff;padding:8px 0"
@@ -789,7 +776,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6 gutter-row"
-      style="padding-left:8px;padding-right:8px;padding-top:12px;padding-bottom:12px"
     >
       <div
         style="background:#0092ff;padding:8px 0"
@@ -799,7 +785,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6 gutter-row"
-      style="padding-left:8px;padding-right:8px;padding-top:12px;padding-bottom:12px"
     >
       <div
         style="background:#0092ff;padding:8px 0"
@@ -809,7 +794,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6 gutter-row"
-      style="padding-left:8px;padding-right:8px;padding-top:12px;padding-bottom:12px"
     >
       <div
         style="background:#0092ff;padding:8px 0"
@@ -1155,11 +1139,10 @@ Array [
   </div>,
   <div
     class="ant-row"
-    style="margin-left:-8px;margin-right:-8px;margin-top:-8px;margin-bottom:-8px"
+    style="--row-gutter-x:16px;--row-gutter-y:16px"
   >
     <div
       class="ant-col ant-col-6"
-      style="padding-left:8px;padding-right:8px;padding-top:8px;padding-bottom:8px"
     >
       <div>
         Column
@@ -1167,7 +1150,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6"
-      style="padding-left:8px;padding-right:8px;padding-top:8px;padding-bottom:8px"
     >
       <div>
         Column
@@ -1175,7 +1157,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6"
-      style="padding-left:8px;padding-right:8px;padding-top:8px;padding-bottom:8px"
     >
       <div>
         Column
@@ -1183,7 +1164,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6"
-      style="padding-left:8px;padding-right:8px;padding-top:8px;padding-bottom:8px"
     >
       <div>
         Column
@@ -1191,7 +1171,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6"
-      style="padding-left:8px;padding-right:8px;padding-top:8px;padding-bottom:8px"
     >
       <div>
         Column
@@ -1199,7 +1178,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6"
-      style="padding-left:8px;padding-right:8px;padding-top:8px;padding-bottom:8px"
     >
       <div>
         Column
@@ -1207,7 +1185,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6"
-      style="padding-left:8px;padding-right:8px;padding-top:8px;padding-bottom:8px"
     >
       <div>
         Column
@@ -1215,7 +1192,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6"
-      style="padding-left:8px;padding-right:8px;padding-top:8px;padding-bottom:8px"
     >
       <div>
         Column
@@ -1225,11 +1201,10 @@ Array [
   "Another Row:",
   <div
     class="ant-row"
-    style="margin-left:-8px;margin-right:-8px;margin-top:-8px;margin-bottom:-8px"
+    style="--row-gutter-x:16px;--row-gutter-y:16px"
   >
     <div
       class="ant-col ant-col-6"
-      style="padding-left:8px;padding-right:8px;padding-top:8px;padding-bottom:8px"
     >
       <div>
         Column
@@ -1237,7 +1212,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6"
-      style="padding-left:8px;padding-right:8px;padding-top:8px;padding-bottom:8px"
     >
       <div>
         Column
@@ -1245,7 +1219,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6"
-      style="padding-left:8px;padding-right:8px;padding-top:8px;padding-bottom:8px"
     >
       <div>
         Column
@@ -1253,7 +1226,6 @@ Array [
     </div>
     <div
       class="ant-col ant-col-6"
-      style="padding-left:8px;padding-right:8px;padding-top:8px;padding-bottom:8px"
     >
       <div>
         Column

--- a/components/grid/__tests__/__snapshots__/index.test.js.snap
+++ b/components/grid/__tests__/__snapshots__/index.test.js.snap
@@ -3,17 +3,15 @@
 exports[`Grid renders wrapped Col correctly 1`] = `
 <div
   class="ant-row"
-  style="margin-left:-10px;margin-right:-10px"
+  style="--row-gutter-x:20px"
 >
   <div>
     <div
       class="ant-col ant-col-12"
-      style="padding-left:10px;padding-right:10px"
     />
   </div>
   <div
     class="ant-col ant-col-12"
-    style="padding-left:10px;padding-right:10px"
   />
 </div>
 `;
@@ -45,6 +43,6 @@ exports[`Grid should render Row 1`] = `
 exports[`Grid when typeof gutter is object array in large screen 1`] = `
 <div
   class="ant-row"
-  style="margin-left:-20px;margin-right:-20px;margin-top:-200px;margin-bottom:-200px"
+  style="--row-gutter-x:40px;--row-gutter-y:400px"
 />
 `;

--- a/components/grid/__tests__/gap.test.js
+++ b/components/grid/__tests__/gap.test.js
@@ -21,22 +21,6 @@ describe('Grid.Gap', () => {
     expect(screen.getByRole('row').style.rowGap).toBe('');
   });
 
-  it('should use gap', () => {
-    const wrapper = mount(
-      <Row gutter={[16, 8]}>
-        <Col />
-      </Row>,
-    );
-
-    expect(wrapper.find('.ant-row').props().style).toEqual(
-      expect.objectContaining({
-        marginLeft: -8,
-        rowGap: 8,
-        marginRight: -8,
-      }),
-    );
-  });
-
   it('not break ssr', () => {
     const warnSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
 

--- a/components/grid/__tests__/gap.test.js
+++ b/components/grid/__tests__/gap.test.js
@@ -4,12 +4,6 @@ import ReactDOMServer from 'react-dom/server';
 import { Col, Row } from '..';
 import { render, screen } from '../../../tests/utils';
 
-jest.mock('../../_util/styleChecker', () => ({
-  canUseDocElement: () => true,
-  isStyleSupport: () => true,
-  detectFlexGapSupported: () => true,
-}));
-
 describe('Grid.Gap', () => {
   it('should not have `row-gap: 0px` style', () => {
     render(

--- a/components/grid/__tests__/gap.test.js
+++ b/components/grid/__tests__/gap.test.js
@@ -1,4 +1,3 @@
-import { mount } from 'enzyme';
 import React from 'react';
 import ReactDOMServer from 'react-dom/server';
 import { Col, Row } from '..';

--- a/components/grid/__tests__/index.test.js
+++ b/components/grid/__tests__/index.test.js
@@ -1,11 +1,11 @@
+import { mount, render } from 'enzyme';
 import React from 'react';
-import { render, mount } from 'enzyme';
 import { act } from 'react-dom/test-utils';
 import { Col, Row } from '..';
 import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
-import useBreakpoint from '../hooks/useBreakpoint';
 import ResponsiveObserve from '../../_util/responsiveObserve';
+import useBreakpoint from '../hooks/useBreakpoint';
 
 describe('Grid', () => {
   mountTest(Row);
@@ -28,8 +28,7 @@ describe('Grid', () => {
     const wrapper = mount(<Row gutter={{ xs: 8, sm: 16, md: 24 }} />);
     expect(wrapper.find('div').first().props().style).toEqual(
       expect.objectContaining({
-        marginLeft: -4,
-        marginRight: -4,
+        '--row-gutter-x': '8px',
       }),
     );
   });
@@ -45,8 +44,7 @@ describe('Grid', () => {
     );
     expect(wrapper.find('div').first().props().style).toEqual(
       expect.objectContaining({
-        marginLeft: -4,
-        marginRight: -4,
+        '--row-gutter-x': '8px',
       }),
     );
   });
@@ -88,18 +86,15 @@ describe('Grid', () => {
   it('should work correct when gutter is object', () => {
     const wrapper = mount(<Row gutter={{ xs: 20 }} />);
     expect(wrapper.find('div').prop('style')).toEqual({
-      marginLeft: -10,
-      marginRight: -10,
+      '--row-gutter-x': '20px',
     });
   });
 
   it('should work current when gutter is array', () => {
     const wrapper = mount(<Row gutter={[16, 20]} />);
     expect(wrapper.find('div').prop('style')).toEqual({
-      marginLeft: -8,
-      marginRight: -8,
-      marginTop: -10,
-      marginBottom: -10,
+      '--row-gutter-x': '16px',
+      '--row-gutter-y': '20px',
     });
   });
 

--- a/components/grid/__tests__/server.test.js
+++ b/components/grid/__tests__/server.test.js
@@ -1,7 +1,5 @@
-import React from 'react';
 import { mount } from 'enzyme';
-// eslint-disable-next-line no-unused-vars
-import canUseDom from 'rc-util/lib/Dom/canUseDom';
+import React from 'react';
 import { Col, Row } from '..';
 
 jest.mock('rc-util/lib/Dom/canUseDom', () => () => false);
@@ -16,19 +14,8 @@ describe('Grid.Server', () => {
 
     expect(wrapper.find('.ant-row').props().style).toEqual(
       expect.objectContaining({
-        marginLeft: -4,
-        marginRight: -4,
-        marginTop: -8,
-        marginBottom: -8,
-      }),
-    );
-
-    expect(wrapper.find('.ant-col').props().style).toEqual(
-      expect.objectContaining({
-        paddingLeft: 4,
-        paddingRight: 4,
-        paddingTop: 8,
-        paddingBottom: 8,
+        '--row-gutter-x': '8px',
+        '--row-gutter-y': '16px',
       }),
     );
   });

--- a/components/grid/__tests__/server.test.js
+++ b/components/grid/__tests__/server.test.js
@@ -2,8 +2,6 @@ import { mount } from 'enzyme';
 import React from 'react';
 import { Col, Row } from '..';
 
-jest.mock('rc-util/lib/Dom/canUseDom', () => () => false);
-
 describe('Grid.Server', () => {
   it('use compatible gap logic', () => {
     const wrapper = mount(

--- a/components/grid/col.tsx
+++ b/components/grid/col.tsx
@@ -47,7 +47,7 @@ function parseFlex(flex: FlexType): string {
 const sizes = ['xs', 'sm', 'md', 'lg', 'xl', 'xxl'] as const;
 const Col = React.forwardRef<HTMLDivElement, ColProps>((props, ref) => {
   const { getPrefixCls, direction } = React.useContext(ConfigContext);
-  const { gutter, wrap, supportFlexGap } = React.useContext(RowContext);
+  const { wrap } = React.useContext(RowContext);
 
   const {
     prefixCls: customizePrefixCls,
@@ -103,19 +103,6 @@ const Col = React.forwardRef<HTMLDivElement, ColProps>((props, ref) => {
   );
 
   const mergedStyle: React.CSSProperties = {};
-  // Horizontal gutter use padding
-  if (gutter && gutter[0] > 0) {
-    const horizontalGutter = gutter[0] / 2;
-    mergedStyle.paddingLeft = horizontalGutter;
-    mergedStyle.paddingRight = horizontalGutter;
-  }
-
-  // Vertical gutter use padding when gap not support
-  if (gutter && gutter[1] > 0 && !supportFlexGap) {
-    const verticalGutter = gutter[1] / 2;
-    mergedStyle.paddingTop = verticalGutter;
-    mergedStyle.paddingBottom = verticalGutter;
-  }
 
   if (flex) {
     mergedStyle.flex = parseFlex(flex);

--- a/components/grid/demo/playground.md
+++ b/components/grid/demo/playground.md
@@ -122,9 +122,6 @@ export default App;
 #components-grid-demo-playground pre.demo-code {
   direction: ltr;
 }
-#components-grid-demo-playground .ant-col {
-  padding: 0;
-}
 ```
 
 <style>

--- a/components/grid/demo/playground.md
+++ b/components/grid/demo/playground.md
@@ -122,6 +122,9 @@ export default App;
 #components-grid-demo-playground pre.demo-code {
   direction: ltr;
 }
+#components-grid-demo-playground .ant-col {
+  padding: 0;
+}
 ```
 
 <style>

--- a/components/grid/row.tsx
+++ b/components/grid/row.tsx
@@ -1,7 +1,6 @@
 import classNames from 'classnames';
 import * as React from 'react';
 import { ConfigContext } from '../config-provider';
-import useFlexGapSupport from '../_util/hooks/useFlexGapSupport';
 import type { Breakpoint, ScreenMap } from '../_util/responsiveObserve';
 import ResponsiveObserve, { responsiveArray } from '../_util/responsiveObserve';
 import { tuple } from '../_util/type';
@@ -43,8 +42,6 @@ const Row = React.forwardRef<HTMLDivElement, RowProps>((props, ref) => {
     xl: true,
     xxl: true,
   });
-
-  const supportFlexGap = useFlexGapSupport();
 
   const gutterRef = React.useRef<Gutter | [Gutter, Gutter]>(gutter);
 
@@ -97,30 +94,20 @@ const Row = React.forwardRef<HTMLDivElement, RowProps>((props, ref) => {
   );
 
   // Add gutter related style
-  const rowStyle: React.CSSProperties = {};
-  const horizontalGutter = gutters[0] != null && gutters[0] > 0 ? gutters[0] / -2 : undefined;
-  const verticalGutter = gutters[1] != null && gutters[1] > 0 ? gutters[1] / -2 : undefined;
+  const rowStyle = {} as React.CSSProperties & {
+    '--row-gutter-x'?: string;
+    '--row-gutter-y'?: string;
+  };
 
-  if (horizontalGutter) {
-    rowStyle.marginLeft = horizontalGutter;
-    rowStyle.marginRight = horizontalGutter;
+  if (gutters[0]) {
+    rowStyle['--row-gutter-x'] = `${gutters[0]}px`;
   }
 
-  if (supportFlexGap) {
-    // Set gap direct if flex gap support
-    [, rowStyle.rowGap] = gutters;
-  } else if (verticalGutter) {
-    rowStyle.marginTop = verticalGutter;
-    rowStyle.marginBottom = verticalGutter;
+  if (gutters[1]) {
+    rowStyle['--row-gutter-y'] = `${gutters[1]}px`;
   }
 
-  // "gutters" is a new array in each rendering phase, it'll make 'React.useMemo' effectless.
-  // So we deconstruct "gutters" variable here.
-  const [gutterH, gutterV] = gutters;
-  const rowContext = React.useMemo(
-    () => ({ gutter: [gutterH, gutterV] as [number, number], wrap, supportFlexGap }),
-    [gutterH, gutterV, wrap, supportFlexGap],
-  );
+  const rowContext = React.useMemo(() => ({ wrap }), [wrap]);
 
   return (
     <RowContext.Provider value={rowContext}>

--- a/components/grid/style/index.less
+++ b/components/grid/style/index.less
@@ -8,7 +8,9 @@
   --row-gutter-y: 0;
   display: flex;
   flex-flow: row wrap;
-  margin: calc(-1 * var(--row-gutter-y)) calc(-0.5 * var(--row-gutter-x)) 0;
+  margin-top: calc(-1 * var(--row-gutter-y));
+  margin-right: calc(-0.5 * var(--row-gutter-x));
+  margin-left: calc(-0.5 * var(--row-gutter-x));
 
   &::before,
   &::after {
@@ -72,7 +74,8 @@
   // Prevent columns from collapsing when empty
   min-height: 1px;
   margin-top: var(--row-gutter-y);
-  padding: 0 calc(0.5 * var(--row-gutter-x));
+  padding-right: calc(0.5 * var(--row-gutter-x));
+  padding-left: calc(0.5 * var(--row-gutter-x));
 }
 
 .make-grid();

--- a/components/grid/style/index.less
+++ b/components/grid/style/index.less
@@ -4,8 +4,11 @@
 
 // Grid system
 .@{row-prefix-cls} {
+  --row-gutter-x: 0px;
+  --row-gutter-y: 0px;
   display: flex;
   flex-flow: row wrap;
+  margin: calc(-0.5 * var(--row-gutter-y)) calc(-0.5 * var(--row-gutter-x)) 0;
 
   &::before,
   &::after {
@@ -68,6 +71,8 @@
   max-width: 100%;
   // Prevent columns from collapsing when empty
   min-height: 1px;
+  margin-top: calc(0.5 * var(--row-gutter-y));
+  padding: 0 calc(0.5 * var(--row-gutter-x));
 }
 
 .make-grid();

--- a/components/grid/style/index.less
+++ b/components/grid/style/index.less
@@ -4,8 +4,8 @@
 
 // Grid system
 .@{row-prefix-cls} {
-  --row-gutter-x: 0px;
-  --row-gutter-y: 0px;
+  --row-gutter-x: 0;
+  --row-gutter-y: 0;
   display: flex;
   flex-flow: row wrap;
   margin: calc(-1 * var(--row-gutter-y)) calc(-0.5 * var(--row-gutter-x)) 0;

--- a/components/grid/style/index.less
+++ b/components/grid/style/index.less
@@ -8,7 +8,7 @@
   --row-gutter-y: 0px;
   display: flex;
   flex-flow: row wrap;
-  margin: calc(-0.5 * var(--row-gutter-y)) calc(-0.5 * var(--row-gutter-x)) 0;
+  margin: calc(-1 * var(--row-gutter-y)) calc(-0.5 * var(--row-gutter-x)) 0;
 
   &::before,
   &::after {
@@ -71,7 +71,7 @@
   max-width: 100%;
   // Prevent columns from collapsing when empty
   min-height: 1px;
-  margin-top: calc(0.5 * var(--row-gutter-y));
+  margin-top: var(--row-gutter-y);
   padding: 0 calc(0.5 * var(--row-gutter-x));
 }
 

--- a/components/input/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/input/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -5201,11 +5201,10 @@ exports[`renders ./components/input/demo/group.md extend context correctly 1`] =
   >
     <div
       class="ant-row"
-      style="margin-left:-4px;margin-right:-4px"
+      style="--row-gutter-x:8px"
     >
       <div
         class="ant-col ant-col-5"
-        style="padding-left:4px;padding-right:4px"
       >
         <input
           class="ant-input"
@@ -5215,7 +5214,6 @@ exports[`renders ./components/input/demo/group.md extend context correctly 1`] =
       </div>
       <div
         class="ant-col ant-col-8"
-        style="padding-left:4px;padding-right:4px"
       >
         <input
           class="ant-input"

--- a/components/input/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/input/__tests__/__snapshots__/demo.test.js.snap
@@ -1418,11 +1418,10 @@ exports[`renders ./components/input/demo/group.md correctly 1`] = `
   >
     <div
       class="ant-row"
-      style="margin-left:-4px;margin-right:-4px"
+      style="--row-gutter-x:8px"
     >
       <div
         class="ant-col ant-col-5"
-        style="padding-left:4px;padding-right:4px"
       >
         <input
           class="ant-input"
@@ -1432,7 +1431,6 @@ exports[`renders ./components/input/demo/group.md correctly 1`] = `
       </div>
       <div
         class="ant-col ant-col-8"
-        style="padding-left:4px;padding-right:4px"
       >
         <input
           class="ant-input"

--- a/components/list/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/list/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -179,14 +179,14 @@ exports[`renders ./components/list/demo/grid.md extend context correctly 1`] = `
     >
       <div
         class="ant-row"
-        style="margin-left:-8px;margin-right:-8px"
+        style="--row-gutter-x:16px"
       >
         <div
           style="width:25%;max-width:25%"
         >
           <div
             class="ant-col"
-            style="padding-left:8px;padding-right:8px;flex:1 1 auto"
+            style="flex:1 1 auto"
           >
             <div
               class="ant-list-item"
@@ -221,7 +221,7 @@ exports[`renders ./components/list/demo/grid.md extend context correctly 1`] = `
         >
           <div
             class="ant-col"
-            style="padding-left:8px;padding-right:8px;flex:1 1 auto"
+            style="flex:1 1 auto"
           >
             <div
               class="ant-list-item"
@@ -256,7 +256,7 @@ exports[`renders ./components/list/demo/grid.md extend context correctly 1`] = `
         >
           <div
             class="ant-col"
-            style="padding-left:8px;padding-right:8px;flex:1 1 auto"
+            style="flex:1 1 auto"
           >
             <div
               class="ant-list-item"
@@ -291,7 +291,7 @@ exports[`renders ./components/list/demo/grid.md extend context correctly 1`] = `
         >
           <div
             class="ant-col"
-            style="padding-left:8px;padding-right:8px;flex:1 1 auto"
+            style="flex:1 1 auto"
           >
             <div
               class="ant-list-item"
@@ -340,14 +340,14 @@ Array [
       >
         <div
           class="ant-row"
-          style="margin-left:-8px;margin-right:-8px"
+          style="--row-gutter-x:16px"
         >
           <div
             style="width:25%;max-width:25%"
           >
             <div
               class="ant-col"
-              style="padding-left:8px;padding-right:8px;flex:1 1 auto"
+              style="flex:1 1 auto"
             >
               <div
                 class="ant-list-item"
@@ -382,7 +382,7 @@ Array [
           >
             <div
               class="ant-col"
-              style="padding-left:8px;padding-right:8px;flex:1 1 auto"
+              style="flex:1 1 auto"
             >
               <div
                 class="ant-list-item"
@@ -417,7 +417,7 @@ Array [
           >
             <div
               class="ant-col"
-              style="padding-left:8px;padding-right:8px;flex:1 1 auto"
+              style="flex:1 1 auto"
             >
               <div
                 class="ant-list-item"
@@ -452,7 +452,7 @@ Array [
           >
             <div
               class="ant-col"
-              style="padding-left:8px;padding-right:8px;flex:1 1 auto"
+              style="flex:1 1 auto"
             >
               <div
                 class="ant-list-item"
@@ -487,7 +487,7 @@ Array [
           >
             <div
               class="ant-col"
-              style="padding-left:8px;padding-right:8px;flex:1 1 auto"
+              style="flex:1 1 auto"
             >
               <div
                 class="ant-list-item"
@@ -522,7 +522,7 @@ Array [
           >
             <div
               class="ant-col"
-              style="padding-left:8px;padding-right:8px;flex:1 1 auto"
+              style="flex:1 1 auto"
             >
               <div
                 class="ant-list-item"
@@ -567,14 +567,14 @@ Array [
       >
         <div
           class="ant-row"
-          style="margin-left:-8px;margin-right:-8px"
+          style="--row-gutter-x:16px"
         >
           <div
             style="width:25%;max-width:25%"
           >
             <div
               class="ant-col"
-              style="padding-left:8px;padding-right:8px;flex:1 1 auto"
+              style="flex:1 1 auto"
             >
               <div
                 class="ant-list-item"
@@ -609,7 +609,7 @@ Array [
           >
             <div
               class="ant-col"
-              style="padding-left:8px;padding-right:8px;flex:1 1 auto"
+              style="flex:1 1 auto"
             >
               <div
                 class="ant-list-item"
@@ -644,7 +644,7 @@ Array [
           >
             <div
               class="ant-col"
-              style="padding-left:8px;padding-right:8px;flex:1 1 auto"
+              style="flex:1 1 auto"
             >
               <div
                 class="ant-list-item"
@@ -679,7 +679,7 @@ Array [
           >
             <div
               class="ant-col"
-              style="padding-left:8px;padding-right:8px;flex:1 1 auto"
+              style="flex:1 1 auto"
             >
               <div
                 class="ant-list-item"
@@ -714,7 +714,7 @@ Array [
           >
             <div
               class="ant-col"
-              style="padding-left:8px;padding-right:8px;flex:1 1 auto"
+              style="flex:1 1 auto"
             >
               <div
                 class="ant-list-item"
@@ -749,7 +749,7 @@ Array [
           >
             <div
               class="ant-col"
-              style="padding-left:8px;padding-right:8px;flex:1 1 auto"
+              style="flex:1 1 auto"
             >
               <div
                 class="ant-list-item"
@@ -794,14 +794,14 @@ Array [
       >
         <div
           class="ant-row"
-          style="margin-left:-8px;margin-right:-8px"
+          style="--row-gutter-x:16px"
         >
           <div
             style="width:25%;max-width:25%"
           >
             <div
               class="ant-col"
-              style="padding-left:8px;padding-right:8px;flex:1 1 auto"
+              style="flex:1 1 auto"
             >
               <div
                 class="ant-list-item"
@@ -837,7 +837,7 @@ Array [
           >
             <div
               class="ant-col"
-              style="padding-left:8px;padding-right:8px;flex:1 1 auto"
+              style="flex:1 1 auto"
             >
               <div
                 class="ant-list-item"
@@ -873,7 +873,7 @@ Array [
           >
             <div
               class="ant-col"
-              style="padding-left:8px;padding-right:8px;flex:1 1 auto"
+              style="flex:1 1 auto"
             >
               <div
                 class="ant-list-item"
@@ -909,7 +909,7 @@ Array [
           >
             <div
               class="ant-col"
-              style="padding-left:8px;padding-right:8px;flex:1 1 auto"
+              style="flex:1 1 auto"
             >
               <div
                 class="ant-list-item"
@@ -945,7 +945,7 @@ Array [
           >
             <div
               class="ant-col"
-              style="padding-left:8px;padding-right:8px;flex:1 1 auto"
+              style="flex:1 1 auto"
             >
               <div
                 class="ant-list-item"
@@ -981,7 +981,7 @@ Array [
           >
             <div
               class="ant-col"
-              style="padding-left:8px;padding-right:8px;flex:1 1 auto"
+              style="flex:1 1 auto"
             >
               <div
                 class="ant-list-item"
@@ -1176,12 +1176,12 @@ exports[`renders ./components/list/demo/responsive.md extend context correctly 1
     >
       <div
         class="ant-row"
-        style="margin-left:-8px;margin-right:-8px"
+        style="--row-gutter-x:16px"
       >
         <div>
           <div
             class="ant-col"
-            style="padding-left:8px;padding-right:8px;flex:1 1 auto"
+            style="flex:1 1 auto"
           >
             <div
               class="ant-list-item"
@@ -1214,7 +1214,7 @@ exports[`renders ./components/list/demo/responsive.md extend context correctly 1
         <div>
           <div
             class="ant-col"
-            style="padding-left:8px;padding-right:8px;flex:1 1 auto"
+            style="flex:1 1 auto"
           >
             <div
               class="ant-list-item"
@@ -1247,7 +1247,7 @@ exports[`renders ./components/list/demo/responsive.md extend context correctly 1
         <div>
           <div
             class="ant-col"
-            style="padding-left:8px;padding-right:8px;flex:1 1 auto"
+            style="flex:1 1 auto"
           >
             <div
               class="ant-list-item"
@@ -1280,7 +1280,7 @@ exports[`renders ./components/list/demo/responsive.md extend context correctly 1
         <div>
           <div
             class="ant-col"
-            style="padding-left:8px;padding-right:8px;flex:1 1 auto"
+            style="flex:1 1 auto"
           >
             <div
               class="ant-list-item"
@@ -1313,7 +1313,7 @@ exports[`renders ./components/list/demo/responsive.md extend context correctly 1
         <div>
           <div
             class="ant-col"
-            style="padding-left:8px;padding-right:8px;flex:1 1 auto"
+            style="flex:1 1 auto"
           >
             <div
               class="ant-list-item"
@@ -1346,7 +1346,7 @@ exports[`renders ./components/list/demo/responsive.md extend context correctly 1
         <div>
           <div
             class="ant-col"
-            style="padding-left:8px;padding-right:8px;flex:1 1 auto"
+            style="flex:1 1 auto"
           >
             <div
               class="ant-list-item"

--- a/components/list/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/list/__tests__/__snapshots__/demo.test.js.snap
@@ -179,14 +179,14 @@ exports[`renders ./components/list/demo/grid.md correctly 1`] = `
     >
       <div
         class="ant-row"
-        style="margin-left:-8px;margin-right:-8px"
+        style="--row-gutter-x:16px"
       >
         <div
           style="width:25%;max-width:25%"
         >
           <div
             class="ant-col"
-            style="padding-left:8px;padding-right:8px;flex:1 1 auto"
+            style="flex:1 1 auto"
           >
             <div
               class="ant-list-item"
@@ -221,7 +221,7 @@ exports[`renders ./components/list/demo/grid.md correctly 1`] = `
         >
           <div
             class="ant-col"
-            style="padding-left:8px;padding-right:8px;flex:1 1 auto"
+            style="flex:1 1 auto"
           >
             <div
               class="ant-list-item"
@@ -256,7 +256,7 @@ exports[`renders ./components/list/demo/grid.md correctly 1`] = `
         >
           <div
             class="ant-col"
-            style="padding-left:8px;padding-right:8px;flex:1 1 auto"
+            style="flex:1 1 auto"
           >
             <div
               class="ant-list-item"
@@ -291,7 +291,7 @@ exports[`renders ./components/list/demo/grid.md correctly 1`] = `
         >
           <div
             class="ant-col"
-            style="padding-left:8px;padding-right:8px;flex:1 1 auto"
+            style="flex:1 1 auto"
           >
             <div
               class="ant-list-item"
@@ -340,14 +340,14 @@ Array [
       >
         <div
           class="ant-row"
-          style="margin-left:-8px;margin-right:-8px"
+          style="--row-gutter-x:16px"
         >
           <div
             style="width:25%;max-width:25%"
           >
             <div
               class="ant-col"
-              style="padding-left:8px;padding-right:8px;flex:1 1 auto"
+              style="flex:1 1 auto"
             >
               <div
                 class="ant-list-item"
@@ -382,7 +382,7 @@ Array [
           >
             <div
               class="ant-col"
-              style="padding-left:8px;padding-right:8px;flex:1 1 auto"
+              style="flex:1 1 auto"
             >
               <div
                 class="ant-list-item"
@@ -417,7 +417,7 @@ Array [
           >
             <div
               class="ant-col"
-              style="padding-left:8px;padding-right:8px;flex:1 1 auto"
+              style="flex:1 1 auto"
             >
               <div
                 class="ant-list-item"
@@ -452,7 +452,7 @@ Array [
           >
             <div
               class="ant-col"
-              style="padding-left:8px;padding-right:8px;flex:1 1 auto"
+              style="flex:1 1 auto"
             >
               <div
                 class="ant-list-item"
@@ -487,7 +487,7 @@ Array [
           >
             <div
               class="ant-col"
-              style="padding-left:8px;padding-right:8px;flex:1 1 auto"
+              style="flex:1 1 auto"
             >
               <div
                 class="ant-list-item"
@@ -522,7 +522,7 @@ Array [
           >
             <div
               class="ant-col"
-              style="padding-left:8px;padding-right:8px;flex:1 1 auto"
+              style="flex:1 1 auto"
             >
               <div
                 class="ant-list-item"
@@ -567,14 +567,14 @@ Array [
       >
         <div
           class="ant-row"
-          style="margin-left:-8px;margin-right:-8px"
+          style="--row-gutter-x:16px"
         >
           <div
             style="width:25%;max-width:25%"
           >
             <div
               class="ant-col"
-              style="padding-left:8px;padding-right:8px;flex:1 1 auto"
+              style="flex:1 1 auto"
             >
               <div
                 class="ant-list-item"
@@ -609,7 +609,7 @@ Array [
           >
             <div
               class="ant-col"
-              style="padding-left:8px;padding-right:8px;flex:1 1 auto"
+              style="flex:1 1 auto"
             >
               <div
                 class="ant-list-item"
@@ -644,7 +644,7 @@ Array [
           >
             <div
               class="ant-col"
-              style="padding-left:8px;padding-right:8px;flex:1 1 auto"
+              style="flex:1 1 auto"
             >
               <div
                 class="ant-list-item"
@@ -679,7 +679,7 @@ Array [
           >
             <div
               class="ant-col"
-              style="padding-left:8px;padding-right:8px;flex:1 1 auto"
+              style="flex:1 1 auto"
             >
               <div
                 class="ant-list-item"
@@ -714,7 +714,7 @@ Array [
           >
             <div
               class="ant-col"
-              style="padding-left:8px;padding-right:8px;flex:1 1 auto"
+              style="flex:1 1 auto"
             >
               <div
                 class="ant-list-item"
@@ -749,7 +749,7 @@ Array [
           >
             <div
               class="ant-col"
-              style="padding-left:8px;padding-right:8px;flex:1 1 auto"
+              style="flex:1 1 auto"
             >
               <div
                 class="ant-list-item"
@@ -794,14 +794,14 @@ Array [
       >
         <div
           class="ant-row"
-          style="margin-left:-8px;margin-right:-8px"
+          style="--row-gutter-x:16px"
         >
           <div
             style="width:25%;max-width:25%"
           >
             <div
               class="ant-col"
-              style="padding-left:8px;padding-right:8px;flex:1 1 auto"
+              style="flex:1 1 auto"
             >
               <div
                 class="ant-list-item"
@@ -837,7 +837,7 @@ Array [
           >
             <div
               class="ant-col"
-              style="padding-left:8px;padding-right:8px;flex:1 1 auto"
+              style="flex:1 1 auto"
             >
               <div
                 class="ant-list-item"
@@ -873,7 +873,7 @@ Array [
           >
             <div
               class="ant-col"
-              style="padding-left:8px;padding-right:8px;flex:1 1 auto"
+              style="flex:1 1 auto"
             >
               <div
                 class="ant-list-item"
@@ -909,7 +909,7 @@ Array [
           >
             <div
               class="ant-col"
-              style="padding-left:8px;padding-right:8px;flex:1 1 auto"
+              style="flex:1 1 auto"
             >
               <div
                 class="ant-list-item"
@@ -945,7 +945,7 @@ Array [
           >
             <div
               class="ant-col"
-              style="padding-left:8px;padding-right:8px;flex:1 1 auto"
+              style="flex:1 1 auto"
             >
               <div
                 class="ant-list-item"
@@ -981,7 +981,7 @@ Array [
           >
             <div
               class="ant-col"
-              style="padding-left:8px;padding-right:8px;flex:1 1 auto"
+              style="flex:1 1 auto"
             >
               <div
                 class="ant-list-item"
@@ -1176,12 +1176,12 @@ exports[`renders ./components/list/demo/responsive.md correctly 1`] = `
     >
       <div
         class="ant-row"
-        style="margin-left:-8px;margin-right:-8px"
+        style="--row-gutter-x:16px"
       >
         <div>
           <div
             class="ant-col"
-            style="padding-left:8px;padding-right:8px;flex:1 1 auto"
+            style="flex:1 1 auto"
           >
             <div
               class="ant-list-item"
@@ -1214,7 +1214,7 @@ exports[`renders ./components/list/demo/responsive.md correctly 1`] = `
         <div>
           <div
             class="ant-col"
-            style="padding-left:8px;padding-right:8px;flex:1 1 auto"
+            style="flex:1 1 auto"
           >
             <div
               class="ant-list-item"
@@ -1247,7 +1247,7 @@ exports[`renders ./components/list/demo/responsive.md correctly 1`] = `
         <div>
           <div
             class="ant-col"
-            style="padding-left:8px;padding-right:8px;flex:1 1 auto"
+            style="flex:1 1 auto"
           >
             <div
               class="ant-list-item"
@@ -1280,7 +1280,7 @@ exports[`renders ./components/list/demo/responsive.md correctly 1`] = `
         <div>
           <div
             class="ant-col"
-            style="padding-left:8px;padding-right:8px;flex:1 1 auto"
+            style="flex:1 1 auto"
           >
             <div
               class="ant-list-item"
@@ -1313,7 +1313,7 @@ exports[`renders ./components/list/demo/responsive.md correctly 1`] = `
         <div>
           <div
             class="ant-col"
-            style="padding-left:8px;padding-right:8px;flex:1 1 auto"
+            style="flex:1 1 auto"
           >
             <div
               class="ant-list-item"
@@ -1346,7 +1346,7 @@ exports[`renders ./components/list/demo/responsive.md correctly 1`] = `
         <div>
           <div
             class="ant-col"
-            style="padding-left:8px;padding-right:8px;flex:1 1 auto"
+            style="flex:1 1 auto"
           >
             <div
               class="ant-list-item"

--- a/components/statistic/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/statistic/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -3,11 +3,10 @@
 exports[`renders ./components/statistic/demo/basic.md extend context correctly 1`] = `
 <div
   class="ant-row"
-  style="margin-left:-8px;margin-right:-8px"
+  style="--row-gutter-x:16px"
 >
   <div
     class="ant-col ant-col-12"
-    style="padding-left:8px;padding-right:8px"
   >
     <div
       class="ant-statistic"
@@ -34,7 +33,6 @@ exports[`renders ./components/statistic/demo/basic.md extend context correctly 1
   </div>
   <div
     class="ant-col ant-col-12"
-    style="padding-left:8px;padding-right:8px"
   >
     <div
       class="ant-statistic"
@@ -75,7 +73,6 @@ exports[`renders ./components/statistic/demo/basic.md extend context correctly 1
   </div>
   <div
     class="ant-col ant-col-12"
-    style="padding-left:8px;padding-right:8px"
   >
     <div
       class="ant-statistic"
@@ -107,11 +104,10 @@ exports[`renders ./components/statistic/demo/card.md extend context correctly 1`
 >
   <div
     class="ant-row"
-    style="margin-left:-8px;margin-right:-8px"
+    style="--row-gutter-x:16px"
   >
     <div
       class="ant-col ant-col-12"
-      style="padding-left:8px;padding-right:8px"
     >
       <div
         class="ant-card ant-card-bordered"
@@ -180,7 +176,6 @@ exports[`renders ./components/statistic/demo/card.md extend context correctly 1`
     </div>
     <div
       class="ant-col ant-col-12"
-      style="padding-left:8px;padding-right:8px"
     >
       <div
         class="ant-card ant-card-bordered"
@@ -254,11 +249,10 @@ exports[`renders ./components/statistic/demo/card.md extend context correctly 1`
 exports[`renders ./components/statistic/demo/countdown.md extend context correctly 1`] = `
 <div
   class="ant-row"
-  style="margin-left:-8px;margin-right:-8px"
+  style="--row-gutter-x:16px"
 >
   <div
     class="ant-col ant-col-12"
-    style="padding-left:8px;padding-right:8px"
   >
     <div
       class="ant-statistic"
@@ -281,7 +275,6 @@ exports[`renders ./components/statistic/demo/countdown.md extend context correct
   </div>
   <div
     class="ant-col ant-col-12"
-    style="padding-left:8px;padding-right:8px"
   >
     <div
       class="ant-statistic"
@@ -304,7 +297,7 @@ exports[`renders ./components/statistic/demo/countdown.md extend context correct
   </div>
   <div
     class="ant-col ant-col-24"
-    style="padding-left:8px;padding-right:8px;margin-top:32px"
+    style="margin-top:32px"
   >
     <div
       class="ant-statistic"
@@ -327,7 +320,6 @@ exports[`renders ./components/statistic/demo/countdown.md extend context correct
   </div>
   <div
     class="ant-col ant-col-12"
-    style="padding-left:8px;padding-right:8px"
   >
     <div
       class="ant-statistic"
@@ -354,11 +346,10 @@ exports[`renders ./components/statistic/demo/countdown.md extend context correct
 exports[`renders ./components/statistic/demo/unit.md extend context correctly 1`] = `
 <div
   class="ant-row"
-  style="margin-left:-8px;margin-right:-8px"
+  style="--row-gutter-x:16px"
 >
   <div
     class="ant-col ant-col-12"
-    style="padding-left:8px;padding-right:8px"
   >
     <div
       class="ant-statistic"
@@ -408,7 +399,6 @@ exports[`renders ./components/statistic/demo/unit.md extend context correctly 1`
   </div>
   <div
     class="ant-col ant-col-12"
-    style="padding-left:8px;padding-right:8px"
   >
     <div
       class="ant-statistic"

--- a/components/statistic/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/statistic/__tests__/__snapshots__/demo.test.js.snap
@@ -3,11 +3,10 @@
 exports[`renders ./components/statistic/demo/basic.md correctly 1`] = `
 <div
   class="ant-row"
-  style="margin-left:-8px;margin-right:-8px"
+  style="--row-gutter-x:16px"
 >
   <div
     class="ant-col ant-col-12"
-    style="padding-left:8px;padding-right:8px"
   >
     <div
       class="ant-statistic"
@@ -34,7 +33,6 @@ exports[`renders ./components/statistic/demo/basic.md correctly 1`] = `
   </div>
   <div
     class="ant-col ant-col-12"
-    style="padding-left:8px;padding-right:8px"
   >
     <div
       class="ant-statistic"
@@ -75,7 +73,6 @@ exports[`renders ./components/statistic/demo/basic.md correctly 1`] = `
   </div>
   <div
     class="ant-col ant-col-12"
-    style="padding-left:8px;padding-right:8px"
   >
     <div
       class="ant-statistic"
@@ -107,11 +104,10 @@ exports[`renders ./components/statistic/demo/card.md correctly 1`] = `
 >
   <div
     class="ant-row"
-    style="margin-left:-8px;margin-right:-8px"
+    style="--row-gutter-x:16px"
   >
     <div
       class="ant-col ant-col-12"
-      style="padding-left:8px;padding-right:8px"
     >
       <div
         class="ant-card ant-card-bordered"
@@ -180,7 +176,6 @@ exports[`renders ./components/statistic/demo/card.md correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-12"
-      style="padding-left:8px;padding-right:8px"
     >
       <div
         class="ant-card ant-card-bordered"
@@ -254,11 +249,10 @@ exports[`renders ./components/statistic/demo/card.md correctly 1`] = `
 exports[`renders ./components/statistic/demo/countdown.md correctly 1`] = `
 <div
   class="ant-row"
-  style="margin-left:-8px;margin-right:-8px"
+  style="--row-gutter-x:16px"
 >
   <div
     class="ant-col ant-col-12"
-    style="padding-left:8px;padding-right:8px"
   >
     <div
       class="ant-statistic"
@@ -281,7 +275,6 @@ exports[`renders ./components/statistic/demo/countdown.md correctly 1`] = `
   </div>
   <div
     class="ant-col ant-col-12"
-    style="padding-left:8px;padding-right:8px"
   >
     <div
       class="ant-statistic"
@@ -304,7 +297,7 @@ exports[`renders ./components/statistic/demo/countdown.md correctly 1`] = `
   </div>
   <div
     class="ant-col ant-col-24"
-    style="padding-left:8px;padding-right:8px;margin-top:32px"
+    style="margin-top:32px"
   >
     <div
       class="ant-statistic"
@@ -327,7 +320,6 @@ exports[`renders ./components/statistic/demo/countdown.md correctly 1`] = `
   </div>
   <div
     class="ant-col ant-col-12"
-    style="padding-left:8px;padding-right:8px"
   >
     <div
       class="ant-statistic"
@@ -354,11 +346,10 @@ exports[`renders ./components/statistic/demo/countdown.md correctly 1`] = `
 exports[`renders ./components/statistic/demo/unit.md correctly 1`] = `
 <div
   class="ant-row"
-  style="margin-left:-8px;margin-right:-8px"
+  style="--row-gutter-x:16px"
 >
   <div
     class="ant-col ant-col-12"
-    style="padding-left:8px;padding-right:8px"
   >
     <div
       class="ant-statistic"
@@ -408,7 +399,6 @@ exports[`renders ./components/statistic/demo/unit.md correctly 1`] = `
   </div>
   <div
     class="ant-col ant-col-12"
-    style="padding-left:8px;padding-right:8px"
   >
     <div
       class="ant-statistic"

--- a/package.json
+++ b/package.json
@@ -304,7 +304,7 @@
   "bundlesize": [
     {
       "path": "./dist/antd.min.js",
-      "maxSize": "283 kB"
+      "maxSize": "284 kB"
     },
     {
       "path": "./dist/antd.min.css",
@@ -312,7 +312,7 @@
     },
     {
       "path": "./dist/antd.dark.min.css",
-      "maxSize": "67 kB"
+      "maxSize": "68 kB"
     },
     {
       "path": "./dist/antd.compact.min.css",

--- a/site/theme/static/dark.less
+++ b/site/theme/static/dark.less
@@ -214,7 +214,6 @@
     }
 
     .code-box-demo .ant-row > div:not(.gutter-row) {
-      padding: 16px 0;
       background: #028ac8;
 
       &:nth-child(2n + 1) {

--- a/site/theme/static/dark.less
+++ b/site/theme/static/dark.less
@@ -214,6 +214,7 @@
     }
 
     .code-box-demo .ant-row > div:not(.gutter-row) {
+      padding: 16px 0;
       background: #028ac8;
 
       &:nth-child(2n + 1) {

--- a/site/theme/static/markdown.less
+++ b/site/theme/static/markdown.less
@@ -405,7 +405,6 @@
   .ant-row > div,
   .code-box-demo .ant-row > div {
     min-height: 30px;
-    margin-top: 8px;
     margin-bottom: 8px;
     color: #fff;
     text-align: center;
@@ -413,7 +412,6 @@
   }
 
   .code-box-demo .ant-row > div:not(.gutter-row) {
-    padding: 16px 0;
     background: @demo-grid-color;
 
     &:nth-child(2n + 1) {
@@ -482,7 +480,6 @@
 [id='components-grid-demo-playground'],
 [id='components-grid-demo-gutter'] {
   > .code-box-demo .ant-row > div {
-    margin-top: 0;
     margin-bottom: 0;
   }
 }

--- a/site/theme/static/markdown.less
+++ b/site/theme/static/markdown.less
@@ -405,6 +405,7 @@
   .ant-row > div,
   .code-box-demo .ant-row > div {
     min-height: 30px;
+    margin-top: 8px;
     margin-bottom: 8px;
     color: #fff;
     text-align: center;
@@ -412,6 +413,7 @@
   }
 
   .code-box-demo .ant-row > div:not(.gutter-row) {
+    padding: 16px 0;
     background: @demo-grid-color;
 
     &:nth-child(2n + 1) {
@@ -480,6 +482,7 @@
 [id='components-grid-demo-playground'],
 [id='components-grid-demo-gutter'] {
   > .code-box-demo .ant-row > div {
+    margin-top: 0;
     margin-bottom: 0;
   }
 }


### PR DESCRIPTION
[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [x] Demo update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

#35376 

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->
问题：给 Row 组件增加 `gap` style 或者给 Col 组件增加 `padding` 样式会在重复渲染时报错，更详细的内容请看上述 issue 链接
解决方案：重构`Row`和`Col`组件样式，改用 css 自定义属性控制
```js
// demo
<Row gutter={[20, 20]}>
    <Col>text</Col>
</Row>

// output before fix
<div class="ant-row" style="margin-left: -10px; margin-right: -10px; row-gap: 20px;">
    <div class="ant-col" style="padding-left: 8px; padding-right: 8px;">content</div>
    <div class="ant-col" style="padding-left: 8px; padding-right: 8px;">content</div>
</div>

// output after fix
<div class="ant-row" style="--row-gutter-x: 20px; --row-gutter-y: 20px;">
    <div class="ant-col">content</div>
    <div class="ant-col">content</div>
</div>

// refactored css style
// 注意：下列 margin 和 padding 属性不能合并，会导致 argos 测试失败；
// 并且合并成 `margin: calc(-1 * var(--row-gutter-y)) calc(-0.5 * var(--row-gutter-x)) 0`  后，
// margin-bottom 就默认设置成 0，会影响其他组件。
.ant-row {
    // ...other styles;
    --row-gutter-x: 0;
    --row-gutter-y: 0;
    margin-top:  calc(-1 * var(--row-gutter-y));
    margin-left:  calc(-0.5 * var(--row-gutter-x));
    margin-right:  calc(-0.5 * var(--row-gutter-x));
}
.ant-col {
    // ...other styles;
    margin-top: var(--row-gutter-y);
    padding-left: calc(0.5 * var(--row-gutter-x));
    padding-right: calc(0.5 * var(--row-gutter-x));
}
```

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix `Row` and `Col` style conflict error |
| 🇨🇳 Chinese | 修复 `Row` and `Col` 样式冲突错误 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated
- [x] Demo is updated
- [x] TypeScript definition is not needed
- [x] Changelog is provided
