### PR TITLE
fix: Tooltip not override children className when it's not a string type

### DIFF
--- a/components/tooltip/__tests__/tooltip.test.tsx
+++ b/components/tooltip/__tests__/tooltip.test.tsx
@@ -533,4 +533,16 @@ describe('Tooltip', () => {
 
     errSpy.mockRestore();
   });
+
+  it('not inject className when children className is not string type', () => {
+    const HOC = ({ className }: { className: Function }) => <span className={className()} />;
+    const { container } = render(
+      <Tooltip open>
+        <HOC className={() => 'bamboo'} />
+      </Tooltip>,
+    );
+
+    expect(container.querySelector('.bamboo')).toBeTruthy();
+    expect(container.querySelector('.ant-tooltip')).toBeTruthy();
+  });
 });

--- a/components/tooltip/index.tsx
+++ b/components/tooltip/index.tsx
@@ -279,9 +279,12 @@ const Tooltip = React.forwardRef<unknown, TooltipProps>((props, ref) => {
     prefixCls,
   );
   const childProps = child.props;
-  const childCls = classNames(childProps.className, {
-    [openClassName || `${prefixCls}-open`]: true,
-  });
+  const childCls =
+    !childProps.className || typeof childProps.className === 'string'
+      ? classNames(childProps.className, {
+          [openClassName || `${prefixCls}-open`]: true,
+        })
+      : childProps.className;
 
   const customOverlayClassName = classNames(overlayClassName, {
     [`${prefixCls}-rtl`]: direction === 'rtl',

--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "rc-rate": "~2.9.0",
     "rc-resize-observer": "^1.2.0",
     "rc-segmented": "~2.1.0",
-    "rc-select": "~14.1.1",
+    "rc-select": "~14.1.13",
     "rc-slider": "~10.0.0",
     "rc-steps": "~4.1.0",
     "rc-switch": "~3.2.0",


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.

Before submitting your pull request, please make sure the checklist below is confirmed.

Your pull requests will be merged after one of the collaborators approve.

Thank you!

-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

fix #37596

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fix Tooltip should not replace children `className` when it's not a string type.      |
| 🇨🇳 Chinese |    修复 Tooltip 当子元素 `className` 非 string 类型时，现在不再会覆盖其 `className`。        |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
