### PR TITLE
chore: fix Menu deprecated warning when item={undefined}

### DIFF
--- a/components/menu/__tests__/index.test.js
+++ b/components/menu/__tests__/index.test.js
@@ -816,6 +816,7 @@ describe('Menu', () => {
     );
     expect(onOpen).not.toHaveBeenCalled();
     expect(onClose).not.toHaveBeenCalled();
+    errorSpy.mockRestore();
   });
 
   // https://github.com/ant-design/ant-design/issues/18825
@@ -1001,5 +1002,14 @@ describe('Menu', () => {
     );
 
     expect(wrapper.render()).toMatchSnapshot();
+  });
+
+  it('should not warning deprecated message when items={undefined}', () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    mount(<Menu items={undefined} />);
+    expect(errorSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining('`children` will be removed in next major version'),
+    );
+    errorSpy.mockRestore();
   });
 });

--- a/components/menu/index.tsx
+++ b/components/menu/index.tsx
@@ -87,7 +87,7 @@ const InternalMenu = forwardRef<MenuRef, InternalMenuProps>((props, ref) => {
   );
 
   warning(
-    !!items && !children,
+    'items' in props && !children,
     'Menu',
     '`children` will be removed in next major version. Please use `items` instead.',
   );


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->
close https://github.com/ant-design/ant-design/issues/36164

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Menu deprecated warning when `item={undefined}`.        |
| 🇨🇳 Chinese | 修复 Menu `item={undefined}` 时会有废弃警告的问题。          |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
