### PR TITLE
style: Code style optimization

### DIFF
--- a/components/result/index.tsx
+++ b/components/result/index.tsx
@@ -50,12 +50,13 @@ const ExceptionStatus = Object.keys(ExceptionMap);
  * @param {status, icon}
  */
 
-interface RenderIconProps {
+interface IconProps {
   prefixCls: string;
-  resultProps: ResultProps;
+  icon: React.ReactNode;
+  status: ResultStatusType;
 }
 
-const RenderIcon: React.FC<RenderIconProps> = ({ prefixCls, resultProps: { status, icon } }) => {
+const Icon: React.FC<IconProps> = ({ prefixCls, icon, status }) => {
   const className = classNames(`${prefixCls}-icon`);
 
   warning(
@@ -79,12 +80,12 @@ const RenderIcon: React.FC<RenderIconProps> = ({ prefixCls, resultProps: { statu
   return <div className={className}>{icon || iconNode}</div>;
 };
 
-interface RenderExtraProps {
+interface ExtraProps {
   prefixCls: string;
-  extraProps: ResultProps;
+  extra: React.ReactNode;
 }
 
-const RenderExtra: React.FC<RenderExtraProps> = ({ prefixCls, extraProps: { extra } }) => {
+const Extra: React.FC<ExtraProps> = ({ prefixCls, extra }) => {
   if (!extra) {
     return null;
   }
@@ -116,10 +117,10 @@ const Result: ResultType = ({
   });
   return (
     <div className={className} style={style}>
-      <RenderIcon prefixCls={prefixCls} resultProps={{ status, icon }} />
+      <Icon prefixCls={prefixCls} status={status} icon={icon} />
       <div className={`${prefixCls}-title`}>{title}</div>
       {subTitle && <div className={`${prefixCls}-subtitle`}>{subTitle}</div>}
-      <RenderExtra prefixCls={prefixCls} extraProps={{ extra }} />
+      <Extra prefixCls={prefixCls} extra={extra} />
       {children && <div className={`${prefixCls}-content`}>{children}</div>}
     </div>
   );

--- a/components/result/index.tsx
+++ b/components/result/index.tsx
@@ -1,9 +1,9 @@
-import * as React from 'react';
-import classNames from 'classnames';
 import CheckCircleFilled from '@ant-design/icons/CheckCircleFilled';
 import CloseCircleFilled from '@ant-design/icons/CloseCircleFilled';
 import ExclamationCircleFilled from '@ant-design/icons/ExclamationCircleFilled';
 import WarningFilled from '@ant-design/icons/WarningFilled';
+import classNames from 'classnames';
+import * as React from 'react';
 
 import { ConfigContext } from '../config-provider';
 import warning from '../_util/warning';
@@ -49,7 +49,13 @@ const ExceptionStatus = Object.keys(ExceptionMap);
  * @param prefixCls
  * @param {status, icon}
  */
-const renderIcon = (prefixCls: string, { status, icon }: ResultProps) => {
+
+interface RenderIconProps {
+  prefixCls: string;
+  resultProps: ResultProps;
+}
+
+const RenderIcon: React.FC<RenderIconProps> = ({ prefixCls, resultProps: { status, icon } }) => {
   const className = classNames(`${prefixCls}-icon`);
 
   warning(
@@ -73,8 +79,17 @@ const renderIcon = (prefixCls: string, { status, icon }: ResultProps) => {
   return <div className={className}>{icon || iconNode}</div>;
 };
 
-const renderExtra = (prefixCls: string, { extra }: ResultProps) =>
-  extra && <div className={`${prefixCls}-extra`}>{extra}</div>;
+interface RenderExtraProps {
+  prefixCls: string;
+  extraProps: ResultProps;
+}
+
+const RenderExtra: React.FC<RenderExtraProps> = ({ prefixCls, extraProps: { extra } }) => {
+  if (!extra) {
+    return null;
+  }
+  return <div className={`${prefixCls}-extra`}>{extra}</div>;
+};
 
 export interface ResultType extends React.FC<ResultProps> {
   PRESENTED_IMAGE_404: React.FC;
@@ -101,10 +116,10 @@ const Result: ResultType = ({
   });
   return (
     <div className={className} style={style}>
-      {renderIcon(prefixCls, { status, icon })}
+      <RenderIcon prefixCls={prefixCls} resultProps={{ status, icon }} />
       <div className={`${prefixCls}-title`}>{title}</div>
       {subTitle && <div className={`${prefixCls}-subtitle`}>{subTitle}</div>}
-      {renderExtra(prefixCls, { extra })}
+      <RenderExtra prefixCls={prefixCls} extraProps={{ extra }} />
       {children && <div className={`${prefixCls}-content`}>{children}</div>}
     </div>
   );


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [x] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

这个pr的改动是将两个返回jsx的函数改成React组件了，相比于调用函数的方式渲染jsx，通过调用组件的方式渲染jsx可以获得更好的性能（React组件会参与diff算法，而函数不会参与），关于这点的详细原因，可以看Dan在博客中的解释：
[https://overreacted.io/zh-hans/react-as-a-ui-runtime/#%E6%8E%A7%E5%88%B6%E5%8F%8D%E8%BD%AC](https://overreacted.io/zh-hans/react-as-a-ui-runtime/#%E6%8E%A7%E5%88%B6%E5%8F%8D%E8%BD%AC)

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Code style optimization |
| 🇨🇳 Chinese | 代码优化 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
