### PR TITLE
style(Select): error border exclueds pagination

### DIFF
--- a/components/select/style/status.less
+++ b/components/select/style/status.less
@@ -1,6 +1,7 @@
 @import '../../input/style/mixin';
 
 @select-prefix-cls: ~'@{ant-prefix}-select';
+@pagination-prefix-cls: ~'@{ant-prefix}-pagination';
 
 .select-status-color(
   @text-color;
@@ -9,7 +10,7 @@
   @hoverBorderColor;
   @outlineColor;
 ) {
-  &.@{select-prefix-cls}:not(.@{select-prefix-cls}-disabled):not(.@{select-prefix-cls}-customize-input) {
+  &.@{select-prefix-cls}:not(.@{select-prefix-cls}-disabled):not(.@{select-prefix-cls}-customize-input):not(.@{pagination-prefix-cls}-size-changer) {
     .@{select-prefix-cls}-selector {
       background-color: @background-color;
       border-color: @border-color !important;


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

- fix #36931
<!--
1. Put the related issue or discussion links here.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

当 `Pagination` 在 `Form` 中 `Form` 校验错误时，会给 Pagination 的选择框一个红色边框(error status)

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Removed exception error border for `Pagination`  |
| 🇨🇳 Chinese |    去掉 `Pagination` 的异常错误边框    |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
