### PR TITLE
🐞 fix: .ant-select-selector是content-box导致宽度不正常

### DIFF
--- a/components/select/style/dropdown.tsx
+++ b/components/select/style/dropdown.tsx
@@ -25,6 +25,7 @@ const genItemStyle: GenerateStyle<SelectToken, CSSObject> = token => {
     fontWeight: 'normal',
     fontSize: token.fontSize,
     lineHeight: token.lineHeight,
+    boxSizing: 'border-box',
   };
 };
 

--- a/components/select/style/single.tsx
+++ b/components/select/style/single.tsx
@@ -89,6 +89,7 @@ function genSizeStyle(token: SelectToken, suffix?: string): CSSObject {
           width: '100%',
           height: token.controlHeight,
           padding: `0 ${inputPaddingHorizontalBase}px`,
+          boxSizing: 'border-box',
 
           [`${componentCls}-selection-search-input`]: {
             height: selectHeightWithoutBorder,

--- a/components/select/style/single.tsx
+++ b/components/select/style/single.tsx
@@ -1,4 +1,5 @@
 import type { CSSInterpolation, CSSObject } from '@ant-design/cssinjs';
+import { resetComponent } from '../../style';
 import type { SelectToken } from '.';
 import { mergeToken } from '../../theme';
 
@@ -17,6 +18,8 @@ function genSizeStyle(token: SelectToken, suffix?: string): CSSObject {
 
       // ========================= Selector =========================
       [`${componentCls}-selector`]: {
+        ...resetComponent(token),
+
         display: 'flex',
         [`${componentCls}-selection-search`]: {
           position: 'absolute',
@@ -89,7 +92,6 @@ function genSizeStyle(token: SelectToken, suffix?: string): CSSObject {
           width: '100%',
           height: token.controlHeight,
           padding: `0 ${inputPaddingHorizontalBase}px`,
-          boxSizing: 'border-box',
 
           [`${componentCls}-selection-search-input`]: {
             height: selectHeightWithoutBorder,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.

Before submitting your pull request, please make sure the checklist below is confirmed.

Your pull requests will be merged after one of the collaborators approve.

Thank you!

-->
使用cra新建一个项目，引入antd 5.0.0-experimental.15，如下图方式使用
<img width="543" alt="image" src="https://user-images.githubusercontent.com/21985353/183612598-5102bbc7-110d-497e-8ed9-f2be5f6cb0f6.png">
结果如下
![image](https://user-images.githubusercontent.com/21985353/183612224-56af37af-9521-4acc-91e4-05486820e50c.png)
<img width="1285" alt="image" src="https://user-images.githubusercontent.com/21985353/183613029-f5d0109e-342b-47ec-9bb8-8315b8d7d86a.png">



[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      fix .ant-select-selector's box-sizing is content-box,cause width abnormal   |
| 🇨🇳 Chinese |     修复 .ant-select-selector的box-sizing是content-box导致宽度不正常     |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
