### PR TITLE
fix: Form vertical with span row

### DIFF
--- a/components/form/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/form/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -1528,6 +1528,43 @@ Array [
         </div>
       </div>
     </div>
+    <div
+      class="ant-form-item"
+    >
+      <div
+        class="ant-row ant-form-item-row"
+      >
+        <div
+          class="ant-col ant-col-12 ant-form-item-label"
+        >
+          <label
+            class=""
+            for="col12"
+            title="col12"
+          >
+            col12
+          </label>
+        </div>
+        <div
+          class="ant-col ant-col-12 ant-form-item-control"
+        >
+          <div
+            class="ant-form-item-control-input"
+          >
+            <div
+              class="ant-form-item-control-input-content"
+            >
+              <input
+                class="ant-input"
+                id="col12"
+                type="text"
+                value=""
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
   </form>,
 ]
 `;

--- a/components/form/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/form/__tests__/__snapshots__/demo.test.js.snap
@@ -1150,6 +1150,43 @@ Array [
         </div>
       </div>
     </div>
+    <div
+      class="ant-form-item"
+    >
+      <div
+        class="ant-row ant-form-item-row"
+      >
+        <div
+          class="ant-col ant-col-12 ant-form-item-label"
+        >
+          <label
+            class=""
+            for="col12"
+            title="col12"
+          >
+            col12
+          </label>
+        </div>
+        <div
+          class="ant-col ant-col-12 ant-form-item-control"
+        >
+          <div
+            class="ant-form-item-control-input"
+          >
+            <div
+              class="ant-form-item-control-input-content"
+            >
+              <input
+                class="ant-input"
+                id="col12"
+                type="text"
+                value=""
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
   </form>,
 ]
 `;

--- a/components/form/demo/col-24-debug.md
+++ b/components/form/demo/col-24-debug.md
@@ -115,7 +115,13 @@ const App: React.FC = () => {
 
       <Divider />
 
-      <Form layout="vertical">{sharedItem}</Form>
+      <Form layout="vertical">
+        {sharedItem}
+
+        <Form.Item label="col12" name="col12" labelCol={{ span: 12 }} wrapperCol={{ span: 12 }}>
+          <Input />
+        </Form.Item>
+      </Form>
     </>
   );
 };

--- a/components/form/style/vertical.less
+++ b/components/form/style/vertical.less
@@ -40,7 +40,9 @@
 
 .@{form-prefix-cls}-vertical {
   .@{form-item-prefix-cls} {
-    flex-direction: column;
+    &-row {
+      flex-direction: column;
+    }
 
     &-label > label {
       height: auto;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.

Before submitting your pull request, please make sure the checklist below is confirmed.

Your pull requests will be merged after one of the collaborators approve.

Thank you!

-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

fix #36780
fix #36783

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fix Form.Item with small size `labelCol` & `wrapperCol` not break line in vertical layout.      |
| 🇨🇳 Chinese |     修复 Form.Item 在垂直布局下使用小尺寸的 `labelCol` 和 `wrapperCol` 时不换行的问题。        |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
