### PR TITLE
fix: Drawer zIndex missing

### DIFF
--- a/components/drawer/__tests__/Drawer.test.js
+++ b/components/drawer/__tests__/Drawer.test.js
@@ -198,4 +198,14 @@ describe('Drawer', () => {
 
     errorSpy.mockRestore();
   });
+
+  it('zIndex should work', () => {
+    const { container } = render(<Drawer getContainer={false} visible zIndex={903} />);
+    expect(container.querySelector('.ant-drawer-mask')).toHaveStyle({
+      zIndex: 903,
+    });
+    expect(container.querySelector('.ant-drawer-content-wrapper')).toHaveStyle({
+      zIndex: 903,
+    });
+  });
 });

--- a/components/drawer/index.tsx
+++ b/components/drawer/index.tsx
@@ -52,7 +52,6 @@ function Drawer({
   className,
   visible,
   children,
-  zIndex,
   style,
   title,
   headerStyle,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.

Before submitting your pull request, please make sure the checklist below is confirmed.

Your pull requests will be merged after one of the collaborators approve.

Thank you!

-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fix Drawer `zIndex` props not working.      |
| 🇨🇳 Chinese |     修复 Drawer `zIndex` 属性无效的问题。     |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
