### PR TITLE
Fix breaks

### DIFF
--- a/site/theme/template/Home/util.tsx
+++ b/site/theme/template/Home/util.tsx
@@ -15,7 +15,7 @@ export function preLoad(list: string[]) {
   }
 }
 
-export function useSiteData<T>(): [T, boolean] {
+export function useSiteData<T extends object>(): [T, boolean] {
   const [data, setData] = React.useState<T>({} as any);
   const [loading, setLoading] = React.useState<boolean>(false);
 

--- a/site/theme/template/utils.tsx
+++ b/site/theme/template/utils.tsx
@@ -212,7 +212,7 @@ export function getMetaDescription(jml?: any[] | null) {
           .join('');
         return [tag, content];
       }),
-  ).find(p => p && typeof p === 'string' && !COMMON_TAGS.includes(p));
+  ).find(p => p && typeof p === 'string' && !COMMON_TAGS.includes(p)) as string;
   return paragraph;
 }
 


### PR DESCRIPTION
### 🤔 This is a ...

- [x] Bug fix

### 💡 Background and solution

There are two upcoming changes in TypeScript 4.8 that will catch some new errors.

The first is better checking of unconstrained type parameters, see https://github.com/microsoft/TypeScript/issues/49489

The second is some (??) change in inference that caused the call in `getMetaDescription` to return `unknown` instead of `any`. This is a correctness improvement but caused downstream breaks. I updated this function so it uniformly returns `string` now.