### PR TITLE
fix: 当表单组件处于一个禁用的表单时, 该表单组件的禁用状态应该优先取决于表单组件本身的禁用状态

### DIFF
--- a/components/button/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/button/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -484,6 +484,19 @@ Array [
       </span>
     </button>
   </div>,
+  <br />,
+  <form
+    class="ant-form ant-form-horizontal"
+  >
+    <button
+      class="ant-btn ant-btn-primary"
+      type="submit"
+    >
+      <span>
+        button in form
+      </span>
+    </button>
+  </form>,
 ]
 `;
 

--- a/components/button/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/button/__tests__/__snapshots__/demo.test.ts.snap
@@ -484,6 +484,19 @@ Array [
       </span>
     </button>
   </div>,
+  <br />,
+  <form
+    class="ant-form ant-form-horizontal"
+  >
+    <button
+      class="ant-btn ant-btn-primary"
+      type="submit"
+    >
+      <span>
+        button in form
+      </span>
+    </button>
+  </form>,
 ]
 `;
 

--- a/components/button/__tests__/index.test.tsx
+++ b/components/button/__tests__/index.test.tsx
@@ -8,6 +8,7 @@ import rtlTest from '../../../tests/shared/rtlTest';
 import { fireEvent, render, sleep } from '../../../tests/utils';
 import ConfigProvider from '../../config-provider';
 import type { SizeType } from '../../config-provider/SizeContext';
+import Form from '../../form';
 
 describe('Button', () => {
   mountTest(Button);
@@ -342,5 +343,32 @@ describe('Button', () => {
       </Button>,
     );
     expect(wrapper.container.firstChild).toMatchSnapshot();
+  });
+
+  it('button should be given priority to own disabled props when it in a disabled form', () => {
+    const wrapper = render(
+      <Form disabled>
+        <Button disabled={false} type="primary" htmlType="submit">
+          button in form
+        </Button>
+      </Form>,
+    );
+    expect(wrapper.container.querySelectorAll('.ant-btn-primary[disabled]').length).toBe(0);
+    const wrapper2 = render(
+      <Form disabled>
+        <Button type="primary" htmlType="submit">
+          button in form
+        </Button>
+      </Form>,
+    );
+    expect(wrapper2.container.querySelectorAll('.ant-btn-primary[disabled]').length).toBe(1);
+    const wrapper3 = render(
+      <Form>
+        <Button disabled type="primary" htmlType="submit">
+          button in form
+        </Button>
+      </Form>,
+    );
+    expect(wrapper3.container.querySelectorAll('.ant-btn-primary[disabled]').length).toBe(1);
   });
 });

