### PR TITLE
feat: replace dropdownClassName to popupClassName

### DIFF
--- a/components/date-picker/__tests__/DatePicker.test.js
+++ b/components/date-picker/__tests__/DatePicker.test.js
@@ -188,20 +188,6 @@ describe('DatePicker', () => {
     ).toBe(60);
   });
 
-  it('DatePicker should show warning when use dropdownClassName', () => {
-    mount(<DatePicker dropdownClassName="myCustomClassName" />);
-    expect(errorSpy).toHaveBeenCalledWith(
-      'Warning: [antd: DatePicker] `dropdownClassName` is deprecated which will be removed in next major version. Please use `popupClassName` instead.',
-    );
-  });
-
-  it('RangePicker should show warning when use dropdownClassName', () => {
-    mount(<DatePicker.RangePicker dropdownClassName="myCustomClassName" />);
-    expect(errorSpy).toHaveBeenCalledWith(
-      'Warning: [antd: RangePicker] `dropdownClassName` is deprecated which will be removed in next major version. Please use `popupClassName` instead.',
-    );
-  });
-
   it('DatePicker.RangePicker with defaultPickerValue and showTime', () => {
     const startDate = dayjs('1982-02-12');
     const endDate = dayjs('1982-02-22');

--- a/components/date-picker/generatePicker/generateRangePicker.tsx
+++ b/components/date-picker/generatePicker/generateRangePicker.tsx
@@ -18,7 +18,6 @@ import { getMergedStatus, getStatusClassNames } from '../../_util/statusUtils';
 import enUS from '../locale/en_US';
 import { getRangePlaceholder, transPlacement2DropdownAlign } from '../util';
 import type { CommonPickerMethods, PickerComponentClass } from './interface';
-import warning from '../../_util/warning';
 
 import useStyle from '../style';
 
@@ -30,11 +29,6 @@ export default function generateRangePicker<DateType>(
   const RangePicker = forwardRef<
     InternalRangePickerProps | CommonPickerMethods,
     RangePickerProps<DateType> & {
-      /**
-       * @deprecated `dropdownClassName` is deprecated which will be removed in next major
-       *   version.Please use `popupClassName` instead.
-       */
-      dropdownClassName: string;
       popupClassName?: string;
     }
   >((props, ref) => {
@@ -48,7 +42,6 @@ export default function generateRangePicker<DateType>(
       bordered = true,
       placeholder,
       popupClassName,
-      dropdownClassName,
       status: customStatus,
       ...restProps
     } = props;
@@ -67,12 +60,6 @@ export default function generateRangePicker<DateType>(
       ...(showTime ? getTimeProps({ format, picker, ...showTime }) : {}),
       ...(picker === 'time' ? getTimeProps({ format, ...props, picker }) : {}),
     };
-
-    warning(
-      !dropdownClassName,
-      'RangePicker',
-      '`dropdownClassName` is deprecated which will be removed in next major version. Please use `popupClassName` instead.',
-    );
 
     // ===================== Size =====================
     const size = React.useContext(SizeContext);
@@ -143,7 +130,7 @@ export default function generateRangePicker<DateType>(
               generateConfig={generateConfig}
               components={Components}
               direction={direction}
-              dropdownClassName={classNames(hashId, popupClassName || dropdownClassName)}
+              dropdownClassName={classNames(hashId, popupClassName)}
             />
           );
         }}

--- a/components/date-picker/generatePicker/generateSinglePicker.tsx
+++ b/components/date-picker/generatePicker/generateSinglePicker.tsx
@@ -27,11 +27,6 @@ export default function generatePicker<DateType>(generateConfig: GenerateConfig<
   type DatePickerProps = PickerProps<DateType> & {
     status?: InputStatus;
     hashId?: string;
-    /**
-     * @deprecated `dropdownClassName` is deprecated which will be removed in next major
-     *   version.Please use `popupClassName` instead.
-     */
-    dropdownClassName?: string;
     popupClassName?: string;
   };
   function getPicker<InnerPickerProps extends DatePickerProps>(
@@ -49,7 +44,6 @@ export default function generatePicker<DateType>(generateConfig: GenerateConfig<
           placement,
           placeholder,
           popupClassName,
-          dropdownClassName,
           disabled: customDisabled,
           status: customStatus,
           ...restProps
@@ -93,11 +87,6 @@ export default function generatePicker<DateType>(generateConfig: GenerateConfig<
           `DatePicker.${displayName} is legacy usage. Please use DatePicker[picker='${picker}'] directly.`,
         );
 
-        warning(
-          !dropdownClassName,
-          'DatePicker',
-          '`dropdownClassName` is deprecated which will be removed in next major version. Please use `popupClassName` instead.',
-        );
         // ===================== Size =====================
         const size = React.useContext(SizeContext);
         const mergedSize = customizeSize || size;
@@ -158,7 +147,7 @@ export default function generatePicker<DateType>(generateConfig: GenerateConfig<
                   components={Components}
                   direction={direction}
                   disabled={mergedDisabled}
-                  dropdownClassName={classNames(hashId, popupClassName || dropdownClassName)}
+                  dropdownClassName={classNames(hashId, popupClassName)}
                 />
               );
             }}

--- a/components/time-picker/__tests__/index.test.tsx
+++ b/components/time-picker/__tests__/index.test.tsx
@@ -88,20 +88,6 @@ describe('TimePicker', () => {
     expect(container.querySelector(`.${popupClassName}`)).toBeTruthy();
   });
 
-  it('RangePicker should show warning when use dropdownClassName', () => {
-    render(<TimePicker.RangePicker dropdownClassName="myCustomClassName" />);
-    expect(errorSpy).toHaveBeenCalledWith(
-      'Warning: [antd: RangePicker] `dropdownClassName` is deprecated which will be removed in next major version. Please use `popupClassName` instead.',
-    );
-  });
-
-  it('TimePicker should show warning when use dropdownClassName', () => {
-    render(<TimePicker dropdownClassName="myCustomClassName" />);
-    expect(errorSpy).toHaveBeenCalledWith(
-      'Warning: [antd: TimePicker] `dropdownClassName` is deprecated which will be removed in next major version. Please use `popupClassName` instead.',
-    );
-  });
-
   it('should support bordered', () => {
     const { container } = render(
       <TimePicker

--- a/components/time-picker/index.tsx
+++ b/components/time-picker/index.tsx
@@ -13,46 +13,19 @@ export interface TimePickerLocale {
   rangePlaceholder?: [string, string];
 }
 
-export interface TimeRangePickerProps extends Omit<RangePickerTimeProps<Dayjs>, 'picker'> {
-  /**
-   * @deprecated `dropdownClassName` is deprecated which will be removed in next major
-   *   version.Please use `popupClassName` instead.
-   */
-  dropdownClassName?: string;
-  popupClassName?: string;
-}
+export interface TimeRangePickerProps extends Omit<RangePickerTimeProps<Dayjs>, 'picker'> {}
 
-const RangePicker = React.forwardRef<any, TimeRangePickerProps>((props, ref) => {
-  const { dropdownClassName, popupClassName } = props;
-  warning(
-    !dropdownClassName,
-    'RangePicker',
-    '`dropdownClassName` is deprecated which will be removed in next major version. Please use `popupClassName` instead.',
-  );
-  return (
-    <InternalRangePicker
-      {...props}
-      dropdownClassName={popupClassName || dropdownClassName}
-      picker="time"
-      mode={undefined}
-      ref={ref}
-    />
-  );
-});
+const RangePicker = React.forwardRef<any, TimeRangePickerProps>((props, ref) => (
+  <InternalRangePicker {...props} picker="time" mode={undefined} ref={ref} />
+));
 
 export interface TimePickerProps extends Omit<PickerTimeProps<Dayjs>, 'picker'> {
   addon?: () => React.ReactNode;
-  popupClassName?: string;
-  /**
-   * @deprecated `dropdownClassName` is deprecated which will be removed in next major
-   *   version.Please use `popupClassName` instead.
-   */
-  dropdownClassName?: string;
   status?: InputStatus;
 }
 
 const TimePicker = React.forwardRef<any, TimePickerProps>(
-  ({ addon, renderExtraFooter, popupClassName, dropdownClassName, ...restProps }, ref) => {
+  ({ addon, renderExtraFooter, ...restProps }, ref) => {
     const internalRenderExtraFooter = React.useMemo(() => {
       if (renderExtraFooter) {
         return renderExtraFooter;
@@ -69,15 +42,8 @@ const TimePicker = React.forwardRef<any, TimePickerProps>(
       return undefined;
     }, [addon, renderExtraFooter]);
 
-    warning(
-      !dropdownClassName,
-      'TimePicker',
-      '`dropdownClassName` is deprecated which will be removed in next major version. Please use `popupClassName` instead.',
-    );
-
     return (
       <InternalTimePicker
-        dropdownClassName={popupClassName || dropdownClassName}
         {...restProps}
         mode={undefined}
         ref={ref}

--- a/components/time-picker/index.tsx
+++ b/components/time-picker/index.tsx
@@ -13,7 +13,9 @@ export interface TimePickerLocale {
   rangePlaceholder?: [string, string];
 }
 
-export interface TimeRangePickerProps extends Omit<RangePickerTimeProps<Dayjs>, 'picker'> {}
+export interface TimeRangePickerProps extends Omit<RangePickerTimeProps<Dayjs>, 'picker'> {
+  popupClassName?: string;
+}
 
 const RangePicker = React.forwardRef<any, TimeRangePickerProps>((props, ref) => (
   <InternalRangePicker {...props} picker="time" mode={undefined} ref={ref} />
@@ -22,6 +24,7 @@ const RangePicker = React.forwardRef<any, TimeRangePickerProps>((props, ref) => 
 export interface TimePickerProps extends Omit<PickerTimeProps<Dayjs>, 'picker'> {
   addon?: () => React.ReactNode;
   status?: InputStatus;
+  popupClassName?: string;
 }
 
 const TimePicker = React.forwardRef<any, TimePickerProps>(

--- a/v5-note.md
+++ b/v5-note.md
@@ -17,4 +17,6 @@
   - Cascader 组件
   - Select 组件
   - TreeSelect 组件
+  - TimePicker 组件
+  - DatePicker 组件
 - open 属性转换：https://github.com/ant-design/ant-design/issues/36609


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.

Before submitting your pull request, please make sure the checklist below is confirmed.

Your pull requests will be merged after one of the collaborators approve.

Thank you!

-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
-->

### 💡 Background and solution
- replace dropdownClassName to popupClassName
  - AutoComplete 组件 #37087
  - Cascader 组件 #37089
  - DatePicker 组件 #37092
  - TimePicker 组件 #37092
  - Mentions 组件 #37122
  - Select 组件 #37091
  - TreeSelect 组件  #37092
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Replace dropdownClassName to popupClassName      |
| 🇨🇳 Chinese |    替换  dropdownClassName 至 popupClassName     |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
