### PR TITLE
fix: When setting maskStyle when the drawer closes, the maskStyle mistake

### DIFF
--- a/components/drawer/index.tsx
+++ b/components/drawer/index.tsx
@@ -62,6 +62,7 @@ function Drawer({
   getContainer: customizeGetContainer,
   extra,
   afterVisibleChange,
+  maskStyle,
   ...rest
 }: DrawerProps) {
   const { getPopupContainer, getPrefixCls, direction } = React.useContext(ConfigContext);
@@ -150,6 +151,7 @@ function Drawer({
         prefixCls={prefixCls}
         onClose={onClose}
         {...rest}
+        maskStyle={visible ? maskStyle : {}}
         open={visible}
         mask={mask}
         push={push}


### PR DESCRIPTION


<!--
First of all, thank you for your contribution! 😄

For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.

Before submitting your pull request, please make sure the checklist below is confirmed.

Your pull requests will be merged after one of the collaborators approve.

Thank you!

-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
-->
https://github.com/ant-design/ant-design/issues/37017

### 💡 Background and solution

question from 4.22.0
need to make a separate judgment to maskStyle

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    fix: When setting maskStyle when the drawer closes, the maskStyle mistake       |
| 🇨🇳 Chinese |     修复：Drawer组件设置maskStyle属性，关闭抽屉, mask 不关闭      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
