### PR TITLE
fix: Fixed the getContainer property in Image not reading the settings in ConfigProvider

### DIFF
--- a/components/image/__tests__/index.test.js
+++ b/components/image/__tests__/index.test.js
@@ -1,8 +1,8 @@
-import React from 'react';
-import { render, fireEvent } from '../../../tests/utils';
 import Image from '..';
 import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
+import { fireEvent, render } from '../../../tests/utils';
+import ConfigProvider from '../../config-provider';
 
 const src = 'https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png';
 
@@ -75,5 +75,18 @@ describe('Image', () => {
 
     expect(baseElement.querySelector('.ant-image-preview')).toHaveClass('abc');
     expect(baseElement.querySelector('.ant-image-preview-mask')).toHaveClass('def');
+  });
+  it('ConfigProvider getPopupContainer', () => {
+    const { container: wrapper, baseElement } = render(
+      <>
+        <div className="container" />
+        <ConfigProvider getPopupContainer={() => document.querySelector('.container')}>
+          <Image src={src} />
+        </ConfigProvider>
+      </>,
+    );
+    fireEvent.click(wrapper.querySelector('.ant-image'));
+    const containerElement = baseElement.querySelector('.container');
+    expect(containerElement.children.length).not.toBe(0);
   });
 });

--- a/components/image/__tests__/index.test.js
+++ b/components/image/__tests__/index.test.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import Image from '..';
 import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';

--- a/components/image/index.tsx
+++ b/components/image/index.tsx
@@ -16,7 +16,12 @@ const Image: CompositionImage<ImageProps> = ({
   preview,
   ...otherProps
 }) => {
-  const { getPrefixCls, locale: contextLocale = defaultLocale } = useContext(ConfigContext);
+  const {
+    getPrefixCls,
+    locale: contextLocale = defaultLocale,
+    getPopupContainer: getContextPopupContainer,
+  } = useContext(ConfigContext);
+
   const prefixCls = getPrefixCls('image', customizePrefixCls);
   const rootPrefixCls = getPrefixCls();
 
@@ -27,7 +32,7 @@ const Image: CompositionImage<ImageProps> = ({
       return preview;
     }
     const _preview = typeof preview === 'object' ? preview : {};
-
+    const { getContainer, ...restPreviewProps } = _preview;
     return {
       mask: (
         <div className={`${prefixCls}-mask-info`}>
@@ -36,7 +41,8 @@ const Image: CompositionImage<ImageProps> = ({
         </div>
       ),
       icons,
-      ..._preview,
+      getContainer: getContainer || getContextPopupContainer,
+      ...restPreviewProps,
       transitionName: getTransitionName(rootPrefixCls, 'zoom', _preview.transitionName),
       maskTransitionName: getTransitionName(rootPrefixCls, 'fade', _preview.maskTransitionName),
     };

--- a/components/image/index.tsx
+++ b/components/image/index.tsx
@@ -41,8 +41,8 @@ const Image: CompositionImage<ImageProps> = ({
         </div>
       ),
       icons,
-      getContainer: getContainer || getContextPopupContainer,
       ...restPreviewProps,
+      getContainer: getContainer || getContextPopupContainer,
       transitionName: getTransitionName(rootPrefixCls, 'zoom', _preview.transitionName),
       maskTransitionName: getTransitionName(rootPrefixCls, 'fade', _preview.maskTransitionName),
     };


### PR DESCRIPTION
### 🤔 Fixed the getContainer property in Image not reading the settings in ConfigProvider

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close https://github.com/ant-design/ant-design/issues/35942

### 💡 Background and solution

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Fixed the getContainer property in Image not reading the settings in ConfigProvider  |
| 🇨🇳 Chinese |    修复 Image 中的 getContainer 属性没有读取 ConfigProvider 中的设置   |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
