### PR TITLE
fix: tooltip cannot close on disabled Radio

### DIFF
--- a/components/radio/index.tsx
+++ b/components/radio/index.tsx
@@ -18,9 +18,11 @@ interface CompoundedComponent
   extends React.ForwardRefExoticComponent<RadioProps & React.RefAttributes<HTMLElement>> {
   Group: typeof Group;
   Button: typeof Button;
+  __ANT_RADIO: boolean;
 }
 
 const Radio = InternalRadio as CompoundedComponent;
 Radio.Button = Button;
 Radio.Group = Group;
+Radio.__ANT_RADIO = true;
 export default Radio;

--- a/components/tooltip/__tests__/tooltip.test.js
+++ b/components/tooltip/__tests__/tooltip.test.js
@@ -9,6 +9,7 @@ import DatePicker from '../../date-picker';
 import Input from '../../input';
 import Group from '../../input/Group';
 import Switch from '../../switch';
+import Radio from '../../radio';
 
 describe('Tooltip', () => {
   mountTest(Tooltip);
@@ -394,6 +395,25 @@ describe('Tooltip', () => {
         onVisibleChange={onVisibleChange}
       >
         <Switch loading defaultChecked />
+      </Tooltip>,
+    );
+    const wrapperEl = container.querySelectorAll('.ant-tooltip-disabled-compatible-wrapper');
+    expect(wrapperEl).toHaveLength(1);
+    fireEvent.mouseEnter(container.getElementsByTagName('span')[0]);
+    expect(onVisibleChange).toHaveBeenLastCalledWith(true);
+    expect(container.querySelector('.ant-tooltip-open')).not.toBeNull();
+  });
+
+  it('should work with disabled Radio', () => {
+    const onVisibleChange = jest.fn();
+    const { container } = render(
+      <Tooltip
+        title="loading tips"
+        mouseEnterDelay={0}
+        mouseLeaveDelay={0}
+        onVisibleChange={onVisibleChange}
+      >
+        <Radio disabled />
       </Tooltip>,
     );
     const wrapperEl = container.querySelectorAll('.ant-tooltip-disabled-compatible-wrapper');

--- a/components/tooltip/index.tsx
+++ b/components/tooltip/index.tsx
@@ -88,7 +88,7 @@ function getDisabledCompatibleChildren(element: React.ReactElement<any>, prefixC
   if (
     ((elementType.__ANT_BUTTON === true || element.type === 'button') && element.props.disabled) ||
     (elementType.__ANT_SWITCH === true && (element.props.disabled || element.props.loading)) ||
-    (elementType.__ANT_RADIO === true && (element.props.disabled || element.props.loading))
+    (elementType.__ANT_RADIO === true && element.props.disabled)
   ) {
     // Pick some layout related style properties up to span
     // Prevent layout bugs like https://github.com/ant-design/ant-design/issues/5254

--- a/components/tooltip/index.tsx
+++ b/components/tooltip/index.tsx
@@ -87,7 +87,8 @@ function getDisabledCompatibleChildren(element: React.ReactElement<any>, prefixC
   const elementType = element.type as any;
   if (
     ((elementType.__ANT_BUTTON === true || element.type === 'button') && element.props.disabled) ||
-    (elementType.__ANT_SWITCH === true && (element.props.disabled || element.props.loading))
+    (elementType.__ANT_SWITCH === true && (element.props.disabled || element.props.loading)) ||
+    (elementType.__ANT_RADIO === true && (element.props.disabled || element.props.loading))
   ) {
     // Pick some layout related style properties up to span
     // Prevent layout bugs like https://github.com/ant-design/ant-design/issues/5254


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
close https://github.com/ant-design/ant-design/issues/35967
<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix that Tooltip cannot close automaticly on disabled Radio.          |
| 🇨🇳 Chinese |  修复 Tooltip 在被禁用的 Radio 上时无法自动关闭的问题。         |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
