### PR TITLE
Avatar group to allow square overflow

### DIFF
--- a/components/avatar/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/avatar/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -837,6 +837,142 @@ Array [
       </div>
     </div>
   </div>,
+  <div
+    class="ant-divider ant-divider-horizontal"
+    role="separator"
+  />,
+  <div
+    class="ant-avatar-group"
+  >
+    <span
+      class="ant-avatar ant-avatar-lg ant-avatar-square ant-avatar-image"
+    >
+      <img
+        src="https://zos.alipayobjects.com/rmsportal/ODTLcjxAfvqbxHnVXCYX.png"
+      />
+    </span>
+    <span
+      class="ant-avatar ant-avatar-lg ant-avatar-square"
+      style="background-color:#f56a00"
+    >
+      <span
+        class="ant-avatar-string"
+        style="opacity:0"
+      >
+        K
+      </span>
+    </span>
+    <span
+      class="ant-avatar ant-avatar-lg ant-avatar-square"
+      style="color:#f56a00;background-color:#fde3cf;cursor:pointer"
+    >
+      <span
+        class="ant-avatar-string"
+        style="opacity:0"
+      >
+        +2
+      </span>
+    </span>
+    <div>
+      <div
+        class="ant-popover ant-avatar-group-popover"
+        style="opacity:0"
+      >
+        <div
+          class="ant-popover-content"
+        >
+          <div
+            class="ant-popover-arrow"
+          >
+            <span
+              class="ant-popover-arrow-content"
+            />
+          </div>
+          <div
+            class="ant-popover-inner"
+            role="tooltip"
+          >
+            <div
+              class="ant-popover-inner-content"
+            >
+              <span
+                class="ant-avatar ant-avatar-lg ant-avatar-square ant-avatar-icon"
+                style="background-color:#87d068"
+              >
+                <span
+                  aria-label="user"
+                  class="anticon anticon-user"
+                  role="img"
+                >
+                  <svg
+                    aria-hidden="true"
+                    data-icon="user"
+                    fill="currentColor"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M858.5 763.6a374 374 0 00-80.6-119.5 375.63 375.63 0 00-119.5-80.6c-.4-.2-.8-.3-1.2-.5C719.5 518 760 444.7 760 362c0-137-111-248-248-248S264 225 264 362c0 82.7 40.5 156 102.8 201.1-.4.2-.8.3-1.2.5-44.8 18.9-85 46-119.5 80.6a375.63 375.63 0 00-80.6 119.5A371.7 371.7 0 00136 901.8a8 8 0 008 8.2h60c4.4 0 7.9-3.5 8-7.8 2-77.2 33-149.5 87.8-204.3 56.7-56.7 132-87.9 212.2-87.9s155.5 31.2 212.2 87.9C779 752.7 810 825 812 902.2c.1 4.4 3.6 7.8 8 7.8h60a8 8 0 008-8.2c-1-47.8-10.9-94.3-29.5-138.2zM512 534c-45.9 0-89.1-17.9-121.6-50.4S340 407.9 340 362c0-45.9 17.9-89.1 50.4-121.6S466.1 190 512 190s89.1 17.9 121.6 50.4S684 316.1 684 362c0 45.9-17.9 89.1-50.4 121.6S557.9 534 512 534z"
+                    />
+                  </svg>
+                </span>
+              </span>
+              <div>
+                <div
+                  class="ant-tooltip"
+                  style="opacity:0"
+                >
+                  <div
+                    class="ant-tooltip-content"
+                  >
+                    <div
+                      class="ant-tooltip-arrow"
+                    >
+                      <span
+                        class="ant-tooltip-arrow-content"
+                      />
+                    </div>
+                    <div
+                      class="ant-tooltip-inner"
+                      role="tooltip"
+                    >
+                      Ant User
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <span
+                class="ant-avatar ant-avatar-lg ant-avatar-square ant-avatar-icon"
+                style="background-color:#1890ff"
+              >
+                <span
+                  aria-label="ant-design"
+                  class="anticon anticon-ant-design"
+                  role="img"
+                >
+                  <svg
+                    aria-hidden="true"
+                    data-icon="ant-design"
+                    fill="currentColor"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M716.3 313.8c19-18.9 19-49.7 0-68.6l-69.9-69.9.1.1c-18.5-18.5-50.3-50.3-95.3-95.2-21.2-20.7-55.5-20.5-76.5.5L80.9 474.2a53.84 53.84 0 000 76.4L474.6 944a54.14 54.14 0 0076.5 0l165.1-165c19-18.9 19-49.7 0-68.6a48.7 48.7 0 00-68.7 0l-125 125.2c-5.2 5.2-13.3 5.2-18.5 0L189.5 521.4c-5.2-5.2-5.2-13.3 0-18.5l314.4-314.2c.4-.4.9-.7 1.3-1.1 5.2-4.1 12.4-3.7 17.2 1.1l125.2 125.1c19 19 49.8 19 68.7 0zM408.6 514.4a106.3 106.2 0 10212.6 0 106.3 106.2 0 10-212.6 0zm536.2-38.6L821.9 353.5c-19-18.9-49.8-18.9-68.7.1a48.4 48.4 0 000 68.6l83 82.9c5.2 5.2 5.2 13.3 0 18.5l-81.8 81.7a48.4 48.4 0 000 68.6 48.7 48.7 0 0068.7 0l121.8-121.7a53.93 53.93 0 00-.1-76.4z"
+                    />
+                  </svg>
+                </span>
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>,
 ]
 `;
 

--- a/components/avatar/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/avatar/__tests__/__snapshots__/demo.test.js.snap
@@ -516,6 +516,43 @@ Array [
       </span>
     </span>
   </div>,
+  <div
+    class="ant-divider ant-divider-horizontal"
+    role="separator"
+  />,
+  <div
+    class="ant-avatar-group"
+  >
+    <span
+      class="ant-avatar ant-avatar-lg ant-avatar-square ant-avatar-image"
+    >
+      <img
+        src="https://zos.alipayobjects.com/rmsportal/ODTLcjxAfvqbxHnVXCYX.png"
+      />
+    </span>
+    <span
+      class="ant-avatar ant-avatar-lg ant-avatar-square"
+      style="background-color:#f56a00"
+    >
+      <span
+        class="ant-avatar-string"
+        style="opacity:0"
+      >
+        K
+      </span>
+    </span>
+    <span
+      class="ant-avatar ant-avatar-lg ant-avatar-square"
+      style="color:#f56a00;background-color:#fde3cf;cursor:pointer"
+    >
+      <span
+        class="ant-avatar-string"
+        style="opacity:0"
+      >
+        +2
+      </span>
+    </span>
+  </div>,
 ]
 `;
 

