### PR TITLE
fix: testing act error

### DIFF
--- a/components/upload/__tests__/dragger.test.js
+++ b/components/upload/__tests__/dragger.test.js
@@ -26,7 +26,7 @@ describe('Upload.Dragger', () => {
       },
     });
 
-    await act(() => {
+    act(() => {
       jest.runAllTimers();
     });
 

--- a/components/upload/__tests__/upload.test.js
+++ b/components/upload/__tests__/upload.test.js
@@ -322,7 +322,9 @@ describe('Upload', () => {
     const { rerender } = render(<Upload ref={ref} />);
     expect(ref.current.fileList).toEqual([]);
     rerender(<Upload ref={ref} fileList={fileList} />);
-    jest.runAllTimers();
+    act(() => {
+      jest.runAllTimers();
+    });
     expect(ref.current.fileList).toEqual(fileList);
     jest.useRealTimers();
   });
@@ -725,7 +727,7 @@ describe('Upload', () => {
         await Promise.resolve();
       }
     });
-    await act(() => {
+    act(() => {
       jest.runAllTimers();
     });
     await act(async () => {
@@ -945,7 +947,7 @@ describe('Upload', () => {
     });
 
     // Motion leave status change: start > active
-    await act(() => {
+    act(() => {
       jest.runAllTimers();
     });
 

--- a/components/upload/__tests__/uploadlist.test.js
+++ b/components/upload/__tests__/uploadlist.test.js
@@ -263,7 +263,7 @@ describe('Upload List', () => {
     // Error message
     fireEvent.mouseEnter(wrapper.querySelector('.ant-upload-list-item'));
 
-    await act(() => {
+    act(() => {
       jest.runAllTimers();
     });
 
@@ -574,7 +574,9 @@ describe('Upload List', () => {
       />,
     );
 
-    jest.runAllTimers();
+    act(() => {
+      jest.runAllTimers();
+    });
 
     unmount();
 
@@ -1138,7 +1140,7 @@ describe('Upload List', () => {
       expect(onChange).toHaveBeenCalled();
 
       // Check for images
-      await act(() => {
+      act(() => {
         jest.runAllTimers();
       });
       const afterImgNode = wrapper.container.querySelectorAll(
@@ -1313,7 +1315,7 @@ describe('Upload List', () => {
 
     expect(uploadRef.current.fileList).toHaveLength(fileNames.length);
 
-    await act(() => {
+    act(() => {
       jest.runAllTimers();
     });
     expect(uploadRef.current.fileList).toHaveLength(fileNames.length);

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -1,9 +1,8 @@
 import MockDate from 'mockdate';
 import type { ReactElement } from 'react';
 import { StrictMode } from 'react';
-import { act } from 'react-dom/test-utils';
 import type { RenderOptions } from '@testing-library/react';
-import { render } from '@testing-library/react';
+import { render, act } from '@testing-library/react';
 import { _rs as onLibResize } from 'rc-resize-observer/lib/utils/observerUtil';
 import { _rs as onEsResize } from 'rc-resize-observer/es/utils/observerUtil';
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.

Before submitting your pull request, please make sure the checklist below is confirmed.

Your pull requests will be merged after one of the collaborators approve.

Thank you!

-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [x] Other (Enhance test dependency)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

1. Recommend use `act` in `testing-library/react` instead of `react-dom` since:
* `act` from `@testing-library/react` will re-export `act` from `react-dom/test-utils` or use a polyfill if `react-dom/test-utils` is not available.
* `act` from `@testing-library/react-hooks` will choose one of `react-test-renderer` or `react-dom/test-utils` to re-export `act` from.
* we use `react-dom` as react renderer, so either way causes the same result. For semantic and tidy Import, we recommend importing `act` form `@testing-library/react-hooks` when testing hooks. And, use `act` form `@testing-library/react` when testing React components.

2. `act` no need to be await when the callback function is a sync function.
3. `jest.runAllTimers()` should be wrapped in `act`.

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Update `act` import from 'testing-library/react', fix `act` sync usage and `jest.runAllTimers()` usage |
| 🇨🇳 Chinese | 更新测试`act`的import，修复`act`的使用以及`jest.runAllTimers()`的使用 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
