### PR TITLE
style: Skeleton.Button square shape style

### DIFF
--- a/components/skeleton/Element.tsx
+++ b/components/skeleton/Element.tsx
@@ -6,7 +6,7 @@ export interface SkeletonElementProps {
   className?: string;
   style?: React.CSSProperties;
   size?: 'large' | 'small' | 'default' | number;
-  shape?: 'circle' | 'square' | 'round';
+  shape?: 'circle' | 'square' | 'round' | 'default';
   active?: boolean;
 }
 

--- a/components/skeleton/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/skeleton/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -114,7 +114,7 @@ Array [
         class="ant-skeleton ant-skeleton-element"
       >
         <span
-          class="ant-skeleton-button ant-skeleton-button-square"
+          class="ant-skeleton-button"
         />
       </div>
     </div>
@@ -148,7 +148,7 @@ Array [
     class="ant-skeleton ant-skeleton-element"
   >
     <span
-      class="ant-skeleton-button ant-skeleton-button-square"
+      class="ant-skeleton-button"
     />
   </div>,
   <br />,
@@ -387,6 +387,25 @@ Array [
                 >
                   <input
                     checked=""
+                    class="ant-radio-button-input"
+                    type="radio"
+                    value="default"
+                  />
+                  <span
+                    class="ant-radio-button-inner"
+                  />
+                </span>
+                <span>
+                  Default
+                </span>
+              </label>
+              <label
+                class="ant-radio-button-wrapper ant-radio-button-wrapper-in-form-item"
+              >
+                <span
+                  class="ant-radio-button"
+                >
+                  <input
                     class="ant-radio-button-input"
                     type="radio"
                     value="square"

--- a/components/skeleton/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/skeleton/__tests__/__snapshots__/demo.test.js.snap
@@ -114,7 +114,7 @@ Array [
         class="ant-skeleton ant-skeleton-element"
       >
         <span
-          class="ant-skeleton-button ant-skeleton-button-square"
+          class="ant-skeleton-button"
         />
       </div>
     </div>
@@ -148,7 +148,7 @@ Array [
     class="ant-skeleton ant-skeleton-element"
   >
     <span
-      class="ant-skeleton-button ant-skeleton-button-square"
+      class="ant-skeleton-button"
     />
   </div>,
   <br />,
@@ -387,6 +387,25 @@ Array [
                 >
                   <input
                     checked=""
+                    class="ant-radio-button-input"
+                    type="radio"
+                    value="default"
+                  />
+                  <span
+                    class="ant-radio-button-inner"
+                  />
+                </span>
+                <span>
+                  Default
+                </span>
+              </label>
+              <label
+                class="ant-radio-button-wrapper ant-radio-button-wrapper-in-form-item"
+              >
+                <span
+                  class="ant-radio-button"
+                >
+                  <input
                     class="ant-radio-button-input"
                     type="radio"
                     value="square"

--- a/components/skeleton/demo/element.md
+++ b/components/skeleton/demo/element.md
@@ -19,7 +19,7 @@ import { Divider, Form, Radio, Skeleton, Space, Switch } from 'antd';
 import React, { useState } from 'react';
 
 type SizeType = 'default' | 'small' | 'large';
-type ButtonShapeType = 'circle' | 'square' | 'round';
+type ButtonShapeType = 'circle' | 'square' | 'round' | 'default';
 type AvatarShapeType = 'circle' | 'square';
 
 const App: React.FC = () => {

--- a/components/skeleton/demo/element.md
+++ b/components/skeleton/demo/element.md
@@ -26,7 +26,7 @@ const App: React.FC = () => {
   const [active, setActive] = useState(false);
   const [block, setBlock] = useState(false);
   const [size, setSize] = useState<SizeType>('default');
-  const [buttonShape, setButtonShape] = useState<ButtonShapeType>('square');
+  const [buttonShape, setButtonShape] = useState<ButtonShapeType>('default');
   const [avatarShape, setAvatarShape] = useState<AvatarShapeType>('circle');
 
   const handleActiveChange = (checked: boolean) => {
@@ -82,6 +82,7 @@ const App: React.FC = () => {
         </Form.Item>
         <Form.Item label="Button Shape">
           <Radio.Group value={buttonShape} onChange={handleShapeButton}>
+            <Radio.Button value="default">Default</Radio.Button>
             <Radio.Button value="square">Square</Radio.Button>
             <Radio.Button value="round">Round</Radio.Button>
             <Radio.Button value="circle">Circle</Radio.Button>

--- a/components/skeleton/index.en-US.md
+++ b/components/skeleton/index.en-US.md
@@ -55,7 +55,7 @@ Provide a placeholder while you wait for content to load, or to visualise conten
 | --- | --- | --- | --- | --- |
 | active | Show animation effect | boolean | false |  |
 | block | Option to fit button width to its parent width | boolean | false | 4.17.0 |
-| shape | Set the shape of button | `circle` \| `round` \| `default` | - |  |
+| shape | Set the shape of button | `circle` \| `round` \| `square` \| `default` | - |  |
 | size | Set the size of button | `large` \| `small` \| `default` | - |  |
 
 ### SkeletonInputProps

--- a/components/skeleton/index.zh-CN.md
+++ b/components/skeleton/index.zh-CN.md
@@ -52,12 +52,12 @@ cover: https://gw.alipayobjects.com/zos/alicdn/KpcciCJgv/Skeleton.svg
 
 ### SkeletonButtonProps
 
-| 属性   | 说明                           | 类型                             | 默认值 | 版本   |
-| ------ | ------------------------------ | -------------------------------- | ------ | ------ |
-| active | 是否展示动画效果               | boolean                          | false  |        |
-| block  | 将按钮宽度调整为其父宽度的选项 | boolean                          | false  | 4.17.0 |
-| shape  | 指定按钮的形状                 | `circle` \| `round` \| `default` | -      |        |
-| size   | 设置按钮的大小                 | `large` \| `small` \| `default`  | -      |        |
+| 属性 | 说明 | 类型 | 默认值 | 版本 |
+| --- | --- | --- | --- | --- |
+| active | 是否展示动画效果 | boolean | false |  |
+| block | 将按钮宽度调整为其父宽度的选项 | boolean | false | 4.17.0 |
+| shape | 指定按钮的形状 | `circle` \| `round` \| `square` \| `default` | - |  |
+| size | 设置按钮的大小 | `large` \| `small` \| `default` | - |  |
 
 ### SkeletonInputProps
 

--- a/components/skeleton/style/index.less
+++ b/components/skeleton/style/index.less
@@ -229,6 +229,11 @@
   min-width: @size * 2;
   .skeleton-element-common-size(@size);
 
+  &.@{skeleton-button-prefix-cls}-square {
+    width: @size;
+    min-width: @size;
+  }
+
   &.@{skeleton-button-prefix-cls}-circle {
     width: @size;
     min-width: @size;


### PR DESCRIPTION
the Button's square shape style is same as Avator's that its width is equal to height,
and the old square shape become the default shape that its width is double bigger than height.

resolve #36119

<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | refactor Sketelon.Button square shape style that its width is equal to height, and old square shape become the default shape that its width is double size to height |
| 🇨🇳 Chinese | 重构 Sketelon.Button square shape 样式（宽高相等），之前的 square 改为默认样式（宽为高的两倍）|

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
