### PR TITLE
fix: getAlphaColor should ignore alpha color

### DIFF
--- a/components/theme/__tests__/util.test.tsx
+++ b/components/theme/__tests__/util.test.tsx
@@ -1,0 +1,9 @@
+import getAlphaColor from '../util/getAlphaColor';
+
+describe('util', () => {
+  describe('getAlphaColor', () => {
+    it('should not process color with alpha', () => {
+      expect(getAlphaColor('rgba(0, 0, 0, 0.5)', 'rgba(255, 255, 255)')).toBe('rgba(0, 0, 0, 0.5)');
+    });
+  });
+});

--- a/components/theme/util/getAlphaColor.ts
+++ b/components/theme/util/getAlphaColor.ts
@@ -5,7 +5,11 @@ function isStableColor(color: number): boolean {
 }
 
 function getAlphaColor(frontColor: string, backgroundColor: string): string {
-  const { r: fR, g: fG, b: fB } = new TinyColor(frontColor).toRgb();
+  const { r: fR, g: fG, b: fB, a: originAlpha } = new TinyColor(frontColor).toRgb();
+  if (originAlpha < 1) {
+    return frontColor;
+  }
+
   const { r: bR, g: bG, b: bB } = new TinyColor(backgroundColor).toRgb();
 
   for (let fA = 0.01; fA <= 1; fA += 0.01) {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.

Before submitting your pull request, please make sure the checklist below is confirmed.

Your pull requests will be merged after one of the collaborators approve.

Thank you!

-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    -       |
| 🇨🇳 Chinese |    `getAlphaColor` 不处理原本有透明度的颜色       |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
