### PR TITLE
fix: Upload listType="picture-card" select button when children is empty

### DIFF
--- a/components/upload/Upload.tsx
+++ b/components/upload/Upload.tsx
@@ -406,17 +406,19 @@ const InternalUpload: React.ForwardRefRenderFunction<unknown, UploadProps> = (pr
     </div>
   );
 
+  const uploadButton = renderUploadButton(children ? undefined : { display: 'none' });
+
   if (listType === 'picture-card') {
     return (
       <span className={classNames(`${prefixCls}-picture-card-wrapper`, className)}>
-        {renderUploadList(renderUploadButton(), !!children)}
+        {renderUploadList(uploadButton, !!children)}
       </span>
     );
   }
 
   return (
     <span className={className}>
-      {renderUploadButton(children ? undefined : { display: 'none' })}
+      {uploadButton}
       {renderUploadList()}
     </span>
   );

--- a/components/upload/__tests__/upload.test.js
+++ b/components/upload/__tests__/upload.test.js
@@ -937,8 +937,11 @@ describe('Upload', () => {
     );
 
     rerender(<Upload listType="picture-card" />);
-    expect(container.querySelector('.ant-upload-select-picture-card')).not.toHaveStyle({
-      display: 'none',
+    expect(container.querySelector('.ant-upload-select-picture-card')).toHaveClass(
+      'ant-upload-animate-inline-leave-start',
+    );
+    expect(container.querySelector('.ant-upload-select-picture-card')).toHaveStyle({
+      pointerEvents: 'none',
     });
 
     // Motion leave status change: start > active
@@ -947,10 +950,9 @@ describe('Upload', () => {
     });
 
     fireEvent.animationEnd(container.querySelector('.ant-upload-select-picture-card'));
-
-    expect(container.querySelector('.ant-upload-select-picture-card')).toHaveStyle({
-      display: 'none',
-    });
+    expect(container.querySelector('.ant-upload-select-picture-card')).not.toHaveClass(
+      'ant-upload-animate-inline-leave-start',
+    );
 
     jest.useRealTimers();
   });

--- a/components/upload/__tests__/uploadlist.test.js
+++ b/components/upload/__tests__/uploadlist.test.js
@@ -1499,4 +1499,43 @@ describe('Upload List', () => {
     });
     unmount();
   });
+
+  describe('should not display upload file-select button when listType is picture-card and children is empty', () => {
+    it('when showUploadList is true', () => {
+      const list = [
+        {
+          uid: '0',
+          name: 'xxx.png',
+          status: 'done',
+          url: 'https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png',
+          thumbUrl: 'https://zos.alipayobjects.com/rmsportal/IQKRngzUuFzJzGzRJXUs.png',
+        },
+      ];
+      const { container: wrapper, unmount } = render(
+        <Upload fileList={list} listType="picture-card" />,
+      );
+      expect(wrapper.querySelectorAll('.ant-upload-select').length).toBe(1);
+      expect(wrapper.querySelectorAll('.ant-upload-select')[0].style.display).toBe('none');
+      unmount();
+    });
+
+    // https://github.com/ant-design/ant-design/issues/36183
+    it('when showUploadList is false', () => {
+      const list = [
+        {
+          uid: '0',
+          name: 'xxx.png',
+          status: 'done',
+          url: 'https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png',
+          thumbUrl: 'https://zos.alipayobjects.com/rmsportal/IQKRngzUuFzJzGzRJXUs.png',
+        },
+      ];
+      const { container: wrapper, unmount } = render(
+        <Upload fileList={list} showUploadList={false} listType="picture-card" />,
+      );
+      expect(wrapper.querySelectorAll('.ant-upload-select').length).toBe(1);
+      expect(wrapper.querySelectorAll('.ant-upload-select')[0].style.display).toBe('none');
+      unmount();
+    });
+  });
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->
close #36183

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Upload `listType="picture-card"` select button not being hidden when children is empty.         |
| 🇨🇳 Chinese |  修复 Upload `listType="picture-card"` 当 children 为空时上传文件按钮没有隐藏的问题  |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
