### PR TITLE
feat: space component support align stretch

### DIFF
--- a/components/space/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/space/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -148,6 +148,42 @@ exports[`renders ./components/space/demo/align.md extend context correctly 1`] =
       </div>
     </div>
   </div>
+  <div
+    class="space-align-block"
+  >
+    <div
+      class="ant-space ant-space-horizontal ant-space-align-stretch"
+    >
+      <div
+        class="ant-space-item"
+        style="margin-right:8px"
+      >
+        stretch
+      </div>
+      <div
+        class="ant-space-item"
+        style="margin-right:8px"
+      >
+        <button
+          class="ant-btn ant-btn-primary"
+          type="button"
+        >
+          <span>
+            Primary
+          </span>
+        </button>
+      </div>
+      <div
+        class="ant-space-item"
+      >
+        <span
+          class="mock-block"
+        >
+          Block
+        </span>
+      </div>
+    </div>
+  </div>
 </div>
 `;
 

--- a/components/space/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/space/__tests__/__snapshots__/demo.test.js.snap
@@ -148,6 +148,42 @@ exports[`renders ./components/space/demo/align.md correctly 1`] = `
       </div>
     </div>
   </div>
+  <div
+    class="space-align-block"
+  >
+    <div
+      class="ant-space ant-space-horizontal ant-space-align-stretch"
+    >
+      <div
+        class="ant-space-item"
+        style="margin-right:8px"
+      >
+        stretch
+      </div>
+      <div
+        class="ant-space-item"
+        style="margin-right:8px"
+      >
+        <button
+          class="ant-btn ant-btn-primary"
+          type="button"
+        >
+          <span>
+            Primary
+          </span>
+        </button>
+      </div>
+      <div
+        class="ant-space-item"
+      >
+        <span
+          class="mock-block"
+        >
+          Block
+        </span>
+      </div>
+    </div>
+  </div>
 </div>
 `;
 

--- a/components/space/demo/align.md
+++ b/components/space/demo/align.md
@@ -47,6 +47,13 @@ const App: React.FC = () => (
         <span className="mock-block">Block</span>
       </Space>
     </div>
+    <div className="space-align-block">
+      <Space align="stretch">
+        stretch
+        <Button type="primary">Primary</Button>
+        <span className="mock-block">Block</span>
+      </Space>
+    </div>
   </div>
 );
 

--- a/components/space/index.en-US.md
+++ b/components/space/index.en-US.md
@@ -16,7 +16,7 @@ Avoid components clinging together and set a unified space.
 
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
-| align | Align items | `start` \| `end` \|`center` \|`baseline` | - | 4.2.0 |
+| align | Align items | `start` \| `end` \|`center` \|`baseline` \|`stretch` | - | 4.2.0 |
 | direction | The space direction | `vertical` \| `horizontal` | `horizontal` | 4.1.0 |
 | size | The space size | [Size](#Size) \| [Size\[\]](#Size) | `small` | 4.1.0 \| Array: 4.9.0 |
 | split | Set split | ReactNode | - | 4.7.0 |

--- a/components/space/index.tsx
+++ b/components/space/index.tsx
@@ -22,7 +22,7 @@ export interface SpaceProps extends React.HTMLAttributes<HTMLDivElement> {
   size?: SpaceSize | [SpaceSize, SpaceSize];
   direction?: 'horizontal' | 'vertical';
   // No `stretch` since many components do not support that.
-  align?: 'start' | 'end' | 'center' | 'baseline';
+  align?: 'start' | 'end' | 'center' | 'baseline' | 'stretch';
   split?: React.ReactNode;
   wrap?: boolean;
 }

--- a/components/space/index.zh-CN.md
+++ b/components/space/index.zh-CN.md
@@ -20,7 +20,7 @@ cover: https://gw.alipayobjects.com/zos/antfincdn/wc6%263gJ0Y8/Space.svg
 
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
-| align | 对齐方式 | `start` \| `end` \|`center` \|`baseline` | - | 4.2.0 |
+| align | 对齐方式 | `start` \| `end` \|`center` \|`baseline` \|`stretch` | - | 4.2.0 |
 | direction | 间距方向 | `vertical` \| `horizontal` | `horizontal` | 4.1.0 |
 | size | 间距大小 | [Size](#Size) \| [Size\[\]](#Size) | `small` | 4.1.0 \| Array: 4.9.0 |
 | split | 设置拆分 | ReactNode | - | 4.7.0 |

--- a/components/space/style/index.less
+++ b/components/space/style/index.less
@@ -27,6 +27,10 @@
     &-baseline {
       align-items: baseline;
     }
+
+    &-stretch {
+      align-items: stretch;
+    }
   }
 }
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
close https://github.com/ant-design/ant-design/issues/36044

### 💡 Background and solution
I add a classname named &-stretch and set align-items to stretch in this classname style definition, I add the stretch align to the align type of Space component

![image](https://user-images.githubusercontent.com/11588555/176552589-e58cf972-c1b7-46f9-af9b-ba31e4ee7d6e.png)

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Space supports `align="stretch"` to allow children to be stretch-aligned. |
| 🇨🇳 Chinese | Space `align` 属性新增 `stretch` 以支持拉伸对齐的方式布局。 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
