### PR TITLE
fix: popover arrow support custom color

### DIFF
--- a/components/popover/style/index.less
+++ b/components/popover/style/index.less
@@ -129,6 +129,7 @@
     pointer-events: none;
 
     &-content {
+      --antd-arrow-background-color: @popover-bg;
       position: absolute;
       top: 0;
       right: 0;
@@ -141,7 +142,7 @@
       background-color: @popover-bg;
       content: '';
       pointer-events: auto;
-      .roundedArrow(@popover-arrow-width, 5px, @popover-bg);
+      .roundedArrow(@popover-arrow-width, 5px);
     }
   }
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
close https://github.com/ant-design/ant-design/issues/36230
<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Popover arrow color with custom `color` prop.          |
| 🇨🇳 Chinese | 修复 Popover 自定义 `color` 时箭头颜色问题。          |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
