### PR TITLE
docs: add changelog 4.21.1

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -22,7 +22,7 @@ timeline: true
 - 🐞 Fixed the `getContainer` property in Image not reading the settings in ConfigProvider. [#36002](https://github.com/ant-design/ant-design/pull/36002) [@robothot](https://github.com/robothot)
 - 🐞 Fixed the issue [#35952](https://github.com/ant-design/ant-design/issues/35952) where the `disabled` attribute does not take effect when a Button has `href`. [#35975](https://github.com/ant-design/ant-design/pull/35975) [@MuxinFeng](https://github.com/MuxinFeng)
 - 🐞 Fix less color palette algorithm accord to `@ant-design/colors`. [#35954](https://github.com/ant-design/ant-design/pull/35954) [@christian-lechner](https://github.com/christian-lechner)
-- 🐞 Fix flickering of the image in Upload. [#35943](https://github.com/ant-design/ant-design/pull/35943)
+- 🐞 Fix Upload image flickering. [#35943](https://github.com/ant-design/ant-design/pull/35943)
 - 💄 Remove styles from Form such as `status` for children of Modal and Drawer. [#35849](https://github.com/ant-design/ant-design/pull/35849)
 - TypeScript
   - 🤖 Fix `autoFocus` property definition in `DropdownProps` in typescript. [#35990](https://github.com/ant-design/ant-design/pull/35990) [@robothot](https://github.com/robothot)

--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -25,10 +25,9 @@ timeline: true
 - 🐞 Fix Upload image flickering. [#35943](https://github.com/ant-design/ant-design/pull/35943)
 - 💄 Remove styles from Form such as `status` for children of Modal and Drawer. [#35849](https://github.com/ant-design/ant-design/pull/35849)
 - TypeScript
-  - 🤖 Fix `autoFocus` property definition in `DropdownProps` in typescript. [#35990](https://github.com/ant-design/ant-design/pull/35990) [@robothot](https://github.com/robothot)
-  - 🤖 Fix type definition of `MenuItemGroupType` in Menu. [#35790](https://github.com/ant-design/ant-design/pull/35790) [@MasaoBlue](https://github.com/MasaoBlue)
-  - 🤖 Fix Carousel TS definition in React 18. [#35959](https://github.com/ant-design/ant-design/pull/35959)
-  - 🤖 Fix missing semicolon in Dropdown TS type definition. [#36008](https://github.com/ant-design/ant-design/pull/36008) [@robothot](https://github.com/robothot)
+  - 🤖 Fix type definition for `autoFocus` in Dropdown. [#35990](https://github.com/ant-design/ant-design/pull/35990) [@robothot](https://github.com/robothot)
+  - 🤖 Fix type definition for `MenuItemGroupType` in Menu. [#35790](https://github.com/ant-design/ant-design/pull/35790) [@MasaoBlue](https://github.com/MasaoBlue)
+  - 🤖 Fix Carousel type definition in React 18. [#35959](https://github.com/ant-design/ant-design/pull/35959)
 - 🌐 Localization
   - 🇮🇹 Fix italian translation for `Table.cancelSort` key. [#35970](https://github.com/ant-design/ant-design/pull/35970) [@gariggio](https://github.com/gariggio)
 

--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -22,7 +22,7 @@ timeline: true
 - 🐞 Fixed the `getContainer` property in Image not reading the settings in ConfigProvider. [#36002](https://github.com/ant-design/ant-design/pull/36002) [@robothot](https://github.com/robothot)
 - 🐞 Fixed the issue [#35952](https://github.com/ant-design/ant-design/issues/35952) where the `disabled` attribute does not take effect when a Button has `href`. [#35975](https://github.com/ant-design/ant-design/pull/35975) [@MuxinFeng](https://github.com/MuxinFeng)
 - 🐞 Fix less color palette algorithm accord to `@ant-design/colors`. [#35954](https://github.com/ant-design/ant-design/pull/35954) [@christian-lechner](https://github.com/christian-lechner)
-- 🐞 Fix `animation-timing-function` in Upload. [#35943](https://github.com/ant-design/ant-design/pull/35943)
+- 🐞 Fix flickering of the image in Upload. [#35943](https://github.com/ant-design/ant-design/pull/35943)
 - 💄 Remove styles from Form such as `status` for children of Modal and Drawer. [#35849](https://github.com/ant-design/ant-design/pull/35849)
 - TypeScript
   - 🤖 Fix `autoFocus` property definition in `DropdownProps` in typescript. [#35990](https://github.com/ant-design/ant-design/pull/35990) [@robothot](https://github.com/robothot)

--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -15,6 +15,26 @@ timeline: true
 
 ---
 
+## 4.21.1
+
+`2022-06-13`
+
+- 🐞 Fixed the `getContainer` property in Image not reading the settings in ConfigProvider. [#36002](https://github.com/ant-design/ant-design/pull/36002) [@robothot](https://github.com/robothot)
+- 🐞 Fixed the issue [#35952] where the `disabled` attribute does not take effect when a Button has `href`. [#35975](https://github.com/ant-design/ant-design/pull/35975) [@MuxinFeng](https://github.com/MuxinFeng)
+- 🐞 Fix less color palette algorithm accord to `@ant-design/colors`. [#35954](https://github.com/ant-design/ant-design/pull/35954) [@christian-lechner](https://github.com/christian-lechner)
+- 🐞 Fix `animation-timing-function` in Upload. [#35943](https://github.com/ant-design/ant-design/pull/35943)
+- 💄 Remove styles from Form such as `status` for children of Modal and Drawer. [#35849](https://github.com/ant-design/ant-design/pull/35849)
+- TypeScript
+  - 🤖 Fix `autoFocus` property definition in `DropdownProps` in typescript. [#35990](https://github.com/ant-design/ant-design/pull/35990) [@robothot](https://github.com/robothot)
+  - 🤖 Fix type definition of `MenuItemGroupType` in Menu. [#35790](https://github.com/ant-design/ant-design/pull/35790) [@MasaoBlue](https://github.com/MasaoBlue)
+  - 🤖 Fix Carousel TS definition in React 18. [#35959](https://github.com/ant-design/ant-design/pull/35959)
+  - 🤖 Fix missing semicolon in Dropdown TS type definition. [#36008](https://github.com/ant-design/ant-design/pull/36008) [@robothot](https://github.com/robothot)
+- Docs
+  - 📃 Fixed `onChange` description repeated twice in AutoComplete docs. [#36013](https://github.com/ant-design/ant-design/pull/36013) [@hinatades](https://github.com/hinatades)
+  - 📃 Fix interface in doc for Segmented component. [#35974](https://github.com/ant-design/ant-design/pull/35974) [@hoosin](https://github.com/hoosin)
+- 🌐 Localization
+  - 🇮🇹 Fix italian translation for `Table.cancelSort` key. [#35970](https://github.com/ant-design/ant-design/pull/35970) [@gariggio](https://github.com/gariggio)
+
 ## 4.21.0
 
 `2022-06-06`

--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -19,9 +19,9 @@ timeline: true
 
 `2022-06-13`
 
-- 🐞 Fixed the `getContainer` property in Image not reading the settings in ConfigProvider. [#36002](https://github.com/ant-design/ant-design/pull/36002) [@robothot](https://github.com/robothot)
-- 🐞 Fixed the issue [#35952](https://github.com/ant-design/ant-design/issues/35952) where the `disabled` attribute does not take effect when a Button has `href`. [#35975](https://github.com/ant-design/ant-design/pull/35975) [@MuxinFeng](https://github.com/MuxinFeng)
-- 🐞 Fix less color palette algorithm accord to `@ant-design/colors`. [#35954](https://github.com/ant-design/ant-design/pull/35954) [@christian-lechner](https://github.com/christian-lechner)
+- 🐞 Fixed Image the `getContainer` property not reading from ConfigProvider. [#36002](https://github.com/ant-design/ant-design/pull/36002) [@robothot](https://github.com/robothot)
+- 🐞 Fixed Button issue [#35952](https://github.com/ant-design/ant-design/issues/35952) where the `disabled` attribute does not take effect with `href`. [#35975](https://github.com/ant-design/ant-design/pull/35975) [@MuxinFeng](https://github.com/MuxinFeng)
+- 🐞 Fix less color palette algorithm according to `@ant-design/colors`. [#35954](https://github.com/ant-design/ant-design/pull/35954) [@christian-lechner](https://github.com/christian-lechner)
 - 🐞 Fix Upload image flickering. [#35943](https://github.com/ant-design/ant-design/pull/35943)
 - 💄 Remove styles from Form such as `status` for children of Modal and Drawer. [#35849](https://github.com/ant-design/ant-design/pull/35849)
 - TypeScript
@@ -29,9 +29,6 @@ timeline: true
   - 🤖 Fix type definition of `MenuItemGroupType` in Menu. [#35790](https://github.com/ant-design/ant-design/pull/35790) [@MasaoBlue](https://github.com/MasaoBlue)
   - 🤖 Fix Carousel TS definition in React 18. [#35959](https://github.com/ant-design/ant-design/pull/35959)
   - 🤖 Fix missing semicolon in Dropdown TS type definition. [#36008](https://github.com/ant-design/ant-design/pull/36008) [@robothot](https://github.com/robothot)
-- Docs
-  - 📃 Fixed `onChange` description repeated twice in AutoComplete docs. [#36013](https://github.com/ant-design/ant-design/pull/36013) [@hinatades](https://github.com/hinatades)
-  - 📃 Fix interface in doc for Segmented component. [#35974](https://github.com/ant-design/ant-design/pull/35974) [@hoosin](https://github.com/hoosin)
 - 🌐 Localization
   - 🇮🇹 Fix italian translation for `Table.cancelSort` key. [#35970](https://github.com/ant-design/ant-design/pull/35970) [@gariggio](https://github.com/gariggio)
 

--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -20,7 +20,7 @@ timeline: true
 `2022-06-13`
 
 - 🐞 Fixed the `getContainer` property in Image not reading the settings in ConfigProvider. [#36002](https://github.com/ant-design/ant-design/pull/36002) [@robothot](https://github.com/robothot)
-- 🐞 Fixed the issue [#35952] where the `disabled` attribute does not take effect when a Button has `href`. [#35975](https://github.com/ant-design/ant-design/pull/35975) [@MuxinFeng](https://github.com/MuxinFeng)
+- 🐞 Fixed the issue [#35952](https://github.com/ant-design/ant-design/issues/35952) where the `disabled` attribute does not take effect when a Button has `href`. [#35975](https://github.com/ant-design/ant-design/pull/35975) [@MuxinFeng](https://github.com/MuxinFeng)
 - 🐞 Fix less color palette algorithm accord to `@ant-design/colors`. [#35954](https://github.com/ant-design/ant-design/pull/35954) [@christian-lechner](https://github.com/christian-lechner)
 - 🐞 Fix `animation-timing-function` in Upload. [#35943](https://github.com/ant-design/ant-design/pull/35943)
 - 💄 Remove styles from Form such as `status` for children of Modal and Drawer. [#35849](https://github.com/ant-design/ant-design/pull/35849)

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -28,7 +28,6 @@ timeline: true
   - 🤖 修复 Dropdown `autoFocus` 属性定义。[#35990](https://github.com/ant-design/ant-design/pull/35990) [@robothot](https://github.com/robothot)
   - 🤖 修复 Menu 中 `MenuItemGroupType` 的类型定义。[#35790](https://github.com/ant-design/ant-design/pull/35790) [@MasaoBlue](https://github.com/MasaoBlue)
   - 🤖 修复 Carousel 在 React 18 下的 TS 定义问题。[#35959](https://github.com/ant-design/ant-design/pull/35959)
-  - 🤖 修复 Dropdown TS 类型定义中缺少分号的问题。[#36008](https://github.com/ant-design/ant-design/pull/36008) [@robothot](https://github.com/robothot)
 - 🌐 国际化
   - 🇮🇹 修复 `Table.cancelSort` 的意大利语翻译。[#35970](https://github.com/ant-design/ant-design/pull/35970) [@gariggio](https://github.com/gariggio)
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -19,7 +19,7 @@ timeline: true
 
 `2022-06-13`
 
-- 🐞 修复 Image 中的 `getContainer` 属性没有读取 ConfigProvider 中的设置。[#36002](https://github.com/ant-design/ant-design/pull/36002) [@robothot](https://github.com/robothot)
+- 🐞 修复 Image `getContainer` 属性没有从 ConfigProvider 中读取的问题。[#36002](https://github.com/ant-design/ant-design/pull/36002) [@robothot](https://github.com/robothot)
 - 🐞 修复 Button 有 `href` 时 `disabled` 属性不生效的问题。[#35952](https://github.com/ant-design/ant-design/issues/35952)。[#35975](https://github.com/ant-design/ant-design/pull/35975) [@MuxinFeng](https://github.com/MuxinFeng)
 - 🐞 修复 Upload 组件动画闪烁的问题。[#35943](https://github.com/ant-design/ant-design/pull/35943)
 - 🐞 修复 less 色彩算法，使其和 `@ant-design/colors` 保持一致。[#35954](https://github.com/ant-design/ant-design/pull/35954) [@christian-lechner](https://github.com/christian-lechner)

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -21,7 +21,7 @@ timeline: true
 
 - 🐞 修复 Image 中的 `getContainer` 属性没有读取 ConfigProvider 中的设置。[#36002](https://github.com/ant-design/ant-design/pull/36002) [@robothot](https://github.com/robothot)
 - 🐞 修复 Button 有 `href` 时 `disabled` 属性不生效的问题 [#35952](https://github.com/ant-design/ant-design/issues/35952)。[#35975](https://github.com/ant-design/ant-design/pull/35975) [@MuxinFeng](https://github.com/MuxinFeng)
-- 🐞 修复 Upload 组件 `animtion-timing-function` 错误。[#35943](https://github.com/ant-design/ant-design/pull/35943)
+- 🐞 修复 Upload 组件动画闪烁的问题。[#35943](https://github.com/ant-design/ant-design/pull/35943)
 - 🐞 修复 less 色彩算法，使其和 `@ant-design/colors` 保持一致。[#35954](https://github.com/ant-design/ant-design/pull/35954) [@christian-lechner](https://github.com/christian-lechner)
 - 💄 Form.Item 中的 Modal 或 Drawer 组件包含的控件去除 `status` 等受 Form 影响的样式。[#35849](https://github.com/ant-design/ant-design/pull/35849)
 - TypeScript

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -25,7 +25,7 @@ timeline: true
 - 🐞 修复 less 色彩算法，使其和 `@ant-design/colors` 保持一致。[#35954](https://github.com/ant-design/ant-design/pull/35954) [@christian-lechner](https://github.com/christian-lechner)
 - 💄 Form.Item 中的 Modal 或 Drawer 组件包含的控件去除 `status` 等受 Form 影响的样式。[#35849](https://github.com/ant-design/ant-design/pull/35849)
 - TypeScript
-  - 🤖 修复 typescript 中的 `DropdownProps` 中的 `autoFocus` 属性定义。[#35990](https://github.com/ant-design/ant-design/pull/35990) [@robothot](https://github.com/robothot)
+  - 🤖 修复 Dropdown `autoFocus` 属性定义。[#35990](https://github.com/ant-design/ant-design/pull/35990) [@robothot](https://github.com/robothot)
   - 🤖 修复 Menu 中 `MenuItemGroupType` 的类型定义。[#35790](https://github.com/ant-design/ant-design/pull/35790) [@MasaoBlue](https://github.com/MasaoBlue)
   - 🤖 修复 Carousel 在 React 18 下的 TS 定义问题。[#35959](https://github.com/ant-design/ant-design/pull/35959)
   - 🤖 修复 Dropdown TS 类型定义中缺少分号的问题。[#36008](https://github.com/ant-design/ant-design/pull/36008) [@robothot](https://github.com/robothot)

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -20,7 +20,7 @@ timeline: true
 `2022-06-13`
 
 - 🐞 修复 Image 中的 `getContainer` 属性没有读取 ConfigProvider 中的设置。[#36002](https://github.com/ant-design/ant-design/pull/36002) [@robothot](https://github.com/robothot)
-- 🐞 修复 Button 有 `href` 时 `disabled` 属性不生效的问题 [#35952]。[#35975](https://github.com/ant-design/ant-design/pull/35975) [@MuxinFeng](https://github.com/MuxinFeng)
+- 🐞 修复 Button 有 `href` 时 `disabled` 属性不生效的问题 [#35952](https://github.com/ant-design/ant-design/issues/35952)。[#35975](https://github.com/ant-design/ant-design/pull/35975) [@MuxinFeng](https://github.com/MuxinFeng)
 - 🐞 修复 Upload 组件 `animtion-timing-function` 错误。[#35943](https://github.com/ant-design/ant-design/pull/35943)
 - 🐞 修复 less 色彩算法，使其和 `@ant-design/colors` 保持一致。[#35954](https://github.com/ant-design/ant-design/pull/35954) [@christian-lechner](https://github.com/christian-lechner)
 - 💄 Form.Item 中的 Modal 或 Drawer 组件包含的控件去除 `status` 等受 Form 影响的样式。[#35849](https://github.com/ant-design/ant-design/pull/35849)

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -15,6 +15,26 @@ timeline: true
 
 ---
 
+## 4.21.1
+
+`2022-06-13`
+
+- 🐞 修复 Image 中的 `getContainer` 属性没有读取 ConfigProvider 中的设置。[#36002](https://github.com/ant-design/ant-design/pull/36002) [@robothot](https://github.com/robothot)
+- 🐞 修复 Button 有 `href` 时 `disabled` 属性不生效的问题 [#35952]。[#35975](https://github.com/ant-design/ant-design/pull/35975) [@MuxinFeng](https://github.com/MuxinFeng)
+- 🐞 修复 Upload 组件 `animtion-timing-function` 错误。[#35943](https://github.com/ant-design/ant-design/pull/35943)
+- 🐞 修复 less 色彩算法，使其和 `@ant-design/colors` 保持一致。[#35954](https://github.com/ant-design/ant-design/pull/35954) [@christian-lechner](https://github.com/christian-lechner)
+- 💄 Form.Item 中的 Modal 或 Drawer 组件包含的控件去除 `status` 等受 Form 影响的样式。[#35849](https://github.com/ant-design/ant-design/pull/35849)
+- TypeScript
+  - 🤖 修复 typescript 中的 `DropdownProps` 中的 `autoFocus` 属性定义。[#35990](https://github.com/ant-design/ant-design/pull/35990) [@robothot](https://github.com/robothot)
+  - 🤖 修复 Menu 中 `MenuItemGroupType` 的类型定义。[#35790](https://github.com/ant-design/ant-design/pull/35790) [@MasaoBlue](https://github.com/MasaoBlue)
+  - 🤖 修复 Carousel 在 React 18 下的 TS 定义问题。[#35959](https://github.com/ant-design/ant-design/pull/35959)
+  - 🤖 修复 Dropdown TS 类型定义中缺少分号的问题。[#36008](https://github.com/ant-design/ant-design/pull/36008) [@robothot](https://github.com/robothot)
+- 文档
+  - 📃 修复了 AutoComplete 文档中重复两次的 `onChange` 描述。[#36013](https://github.com/ant-design/ant-design/pull/36013) [@hinatades](https://github.com/hinatades)
+  - 📃 修复 Segmented 组件文档中 interface 描述。[#35974](https://github.com/ant-design/ant-design/pull/35974) [@hoosin](https://github.com/hoosin)
+- 🌐 国际化
+  - 🇮🇹 修复 `Table.cancelSort` 的意大利语翻译。[#35970](https://github.com/ant-design/ant-design/pull/35970) [@gariggio](https://github.com/gariggio)
+
 ## 4.21.0
 
 `2022-06-06`

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -29,9 +29,6 @@ timeline: true
   - 🤖 修复 Menu 中 `MenuItemGroupType` 的类型定义。[#35790](https://github.com/ant-design/ant-design/pull/35790) [@MasaoBlue](https://github.com/MasaoBlue)
   - 🤖 修复 Carousel 在 React 18 下的 TS 定义问题。[#35959](https://github.com/ant-design/ant-design/pull/35959)
   - 🤖 修复 Dropdown TS 类型定义中缺少分号的问题。[#36008](https://github.com/ant-design/ant-design/pull/36008) [@robothot](https://github.com/robothot)
-- 文档
-  - 📃 修复了 AutoComplete 文档中重复两次的 `onChange` 描述。[#36013](https://github.com/ant-design/ant-design/pull/36013) [@hinatades](https://github.com/hinatades)
-  - 📃 修复 Segmented 组件文档中 interface 描述。[#35974](https://github.com/ant-design/ant-design/pull/35974) [@hoosin](https://github.com/hoosin)
 - 🌐 国际化
   - 🇮🇹 修复 `Table.cancelSort` 的意大利语翻译。[#35970](https://github.com/ant-design/ant-design/pull/35970) [@gariggio](https://github.com/gariggio)
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -20,7 +20,7 @@ timeline: true
 `2022-06-13`
 
 - 🐞 修复 Image 中的 `getContainer` 属性没有读取 ConfigProvider 中的设置。[#36002](https://github.com/ant-design/ant-design/pull/36002) [@robothot](https://github.com/robothot)
-- 🐞 修复 Button 有 `href` 时 `disabled` 属性不生效的问题 [#35952](https://github.com/ant-design/ant-design/issues/35952)。[#35975](https://github.com/ant-design/ant-design/pull/35975) [@MuxinFeng](https://github.com/MuxinFeng)
+- 🐞 修复 Button 有 `href` 时 `disabled` 属性不生效的问题。[#35952](https://github.com/ant-design/ant-design/issues/35952)。[#35975](https://github.com/ant-design/ant-design/pull/35975) [@MuxinFeng](https://github.com/MuxinFeng)
 - 🐞 修复 Upload 组件动画闪烁的问题。[#35943](https://github.com/ant-design/ant-design/pull/35943)
 - 🐞 修复 less 色彩算法，使其和 `@ant-design/colors` 保持一致。[#35954](https://github.com/ant-design/ant-design/pull/35954) [@christian-lechner](https://github.com/christian-lechner)
 - 💄 Form.Item 中的 Modal 或 Drawer 组件包含的控件去除 `status` 等受 Form 影响的样式。[#35849](https://github.com/ant-design/ant-design/pull/35849)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "antd",
-  "version": "4.21.0",
+  "version": "4.21.1",
   "description": "An enterprise-class UI design language and React components implementation",
   "title": "Ant Design",
   "keywords": [


### PR DESCRIPTION

## 4.21.1

`2022-06-13`

- 🐞 修复 Image 中的 `getContainer` 属性没有读取 ConfigProvider 中的设置。[#36002](https://github.com/ant-design/ant-design/pull/36002) [@robothot](https://github.com/robothot)
- 🐞 修复 Button 有 `href` 时 `disabled` 属性不生效的问题 [#35952](https://github.com/ant-design/ant-design/issues/35952)。[#35975](https://github.com/ant-design/ant-design/pull/35975) [@MuxinFeng](https://github.com/MuxinFeng)
- 🐞 修复 Upload 组件动画闪烁的问题。[#35943](https://github.com/ant-design/ant-design/pull/35943)
- 🐞 修复 less 色彩算法，使其和 `@ant-design/colors` 保持一致。[#35954](https://github.com/ant-design/ant-design/pull/35954) [@christian-lechner](https://github.com/christian-lechner)
- 💄 Form.Item 中的 Modal 或 Drawer 组件包含的控件去除 `status` 等受 Form 影响的样式。[#35849](https://github.com/ant-design/ant-design/pull/35849)
- TypeScript
  - 🤖 修复 typescript 中的 `DropdownProps` 中的 `autoFocus` 属性定义。[#35990](https://github.com/ant-design/ant-design/pull/35990) [@robothot](https://github.com/robothot)
  - 🤖 修复 Menu 中 `MenuItemGroupType` 的类型定义。[#35790](https://github.com/ant-design/ant-design/pull/35790) [@MasaoBlue](https://github.com/MasaoBlue)
  - 🤖 修复 Carousel 在 React 18 下的 TS 定义问题。[#35959](https://github.com/ant-design/ant-design/pull/35959)
  - 🤖 修复 Dropdown TS 类型定义中缺少分号的问题。[#36008](https://github.com/ant-design/ant-design/pull/36008) [@robothot](https://github.com/robothot)
- 🌐 国际化
  - 🇮🇹 修复 `Table.cancelSort` 的意大利语翻译。[#35970](https://github.com/ant-design/ant-design/pull/35970) [@gariggio](https://github.com/gariggio)

----------------- 

## 4.21.1

`2022-06-13`

- 🐞 Fixed Image the `getContainer` property not reading from ConfigProvider. [#36002](https://github.com/ant-design/ant-design/pull/36002) [@robothot](https://github.com/robothot)
- 🐞 Fixed Button issue [#35952](https://github.com/ant-design/ant-design/issues/35952) where the `disabled` attribute does not take effect with `href`. [#35975](https://github.com/ant-design/ant-design/pull/35975) [@MuxinFeng](https://github.com/MuxinFeng)
- 🐞 Fix less color palette algorithm according to `@ant-design/colors`. [#35954](https://github.com/ant-design/ant-design/pull/35954) [@christian-lechner](https://github.com/christian-lechner)
- 🐞 Fix Upload image flickering. [#35943](https://github.com/ant-design/ant-design/pull/35943)
- 💄 Remove styles from Form such as `status` for children of Modal and Drawer. [#35849](https://github.com/ant-design/ant-design/pull/35849)
- TypeScript
  - 🤖 Fix `autoFocus` property definition in `DropdownProps` in typescript. [#35990](https://github.com/ant-design/ant-design/pull/35990) [@robothot](https://github.com/robothot)
  - 🤖 Fix type definition of `MenuItemGroupType` in Menu. [#35790](https://github.com/ant-design/ant-design/pull/35790) [@MasaoBlue](https://github.com/MasaoBlue)
  - 🤖 Fix Carousel TS definition in React 18. [#35959](https://github.com/ant-design/ant-design/pull/35959)
  - 🤖 Fix missing semicolon in Dropdown TS type definition. [#36008](https://github.com/ant-design/ant-design/pull/36008) [@robothot](https://github.com/robothot)
- 🌐 Localization
  - 🇮🇹 Fix italian translation for `Table.cancelSort` key. [#35970](https://github.com/ant-design/ant-design/pull/35970) [@gariggio](https://github.com/gariggio)