### PR TITLE
Fix color generation for grey colors in less

### DIFF
--- a/components/style/color/colorPalette.less
+++ b/components/style/color/colorPalette.less
@@ -31,6 +31,10 @@
     return Math.round(hue);
   };
   var getSaturation = function(hsv, i, isLight) {
+    // grey color don't change saturation
+    if (hsv.h === 0 && hsv.s === 0) {
+      return hsv.s;
+    }
     var saturation;
     if (isLight) {
       saturation = hsv.s - saturationStep * i;


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

None

### 💡 Background and solution

The color palettes generation algorithm has a bug when generating grey colors. Fix: the saturation must not be changed. Taken from [here](https://github.com/ant-design/ant-design-colors/blob/master/src/generate.ts#L79-L82).

### 📝 Changelog


| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fix less color pallate algorithm accord to `@ant-design/colors`.          |
| 🇨🇳 Chinese | 修复 less 色彩算法，使其和 `@ant-design/colors` 保持一致。          |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
