### PR TITLE
fix(Card): with tabList props still warning deprecated TabPane and update jest snapshot

### DIFF
--- a/components/card/Card.tsx
+++ b/components/card/Card.tsx
@@ -118,11 +118,12 @@ const Card = React.forwardRef((props: CardProps, ref: React.Ref<HTMLDivElement>)
         {...extraProps}
         className={`${prefixCls}-head-tabs`}
         onChange={onTabChange}
-      >
-        {tabList.map(item => (
-          <Tabs.TabPane tab={item.tab} disabled={item.disabled} key={item.key} />
-        ))}
-      </Tabs>
+        items={tabList.map(item => ({
+          label: item.tab,
+          key: item.key,
+          disabled: item.disabled ?? false,
+        }))}
+      />
     ) : null;
   if (title || extra || tabs) {
     head = (

--- a/components/card/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/card/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -760,6 +760,7 @@ Array [
               >
                 <div
                   aria-controls="rc-tabs-test-panel-tabtest"
+                  aria-disabled="false"
                   aria-selected="true"
                   class="ant-tabs-tab-btn"
                   id="rc-tabs-test-tab-tabtest"
@@ -774,6 +775,7 @@ Array [
               >
                 <div
                   aria-controls="rc-tabs-test-panel-tabtest"
+                  aria-disabled="false"
                   aria-selected="false"
                   class="ant-tabs-tab-btn"
                   id="rc-tabs-test-tab-tabtest"
@@ -900,6 +902,7 @@ Array [
               >
                 <div
                   aria-controls="rc-tabs-test-panel-article"
+                  aria-disabled="false"
                   aria-selected="false"
                   class="ant-tabs-tab-btn"
                   id="rc-tabs-test-tab-article"
@@ -914,6 +917,7 @@ Array [
               >
                 <div
                   aria-controls="rc-tabs-test-panel-app"
+                  aria-disabled="false"
                   aria-selected="true"
                   class="ant-tabs-tab-btn"
                   id="rc-tabs-test-tab-app"
@@ -928,6 +932,7 @@ Array [
               >
                 <div
                   aria-controls="rc-tabs-test-panel-project"
+                  aria-disabled="false"
                   aria-selected="false"
                   class="ant-tabs-tab-btn"
                   id="rc-tabs-test-tab-project"

--- a/components/card/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/card/__tests__/__snapshots__/demo.test.ts.snap
@@ -760,6 +760,7 @@ Array [
               >
                 <div
                   aria-controls="rc-tabs-test-panel-tabtest"
+                  aria-disabled="false"
                   aria-selected="true"
                   class="ant-tabs-tab-btn"
                   id="rc-tabs-test-tab-tabtest"
@@ -774,6 +775,7 @@ Array [
               >
                 <div
                   aria-controls="rc-tabs-test-panel-tabtest"
+                  aria-disabled="false"
                   aria-selected="false"
                   class="ant-tabs-tab-btn"
                   id="rc-tabs-test-tab-tabtest"
@@ -881,6 +883,7 @@ Array [
               >
                 <div
                   aria-controls="rc-tabs-test-panel-article"
+                  aria-disabled="false"
                   aria-selected="false"
                   class="ant-tabs-tab-btn"
                   id="rc-tabs-test-tab-article"
@@ -895,6 +898,7 @@ Array [
               >
                 <div
                   aria-controls="rc-tabs-test-panel-app"
+                  aria-disabled="false"
                   aria-selected="true"
                   class="ant-tabs-tab-btn"
                   id="rc-tabs-test-tab-app"
@@ -909,6 +913,7 @@ Array [
               >
                 <div
                   aria-controls="rc-tabs-test-panel-project"
+                  aria-disabled="false"
                   aria-selected="false"
                   class="ant-tabs-tab-btn"
                   id="rc-tabs-test-tab-project"


### PR DESCRIPTION

<!--
First of all, thank you for your contribution! 😄

For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.

Before submitting your pull request, please make sure the checklist below is confirmed.

Your pull requests will be merged after one of the collaborators approve.

Thank you!

-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [X] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
-->
close #37515 
### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fixed the warning problem of tab on the console when card passed in the tabList attribute      |
| 🇨🇳 Chinese |     修复Card传入tabList属性时，控制台有tab的警告问题      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before review. ⚠️

- [X] Doc is updated/provided or not needed
- [X] Demo is updated/provided or not needed
- [X] TypeScript definition is updated/provided or not needed
- [X] Changelog is provided or not needed