--- a/components/button/button.tsx
+++ b/components/button/button.tsx
@@ -162,7 +162,7 @@ const InternalButton: React.ForwardRefRenderFunction<unknown, ButtonProps> = (pr
   const size = React.useContext(SizeContext);
   // ===================== Disabled =====================
   const disabled = React.useContext(DisabledContext);
-  const mergedDisabled = customDisabled || disabled;
+  const mergedDisabled = customDisabled ?? disabled;
 
   const groupSize = React.useContext(GroupSizeContext);
   const [innerLoading, setLoading] = React.useState<Loading>(!!loading);

--- a/components/button/demo/disabled.md
+++ b/components/button/demo/disabled.md
@@ -14,7 +14,7 @@ title:
 To mark a button as disabled, add the `disabled` property to the `Button`.
 
 ```tsx
-import { Button } from 'antd';
+import { Button, Form } from 'antd';
 import React from 'react';
 
 const App: React.FC = () => (
@@ -66,6 +66,12 @@ const App: React.FC = () => (
         Ghost(disabled)
       </Button>
     </div>
+    <br />
+    <Form disabled>
+      <Button disabled={false} type="primary" htmlType="submit">
+        button in form
+      </Button>
+    </Form>
   </>
 );
 

--- a/components/cascader/__tests__/index.test.tsx
+++ b/components/cascader/__tests__/index.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import type { SingleValueType } from 'rc-cascader/lib/Cascader';
 import type { BaseOptionType, DefaultOptionType } from '..';
 import Cascader from '..';
+import Form from '../../form';
 import excludeAllWarning from '../../../tests/shared/excludeWarning';
 import focusTest from '../../../tests/shared/focusTest';
 import mountTest from '../../../tests/shared/mountTest';
@@ -684,5 +685,69 @@ describe('Cascader', () => {
       expect(selectedValue!.length).toBe(1);
       expect(selectedValue!.join(',')).toBe('zhejiang');
     });
+  });
+
+  it('cascader should be given priority to own disabled props when it in a disabled form', () => {
+    const multipleOptions = [
+      {
+        value: 'zhejiang',
+        label: 'Zhejiang',
+        children: [
+          {
+            value: 'hangzhou',
+            label: 'Hangzhou',
+            children: [
+              {
+                value: 'xihu',
+                label: 'West Lake',
+              },
+              {
+                value: 'donghu',
+                label: 'East Lake',
+              },
+            ],
+          },
+        ],
+      },
+      {
+        value: 'jiangsu',
+        label: 'Jiangsu',
+        children: [
+          {
+            value: 'nanjing',
+            label: 'Nanjing',
+            children: [
+              {
+                value: 'zhonghuamen',
+                label: 'Zhong Hua Men',
+              },
+            ],
+          },
+        ],
+      },
+    ];
+    const wrapper = render(
+      <Form disabled>
+        <Cascader
+          disabled={false}
+          options={multipleOptions}
+          multiple
+          showCheckedStrategy={SHOW_PARENT}
+        />
+      </Form>,
+    );
+    expect(wrapper.container.querySelectorAll('[disabled]').length).toBe(0);
+    const wrapper2 = render(
+      <Form disabled>
+        <Cascader options={multipleOptions} multiple showCheckedStrategy={SHOW_PARENT} />
+      </Form>,
+    );
+    expect(wrapper2.container.querySelectorAll('[disabled]').length).toBe(1);
+    const wrapper3 = render(
+      <Form>
+        <Cascader disabled options={multipleOptions} multiple showCheckedStrategy={SHOW_PARENT} />
+      </Form>,
+    );
+    expect(wrapper3.container.querySelectorAll('[disabled]').length).toBe(1);
   });
 });

--- a/components/cascader/index.tsx
+++ b/components/cascader/index.tsx
@@ -219,11 +219,11 @@ const Cascader = React.forwardRef((props: CascaderProps<any>, ref: React.Ref<Cas
 
   // ===================== Size ======================
   const size = React.useContext(SizeContext);
-  const mergedSize = customizeSize || size;
+  const mergedSize = customizeSize ?? size;
 
   // ===================== Disabled =====================
   const disabled = React.useContext(DisabledContext);
-  const mergedDisabled = customDisabled || disabled;
+  const mergedDisabled = customDisabled ?? disabled;
 
   // ===================== Icon ======================
   let mergedExpandIcon = expandIcon;

--- a/components/checkbox/Checkbox.tsx
+++ b/components/checkbox/Checkbox.tsx
@@ -65,7 +65,7 @@ const InternalCheckbox: React.ForwardRefRenderFunction<HTMLInputElement, Checkbo
   const checkboxGroup = React.useContext(GroupContext);
   const { isFormItemInput } = useContext(FormItemInputContext);
   const contextDisabled = useContext(DisabledContext);
-  const mergedDisabled = disabled || checkboxGroup?.disabled || contextDisabled;
+  const mergedDisabled = disabled ?? checkboxGroup?.disabled ?? contextDisabled;
 
   const prevValue = React.useRef(restProps.value);
 

--- a/components/checkbox/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/checkbox/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -581,14 +581,13 @@ Array [
       </span>
     </label>
     <label
-      class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled ant-checkbox-group-item"
+      class="ant-checkbox-wrapper ant-checkbox-group-item"
     >
       <span
-        class="ant-checkbox ant-checkbox-disabled"
+        class="ant-checkbox"
       >
         <input
           class="ant-checkbox-input"
-          disabled=""
           type="checkbox"
           value="Orange"
         />

--- a/components/checkbox/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/checkbox/__tests__/__snapshots__/demo.test.ts.snap
@@ -581,14 +581,13 @@ Array [
       </span>
     </label>
     <label
-      class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled ant-checkbox-group-item"
+      class="ant-checkbox-wrapper ant-checkbox-group-item"
     >
       <span
-        class="ant-checkbox ant-checkbox-disabled"
+        class="ant-checkbox"
       >
         <input
           class="ant-checkbox-input"
-          disabled=""
           type="checkbox"
           value="Orange"
         />

--- a/components/checkbox/__tests__/checkbox.test.tsx
+++ b/components/checkbox/__tests__/checkbox.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Checkbox from '..';
+import Form from '../../form';
 import focusTest from '../../../tests/shared/focusTest';
 import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
@@ -35,5 +36,26 @@ describe('Checkbox', () => {
       'Warning: [antd: Checkbox] `value` is not a valid prop, do you mean `checked`?',
     );
     errorSpy.mockRestore();
+  });
+
+  it('checkbox should be given priority to own disabled props when it in a disabled form', () => {
+    const wrapper = render(
+      <Form disabled>
+        <Checkbox disabled={false} />
+      </Form>,
+    );
+    expect(wrapper.container.querySelectorAll('[disabled]').length).toBe(0);
+    const wrapper2 = render(
+      <Form disabled>
+        <Checkbox />
+      </Form>,
+    );
+    expect(wrapper2.container.querySelectorAll('[disabled]').length).toBe(1);
+    const wrapper3 = render(
+      <Form>
+        <Checkbox disabled />
+      </Form>,
+    );
+    expect(wrapper3.container.querySelectorAll('[disabled]').length).toBe(1);
   });
 });

--- a/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
+++ b/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
@@ -42692,11 +42692,12 @@ exports[`ConfigProvider components Upload configProvider componentDisabled 1`] =
   class=""
 >
   <div
-    class="config-upload config-upload-select config-upload-select-text config-upload-disabled"
+    class="config-upload config-upload-select config-upload-select-text"
   >
     <span
-      class="config-upload config-upload-disabled"
+      class="config-upload"
       role="button"
+      tabindex="0"
     >
       <input
         accept=""
@@ -42752,7 +42753,35 @@ exports[`ConfigProvider components Upload configProvider componentDisabled 1`] =
             </span>
             <span
               class="config-upload-list-item-card-actions"
-            />
+            >
+              <button
+                class="config-btn config-btn-text config-btn-sm config-btn-icon-only config-upload-list-item-card-actions-btn"
+                disabled=""
+                title="Remove file"
+                type="button"
+              >
+                <span
+                  aria-label="delete"
+                  class="anticon anticon-delete"
+                  role="img"
+                  tabindex="-1"
+                >
+                  <svg
+                    aria-hidden="true"
+                    data-icon="delete"
+                    fill="currentColor"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M360 184h-8c4.4 0 8-3.6 8-8v8h304v-8c0 4.4 3.6 8 8 8h-8v72h72v-80c0-35.3-28.7-64-64-64H352c-35.3 0-64 28.7-64 64v80h72v-72zm504 72H160c-17.7 0-32 14.3-32 32v32c0 4.4 3.6 8 8 8h60.4l24.7 523c1.6 34.1 29.8 61 63.9 61h454c34.2 0 62.3-26.8 63.9-61l24.7-523H888c4.4 0 8-3.6 8-8v-32c0-17.7-14.3-32-32-32zM731.3 840H292.7l-24.2-512h487l-24.2 512z"
+                    />
+                  </svg>
+                </span>
+              </button>
+            </span>
           </span>
         </div>
       </div>

--- a/components/date-picker/__tests__/DatePicker.test.tsx
+++ b/components/date-picker/__tests__/DatePicker.test.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import type { TriggerProps } from 'rc-trigger';
 import { fireEvent, render } from '../../../tests/utils';
 import DatePicker from '..';
+import Form from '../../form';
 import focusTest from '../../../tests/shared/focusTest';
 import type { PickerLocale } from '../generatePicker';
 
@@ -278,5 +279,45 @@ describe('DatePicker', () => {
         bottomRight: expect.objectContaining({ offset: [0, 4], points: ['tr', 'br'] }),
       }),
     );
+  });
+
+  it('DatePicker should be given priority to own disabled props when it in a disabled form', () => {
+    const wrapper = render(
+      <Form disabled>
+        <DatePicker disabled={false} />
+        <DatePicker.RangePicker disabled={false} />
+        <DatePicker.MonthPicker disabled={false} />
+        <DatePicker.QuarterPicker disabled={false} />
+        <DatePicker.WeekPicker disabled={false} />
+        <DatePicker.YearPicker disabled={false} />
+        <DatePicker.TimePicker disabled={false} />
+      </Form>,
+    );
+    expect(wrapper.container.querySelectorAll('[disabled]').length).toBe(0);
+    const wrapper2 = render(
+      <Form disabled>
+        <DatePicker />
+        <DatePicker.RangePicker />
+        <DatePicker.MonthPicker />
+        <DatePicker.QuarterPicker />
+        <DatePicker.WeekPicker />
+        <DatePicker.YearPicker />
+        <DatePicker.TimePicker />
+      </Form>,
+    );
+    // RangePicker has 2 input
+    expect(wrapper2.container.querySelectorAll('[disabled]').length).toBe(8);
+    const wrapper3 = render(
+      <Form>
+        <DatePicker disabled />
+        <DatePicker.RangePicker disabled />
+        <DatePicker.MonthPicker disabled />
+        <DatePicker.QuarterPicker disabled />
+        <DatePicker.WeekPicker disabled />
+        <DatePicker.YearPicker disabled />
+        <DatePicker.TimePicker disabled />
+      </Form>,
+    );
+    expect(wrapper3.container.querySelectorAll('[disabled]').length).toBe(8);
   });
 });

--- a/components/date-picker/generatePicker/generateRangePicker.tsx
+++ b/components/date-picker/generatePicker/generateRangePicker.tsx
@@ -72,11 +72,11 @@ export default function generateRangePicker<DateType>(
 
     // ===================== Size =====================
     const size = React.useContext(SizeContext);
-    const mergedSize = customizeSize || size;
+    const mergedSize = customizeSize ?? size;
 
     // ===================== Disabled =====================
     const disabled = React.useContext(DisabledContext);
-    const mergedDisabled = customDisabled || disabled;
+    const mergedDisabled = customDisabled ?? disabled;
 
     // ===================== FormItemInput =====================
     const formItemContext = useContext(FormItemInputContext);

--- a/components/date-picker/generatePicker/generateSinglePicker.tsx
+++ b/components/date-picker/generatePicker/generateSinglePicker.tsx
@@ -95,11 +95,11 @@ export default function generatePicker<DateType>(generateConfig: GenerateConfig<
         );
         // ===================== Size =====================
         const size = React.useContext(SizeContext);
-        const mergedSize = customizeSize || size;
+        const mergedSize = customizeSize ?? size;
 
         // ===================== Disabled =====================
         const disabled = React.useContext(DisabledContext);
-        const mergedDisabled = customDisabled || disabled;
+        const mergedDisabled = customDisabled ?? disabled;
 
         // ===================== FormItemInput =====================
         const formItemContext = useContext(FormItemInputContext);

--- a/components/form/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/form/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -5071,11 +5071,12 @@ Array [
                   class="ant-upload-list ant-upload-list-picture-card"
                 >
                   <div
-                    class="ant-upload ant-upload-select ant-upload-select-picture-card ant-upload-disabled"
+                    class="ant-upload ant-upload-select ant-upload-select-picture-card"
                   >
                     <span
-                      class="ant-upload ant-upload-disabled"
+                      class="ant-upload"
                       role="button"
+                      tabindex="0"
                     >
                       <input
                         accept=""

--- a/components/form/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/form/__tests__/__snapshots__/demo.test.ts.snap
@@ -2554,11 +2554,12 @@ Array [
                   class="ant-upload-list ant-upload-list-picture-card"
                 >
                   <div
-                    class="ant-upload ant-upload-select ant-upload-select-picture-card ant-upload-disabled"
+                    class="ant-upload ant-upload-select ant-upload-select-picture-card"
                   >
                     <span
-                      class="ant-upload ant-upload-disabled"
+                      class="ant-upload"
                       role="button"
+                      tabindex="0"
                     >
                       <input
                         accept=""

--- a/components/form/__tests__/__snapshots__/index.test.js.snap
+++ b/components/form/__tests__/__snapshots__/index.test.js.snap
@@ -923,12 +923,13 @@ exports[`Form form should support disabled 1`] = `
               class=""
             >
               <div
-                class="ant-upload ant-upload-select ant-upload-select-text ant-upload-disabled"
+                class="ant-upload ant-upload-select ant-upload-select-text"
                 style="display: none;"
               >
                 <span
-                  class="ant-upload ant-upload-disabled"
+                  class="ant-upload"
                   role="button"
+                  tabindex="0"
                 >
                   <input
                     accept=""

--- a/components/input-number/__tests__/index.test.tsx
+++ b/components/input-number/__tests__/index.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { ArrowDownOutlined, ArrowUpOutlined } from '@ant-design/icons';
 import InputNumber from '..';
+import Form from '../../form';
 import focusTest from '../../../tests/shared/focusTest';
 import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
@@ -68,5 +69,26 @@ describe('InputNumber', () => {
     expect(
       container.querySelector('.anticon-arrow-down')?.className.includes('my-class-name'),
     ).toBe(true);
+  });
+
+  it('InputNumber should be given priority to own disabled props when it in a disabled form', () => {
+    const wrapper = render(
+      <Form disabled>
+        <InputNumber disabled={false} />
+      </Form>,
+    );
+    expect(wrapper.container.querySelectorAll('[disabled]').length).toBe(0);
+    const wrapper2 = render(
+      <Form disabled>
+        <InputNumber />
+      </Form>,
+    );
+    expect(wrapper2.container.querySelectorAll('[disabled]').length).toBe(1);
+    const wrapper3 = render(
+      <Form>
+        <InputNumber disabled />
+      </Form>,
+    );
+    expect(wrapper3.container.querySelectorAll('[disabled]').length).toBe(1);
   });
 });

