### PR TITLE
fix: visible follow up of confirm back to true

### DIFF
--- a/components/modal/ConfirmDialog.tsx
+++ b/components/modal/ConfirmDialog.tsx
@@ -45,11 +45,19 @@ const ConfirmDialog = (props: ConfirmDialogProps) => {
     focusTriggerAfterClose,
   } = props;
 
-  warning(
-    !(typeof icon === 'string' && icon.length > 2),
-    'Modal',
-    `\`icon\` is using ReactNode instead of string naming in v4. Please check \`${icon}\` at https://ant.design/components/icon`,
-  );
+  if (process.env.NODE_ENV !== 'production') {
+    warning(
+      !(typeof icon === 'string' && icon.length > 2),
+      'Modal',
+      `\`icon\` is using ReactNode instead of string naming in v4. Please check \`${icon}\` at https://ant.design/components/icon`,
+    );
+
+    warning(
+      visible === undefined,
+      'Modal',
+      `\`visible\` is deprecated, please use \`open\` instead.`,
+    );
+  }
 
   // 支持传入{ icon: null }来隐藏`Modal.confirm`默认的Icon
   const okType = props.okType || 'primary';

--- a/components/modal/__tests__/confirm.test.tsx
+++ b/components/modal/__tests__/confirm.test.tsx
@@ -853,28 +853,41 @@ describe('Modal.confirm triggers callbacks correctly', () => {
 
   // https://github.com/ant-design/ant-design/issues/37461
   it('Update should closable', async () => {
+    resetWarned();
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
     jest.useFakeTimers();
 
-    Modal.confirm({}).update({
-      visible: true,
-    });
+    const modal = Modal.confirm({});
 
-    await act(async () => {
-      jest.runAllTimers();
-      await sleep();
-    });
+    /* eslint-disable no-await-in-loop */
+    for (let i = 0; i < 3; i += 1) {
+      modal.update({
+        visible: true,
+      });
 
-    expect($$('.ant-modal-confirm-confirm')).toHaveLength(1);
+      await act(async () => {
+        jest.runAllTimers();
+        await sleep();
+      });
 
-    $$('.ant-modal-confirm-btns > .ant-btn')[0].click();
+      expect($$('.ant-modal-confirm-confirm')).toHaveLength(1);
 
-    await act(async () => {
-      jest.runAllTimers();
-      await sleep();
-    });
+      $$('.ant-modal-confirm-btns > .ant-btn')[0].click();
 
-    expect($$('.ant-modal-confirm-confirm')).toHaveLength(0);
+      await act(async () => {
+        jest.runAllTimers();
+        await sleep();
+      });
+
+      expect($$('.ant-modal-confirm-confirm')).toHaveLength(0);
+    }
+    /* eslint-enable */
+
+    expect(errSpy).toHaveBeenCalledWith(
+      'Warning: [antd: Modal] `visible` is deprecated, please use `open` instead.',
+    );
 
     jest.useRealTimers();
+    errSpy.mockRestore();
   });
 });

--- a/components/modal/confirm.tsx
+++ b/components/modal/confirm.tsx
@@ -48,14 +48,7 @@ export default function confirm(config: ModalFuncProps) {
     reactUnmount(container);
   }
 
-  function render({
-    okText,
-    cancelText,
-    prefixCls: customizePrefixCls,
-    open,
-    visible,
-    ...props
-  }: any) {
+  function render({ okText, cancelText, prefixCls: customizePrefixCls, ...props }: any) {
     /**
      * https://github.com/ant-design/ant-design/issues/23623
      *
@@ -72,7 +65,6 @@ export default function confirm(config: ModalFuncProps) {
       reactRender(
         <ConfirmDialog
           {...props}
-          open={open ?? visible}
           prefixCls={prefixCls}
           rootPrefixCls={rootPrefixCls}
           iconPrefixCls={iconPrefixCls}
@@ -96,6 +88,12 @@ export default function confirm(config: ModalFuncProps) {
         destroy.apply(this, args);
       },
     };
+
+    // Legacy support
+    if (currentConfig.visible) {
+      delete currentConfig.visible;
+    }
+
     render(currentConfig);
   }
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.

Before submitting your pull request, please make sure the checklist below is confirmed.

Your pull requests will be merged after one of the collaborators approve.

Thank you!

-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

ref https://github.com/ant-design/ant-design/pull/37471#discussion_r965736108

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fix Modal.confirm instance ref legacy config `visible=true` back to show not work.      |
| 🇨🇳 Chinese |     修复 Modal.confirm 实例引用配置废弃 `visible=true` 重新展示时不生效的问题。     |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
