### PR TITLE
Add key prop to breadcrumb in order to support multiple routes with s…

### DIFF
--- a/components/breadcrumb/Breadcrumb.tsx
+++ b/components/breadcrumb/Breadcrumb.tsx
@@ -11,6 +11,7 @@ import BreadcrumbSeparator from './BreadcrumbSeparator';
 export interface Route {
   path: string;
   breadcrumbName: string;
+  key?: string;
   children?: Omit<Route, 'children'>[];
 }
 
@@ -100,7 +101,7 @@ const Breadcrumb: BreadcrumbInterface = ({
         overlay = (
           <Menu
             items={route.children.map(child => ({
-              key: child.path || child.breadcrumbName,
+              key: child.key || child.path || child.breadcrumbName,
               label: itemRender(child, params, routes, addChildPath(paths, child.path, params)),
             }))}
           />
@@ -108,7 +109,11 @@ const Breadcrumb: BreadcrumbInterface = ({
       }
 
       return (
-        <BreadcrumbItem overlay={overlay} separator={separator} key={path || route.breadcrumbName}>
+        <BreadcrumbItem
+          overlay={overlay}
+          separator={separator}
+          key={route.key || path || route.breadcrumbName}
+        >
           {itemRender(route, params, routes, paths)}
         </BreadcrumbItem>
       );

--- a/components/breadcrumb/BreadcrumbItem.tsx
+++ b/components/breadcrumb/BreadcrumbItem.tsx
@@ -12,6 +12,7 @@ export interface BreadcrumbItemProps {
   overlay?: DropdownProps['overlay'];
   dropdownProps?: DropdownProps;
   onClick?: React.MouseEventHandler<HTMLAnchorElement | HTMLSpanElement>;
+  key?: string;
   className?: string;
   children?: React.ReactNode;
 }

--- a/components/breadcrumb/__tests__/Breadcrumb.test.js
+++ b/components/breadcrumb/__tests__/Breadcrumb.test.js
@@ -156,4 +156,40 @@ describe('Breadcrumb', () => {
     );
     expect(asFragment().firstChild).toMatchSnapshot();
   });
+
+  // https://github.com/ant-design/ant-design/issues/37134
+  it('Breadcrumb.Item should support key prop', () => {
+    const path = 'same-path';
+    render(
+      <Breadcrumb>
+        <Breadcrumb.Item key="itemKey1" href={path}>
+          item 1
+        </Breadcrumb.Item>
+        <Breadcrumb.Item key="itemKey2" href={path}>
+          item 2
+        </Breadcrumb.Item>
+      </Breadcrumb>,
+    );
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  // https://github.com/ant-design/ant-design/issues/37134
+  it('should support multiple items with same path with different keys using routes', () => {
+    const path = 'same-path';
+    const routes = [
+      {
+        path,
+        breadcrumbName: 'route 1',
+        key: 'routeKey1',
+      },
+      {
+        path,
+        breadcrumbName: 'route 2',
+        key: 'routeKey2',
+      },
+    ];
+
+    render(<Breadcrumb routes={routes} />);
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.

Before submitting your pull request, please make sure the checklist below is confirmed.

Your pull requests will be merged after one of the collaborators approve.

Thank you!

-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [x] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
-->
https://github.com/ant-design/ant-design/issues/37134

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

If two routes in a breadcrumb have the same path you will get the following warning.
```
Warning: Encountered two children with the same key, `KEY`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
    in div (created by Breadcrumb)
...
```

This solution adds a new optional field called `key`, which would be the first choice for a key of a breadcrumb route.

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 🆕 Breadcrumb Route supports `key` |
| 🇨🇳 Chinese | 🆕 Breadcrumb Route 支持 `key` |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
