### PR TITLE
fix:Autocomplete children cannot use InputNumber

### DIFF
--- a/components/auto-complete/index.tsx
+++ b/components/auto-complete/index.tsx
@@ -10,6 +10,7 @@ import classNames from 'classnames';
 import type { BaseSelectRef } from 'rc-select';
 import toArray from 'rc-util/lib/Children/toArray';
 import omit from 'rc-util/lib/omit';
+import { composeRef } from 'rc-util/lib/ref';
 import * as React from 'react';
 import type { ConfigConsumerProps } from '../config-provider';
 import { ConfigConsumer } from '../config-provider';
@@ -34,12 +35,15 @@ export type DataSourceItemType = DataSourceItemObject | React.ReactNode;
 
 function Input(
   props: {
-    inputNode: React.ReactElement;
+    inputElement: React.ReactElement;
     onChange?: <T>(event: T) => {};
+    className?: string;
   },
   ref: React.ForwardedRef<{ focus: () => void; blur: () => void }>,
 ) {
-  let InputNode: React.ReactNode = props.inputNode;
+  let inputNode = props.inputElement || <input />;
+
+  const originRef = (inputNode as React.ComponentElement<any, any>).ref;
   const inputRef = React.useRef<HTMLInputElement>(null);
 
   React.useImperativeHandle(ref, () => ({
@@ -55,10 +59,11 @@ function Input(
     },
   }));
 
-  InputNode = React.cloneElement(InputNode, {
-    ...omit(props, ['inputNode']),
-    ...InputNode.props,
-    ref: inputRef,
+  inputNode = React.cloneElement(inputNode, {
+    ...omit(props, ['inputElement']),
+    ...inputNode.props,
+    className: classNames(props.className, inputNode?.props?.className),
+    ref: composeRef(inputRef, originRef as any),
     onChange: (event: Event) => {
       if (props.onChange) {
         if (!event?.target) {
@@ -70,7 +75,7 @@ function Input(
       }
     },
   });
-  return InputNode;
+  return inputNode;
 }
 
 const InputRef = React.forwardRef(Input);
@@ -122,7 +127,7 @@ const AutoComplete: React.ForwardRefRenderFunction<RefSelectProps, AutoCompleteP
   }
 
   const getInputElement = customizeInput
-    ? (): React.ReactElement => <InputRef inputNode={customizeInput!} />
+    ? (): React.ReactElement => <InputRef inputElement={customizeInput!} />
     : undefined;
 
   // ============================ Options ============================

--- a/components/auto-complete/index.tsx
+++ b/components/auto-complete/index.tsx
@@ -57,6 +57,7 @@ function Input(
 
   InputNode = React.cloneElement(InputNode, {
     ...omit(props, ['inputNode']),
+    ...InputNode.props,
     ref: inputRef,
     onChange: (event: Event) => {
       if (props.onChange) {


### PR DESCRIPTION
[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
fix: [autocomplete set InputNumber children,it will be error when I input anything](https://github.com/ant-design/ant-design/issues/37470)
<!--
1. Put the related issue or discussion links here.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  fix:  Autocomplete children cannot use InputNumber |
| 🇨🇳 Chinese | 修复 Autocomplete在自定义输入框使用InputNumber报错问题 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
