### PR TITLE
Adding filterCheckall to the below mentioned files.

### DIFF
--- a/components/locale/de_DE.tsx
+++ b/components/locale/de_DE.tsx
@@ -21,6 +21,7 @@ const localeValues: Locale = {
     filterConfirm: 'OK',
     filterReset: 'Zurücksetzen',
     filterSearchPlaceholder: 'Suche in Filtern',
+    filterCheckall: 'Alle auswählen',
     selectAll: 'Selektiere Alle',
     selectInvert: 'Selektion Invertieren',
     selectionAll: 'Wählen Sie alle Daten aus',

--- a/components/locale/fr_BE.tsx
+++ b/components/locale/fr_BE.tsx
@@ -14,6 +14,7 @@ const localeValues: Locale = {
     filterTitle: 'Filtrer',
     filterConfirm: 'OK',
     filterReset: 'Réinitialiser',
+    filterCheckall: 'Sélectionner la page actuelle',
   },
   Modal: {
     okText: 'OK',

--- a/components/locale/fr_CA.tsx
+++ b/components/locale/fr_CA.tsx
@@ -14,6 +14,7 @@ const localeValues: Locale = {
     filterTitle: 'Filtrer',
     filterConfirm: 'OK',
     filterReset: 'Réinitialiser',
+    filterCheckall: 'Sélectionner la page actuelle',
     selectAll: 'Sélectionner la page actuelle',
     selectInvert: 'Inverser la sélection de la page actuelle',
     selectionAll: 'Sélectionner toutes les données',

--- a/components/locale/fr_FR.tsx
+++ b/components/locale/fr_FR.tsx
@@ -18,6 +18,7 @@ const localeValues: Locale = {
     filterConfirm: 'OK',
     filterReset: 'Réinitialiser',
     filterEmptyText: 'Aucun filtre',
+    filterCheckall: 'Sélectionner la page actuelle',
     emptyText: 'Aucune donnée',
     selectAll: 'Sélectionner la page actuelle',
     selectInvert: 'Inverser la sélection de la page actuelle',


### PR DESCRIPTION
This will ensure a proper translation in the table filter checkbox.
when filterMode is set to 'tree'

Changes to be committed:
	modified:   components/locale/de_DE.tsx
	modified:   components/locale/fr_BE.tsx
	modified:   components/locale/fr_CA.tsx
	modified:   components/locale/fr_FR.tsx

### 🤔 This is a ...

- [X] Bug fix

### 🔗 Related issue link

[Discussion Link: 37240](https://github.com/ant-design/ant-design/issues/37240)

### 💡 Background and solution

The [FilterDropdown.tsx](https://github.com/ant-design/ant-design/blob/8d2ae4bedb3a065e615d3e0e223cfbc786735c6b/components/table/hooks/useFilter/FilterDropdown.tsx#L347) is using `locale.filterCheckall` property to localize the string to "Select all items" or the equivalent in Chinese. However in German, as well as French, these keys are missing in the modified files. I've added them in and added the appropriate translation, to the best of my knowledge. However, it would be great, if a native French speaking person, would double check

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Add missing filterCheckall key to Table component localization            |
| 🇨🇳 Chinese |  在Table组件的本地化中添加缺失的filterCheckall键    |

(Chinese translation via Deepl.com)

### ☑️ Self-Check before Merge

⚠️ Please check all items below before review. ⚠️

- [X] Doc is updated/provided or not needed
- [X] Demo is updated/provided or not needed
- [X] TypeScript definition is updated/provided or not needed
- [X] Changelog is provided or not needed
