### PR TITLE
fix: Button has no disabled style when link type，add disabled to <a>

### DIFF
--- a/components/button/button.tsx
+++ b/components/button/button.tsx
@@ -279,7 +279,14 @@ const InternalButton: React.ForwardRefRenderFunction<unknown, ButtonProps> = (pr
   const linkButtonRestProps = omit(rest as AnchorButtonProps & { navigate: any }, ['navigate']);
   if (linkButtonRestProps.href !== undefined) {
     return (
-      <a {...linkButtonRestProps} className={classes} onClick={handleClick} ref={buttonRef}>
+      <a
+        {...linkButtonRestProps}
+        className={classes}
+        onClick={handleClick}
+        // @ts-ignore
+        disabled={mergedDisabled}
+        ref={buttonRef}
+      >
         {iconNode}
         {kids}
       </a>


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link 
[related issue](https://github.com/ant-design/ant-design/issues/35952)
<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution
目前按钮的 `disabled` 状态是通过属性选择器来匹配的，当 `type` 为 `link`，并且添加 `href` 属性时，`button` 会变成 `a` 标签，而 `a` 标签没有 `disabled` 属性。
解决方法是为 `a` 标签单独写一套 `disabled` 样式。
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     -      |
| 🇨🇳 Chinese |      -     |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
