### PR TITLE
fix: Fixed an error when the loading property of the Button component…

### DIFF
--- a/components/button/button.tsx
+++ b/components/button/button.tsx
@@ -190,7 +190,7 @@ const InternalButton: React.ForwardRefRenderFunction<unknown, ButtonProps> = (pr
 
   // =============== Update Loading ===============
   const loadingOrDelay: Loading =
-      loading?.delay ?? !!loading;
+      typeof loading === 'boolean' ? loading : loading?.delay;
 
   React.useEffect(() => {
     let delayTimer: number | null = null;

--- a/components/button/button.tsx
+++ b/components/button/button.tsx
@@ -190,7 +190,7 @@ const InternalButton: React.ForwardRefRenderFunction<unknown, ButtonProps> = (pr
 
   // =============== Update Loading ===============
   const loadingOrDelay: Loading =
-    typeof loading === 'object' && loading.delay ? loading.delay || true : !!loading;
+    Object.prototype.toString.call(loading) === '[object Object]' && loading.delay ? loading.delay || true : !!loading;
 
   React.useEffect(() => {
     let delayTimer: number | null = null;

--- a/components/button/button.tsx
+++ b/components/button/button.tsx
@@ -190,7 +190,7 @@ const InternalButton: React.ForwardRefRenderFunction<unknown, ButtonProps> = (pr
 
   // =============== Update Loading ===============
   const loadingOrDelay: Loading =
-      typeof loading === 'boolean' ? loading : loading?.delay;
+      typeof loading === 'boolean' ? loading : (loading?.delay || true);
 
   React.useEffect(() => {
     let delayTimer: number | null = null;

--- a/components/button/button.tsx
+++ b/components/button/button.tsx
@@ -190,7 +190,7 @@ const InternalButton: React.ForwardRefRenderFunction<unknown, ButtonProps> = (pr
 
   // =============== Update Loading ===============
   const loadingOrDelay: Loading =
-    Object.prototype.toString.call(loading) === '[object Object]' && loading.delay ? loading.delay || true : !!loading;
+      loading?.delay ?? !!loading;
 
   React.useEffect(() => {
     let delayTimer: number | null = null;


### PR DESCRIPTION
… was passed into null

<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

[https://github.com/ant-design/ant-design/issues/36282](https://github.com/ant-design/ant-design/issues/36282)

### 💡 Background and solution

- background:  An error occurs when the loading attribute of the Button component is passed into null
- solution： I hope to change typeof loading === 'object' in the source code to Object.prototype.toString.call(loading)
This will not report an error even if it is null. In this way, the scene component itself that will report an error should be avoided. No matter what parameters are passed in, the error will not cause the page to crash directly.

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     When determining whether the passed loading parameter is an object, change typeof to Object.prototype.toString.call     |
| 🇨🇳 Chinese |      判断传入的loading参数是否为对象时，把 typeof 改为 Object.prototype.toString.call     |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
