### PR TITLE
fix: components in Modal have no form status by default

### DIFF
--- a/components/form/__tests__/index.test.js
+++ b/components/form/__tests__/index.test.js
@@ -1,17 +1,18 @@
-import React, { Component, useState } from 'react';
 import { mount } from 'enzyme';
+import React, { Component, useState } from 'react';
 import { act } from 'react-dom/test-utils';
 import scrollIntoView from 'scroll-into-view-if-needed';
 import Form from '..';
 import * as Util from '../util';
 
-import Input from '../../input';
 import Button from '../../button';
+import Input from '../../input';
+import Modal from '../../modal';
 import Select from '../../select';
 
 import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
-import { sleep, render, fireEvent } from '../../../tests/utils';
+import { fireEvent, render, sleep } from '../../../tests/utils';
 import ConfigProvider from '../../config-provider';
 import zhCN from '../../locale/zh_CN';
 
@@ -1102,5 +1103,19 @@ describe('Form', () => {
 
     render(<Demo />);
     expect(subFormInstance).toBe(formInstance);
+  });
+
+  it('should not affect Modal children style', () => {
+    const Demo = () => (
+      <Form>
+        <Form.Item>
+          <Modal visible>
+            <Select className="modal-select" />
+          </Modal>
+        </Form.Item>
+      </Form>
+    );
+    const { container } = render(<Demo />, { container: document.body });
+    expect(container.querySelector('.modal-select')?.className).not.toContain('in-form-item');
   });
 });

--- a/components/modal/Modal.tsx
+++ b/components/modal/Modal.tsx
@@ -8,7 +8,7 @@ import type { ButtonProps, LegacyButtonType } from '../button/button';
 import { convertLegacyProps } from '../button/button';
 import type { DirectionType } from '../config-provider';
 import { ConfigContext } from '../config-provider';
-import { NoFormStatus } from '../form/context';
+import { FormItemInputContext } from '../form/context';
 import LocaleReceiver from '../locale-provider/LocaleReceiver';
 import { getTransitionName } from '../_util/motion';
 import { canUseDocElement } from '../_util/styleChecker';
@@ -140,6 +140,14 @@ const Modal: React.FC<ModalProps> = props => {
     getPrefixCls,
     direction,
   } = React.useContext(ConfigContext);
+  const formItemContext = React.useContext(FormItemInputContext);
+  const mergedFormItemContext = React.useMemo(
+    () => ({
+      ...formItemContext,
+      isFormItemInput: false,
+    }),
+    [formItemContext],
+  );
 
   const handleCancel = (e: React.MouseEvent<HTMLButtonElement>) => {
     const { onCancel } = props;
@@ -219,7 +227,9 @@ const Modal: React.FC<ModalProps> = props => {
       transitionName={getTransitionName(rootPrefixCls, 'zoom', props.transitionName)}
       maskTransitionName={getTransitionName(rootPrefixCls, 'fade', props.maskTransitionName)}
     >
-      <NoFormStatus>{children}</NoFormStatus>
+      <FormItemInputContext.Provider value={mergedFormItemContext}>
+        {children}
+      </FormItemInputContext.Provider>
     </Dialog>
   );
 };

--- a/components/modal/Modal.tsx
+++ b/components/modal/Modal.tsx
@@ -1,17 +1,18 @@
-import * as React from 'react';
-import Dialog from 'rc-dialog';
-import classNames from 'classnames';
 import CloseOutlined from '@ant-design/icons/CloseOutlined';
+import classNames from 'classnames';
+import Dialog from 'rc-dialog';
+import * as React from 'react';
 
-import { getConfirmLocale } from './locale';
 import Button from '../button';
-import type { LegacyButtonType, ButtonProps } from '../button/button';
+import type { ButtonProps, LegacyButtonType } from '../button/button';
 import { convertLegacyProps } from '../button/button';
-import LocaleReceiver from '../locale-provider/LocaleReceiver';
 import type { DirectionType } from '../config-provider';
 import { ConfigContext } from '../config-provider';
-import { canUseDocElement } from '../_util/styleChecker';
+import { NoFormStatus } from '../form/context';
+import LocaleReceiver from '../locale-provider/LocaleReceiver';
 import { getTransitionName } from '../_util/motion';
+import { canUseDocElement } from '../_util/styleChecker';
+import { getConfirmLocale } from './locale';
 
 let mousePosition: { x: number; y: number } | null;
 
@@ -178,6 +179,7 @@ const Modal: React.FC<ModalProps> = props => {
     getContainer,
     closeIcon,
     focusTriggerAfterClose = true,
+    children,
     ...restProps
   } = props;
 
@@ -216,7 +218,9 @@ const Modal: React.FC<ModalProps> = props => {
       focusTriggerAfterClose={focusTriggerAfterClose}
       transitionName={getTransitionName(rootPrefixCls, 'zoom', props.transitionName)}
       maskTransitionName={getTransitionName(rootPrefixCls, 'fade', props.maskTransitionName)}
-    />
+    >
+      <NoFormStatus>{children}</NoFormStatus>
+    </Dialog>
   );
 };
 

--- a/components/modal/style/index.tsx
+++ b/components/modal/style/index.tsx
@@ -1,5 +1,6 @@
 import '../../style/index.less';
 import './index.less';
 
+// deps-lint-skip: form
 // style dependencies
 import '../../button/style';


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
close https://github.com/ant-design/ant-design/issues/35821
<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Modal `children` remove style affected by Form by default.          |
| 🇨🇳 Chinese | Modal 子元素默认不受 Form 样式影响。          |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
