### PR TITLE
docs: Prevent overriding when customizing less variable theme color

### DIFF
--- a/docs/react/replace-moment.en-US.md
+++ b/docs/react/replace-moment.en-US.md
@@ -21,7 +21,6 @@ For example:
 import { Dayjs } from 'dayjs';
 import dayjsGenerateConfig from 'rc-picker/lib/generate/dayjs';
 import generatePicker from 'antd/es/date-picker/generatePicker';
-import 'antd/es/date-picker/style/index';
 
 const DatePicker = generatePicker<Dayjs>(dayjsGenerateConfig);
 
@@ -61,7 +60,6 @@ For example:
 import { Dayjs } from 'dayjs';
 import dayjsGenerateConfig from 'rc-picker/lib/generate/dayjs';
 import generateCalendar from 'antd/es/calendar/generateCalendar';
-import 'antd/es/calendar/style';
 
 const Calendar = generateCalendar<Dayjs>(dayjsGenerateConfig);
 

--- a/docs/react/replace-moment.zh-CN.md
+++ b/docs/react/replace-moment.zh-CN.md
@@ -21,7 +21,6 @@ title: 替换 Moment.js
 import { Dayjs } from 'dayjs';
 import dayjsGenerateConfig from 'rc-picker/es/generate/dayjs';
 import generatePicker from 'antd/es/date-picker/generatePicker';
-import 'antd/es/date-picker/style/index';
 
 const DatePicker = generatePicker<Dayjs>(dayjsGenerateConfig);
 
@@ -61,7 +60,6 @@ export default TimePicker;
 import { Dayjs } from 'dayjs';
 import dayjsGenerateConfig from 'rc-picker/es/generate/dayjs';
 import generateCalendar from 'antd/es/calendar/generateCalendar';
-import 'antd/es/calendar/style';
 
 const Calendar = generateCalendar<Dayjs>(dayjsGenerateConfig);
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.

Before submitting your pull request, please make sure the checklist below is confirmed.

Your pull requests will be merged after one of the collaborators approve.

Thank you!

-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

#36804

### 💡 Background and solution

背景：当我采用全局less变量覆盖的方式更改主题色时，如果后续组件有再次引入antd样式，那么我的自定义变量将被覆盖。为了防止这种情况产生的隐性问题，我发现文档中 [替换 Moment.js](https://ant.design/docs/react/replace-moment-cn) 对`DatePicker` 和 `Calendar` 组件的重写会重新引入antd样式而导致这种情况的出现。

解决方案：直接删除这两个组件中的样式引入便不会出现此问题。

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     In the document [Replace Moment.js](https://ant.design/docs/react/replace-moment-cn) The rewrite of `DatePicker` and `Calendar` components no longer needs to introduce styles   |
| 🇨🇳 Chinese |    文档中 [替换 Moment.js](https://ant.design/docs/react/replace-moment-cn) 对`DatePicker` 和 `Calendar` 组件的重写不再需要引入样式    |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
