### PR TITLE
fix: Fix menu items typings

### DIFF
--- a/components/menu/__tests__/__snapshots__/index.test.js.snap
+++ b/components/menu/__tests__/__snapshots__/index.test.js.snap
@@ -162,6 +162,167 @@ Array [
 ]
 `;
 
+exports[`Menu all types must be available in the "items" syntax 1`] = `
+Array [
+  <ul
+    class="ant-menu ant-menu-root ant-menu-inline ant-menu-light"
+    data-menu-list="true"
+    role="menu"
+    tabindex="0"
+  >
+    <li
+      class="ant-menu-submenu ant-menu-submenu-inline ant-menu-submenu-open"
+      role="none"
+    >
+      <div
+        aria-controls="rc-menu-uuid-test-submenu-popup"
+        aria-expanded="true"
+        aria-haspopup="true"
+        class="ant-menu-submenu-title"
+        data-menu-id="rc-menu-uuid-test-submenu"
+        role="menuitem"
+        style="padding-left: 24px;"
+        tabindex="-1"
+      >
+        <span
+          class="ant-menu-title-content"
+        >
+          Submenu
+        </span>
+        <i
+          class="ant-menu-submenu-arrow"
+        />
+      </div>
+      <ul
+        class="ant-menu ant-menu-sub ant-menu-inline"
+        data-menu-list="true"
+        id="rc-menu-uuid-test-submenu-popup"
+      >
+        <li
+          class="ant-menu-item ant-menu-item-only-child"
+          data-menu-id="rc-menu-uuid-test-submenu-item1"
+          role="menuitem"
+          style="padding-left: 48px;"
+          tabindex="-1"
+        >
+          <span
+            class="ant-menu-title-content"
+          >
+            SubmenuItem 1
+          </span>
+        </li>
+        <li
+          class="ant-menu-item ant-menu-item-only-child"
+          data-menu-id="rc-menu-uuid-test-submenu-item2"
+          role="menuitem"
+          style="padding-left: 48px;"
+          tabindex="-1"
+        >
+          <span
+            class="ant-menu-title-content"
+          >
+            SubmenuItem 2
+          </span>
+        </li>
+      </ul>
+    </li>
+    <li
+      class="ant-menu-item-divider"
+    />
+    <li
+      class="ant-menu-item-group"
+    >
+      <div
+        class="ant-menu-item-group-title"
+        title="Group"
+      >
+        Group
+      </div>
+      <ul
+        class="ant-menu-item-group-list"
+      >
+        <li
+          class="ant-menu-item ant-menu-item-only-child"
+          data-menu-id="rc-menu-uuid-test-group-item"
+          role="menuitem"
+          style="padding-left: 24px;"
+          tabindex="-1"
+        >
+          <span
+            class="ant-menu-title-content"
+          >
+            GroupItem
+          </span>
+        </li>
+        <li
+          class="ant-menu-item-divider"
+        />
+        <li
+          class="ant-menu-submenu ant-menu-submenu-inline ant-menu-submenu-open"
+          role="none"
+        >
+          <div
+            aria-controls="rc-menu-uuid-test-group-submenu-popup"
+            aria-expanded="true"
+            aria-haspopup="true"
+            class="ant-menu-submenu-title"
+            data-menu-id="rc-menu-uuid-test-group-submenu"
+            role="menuitem"
+            style="padding-left: 24px;"
+            tabindex="-1"
+          >
+            <span
+              class="ant-menu-title-content"
+            >
+              GroupSubmenu
+            </span>
+            <i
+              class="ant-menu-submenu-arrow"
+            />
+          </div>
+          <ul
+            class="ant-menu ant-menu-sub ant-menu-inline"
+            data-menu-list="true"
+            id="rc-menu-uuid-test-group-submenu-popup"
+          >
+            <li
+              class="ant-menu-item ant-menu-item-only-child"
+              data-menu-id="rc-menu-uuid-test-group-submenu-item1"
+              role="menuitem"
+              style="padding-left: 48px;"
+              tabindex="-1"
+            >
+              <span
+                class="ant-menu-title-content"
+              >
+                GroupSubmenuItem 1
+              </span>
+            </li>
+            <li
+              class="ant-menu-item ant-menu-item-only-child"
+              data-menu-id="rc-menu-uuid-test-group-submenu-item2"
+              role="menuitem"
+              style="padding-left: 48px;"
+              tabindex="-1"
+            >
+              <span
+                class="ant-menu-title-content"
+              >
+                GroupSubmenuItem 2
+              </span>
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </li>
+  </ul>,
+  <div
+    aria-hidden="true"
+    style="display: none;"
+  />,
+]
+`;
+
 exports[`Menu rtl render component should be rendered correctly in RTL direction 1`] = `
 Array [
   <ul

--- a/components/menu/__tests__/index.test.js
+++ b/components/menu/__tests__/index.test.js
@@ -962,4 +962,46 @@ describe('Menu', () => {
 
     expect(wrapper.exists('.bamboo')).toBeTruthy();
   });
+
+  it('all types must be available in the "items" syntax', () => {
+    const wrapper = mount(
+      <Menu
+        mode="inline"
+        defaultOpenKeys={['submenu', 'group-submenu']}
+        items={[
+          {
+            key: 'submenu',
+            label: 'Submenu',
+            children: [
+              { key: 'submenu-item1', label: 'SubmenuItem 1' },
+              { key: 'submenu-item2', label: 'SubmenuItem 2' },
+            ],
+          },
+          { key: 'divider', type: 'divider' },
+          {
+            key: 'group',
+            type: 'group',
+            label: 'Group',
+            children: [
+              {
+                key: 'group-item',
+                label: 'GroupItem',
+              },
+              { key: 'group-divider', type: 'divider' },
+              {
+                key: 'group-submenu',
+                label: 'GroupSubmenu',
+                children: [
+                  { key: 'group-submenu-item1', label: 'GroupSubmenuItem 1' },
+                  { key: 'group-submenu-item2', label: 'GroupSubmenuItem 2' },
+                ],
+              },
+            ],
+          },
+        ]}
+      />,
+    );
+
+    expect(wrapper.render()).toMatchSnapshot();
+  });
 });

