### PR TITLE
fix: Select with percent width leaves unexpected height in Form

### DIFF
--- a/components/form/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/form/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -848,6 +848,231 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
+      style="box-shadow:0 0 3px red"
+    >
+      <div
+        class="ant-col ant-col-24 ant-form-item-label"
+      >
+        <label
+          class=""
+          for="basic_select"
+          title=""
+        >
+          <a
+            href="https://github.com/ant-design/ant-design/issues/36459"
+          >
+            #36459
+          </a>
+        </label>
+      </div>
+      <div
+        class="ant-col ant-col-24 ant-form-item-control"
+      >
+        <div
+          class="ant-form-item-control-input"
+        >
+          <div
+            class="ant-form-item-control-input-content"
+          >
+            <div
+              class="ant-select ant-select-in-form-item ant-select-multiple ant-select-show-search"
+              style="width:70%"
+            >
+              <div
+                class="ant-select-selector"
+              >
+                <div
+                  class="ant-select-selection-overflow"
+                >
+                  <div
+                    class="ant-select-selection-overflow-item"
+                    style="opacity:1"
+                  >
+                    <span
+                      class="ant-select-selection-item"
+                      title="Bamboo"
+                    >
+                      <span
+                        class="ant-select-selection-item-content"
+                      >
+                        Bamboo
+                      </span>
+                      <span
+                        aria-hidden="true"
+                        class="ant-select-selection-item-remove"
+                        style="user-select:none;-webkit-user-select:none"
+                        unselectable="on"
+                      >
+                        <span
+                          aria-label="close"
+                          class="anticon anticon-close"
+                          role="img"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            data-icon="close"
+                            fill="currentColor"
+                            focusable="false"
+                            height="1em"
+                            viewBox="64 64 896 896"
+                            width="1em"
+                          >
+                            <path
+                              d="M563.8 512l262.5-312.9c4.4-5.2.7-13.1-6.1-13.1h-79.8c-4.7 0-9.2 2.1-12.3 5.7L511.6 449.8 295.1 191.7c-3-3.6-7.5-5.7-12.3-5.7H203c-6.8 0-10.5 7.9-6.1 13.1L459.4 512 196.9 824.9A7.95 7.95 0 00203 838h79.8c4.7 0 9.2-2.1 12.3-5.7l216.5-258.1 216.5 258.1c3 3.6 7.5 5.7 12.3 5.7h79.8c6.8 0 10.5-7.9 6.1-13.1L563.8 512z"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                    </span>
+                  </div>
+                  <div
+                    class="ant-select-selection-overflow-item ant-select-selection-overflow-item-suffix"
+                    style="opacity:1"
+                  >
+                    <div
+                      class="ant-select-selection-search"
+                      style="width:0"
+                    >
+                      <input
+                        aria-activedescendant="basic_select_list_0"
+                        aria-autocomplete="list"
+                        aria-controls="basic_select_list"
+                        aria-haspopup="listbox"
+                        aria-owns="basic_select_list"
+                        autocomplete="off"
+                        class="ant-select-selection-search-input"
+                        id="basic_select"
+                        readonly=""
+                        role="combobox"
+                        style="opacity:0"
+                        type="search"
+                        unselectable="on"
+                        value=""
+                      />
+                      <span
+                        aria-hidden="true"
+                        class="ant-select-selection-search-mirror"
+                      >
+                         
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div>
+                <div
+                  class="ant-select-dropdown"
+                  style="opacity:0"
+                >
+                  <div>
+                    <div
+                      id="basic_select_list"
+                      role="listbox"
+                      style="height:0;width:0;overflow:hidden"
+                    >
+                      <div
+                        aria-label="Bamboo"
+                        aria-selected="true"
+                        id="basic_select_list_0"
+                        role="option"
+                      >
+                        bamboo
+                      </div>
+                      <div
+                        aria-label="Little"
+                        aria-selected="false"
+                        id="basic_select_list_1"
+                        role="option"
+                      >
+                        little
+                      </div>
+                    </div>
+                    <div
+                      class="rc-virtual-list"
+                      style="position:relative"
+                    >
+                      <div
+                        class="rc-virtual-list-holder"
+                        style="max-height:256px;overflow-y:auto;overflow-anchor:none"
+                      >
+                        <div>
+                          <div
+                            class="rc-virtual-list-holder-inner"
+                            style="display:flex;flex-direction:column"
+                          >
+                            <div
+                              aria-selected="true"
+                              class="ant-select-item ant-select-item-option ant-select-item-option-active ant-select-item-option-selected"
+                              title="Bamboo"
+                            >
+                              <div
+                                class="ant-select-item-option-content"
+                              >
+                                Bamboo
+                              </div>
+                              <span
+                                aria-hidden="true"
+                                class="ant-select-item-option-state"
+                                style="user-select:none;-webkit-user-select:none"
+                                unselectable="on"
+                              >
+                                <span
+                                  aria-label="check"
+                                  class="anticon anticon-check"
+                                  role="img"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    data-icon="check"
+                                    fill="currentColor"
+                                    focusable="false"
+                                    height="1em"
+                                    viewBox="64 64 896 896"
+                                    width="1em"
+                                  >
+                                    <path
+                                      d="M912 190h-69.9c-9.8 0-19.1 4.5-25.1 12.2L404.7 724.5 207 474a32 32 0 00-25.1-12.2H112c-6.7 0-10.4 7.7-6.3 12.9l273.9 347c12.8 16.2 37.4 16.2 50.3 0l488.4-618.9c4.1-5.1.4-12.8-6.3-12.8z"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </div>
+                            <div
+                              aria-selected="false"
+                              class="ant-select-item ant-select-item-option"
+                              title="Little"
+                            >
+                              <div
+                                class="ant-select-item-option-content"
+                              >
+                                Little
+                              </div>
+                            </div>
+                            <div
+                              aria-selected="false"
+                              class="ant-select-item ant-select-item-option"
+                              title="Light"
+                            >
+                              <div
+                                class="ant-select-item-option-content"
+                              >
+                                Light
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="ant-row ant-form-item"
     >
       <div
         class="ant-col ant-col-24 ant-form-item-control"
