### PR TITLE
fix: ant- prefix default set font family & size

### DIFF
--- a/components/style/index.tsx
+++ b/components/style/index.tsx
@@ -98,11 +98,12 @@ export const genLinkStyle = (token: DerivativeToken): CSSObject => ({
 });
 
 export const genFontStyle = (token: DerivativeToken, rootPrefixCls: string) => {
-  const { fontFamily } = token;
+  const { fontFamily, fontSize } = token;
 
   return {
     [`[class^="${rootPrefixCls}-"], [class*=" ${rootPrefixCls}-"]`]: {
       fontFamily,
+      fontSize,
     },
   };
 };

--- a/components/style/index.tsx
+++ b/components/style/index.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable import/prefer-default-export */
 import type { CSSObject } from '@ant-design/cssinjs';
-import type { DerivativeToken, GenerateStyle } from '../theme';
+import type { DerivativeToken } from '../theme';
 
 export { operationUnit } from './operationUnit';
 export { roundedArrow } from './roundedArrow';

--- a/components/style/index.tsx
+++ b/components/style/index.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable import/prefer-default-export */
 import type { CSSObject } from '@ant-design/cssinjs';
-import type { DerivativeToken } from '../theme';
+import type { DerivativeToken, GenerateStyle } from '../theme';
 
 export { operationUnit } from './operationUnit';
 export { roundedArrow } from './roundedArrow';
@@ -15,6 +15,7 @@ export const resetComponent = (token: DerivativeToken): CSSObject => ({
   lineHeight: token.lineHeight,
   listStyle: 'none',
   // font-feature-settings: @font-feature-settings-base;
+  fontFamily: token.fontFamily,
 });
 
 export const resetIcon = (): CSSObject => ({
@@ -95,6 +96,16 @@ export const genLinkStyle = (token: DerivativeToken): CSSObject => ({
     },
   },
 });
+
+export const genFontStyle = (token: DerivativeToken, rootPrefixCls: string) => {
+  const { fontFamily } = token;
+
+  return {
+    [`[class^="${rootPrefixCls}-"], [class*=" ${rootPrefixCls}-"]`]: {
+      fontFamily,
+    },
+  };
+};
 
 export const genFocusOutline = (token: DerivativeToken): CSSObject => ({
   outline: `${token.lineWidth * 4}px solid ${token.colorPrimaryBorder}`,

--- a/components/theme/util/genComponentStyleHook.ts
+++ b/components/theme/util/genComponentStyleHook.ts
@@ -2,7 +2,7 @@
 import type { CSSInterpolation } from '@ant-design/cssinjs';
 import { useStyleRegister } from '@ant-design/cssinjs';
 import { useContext } from 'react';
-import { genLinkStyle } from '../../style';
+import { genFontStyle, genLinkStyle } from '../../style';
 import { ConfigContext } from '../../config-provider/context';
 import type { UseComponentStyleResult } from '../index';
 import { mergeToken, statisticToken, useToken } from '../index';
@@ -61,9 +61,13 @@ export default function genComponentStyleHook<ComponentName extends OverrideComp
     }
 
     // Generate style for all a tags in antd component.
-    useStyleRegister({ theme, token, hashId, path: ['Link'] }, () => ({
-      '&': genLinkStyle(token),
-    }));
+    useStyleRegister({ theme, token, hashId, path: ['Shared', rootPrefixCls] }, () => [
+      {
+        // Link
+        '&': genLinkStyle(token),
+      },
+      genFontStyle(token, rootPrefixCls),
+    ]);
 
     return [
       useStyleRegister(


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.

Before submitting your pull request, please make sure the checklist below is confirmed.

Your pull requests will be merged after one of the collaborators approve.

Thank you!

-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fix components that do not have default `font-family` & `font-size`.      |
| 🇨🇳 Chinese |      -     |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
