### PR TITLE
fix: unable to close modal when using visible in Modal.confirm().update

### DIFF
--- a/components/modal/__tests__/confirm.test.tsx
+++ b/components/modal/__tests__/confirm.test.tsx
@@ -850,4 +850,31 @@ describe('Modal.confirm triggers callbacks correctly', () => {
 
     jest.useRealTimers();
   });
+
+  // https://github.com/ant-design/ant-design/issues/37461
+  it('Update should closable', async () => {
+    jest.useFakeTimers();
+
+    Modal.confirm({}).update({
+      visible: true,
+    });
+
+    await act(async () => {
+      jest.runAllTimers();
+      await sleep();
+    });
+
+    expect($$('.ant-modal-confirm-confirm')).toHaveLength(1);
+
+    $$('.ant-modal-confirm-btns > .ant-btn')[0].click();
+
+    await act(async () => {
+      jest.runAllTimers();
+      await sleep();
+    });
+
+    expect($$('.ant-modal-confirm-confirm')).toHaveLength(0);
+
+    jest.useRealTimers();
+  });
 });

--- a/components/modal/confirm.tsx
+++ b/components/modal/confirm.tsx
@@ -48,7 +48,14 @@ export default function confirm(config: ModalFuncProps) {
     reactUnmount(container);
   }
 
-  function render({ okText, cancelText, prefixCls: customizePrefixCls, ...props }: any) {
+  function render({
+    okText,
+    cancelText,
+    prefixCls: customizePrefixCls,
+    open,
+    visible,
+    ...props
+  }: any) {
     /**
      * https://github.com/ant-design/ant-design/issues/23623
      *
@@ -65,6 +72,7 @@ export default function confirm(config: ModalFuncProps) {
       reactRender(
         <ConfirmDialog
           {...props}
+          open={open ?? visible}
           prefixCls={prefixCls}
           rootPrefixCls={rootPrefixCls}
           iconPrefixCls={iconPrefixCls}
@@ -80,7 +88,6 @@ export default function confirm(config: ModalFuncProps) {
     currentConfig = {
       ...currentConfig,
       open: false,
-      visible: false,
       afterClose: () => {
         if (typeof config.afterClose === 'function') {
           config.afterClose();

--- a/components/modal/confirm.tsx
+++ b/components/modal/confirm.tsx
@@ -80,6 +80,7 @@ export default function confirm(config: ModalFuncProps) {
     currentConfig = {
       ...currentConfig,
       open: false,
+      visible: false,
       afterClose: () => {
         if (typeof config.afterClose === 'function') {
           config.afterClose();

--- a/scripts/post-script.js
+++ b/scripts/post-script.js
@@ -13,6 +13,7 @@ const DEPRECIATED_VERSION = {
     'https://github.com/ant-design/ant-design/pull/36800',
     'https://github.com/ant-design/ant-design/issues/37024',
   ],
+  '4.23.0': ['https://github.com/ant-design/ant-design/issues/37461'],
 };
 
 function matchDeprecated(version) {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.

Before submitting your pull request, please make sure the checklist below is confirmed.

Your pull requests will be merged after one of the collaborators approve.

Thank you!

-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link


fix #37461

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      fix: unable to close modal when using visible in Modal.confirm().update     |
| 🇨🇳 Chinese |    修复Modal.confirm().update({visible: true}) 导致无法关闭modal的问题      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
