### PR TITLE
fix: theme swith back to undefined makes unmount

### DIFF
--- a/components/config-provider/__tests__/theme.test.tsx
+++ b/components/config-provider/__tests__/theme.test.tsx
@@ -1,6 +1,6 @@
 import { kebabCase } from 'lodash';
 import canUseDom from 'rc-util/lib/Dom/canUseDom';
-import React from 'react';
+import React, { useEffect } from 'react';
 import ConfigProvider from '..';
 import { InputNumber } from '../..';
 import { render } from '../../../tests/utils';
@@ -133,5 +133,35 @@ describe('ConfigProvider.Theme', () => {
         style => style.includes('.ant-input-number') && style.includes('width:50.1234px'),
       ),
     ).toBeTruthy();
+  });
+
+  it('switch theme should not unmount', () => {
+    let unmountCalled = false;
+
+    const Checker = () => {
+      useEffect(
+        () => () => {
+          unmountCalled = true;
+        },
+        [],
+      );
+      return null;
+    };
+
+    const { rerender } = render(
+      <ConfigProvider theme={{ token: { colorPrimary: 'black' } }}>
+        <Checker />
+      </ConfigProvider>,
+    );
+
+    // Change theme
+    unmountCalled = false;
+    rerender(
+      <ConfigProvider theme={undefined}>
+        <Checker />
+      </ConfigProvider>,
+    );
+
+    expect(unmountCalled).toBeFalsy();
   });
 });

--- a/components/config-provider/index.tsx
+++ b/components/config-provider/index.tsx
@@ -271,7 +271,12 @@ const ProviderChildren: React.FC<ProviderChildrenProps> = props => {
     };
   }, [mergedTheme]);
 
-  if (theme) {
+  // To avoid developer set theme from `object` back to `undefined` make unmount.
+  // We record `theme` set here and use it.
+  const themedRef = React.useRef<boolean>();
+  themedRef.current = themedRef.current || !!theme;
+
+  if (themedRef.current) {
     childNode = (
       <DesignTokenContext.Provider value={memoTheme}>{childNode}</DesignTokenContext.Provider>
     );

--- a/components/theme/index.tsx
+++ b/components/theme/index.tsx
@@ -42,17 +42,19 @@ export type {
 
 // ================================ Context =================================
 // To ensure snapshot stable. We disable hashed in test env.
-export const defaultConfig = {
+export const defaultConfig: DesignTokenContextProps = {
   token: defaultSeedToken,
   hashed: true,
 };
 
-export const DesignTokenContext = React.createContext<{
+interface DesignTokenContextProps {
   token: Partial<SeedToken>;
   theme?: Theme<SeedToken, MapToken>;
   override?: OverrideToken;
   hashed?: string | boolean;
-}>(defaultConfig);
+}
+
+export const DesignTokenContext = React.createContext<DesignTokenContextProps | null>(null);
 
 // ================================== Hook ==================================
 // In dev env, we refresh salt per hour to avoid user use this
@@ -61,7 +63,12 @@ const saltPrefix =
   process.env.NODE_ENV === 'production' ? version : `${version}-${new Date().getHours()}`;
 
 export function useToken(): [Theme<SeedToken, MapToken>, GlobalToken, string] {
-  const { token: rootDesignToken, override, hashed, theme } = React.useContext(DesignTokenContext);
+  const {
+    token: rootDesignToken,
+    override,
+    hashed,
+    theme,
+  } = React.useContext(DesignTokenContext) || defaultConfig;
 
   const salt = `${saltPrefix}-${hashed || ''}`;
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.

Before submitting your pull request, please make sure the checklist below is confirmed.

Your pull requests will be merged after one of the collaborators approve.

Thank you!

-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Fix ConfigProvider `theme` switch back to `undefined` makes `children` re-mount.     |
| 🇨🇳 Chinese |   -        |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