--- a/components/input-number/index.tsx
+++ b/components/input-number/index.tsx
@@ -79,10 +79,10 @@ const InputNumber = React.forwardRef<HTMLInputElement, InputNumberProps>((props,
   } = useContext(FormItemInputContext);
   const mergedStatus = getMergedStatus(contextStatus, customStatus);
 
-  const mergeSize = customizeSize || size;
+  const mergeSize = customizeSize ?? size;
   // ===================== Disabled =====================
   const disabled = React.useContext(DisabledContext);
-  const mergedDisabled = customDisabled || disabled;
+  const mergedDisabled = customDisabled ?? disabled;
 
   const inputNumberClass = classNames(
     {

--- a/components/input/Input.tsx
+++ b/components/input/Input.tsx
@@ -143,11 +143,11 @@ const Input = forwardRef<InputRef, InputProps>((props, ref) => {
 
   // ===================== Size =====================
   const size = React.useContext(SizeContext);
-  const mergedSize = customSize || size;
+  const mergedSize = customSize ?? size;
 
   // ===================== Disabled =====================
   const disabled = React.useContext(DisabledContext);
-  const mergedDisabled = customDisabled || disabled;
+  const mergedDisabled = customDisabled ?? disabled;
 
   // ===================== Status =====================
   const { status: contextStatus, hasFeedback, feedbackIcon } = useContext(FormItemInputContext);

--- a/components/input/TextArea.tsx
+++ b/components/input/TextArea.tsx
@@ -83,7 +83,7 @@ const TextArea = React.forwardRef<TextAreaRef, TextAreaProps>(
 
     // ===================== Disabled =====================
     const disabled = React.useContext(DisabledContext);
-    const mergedDisabled = customDisabled || disabled;
+    const mergedDisabled = customDisabled ?? disabled;
 
     const {
       status: contextStatus,

--- a/components/input/__tests__/index.test.tsx
+++ b/components/input/__tests__/index.test.tsx
@@ -447,4 +447,25 @@ describe('typescript types ', () => {
     expect(input?.getAttribute('data-testid')).toBe('test-id');
     expect(input?.getAttribute('data-id')).toBe('12345');
   });
+
+  it('input should be given priority to own disabled props when it in a disabled form', () => {
+    const wrapper = render(
+      <Form disabled>
+        <Input disabled={false} />
+      </Form>,
+    );
+    expect(wrapper.container.querySelectorAll('[disabled]').length).toBe(0);
+    const wrapper2 = render(
+      <Form disabled>
+        <Input />
+      </Form>,
+    );
+    expect(wrapper2.container.querySelectorAll('[disabled]').length).toBe(1);
+    const wrapper3 = render(
+      <Form>
+        <Input disabled />
+      </Form>,
+    );
+    expect(wrapper3.container.querySelectorAll('[disabled]').length).toBe(1);
+  });
 });

--- a/components/select/__tests__/index.test.tsx
+++ b/components/select/__tests__/index.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { CloseOutlined } from '@ant-design/icons';
 import type { SelectProps } from '..';
 import Select from '..';
+import Form from '../../form';
 import focusTest from '../../../tests/shared/focusTest';
 import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
@@ -142,5 +143,25 @@ describe('Select', () => {
       );
       expect(asFragment().firstChild).toMatchSnapshot();
     });
+  });
+  it('select should be given priority to own disabled props when it in a disabled form', () => {
+    const wrapper = render(
+      <Form disabled>
+        <Select disabled={false} />
+      </Form>,
+    );
+    expect(wrapper.container.querySelectorAll('[disabled]').length).toBe(0);
+    const wrapper2 = render(
+      <Form disabled>
+        <Select />
+      </Form>,
+    );
+    expect(wrapper2.container.querySelectorAll('[disabled]').length).toBe(1);
+    const wrapper3 = render(
+      <Form>
+        <Select disabled />
+      </Form>,
+    );
+    expect(wrapper3.container.querySelectorAll('[disabled]').length).toBe(1);
   });
 });