@@ -994,6 +1219,239 @@ Array [
                 Submit
               </span>
             </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </form>,
+  <div
+    class="ant-divider ant-divider-horizontal"
+    role="separator"
+  />,
+  <form
+    class="ant-form ant-form-vertical"
+  >
+    <div
+      class="ant-row ant-form-item"
+      style="box-shadow:0 0 3px red"
+    >
+      <div
+        class="ant-col ant-form-item-label"
+      >
+        <label
+          class=""
+          for="select"
+          title=""
+        >
+          <a
+            href="https://github.com/ant-design/ant-design/issues/36459"
+          >
+            #36459
+          </a>
+        </label>
+      </div>
+      <div
+        class="ant-col ant-form-item-control"
+      >
+        <div
+          class="ant-form-item-control-input"
+        >
+          <div
+            class="ant-form-item-control-input-content"
+          >
+            <div
+              class="ant-select ant-select-in-form-item ant-select-multiple ant-select-show-search"
+              style="width:70%"
+            >
+              <div
+                class="ant-select-selector"
+              >
+                <div
+                  class="ant-select-selection-overflow"
+                >
+                  <div
+                    class="ant-select-selection-overflow-item"
+                    style="opacity:1"
+                  >
+                    <span
+                      class="ant-select-selection-item"
+                      title="Bamboo"
+                    >
+                      <span
+                        class="ant-select-selection-item-content"
+                      >
+                        Bamboo
+                      </span>
+                      <span
+                        aria-hidden="true"
+                        class="ant-select-selection-item-remove"
+                        style="user-select:none;-webkit-user-select:none"
+                        unselectable="on"
+                      >
+                        <span
+                          aria-label="close"
+                          class="anticon anticon-close"
+                          role="img"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            data-icon="close"
+                            fill="currentColor"
+                            focusable="false"
+                            height="1em"
+                            viewBox="64 64 896 896"
+                            width="1em"
+                          >
+                            <path
+                              d="M563.8 512l262.5-312.9c4.4-5.2.7-13.1-6.1-13.1h-79.8c-4.7 0-9.2 2.1-12.3 5.7L511.6 449.8 295.1 191.7c-3-3.6-7.5-5.7-12.3-5.7H203c-6.8 0-10.5 7.9-6.1 13.1L459.4 512 196.9 824.9A7.95 7.95 0 00203 838h79.8c4.7 0 9.2-2.1 12.3-5.7l216.5-258.1 216.5 258.1c3 3.6 7.5 5.7 12.3 5.7h79.8c6.8 0 10.5-7.9 6.1-13.1L563.8 512z"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                    </span>
+                  </div>
+                  <div
+                    class="ant-select-selection-overflow-item ant-select-selection-overflow-item-suffix"
+                    style="opacity:1"
+                  >
+                    <div
+                      class="ant-select-selection-search"
+                      style="width:0"
+                    >
+                      <input
+                        aria-activedescendant="select_list_0"
+                        aria-autocomplete="list"
+                        aria-controls="select_list"
+                        aria-haspopup="listbox"
+                        aria-owns="select_list"
+                        autocomplete="off"
+                        class="ant-select-selection-search-input"
+                        id="select"
+                        readonly=""
+                        role="combobox"
+                        style="opacity:0"
+                        type="search"
+                        unselectable="on"
+                        value=""
+                      />
+                      <span
+                        aria-hidden="true"
+                        class="ant-select-selection-search-mirror"
+                      >
+                         
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div>
+                <div
+                  class="ant-select-dropdown"
+                  style="opacity:0"
+                >
+                  <div>
+                    <div
+                      id="select_list"
+                      role="listbox"
+                      style="height:0;width:0;overflow:hidden"
+                    >
+                      <div
+                        aria-label="Bamboo"
+                        aria-selected="true"
+                        id="select_list_0"
+                        role="option"
+                      >
+                        bamboo
+                      </div>
+                      <div
+                        aria-label="Little"
+                        aria-selected="false"
+                        id="select_list_1"
+                        role="option"
+                      >
+                        little
+                      </div>
+                    </div>
+                    <div
+                      class="rc-virtual-list"
+                      style="position:relative"
+                    >
+                      <div
+                        class="rc-virtual-list-holder"
+                        style="max-height:256px;overflow-y:auto;overflow-anchor:none"
+                      >
+                        <div>
+                          <div
+                            class="rc-virtual-list-holder-inner"
+                            style="display:flex;flex-direction:column"
+                          >
+                            <div
+                              aria-selected="true"
+                              class="ant-select-item ant-select-item-option ant-select-item-option-active ant-select-item-option-selected"
+                              title="Bamboo"
+                            >
+                              <div
+                                class="ant-select-item-option-content"
+                              >
+                                Bamboo
+                              </div>
+                              <span
+                                aria-hidden="true"
+                                class="ant-select-item-option-state"
+                                style="user-select:none;-webkit-user-select:none"
+                                unselectable="on"
+                              >
+                                <span
+                                  aria-label="check"
+                                  class="anticon anticon-check"
+                                  role="img"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    data-icon="check"
+                                    fill="currentColor"
+                                    focusable="false"
+                                    height="1em"
+                                    viewBox="64 64 896 896"
+                                    width="1em"
+                                  >
+                                    <path
+                                      d="M912 190h-69.9c-9.8 0-19.1 4.5-25.1 12.2L404.7 724.5 207 474a32 32 0 00-25.1-12.2H112c-6.7 0-10.4 7.7-6.3 12.9l273.9 347c12.8 16.2 37.4 16.2 50.3 0l488.4-618.9c4.1-5.1.4-12.8-6.3-12.8z"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </div>
+                            <div
+                              aria-selected="false"
+                              class="ant-select-item ant-select-item-option"
+                              title="Little"
+                            >
+                              <div
+                                class="ant-select-item-option-content"
+                              >
+                                Little
+                              </div>
+                            </div>
+                            <div
+                              aria-selected="false"
+                              class="ant-select-item ant-select-item-option"
+                              title="Light"
+                            >
+                              <div
+                                class="ant-select-item-option-content"
+                              >
+                                Light
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
           </div>
         </div>
       </div>

--- a/components/form/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/form/__tests__/__snapshots__/demo.test.js.snap
@@ -684,6 +684,124 @@ Array [
     </div>
     <div
       class="ant-row ant-form-item"
+      style="box-shadow:0 0 3px red"
+    >
+      <div
+        class="ant-col ant-col-24 ant-form-item-label"
+      >
+        <label
+          class=""
+          for="basic_select"
+          title=""
+        >
+          <a
+            href="https://github.com/ant-design/ant-design/issues/36459"
+          >
+            #36459
+          </a>
+        </label>
+      </div>
+      <div
+        class="ant-col ant-col-24 ant-form-item-control"
+      >
+        <div
+          class="ant-form-item-control-input"
+        >
+          <div
+            class="ant-form-item-control-input-content"
+          >
+            <div
+              class="ant-select ant-select-in-form-item ant-select-multiple ant-select-show-search"
+              style="width:70%"
+            >
+              <div
+                class="ant-select-selector"
+              >
+                <div
+                  class="ant-select-selection-overflow"
+                >
+                  <div
+                    class="ant-select-selection-overflow-item"
+                    style="opacity:1"
+                  >
+                    <span
+                      class="ant-select-selection-item"
+                      title="Bamboo"
+                    >
+                      <span
+                        class="ant-select-selection-item-content"
+                      >
+                        Bamboo
+                      </span>
+                      <span
+                        aria-hidden="true"
+                        class="ant-select-selection-item-remove"
+                        style="user-select:none;-webkit-user-select:none"
+                        unselectable="on"
+                      >
+                        <span
+                          aria-label="close"
+                          class="anticon anticon-close"
+                          role="img"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            data-icon="close"
+                            fill="currentColor"
+                            focusable="false"
+                            height="1em"
+                            viewBox="64 64 896 896"
+                            width="1em"
+                          >
+                            <path
+                              d="M563.8 512l262.5-312.9c4.4-5.2.7-13.1-6.1-13.1h-79.8c-4.7 0-9.2 2.1-12.3 5.7L511.6 449.8 295.1 191.7c-3-3.6-7.5-5.7-12.3-5.7H203c-6.8 0-10.5 7.9-6.1 13.1L459.4 512 196.9 824.9A7.95 7.95 0 00203 838h79.8c4.7 0 9.2-2.1 12.3-5.7l216.5-258.1 216.5 258.1c3 3.6 7.5 5.7 12.3 5.7h79.8c6.8 0 10.5-7.9 6.1-13.1L563.8 512z"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                    </span>
+                  </div>
+                  <div
+                    class="ant-select-selection-overflow-item ant-select-selection-overflow-item-suffix"
+                    style="opacity:1"
+                  >
+                    <div
+                      class="ant-select-selection-search"
+                      style="width:0"
+                    >
+                      <input
+                        aria-activedescendant="basic_select_list_0"
+                        aria-autocomplete="list"
+                        aria-controls="basic_select_list"
+                        aria-haspopup="listbox"
+                        aria-owns="basic_select_list"
+                        autocomplete="off"
+                        class="ant-select-selection-search-input"
+                        id="basic_select"
+                        readonly=""
+                        role="combobox"
+                        style="opacity:0"
+                        type="search"
+                        unselectable="on"
+                        value=""
+                      />
+                      <span
+                        aria-hidden="true"
+                        class="ant-select-selection-search-mirror"
+                      >
+                         
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="ant-row ant-form-item"
     >
       <div
         class="ant-col ant-col-24 ant-form-item-control"
@@ -830,6 +948,132 @@ Array [
                 Submit
               </span>
             </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </form>,
+  <div
+    class="ant-divider ant-divider-horizontal"
+    role="separator"
+  />,
+  <form
+    class="ant-form ant-form-vertical"
+  >
+    <div
+      class="ant-row ant-form-item"
+      style="box-shadow:0 0 3px red"
+    >
+      <div
+        class="ant-col ant-form-item-label"
+      >
+        <label
+          class=""
+          for="select"
+          title=""
+        >
+          <a
+            href="https://github.com/ant-design/ant-design/issues/36459"
+          >
+            #36459
+          </a>
+        </label>
+      </div>
+      <div
+        class="ant-col ant-form-item-control"
+      >
+        <div
+          class="ant-form-item-control-input"
+        >
+          <div
+            class="ant-form-item-control-input-content"
+          >
+            <div
+              class="ant-select ant-select-in-form-item ant-select-multiple ant-select-show-search"
+              style="width:70%"
+            >
+              <div
+                class="ant-select-selector"
+              >
+                <div
+                  class="ant-select-selection-overflow"
+                >
+                  <div
+                    class="ant-select-selection-overflow-item"
+                    style="opacity:1"
+                  >
+                    <span
+                      class="ant-select-selection-item"
+                      title="Bamboo"
+                    >
+                      <span
+                        class="ant-select-selection-item-content"
+                      >
+                        Bamboo
+                      </span>
+                      <span
+                        aria-hidden="true"
+                        class="ant-select-selection-item-remove"
+                        style="user-select:none;-webkit-user-select:none"
+                        unselectable="on"
+                      >
+                        <span
+                          aria-label="close"
+                          class="anticon anticon-close"
+                          role="img"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            data-icon="close"
+                            fill="currentColor"
+                            focusable="false"
+                            height="1em"
+                            viewBox="64 64 896 896"
+                            width="1em"
+                          >
+                            <path
+                              d="M563.8 512l262.5-312.9c4.4-5.2.7-13.1-6.1-13.1h-79.8c-4.7 0-9.2 2.1-12.3 5.7L511.6 449.8 295.1 191.7c-3-3.6-7.5-5.7-12.3-5.7H203c-6.8 0-10.5 7.9-6.1 13.1L459.4 512 196.9 824.9A7.95 7.95 0 00203 838h79.8c4.7 0 9.2-2.1 12.3-5.7l216.5-258.1 216.5 258.1c3 3.6 7.5 5.7 12.3 5.7h79.8c6.8 0 10.5-7.9 6.1-13.1L563.8 512z"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                    </span>
+                  </div>
+                  <div
+                    class="ant-select-selection-overflow-item ant-select-selection-overflow-item-suffix"
+                    style="opacity:1"
+                  >
+                    <div
+                      class="ant-select-selection-search"
+                      style="width:0"
+                    >
+                      <input
+                        aria-activedescendant="select_list_0"
+                        aria-autocomplete="list"
+                        aria-controls="select_list"
+                        aria-haspopup="listbox"
+                        aria-owns="select_list"
+                        autocomplete="off"
+                        class="ant-select-selection-search-input"
+                        id="select"
+                        readonly=""
+                        role="combobox"
+                        style="opacity:0"
+                        type="search"
+                        unselectable="on"
+                        value=""
+                      />
+                      <span
+                        aria-hidden="true"
+                        class="ant-select-selection-search-mirror"
+                      >
+                         
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
           </div>
         </div>
       </div>

--- a/components/form/demo/col-24-debug.md
+++ b/components/form/demo/col-24-debug.md
@@ -15,8 +15,27 @@ See issue [#32980](https://github.com/ant-design/ant-design/issues/32980).
 See issue [#32980](https://github.com/ant-design/ant-design/issues/32980).
 
 ```tsx
-import { Button, Form, Input } from 'antd';
+import { Button, Select, Form, Input, Divider } from 'antd';
 import React from 'react';
+
+const sharedItem = (
+  <Form.Item
+    label={<a href="https://github.com/ant-design/ant-design/issues/36459">#36459</a>}
+    initialValue={['bamboo']}
+    name="select"
+    style={{ boxShadow: '0 0 3px red' }}
+  >
+    <Select
+      style={{ width: '70%' }}
+      mode="multiple"
+      options={[
+        { label: 'Bamboo', value: 'bamboo' },
+        { label: 'Little', value: 'little' },
+        { label: 'Light', value: 'light' },
+      ]}
+    />
+  </Form.Item>
+);
 
 const App: React.FC = () => {
   const onFinish = (values: any) => {
@@ -53,6 +72,8 @@ const App: React.FC = () => {
         >
           <Input.Password />
         </Form.Item>
+
+        {sharedItem}
 
         <Form.Item>
           <Button type="primary" htmlType="submit">
@@ -91,6 +112,10 @@ const App: React.FC = () => {
           </Button>
         </Form.Item>
       </Form>
+
+      <Divider />
+
+      <Form layout="vertical">{sharedItem}</Form>
     </>
   );
 };

--- a/components/form/style/vertical.less
+++ b/components/form/style/vertical.less
@@ -45,6 +45,10 @@
     &-label > label {
       height: auto;
     }
+
+    .@{form-prefix-cls}-item-control {
+      width: 100%;
+    }
   }
 }
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

fix #36459

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Fix Form with percentage width Select may leaves unexpected height.     |
| 🇨🇳 Chinese |    修复 Form 下设置 Select 百分比宽度时会有未预期空行问题。      |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
