### PR TITLE
fix: Upload in React 18 sync problem

### DIFF
--- a/components/upload/Upload.tsx
+++ b/components/upload/Upload.tsx
@@ -3,6 +3,7 @@ import type { UploadProps as RcUploadProps } from 'rc-upload';
 import RcUpload from 'rc-upload';
 import useMergedState from 'rc-util/lib/hooks/useMergedState';
 import * as React from 'react';
+import { flushSync } from 'react-dom';
 import { ConfigContext } from '../config-provider';
 import DisabledContext from '../config-provider/DisabledContext';
 import LocaleReceiver from '../locale-provider/LocaleReceiver';
@@ -101,7 +102,9 @@ const InternalUpload: React.ForwardRefRenderFunction<unknown, UploadProps> = (pr
       cloneList = cloneList.slice(0, maxCount);
     }
 
-    setMergedFileList(cloneList);
+    flushSync(() => {
+      setMergedFileList(cloneList);
+    });
 
     const changeInfo: UploadChangeParam<UploadFile> = {
       file: file as UploadFile,

--- a/components/upload/Upload.tsx
+++ b/components/upload/Upload.tsx
@@ -102,6 +102,8 @@ const InternalUpload: React.ForwardRefRenderFunction<unknown, UploadProps> = (pr
       cloneList = cloneList.slice(0, maxCount);
     }
 
+    // Prevent React18 auto batch since input[upload] trigger process at same time
+    // which makes fileList closure problem
     flushSync(() => {
       setMergedFileList(cloneList);
     });

--- a/components/upload/__tests__/upload.test.js
+++ b/components/upload/__tests__/upload.test.js
@@ -914,7 +914,7 @@ describe('Upload', () => {
       throw new TypeError("Object doesn't support this action");
     };
 
-    jest.spyOn(global, 'File').mockImplementationOnce(fileConstructor);
+    const spyIE = jest.spyOn(global, 'File').mockImplementationOnce(fileConstructor);
     fireEvent.change(container.querySelector('input'), {
       target: {
         files: [{ file: 'foo.png' }],
@@ -925,6 +925,7 @@ describe('Upload', () => {
     await sleep();
 
     expect(onChange.mock.calls[0][0].fileList).toHaveLength(1);
+    spyIE.mockRestore();
   });
 
   // https://github.com/ant-design/ant-design/issues/33819

--- a/components/upload/__tests__/upload.test.js
+++ b/components/upload/__tests__/upload.test.js
@@ -965,4 +965,58 @@ describe('Upload', () => {
     const { container: wrapper2 } = render(<Upload prefixCls="custom-upload" />);
     expect(wrapper2.querySelectorAll('.custom-upload-list').length).toBeGreaterThan(0);
   });
+
+  // https://github.com/ant-design/ant-design/issues/36869
+  it('Prevent auto batch', async () => {
+    const mockFile1 = new File(['bamboo'], 'bamboo.png', {
+      type: 'image/png',
+    });
+    const mockFile2 = new File(['light'], 'light.png', {
+      type: 'image/png',
+    });
+
+    let info1;
+    let info2;
+
+    const onChange = jest.fn();
+    const { container } = render(
+      <Upload
+        customRequest={info => {
+          if (info.file === mockFile1) {
+            info1 = info;
+          } else {
+            info2 = info;
+          }
+        }}
+        onChange={onChange}
+      />,
+    );
+
+    fireEvent.change(container.querySelector('input'), {
+      target: {
+        files: [mockFile1, mockFile2],
+      },
+    });
+
+    // React 18 is async now
+    await act(async () => {
+      await sleep();
+    });
+    onChange.mockReset();
+
+    // Processing
+    act(() => {
+      info1.onProgress({ percent: 10 }, mockFile1);
+      info2.onProgress({ percent: 20 }, mockFile2);
+    });
+
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fileList: [
+          expect.objectContaining({ percent: 10 }),
+          expect.objectContaining({ percent: 20 }),
+        ],
+      }),
+    );
+  });
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.

Before submitting your pull request, please make sure the checklist below is confirmed.

Your pull requests will be merged after one of the collaborators approve.

Thank you!

-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
-->

fix #36869

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Fix Upload trigger mistake files status when upload multiple files at same time in React 18.     |
| 🇨🇳 Chinese |     修复 Upload 在 React 18 下同时上传多份文件会出现上传状态不正确的问题。     |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
