### PR TITLE
fix: breadcrumb seperators hidden when used in list

### DIFF
--- a/components/breadcrumb/style/index.less
+++ b/components/breadcrumb/style/index.less
@@ -38,7 +38,7 @@
     }
   }
 
-  li:last-child &-separator {
+  li:last-child > &-separator {
     display: none;
   }
 


### PR DESCRIPTION
[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close https://github.com/ant-design/ant-design/issues/36447

### 💡 Background and solution

When Breadcrumbs are used in a List the seperators are hidden on the last element. 
-> Set `display: none` only to direct children

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed Breadcrumb seperators disappearing when used as last element in a List |
| 🇨🇳 Chinese | - |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