--- a/components/menu/__tests__/type.test.tsx
+++ b/components/menu/__tests__/type.test.tsx
@@ -1,0 +1,40 @@
+import * as React from 'react';
+import Menu from '..';
+
+describe('Menu.typescript', () => {
+  it('Menu.items', () => {
+    const menu = (
+      <Menu
+        items={[
+          { key: 'item', title: 'Item' },
+          {
+            key: 'submenu',
+            theme: 'light',
+            children: [
+              { key: 'submenu-item', title: 'SubmenuItem' },
+              { key: 'submenu-submenu', theme: 'light', children: [] },
+              { key: 'submenu-divider', type: 'divider' },
+              { key: 'submenu-group', type: 'group' },
+              null,
+            ],
+          },
+          {
+            key: 'group',
+            type: 'group',
+            children: [
+              { key: 'group-item', label: 'GroupItem' },
+              { key: 'group-submenu', theme: 'light', children: [] },
+              { key: 'group-divider', type: 'divider' },
+              { key: 'group-group', type: 'group' },
+              null,
+            ],
+          },
+          { key: 'divider', type: 'divider' },
+          null,
+        ]}
+      />
+    );
+
+    expect(menu).toBeTruthy();
+  });
+});

--- a/components/menu/hooks/useItems.tsx
+++ b/components/menu/hooks/useItems.tsx
@@ -23,7 +23,7 @@ interface SubMenuType extends Omit<RcSubMenuType, 'children'> {
 }
 
 interface MenuItemGroupType extends Omit<RcMenuItemGroupType, 'children'> {
-  children?: MenuItemType[];
+  children?: ItemType[];
   key?: React.Key;
 }
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

none

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

#### Background

In the `items` property of `Menu`, adopted from 4.20.0, children of items using `type: 'group'` could not contain definitions such as `divider` and `submenu`.

<img width="903" alt="image" src="https://user-images.githubusercontent.com/16271994/170825451-f7aa3f97-2889-4f29-a2cc-4925bcb73ea9.png">

#### Solution
This is only a type definition issue and actually works. Therefore, we have fixed the following two issues

- Changed the type of `children` in `MenuItemGroupType` from `MenuItemType` to `ItemType`.
- Added a simple test case to verify that all item types can be rendered using the `items` property

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fix type definition of `MenuItemGroupType` in `Menu` |
| 🇨🇳 Chinese | 修复 `Menu` 中 `MenuItemGroupType` 的类型定义 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
