### PR TITLE
style: fix size of close icon on Modal header

### DIFF
--- a/components/style/themes/compact.less
+++ b/components/style/themes/compact.less
@@ -186,9 +186,10 @@
 
 // Modal
 // --
-@modal-header-padding: 11px @modal-header-padding-horizontal;
+@modal-header-padding-vertical: 11px;
+@modal-header-padding: @modal-header-padding-vertical @modal-header-padding-horizontal;
 @modal-footer-padding-vertical: @padding-sm;
-@modal-header-close-size: 44px;
+@modal-header-close-size: @modal-header-title-line-height + 2 * @modal-header-padding-vertical;
 @modal-confirm-body-padding: 24px 24px 16px;
 
 // Message

--- a/components/style/themes/default.less
+++ b/components/style/themes/default.less
@@ -561,7 +561,7 @@
 @modal-header-title-line-height: 22px;
 @modal-header-title-font-size: @font-size-lg;
 @modal-header-border-color-split: @border-color-split;
-@modal-header-close-size: 56px;
+@modal-header-close-size: @modal-header-title-line-height + 2 * @modal-header-padding-vertical;
 @modal-content-bg: @component-background;
 @modal-heading-color: @heading-color;
 @modal-close-color: @text-color-secondary;

--- a/components/style/themes/variable.less
+++ b/components/style/themes/variable.less
@@ -616,7 +616,7 @@
 @modal-header-title-line-height: 22px;
 @modal-header-title-font-size: @font-size-lg;
 @modal-header-border-color-split: @border-color-split;
-@modal-header-close-size: 56px;
+@modal-header-close-size: @modal-header-title-line-height + 2 * @modal-header-padding-vertical;
 @modal-content-bg: @component-background;
 @modal-heading-color: @heading-color;
 @modal-close-color: @text-color-secondary;


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue
close https://github.com/ant-design/ant-design/issues/36293

### 💡 需求背景和解决方案
修改 Modal 组件的 close icon 的长宽为 `header title 行高 + 2 * header 的 垂直 padding 尺寸`

![image](https://user-images.githubusercontent.com/11588555/176543815-5c0cd49d-004f-40b2-8058-e6de7f40aaa9.png)
![image](https://user-images.githubusercontent.com/11588555/176543858-8543eba5-bc31-4655-b578-ce156d613044.png)


### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | Fix Modal component close button size to keep the close icon in the vertical center of header |
| 🇨🇳 中文 | 修复 Modal 对话框的关闭按钮未在 header 内垂直居中的 BUG |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
