### PR TITLE
docs: update demo code

### DIFF
--- a/components/table/demo/virtual-list.md
+++ b/components/table/demo/virtual-list.md
@@ -40,7 +40,12 @@ const VirtualTable = (props: Parameters<typeof Table>[0]) => {
   const [connectObject] = useState<any>(() => {
     const obj = {};
     Object.defineProperty(obj, 'scrollLeft', {
-      get: () => null,
+      get: () => {
+        if (gridRef.current) {
+          return gridRef.current?.state?.scrollLeft;
+        }
+        return null;
+      },
       set: (scrollLeft: number) => {
         if (gridRef.current) {
           gridRef.current.scrollTo({ scrollLeft });


### PR DESCRIPTION


[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [x] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->
https://github.com/ant-design/ant-design/issues/36127

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

当修改table的dataSource时，拿不到正确的scrollBodyRef.scrollLeft而导致的header的scrollLeft不正确


```diff
const [connectObject] = useState(() => {
    const obj = {};
    Object.defineProperty(obj, "scrollLeft", {
-     get: () => null,
+     get: () => {
+       if (gridRef.current) {
+          return gridRef.current?.state?.scrollLeft;
+       }
+       return null;
+      },
      set: (scrollLeft) => {
        if (gridRef.current) {
          gridRef.current.scrollTo({
            scrollLeft
          });
        }
      }
    });
    return obj;
  });


```

### 📝 ~~Changelog~~

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | ~~Changelog~~ |
| ---------- | --------- |
| 🇺🇸 ~~English~~ |           |
| 🇨🇳 ~~Chinese~~ |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
