### PR TITLE
fix(Typography): editable onChange behavior

### DIFF
--- a/components/typography/Base/index.tsx
+++ b/components/typography/Base/index.tsx
@@ -165,6 +165,10 @@ const Base = React.forwardRef((props: InternalBlockProps, ref: any) => {
     setEditing(edit);
   };
 
+  const closeEdit = () => {
+    setEditing(false);
+  };
+
   // Focus edit icon when back
   useUpdatedEffect(() => {
     if (!editing) {
@@ -179,7 +183,6 @@ const Base = React.forwardRef((props: InternalBlockProps, ref: any) => {
 
   const onEditChange = (value: string) => {
     editConfig.onChange?.(value);
-    triggerEdit(false);
   };
 
   const onEditCancel = () => {
@@ -384,6 +387,7 @@ const Base = React.forwardRef((props: InternalBlockProps, ref: any) => {
         maxLength={editConfig.maxLength}
         autoSize={editConfig.autoSize}
         enterIcon={editConfig.enterIcon}
+        closeEdit={closeEdit}
       />
     );
   }

--- a/components/typography/Editable.tsx
+++ b/components/typography/Editable.tsx
@@ -21,6 +21,7 @@ interface EditableProps {
   autoSize?: boolean | AutoSizeType;
   enterIcon?: React.ReactNode;
   component?: string;
+  closeEdit: () => void;
 }
 
 const Editable: React.FC<EditableProps> = ({
@@ -37,11 +38,13 @@ const Editable: React.FC<EditableProps> = ({
   onEnd,
   component,
   enterIcon = <EnterOutlined />,
+  closeEdit,
 }) => {
   const ref = React.useRef<any>();
 
   const inComposition = React.useRef(false);
   const lastKeyCode = React.useRef<number>();
+  const originalValue = React.useRef<string>(value);
 
   const [current, setCurrent] = React.useState(value);
 
@@ -77,10 +80,6 @@ const Editable: React.FC<EditableProps> = ({
     lastKeyCode.current = keyCode;
   };
 
-  const confirmChange = () => {
-    onSave(current.trim());
-  };
-
   const onKeyUp: React.KeyboardEventHandler<HTMLTextAreaElement> = ({
     keyCode,
     ctrlKey,
@@ -88,6 +87,10 @@ const Editable: React.FC<EditableProps> = ({
     metaKey,
     shiftKey,
   }) => {
+    if (current !== value) {
+      onSave(current);
+    }
+
     // Check if it's a real key
     if (
       lastKeyCode.current === keyCode &&
@@ -98,16 +101,19 @@ const Editable: React.FC<EditableProps> = ({
       !shiftKey
     ) {
       if (keyCode === KeyCode.ENTER) {
-        confirmChange();
+        onSave(current.trim());
         onEnd?.();
+        closeEdit();
       } else if (keyCode === KeyCode.ESC) {
+        onSave(originalValue.current);
         onCancel();
       }
     }
   };
 
   const onBlur: React.FocusEventHandler<HTMLTextAreaElement> = () => {
-    confirmChange();
+    onSave(current.trim());
+    closeEdit();
   };
 
   const textClassName = component ? `${prefixCls}-${component}` : '';

--- a/components/typography/__tests__/index.test.tsx
+++ b/components/typography/__tests__/index.test.tsx
@@ -316,7 +316,7 @@ describe('Typography', () => {
             if (triggerType !== undefined && triggerType.indexOf('text') !== -1) {
               fireEvent.keyDown(wrapper.querySelector('textarea')!, { keyCode: KeyCode.ESC });
               fireEvent.keyUp(wrapper.querySelector('textarea')!, { keyCode: KeyCode.ESC });
-              expect(onChange).not.toHaveBeenCalled();
+              expect(onChange).toHaveBeenCalledWith('Bamboo');
             }
           }
 
@@ -377,17 +377,10 @@ describe('Typography', () => {
         fireEvent.keyUp(wrapper.querySelector('textarea')!, { keyCode: KeyCode.ENTER });
       });
 
-      testStep(
-        { name: 'by esc key' },
-        wrapper => {
-          fireEvent.keyDown(wrapper.querySelector('textarea')!, { keyCode: KeyCode.ESC });
-          fireEvent.keyUp(wrapper.querySelector('textarea')!, { keyCode: KeyCode.ESC });
-        },
-        onChange => {
-          // eslint-disable-next-line jest/no-standalone-expect
-          expect(onChange).not.toHaveBeenCalled();
-        },
-      );
+      testStep({ name: 'by esc key' }, wrapper => {
+        fireEvent.keyDown(wrapper.querySelector('textarea')!, { keyCode: KeyCode.ESC });
+        fireEvent.keyUp(wrapper.querySelector('textarea')!, { keyCode: KeyCode.ESC });
+      });
 
       testStep({ name: 'by blur' }, wrapper => {
         fireEvent.blur(wrapper.querySelector('textarea')!);
@@ -404,6 +397,42 @@ describe('Typography', () => {
       testStep({ name: 'trigger by icon', triggerType: ['icon'] });
       testStep({ name: 'trigger by text', triggerType: ['text'] });
       testStep({ name: 'trigger by both icon and text', triggerType: ['icon', 'text'] });
+
+      it('should trigger onChange when editing', () => {
+        const onChange = jest.fn();
+        const { container: wrapper } = render(
+          <Paragraph editable={{ onChange }}>Bamboo</Paragraph>,
+        );
+        fireEvent.click(wrapper.querySelectorAll('.ant-typography-edit')[0]);
+        fireEvent.change(wrapper.querySelector('textarea')!, {
+          target: { value: 'Bamboo ' },
+        });
+        fireEvent.keyUp(wrapper.querySelector('textarea')!);
+        expect(onChange).toHaveBeenCalledWith('Bamboo ');
+        fireEvent.change(wrapper.querySelector('textarea')!, {
+          target: { value: 'Bamboo1' },
+        });
+        fireEvent.keyUp(wrapper.querySelector('textarea')!);
+        expect(onChange).toHaveBeenCalledWith('Bamboo1');
+        fireEvent.change(wrapper.querySelector('textarea')!, {
+          target: { value: '' },
+        });
+        fireEvent.keyUp(wrapper.querySelector('textarea')!);
+        expect(onChange).toHaveBeenCalledWith('');
+      });
+
+      it('should not trigger onChange when value has no change', () => {
+        const onChange = jest.fn();
+        const { container: wrapper } = render(
+          <Paragraph editable={{ onChange }}>Bamboo</Paragraph>,
+        );
+        fireEvent.click(wrapper.querySelectorAll('.ant-typography-edit')[0]);
+        fireEvent.change(wrapper.querySelector('textarea')!, {
+          target: { value: 'Bamboo' },
+        });
+        fireEvent.keyUp(wrapper.querySelector('textarea')!);
+        expect(onChange).not.toHaveBeenCalled();
+      });
 
       it('should trigger onEnd when type Enter', () => {
         const onEnd = jest.fn();

--- a/components/typography/demo/interactive.md
+++ b/components/typography/demo/interactive.md
@@ -59,12 +59,24 @@ const App: React.FC = () => {
 
   return (
     <>
-      <Paragraph editable={{ onChange: setEditableStr }}>{editableStr}</Paragraph>
+      <Paragraph
+        editable={{
+          onChange: str => {
+            console.log('changed:', str);
+            setEditableStr(str);
+          },
+        }}
+      >
+        {editableStr}
+      </Paragraph>
       <Paragraph
         editable={{
           icon: <HighlightOutlined />,
           tooltip: 'click to edit text',
-          onChange: setCustomIconStr,
+          onChange: str => {
+            console.log('changed:', str);
+            setCustomIconStr(str);
+          },
         }}
       >
         {customIconStr}
@@ -81,7 +93,10 @@ const App: React.FC = () => {
       <Paragraph
         editable={{
           tooltip: 'click to edit text',
-          onChange: setClickTriggerStr,
+          onChange: str => {
+            console.log('changed:', str);
+            setClickTriggerStr(str);
+          },
           triggerType: chooseTrigger,
         }}
       >
@@ -91,7 +106,10 @@ const App: React.FC = () => {
         editable={{
           icon: <HighlightOutlined />,
           tooltip: 'click to edit text',
-          onChange: setCustomEnterIconStr,
+          onChange: str => {
+            console.log('changed:', str);
+            setCustomEnterIconStr(str);
+          },
           enterIcon: <CheckOutlined />,
         }}
       >
@@ -101,18 +119,32 @@ const App: React.FC = () => {
         editable={{
           icon: <HighlightOutlined />,
           tooltip: 'click to edit text',
-          onChange: setNoEnterIconStr,
+          onChange: str => {
+            console.log('changed:', str);
+            setNoEnterIconStr(str);
+          },
           enterIcon: null,
         }}
       >
         {noEnterIconStr}
       </Paragraph>
-      <Paragraph editable={{ tooltip: false, onChange: setHideTooltipStr }}>
+      <Paragraph
+        editable={{
+          tooltip: false,
+          onChange: str => {
+            console.log('changed:', str);
+            setHideTooltipStr(str);
+          },
+        }}
+      >
         {hideTooltipStr}
       </Paragraph>
       <Paragraph
         editable={{
-          onChange: setLengthLimitedStr,
+          onChange: str => {
+            console.log('changed:', str);
+            setLengthLimitedStr(str);
+          },
           maxLength: 50,
           autoSize: { maxRows: 5, minRows: 3 },
         }}


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [x] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->
#36382

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fix `editable.onChange` behavior for Typography component |
| 🇨🇳 Chinese |   修复 Typography 组件 `editable.onChange` 的异常行为     |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
