### PR TITLE
feat: Notification support for data-testid

### DIFF
--- a/components/notification/__tests__/index.test.tsx
+++ b/components/notification/__tests__/index.test.tsx
@@ -336,4 +336,16 @@ describe('notification', () => {
 
     expect(document.querySelectorAll('.anticon-user').length).toBe(1);
   });
+
+  it('support props', () => {
+    act(() => {
+      notification.open({
+        message: 'Notification Title',
+        duration: 0,
+        props: { 'data-testid': 'test-notification' },
+      });
+    });
+
+    expect(document.querySelectorAll("[data-testid='test-notification']").length).toBe(1);
+  });
 });

--- a/components/notification/index.en-US.md
+++ b/components/notification/index.en-US.md
@@ -46,6 +46,7 @@ The properties of config are as follows:
 | top | Distance from the top of the viewport, when `placement` is `topRight` or `topLeft` (unit: pixels) | number | 24 |
 | onClick | Specify a function that will be called when the notification is clicked | function | - |
 | onClose | Trigger when notification closed | function | - |
+| props | Props passed down | Object | An object that can contain `data-*`, `aria-*`, or `role` props, to be put on the notification `div`. This currently only allows `data-testid` instead of `data-*` in TypeScript. See https://github.com/microsoft/TypeScript/issues/28960. |
 
 `notification` also provides a global `config()` method that can be used for specifying the default options. Once this method is used, all the notification boxes will take into account these globally defined options when displaying.
 

--- a/components/notification/index.tsx
+++ b/components/notification/index.tsx
@@ -10,6 +10,10 @@ import * as React from 'react';
 import ConfigProvider, { globalConfig } from '../config-provider';
 import createUseNotification from './hooks/useNotification';
 
+interface DivProps extends React.HTMLProps<HTMLDivElement> {
+  'data-testid'?: string;
+}
+
 export type NotificationPlacement =
   | 'top'
   | 'topLeft'
@@ -43,6 +47,7 @@ export interface ConfigProps {
   closeIcon?: React.ReactNode;
   rtl?: boolean;
   maxCount?: number;
+  props?: DivProps;
 }
 
 function setNotificationConfig(options: ConfigProps) {
@@ -216,6 +221,7 @@ export interface ArgsProps {
   bottom?: number;
   getContainer?: () => HTMLElement;
   closeIcon?: React.ReactNode;
+  props?: DivProps;
 }
 
 function getRCNoticeProps(args: ArgsProps, prefixCls: string, iconPrefixCls?: string) {
@@ -232,6 +238,7 @@ function getRCNoticeProps(args: ArgsProps, prefixCls: string, iconPrefixCls?: st
     style,
     className,
     closeIcon = defaultCloseIcon,
+    props,
   } = args;
 
   const duration = durationArg === undefined ? defaultDuration : durationArg;
@@ -280,6 +287,7 @@ function getRCNoticeProps(args: ArgsProps, prefixCls: string, iconPrefixCls?: st
     className: classNames(className, {
       [`${prefixCls}-${type}`]: !!type,
     }),
+    props,
   };
 }
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.

Before submitting your pull request, please make sure the checklist below is confirmed.

Your pull requests will be merged after one of the collaborators approve.

Thank you!

-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [x] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
-->

### 💡 Background and solution

Support for `props` config in Notification

https://notification-react-component.vercel.app/#notificationnoticeprops

```
props | Object |  An object that can contain data-*, aria-*, or role props, to be put on the notification div. This currently only allows data-testid instead of data-* in TypeScript. See microsoft/TypeScript#28960.
```

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Support for `data-testid` on Notification component      |
| 🇨🇳 Chinese |  支持通知组件上的 `data-testid`         |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
