### PR TITLE
fix: align with the less algorithm for generating css variable value

### DIFF
--- a/components/config-provider/__tests__/theme.test.ts
+++ b/components/config-provider/__tests__/theme.test.ts
@@ -33,6 +33,34 @@ describe('ConfigProvider.Theme', () => {
     });
   });
 
+  it('should generate the same css variable as less algorithm', () => {
+    const prefixCls = 'test';
+    const infoColor = {
+      hover: '#40a9ff',
+      active: '#096dd9',
+      deprecatedBg: '#e6f7ff',
+      deprecatedBorder: '#91d5ff',
+    };
+
+    ConfigProvider.config({
+      prefixCls,
+      theme: {
+        infoColor: '#1890ff',
+      },
+    });
+
+    const styles: any[] = Array.from(document.querySelectorAll('style'));
+    const themeStyle = styles.find(style =>
+      style.getAttribute('rc-util-key').includes('-dynamic-theme'),
+    );
+
+    (Object.keys(infoColor) as Array<keyof typeof infoColor>).forEach(key => {
+      expect(themeStyle.innerHTML).toContain(
+        `--${prefixCls}-info-color-${kebabCase(key)}: ${infoColor[key]}`,
+      );
+    });
+  });
+
   it('warning for SSR', () => {
     resetWarned();
 

--- a/components/config-provider/cssVariables.tsx
+++ b/components/config-provider/cssVariables.tsx
@@ -28,10 +28,10 @@ export function getStyle(globalPrefixCls: string, theme: Theme) {
     variables[`${type}-color`] = formatColor(baseColor);
     variables[`${type}-color-disabled`] = colorPalettes[1];
     variables[`${type}-color-hover`] = colorPalettes[4];
-    variables[`${type}-color-active`] = colorPalettes[7];
+    variables[`${type}-color-active`] = colorPalettes[6];
     variables[`${type}-color-outline`] = baseColor.clone().setAlpha(0.2).toRgbString();
-    variables[`${type}-color-deprecated-bg`] = colorPalettes[1];
-    variables[`${type}-color-deprecated-border`] = colorPalettes[3];
+    variables[`${type}-color-deprecated-bg`] = colorPalettes[0];
+    variables[`${type}-color-deprecated-border`] = colorPalettes[2];
   };
 
   // ================ Primary Color ================


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.

Before submitting your pull request, please make sure the checklist below is confirmed.

Your pull requests will be merged after one of the collaborators approve.

Thank you!

-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
-->

使用`ConfigProvider`配置自定义主题色信息的时候，发现最后生成的一些css变量值跟less算法并不一致。

复现步骤：
1.访问线上的[demo地址](https://ant.design/components/config-provider-cn/#components-config-provider-demo-theme)
2.点击`var(--ant-info-color)`对应的调色盘（只是触发生成css变量的逻辑，颜色并没有变）
3.可以查看到alert的ui发生了改变，背景以及边框颜色发生了变化

<img width="1400" alt="截屏2022-08-15 22 56 48" src="https://user-images.githubusercontent.com/33021497/184660303-9d3d813a-d6ea-47f1-80d3-03dc083514fe.png">

### 💡 Background and solution
修改生成css变量值的js算法
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     align with the less algorithm for generating css variable value     |
| 🇨🇳 Chinese |     跟用于生成css变量值的less算法保持一致      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
