### PR TITLE
bugfix: defaultChecked should work when checked is passed as undefine…

### DIFF
--- a/components/checkbox/Checkbox.tsx
+++ b/components/checkbox/Checkbox.tsx
@@ -104,6 +104,9 @@ const InternalCheckbox: React.ForwardRefRenderFunction<HTMLInputElement, Checkbo
     checkboxProps.name = checkboxGroup.name;
     checkboxProps.checked = checkboxGroup.value.indexOf(restProps.value) !== -1;
   }
+  if (restProps.checked === undefined) {
+    delete checkboxProps.checked;
+  }
   const classString = classNames(
     {
       [`${prefixCls}-wrapper`]: true,

--- a/components/checkbox/__tests__/checkbox.test.js
+++ b/components/checkbox/__tests__/checkbox.test.js
@@ -36,4 +36,16 @@ describe('Checkbox', () => {
     );
     errorSpy.mockRestore();
   });
+
+  it('defaultChecked should work if checked is passed as undefined and should be able to change state', () => {
+    resetWarned();
+    const { container } = render(<Checkbox defaultChecked checked={undefined} />);
+    const checkbox = container.getElementsByClassName('ant-checkbox-input')[0];
+
+    expect(checkbox).toBeChecked();
+
+    fireEvent.click(checkbox);
+
+    expect(checkbox).not.toBeChecked();
+  });
 });


### PR DESCRIPTION
…d issue #35130


[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link


1. https://github.com/ant-design/ant-design/issues/35130


### 💡 Background and solution


What is expected?
defaultChecked should work when checked is undefined

What is actually happening?
defaultChecked is ignored when checked is undefined

Solution: it seems the base checkbox antd is using "rc-checkbox" has this issue , and even though we are passing the value of checked as undefined , this component does a priority check based on the key existance in the prop object and not the value itself , i.e { "key" in propObject }, my solution just deleted the key incase the value is passed as undefined , this is the simplest way I could think of without the access of the base component (added a basic test case)


### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | my solution just deleted the key incase the value is passed as undefined |
| 🇨🇳 Chinese | 値が未定義として渡された場合に備えてキーを削除します (Google Translate) |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
