### PR TITLE
fix: correct border radius when table has title

### DIFF
--- a/components/table/style/radius.less
+++ b/components/table/style/radius.less
@@ -1,5 +1,5 @@
 // ================================================================
-// =                         Border Radio                         =
+// =                         Border Radius                         =
 // ================================================================
 .@{table-prefix-cls} {
   /* title + table */
@@ -11,13 +11,17 @@
     border-top-left-radius: 0;
     border-top-right-radius: 0;
 
-    table > thead > tr:first-child {
-      th:first-child {
-        border-radius: 0;
-      }
+    table {
+      border-radius: 0;
 
-      th:last-child {
-        border-radius: 0;
+      > thead > tr:first-child {
+        th:first-child {
+          border-radius: 0;
+        }
+
+        th:last-child {
+          border-radius: 0;
+        }
       }
     }
   }


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

before

![image](https://user-images.githubusercontent.com/42885087/177287550-59e7f301-54fe-4935-9e3f-7370054bfc2b.png)

after

![image](https://user-images.githubusercontent.com/42885087/177287571-37826b85-d1b1-43c4-9886-58681f23400c.png)

in [here](https://ant.design/components/table/#components-table-demo-bordered)

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     correct border radius when table has title      |
| 🇨🇳 Chinese |      表格有标题时正确的边框半径     |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
