### PR TITLE
fix: Accordions are missing expand and collapse states

### DIFF
--- a/components/table/ExpandIcon.tsx
+++ b/components/table/ExpandIcon.tsx
@@ -33,6 +33,7 @@ function renderExpandIcon(locale: TableLocale) {
           [`${iconPrefix}-collapsed`]: expandable && !expanded,
         })}
         aria-label={expanded ? locale.collapse : locale.expand}
+        aria-expanded={expanded}
       />
     );
   };

--- a/components/table/__tests__/Table.expand.test.js
+++ b/components/table/__tests__/Table.expand.test.js
@@ -81,6 +81,13 @@ describe('Table.expand', () => {
     fireEvent.click(container.querySelector('.ant-table-row-expand-icon'));
     expect(container.querySelector('.indent-level-1').style.paddingLeft).toEqual('0px');
   });
+  
+  it('has right aria-expanded state', () => {
+    const { container } = render(<Table columns={columns} dataSource={data} />);
+    expect(container.querySelector('[aria-expanded=false]')).toBeTruthy();
+    fireEvent.click(container.querySelector('.ant-table-row-expand-icon'));
+    expect(container.querySelector('[aria-expanded=true]')).toBeTruthy();
+  });
 
   describe('expandIconColumnIndex', () => {
     it('basic', () => {

--- a/components/table/__tests__/__snapshots__/Table.expand.test.js.snap
+++ b/components/table/__tests__/__snapshots__/Table.expand.test.js.snap
@@ -49,6 +49,7 @@ exports[`Table.expand click to expand 1`] = `
                       style="padding-left: 0px;"
                     />
                     <button
+                      aria-expanded="true"
                       aria-label="Collapse row"
                       class="ant-table-row-expand-icon ant-table-row-expand-icon-expanded"
                       type="button"
@@ -67,6 +68,7 @@ exports[`Table.expand click to expand 1`] = `
                       style="padding-left: 15px;"
                     />
                     <button
+                      aria-expanded="false"
                       aria-label="Expand row"
                       class="ant-table-row-expand-icon ant-table-row-expand-icon-spaced"
                       type="button"

--- a/components/table/__tests__/__snapshots__/Table.rowSelection.test.js.snap
+++ b/components/table/__tests__/__snapshots__/Table.rowSelection.test.js.snap
@@ -116,6 +116,7 @@ exports[`Table.rowSelection fix expand on th left when selection column fixed on
                     style="position: sticky; left: 0px;"
                   >
                     <button
+                      aria-expanded="false"
                       aria-label="Expand row"
                       class="ant-table-row-expand-icon ant-table-row-expand-icon-collapsed"
                       type="button"
@@ -157,6 +158,7 @@ exports[`Table.rowSelection fix expand on th left when selection column fixed on
                     style="position: sticky; left: 0px;"
                   >
                     <button
+                      aria-expanded="false"
                       aria-label="Expand row"
                       class="ant-table-row-expand-icon ant-table-row-expand-icon-collapsed"
                       type="button"
@@ -198,6 +200,7 @@ exports[`Table.rowSelection fix expand on th left when selection column fixed on
                     style="position: sticky; left: 0px;"
                   >
                     <button
+                      aria-expanded="false"
                       aria-label="Expand row"
                       class="ant-table-row-expand-icon ant-table-row-expand-icon-collapsed"
                       type="button"
@@ -239,6 +242,7 @@ exports[`Table.rowSelection fix expand on th left when selection column fixed on
                     style="position: sticky; left: 0px;"
                   >
                     <button
+                      aria-expanded="false"
                       aria-label="Expand row"
                       class="ant-table-row-expand-icon ant-table-row-expand-icon-collapsed"
                       type="button"

--- a/components/table/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/table/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -3672,6 +3672,7 @@ Array [
                       class="ant-table-cell ant-table-row-expand-icon-cell"
                     >
                       <button
+                        aria-expanded="false"
                         aria-label="Expand row"
                         class="ant-table-row-expand-icon ant-table-row-expand-icon-collapsed"
                         type="button"
@@ -3775,6 +3776,7 @@ Array [
                       class="ant-table-cell ant-table-row-expand-icon-cell"
                     >
                       <button
+                        aria-expanded="false"
                         aria-label="Expand row"
                         class="ant-table-row-expand-icon ant-table-row-expand-icon-collapsed"
                         type="button"
@@ -3878,6 +3880,7 @@ Array [
                       class="ant-table-cell ant-table-row-expand-icon-cell"
                     >
                       <button
+                        aria-expanded="false"
                         aria-label="Expand row"
                         class="ant-table-row-expand-icon ant-table-row-expand-icon-collapsed"
                         type="button"
@@ -3981,6 +3984,7 @@ Array [
                       class="ant-table-cell ant-table-row-expand-icon-cell"
                     >
                       <button
+                        aria-expanded="false"
                         aria-label="Expand row"
                         class="ant-table-row-expand-icon ant-table-row-expand-icon-collapsed"
                         type="button"
@@ -4084,6 +4088,7 @@ Array [
                       class="ant-table-cell ant-table-row-expand-icon-cell"
                     >
                       <button
+                        aria-expanded="false"
                         aria-label="Expand row"
                         class="ant-table-row-expand-icon ant-table-row-expand-icon-collapsed"
                         type="button"
@@ -4187,6 +4192,7 @@ Array [
                       class="ant-table-cell ant-table-row-expand-icon-cell"
                     >
                       <button
+                        aria-expanded="false"
                         aria-label="Expand row"
                         class="ant-table-row-expand-icon ant-table-row-expand-icon-collapsed"
                         type="button"
@@ -4290,6 +4296,7 @@ Array [
                       class="ant-table-cell ant-table-row-expand-icon-cell"
                     >
                       <button
+                        aria-expanded="false"
                         aria-label="Expand row"
                         class="ant-table-row-expand-icon ant-table-row-expand-icon-collapsed"
                         type="button"
@@ -4393,6 +4400,7 @@ Array [
                       class="ant-table-cell ant-table-row-expand-icon-cell"
                     >
                       <button
+                        aria-expanded="false"
                         aria-label="Expand row"
                         class="ant-table-row-expand-icon ant-table-row-expand-icon-collapsed"
                         type="button"
@@ -4496,6 +4504,7 @@ Array [
                       class="ant-table-cell ant-table-row-expand-icon-cell"
                     >
                       <button
+                        aria-expanded="false"
                         aria-label="Expand row"
                         class="ant-table-row-expand-icon ant-table-row-expand-icon-collapsed"
                         type="button"
@@ -4599,6 +4608,7 @@ Array [
                       class="ant-table-cell ant-table-row-expand-icon-cell"
                     >
                       <button
+                        aria-expanded="false"
                         aria-label="Expand row"
                         class="ant-table-row-expand-icon ant-table-row-expand-icon-collapsed"
                         type="button"
@@ -6817,6 +6827,7 @@ exports[`renders ./components/table/demo/expand.md extend context correctly 1`] 
                     class="ant-table-cell ant-table-row-expand-icon-cell"
                   >
                     <button
+                      aria-expanded="false"
                       aria-label="Expand row"
                       class="ant-table-row-expand-icon ant-table-row-expand-icon-collapsed"
                       type="button"
@@ -6853,6 +6864,7 @@ exports[`renders ./components/table/demo/expand.md extend context correctly 1`] 
                     class="ant-table-cell ant-table-row-expand-icon-cell"
                   >
                     <button
+                      aria-expanded="false"
                       aria-label="Expand row"
                       class="ant-table-row-expand-icon ant-table-row-expand-icon-collapsed"
                       type="button"
@@ -6889,6 +6901,7 @@ exports[`renders ./components/table/demo/expand.md extend context correctly 1`] 
                     class="ant-table-cell ant-table-row-expand-icon-cell"
                   >
                     <button
+                      aria-expanded="false"
                       aria-label="Expand row"
                       class="ant-table-row-expand-icon ant-table-row-expand-icon-spaced"
                       type="button"
@@ -6925,6 +6938,7 @@ exports[`renders ./components/table/demo/expand.md extend context correctly 1`] 
                     class="ant-table-cell ant-table-row-expand-icon-cell"
                   >
                     <button
+                      aria-expanded="false"
                       aria-label="Expand row"
                       class="ant-table-row-expand-icon ant-table-row-expand-icon-collapsed"
                       type="button"
@@ -15952,6 +15966,7 @@ Array [
                       class="ant-table-cell ant-table-row-expand-icon-cell"
                     >
                       <button
+                        aria-expanded="false"
                         aria-label="Expand row"
                         class="ant-table-row-expand-icon ant-table-row-expand-icon-collapsed"
                         type="button"
@@ -16003,6 +16018,7 @@ Array [
                       class="ant-table-cell ant-table-row-expand-icon-cell"
                     >
                       <button
+                        aria-expanded="false"
                         aria-label="Expand row"
                         class="ant-table-row-expand-icon ant-table-row-expand-icon-collapsed"
                         type="button"
@@ -16054,6 +16070,7 @@ Array [
                       class="ant-table-cell ant-table-row-expand-icon-cell"
                     >
                       <button
+                        aria-expanded="false"
                         aria-label="Expand row"
                         class="ant-table-row-expand-icon ant-table-row-expand-icon-collapsed"
                         type="button"
@@ -16276,6 +16293,7 @@ Array [
                       class="ant-table-cell ant-table-row-expand-icon-cell"
                     >
                       <button
+                        aria-expanded="true"
                         aria-label="Collapse row"
                         class="ant-table-row-expand-icon ant-table-row-expand-icon-expanded"
                         type="button"
@@ -17054,6 +17072,7 @@ Array [
                       class="ant-table-cell ant-table-row-expand-icon-cell"
                     >
                       <button
+                        aria-expanded="false"
                         aria-label="Expand row"
                         class="ant-table-row-expand-icon ant-table-row-expand-icon-collapsed"
                         type="button"
@@ -17105,6 +17124,7 @@ Array [
                       class="ant-table-cell ant-table-row-expand-icon-cell"
                     >
                       <button
+                        aria-expanded="false"
                         aria-label="Expand row"
                         class="ant-table-row-expand-icon ant-table-row-expand-icon-collapsed"
                         type="button"
@@ -17317,6 +17337,7 @@ Array [
                       class="ant-table-cell ant-table-row-expand-icon-cell"
                     >
                       <button
+                        aria-expanded="true"
                         aria-label="Collapse row"
                         class="ant-table-row-expand-icon ant-table-row-expand-icon-expanded"
                         type="button"
@@ -18095,6 +18116,7 @@ Array [
                       class="ant-table-cell ant-table-row-expand-icon-cell"
                     >
                       <button
+                        aria-expanded="false"
                         aria-label="Expand row"
                         class="ant-table-row-expand-icon ant-table-row-expand-icon-collapsed"
                         type="button"
@@ -18146,6 +18168,7 @@ Array [
                       class="ant-table-cell ant-table-row-expand-icon-cell"
                     >
                       <button
+                        aria-expanded="false"
                         aria-label="Expand row"
                         class="ant-table-row-expand-icon ant-table-row-expand-icon-collapsed"
                         type="button"
@@ -18358,6 +18381,7 @@ Array [
                       class="ant-table-cell ant-table-row-expand-icon-cell"
                     >
                       <button
+                        aria-expanded="true"
                         aria-label="Collapse row"
                         class="ant-table-row-expand-icon ant-table-row-expand-icon-expanded"
                         type="button"
@@ -19136,6 +19160,7 @@ Array [
                       class="ant-table-cell ant-table-row-expand-icon-cell"
                     >
                       <button
+                        aria-expanded="false"
                         aria-label="Expand row"
                         class="ant-table-row-expand-icon ant-table-row-expand-icon-collapsed"
                         type="button"
@@ -19187,6 +19212,7 @@ Array [
                       class="ant-table-cell ant-table-row-expand-icon-cell"
                     >
                       <button
+                        aria-expanded="false"
                         aria-label="Expand row"
                         class="ant-table-row-expand-icon ant-table-row-expand-icon-collapsed"
                         type="button"
@@ -19416,6 +19442,7 @@ exports[`renders ./components/table/demo/order-column.md extend context correctl
                     class="ant-table-cell ant-table-row-expand-icon-cell"
                   >
                     <button
+                      aria-expanded="false"
                       aria-label="Expand row"
                       class="ant-table-row-expand-icon ant-table-row-expand-icon-collapsed"
                       type="button"
@@ -19464,6 +19491,7 @@ exports[`renders ./components/table/demo/order-column.md extend context correctl
                     class="ant-table-cell ant-table-row-expand-icon-cell"
                   >
                     <button
+                      aria-expanded="false"
                       aria-label="Expand row"
                       class="ant-table-row-expand-icon ant-table-row-expand-icon-collapsed"
                       type="button"
@@ -19512,6 +19540,7 @@ exports[`renders ./components/table/demo/order-column.md extend context correctl
                     class="ant-table-cell ant-table-row-expand-icon-cell"
                   >
                     <button
+                      aria-expanded="false"
                       aria-label="Expand row"
                       class="ant-table-row-expand-icon ant-table-row-expand-icon-collapsed"
                       type="button"
@@ -19560,6 +19589,7 @@ exports[`renders ./components/table/demo/order-column.md extend context correctl
                     class="ant-table-cell ant-table-row-expand-icon-cell"
                   >
                     <button
+                      aria-expanded="false"
                       aria-label="Expand row"
                       class="ant-table-row-expand-icon ant-table-row-expand-icon-collapsed"
                       type="button"
@@ -26481,6 +26511,7 @@ Array [
                         style="padding-left:0px"
                       />
                       <button
+                        aria-expanded="false"
                         aria-label="Expand row"
                         class="ant-table-row-expand-icon ant-table-row-expand-icon-collapsed"
                         type="button"
@@ -26529,6 +26560,7 @@ Array [
                         style="padding-left:0px"
                       />
                       <button
+                        aria-expanded="false"
                         aria-label="Expand row"
                         class="ant-table-row-expand-icon ant-table-row-expand-icon-spaced"
                         type="button"
@@ -26788,6 +26820,7 @@ Array [
                         style="padding-left:0px"
                       />
                       <button
+                        aria-expanded="true"
                         aria-label="Collapse row"
                         class="ant-table-row-expand-icon ant-table-row-expand-icon-expanded"
                         type="button"
@@ -26843,6 +26876,7 @@ Array [
                         style="padding-left:15px"
                       />
                       <button
+                        aria-expanded="true"
                         aria-label="Collapse row"
                         class="ant-table-row-expand-icon ant-table-row-expand-icon-spaced"
                         type="button"
@@ -26898,6 +26932,7 @@ Array [
                         style="padding-left:15px"
                       />
                       <button
+                        aria-expanded="true"
                         aria-label="Collapse row"
                         class="ant-table-row-expand-icon ant-table-row-expand-icon-expanded"
                         type="button"
@@ -26953,6 +26988,7 @@ Array [
                         style="padding-left:30px"
                       />
                       <button
+                        aria-expanded="true"
                         aria-label="Collapse row"
                         class="ant-table-row-expand-icon ant-table-row-expand-icon-spaced"
                         type="button"
@@ -27008,6 +27044,7 @@ Array [
                         style="padding-left:15px"
                       />
                       <button
+                        aria-expanded="true"
                         aria-label="Collapse row"
                         class="ant-table-row-expand-icon ant-table-row-expand-icon-expanded"
                         type="button"
@@ -27063,6 +27100,7 @@ Array [
                         style="padding-left:30px"
                       />
                       <button
+                        aria-expanded="true"
                         aria-label="Collapse row"
                         class="ant-table-row-expand-icon ant-table-row-expand-icon-expanded"
                         type="button"
@@ -27118,6 +27156,7 @@ Array [
                         style="padding-left:45px"
                       />
                       <button
+                        aria-expanded="true"
                         aria-label="Collapse row"
                         class="ant-table-row-expand-icon ant-table-row-expand-icon-spaced"
                         type="button"
@@ -27173,6 +27212,7 @@ Array [
                         style="padding-left:45px"
                       />
                       <button
+                        aria-expanded="true"
                         aria-label="Collapse row"
                         class="ant-table-row-expand-icon ant-table-row-expand-icon-spaced"
                         type="button"
@@ -27228,6 +27268,7 @@ Array [
                         style="padding-left:0px"
                       />
                       <button
+                        aria-expanded="true"
                         aria-label="Collapse row"
                         class="ant-table-row-expand-icon ant-table-row-expand-icon-spaced"
                         type="button"

--- a/components/table/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/table/__tests__/__snapshots__/demo.test.js.snap
@@ -2945,6 +2945,7 @@ Array [
                       class="ant-table-cell ant-table-row-expand-icon-cell"
                     >
                       <button
+                        aria-expanded="false"
                         aria-label="Expand row"
                         class="ant-table-row-expand-icon ant-table-row-expand-icon-collapsed"
                         type="button"
@@ -3048,6 +3049,7 @@ Array [
                       class="ant-table-cell ant-table-row-expand-icon-cell"
                     >
                       <button
+                        aria-expanded="false"
                         aria-label="Expand row"
                         class="ant-table-row-expand-icon ant-table-row-expand-icon-collapsed"
                         type="button"
@@ -3151,6 +3153,7 @@ Array [
                       class="ant-table-cell ant-table-row-expand-icon-cell"
                     >
                       <button
+                        aria-expanded="false"
                         aria-label="Expand row"
                         class="ant-table-row-expand-icon ant-table-row-expand-icon-collapsed"
                         type="button"
@@ -3254,6 +3257,7 @@ Array [
                       class="ant-table-cell ant-table-row-expand-icon-cell"
                     >
                       <button
+                        aria-expanded="false"
                         aria-label="Expand row"
                         class="ant-table-row-expand-icon ant-table-row-expand-icon-collapsed"
                         type="button"
@@ -3357,6 +3361,7 @@ Array [
                       class="ant-table-cell ant-table-row-expand-icon-cell"
                     >
                       <button
+                        aria-expanded="false"
                         aria-label="Expand row"
                         class="ant-table-row-expand-icon ant-table-row-expand-icon-collapsed"
                         type="button"
@@ -3460,6 +3465,7 @@ Array [
                       class="ant-table-cell ant-table-row-expand-icon-cell"
                     >
                       <button
+                        aria-expanded="false"
                         aria-label="Expand row"
                         class="ant-table-row-expand-icon ant-table-row-expand-icon-collapsed"
                         type="button"
@@ -3563,6 +3569,7 @@ Array [
                       class="ant-table-cell ant-table-row-expand-icon-cell"
                     >
                       <button
+                        aria-expanded="false"
                         aria-label="Expand row"
                         class="ant-table-row-expand-icon ant-table-row-expand-icon-collapsed"
                         type="button"
@@ -3666,6 +3673,7 @@ Array [
                       class="ant-table-cell ant-table-row-expand-icon-cell"
                     >
                       <button
+                        aria-expanded="false"
                         aria-label="Expand row"
                         class="ant-table-row-expand-icon ant-table-row-expand-icon-collapsed"
                         type="button"
@@ -3769,6 +3777,7 @@ Array [
                       class="ant-table-cell ant-table-row-expand-icon-cell"
                     >
                       <button
+                        aria-expanded="false"
                         aria-label="Expand row"
                         class="ant-table-row-expand-icon ant-table-row-expand-icon-collapsed"
                         type="button"
@@ -3872,6 +3881,7 @@ Array [
                       class="ant-table-cell ant-table-row-expand-icon-cell"
                     >
                       <button
+                        aria-expanded="false"
                         aria-label="Expand row"
                         class="ant-table-row-expand-icon ant-table-row-expand-icon-collapsed"
                         type="button"
@@ -5536,6 +5546,7 @@ exports[`renders ./components/table/demo/expand.md correctly 1`] = `
                     class="ant-table-cell ant-table-row-expand-icon-cell"
                   >
                     <button
+                      aria-expanded="false"
                       aria-label="Expand row"
                       class="ant-table-row-expand-icon ant-table-row-expand-icon-collapsed"
                       type="button"
@@ -5572,6 +5583,7 @@ exports[`renders ./components/table/demo/expand.md correctly 1`] = `
                     class="ant-table-cell ant-table-row-expand-icon-cell"
                   >
                     <button
+                      aria-expanded="false"
                       aria-label="Expand row"
                       class="ant-table-row-expand-icon ant-table-row-expand-icon-collapsed"
                       type="button"
@@ -5608,6 +5620,7 @@ exports[`renders ./components/table/demo/expand.md correctly 1`] = `
                     class="ant-table-cell ant-table-row-expand-icon-cell"
                   >
                     <button
+                      aria-expanded="false"
                       aria-label="Expand row"
                       class="ant-table-row-expand-icon ant-table-row-expand-icon-spaced"
                       type="button"
@@ -5644,6 +5657,7 @@ exports[`renders ./components/table/demo/expand.md correctly 1`] = `
                     class="ant-table-cell ant-table-row-expand-icon-cell"
                   >
                     <button
+                      aria-expanded="false"
                       aria-label="Expand row"
                       class="ant-table-row-expand-icon ant-table-row-expand-icon-collapsed"
                       type="button"
@@ -12174,6 +12188,7 @@ Array [
                       class="ant-table-cell ant-table-row-expand-icon-cell"
                     >
                       <button
+                        aria-expanded="false"
                         aria-label="Expand row"
                         class="ant-table-row-expand-icon ant-table-row-expand-icon-collapsed"
                         type="button"
@@ -12225,6 +12240,7 @@ Array [
                       class="ant-table-cell ant-table-row-expand-icon-cell"
                     >
                       <button
+                        aria-expanded="false"
                         aria-label="Expand row"
                         class="ant-table-row-expand-icon ant-table-row-expand-icon-collapsed"
                         type="button"
@@ -12276,6 +12292,7 @@ Array [
                       class="ant-table-cell ant-table-row-expand-icon-cell"
                     >
                       <button
+                        aria-expanded="false"
                         aria-label="Expand row"
                         class="ant-table-row-expand-icon ant-table-row-expand-icon-collapsed"
                         type="button"
@@ -12498,6 +12515,7 @@ Array [
                       class="ant-table-cell ant-table-row-expand-icon-cell"
                     >
                       <button
+                        aria-expanded="true"
                         aria-label="Collapse row"
                         class="ant-table-row-expand-icon ant-table-row-expand-icon-expanded"
                         type="button"
@@ -12889,6 +12907,7 @@ Array [
                       class="ant-table-cell ant-table-row-expand-icon-cell"
                     >
                       <button
+                        aria-expanded="false"
                         aria-label="Expand row"
                         class="ant-table-row-expand-icon ant-table-row-expand-icon-collapsed"
                         type="button"
@@ -12940,6 +12959,7 @@ Array [
                       class="ant-table-cell ant-table-row-expand-icon-cell"
                     >
                       <button
+                        aria-expanded="false"
                         aria-label="Expand row"
                         class="ant-table-row-expand-icon ant-table-row-expand-icon-collapsed"
                         type="button"
@@ -13152,6 +13172,7 @@ Array [
                       class="ant-table-cell ant-table-row-expand-icon-cell"
                     >
                       <button
+                        aria-expanded="true"
                         aria-label="Collapse row"
                         class="ant-table-row-expand-icon ant-table-row-expand-icon-expanded"
                         type="button"
@@ -13543,6 +13564,7 @@ Array [
                       class="ant-table-cell ant-table-row-expand-icon-cell"
                     >
                       <button
+                        aria-expanded="false"
                         aria-label="Expand row"
                         class="ant-table-row-expand-icon ant-table-row-expand-icon-collapsed"
                         type="button"
@@ -13594,6 +13616,7 @@ Array [
                       class="ant-table-cell ant-table-row-expand-icon-cell"
                     >
                       <button
+                        aria-expanded="false"
                         aria-label="Expand row"
                         class="ant-table-row-expand-icon ant-table-row-expand-icon-collapsed"
                         type="button"
@@ -13806,6 +13829,7 @@ Array [
                       class="ant-table-cell ant-table-row-expand-icon-cell"
                     >
                       <button
+                        aria-expanded="true"
                         aria-label="Collapse row"
                         class="ant-table-row-expand-icon ant-table-row-expand-icon-expanded"
                         type="button"
@@ -14197,6 +14221,7 @@ Array [
                       class="ant-table-cell ant-table-row-expand-icon-cell"
                     >
                       <button
+                        aria-expanded="false"
                         aria-label="Expand row"
                         class="ant-table-row-expand-icon ant-table-row-expand-icon-collapsed"
                         type="button"
@@ -14248,6 +14273,7 @@ Array [
                       class="ant-table-cell ant-table-row-expand-icon-cell"
                     >
                       <button
+                        aria-expanded="false"
                         aria-label="Expand row"
                         class="ant-table-row-expand-icon ant-table-row-expand-icon-collapsed"
                         type="button"
@@ -14477,6 +14503,7 @@ exports[`renders ./components/table/demo/order-column.md correctly 1`] = `
                     class="ant-table-cell ant-table-row-expand-icon-cell"
                   >
                     <button
+                      aria-expanded="false"
                       aria-label="Expand row"
                       class="ant-table-row-expand-icon ant-table-row-expand-icon-collapsed"
                       type="button"
@@ -14525,6 +14552,7 @@ exports[`renders ./components/table/demo/order-column.md correctly 1`] = `
                     class="ant-table-cell ant-table-row-expand-icon-cell"
                   >
                     <button
+                      aria-expanded="false"
                       aria-label="Expand row"
                       class="ant-table-row-expand-icon ant-table-row-expand-icon-collapsed"
                       type="button"
@@ -14573,6 +14601,7 @@ exports[`renders ./components/table/demo/order-column.md correctly 1`] = `
                     class="ant-table-cell ant-table-row-expand-icon-cell"
                   >
                     <button
+                      aria-expanded="false"
                       aria-label="Expand row"
                       class="ant-table-row-expand-icon ant-table-row-expand-icon-collapsed"
                       type="button"
@@ -14621,6 +14650,7 @@ exports[`renders ./components/table/demo/order-column.md correctly 1`] = `
                     class="ant-table-cell ant-table-row-expand-icon-cell"
                   >
                     <button
+                      aria-expanded="false"
                       aria-label="Expand row"
                       class="ant-table-row-expand-icon ant-table-row-expand-icon-collapsed"
                       type="button"
@@ -20660,6 +20690,7 @@ Array [
                         style="padding-left:0px"
                       />
                       <button
+                        aria-expanded="false"
                         aria-label="Expand row"
                         class="ant-table-row-expand-icon ant-table-row-expand-icon-collapsed"
                         type="button"
@@ -20708,6 +20739,7 @@ Array [
                         style="padding-left:0px"
                       />
                       <button
+                        aria-expanded="false"
                         aria-label="Expand row"
                         class="ant-table-row-expand-icon ant-table-row-expand-icon-spaced"
                         type="button"
@@ -20967,6 +20999,7 @@ Array [
                         style="padding-left:0px"
                       />
                       <button
+                        aria-expanded="true"
                         aria-label="Collapse row"
                         class="ant-table-row-expand-icon ant-table-row-expand-icon-expanded"
                         type="button"
@@ -21022,6 +21055,7 @@ Array [
                         style="padding-left:15px"
                       />
                       <button
+                        aria-expanded="true"
                         aria-label="Collapse row"
                         class="ant-table-row-expand-icon ant-table-row-expand-icon-spaced"
                         type="button"
@@ -21077,6 +21111,7 @@ Array [
                         style="padding-left:15px"
                       />
                       <button
+                        aria-expanded="true"
                         aria-label="Collapse row"
                         class="ant-table-row-expand-icon ant-table-row-expand-icon-expanded"
                         type="button"
@@ -21132,6 +21167,7 @@ Array [
                         style="padding-left:30px"
                       />
                       <button
+                        aria-expanded="true"
                         aria-label="Collapse row"
                         class="ant-table-row-expand-icon ant-table-row-expand-icon-spaced"
                         type="button"
@@ -21187,6 +21223,7 @@ Array [
                         style="padding-left:15px"
                       />
                       <button
+                        aria-expanded="true"
                         aria-label="Collapse row"
                         class="ant-table-row-expand-icon ant-table-row-expand-icon-expanded"
                         type="button"
@@ -21242,6 +21279,7 @@ Array [
                         style="padding-left:30px"
                       />
                       <button
+                        aria-expanded="true"
                         aria-label="Collapse row"
                         class="ant-table-row-expand-icon ant-table-row-expand-icon-expanded"
                         type="button"
@@ -21297,6 +21335,7 @@ Array [
                         style="padding-left:45px"
                       />
                       <button
+                        aria-expanded="true"
                         aria-label="Collapse row"
                         class="ant-table-row-expand-icon ant-table-row-expand-icon-spaced"
                         type="button"
@@ -21352,6 +21391,7 @@ Array [
                         style="padding-left:45px"
                       />
                       <button
+                        aria-expanded="true"
                         aria-label="Collapse row"
                         class="ant-table-row-expand-icon ant-table-row-expand-icon-spaced"
                         type="button"
@@ -21407,6 +21447,7 @@ Array [
                         style="padding-left:0px"
                       />
                       <button
+                        aria-expanded="true"
                         aria-label="Collapse row"
                         class="ant-table-row-expand-icon ant-table-row-expand-icon-spaced"
                         type="button"


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 💡 Background and solution
This is an accessibility issue.
In the nested and tree tables all 'expand/collapse' row buttons don't have states of expand and collapse. It is currently relying on aria-labels to relay this information. When controls do not provide state, screen reader users will not know their purpose/current state.

### 📝 Changelog
aria-expanded attribute was added

Ref: UIEN-1399