### PR TITLE
chore: warning divider not support text

### DIFF
--- a/components/divider/__tests__/index.test.ts
+++ b/components/divider/__tests__/index.test.ts
@@ -1,6 +1,0 @@
-import Divider from '..';
-import mountTest from '../../../tests/shared/mountTest';
-
-describe('Divider', () => {
-  mountTest(Divider);
-});

--- a/components/divider/__tests__/index.test.tsx
+++ b/components/divider/__tests__/index.test.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import { render } from '../../../tests/utils';
+import Divider from '..';
+import mountTest from '../../../tests/shared/mountTest';
+
+describe('Divider', () => {
+  mountTest(Divider);
+
+  it('not show children when vertical', () => {
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { container } = render(<Divider type="vertical">Bamboo</Divider>);
+    expect(container.querySelector('.ant-divider-inner-text')).toBeFalsy();
+
+    errSpy.mockRestore();
+  });
+});

--- a/components/divider/index.tsx
+++ b/components/divider/index.tsx
@@ -1,6 +1,7 @@
 import classNames from 'classnames';
 import * as React from 'react';
 import { ConfigContext } from '../config-provider';
+import warning from '../_util/warning';
 
 export interface DividerProps {
   prefixCls?: string;
@@ -53,9 +54,18 @@ const Divider: React.FC<DividerProps> = props => {
     ...(hasCustomMarginRight && { marginRight: orientationMargin }),
   };
 
+  // Warning children not work in vertical mode
+  if (process.env.NODE_ENV !== 'production') {
+    warning(
+      !children || type !== 'vertical',
+      'Divider',
+      '`children` not working in `vertical` mode.',
+    );
+  }
+
   return (
     <div className={classString} {...restProps} role="separator">
-      {children && (
+      {children && type !== 'vertical' && (
         <span className={`${prefixCls}-inner-text`} style={innerStyle}>
           {children}
         </span>


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.

Before submitting your pull request, please make sure the checklist below is confirmed.

Your pull requests will be merged after one of the collaborators approve.

Thank you!

-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [x] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fix Divider shows `children` when in `vertical` mode.      |
| 🇨🇳 Chinese |     修复 Divider 在 `vertical` 模式下仍然会错误展示 `children` 的问题。    |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
