### PR TITLE
fix: export individual menu type declarations

### DIFF
--- a/components/menu/hooks/useItems.tsx
+++ b/components/menu/hooks/useItems.tsx
@@ -10,24 +10,24 @@ import MenuDivider from '../MenuDivider';
 import MenuItem from '../MenuItem';
 import SubMenu from '../SubMenu';
 
-interface MenuItemType extends RcMenuItemType {
+export interface MenuItemType extends RcMenuItemType {
   danger?: boolean;
   icon?: React.ReactNode;
   title?: string;
 }
 
-interface SubMenuType extends Omit<RcSubMenuType, 'children'> {
+export interface SubMenuType extends Omit<RcSubMenuType, 'children'> {
   icon?: React.ReactNode;
   theme?: 'dark' | 'light';
   children: ItemType[];
 }
 
-interface MenuItemGroupType extends Omit<RcMenuItemGroupType, 'children'> {
+export interface MenuItemGroupType extends Omit<RcMenuItemGroupType, 'children'> {
   children?: ItemType[];
   key?: React.Key;
 }
 
-interface MenuDividerType extends RcMenuDividerType {
+export interface MenuDividerType extends RcMenuDividerType {
   dashed?: boolean;
   key?: React.Key;
 }


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

n/a

### 💡 Background and solution

I am using the ant design menu item type to add some custom functionality to my app (e.g. permissions, a path to route to when clicked, etc). I'd like to do:

```typescript
interface MyCustomMenuType extends ItemType { // ...custom properties }
```

However, the properties need to be different depending on what type of menu item it is (a divider won't have a path to be clicked). As such, I need to do this:

```typescript
interface CustomMenuItemType extends MenuItemType { /* ... */ }

interface CustomSubMenuType extends SubMenuType { /* ... */ }

interface CustomMenuItemGroupType extends MenuItemGroupType { /* ... */ }

interface CustomMenuDividerType extends MenuDividerType { /* ... */ }

type CustomItemType = CustomMenuItemType | CustomSubMenuType | CustomMenuItemGroupType | CustomMenuDividerType | null;
```

But that requires the individual types to be exported.

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |Export menu item type declarations|
| 🇨🇳 Chinese |导出菜单项目类型声明 (google translated)|

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
