### PR TITLE
fix: Upload item removed should keep status className

### DIFF
--- a/components/upload/UploadList/ListItem.tsx
+++ b/components/upload/UploadList/ListItem.tsx
@@ -72,6 +72,15 @@ const ListItem = React.forwardRef(
     }: ListItemProps,
     ref: React.Ref<HTMLDivElement>,
   ) => {
+    // Status: which will ignore `removed` status
+    const { status } = file;
+    const [mergedStatus, setMergedStatus] = React.useState(status);
+    React.useEffect(() => {
+      if (status !== 'removed') {
+        setMergedStatus(status);
+      }
+    }, [status]);
+
     // Delay to show the progress bar
     const [showProgress, setShowProgress] = React.useState(false);
     const progressRafRef = React.useRef<any>();
@@ -92,10 +101,10 @@ const ListItem = React.forwardRef(
     const iconNode = iconRender(file);
     let icon = <div className={`${prefixCls}-text-icon`}>{iconNode}</div>;
     if (listType === 'picture' || listType === 'picture-card') {
-      if (file.status === 'uploading' || (!file.thumbUrl && !file.url)) {
+      if (mergedStatus === 'uploading' || (!file.thumbUrl && !file.url)) {
         const uploadingClassName = classNames({
           [`${prefixCls}-list-item-thumbnail`]: true,
-          [`${prefixCls}-list-item-file`]: file.status !== 'uploading',
+          [`${prefixCls}-list-item-file`]: mergedStatus !== 'uploading',
         });
         icon = <div className={uploadingClassName}>{iconNode}</div>;
       } else {
@@ -129,7 +138,7 @@ const ListItem = React.forwardRef(
 
     const infoUploadingClass = classNames({
       [`${prefixCls}-list-item`]: true,
-      [`${prefixCls}-list-item-${file.status}`]: true,
+      [`${prefixCls}-list-item-${mergedStatus}`]: true,
       [`${prefixCls}-list-item-list-type-${listType}`]: true,
     });
     const linkProps =
@@ -147,7 +156,7 @@ const ListItem = React.forwardRef(
       : null;
 
     const downloadIcon =
-      showDownloadIcon && file.status === 'done'
+      showDownloadIcon && mergedStatus === 'done'
         ? actionIconRender(
             (typeof customDownloadIcon === 'function'
               ? customDownloadIcon(file)
@@ -215,10 +224,10 @@ const ListItem = React.forwardRef(
       </a>
     ) : null;
 
-    const actions = listType === 'picture-card' && file.status !== 'uploading' && (
+    const actions = listType === 'picture-card' && mergedStatus !== 'uploading' && (
       <span className={`${prefixCls}-list-item-actions`}>
         {previewIcon}
-        {file.status === 'done' && downloadIcon}
+        {mergedStatus === 'done' && downloadIcon}
         {removeIcon}
       </span>
     );
@@ -245,7 +254,7 @@ const ListItem = React.forwardRef(
         {showProgress && (
           <CSSMotion
             motionName={`${rootPrefixCls}-fade`}
-            visible={file.status === 'uploading'}
+            visible={mergedStatus === 'uploading'}
             motionDeadline={2000}
           >
             {({ className: motionClassName }) => {
@@ -267,7 +276,7 @@ const ListItem = React.forwardRef(
     );
     const listContainerNameClass = classNames(`${prefixCls}-list-${listType}-container`, className);
     const item =
-      file.status === 'error' ? (
+      mergedStatus === 'error' ? (
         <Tooltip title={message} getPopupContainer={node => node.parentNode as HTMLElement}>
           {dom}
         </Tooltip>

--- a/components/upload/__tests__/uploadlist.test.js
+++ b/components/upload/__tests__/uploadlist.test.js
@@ -1567,4 +1567,45 @@ describe('Upload List', () => {
       unmount();
     });
   });
+
+  // https://github.com/ant-design/ant-design/issues/36286
+  it('remove should keep origin className', async () => {
+    jest.useFakeTimers();
+
+    const onChange = jest.fn();
+    const list = [
+      {
+        uid: '0',
+        name: 'xxx.png',
+        status: 'error',
+      },
+    ];
+    const { container } = render(
+      <Upload fileList={list} listType="picture-card" onChange={onChange} />,
+    );
+
+    fireEvent.click(container.querySelector('.anticon-delete'));
+
+    // Wait for Upload sync
+    for (let i = 0; i < 10; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      await Promise.resolve();
+    }
+
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        file: expect.objectContaining({
+          status: 'removed',
+        }),
+      }),
+    );
+
+    expect(container.querySelector('.ant-upload-list-item-error')).toBeTruthy();
+
+    jest.useRealTimers();
+  });
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.

Before submitting your pull request, please make sure the checklist below is confirmed.

Your pull requests will be merged after one of the collaborators approve.

Thank you!

-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

fix #36286

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Fixed Upload removing file status color is wrong.       |
| 🇨🇳 Chinese |       修复 Upload 移除文件时状态色会变化的问题。    |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