--- a/components/select/index.tsx
+++ b/components/select/index.tsx
@@ -157,11 +157,11 @@ const InternalSelect = <OptionType extends BaseOptionType | DefaultOptionType = 
     [`${prefixCls}-dropdown-${direction}`]: direction === 'rtl',
   });
 
-  const mergedSize = customizeSize || size;
+  const mergedSize = customizeSize ?? size;
 
   // ===================== Disabled =====================
   const disabled = React.useContext(DisabledContext);
-  const mergedDisabled = customDisabled || disabled;
+  const mergedDisabled = customDisabled ?? disabled;
 
   const mergedClassName = classNames(
     {

--- a/components/switch/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/switch/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -48,8 +48,7 @@ exports[`renders ./components/switch/demo/loading.md extend context correctly 1`
 Array [
   <button
     aria-checked="true"
-    class="ant-switch ant-switch-loading ant-switch-checked ant-switch-disabled"
-    disabled=""
+    class="ant-switch ant-switch-loading ant-switch-checked"
     role="switch"
     type="button"
   >
@@ -83,8 +82,7 @@ Array [
   <br />,
   <button
     aria-checked="false"
-    class="ant-switch ant-switch-small ant-switch-loading ant-switch-disabled"
-    disabled=""
+    class="ant-switch ant-switch-small ant-switch-loading"
     role="switch"
     type="button"
   >

--- a/components/switch/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/switch/__tests__/__snapshots__/demo.test.ts.snap
@@ -48,8 +48,7 @@ exports[`renders ./components/switch/demo/loading.md correctly 1`] = `
 Array [
   <button
     aria-checked="true"
-    class="ant-switch ant-switch-loading ant-switch-checked ant-switch-disabled"
-    disabled=""
+    class="ant-switch ant-switch-loading ant-switch-checked"
     role="switch"
     type="button"
   >
@@ -83,8 +82,7 @@ Array [
   <br />,
   <button
     aria-checked="false"
-    class="ant-switch ant-switch-small ant-switch-loading ant-switch-disabled"
-    disabled=""
+    class="ant-switch ant-switch-small ant-switch-loading"
     role="switch"
     type="button"
   >

--- a/components/switch/__tests__/index.test.tsx
+++ b/components/switch/__tests__/index.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Switch from '..';
+import Form from '../../form';
 import focusTest from '../../../tests/shared/focusTest';
 import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
@@ -28,5 +29,25 @@ describe('Switch', () => {
       'Warning: [antd: Switch] `value` is not a valid prop, do you mean `checked`?',
     );
     errorSpy.mockRestore();
+  });
+  it('switch should be given priority to own disabled props when it in a disabled form', () => {
+    const wrapper = render(
+      <Form disabled>
+        <Switch disabled={false} />
+      </Form>,
+    );
+    expect(wrapper.container.querySelectorAll('[disabled]').length).toBe(0);
+    const wrapper2 = render(
+      <Form disabled>
+        <Switch />
+      </Form>,
+    );
+    expect(wrapper2.container.querySelectorAll('[disabled]').length).toBe(1);
+    const wrapper3 = render(
+      <Form>
+        <Switch disabled />
+      </Form>,
+    );
+    expect(wrapper3.container.querySelectorAll('[disabled]').length).toBe(1);
   });
 });

--- a/components/switch/index.tsx
+++ b/components/switch/index.tsx
@@ -63,7 +63,7 @@ const Switch = React.forwardRef<HTMLButtonElement, SwitchProps>(
 
     // ===================== Disabled =====================
     const disabled = React.useContext(DisabledContext);
-    const mergedDisabled = customDisabled || disabled || loading;
+    const mergedDisabled = customDisabled ?? disabled ?? loading;
 
     const prefixCls = getPrefixCls('switch', customizePrefixCls);
     const loadingIcon = (

--- a/components/tree-select/__tests__/index.test.tsx
+++ b/components/tree-select/__tests__/index.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render } from '../../../tests/utils';
 import TreeSelect, { TreeNode } from '..';
+import Form from '../../form';
 import focusTest from '../../../tests/shared/focusTest';
 import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
@@ -59,5 +60,25 @@ describe('TreeSelect', () => {
       'Warning: [antd: TreeSelect] `dropdownClassName` is deprecated which will be removed in next major version. Please use `popupClassName` instead.',
     );
     errorSpy.mockRestore();
+  });
+  it('TreeSelect should be given priority to own disabled props when it in a disabled form', () => {
+    const wrapper = render(
+      <Form disabled>
+        <TreeSelect disabled={false} />
+      </Form>,
+    );
+    expect(wrapper.container.querySelectorAll('[disabled]').length).toBe(0);
+    const wrapper2 = render(
+      <Form disabled>
+        <TreeSelect />
+      </Form>,
+    );
+    expect(wrapper2.container.querySelectorAll('[disabled]').length).toBe(1);
+    const wrapper3 = render(
+      <Form>
+        <TreeSelect disabled />
+      </Form>,
+    );
+    expect(wrapper3.container.querySelectorAll('[disabled]').length).toBe(1);
   });
 });

--- a/components/tree-select/index.tsx
+++ b/components/tree-select/index.tsx
@@ -173,10 +173,10 @@ const InternalTreeSelect = <OptionType extends BaseOptionType | DefaultOptionTyp
       : ('bottomLeft' as SelectCommonPlacement);
   };
 
-  const mergedSize = customizeSize || size;
+  const mergedSize = customizeSize ?? size;
   // ===================== Disabled =====================
   const disabled = React.useContext(DisabledContext);
-  const mergedDisabled = customDisabled || disabled;
+  const mergedDisabled = customDisabled ?? disabled;
 
   const mergedClassName = classNames(
     !customizePrefixCls && treeSelectPrefixCls,

--- a/components/upload/Upload.tsx
+++ b/components/upload/Upload.tsx
@@ -54,7 +54,7 @@ const InternalUpload: React.ForwardRefRenderFunction<unknown, UploadProps> = (pr
 
   // ===================== Disabled =====================
   const disabled = React.useContext(DisabledContext);
-  const mergedDisabled = customDisabled || disabled;
+  const mergedDisabled = customDisabled ?? disabled;
 
   const [mergedFileList, setMergedFileList] = useMergedState(defaultFileList || [], {
     value: fileList,

--- a/components/upload/__tests__/upload.test.tsx
+++ b/components/upload/__tests__/upload.test.tsx
@@ -5,6 +5,7 @@ import type { UploadRequestOption } from 'rc-upload/lib/interface';
 import React from 'react';
 import type { RcFile, UploadFile, UploadProps } from '..';
 import Upload from '..';
+import Button from '../../button';
 import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
 import { fireEvent, render, sleep, act } from '../../../tests/utils';
@@ -997,5 +998,40 @@ describe('Upload', () => {
         ],
       }),
     );
+  });
+  it('Upload should be given priority to own disabled props when it in a disabled form', () => {
+    const props: UploadProps = {
+      name: 'file',
+      action: 'https://www.mocky.io/v2/5cc8019d300000980a055e76',
+      headers: {
+        authorization: 'authorization-text',
+      },
+      capture: true,
+    };
+    const wrapper = render(
+      <Form disabled>
+        <Upload {...props} disabled={false}>
+          <Button disabled={false}>Click to Upload</Button>
+        </Upload>
+      </Form>,
+    );
+    expect(wrapper.container.querySelectorAll('[disabled]').length).toBe(0);
+    const wrapper2 = render(
+      <Form disabled>
+        <Upload {...props}>
+          <Button>Click to Upload</Button>
+        </Upload>
+      </Form>,
+    );
+
+    expect(wrapper2.container.querySelectorAll('[disabled]').length).toBe(1);
+    const wrapper3 = render(
+      <Form>
+        <Upload {...props} disabled>
+          <Button disabled>Click to Upload</Button>
+        </Upload>
+      </Form>,
+    );
+    expect(wrapper3.container.querySelectorAll('[disabled]').length).toBe(1);
   });
 });


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

新特性请提交至 feature 分支，其余可提交至 master 分支。
在维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

[[English Template / 英文模板](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE.md)]

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [X] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue
- fix: #37590 
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
当一个按钮处于一个禁用状态的表单中时，按钮的禁用状态应该就近原则，优先取决于该按钮本身的禁用状态，其次才是从表单上下文继承过来的禁用状态
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |    button should be given priority to own disabled props when it in a disabled form      |
| 🇨🇳 中文 |    当按钮处于一个禁用的表单时, 按钮的禁用状态应该优先取决于按钮本身的禁用状态      |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [X] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [X] Changelog 已提供或无须提供