### PR TITLE
fix: Drawer add motion deadline

### DIFF
--- a/components/drawer/__tests__/__snapshots__/Drawer.test.js.snap
+++ b/components/drawer/__tests__/__snapshots__/Drawer.test.js.snap
@@ -15,7 +15,7 @@ exports[`Drawer className is test_drawer 1`] = `
     tabindex="0"
   />
   <div
-    class="ant-drawer-content-wrapper ant-drawer-panel-motion-right-appear ant-drawer-panel-motion-right-appear-active ant-drawer-panel-motion-right"
+    class="ant-drawer-content-wrapper"
     style="width: 378px;"
   >
     <div
@@ -91,7 +91,7 @@ exports[`Drawer closable is false 1`] = `
     tabindex="0"
   />
   <div
-    class="ant-drawer-content-wrapper ant-drawer-panel-motion-right-appear ant-drawer-panel-motion-right-appear-active ant-drawer-panel-motion-right"
+    class="ant-drawer-content-wrapper"
     style="width: 378px;"
   >
     <div
@@ -139,7 +139,7 @@ exports[`Drawer getContainer return undefined 2`] = `
       tabindex="0"
     />
     <div
-      class="ant-drawer-content-wrapper ant-drawer-panel-motion-right-appear ant-drawer-panel-motion-right-appear-active ant-drawer-panel-motion-right"
+      class="ant-drawer-content-wrapper"
       style="width: 400px;"
     >
       <div
@@ -216,7 +216,7 @@ exports[`Drawer have a footer 1`] = `
     tabindex="0"
   />
   <div
-    class="ant-drawer-content-wrapper ant-drawer-panel-motion-right-appear ant-drawer-panel-motion-right-appear-active ant-drawer-panel-motion-right"
+    class="ant-drawer-content-wrapper"
     style="width: 378px;"
   >
     <div
@@ -297,7 +297,7 @@ exports[`Drawer have a title 1`] = `
     tabindex="0"
   />
   <div
-    class="ant-drawer-content-wrapper ant-drawer-panel-motion-right-appear ant-drawer-panel-motion-right-appear-active ant-drawer-panel-motion-right"
+    class="ant-drawer-content-wrapper"
     style="width: 378px;"
   >
     <div
@@ -378,7 +378,7 @@ exports[`Drawer render correctly 1`] = `
     tabindex="0"
   />
   <div
-    class="ant-drawer-content-wrapper ant-drawer-panel-motion-right-appear ant-drawer-panel-motion-right-appear-active ant-drawer-panel-motion-right"
+    class="ant-drawer-content-wrapper"
     style="width: 400px;"
   >
     <div
@@ -454,7 +454,7 @@ exports[`Drawer render top drawer 1`] = `
     tabindex="0"
   />
   <div
-    class="ant-drawer-content-wrapper ant-drawer-panel-motion-top-appear ant-drawer-panel-motion-top-appear-active ant-drawer-panel-motion-top"
+    class="ant-drawer-content-wrapper"
     style="height: 400px;"
   >
     <div
@@ -533,7 +533,7 @@ exports[`Drawer style/drawerStyle/headerStyle/bodyStyle should work 1`] = `
     tabindex="0"
   />
   <div
-    class="ant-drawer-content-wrapper ant-drawer-panel-motion-right-appear ant-drawer-panel-motion-right-appear-active ant-drawer-panel-motion-right"
+    class="ant-drawer-content-wrapper"
     style="width: 378px;"
   >
     <div
@@ -612,7 +612,7 @@ exports[`Drawer support closeIcon 1`] = `
     tabindex="0"
   />
   <div
-    class="ant-drawer-content-wrapper ant-drawer-panel-motion-right-appear ant-drawer-panel-motion-right-appear-active ant-drawer-panel-motion-right"
+    class="ant-drawer-content-wrapper"
     style="width: 400px;"
   >
     <div

--- a/components/drawer/__tests__/__snapshots__/demo-extend.test.tsx.snap
+++ b/components/drawer/__tests__/__snapshots__/demo-extend.test.tsx.snap
@@ -117,7 +117,7 @@ exports[`renders ./components/drawer/demo/config-provider.md extend context corr
     tabindex="-1"
   >
     <div
-      class="ant-drawer-mask ant-drawer-mask-motion-appear ant-drawer-mask-motion-appear-active ant-drawer-mask-motion"
+      class="ant-drawer-mask"
     />
     <div
       aria-hidden="true"
