### PR TITLE
fix(modal):  Modal.xxx onCancel close argument is not a function 

### DIFF
--- a/components/modal/__tests__/confirm.test.js
+++ b/components/modal/__tests__/confirm.test.js
@@ -305,7 +305,7 @@ describe('Modal.confirm triggers callbacks correctly', () => {
   });
 
   describe('should not close modals when click confirm button when onOk has argument', () => {
-    ['info', 'success', 'warning', 'error'].forEach(type => {
+    ['confirm', 'info', 'success', 'warning', 'error'].forEach(type => {
       it(type, async () => {
         jest.useFakeTimers();
         Modal[type]({
@@ -318,7 +318,7 @@ describe('Modal.confirm triggers callbacks correctly', () => {
           await sleep();
         });
         expect($$(`.ant-modal-confirm-${type}`)).toHaveLength(1);
-        $$('.ant-btn')[0].click();
+        $$('.ant-btn-primary')[0].click();
 
         await act(async () => {
           jest.runAllTimers();
@@ -673,5 +673,150 @@ describe('Modal.confirm triggers callbacks correctly', () => {
     await sleep();
     const { width } = $$('.ant-modal-body')[0].style;
     expect(width).toBe('500px');
+  });
+
+  describe('the callback close should be a method when onCancel has a close parameter', () => {
+    ['confirm', 'info', 'success', 'warning', 'error'].forEach(type => {
+      it(`click the close icon to trigger ${type} onCancel`, async () => {
+        jest.useFakeTimers();
+        const mock = jest.fn();
+
+        Modal[type]({
+          closable: true,
+          onCancel: close => mock(close),
+        });
+
+        await act(async () => {
+          jest.runAllTimers();
+          await sleep();
+        });
+
+        expect($$(`.ant-modal-confirm-${type}`)).toHaveLength(1);
+        $$('.ant-modal-close')[0].click();
+
+        await act(async () => {
+          jest.runAllTimers();
+          await sleep();
+        });
+
+        expect($$(`.ant-modal-confirm-${type}`)).toHaveLength(0);
+        expect(mock).toBeCalledWith(expect.any(Function));
+
+        jest.useRealTimers();
+      });
+    });
+
+    ['confirm', 'info', 'success', 'warning', 'error'].forEach(type => {
+      it(`press ESC to trigger ${type} onCancel`, async () => {
+        jest.useFakeTimers();
+        const mock = jest.fn();
+
+        Modal[type]({
+          keyboard: true,
+          onCancel: close => mock(close),
+        });
+
+        jest.runAllTimers();
+        await sleep();
+        jest.runAllTimers();
+
+        expect($$(`.ant-modal-confirm-${type}`)).toHaveLength(1);
+        TestUtils.Simulate.keyDown($$('.ant-modal')[0], {
+          keyCode: KeyCode.ESC,
+        });
+
+        jest.runAllTimers();
+        await sleep(0);
+        jest.runAllTimers();
+
+        expect($$(`.ant-modal-confirm-${type}`)).toHaveLength(0);
+        expect(mock).toBeCalledWith(expect.any(Function));
+
+        jest.useRealTimers();
+      });
+    });
+
+    ['confirm', 'info', 'success', 'warning', 'error'].forEach(type => {
+      it(`click the mask to trigger ${type} onCancel`, async () => {
+        jest.useFakeTimers();
+        const mock = jest.fn();
+
+        Modal[type]({
+          maskClosable: true,
+          onCancel: close => mock(close),
+        });
+
+        await act(async () => {
+          jest.runAllTimers();
+          await sleep();
+        });
+
+        expect($$('.ant-modal-mask')).toHaveLength(1);
+        expect($$(`.ant-modal-confirm-${type}`)).toHaveLength(1);
+
+        $$('.ant-modal-wrap')[0].click();
+
+        await act(async () => {
+          jest.runAllTimers();
+          await sleep();
+        });
+
+        expect($$(`.ant-modal-confirm-${type}`)).toHaveLength(0);
+        expect(mock).toBeCalledWith(expect.any(Function));
+
+        jest.useRealTimers();
+      });
+    });
+  });
+
+  it('confirm modal click Cancel button close callback is a function', async () => {
+    jest.useFakeTimers();
+    const mock = jest.fn();
+
+    Modal.confirm({
+      onCancel: close => mock(close),
+    });
+
+    await act(async () => {
+      jest.runAllTimers();
+      await sleep();
+    });
+
+    $$('.ant-modal-confirm-btns > .ant-btn')[0].click();
+
+    await act(async () => {
+      jest.runAllTimers();
+      await sleep();
+    });
+
+    expect(mock).toBeCalledWith(expect.any(Function));
+
+    jest.useRealTimers();
+  });
+
+  it('close can close modal when onCancel has a close parameter', async () => {
+    jest.useFakeTimers();
+
+    Modal.confirm({
+      onCancel: close => close(),
+    });
+
+    await act(async () => {
+      jest.runAllTimers();
+      await sleep();
+    });
+
+    expect($$('.ant-modal-confirm-confirm')).toHaveLength(1);
+
+    $$('.ant-modal-confirm-btns > .ant-btn')[0].click();
+
+    await act(async () => {
+      jest.runAllTimers();
+      await sleep();
+    });
+
+    expect($$('.ant-modal-confirm-confirm')).toHaveLength(0);
+
+    jest.useRealTimers();
   });
 });

--- a/components/modal/confirm.tsx
+++ b/components/modal/confirm.tsx
@@ -2,7 +2,6 @@ import CheckCircleOutlined from '@ant-design/icons/CheckCircleOutlined';
 import CloseCircleOutlined from '@ant-design/icons/CloseCircleOutlined';
 import ExclamationCircleOutlined from '@ant-design/icons/ExclamationCircleOutlined';
 import InfoCircleOutlined from '@ant-design/icons/InfoCircleOutlined';
-import noop from 'lodash/noop';
 import { render as reactRender, unmount as reactUnmount } from 'rc-util/lib/React/render';
 import * as React from 'react';
 import { globalConfig } from '../config-provider';
@@ -35,7 +34,7 @@ export default function confirm(config: ModalFuncProps) {
   function destroy(...args: any[]) {
     const triggerCancel = args.some(param => param && param.triggerCancel);
     if (config.onCancel && triggerCancel) {
-      config.onCancel(noop, ...args.slice(1));
+      config.onCancel(() => {}, ...args.slice(1));
     }
     for (let i = 0; i < destroyFns.length; i++) {
       const fn = destroyFns[i];

--- a/components/modal/confirm.tsx
+++ b/components/modal/confirm.tsx
@@ -2,6 +2,7 @@ import CheckCircleOutlined from '@ant-design/icons/CheckCircleOutlined';
 import CloseCircleOutlined from '@ant-design/icons/CloseCircleOutlined';
 import ExclamationCircleOutlined from '@ant-design/icons/ExclamationCircleOutlined';
 import InfoCircleOutlined from '@ant-design/icons/InfoCircleOutlined';
+import noop from 'lodash/noop';
 import { render as reactRender, unmount as reactUnmount } from 'rc-util/lib/React/render';
 import * as React from 'react';
 import { globalConfig } from '../config-provider';
@@ -34,7 +35,7 @@ export default function confirm(config: ModalFuncProps) {
   function destroy(...args: any[]) {
     const triggerCancel = args.some(param => param && param.triggerCancel);
     if (config.onCancel && triggerCancel) {
-      config.onCancel(...args);
+      config.onCancel(noop, ...args.slice(1));
     }
     for (let i = 0; i < destroyFns.length; i++) {
       const fn = destroyFns[i];

--- a/components/modal/useModal/HookModal.tsx
+++ b/components/modal/useModal/HookModal.tsx
@@ -36,7 +36,7 @@ const HookModal: React.ForwardRefRenderFunction<HookModalRef, HookModalProps> = 
     setVisible(false);
     const triggerCancel = args.some(param => param && param.triggerCancel);
     if (innerConfig.onCancel && triggerCancel) {
-      innerConfig.onCancel();
+      innerConfig.onCancel(...args);
     }
   };
 

--- a/components/modal/useModal/HookModal.tsx
+++ b/components/modal/useModal/HookModal.tsx
@@ -1,4 +1,3 @@
-import noop from 'lodash/noop';
 import * as React from 'react';
 import { ConfigContext } from '../../config-provider';
 import LocaleReceiver from '../../locale-provider/LocaleReceiver';
@@ -37,7 +36,7 @@ const HookModal: React.ForwardRefRenderFunction<HookModalRef, HookModalProps> = 
     setVisible(false);
     const triggerCancel = args.some(param => param && param.triggerCancel);
     if (innerConfig.onCancel && triggerCancel) {
-      innerConfig.onCancel(noop, ...args.slice(1));
+      innerConfig.onCancel(() => {}, ...args.slice(1));
     }
   };
 

--- a/components/modal/useModal/HookModal.tsx
+++ b/components/modal/useModal/HookModal.tsx
@@ -36,7 +36,7 @@ const HookModal: React.ForwardRefRenderFunction<HookModalRef, HookModalProps> = 
     setVisible(false);
     const triggerCancel = args.some(param => param && param.triggerCancel);
     if (innerConfig.onCancel && triggerCancel) {
-      innerConfig.onCancel(...args);
+      innerConfig.onCancel();
     }
   };
 

--- a/components/modal/useModal/HookModal.tsx
+++ b/components/modal/useModal/HookModal.tsx
@@ -1,3 +1,4 @@
+import noop from 'lodash/noop';
 import * as React from 'react';
 import { ConfigContext } from '../../config-provider';
 import LocaleReceiver from '../../locale-provider/LocaleReceiver';
@@ -36,7 +37,7 @@ const HookModal: React.ForwardRefRenderFunction<HookModalRef, HookModalProps> = 
     setVisible(false);
     const triggerCancel = args.some(param => param && param.triggerCancel);
     if (innerConfig.onCancel && triggerCancel) {
-      innerConfig.onCancel();
+      innerConfig.onCancel(noop, ...args.slice(1));
     }
   };
 


### PR DESCRIPTION


<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to feature branch, and rest to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

close #36581
### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->
ref: https://github.com/ant-design/ant-design/issues/36581#issuecomment-1189396007

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Modal.confirm `onCancel` argument close is not a function sometimes.  |
| 🇨🇳 Chinese | 修复 Modal.confirm 中 `onCancel(close)` 参数有时候不是 function 的问题。          |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
