### PR TITLE
fix: SVG Upload Preview Error

### DIFF
--- a/components/upload/__tests__/uploadlist.test.js
+++ b/components/upload/__tests__/uploadlist.test.js
@@ -899,7 +899,7 @@ describe('Upload List', () => {
     unmount();
   });
 
-  it('upload image file should be converted to the base64', async () => {
+  it('upload non-svg image file should be converted to the base64', async () => {
     const mockFile = new File([''], 'foo.png', {
       type: 'image/png',
     });
@@ -924,6 +924,37 @@ describe('Upload List', () => {
     });
     await previewFunc(mockFile).then(dataUrl => {
       expect(dataUrl).toEqual('data:image/png;base64,');
+    });
+    unmount();
+  });
+
+  it('upload svg image file should be embedded inline directly in the preview data url', async () => {
+    const mockFile = new File(
+      ['<svg viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><foreignObject x="20" y="20" width="160" height="160"><div xmlns="http://www.w3.org/1999/xhtml">Test</div></foreignObject></svg>'], 
+      'bar.svg', 
+      { type: 'image/svg+xml' },
+    );
+
+    const previewFunc = jest.fn(previewImage);
+
+    const { unmount } = render(
+      <Upload
+        fileList={[
+          {
+            originFileObj: mockFile,
+          },
+        ]}
+        previewFile={previewFunc}
+        locale={{ uploading: 'uploading' }}
+        listType="picture-card"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(previewFunc).toHaveBeenCalled();
+    });
+    await previewFunc(mockFile).then(dataUrl => {
+      expect(dataUrl).toMatch(/^data:image\/svg\+xml;charset=utf-8,<svg.+\/svg>/);
     });
     unmount();
   });

--- a/components/upload/__tests__/uploadlist.test.js
+++ b/components/upload/__tests__/uploadlist.test.js
@@ -954,7 +954,7 @@ describe('Upload List', () => {
       expect(previewFunc).toHaveBeenCalled();
     });
     await previewFunc(mockFile).then(dataUrl => {
-      expect(dataUrl).toMatch(/^data:image\/svg\+xml;charset=utf-8,<svg.+\/svg>/);
+      expect(dataUrl).toMatch(/^data:image\/svg\+xml,<svg.+\/svg>/);
     });
     unmount();
   });

--- a/components/upload/__tests__/uploadlist.test.js
+++ b/components/upload/__tests__/uploadlist.test.js
@@ -899,7 +899,7 @@ describe('Upload List', () => {
     unmount();
   });
 
-  it('upload non-svg image file should be converted to the base64', async () => {
+  it('upload image file should be converted to the base64', async () => {
     const mockFile = new File([''], 'foo.png', {
       type: 'image/png',
     });
@@ -928,10 +928,12 @@ describe('Upload List', () => {
     unmount();
   });
 
-  it('upload svg image file should be embedded inline directly in the preview data url', async () => {
+  it('upload svg file with <foreignObject> should not have CORS error', async () => {
     const mockFile = new File(
-      ['<svg viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><foreignObject x="20" y="20" width="160" height="160"><div xmlns="http://www.w3.org/1999/xhtml">Test</div></foreignObject></svg>'], 
-      'bar.svg', 
+      [
+        '<svg viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><foreignObject x="20" y="20" width="160" height="160"><div xmlns="http://www.w3.org/1999/xhtml">Test</div></foreignObject></svg>',
+      ],
+      'bar.svg',
       { type: 'image/svg+xml' },
     );
 
@@ -939,11 +941,7 @@ describe('Upload List', () => {
 
     const { unmount } = render(
       <Upload
-        fileList={[
-          {
-            originFileObj: mockFile,
-          },
-        ]}
+        fileList={[{ originFileObj: mockFile }]}
         previewFile={previewFunc}
         locale={{ uploading: 'uploading' }}
         listType="picture-card"
@@ -954,7 +952,7 @@ describe('Upload List', () => {
       expect(previewFunc).toHaveBeenCalled();
     });
     await previewFunc(mockFile).then(dataUrl => {
-      expect(dataUrl).toMatch(/^data:image\/svg\+xml,<svg.+\/svg>/);
+      expect(dataUrl).toEqual('data:image/png;base64,');
     });
     unmount();
   });

--- a/components/upload/utils.tsx
+++ b/components/upload/utils.tsx
@@ -110,7 +110,7 @@ export function previewImage(file: File | Blob): Promise<string> {
 
       resolve(dataURL);
     };
-    img.setAttribute("crossOrigin", "anonymous");
+    img.crossOrigin = "anonymous";
     if (file.type.startsWith("image/svg+xml")) {
       img.src = `data:image/svg+xml;charset=utf-8,${file}`;
     } else {

--- a/components/upload/utils.tsx
+++ b/components/upload/utils.tsx
@@ -110,6 +110,11 @@ export function previewImage(file: File | Blob): Promise<string> {
 
       resolve(dataURL);
     };
-    img.src = window.URL.createObjectURL(file);
+    img.setAttribute("crossOrigin", "anonymous");
+    if (file.type.startsWith("image/svg+xml")) {
+      img.src = `data:image/svg+xml;charset=utf-8,${file}`;
+    } else {
+      img.src = window.URL.createObjectURL(file);
+    }
   });
 }

--- a/components/upload/utils.tsx
+++ b/components/upload/utils.tsx
@@ -112,7 +112,7 @@ export function previewImage(file: File | Blob): Promise<string> {
     };
     img.crossOrigin = "anonymous";
     if (file.type.startsWith("image/svg+xml")) {
-      img.src = `data:image/svg+xml;${file}`;
+      img.src = `data:image/svg+xml,${file}`;
     } else {
       img.src = window.URL.createObjectURL(file);
     }

--- a/components/upload/utils.tsx
+++ b/components/upload/utils.tsx
@@ -112,7 +112,7 @@ export function previewImage(file: File | Blob): Promise<string> {
     };
     img.crossOrigin = "anonymous";
     if (file.type.startsWith("image/svg+xml")) {
-      img.src = `data:image/svg+xml;charset=utf-8,${file}`;
+      img.src = `data:image/svg+xml;${file}`;
     } else {
       img.src = window.URL.createObjectURL(file);
     }

--- a/components/upload/utils.tsx
+++ b/components/upload/utils.tsx
@@ -112,7 +112,11 @@ export function previewImage(file: File | Blob): Promise<string> {
     };
     img.crossOrigin = "anonymous";
     if (file.type.startsWith("image/svg+xml")) {
-      img.src = `data:image/svg+xml,${file}`;
+      const reader = new FileReader();
+      reader.addEventListener('load', () => {
+        if (reader.result) img.src = reader.result as string;
+      });
+      reader.readAsDataURL(file);
     } else {
       img.src = window.URL.createObjectURL(file);
     }


### PR DESCRIPTION
### 🤔 This is a ...

- [x] Bug fix

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

#36388 SVG Upload Error

### 💡 Background and solution

Uploading an SVG that contains `<foreignObject>` results in console error if using the default image preview.

Error message:

```
SecurityError: Failed to execute 'toDataURL' on 'HTMLCanvasElement': Tainted canvases may not be exported.
```

It is a browser security protection that prevents cross origin URL from being used on `createObjectURL`.

Embedding the svg content directly as data url resolves the issue and permits image preview (i.e. using `readAsDataURL` instead of `createObjectURL` for SVG file).

https://stackoverflow.com/questions/50824012/why-does-this-svg-holding-blob-url-taint-the-canvas-in-chrome

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fixes `Upload` preview error on SVG with `<foreignObject>` and cross-origin links  |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