--- a/components/avatar/demo/group.md
+++ b/components/avatar/demo/group.md
@@ -64,6 +64,26 @@ const App: React.FC = () => (
       </Tooltip>
       <Avatar style={{ backgroundColor: '#1890ff' }} icon={<AntDesignOutlined />} />
     </Avatar.Group>
+    <Divider />
+    <Avatar.Group
+      maxCount={2}
+      maxPopoverTrigger="click"
+      size="large"
+      maxStyle={{ color: '#f56a00', backgroundColor: '#fde3cf', cursor: 'pointer' }}
+      maxShape="square"
+    >
+      <Avatar
+        src="https://zos.alipayobjects.com/rmsportal/ODTLcjxAfvqbxHnVXCYX.png"
+        shape="square"
+      />
+      <Avatar style={{ backgroundColor: '#f56a00' }} shape="square">
+        K
+      </Avatar>
+      <Tooltip title="Ant User" placement="top">
+        <Avatar style={{ backgroundColor: '#87d068' }} icon={<UserOutlined />} shape="square" />
+      </Tooltip>
+      <Avatar style={{ backgroundColor: '#1890ff' }} icon={<AntDesignOutlined />} shape="square" />
+    </Avatar.Group>
   </>
 );
 

--- a/components/avatar/demo/group.md
+++ b/components/avatar/demo/group.md
@@ -70,7 +70,7 @@ const App: React.FC = () => (
       maxPopoverTrigger="click"
       size="large"
       maxStyle={{ color: '#f56a00', backgroundColor: '#fde3cf', cursor: 'pointer' }}
-      maxShape="square"
+      shape="square"
     >
       <Avatar
         src="https://zos.alipayobjects.com/rmsportal/ODTLcjxAfvqbxHnVXCYX.png"

--- a/components/avatar/group.tsx
+++ b/components/avatar/group.tsx
@@ -15,6 +15,7 @@ export interface GroupProps {
   prefixCls?: string;
   maxCount?: number;
   maxStyle?: React.CSSProperties;
+  maxShape?: 'circle' | 'square';
   maxPopoverPlacement?: 'top' | 'bottom';
   maxPopoverTrigger?: 'hover' | 'focus' | 'click';
   /*
@@ -26,7 +27,14 @@ export interface GroupProps {
 
 const Group: React.FC<GroupProps> = props => {
   const { getPrefixCls, direction } = React.useContext(ConfigContext);
-  const { prefixCls: customizePrefixCls, className = '', maxCount, maxStyle, size } = props;
+  const {
+    prefixCls: customizePrefixCls,
+    className = '',
+    maxCount,
+    maxStyle,
+    maxShape = 'circle',
+    size,
+  } = props;
 
   const prefixCls = getPrefixCls('avatar-group', customizePrefixCls);
 
@@ -57,7 +65,7 @@ const Group: React.FC<GroupProps> = props => {
         placement={maxPopoverPlacement}
         overlayClassName={`${prefixCls}-popover`}
       >
-        <Avatar style={maxStyle}>{`+${numOfChildren - maxCount}`}</Avatar>
+        <Avatar style={maxStyle} shape={maxShape}>{`+${numOfChildren - maxCount}`}</Avatar>
       </Popover>,
     );
     return (

--- a/components/avatar/group.tsx
+++ b/components/avatar/group.tsx
@@ -15,7 +15,7 @@ export interface GroupProps {
   prefixCls?: string;
   maxCount?: number;
   maxStyle?: React.CSSProperties;
-  maxShape?: 'circle' | 'square';
+  shape?: 'circle' | 'square';
   maxPopoverPlacement?: 'top' | 'bottom';
   maxPopoverTrigger?: 'hover' | 'focus' | 'click';
   /*
@@ -32,7 +32,7 @@ const Group: React.FC<GroupProps> = props => {
     className = '',
     maxCount,
     maxStyle,
-    maxShape = 'circle',
+    shape = 'circle',
     size,
   } = props;
 
@@ -65,7 +65,7 @@ const Group: React.FC<GroupProps> = props => {
         placement={maxPopoverPlacement}
         overlayClassName={`${prefixCls}-popover`}
       >
-        <Avatar style={maxStyle} shape={maxShape}>{`+${numOfChildren - maxCount}`}</Avatar>
+        <Avatar style={maxStyle} shape={shape}>{`+${numOfChildren - maxCount}`}</Avatar>
       </Popover>,
     );
     return (

--- a/components/avatar/index.en-US.md
+++ b/components/avatar/index.en-US.md
@@ -34,5 +34,5 @@ Avatars can be used to represent people or objects. It supports images, `Icon`s,
 | maxPopoverPlacement | The placement of excess avatar Popover | `top` \| `bottom` | `top` |  |
 | maxPopoverTrigger | Set the trigger of excess avatar Popover | `hover` \| `focus` \| `click` | `hover` | 4.17.0 |
 | maxStyle | The style of excess avatar style | CSSProperties | - |  |
-| maxShape | The shape of excess avatar container | `circle` \| `square` | `circle` |  |
+| shape | The shape of excess avatar container | `circle` \| `square` | `circle` | 4.23.0 |
 | size | The size of the avatar | number \| `large` \| `small` \| `default` \| { xs: number, sm: number, ...} | `default` | 4.8.0 |

--- a/components/avatar/index.en-US.md
+++ b/components/avatar/index.en-US.md
@@ -34,4 +34,5 @@ Avatars can be used to represent people or objects. It supports images, `Icon`s,
 | maxPopoverPlacement | The placement of excess avatar Popover | `top` \| `bottom` | `top` |  |
 | maxPopoverTrigger | Set the trigger of excess avatar Popover | `hover` \| `focus` \| `click` | `hover` | 4.17.0 |
 | maxStyle | The style of excess avatar style | CSSProperties | - |  |
+| maxShape | The shape of excess avatar container | `circle` \| `square` | `circle` |  |
 | size | The size of the avatar | number \| `large` \| `small` \| `default` \| { xs: number, sm: number, ...} | `default` | 4.8.0 |

--- a/components/avatar/index.zh-CN.md
+++ b/components/avatar/index.zh-CN.md
@@ -39,4 +39,5 @@ cover: https://gw.alipayobjects.com/zos/antfincdn/aBcnbw68hP/Avatar.svg
 | maxPopoverPlacement | 多余头像气泡弹出位置 | `top` \| `bottom` | `top` |  |
 | maxPopoverTrigger | 设置多余头像 Popover 的触发方式 | `hover` \| `focus` \| `click` | `hover` | 4.17.0 |
 | maxStyle | 多余头像样式 | CSSProperties | - |  |
+| maxShape | 多余头像容器的形状 | `circle` \| `square` | `circle` |  |
 | size | 设置头像的大小 | number \| `large` \| `small` \| `default` \| { xs: number, sm: number, ...} | `default` | 4.8.0 |

--- a/components/avatar/index.zh-CN.md
+++ b/components/avatar/index.zh-CN.md
@@ -39,5 +39,5 @@ cover: https://gw.alipayobjects.com/zos/antfincdn/aBcnbw68hP/Avatar.svg
 | maxPopoverPlacement | 多余头像气泡弹出位置 | `top` \| `bottom` | `top` |  |
 | maxPopoverTrigger | 设置多余头像 Popover 的触发方式 | `hover` \| `focus` \| `click` | `hover` | 4.17.0 |
 | maxStyle | 多余头像样式 | CSSProperties | - |  |
-| maxShape | 多余头像容器的形状 | `circle` \| `square` | `circle` |  |
+| shape | 多余头像容器的形状 | `circle` \| `square` | `circle` | 4.23.0 |
 | size | 设置头像的大小 | number \| `large` \| `small` \| `default` \| { xs: number, sm: number, ...} | `default` | 4.8.0 |


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.

Before submitting your pull request, please make sure the checklist below is confirmed.

Your pull requests will be merged after one of the collaborators approve.

Thank you!

-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [x] Demo update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [x] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
close https://github.com/ant-design/ant-design/issues/36691
<!--
1. Put the related issue or discussion links [here](https://github.com/ant-design/ant-design/issues/36691).

https://github.com/ant-design/ant-design/issues/36691

-->

### 💡 Background and solution

<!--
When making all Avatar Square in Avatar.Group, the overflow component renders as a circle and cannot be changed to a square as needed by providing the shape property to the Group.

In the screenshot below we can see that the ant-avatar ant-avatar-circle classnames are being applied to the overflow component.

The end user experience would be to maintain the consistency of the shape of Avatars across the .Group component.

The solution was to provide an additional prop to the `Group` to accept `maxShape` prop as either `'circle' | 'square'` the default will be kept `circle` to avoid breaking previous implementations.
-->

### 📝 Changelog

<!--

This is a PR to resolve the following issue:
Ant Avatar.Group overflow item seems to be hardcoded to a circle shape and cannot be changed to square
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Produce a prop for the Avatar.Group to accept a shape prop of `circle` or `square`      |
| 🇨🇳 Chinese |     为 Avatar.Group 生成一个 prop 以接受 `circle` 或 `square` 的 shape prop      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
