### PR TITLE
fix: InputNumber border-radius and handle color style

### DIFF
--- a/components/input-number/style/index.less
+++ b/components/input-number/style/index.less
@@ -27,8 +27,8 @@
   width: 90px;
   margin: 0;
   padding: 0;
-  border: @border-width-base @border-style-base @border-color-base;
-  border-radius: @border-radius-base;
+  border: @border-width-base @border-style-base @input-border-color;
+  border-radius: @control-border-radius;
 
   &-handler {
     position: relative;
@@ -102,7 +102,7 @@
     text-align: left;
     background-color: transparent;
     border: 0;
-    border-radius: @border-radius-base;
+    border-radius: @control-border-radius;
     outline: 0;
     transition: all 0.3s linear;
     appearance: textfield !important;
@@ -142,7 +142,7 @@
     width: 22px;
     height: 100%;
     background: @input-number-handler-bg;
-    border-radius: 0 @border-radius-base @border-radius-base 0;
+    border-radius: 0 @control-border-radius @control-border-radius 0;
     opacity: 0;
     transition: opacity 0.24s linear 0.1s;
 
@@ -176,7 +176,7 @@
   }
 
   &-handler-up {
-    border-top-right-radius: @border-radius-base;
+    border-top-right-radius: @control-border-radius;
     cursor: pointer;
 
     &-inner {
@@ -192,8 +192,8 @@
 
   &-handler-down {
     top: 0;
-    border-top: @border-width-base @border-style-base @border-color-base;
-    border-bottom-right-radius: @border-radius-base;
+    border-top: @border-width-base @border-style-base @input-number-handler-border-color;
+    border-bottom-right-radius: @control-border-radius;
     cursor: pointer;
 
     &-inner {
@@ -208,6 +208,11 @@
     .@{input-number-prefix-cls}-borderless & {
       border-top-width: 0;
     }
+  }
+
+  &:hover:not(.@{input-number-prefix-cls}-borderless) &-handler-down,
+  &-focused:not(.@{input-number-prefix-cls}-borderless) &-handler-down {
+    border-top: @border-width-base @border-style-base @input-number-handler-border-color;
   }
 
   &-handler-up-disabled,


### PR DESCRIPTION
[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

[ Reproduce Problem Demo](https://codesandbox.io/s/inputnumber-border-radius-demo-u809ig?file=/.umirc.js)

### 💡 Background and solution



### 📝 Changelog


| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the modify control-border-radius theme variables, InputNumber border-radius are different from Input and Select;<br />Fix the input-number-handler-border-color variable does not change the color of the middle border of the InputNumber handler. |
| 🇨🇳 Chinese | 修复修改 control-border-radius 主题变量，InputNumber 边框圆角与 Input、Select 不同的问题；<br />修复input-number-handler-border-color 变量不改变 InputNumber handler 中间边框颜色的问题。 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
