### PR TITLE
chore: collapse title text auto width

### DIFF
--- a/components/collapse/style/index.less
+++ b/components/collapse/style/index.less
@@ -43,6 +43,10 @@
         }
       }
 
+      .@{collapse-prefix-cls}-header-text {
+        flex: auto;
+      }
+
       .@{collapse-prefix-cls}-extra {
         margin-left: auto;
       }
@@ -55,6 +59,7 @@
     .@{collapse-prefix-cls}-header-collapsible-only {
       cursor: default;
       .@{collapse-prefix-cls}-header-text {
+        flex: none;
         cursor: pointer;
       }
     }

--- a/components/drawer/__tests__/__snapshots__/demo-extend.test.tsx.snap
+++ b/components/drawer/__tests__/__snapshots__/demo-extend.test.tsx.snap
@@ -1384,14 +1384,14 @@ HTMLCollection [
                                                 tabindex="-1"
                                                 type="button"
                                               >
-                                                Jul
+                                                Nov
                                               </button>
                                               <button
                                                 class="ant-picker-year-btn"
                                                 tabindex="-1"
                                                 type="button"
                                               >
-                                                2022
+                                                2016
                                               </button>
                                             </div>
                                             <button
@@ -1450,47 +1450,7 @@ HTMLCollection [
                                                 <tr>
                                                   <td
                                                     class="ant-picker-cell"
-                                                    title="2022-06-26"
-                                                  >
-                                                    <div
-                                                      class="ant-picker-cell-inner"
-                                                    >
-                                                      26
-                                                    </div>
-                                                  </td>
-                                                  <td
-                                                    class="ant-picker-cell"
-                                                    title="2022-06-27"
-                                                  >
-                                                    <div
-                                                      class="ant-picker-cell-inner"
-                                                    >
-                                                      27
-                                                    </div>
-                                                  </td>
-                                                  <td
-                                                    class="ant-picker-cell"
-                                                    title="2022-06-28"
-                                                  >
-                                                    <div
-                                                      class="ant-picker-cell-inner"
-                                                    >
-                                                      28
-                                                    </div>
-                                                  </td>
-                                                  <td
-                                                    class="ant-picker-cell"
-                                                    title="2022-06-29"
-                                                  >
-                                                    <div
-                                                      class="ant-picker-cell-inner"
-                                                    >
-                                                      29
-                                                    </div>
-                                                  </td>
-                                                  <td
-                                                    class="ant-picker-cell ant-picker-cell-end"
-                                                    title="2022-06-30"
+                                                    title="2016-10-30"
                                                   >
                                                     <div
                                                       class="ant-picker-cell-inner"
@@ -1499,8 +1459,18 @@ HTMLCollection [
                                                     </div>
                                                   </td>
                                                   <td
+                                                    class="ant-picker-cell ant-picker-cell-end"
+                                                    title="2016-10-31"
+                                                  >
+                                                    <div
+                                                      class="ant-picker-cell-inner"
+                                                    >
+                                                      31
+                                                    </div>
+                                                  </td>
+                                                  <td
                                                     class="ant-picker-cell ant-picker-cell-start ant-picker-cell-in-view"
-                                                    title="2022-07-01"
+                                                    title="2016-11-01"
                                                   >
                                                     <div
                                                       class="ant-picker-cell-inner"
@@ -1510,7 +1480,7 @@ HTMLCollection [
                                                   </td>
                                                   <td
                                                     class="ant-picker-cell ant-picker-cell-in-view"
-                                                    title="2022-07-02"
+                                                    title="2016-11-02"
                                                   >
                                                     <div
                                                       class="ant-picker-cell-inner"
@@ -1518,11 +1488,9 @@ HTMLCollection [
                                                       2
                                                     </div>
                                                   </td>
-                                                </tr>
-                                                <tr>
                                                   <td
                                                     class="ant-picker-cell ant-picker-cell-in-view"
-                                                    title="2022-07-03"
+                                                    title="2016-11-03"
                                                   >
                                                     <div
                                                       class="ant-picker-cell-inner"
@@ -1532,7 +1500,7 @@ HTMLCollection [
                                                   </td>
                                                   <td
                                                     class="ant-picker-cell ant-picker-cell-in-view"
-                                                    title="2022-07-04"
+                                                    title="2016-11-04"
                                                   >
                                                     <div
                                                       class="ant-picker-cell-inner"
@@ -1542,7 +1510,7 @@ HTMLCollection [
                                                   </td>
                                                   <td
                                                     class="ant-picker-cell ant-picker-cell-in-view"
-                                                    title="2022-07-05"
+                                                    title="2016-11-05"
                                                   >
                                                     <div
                                                       class="ant-picker-cell-inner"
@@ -1550,9 +1518,11 @@ HTMLCollection [
                                                       5
                                                     </div>
                                                   </td>
+                                                </tr>
+                                                <tr>
                                                   <td
                                                     class="ant-picker-cell ant-picker-cell-in-view"
-                                                    title="2022-07-06"
+                                                    title="2016-11-06"
                                                   >
                                                     <div
                                                       class="ant-picker-cell-inner"
@@ -1562,7 +1532,7 @@ HTMLCollection [
                                                   </td>
                                                   <td
                                                     class="ant-picker-cell ant-picker-cell-in-view"
-                                                    title="2022-07-07"
+                                                    title="2016-11-07"
                                                   >
                                                     <div
                                                       class="ant-picker-cell-inner"
@@ -1572,7 +1542,7 @@ HTMLCollection [
                                                   </td>
                                                   <td
                                                     class="ant-picker-cell ant-picker-cell-in-view"
-                                                    title="2022-07-08"
+                                                    title="2016-11-08"
                                                   >
                                                     <div
                                                       class="ant-picker-cell-inner"
@@ -1582,7 +1552,7 @@ HTMLCollection [
                                                   </td>
                                                   <td
                                                     class="ant-picker-cell ant-picker-cell-in-view"
-                                                    title="2022-07-09"
+                                                    title="2016-11-09"
                                                   >
                                                     <div
                                                       class="ant-picker-cell-inner"
@@ -1590,11 +1560,9 @@ HTMLCollection [
                                                       9
                                                     </div>
                                                   </td>
-                                                </tr>
-                                                <tr>
                                                   <td
                                                     class="ant-picker-cell ant-picker-cell-in-view"
-                                                    title="2022-07-10"
+                                                    title="2016-11-10"
                                                   >
                                                     <div
                                                       class="ant-picker-cell-inner"
@@ -1604,7 +1572,7 @@ HTMLCollection [
                                                   </td>
                                                   <td
                                                     class="ant-picker-cell ant-picker-cell-in-view"
-                                                    title="2022-07-11"
+                                                    title="2016-11-11"
                                                   >
                                                     <div
                                                       class="ant-picker-cell-inner"
@@ -1614,7 +1582,7 @@ HTMLCollection [
                                                   </td>
                                                   <td
                                                     class="ant-picker-cell ant-picker-cell-in-view"
-                                                    title="2022-07-12"
+                                                    title="2016-11-12"
                                                   >
                                                     <div
                                                       class="ant-picker-cell-inner"
@@ -1622,9 +1590,11 @@ HTMLCollection [
                                                       12
                                                     </div>
                                                   </td>
+                                                </tr>
+                                                <tr>
                                                   <td
                                                     class="ant-picker-cell ant-picker-cell-in-view"
-                                                    title="2022-07-13"
+                                                    title="2016-11-13"
                                                   >
                                                     <div
                                                       class="ant-picker-cell-inner"
@@ -1634,7 +1604,7 @@ HTMLCollection [
                                                   </td>
                                                   <td
                                                     class="ant-picker-cell ant-picker-cell-in-view"
-                                                    title="2022-07-14"
+                                                    title="2016-11-14"
                                                   >
                                                     <div
                                                       class="ant-picker-cell-inner"
@@ -1644,7 +1614,7 @@ HTMLCollection [
                                                   </td>
                                                   <td
                                                     class="ant-picker-cell ant-picker-cell-in-view"
-                                                    title="2022-07-15"
+                                                    title="2016-11-15"
                                                   >
                                                     <div
                                                       class="ant-picker-cell-inner"
@@ -1654,7 +1624,7 @@ HTMLCollection [
                                                   </td>
                                                   <td
                                                     class="ant-picker-cell ant-picker-cell-in-view"
-                                                    title="2022-07-16"
+                                                    title="2016-11-16"
                                                   >
                                                     <div
                                                       class="ant-picker-cell-inner"
@@ -1662,11 +1632,9 @@ HTMLCollection [
                                                       16
                                                     </div>
                                                   </td>
-                                                </tr>
-                                                <tr>
                                                   <td
                                                     class="ant-picker-cell ant-picker-cell-in-view"
-                                                    title="2022-07-17"
+                                                    title="2016-11-17"
                                                   >
                                                     <div
                                                       class="ant-picker-cell-inner"
@@ -1676,7 +1644,7 @@ HTMLCollection [
                                                   </td>
                                                   <td
                                                     class="ant-picker-cell ant-picker-cell-in-view"
-                                                    title="2022-07-18"
+                                                    title="2016-11-18"
                                                   >
                                                     <div
                                                       class="ant-picker-cell-inner"
@@ -1686,7 +1654,7 @@ HTMLCollection [
                                                   </td>
                                                   <td
                                                     class="ant-picker-cell ant-picker-cell-in-view"
-                                                    title="2022-07-19"
+                                                    title="2016-11-19"
                                                   >
                                                     <div
                                                       class="ant-picker-cell-inner"
@@ -1694,9 +1662,11 @@ HTMLCollection [
                                                       19
                                                     </div>
                                                   </td>
+                                                </tr>
+                                                <tr>
                                                   <td
                                                     class="ant-picker-cell ant-picker-cell-in-view"
-                                                    title="2022-07-20"
+                                                    title="2016-11-20"
                                                   >
                                                     <div
                                                       class="ant-picker-cell-inner"
@@ -1706,7 +1676,7 @@ HTMLCollection [
                                                   </td>
                                                   <td
                                                     class="ant-picker-cell ant-picker-cell-in-view"
-                                                    title="2022-07-21"
+                                                    title="2016-11-21"
                                                   >
                                                     <div
                                                       class="ant-picker-cell-inner"
@@ -1715,8 +1685,8 @@ HTMLCollection [
                                                     </div>
                                                   </td>
                                                   <td
-                                                    class="ant-picker-cell ant-picker-cell-in-view"
-                                                    title="2022-07-22"
+                                                    class="ant-picker-cell ant-picker-cell-in-view ant-picker-cell-today"
+                                                    title="2016-11-22"
                                                   >
                                                     <div
                                                       class="ant-picker-cell-inner"
@@ -1726,7 +1696,7 @@ HTMLCollection [
                                                   </td>
                                                   <td
                                                     class="ant-picker-cell ant-picker-cell-in-view"
-                                                    title="2022-07-23"
+                                                    title="2016-11-23"
                                                   >
                                                     <div
                                                       class="ant-picker-cell-inner"
@@ -1734,11 +1704,9 @@ HTMLCollection [
                                                       23
                                                     </div>
                                                   </td>
-                                                </tr>
-                                                <tr>
                                                   <td
                                                     class="ant-picker-cell ant-picker-cell-in-view"
-                                                    title="2022-07-24"
+                                                    title="2016-11-24"
                                                   >
                                                     <div
                                                       class="ant-picker-cell-inner"
@@ -1748,7 +1716,7 @@ HTMLCollection [
                                                   </td>
                                                   <td
                                                     class="ant-picker-cell ant-picker-cell-in-view"
-                                                    title="2022-07-25"
+                                                    title="2016-11-25"
                                                   >
                                                     <div
                                                       class="ant-picker-cell-inner"
@@ -1758,7 +1726,7 @@ HTMLCollection [
                                                   </td>
                                                   <td
                                                     class="ant-picker-cell ant-picker-cell-in-view"
-                                                    title="2022-07-26"
+                                                    title="2016-11-26"
                                                   >
                                                     <div
                                                       class="ant-picker-cell-inner"
@@ -1766,9 +1734,11 @@ HTMLCollection [
                                                       26
                                                     </div>
                                                   </td>
+                                                </tr>
+                                                <tr>
                                                   <td
-                                                    class="ant-picker-cell ant-picker-cell-in-view ant-picker-cell-today"
-                                                    title="2022-07-27"
+                                                    class="ant-picker-cell ant-picker-cell-in-view"
+                                                    title="2016-11-27"
                                                   >
                                                     <div
                                                       class="ant-picker-cell-inner"
@@ -1778,7 +1748,7 @@ HTMLCollection [
                                                   </td>
                                                   <td
                                                     class="ant-picker-cell ant-picker-cell-in-view"
-                                                    title="2022-07-28"
+                                                    title="2016-11-28"
                                                   >
                                                     <div
                                                       class="ant-picker-cell-inner"
@@ -1788,7 +1758,7 @@ HTMLCollection [
                                                   </td>
                                                   <td
                                                     class="ant-picker-cell ant-picker-cell-in-view"
-                                                    title="2022-07-29"
+                                                    title="2016-11-29"
                                                   >
                                                     <div
                                                       class="ant-picker-cell-inner"
@@ -1797,8 +1767,8 @@ HTMLCollection [
                                                     </div>
                                                   </td>
                                                   <td
-                                                    class="ant-picker-cell ant-picker-cell-in-view"
-                                                    title="2022-07-30"
+                                                    class="ant-picker-cell ant-picker-cell-end ant-picker-cell-in-view"
+                                                    title="2016-11-30"
                                                   >
                                                     <div
                                                       class="ant-picker-cell-inner"
@@ -1806,21 +1776,9 @@ HTMLCollection [
                                                       30
                                                     </div>
                                                   </td>
-                                                </tr>
-                                                <tr>
-                                                  <td
-                                                    class="ant-picker-cell ant-picker-cell-end ant-picker-cell-in-view"
-                                                    title="2022-07-31"
-                                                  >
-                                                    <div
-                                                      class="ant-picker-cell-inner"
-                                                    >
-                                                      31
-                                                    </div>
-                                                  </td>
                                                   <td
                                                     class="ant-picker-cell ant-picker-cell-start"
-                                                    title="2022-08-01"
+                                                    title="2016-12-01"
                                                   >
                                                     <div
                                                       class="ant-picker-cell-inner"
@@ -1830,7 +1788,7 @@ HTMLCollection [
                                                   </td>
                                                   <td
                                                     class="ant-picker-cell"
-                                                    title="2022-08-02"
+                                                    title="2016-12-02"
                                                   >
                                                     <div
                                                       class="ant-picker-cell-inner"
@@ -1840,7 +1798,7 @@ HTMLCollection [
                                                   </td>
                                                   <td
                                                     class="ant-picker-cell"
-                                                    title="2022-08-03"
+                                                    title="2016-12-03"
                                                   >
                                                     <div
                                                       class="ant-picker-cell-inner"
@@ -1848,9 +1806,11 @@ HTMLCollection [
                                                       3
                                                     </div>
                                                   </td>
+                                                </tr>
+                                                <tr>
                                                   <td
                                                     class="ant-picker-cell"
-                                                    title="2022-08-04"
+                                                    title="2016-12-04"
                                                   >
                                                     <div
                                                       class="ant-picker-cell-inner"
@@ -1860,7 +1820,7 @@ HTMLCollection [
                                                   </td>
                                                   <td
                                                     class="ant-picker-cell"
-                                                    title="2022-08-05"
+                                                    title="2016-12-05"
                                                   >
                                                     <div
                                                       class="ant-picker-cell-inner"
@@ -1870,12 +1830,52 @@ HTMLCollection [
                                                   </td>
                                                   <td
                                                     class="ant-picker-cell"
-                                                    title="2022-08-06"
+                                                    title="2016-12-06"
                                                   >
                                                     <div
                                                       class="ant-picker-cell-inner"
                                                     >
                                                       6
+                                                    </div>
+                                                  </td>
+                                                  <td
+                                                    class="ant-picker-cell"
+                                                    title="2016-12-07"
+                                                  >
+                                                    <div
+                                                      class="ant-picker-cell-inner"
+                                                    >
+                                                      7
+                                                    </div>
+                                                  </td>
+                                                  <td
+                                                    class="ant-picker-cell"
+                                                    title="2016-12-08"
+                                                  >
+                                                    <div
+                                                      class="ant-picker-cell-inner"
+                                                    >
+                                                      8
+                                                    </div>
+                                                  </td>
+                                                  <td
+                                                    class="ant-picker-cell"
+                                                    title="2016-12-09"
+                                                  >
+                                                    <div
+                                                      class="ant-picker-cell-inner"
+                                                    >
+                                                      9
+                                                    </div>
+                                                  </td>
+                                                  <td
+                                                    class="ant-picker-cell"
+                                                    title="2016-12-10"
+                                                  >
+                                                    <div
+                                                      class="ant-picker-cell-inner"
+                                                    >
+                                                      10
                                                     </div>
                                                   </td>
                                                 </tr>
@@ -1922,14 +1922,14 @@ HTMLCollection [
                                                 tabindex="-1"
                                                 type="button"
                                               >
-                                                Aug
+                                                Dec
                                               </button>
                                               <button
                                                 class="ant-picker-year-btn"
                                                 tabindex="-1"
                                                 type="button"
                                               >
-                                                2022
+                                                2016
                                               </button>
                                             </div>
                                             <button
@@ -1985,18 +1985,48 @@ HTMLCollection [
                                               <tbody>
                                                 <tr>
                                                   <td
-                                                    class="ant-picker-cell ant-picker-cell-end"
-                                                    title="2022-07-31"
+                                                    class="ant-picker-cell"
+                                                    title="2016-11-27"
                                                   >
                                                     <div
                                                       class="ant-picker-cell-inner"
                                                     >
-                                                      31
+                                                      27
+                                                    </div>
+                                                  </td>
+                                                  <td
+                                                    class="ant-picker-cell"
+                                                    title="2016-11-28"
+                                                  >
+                                                    <div
+                                                      class="ant-picker-cell-inner"
+                                                    >
+                                                      28
+                                                    </div>
+                                                  </td>
+                                                  <td
+                                                    class="ant-picker-cell"
+                                                    title="2016-11-29"
+                                                  >
+                                                    <div
+                                                      class="ant-picker-cell-inner"
+                                                    >
+                                                      29
+                                                    </div>
+                                                  </td>
+                                                  <td
+                                                    class="ant-picker-cell ant-picker-cell-end"
+                                                    title="2016-11-30"
+                                                  >
+                                                    <div
+                                                      class="ant-picker-cell-inner"
+                                                    >
+                                                      30
                                                     </div>
                                                   </td>
                                                   <td
                                                     class="ant-picker-cell ant-picker-cell-start ant-picker-cell-in-view"
-                                                    title="2022-08-01"
+                                                    title="2016-12-01"
                                                   >
                                                     <div
                                                       class="ant-picker-cell-inner"
@@ -2006,7 +2036,7 @@ HTMLCollection [
                                                   </td>
                                                   <td
                                                     class="ant-picker-cell ant-picker-cell-in-view"
-                                                    title="2022-08-02"
+                                                    title="2016-12-02"
                                                   >
                                                     <div
                                                       class="ant-picker-cell-inner"
@@ -2016,7 +2046,7 @@ HTMLCollection [
                                                   </td>
                                                   <td
                                                     class="ant-picker-cell ant-picker-cell-in-view"
-                                                    title="2022-08-03"
+                                                    title="2016-12-03"
                                                   >
                                                     <div
                                                       class="ant-picker-cell-inner"
@@ -2024,9 +2054,11 @@ HTMLCollection [
                                                       3
                                                     </div>
                                                   </td>
+                                                </tr>
+                                                <tr>
                                                   <td
                                                     class="ant-picker-cell ant-picker-cell-in-view"
-                                                    title="2022-08-04"
+                                                    title="2016-12-04"
                                                   >
                                                     <div
                                                       class="ant-picker-cell-inner"
@@ -2036,7 +2068,7 @@ HTMLCollection [
                                                   </td>
                                                   <td
                                                     class="ant-picker-cell ant-picker-cell-in-view"
-                                                    title="2022-08-05"
+                                                    title="2016-12-05"
                                                   >
                                                     <div
                                                       class="ant-picker-cell-inner"
@@ -2046,7 +2078,7 @@ HTMLCollection [
                                                   </td>
                                                   <td
                                                     class="ant-picker-cell ant-picker-cell-in-view"
-                                                    title="2022-08-06"
+                                                    title="2016-12-06"
                                                   >
                                                     <div
                                                       class="ant-picker-cell-inner"
@@ -2054,11 +2086,9 @@ HTMLCollection [
                                                       6
                                                     </div>
                                                   </td>
-                                                </tr>
-                                                <tr>
                                                   <td
                                                     class="ant-picker-cell ant-picker-cell-in-view"
-                                                    title="2022-08-07"
+                                                    title="2016-12-07"
                                                   >
                                                     <div
                                                       class="ant-picker-cell-inner"
@@ -2068,7 +2098,7 @@ HTMLCollection [
                                                   </td>
                                                   <td
                                                     class="ant-picker-cell ant-picker-cell-in-view"
-                                                    title="2022-08-08"
+                                                    title="2016-12-08"
                                                   >
                                                     <div
                                                       class="ant-picker-cell-inner"
@@ -2078,7 +2108,7 @@ HTMLCollection [
                                                   </td>
                                                   <td
                                                     class="ant-picker-cell ant-picker-cell-in-view"
-                                                    title="2022-08-09"
+                                                    title="2016-12-09"
                                                   >
                                                     <div
                                                       class="ant-picker-cell-inner"
@@ -2088,7 +2118,7 @@ HTMLCollection [
                                                   </td>
                                                   <td
                                                     class="ant-picker-cell ant-picker-cell-in-view"
-                                                    title="2022-08-10"
+                                                    title="2016-12-10"
                                                   >
                                                     <div
                                                       class="ant-picker-cell-inner"
@@ -2096,9 +2126,11 @@ HTMLCollection [
                                                       10
                                                     </div>
                                                   </td>
+                                                </tr>
+                                                <tr>
                                                   <td
                                                     class="ant-picker-cell ant-picker-cell-in-view"
-                                                    title="2022-08-11"
+                                                    title="2016-12-11"
                                                   >
                                                     <div
                                                       class="ant-picker-cell-inner"
@@ -2108,7 +2140,7 @@ HTMLCollection [
                                                   </td>
                                                   <td
                                                     class="ant-picker-cell ant-picker-cell-in-view"
-                                                    title="2022-08-12"
+                                                    title="2016-12-12"
                                                   >
                                                     <div
                                                       class="ant-picker-cell-inner"
@@ -2118,7 +2150,7 @@ HTMLCollection [
                                                   </td>
                                                   <td
                                                     class="ant-picker-cell ant-picker-cell-in-view"
-                                                    title="2022-08-13"
+                                                    title="2016-12-13"
                                                   >
                                                     <div
                                                       class="ant-picker-cell-inner"
@@ -2126,11 +2158,9 @@ HTMLCollection [
                                                       13
                                                     </div>
                                                   </td>
-                                                </tr>
-                                                <tr>
                                                   <td
                                                     class="ant-picker-cell ant-picker-cell-in-view"
-                                                    title="2022-08-14"
+                                                    title="2016-12-14"
                                                   >
                                                     <div
                                                       class="ant-picker-cell-inner"
@@ -2140,7 +2170,7 @@ HTMLCollection [
                                                   </td>
                                                   <td
                                                     class="ant-picker-cell ant-picker-cell-in-view"
-                                                    title="2022-08-15"
+                                                    title="2016-12-15"
                                                   >
                                                     <div
                                                       class="ant-picker-cell-inner"
@@ -2150,7 +2180,7 @@ HTMLCollection [
                                                   </td>
                                                   <td
                                                     class="ant-picker-cell ant-picker-cell-in-view"
-                                                    title="2022-08-16"
+                                                    title="2016-12-16"
                                                   >
                                                     <div
                                                       class="ant-picker-cell-inner"
@@ -2160,7 +2190,7 @@ HTMLCollection [
                                                   </td>
                                                   <td
                                                     class="ant-picker-cell ant-picker-cell-in-view"
-                                                    title="2022-08-17"
+                                                    title="2016-12-17"
                                                   >
                                                     <div
                                                       class="ant-picker-cell-inner"
@@ -2168,9 +2198,11 @@ HTMLCollection [
                                                       17
                                                     </div>
                                                   </td>
+                                                </tr>
+                                                <tr>
                                                   <td
                                                     class="ant-picker-cell ant-picker-cell-in-view"
-                                                    title="2022-08-18"
+                                                    title="2016-12-18"
                                                   >
                                                     <div
                                                       class="ant-picker-cell-inner"
@@ -2180,7 +2212,7 @@ HTMLCollection [
                                                   </td>
                                                   <td
                                                     class="ant-picker-cell ant-picker-cell-in-view"
-                                                    title="2022-08-19"
+                                                    title="2016-12-19"
                                                   >
                                                     <div
                                                       class="ant-picker-cell-inner"
@@ -2190,7 +2222,7 @@ HTMLCollection [
                                                   </td>
                                                   <td
                                                     class="ant-picker-cell ant-picker-cell-in-view"
-                                                    title="2022-08-20"
+                                                    title="2016-12-20"
                                                   >
                                                     <div
                                                       class="ant-picker-cell-inner"
@@ -2198,11 +2230,9 @@ HTMLCollection [
                                                       20
                                                     </div>
                                                   </td>
-                                                </tr>
-                                                <tr>
                                                   <td
                                                     class="ant-picker-cell ant-picker-cell-in-view"
-                                                    title="2022-08-21"
+                                                    title="2016-12-21"
                                                   >
                                                     <div
                                                       class="ant-picker-cell-inner"
@@ -2212,7 +2242,7 @@ HTMLCollection [
                                                   </td>
                                                   <td
                                                     class="ant-picker-cell ant-picker-cell-in-view"
-                                                    title="2022-08-22"
+                                                    title="2016-12-22"
                                                   >
                                                     <div
                                                       class="ant-picker-cell-inner"
@@ -2222,7 +2252,7 @@ HTMLCollection [
                                                   </td>
                                                   <td
                                                     class="ant-picker-cell ant-picker-cell-in-view"
-                                                    title="2022-08-23"
+                                                    title="2016-12-23"
                                                   >
                                                     <div
                                                       class="ant-picker-cell-inner"
@@ -2232,7 +2262,7 @@ HTMLCollection [
                                                   </td>
                                                   <td
                                                     class="ant-picker-cell ant-picker-cell-in-view"
-                                                    title="2022-08-24"
+                                                    title="2016-12-24"
                                                   >
                                                     <div
                                                       class="ant-picker-cell-inner"
@@ -2240,9 +2270,11 @@ HTMLCollection [
                                                       24
                                                     </div>
                                                   </td>
+                                                </tr>
+                                                <tr>
                                                   <td
                                                     class="ant-picker-cell ant-picker-cell-in-view"
-                                                    title="2022-08-25"
+                                                    title="2016-12-25"
                                                   >
                                                     <div
                                                       class="ant-picker-cell-inner"
@@ -2252,7 +2284,7 @@ HTMLCollection [
                                                   </td>
                                                   <td
                                                     class="ant-picker-cell ant-picker-cell-in-view"
-                                                    title="2022-08-26"
+                                                    title="2016-12-26"
                                                   >
                                                     <div
                                                       class="ant-picker-cell-inner"
@@ -2262,7 +2294,7 @@ HTMLCollection [
                                                   </td>
                                                   <td
                                                     class="ant-picker-cell ant-picker-cell-in-view"
-                                                    title="2022-08-27"
+                                                    title="2016-12-27"
                                                   >
                                                     <div
                                                       class="ant-picker-cell-inner"
@@ -2270,11 +2302,9 @@ HTMLCollection [
                                                       27
                                                     </div>
                                                   </td>
-                                                </tr>
-                                                <tr>
                                                   <td
                                                     class="ant-picker-cell ant-picker-cell-in-view"
-                                                    title="2022-08-28"
+                                                    title="2016-12-28"
                                                   >
                                                     <div
                                                       class="ant-picker-cell-inner"
@@ -2284,7 +2314,7 @@ HTMLCollection [
                                                   </td>
                                                   <td
                                                     class="ant-picker-cell ant-picker-cell-in-view"
-                                                    title="2022-08-29"
+                                                    title="2016-12-29"
                                                   >
                                                     <div
                                                       class="ant-picker-cell-inner"
@@ -2294,7 +2324,7 @@ HTMLCollection [
                                                   </td>
                                                   <td
                                                     class="ant-picker-cell ant-picker-cell-in-view"
-                                                    title="2022-08-30"
+                                                    title="2016-12-30"
                                                   >
                                                     <div
                                                       class="ant-picker-cell-inner"
@@ -2304,7 +2334,7 @@ HTMLCollection [
                                                   </td>
                                                   <td
                                                     class="ant-picker-cell ant-picker-cell-end ant-picker-cell-in-view"
-                                                    title="2022-08-31"
+                                                    title="2016-12-31"
                                                   >
                                                     <div
                                                       class="ant-picker-cell-inner"
@@ -2312,9 +2342,11 @@ HTMLCollection [
                                                       31
                                                     </div>
                                                   </td>
+                                                </tr>
+                                                <tr>
                                                   <td
                                                     class="ant-picker-cell ant-picker-cell-start"
-                                                    title="2022-09-01"
+                                                    title="2017-01-01"
                                                   >
                                                     <div
                                                       class="ant-picker-cell-inner"
@@ -2324,7 +2356,7 @@ HTMLCollection [
                                                   </td>
                                                   <td
                                                     class="ant-picker-cell"
-                                                    title="2022-09-02"
+                                                    title="2017-01-02"
                                                   >
                                                     <div
                                                       class="ant-picker-cell-inner"
@@ -2334,7 +2366,7 @@ HTMLCollection [
                                                   </td>
                                                   <td
                                                     class="ant-picker-cell"
-                                                    title="2022-09-03"
+                                                    title="2017-01-03"
                                                   >
                                                     <div
                                                       class="ant-picker-cell-inner"
@@ -2342,11 +2374,9 @@ HTMLCollection [
                                                       3
                                                     </div>
                                                   </td>
-                                                </tr>
-                                                <tr>
                                                   <td
                                                     class="ant-picker-cell"
-                                                    title="2022-09-04"
+                                                    title="2017-01-04"
                                                   >
                                                     <div
                                                       class="ant-picker-cell-inner"
@@ -2356,7 +2386,7 @@ HTMLCollection [
                                                   </td>
                                                   <td
                                                     class="ant-picker-cell"
-                                                    title="2022-09-05"
+                                                    title="2017-01-05"
                                                   >
                                                     <div
                                                       class="ant-picker-cell-inner"
@@ -2366,7 +2396,7 @@ HTMLCollection [
                                                   </td>
                                                   <td
                                                     class="ant-picker-cell"
-                                                    title="2022-09-06"
+                                                    title="2017-01-06"
                                                   >
                                                     <div
                                                       class="ant-picker-cell-inner"
@@ -2376,42 +2406,12 @@ HTMLCollection [
                                                   </td>
                                                   <td
                                                     class="ant-picker-cell"
-                                                    title="2022-09-07"
+                                                    title="2017-01-07"
                                                   >
                                                     <div
                                                       class="ant-picker-cell-inner"
                                                     >
                                                       7
-                                                    </div>
-                                                  </td>
-                                                  <td
-                                                    class="ant-picker-cell"
-                                                    title="2022-09-08"
-                                                  >
-                                                    <div
-                                                      class="ant-picker-cell-inner"
-                                                    >
-                                                      8
-                                                    </div>
-                                                  </td>
-                                                  <td
-                                                    class="ant-picker-cell"
-                                                    title="2022-09-09"
-                                                  >
-                                                    <div
-                                                      class="ant-picker-cell-inner"
-                                                    >
-                                                      9
-                                                    </div>
-                                                  </td>
-                                                  <td
-                                                    class="ant-picker-cell"
-                                                    title="2022-09-10"
-                                                  >
-                                                    <div
-                                                      class="ant-picker-cell-inner"
-                                                    >
-                                                      10
                                                     </div>
                                                   </td>
                                                 </tr>

--- a/tests/shared/demoTest.tsx
+++ b/tests/shared/demoTest.tsx
@@ -68,8 +68,9 @@ function baseText(doInject: boolean, component: string, options: Options = {}) {
       doInject ? `renders ${file} extend context correctly` : `renders ${file} correctly`,
       () => {
         const errSpy = excludeWarning();
+        const mockDate = moment('2016-11-22').valueOf();
 
-        MockDate.set(moment('2016-11-22').valueOf());
+        MockDate.set(mockDate);
         let Demo = require(`../.${file}`).default; // eslint-disable-line global-require, import/no-dynamic-require
         // Inject Trigger status unless skipped
         Demo = typeof Demo === 'function' ? <Demo /> : Demo;
@@ -86,7 +87,7 @@ function baseText(doInject: boolean, component: string, options: Options = {}) {
         }
 
         if (options?.testingLib) {
-          jest.useFakeTimers();
+          jest.useFakeTimers().setSystemTime(mockDate);
 
           const { container } = render(Demo);
           act(() => {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.

Before submitting your pull request, please make sure the checklist below is confirmed.

Your pull requests will be merged after one of the collaborators approve.

Thank you!

-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Preview

https://preview-36761-ant-design.surge.sh/components/collapse-cn/

### 💡 Background and solution

云凤蝶中使用：
```tsx
<Panel header={<div style={{ flex: 'auto' }}>Title</div>} />
```

实现撑满效果，现在由于 title 总会包裹 `div.title-text` 导致注入失效。直接将撑满能力提供到标题上自行实现。

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Adjust Collapse title click region which will be fully width when `collapsible=default` now.       |
| 🇨🇳 Chinese |     调整 Collapse 标题文本在 `collapsible=default` 时为完整宽度点击区域。    |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
