### PR TITLE
fix(popconfirm): still has padding-left when icon is empty

### DIFF
--- a/components/popconfirm/PurePanel.tsx
+++ b/components/popconfirm/PurePanel.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames';
 import * as React from 'react';
 import type { PopconfirmProps } from '.';
 import Button from '../button';
@@ -48,6 +49,10 @@ export function Overlay(props: OverlayProps) {
   } = props;
 
   const { getPrefixCls } = React.useContext(ConfigContext);
+  const titleClassNames = classNames(
+    `${prefixCls}-message-title`,
+    icon ? null : `${prefixCls}-message-title-no-padding`,
+  );
 
   return (
     <LocaleReceiver componentName="Popconfirm" defaultLocale={defaultLocale.Popconfirm}>
@@ -55,7 +60,7 @@ export function Overlay(props: OverlayProps) {
         <div className={`${prefixCls}-inner-content`}>
           <div className={`${prefixCls}-message`}>
             {icon}
-            <div className={`${prefixCls}-message-title`}>{getRenderPropValue(title)}</div>
+            <div className={titleClassNames}>{getRenderPropValue(title)}</div>
           </div>
           <div className={`${prefixCls}-buttons`}>
             {showCancel && (

--- a/components/popconfirm/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/popconfirm/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -276,11 +276,14 @@ exports[`renders ./components/popconfirm/demo/dynamic-trigger.md extend context 
 
 exports[`renders ./components/popconfirm/demo/icon.md extend context correctly 1`] = `
 Array [
-  <a
-    href="#"
+  <button
+    class="ant-btn ant-btn-danger"
+    type="button"
   >
-    Delete
-  </a>,
+    <span>
+      Delete
+    </span>
+  </button>,
   <div>
     <div
       class="ant-popover ant-popconfirm"
@@ -331,6 +334,70 @@ Array [
               </span>
               <div
                 class="ant-popover-message-title"
+              >
+                Are you sure？
+              </div>
+            </div>
+            <div
+              class="ant-popover-buttons"
+            >
+              <button
+                class="ant-btn ant-btn-default ant-btn-sm"
+                type="button"
+              >
+                <span>
+                  Cancel
+                </span>
+              </button>
+              <button
+                class="ant-btn ant-btn-primary ant-btn-sm"
+                type="button"
+              >
+                <span>
+                  OK
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>,
+  <button
+    class="ant-btn ant-btn-primary"
+    type="button"
+  >
+    <span>
+      Pure Text
+    </span>
+  </button>,
+  <div>
+    <div
+      class="ant-popover ant-popconfirm"
+      style="opacity:0"
+    >
+      <div
+        class="ant-popover-content"
+      >
+        <div
+          class="ant-popover-arrow"
+        >
+          <span
+            class="ant-popover-arrow-content"
+          />
+        </div>
+        <div
+          class="ant-popover-inner"
+          role="tooltip"
+        >
+          <div
+            class="ant-popover-inner-content"
+          >
+            <div
+              class="ant-popover-message"
+            >
+              <div
+                class="ant-popover-message-title ant-popover-message-title-no-padding"
               >
                 Are you sure？
               </div>

--- a/components/popconfirm/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/popconfirm/__tests__/__snapshots__/demo.test.js.snap
@@ -46,11 +46,24 @@ exports[`renders ./components/popconfirm/demo/dynamic-trigger.md correctly 1`] =
 `;
 
 exports[`renders ./components/popconfirm/demo/icon.md correctly 1`] = `
-<a
-  href="#"
->
-  Delete
-</a>
+Array [
+  <button
+    class="ant-btn ant-btn-danger"
+    type="button"
+  >
+    <span>
+      Delete
+    </span>
+  </button>,
+  <button
+    class="ant-btn ant-btn-primary"
+    type="button"
+  >
+    <span>
+      Pure Text
+    </span>
+  </button>,
+]
 `;
 
 exports[`renders ./components/popconfirm/demo/locale.md correctly 1`] = `

--- a/components/popconfirm/__tests__/index.test.js
+++ b/components/popconfirm/__tests__/index.test.js
@@ -162,6 +162,18 @@ describe('Popconfirm', () => {
     expect(wrapper.find('.customize-icon').length).toBe(1);
   });
 
+  it('should support customize has no icon', () => {
+    const wrapper = mount(
+      <Popconfirm title="code" icon={null}>
+        <span>show me your code</span>
+      </Popconfirm>,
+    );
+
+    const triggerNode = wrapper.find('span').at(0);
+    triggerNode.simulate('click');
+    expect(wrapper.find('.ant-popover-message-title-no-padding').length).toBe(1);
+  });
+
   it('should prefixCls correctly', () => {
     const btnPrefixCls = 'custom-btn';
     const wrapper = mount(

--- a/components/popconfirm/demo/icon.md
+++ b/components/popconfirm/demo/icon.md
@@ -15,13 +15,18 @@ Set `icon` props to customize the icon.
 
 ```tsx
 import { QuestionCircleOutlined } from '@ant-design/icons';
-import { Popconfirm } from 'antd';
+import { Button, Popconfirm } from 'antd';
 import React from 'react';
 
 const App: React.FC = () => (
-  <Popconfirm title="Are you sure？" icon={<QuestionCircleOutlined style={{ color: 'red' }} />}>
-    <a href="#">Delete</a>
-  </Popconfirm>
+  <>
+    <Popconfirm title="Are you sure？" icon={<QuestionCircleOutlined style={{ color: 'red' }} />}>
+      <Button type="danger">Delete</Button>
+    </Popconfirm>
+    <Popconfirm title="Are you sure？" icon={null}>
+      <Button type="primary">Pure Text</Button>
+    </Popconfirm>
+  </>
 );
 
 export default App;

--- a/components/popover/style/index.less
+++ b/components/popover/style/index.less
@@ -106,6 +106,10 @@
     &-title {
       padding-left: @font-size-base + 8px;
     }
+
+    &-title-no-padding {
+      padding-left: 0;
+    }
   }
 
   &-buttons {

--- a/components/popover/style/rtl.less
+++ b/components/popover/style/rtl.less
@@ -16,6 +16,12 @@
         padding-left: @padding-md;
       }
     }
+
+    &-title-no-padding {
+      .@{popover-prefix-cls}-rtl & {
+        padding-right: 0;
+      }
+    }
   }
 
   &-buttons {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.

Before submitting your pull request, please make sure the checklist below is confirmed.

Your pull requests will be merged after one of the collaborators approve.

Thank you!

-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
#37346 

<!--
1. Put the related issue or discussion links here.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix popconfirm what still has padding-left when icon is empty |
| 🇨🇳 Chinese | 修复Popconfirm设置icon为空title依然有padding-left |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
