### PR TITLE
feat: Cascader  replace dropdownClassName to popupClassName

### DIFF
--- a/components/cascader/__tests__/index.test.js
+++ b/components/cascader/__tests__/index.test.js
@@ -538,21 +538,9 @@ describe('Cascader', () => {
 
   describe('legacy props', () => {
     it('popupClassName', () => {
-      const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-      const { container } = render(
-        <Cascader open popupPlacement="bottomLeft" dropdownClassName="mock-cls" />,
-      );
-
-      expect(container.querySelector('.mock-cls')).toBeTruthy();
-
+      render(<Cascader open popupPlacement="bottomLeft" />);
       // Inject in tests/__mocks__/rc-trigger.js
       expect(global.triggerProps.popupPlacement).toEqual('bottomLeft');
-
-      expect(errorSpy).toHaveBeenCalledWith(
-        'Warning: [antd: Cascader] `dropdownClassName` is deprecated which will be removed in next major version. Please use `popupClassName` instead.',
-      );
-
-      errorSpy.mockRestore();
     });
 
     it('should support showCheckedStrategy child', () => {

--- a/components/cascader/index.tsx
+++ b/components/cascader/index.tsx
@@ -112,11 +112,6 @@ export type CascaderProps<DataNodeType> = UnionCascaderProps & {
   suffixIcon?: React.ReactNode;
   options?: DataNodeType[];
   status?: InputStatus;
-  /**
-   * @deprecated `dropdownClassName` is deprecated which will be removed in next major
-   *   version.Please use `popupClassName` instead.
-   */
-  dropdownClassName?: string;
 };
 
 export interface CascaderRef {
@@ -135,7 +130,6 @@ const Cascader = React.forwardRef((props: CascaderProps<any>, ref: React.Ref<Cas
     transitionName,
     choiceTransitionName = '',
     popupClassName,
-    dropdownClassName,
     expandIcon,
     placement,
     showSearch,
@@ -172,11 +166,6 @@ const Cascader = React.forwardRef((props: CascaderProps<any>, ref: React.Ref<Cas
   const mergedStatus = getMergedStatus(contextStatus, customStatus);
 
   // =================== Warning =====================
-  warning(
-    !dropdownClassName,
-    'Cascader',
-    '`dropdownClassName` is deprecated which will be removed in next major version. Please use `popupClassName` instead.',
-  );
 
   warning(
     !multiple || !props.displayRender,
@@ -197,7 +186,7 @@ const Cascader = React.forwardRef((props: CascaderProps<any>, ref: React.Ref<Cas
 
   // =================== Dropdown ====================
   const mergedDropdownClassName = classNames(
-    popupClassName || dropdownClassName,
+    popupClassName,
     `${cascaderPrefixCls}-dropdown`,
     {
       [`${cascaderPrefixCls}-dropdown-rtl`]: mergedDirection === 'rtl',

--- a/v5-note.md
+++ b/v5-note.md
@@ -14,4 +14,5 @@
   - 移除 visible 属性
 - 组件 `dropdownClassName` 替换为 `popupClassName`
   - AutoComplete 组件
+  - Cascader 组件
 - open 属性转换：https://github.com/ant-design/ant-design/issues/36609


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.

Before submitting your pull request, please make sure the checklist below is confirmed.

Your pull requests will be merged after one of the collaborators approve.

Thank you!

-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
-->

### 💡 Background and solution
- replace dropdownClassName to popupClassName
  - AutoComplete 组件 #37087
  - Cascader 组件 #37089
  - DatePicker 组件 #37092
  - TimePicker 组件 #37092
  - Mentions 组件 #37122
  - Select 组件 #37091
  - TreeSelect 组件  #37092
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Replace dropdownClassName to popupClassName      |
| 🇨🇳 Chinese |    替换  dropdownClassName 至 popupClassName     |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed