### PR TITLE
fix: Dropdown with group menu can not close

### DIFF
--- a/components/dropdown/__tests__/index.test.js
+++ b/components/dropdown/__tests__/index.test.js
@@ -142,7 +142,10 @@ describe('Dropdown', () => {
       });
     }
 
-    console.log(container.innerHTML);
+    // Motion End
+    fireEvent.animationEnd(container.querySelector('.ant-slide-up-leave-active'));
+
+    expect(container.querySelector('.ant-dropdown-hidden')).toBeTruthy();
 
     jest.useRealTimers();
   });

--- a/components/dropdown/__tests__/index.test.js
+++ b/components/dropdown/__tests__/index.test.js
@@ -1,10 +1,10 @@
-import React from 'react';
 import { mount } from 'enzyme';
+import React from 'react';
 import Dropdown from '..';
-import Menu from '../../menu';
 import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
-import { sleep } from '../../../tests/utils';
+import { act, fireEvent, render, sleep } from '../../../tests/utils';
+import Menu from '../../menu';
 
 describe('Dropdown', () => {
   mountTest(() => (
@@ -98,5 +98,52 @@ describe('Dropdown', () => {
         }),
       }),
     );
+  });
+
+  it('menu item with group', () => {
+    jest.useFakeTimers();
+    const { container } = render(
+      <Dropdown
+        trigger="click"
+        overlay={
+          <Menu
+            items={[
+              {
+                label: 'grp',
+                type: 'group',
+                children: [
+                  {
+                    label: '1',
+                    key: 1,
+                  },
+                ],
+              },
+            ]}
+          />
+        }
+      >
+        <a />
+      </Dropdown>,
+    );
+
+    // Open
+    fireEvent.click(container.querySelector('a'));
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    // Close
+    fireEvent.click(container.querySelector('.ant-dropdown-menu-item'));
+
+    // Force Motion move on
+    for (let i = 0; i < 10; i += 1) {
+      act(() => {
+        jest.runAllTimers();
+      });
+    }
+
+    console.log(container.innerHTML);
+
+    jest.useRealTimers();
   });
 });

--- a/components/dropdown/dropdown.tsx
+++ b/components/dropdown/dropdown.tsx
@@ -1,6 +1,8 @@
 import RightOutlined from '@ant-design/icons/RightOutlined';
 import classNames from 'classnames';
 import RcDropdown from 'rc-dropdown';
+import useEvent from 'rc-util/lib/hooks/useEvent';
+import useMergedState from 'rc-util/lib/hooks/useMergedState';
 import * as React from 'react';
 import { ConfigContext } from '../config-provider';
 import { OverrideProvider } from '../menu/OverrideContext';
@@ -116,6 +118,8 @@ const Dropdown: DropdownInterface = props => {
     disabled,
     getPopupContainer,
     overlayClassName,
+    visible,
+    onVisibleChange,
   } = props;
 
   const prefixCls = getPrefixCls('dropdown', customizePrefixCls);
@@ -132,20 +136,35 @@ const Dropdown: DropdownInterface = props => {
     disabled,
   });
 
-  const overlayClassNameCustomized = classNames(overlayClassName, {
-    [`${prefixCls}-rtl`]: direction === 'rtl',
-  });
-
   const triggerActions = disabled ? [] : trigger;
   let alignPoint;
   if (triggerActions && triggerActions.indexOf('contextMenu') !== -1) {
     alignPoint = true;
   }
 
+  // =========================== Visible ============================
+  const [mergedVisible, setVisible] = useMergedState(false, {
+    value: visible,
+  });
+
+  const onInnerVisibleChange = useEvent((nextVisible: boolean) => {
+    onVisibleChange?.(nextVisible);
+    setVisible(nextVisible);
+  });
+
+  // =========================== Overlay ============================
+  const overlayClassNameCustomized = classNames(overlayClassName, {
+    [`${prefixCls}-rtl`]: direction === 'rtl',
+  });
+
   const builtinPlacements = getPlacements({
     arrowPointAtCenter: typeof arrow === 'object' && arrow.pointAtCenter,
     autoAdjustOverflow: true,
   });