@@ -126,7 +126,7 @@ exports[`renders ./components/drawer/demo/config-provider.md extend context corr
       tabindex="0"
     />
     <div
-      class="ant-drawer-content-wrapper ant-drawer-panel-motion-right-appear ant-drawer-panel-motion-right-appear-active ant-drawer-panel-motion-right"
+      class="ant-drawer-content-wrapper"
       style="width: 378px;"
     >
       <div
@@ -310,7 +310,7 @@ HTMLCollection [
     tabindex="-1"
   >
     <div
-      class="ant-drawer-mask ant-drawer-mask-motion-appear ant-drawer-mask-motion-appear-active ant-drawer-mask-motion"
+      class="ant-drawer-mask"
     />
     <div
       aria-hidden="true"
@@ -319,7 +319,7 @@ HTMLCollection [
       tabindex="0"
     />
     <div
-      class="ant-drawer-content-wrapper ant-drawer-panel-motion-right-appear ant-drawer-panel-motion-right-appear-active ant-drawer-panel-motion-right"
+      class="ant-drawer-content-wrapper"
       style="width: 500px;"
     >
       <div
@@ -467,7 +467,7 @@ HTMLCollection [
     tabindex="-1"
   >
     <div
-      class="ant-drawer-mask ant-drawer-mask-motion-appear ant-drawer-mask-motion-appear-active ant-drawer-mask-motion"
+      class="ant-drawer-mask"
     />
     <div
       aria-hidden="true"
@@ -476,7 +476,7 @@ HTMLCollection [
       tabindex="0"
     />
     <div
-      class="ant-drawer-content-wrapper ant-drawer-panel-motion-right-appear ant-drawer-panel-motion-right-appear-active ant-drawer-panel-motion-right"
+      class="ant-drawer-content-wrapper"
       style="width: 720px;"
     >
       <div
@@ -2512,7 +2512,7 @@ HTMLCollection [
     tabindex="-1"
   >
     <div
-      class="ant-drawer-mask ant-drawer-mask-motion-appear ant-drawer-mask-motion-appear-active ant-drawer-mask-motion"
+      class="ant-drawer-mask"
     />
     <div
       aria-hidden="true"
@@ -2521,7 +2521,7 @@ HTMLCollection [
       tabindex="0"
     />
     <div
-      class="ant-drawer-content-wrapper ant-drawer-panel-motion-right-appear ant-drawer-panel-motion-right-appear-active ant-drawer-panel-motion-right"
+      class="ant-drawer-content-wrapper"
       style="width: 520px; transform: translateX(-180px);"
     >
       <div
@@ -2561,7 +2561,7 @@ HTMLCollection [
               tabindex="-1"
             >
               <div
-                class="ant-drawer-mask ant-drawer-mask-motion-appear ant-drawer-mask-motion-appear-active ant-drawer-mask-motion"
+                class="ant-drawer-mask"
               />
               <div
                 aria-hidden="true"
@@ -2570,7 +2570,7 @@ HTMLCollection [
                 tabindex="0"
               />
               <div
-                class="ant-drawer-content-wrapper ant-drawer-panel-motion-right-appear ant-drawer-panel-motion-right-appear-active ant-drawer-panel-motion-right"
+                class="ant-drawer-content-wrapper"
                 style="width: 320px;"
               >
                 <div
@@ -2644,7 +2644,7 @@ HTMLCollection [
       tabindex="0"
     />
     <div
-      class="ant-drawer-content-wrapper ant-drawer-panel-motion-right-appear ant-drawer-panel-motion-right-appear-active ant-drawer-panel-motion-right"
+      class="ant-drawer-content-wrapper"
       style="width: 333px; background: red; border-radius: 20px; box-shadow: -5px 0 5px green; overflow: hidden;"
     >
       <div
@@ -2828,7 +2828,7 @@ HTMLCollection [
     tabindex="-1"
   >
     <div
-      class="ant-drawer-mask ant-drawer-mask-motion-appear ant-drawer-mask-motion-appear-active ant-drawer-mask-motion"
+      class="ant-drawer-mask"
     />
     <div
       aria-hidden="true"
@@ -2837,7 +2837,7 @@ HTMLCollection [
       tabindex="0"
     />
     <div
-      class="ant-drawer-content-wrapper ant-drawer-panel-motion-left-appear ant-drawer-panel-motion-left-appear-active ant-drawer-panel-motion-left"
+      class="ant-drawer-content-wrapper"
       style="width: 378px;"
     >
       <div
@@ -2910,7 +2910,7 @@ exports[`renders ./components/drawer/demo/render-in-current.md extend context co
     tabindex="-1"
   >
     <div
-      class="ant-drawer-mask ant-drawer-mask-motion-appear ant-drawer-mask-motion-appear-active ant-drawer-mask-motion"
+      class="ant-drawer-mask"
     />
     <div
       aria-hidden="true"
@@ -2919,7 +2919,7 @@ exports[`renders ./components/drawer/demo/render-in-current.md extend context co
       tabindex="0"
     />
     <div
-      class="ant-drawer-content-wrapper ant-drawer-panel-motion-right-appear ant-drawer-panel-motion-right-appear-active ant-drawer-panel-motion-right"
+      class="ant-drawer-content-wrapper"
       style="width: 378px;"
     >
       <div
@@ -2999,7 +2999,7 @@ HTMLCollection [
     tabindex="-1"
   >
     <div
-      class="ant-drawer-mask ant-drawer-mask-motion-appear ant-drawer-mask-motion-appear-active ant-drawer-mask-motion"
+      class="ant-drawer-mask"
     />
     <div
       aria-hidden="true"
@@ -3008,7 +3008,7 @@ HTMLCollection [
       tabindex="0"
     />
     <div
-      class="ant-drawer-content-wrapper ant-drawer-panel-motion-right-appear ant-drawer-panel-motion-right-appear-active ant-drawer-panel-motion-right"
+      class="ant-drawer-content-wrapper"
       style="width: 378px;"
     >
       <div
@@ -3231,7 +3231,7 @@ HTMLCollection [
     tabindex="-1"
   >
     <div
-      class="ant-drawer-mask ant-drawer-mask-motion-appear ant-drawer-mask-motion-appear-active ant-drawer-mask-motion"
+      class="ant-drawer-mask"
     />
     <div
       aria-hidden="true"
@@ -3240,7 +3240,7 @@ HTMLCollection [
       tabindex="0"
     />
     <div
-      class="ant-drawer-content-wrapper ant-drawer-panel-motion-right-appear ant-drawer-panel-motion-right-appear-active ant-drawer-panel-motion-right"
+      class="ant-drawer-content-wrapper"
       style="width: 640px;"
     >
       <div

--- a/components/drawer/__tests__/__snapshots__/demo-extend.test.tsx.snap
+++ b/components/drawer/__tests__/__snapshots__/demo-extend.test.tsx.snap
@@ -15,7 +15,7 @@ HTMLCollection [
     tabindex="-1"
   >
     <div
-      class="ant-drawer-mask ant-drawer-mask-motion-appear ant-drawer-mask-motion-appear-active ant-drawer-mask-motion"
+      class="ant-drawer-mask"
     />
     <div
       aria-hidden="true"
@@ -24,7 +24,7 @@ HTMLCollection [
       tabindex="0"
     />
     <div
-      class="ant-drawer-content-wrapper ant-drawer-panel-motion-right-appear ant-drawer-panel-motion-right-appear-active ant-drawer-panel-motion-right"
+      class="ant-drawer-content-wrapper"
       style="width: 378px;"
     >
       <div

--- a/components/drawer/__tests__/demo-extend.test.tsx
+++ b/components/drawer/__tests__/demo-extend.test.tsx
@@ -9,6 +9,8 @@ jest.mock('rc-drawer', () => {
       ...props,
       open: true,
       getContainer: false,
+      maskMotion: null,
+      motion: null,
     };
     return <MockDrawer {...newProps} />;
   };

--- a/components/drawer/index.tsx
+++ b/components/drawer/index.tsx
@@ -134,6 +134,7 @@ function Drawer({
     motionAppear: true,
     motionEnter: true,
     motionLeave: true,
+    motionDeadline: 500,
   };
 
   const panelMotion: RcDrawerProps['motion'] = motionPlacement => ({
@@ -141,6 +142,7 @@ function Drawer({
     motionAppear: true,
     motionEnter: true,
     motionLeave: true,
+    motionDeadline: 500,
   });
 
   // =========================== Render ===========================


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.

Before submitting your pull request, please make sure the checklist below is confirmed.

Your pull requests will be merged after one of the collaborators approve.

Thank you!

-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

fix https://github.com/ant-design/ant-design/issues/37017
close https://github.com/ant-design/ant-design/pull/37081
close https://github.com/react-component/drawer/pull/295

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fix Drawer can not close when config `opacity` on the `maskStyle`.      |
| 🇨🇳 Chinese |      修复 Drawer 的 `maskStyle` 配置 `opacity` 样式时无法关闭的问题。     |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
