### PR TITLE
fix: fix table container z-index

### DIFF
--- a/components/table/style/index.less
+++ b/components/table/style/index.less
@@ -647,7 +647,7 @@
       position: absolute;
       top: 0;
       bottom: 0;
-      z-index: 1;
+      z-index: @zindex-table-fixed;
       width: 30px;
       transition: box-shadow 0.3s;
       content: '';


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      /    |
| 🇨🇳 Chinese |      /   |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

before:
<img width="786" alt="image" src="https://user-images.githubusercontent.com/47295879/177799771-00529df4-3985-4079-8c5d-26a50e0ce6f9.png">


after:
<img width="809" alt="image" src="https://user-images.githubusercontent.com/47295879/177799502-e72e39ff-30de-44ca-a34c-191a167123a7.png">

