### PR TITLE
fix: fix incorrect form status with noStyle

### DIFF
--- a/components/form/FormItem.tsx
+++ b/components/form/FormItem.tsx
@@ -217,14 +217,9 @@ function FormItem<Values = any>(props: FormItemProps<Values>): React.ReactElemen
   const getItemRef = useItemRef();
 
   // ======================== Status ========================
-  const { status: contextStatus, hasFeedback: contextHasFeedback } =
-    useContext(FormItemInputContext);
-
-  let mergedValidateStatus: ValidateStatus | undefined;
+  let mergedValidateStatus: ValidateStatus = '';
   if (validateStatus !== undefined) {
     mergedValidateStatus = validateStatus;
-  } else if (contextStatus !== undefined) {
-    mergedValidateStatus = contextStatus;
   } else if (meta?.validating) {
     mergedValidateStatus = 'validating';
   } else if (debounceErrors.length) {
@@ -235,11 +230,9 @@ function FormItem<Values = any>(props: FormItemProps<Values>): React.ReactElemen
     mergedValidateStatus = 'success';
   }
 
-  const mergedHasFeedback = hasFeedback || contextHasFeedback;
-
   const formItemStatusContext = useMemo<FormItemStatusContextProps>(() => {
     let feedbackIcon: ReactNode;
-    if (mergedHasFeedback) {
+    if (hasFeedback) {
       const IconNode = mergedValidateStatus && iconMap[mergedValidateStatus];
       feedbackIcon = IconNode ? (
         <span
@@ -255,19 +248,11 @@ function FormItem<Values = any>(props: FormItemProps<Values>): React.ReactElemen
 
     return {
       status: mergedValidateStatus,
-      hasFeedback: mergedHasFeedback,
+      hasFeedback,
       feedbackIcon,
       isFormItemInput: true,
     };
-  }, [mergedValidateStatus, mergedHasFeedback]);
-
-  const noOverrideFormItemContext = useMemo<FormItemStatusContextProps>(
-    () => ({
-      ...formItemStatusContext,
-      isFormItemInput: false,
-    }),
-    [formItemStatusContext],
-  );
+  }, [mergedValidateStatus, hasFeedback]);
 
   // ======================== Render ========================
   function renderLayout(
@@ -276,11 +261,7 @@ function FormItem<Values = any>(props: FormItemProps<Values>): React.ReactElemen
     isRequired?: boolean,
   ): React.ReactNode {
     if (noStyle && !hidden) {
-      return (
-        <FormItemInputContext.Provider value={noOverrideFormItemContext}>
-          {baseChildren}
-        </FormItemInputContext.Provider>
-      );
+      return baseChildren;
     }
 
     const itemClassName = {
@@ -290,7 +271,7 @@ function FormItem<Values = any>(props: FormItemProps<Values>): React.ReactElemen
       [`${className}`]: !!className,
 
       // Status
-      [`${prefixCls}-item-has-feedback`]: mergedValidateStatus && mergedHasFeedback,
+      [`${prefixCls}-item-has-feedback`]: mergedValidateStatus && hasFeedback,
       [`${prefixCls}-item-has-success`]: mergedValidateStatus === 'success',
       [`${prefixCls}-item-has-warning`]: mergedValidateStatus === 'warning',
       [`${prefixCls}-item-has-error`]: mergedValidateStatus === 'error',

--- a/components/form/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/form/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -6836,7 +6836,7 @@ exports[`renders ./components/form/demo/normal-login.md extend context correctly
           class="ant-form-item-control-input-content"
         >
           <label
-            class="ant-checkbox-wrapper ant-checkbox-wrapper-checked"
+            class="ant-checkbox-wrapper ant-checkbox-wrapper-checked ant-checkbox-wrapper-in-form-item"
           >
             <span
               class="ant-checkbox ant-checkbox-checked"
@@ -18031,7 +18031,7 @@ exports[`renders ./components/form/demo/validate-other.md extend context correct
           class="ant-form-item-control-input-content"
         >
           <div
-            class="ant-input-number"
+            class="ant-input-number ant-input-number-in-form-item"
           >
             <div
               class="ant-input-number-handler-wrap"

--- a/components/form/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/form/__tests__/__snapshots__/demo.test.js.snap
@@ -4451,7 +4451,7 @@ exports[`renders ./components/form/demo/normal-login.md correctly 1`] = `
           class="ant-form-item-control-input-content"
         >
           <label
-            class="ant-checkbox-wrapper ant-checkbox-wrapper-checked"
+            class="ant-checkbox-wrapper ant-checkbox-wrapper-checked ant-checkbox-wrapper-in-form-item"
           >
             <span
               class="ant-checkbox ant-checkbox-checked"
@@ -7257,7 +7257,7 @@ exports[`renders ./components/form/demo/validate-other.md correctly 1`] = `
           class="ant-form-item-control-input-content"
         >
           <div
-            class="ant-input-number"
+            class="ant-input-number ant-input-number-in-form-item"
           >
             <div
               class="ant-input-number-handler-wrap"

--- a/components/form/__tests__/index.test.js
+++ b/components/form/__tests__/index.test.js
@@ -1207,20 +1207,6 @@ describe('Form', () => {
     expect(subFormInstance).toBe(formInstance);
   });
 
-  it('noStyle should not be affected by parent', () => {
-    const Demo = () => (
-      <Form>
-        <Form.Item>
-          <Form.Item noStyle>
-            <Select className="custom-select" />
-          </Form.Item>
-        </Form.Item>
-      </Form>
-    );
-    const { container } = render(<Demo />);
-    expect(container.querySelector('.custom-select')?.className).not.toContain('in-form-item');
-  });
-
   it('noStyle should not affect status', () => {
     const Demo = () => (
       <Form>
@@ -1246,9 +1232,13 @@ describe('Form', () => {
     );
     const { container } = render(<Demo />);
     expect(container.querySelector('.custom-select')?.className).not.toContain('status-error');
+    expect(container.querySelector('.custom-select')?.className).not.toContain('in-form-item');
     expect(container.querySelector('.custom-select-b')?.className).toContain('status-error');
-    expect(container.querySelector('.custom-select-c')?.className).toContain('status-warning');
+    expect(container.querySelector('.custom-select-b')?.className).toContain('in-form-item');
+    expect(container.querySelector('.custom-select-c')?.className).toContain('status-error');
+    expect(container.querySelector('.custom-select-c')?.className).toContain('in-form-item');
     expect(container.querySelector('.custom-select-d')?.className).toContain('status-warning');
+    expect(container.querySelector('.custom-select-d')?.className).toContain('in-form-item');
   });
 
   it('should not affect Popup children style', () => {

--- a/components/form/__tests__/index.test.js
+++ b/components/form/__tests__/index.test.js
@@ -1237,12 +1237,18 @@ describe('Form', () => {
             <Select className="custom-select-c" />
           </Form.Item>
         </Form.Item>
+        <Form.Item noStyle>
+          <Form.Item validateStatus="warning">
+            <Select className="custom-select-d" />
+          </Form.Item>
+        </Form.Item>
       </Form>
     );
     const { container } = render(<Demo />);
-    expect(container.querySelector('.custom-select')?.className).toContain('status-error');
+    expect(container.querySelector('.custom-select')?.className).not.toContain('status-error');
     expect(container.querySelector('.custom-select-b')?.className).toContain('status-error');
     expect(container.querySelector('.custom-select-c')?.className).toContain('status-warning');
+    expect(container.querySelector('.custom-select-d')?.className).toContain('status-warning');
   });
 
   it('should not affect Popup children style', () => {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
close https://github.com/ant-design/ant-design/issues/36052
<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

Sample with code below:
```
<Form>
      <Form.Item validateStatus="error" noStyle>
        <Select className="custom-select" />
      </Form.Item>
      <Form.Item validateStatus="error">
        <Form.Item noStyle>
          <Select className="custom-select-b" />
        </Form.Item>
      </Form.Item>
      <Form.Item validateStatus="error">
        <Form.Item noStyle validateStatus="warning">
          <Select className="custom-select-c" />
        </Form.Item>
      </Form.Item>
      <Form.Item noStyle>
        <Form.Item validateStatus="warning">
          <Select className="custom-select-d" />
        </Form.Item>
      </Form.Item>
    </Form>
```

**v4.18.9**
https://codesandbox.io/s/form-methods-antd-4-21-1-forked-lcpmkq?file=/demo.js
![image](https://user-images.githubusercontent.com/27722486/173616090-af65798b-a002-44a5-9d99-e1e6889242bf.png)

**v4.21.0**
https://codesandbox.io/s/form-methods-antd-4-21-1-forked-3oddpq?file=/demo.js
![image](https://user-images.githubusercontent.com/27722486/173616143-5838194b-e0a8-4b13-9711-5a9748f66c41.png)

**v4.21.1**
https://codesandbox.io/s/form-methods-antd-4-21-1-forked-8ywwnt?file=/demo.js:991-1623
![image](https://user-images.githubusercontent.com/27722486/173616195-03e0ccc5-96ce-4bb8-ba65-b4deb52bc7b5.png)

So I REVERT related code, and correct test case.
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix incorrect Form status with `noStyle`.          |
| 🇨🇳 Chinese | 修复 Form 有 `noStyle` 属性时校验状态错误的问题。          |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
