### PR TITLE
test(affix): split the last checkpoint

### DIFF
--- a/components/affix/__tests__/Affix.test.tsx
+++ b/components/affix/__tests__/Affix.test.tsx
@@ -191,21 +191,16 @@ describe('Affix Render', () => {
   });
 
   describe('updatePosition when size changed', () => {
-    it.each([
-      { name: 'inner', index: 0 },
-      { name: 'outer', index: 1 },
-    ])('inner or outer', async () => {
+    it('add class automatically', async () => {
       document.body.innerHTML = '<div id="mounter" />';
 
       let affixInstance: InternalAffixClass | null = null;
-      const updateCalled = jest.fn();
-      const { container } = render(
+      render(
         <AffixMounter
           getInstance={inst => {
             affixInstance = inst;
           }}
           offsetBottom={0}
-          onTestUpdatePosition={updateCalled}
         />,
         {
           container: document.getElementById('mounter')!,
@@ -213,18 +208,25 @@ describe('Affix Render', () => {
       );
 
       await sleep(20);
-
       await movePlaceholder(300);
       expect(affixInstance!.state.affixStyle).toBeTruthy();
+    });
 
-      // Mock trigger resize
-      updateCalled.mockReset();
-      triggerResize(container.querySelector('.fixed')!);
-      await sleep(20);
-      expect(updateCalled).toHaveBeenCalled();
+    // Trigger inner and outer element for the two <ResizeObserver>s.
+    it.each([
+      { selector: '.ant-btn' }, // inner
+      { selector: '.fixed' }, // outer
+    ])('trigger listener when size change', async ({ selector }) => {
+      const updateCalled = jest.fn();
+      const { container } = render(
+        <AffixMounter offsetBottom={0} onTestUpdatePosition={updateCalled} />,
+        {
+          container: document.getElementById('mounter')!,
+        },
+      );
 
       updateCalled.mockReset();
-      triggerResize(container.querySelector('.ant-btn')!);
+      triggerResize(container.querySelector(selector)!);
       await sleep(20);
       expect(updateCalled).toHaveBeenCalled();
     });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.

Before submitting your pull request, please make sure the checklist below is confirmed.

Your pull requests will be merged after one of the collaborators approve.

Thank you!

-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

The current test case "updatePosition when size changed" is confusing because it mixes two functions:

- add `style` automatically
- trigger `<ResizeObserver>` when size change

So I split them into two cases.

BTW, the previous code uses `it.each` and passes the index to the self-implemented `Enzyme.ReactWrapper.prototype.triggerResize`, which is hard to understand. After switching to testing-library, I change it by using `it.each` to two specified selectors, which is more explicit and easier to read.

目前的测试用例“updatePosition when size changed”让人很迷惑，因为它把两个功能混起来了：

- 自动添加 `style`
- 当尺寸变化时触发 `<ResizeObserver>`

所以我把它们拆开了。

此外，之前使用 `it.each` 并将 index 传入自己封装的 `Enzyme.ReactWrapper.prototype.triggerResize` 的行为较为难懂，刚好趁着替换为 testing-library 的机会，将其改为对两个指定的 selector 做 `it.each`，会更显式且好懂。

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
