### PR TITLE
fix: remove extraneous space from rc-segmented version

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
     "rc-progress": "~3.2.1",
     "rc-rate": "~2.9.0",
     "rc-resize-observer": "^1.2.0",
-    "rc-segmented": "~2.1.0 ",
+    "rc-segmented": "~2.1.0",
     "rc-select": "~14.1.1",
     "rc-slider": "~10.0.0",
     "rc-steps": "~4.1.0",


### PR DESCRIPTION
The extra spaces confuses some third-party tooling.