+
+  const onMenuClick = React.useCallback(() => {
+    setVisible(false);
+  }, []);
 
   const renderOverlay = () => {
     // rc-dropdown already can process the function of overlay, but we have check logic here.
@@ -172,6 +191,7 @@ const Dropdown: DropdownInterface = props => {
         }
         mode="vertical"
         selectable={false}
+        onClick={onMenuClick}
         validator={({ mode }) => {
           // Warning if use other mode
           warning(
@@ -186,10 +206,12 @@ const Dropdown: DropdownInterface = props => {
     );
   };
 
+  // ============================ Render ============================
   return (
     <RcDropdown
       alignPoint={alignPoint}
       {...props}
+      visible={mergedVisible}
       builtinPlacements={builtinPlacements}
       arrow={!!arrow}
       overlayClassName={overlayClassNameCustomized}
@@ -199,6 +221,7 @@ const Dropdown: DropdownInterface = props => {
       trigger={triggerActions}
       overlay={renderOverlay}
       placement={getPlacement()}
+      onVisibleChange={onInnerVisibleChange}
     >
       {dropdownTrigger}
     </RcDropdown>

--- a/components/menu/OverrideContext.tsx
+++ b/components/menu/OverrideContext.tsx
@@ -8,6 +8,7 @@ export interface OverrideContextProps {
   mode?: MenuProps['mode'];
   selectable?: boolean;
   validator?: (menuProps: Pick<MenuProps, 'mode'>) => void;
+  onClick?: () => void;
 }
 
 /** @private Internal Usage. Only used for Dropdown component. Do not use this in your production. */

--- a/components/menu/index.tsx
+++ b/components/menu/index.tsx
@@ -1,27 +1,28 @@
-import * as React from 'react';
+import EllipsisOutlined from '@ant-design/icons/EllipsisOutlined';
+import classNames from 'classnames';
 import type { MenuProps as RcMenuProps, MenuRef } from 'rc-menu';
 import RcMenu, { ItemGroup } from 'rc-menu';
-import classNames from 'classnames';
+import useEvent from 'rc-util/lib/hooks/useEvent';
 import omit from 'rc-util/lib/omit';
-import EllipsisOutlined from '@ant-design/icons/EllipsisOutlined';
+import * as React from 'react';
 import { forwardRef } from 'react';
-import SubMenu, { SubMenuProps } from './SubMenu';
-import Item, { MenuItemProps } from './MenuItem';
 import { ConfigContext } from '../config-provider';
-import warning from '../_util/warning';
 import type { SiderContextProps } from '../layout/Sider';
 import { SiderContext } from '../layout/Sider';
 import collapseMotion from '../_util/motion';
 import { cloneElement } from '../_util/reactNode';
-import MenuContext, { MenuTheme } from './MenuContext';
-import MenuDivider from './MenuDivider';
+import warning from '../_util/warning';
 import type { ItemType } from './hooks/useItems';
 import useItems from './hooks/useItems';
+import MenuContext, { MenuTheme } from './MenuContext';
+import MenuDivider from './MenuDivider';
+import Item, { MenuItemProps } from './MenuItem';
 import OverrideContext from './OverrideContext';
-
-export { MenuDividerProps } from './MenuDivider';
+import SubMenu, { SubMenuProps } from './SubMenu';
 
 export { MenuItemGroupProps } from 'rc-menu';
+export { MenuDividerProps } from './MenuDivider';
+export { MenuTheme, SubMenuProps, MenuItemProps };
 
 export type MenuMode = 'vertical' | 'vertical-left' | 'vertical-right' | 'horizontal' | 'inline';
 
@@ -46,6 +47,7 @@ type InternalMenuProps = MenuProps &
 
 const InternalMenu = forwardRef<MenuRef, InternalMenuProps>((props, ref) => {
   const override = React.useContext(OverrideContext) || {};
+
   const { getPrefixCls, getPopupContainer, direction } = React.useContext(ConfigContext);
 
   const rootPrefixCls = getPrefixCls();
@@ -62,6 +64,7 @@ const InternalMenu = forwardRef<MenuRef, InternalMenuProps>((props, ref) => {
     children,
     mode,
     selectable,
+    onClick,
     ...restProps
   } = props;
 
@@ -90,6 +93,13 @@ const InternalMenu = forwardRef<MenuRef, InternalMenuProps>((props, ref) => {
   );
 
   override.validator?.({ mode });
+
+  // ========================== Click ==========================
+  // Tell dropdown that item clicked
+  const onItemClick = useEvent<Required<MenuProps>['onClick']>((...args) => {
+    onClick?.(...args);
+    override?.onClick?.();
+  });
 
   // ========================== Mode ===========================
   const mergedMode = override.mode || mode;
@@ -148,6 +158,7 @@ const InternalMenu = forwardRef<MenuRef, InternalMenuProps>((props, ref) => {
           overflowedIndicatorPopupClassName={`${prefixCls}-${theme}`}
           mode={mergedMode}
           selectable={mergedSelectable}
+          onClick={onItemClick}
           {...passedProps}
           inlineCollapsed={mergedInlineCollapsed}
           className={menuClassName}
@@ -196,7 +207,5 @@ class Menu extends React.Component<MenuProps, {}> {
     );
   }
 }
-
-export { MenuTheme, SubMenuProps, MenuItemProps };
 
 export default Menu;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

fix #36047

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Fix Dropdown using Menu with group item can not close by click.       |
| 🇨🇳 Chinese |   修复 Dropdown 中 Menu 分组下的 Item 点击不会关闭的问题。       |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
