### PR TITLE
feat(typograph): add text field for Editconfig

### DIFF
--- a/components/typography/Base/index.tsx
+++ b/components/typography/Base/index.tsx
@@ -36,6 +36,7 @@ interface CopyConfig {
 }
 
 interface EditConfig {
+  text?: string;
   editing?: boolean;
   icon?: React.ReactNode;
   tooltip?: boolean | React.ReactNode;
@@ -340,11 +341,11 @@ const Base = React.forwardRef((props: InternalBlockProps, ref: any) => {
   // ========================== Tooltip ===========================
   let tooltipProps: TooltipProps = {};
   if (ellipsisConfig.tooltip === true) {
-    tooltipProps = { title: children };
+    tooltipProps = { title: editConfig.text ?? children };
   } else if (React.isValidElement(ellipsisConfig.tooltip)) {
     tooltipProps = { title: ellipsisConfig.tooltip };
   } else if (typeof ellipsisConfig.tooltip === 'object') {
-    tooltipProps = { title: children, ...ellipsisConfig.tooltip };
+    tooltipProps = { title: editConfig.text ?? children, ...ellipsisConfig.tooltip };
   } else {
     tooltipProps = { title: ellipsisConfig.tooltip };
   }
@@ -353,6 +354,10 @@ const Base = React.forwardRef((props: InternalBlockProps, ref: any) => {
 
     if (!enableEllipsis || cssEllipsis) {
       return undefined;
+    }
+
+    if (isValid(editConfig.text)) {
+      return editConfig.text;
     }
 
     if (isValid(children)) {
@@ -375,7 +380,7 @@ const Base = React.forwardRef((props: InternalBlockProps, ref: any) => {
   if (editing) {
     return (
       <Editable
-        value={typeof children === 'string' ? children : ''}
+        value={editConfig.text ?? (typeof children === 'string' ? children : '')}
         onSave={onEditChange}
         onCancel={onEditCancel}
         onEnd={editConfig.onEnd}

--- a/components/typography/Editable.tsx
+++ b/components/typography/Editable.tsx
@@ -5,6 +5,7 @@ import KeyCode from 'rc-util/lib/KeyCode';
 import * as React from 'react';
 import type { DirectionType } from '../config-provider';
 import TextArea from '../input/TextArea';
+import type { TextAreaRef } from '../input/TextArea';
 import { cloneElement } from '../_util/reactNode';
 
 interface EditableProps {
@@ -38,7 +39,7 @@ const Editable: React.FC<EditableProps> = ({
   component,
   enterIcon = <EnterOutlined />,
 }) => {
-  const ref = React.useRef<any>();
+  const ref = React.useRef<TextAreaRef>(null);
 
   const inComposition = React.useRef(false);
   const lastKeyCode = React.useRef<number>();
@@ -125,7 +126,7 @@ const Editable: React.FC<EditableProps> = ({
   return (
     <div className={textAreaClassName} style={style}>
       <TextArea
-        ref={ref as any}
+        ref={ref}
         maxLength={maxLength}
         value={current}
         onChange={onChange}

--- a/components/typography/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/typography/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -675,6 +675,132 @@ Array [
     </div>
   </div>,
   <div
+    aria-label="This is a loooooooooooooooooooooooooooooooong editable text with suffix."
+    class="ant-typography ant-typography-ellipsis ant-typography-single-line"
+  >
+    This is a loooooooooooooooooooooooooooooooong editable text
+    with suffix.
+    <div
+      aria-label="Edit"
+      class="ant-typography-edit"
+      role="button"
+      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-block;"
+      tabindex="0"
+    >
+      <span
+        aria-label="edit"
+        class="anticon anticon-edit"
+        role="button"
+      >
+        <svg
+          aria-hidden="true"
+          data-icon="edit"
+          fill="currentColor"
+          focusable="false"
+          height="1em"
+          viewBox="64 64 896 896"
+          width="1em"
+        >
+          <path
+            d="M257.7 752c2 0 4-.2 6-.5L431.9 722c2-.4 3.9-1.3 5.3-2.8l423.9-423.9a9.96 9.96 0 000-14.1L694.9 114.9c-1.9-1.9-4.4-2.9-7.1-2.9s-5.2 1-7.1 2.9L256.8 538.8c-1.5 1.5-2.4 3.3-2.8 5.3l-29.5 168.2a33.5 33.5 0 009.4 29.8c6.6 6.4 14.9 9.9 23.8 9.9zm67.4-174.4L687.8 215l73.3 73.3-362.7 362.6-88.9 15.7 15.6-89zM880 836H144c-17.7 0-32 14.3-32 32v36c0 4.4 3.6 8 8 8h784c4.4 0 8-3.6 8-8v-36c0-17.7-14.3-32-32-32z"
+          />
+        </svg>
+      </span>
+    </div>
+    <div>
+      <div
+        class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast"
+        style="opacity: 0;"
+      >
+        <div
+          class="ant-tooltip-content"
+        >
+          <div
+            class="ant-tooltip-arrow"
+          >
+            <span
+              class="ant-tooltip-arrow-content"
+            />
+          </div>
+          <div
+            class="ant-tooltip-inner"
+            role="tooltip"
+          >
+            Edit
+          </div>
+        </div>
+      </div>
+    </div>
+    <span
+      aria-hidden="true"
+      style="position: fixed; display: block; left: 0px; top: 0px; z-index: -9999; visibility: hidden; pointer-events: none; font-size: 14px; word-break: keep-all; white-space: nowrap;"
+    >
+      lg
+    </span>
+    <span
+      aria-hidden="true"
+      style="position: fixed; display: block; left: 0px; top: 0px; z-index: -9999; visibility: hidden; pointer-events: none; font-size: 14px; width: 0px; white-space: normal; margin: 0px; padding: 0px;"
+    >
+      <span
+        aria-hidden="true"
+      >
+        ...
+      </span>
+      with suffix.
+      <div
+        aria-label="Edit"
+        class="ant-typography-edit"
+        role="button"
+        style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-block;"
+        tabindex="0"
+      >
+        <span
+          aria-label="edit"
+          class="anticon anticon-edit"
+          role="button"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="edit"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M257.7 752c2 0 4-.2 6-.5L431.9 722c2-.4 3.9-1.3 5.3-2.8l423.9-423.9a9.96 9.96 0 000-14.1L694.9 114.9c-1.9-1.9-4.4-2.9-7.1-2.9s-5.2 1-7.1 2.9L256.8 538.8c-1.5 1.5-2.4 3.3-2.8 5.3l-29.5 168.2a33.5 33.5 0 009.4 29.8c6.6 6.4 14.9 9.9 23.8 9.9zm67.4-174.4L687.8 215l73.3 73.3-362.7 362.6-88.9 15.7 15.6-89zM880 836H144c-17.7 0-32 14.3-32 32v36c0 4.4 3.6 8 8 8h784c4.4 0 8-3.6 8-8v-36c0-17.7-14.3-32-32-32z"
+            />
+          </svg>
+        </span>
+      </div>
+      <div>
+        <div
+          class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast"
+          style="opacity: 0;"
+        >
+          <div
+            class="ant-tooltip-content"
+          >
+            <div
+              class="ant-tooltip-arrow"
+            >
+              <span
+                class="ant-tooltip-arrow-content"
+              />
+            </div>
+            <div
+              class="ant-tooltip-inner"
+              role="tooltip"
+            >
+              Edit
+            </div>
+          </div>
+        </div>
+      </div>
+    </span>
+  </div>,
+  <div
     class="ant-typography"
   >
     Custom Edit icon and replace tooltip text.

--- a/components/typography/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/typography/__tests__/__snapshots__/demo.test.ts.snap
@@ -531,6 +531,84 @@ Array [
     </div>
   </div>,
   <div
+    aria-label="This is a loooooooooooooooooooooooooooooooong editable text with suffix."
+    class="ant-typography ant-typography-ellipsis ant-typography-single-line"
+  >
+    This is a loooooooooooooooooooooooooooooooong editable text
+    with suffix.
+    <div
+      aria-label="Edit"
+      class="ant-typography-edit"
+      role="button"
+      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-block;"
+      tabindex="0"
+    >
+      <span
+        aria-label="edit"
+        class="anticon anticon-edit"
+        role="button"
+      >
+        <svg
+          aria-hidden="true"
+          data-icon="edit"
+          fill="currentColor"
+          focusable="false"
+          height="1em"
+          viewBox="64 64 896 896"
+          width="1em"
+        >
+          <path
+            d="M257.7 752c2 0 4-.2 6-.5L431.9 722c2-.4 3.9-1.3 5.3-2.8l423.9-423.9a9.96 9.96 0 000-14.1L694.9 114.9c-1.9-1.9-4.4-2.9-7.1-2.9s-5.2 1-7.1 2.9L256.8 538.8c-1.5 1.5-2.4 3.3-2.8 5.3l-29.5 168.2a33.5 33.5 0 009.4 29.8c6.6 6.4 14.9 9.9 23.8 9.9zm67.4-174.4L687.8 215l73.3 73.3-362.7 362.6-88.9 15.7 15.6-89zM880 836H144c-17.7 0-32 14.3-32 32v36c0 4.4 3.6 8 8 8h784c4.4 0 8-3.6 8-8v-36c0-17.7-14.3-32-32-32z"
+          />
+        </svg>
+      </span>
+    </div>
+    <span
+      aria-hidden="true"
+      style="position: fixed; display: block; left: 0px; top: 0px; z-index: -9999; visibility: hidden; pointer-events: none; font-size: 14px; word-break: keep-all; white-space: nowrap;"
+    >
+      lg
+    </span>
+    <span
+      aria-hidden="true"
+      style="position: fixed; display: block; left: 0px; top: 0px; z-index: -9999; visibility: hidden; pointer-events: none; font-size: 14px; width: 0px; white-space: normal; margin: 0px; padding: 0px;"
+    >
+      <span
+        aria-hidden="true"
+      >
+        ...
+      </span>
+      with suffix.
+      <div
+        aria-label="Edit"
+        class="ant-typography-edit"
+        role="button"
+        style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-block;"
+        tabindex="0"
+      >
+        <span
+          aria-label="edit"
+          class="anticon anticon-edit"
+          role="button"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="edit"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M257.7 752c2 0 4-.2 6-.5L431.9 722c2-.4 3.9-1.3 5.3-2.8l423.9-423.9a9.96 9.96 0 000-14.1L694.9 114.9c-1.9-1.9-4.4-2.9-7.1-2.9s-5.2 1-7.1 2.9L256.8 538.8c-1.5 1.5-2.4 3.3-2.8 5.3l-29.5 168.2a33.5 33.5 0 009.4 29.8c6.6 6.4 14.9 9.9 23.8 9.9zm67.4-174.4L687.8 215l73.3 73.3-362.7 362.6-88.9 15.7 15.6-89zM880 836H144c-17.7 0-32 14.3-32 32v36c0 4.4 3.6 8 8 8h784c4.4 0 8-3.6 8-8v-36c0-17.7-14.3-32-32-32z"
+            />
+          </svg>
+        </span>
+      </div>
+    </span>
+  </div>,
+  <div
     class="ant-typography"
   >
     Custom Edit icon and replace tooltip text.

--- a/components/typography/__tests__/editable.test.tsx
+++ b/components/typography/__tests__/editable.test.tsx
@@ -194,43 +194,6 @@ describe('Typography.Ellipsis', () => {
     unmount();
   });
 
-  it('should use editConfig.text over children in editing mode ', async () => {
-    const suffix = '--The information is very important';
-    const ref = React.createRef<any>();
-    const { container: wrapper, unmount } = render(
-      <Base
-        ellipsis={{ rows: 1, suffix }}
-        component="p"
-        editable={{ text: fullStr + suffix }}
-        ref={ref}
-      >
-        {fullStr}
-      </Base>,
-    );
-
-    fireEvent.click(wrapper.querySelector('.ant-typography-edit')!);
-
-    expect(wrapper.querySelector('textarea')?.textContent).toEqual(fullStr + suffix);
-
-    unmount();
-  });
-
-  it('should use children as the fallback of editConfig.text in editing mode', async () => {
-    const suffix = '--The information is very important';
-    const ref = React.createRef<any>();
-    const { container: wrapper, unmount } = render(
-      <Base ellipsis={{ rows: 1, suffix }} component="p" ref={ref} editable>
-        {fullStr}
-      </Base>,
-    );
-
-    fireEvent.click(wrapper.querySelector('.ant-typography-edit')!);
-
-    expect(wrapper.querySelector('textarea')?.textContent).toEqual(fullStr);
-
-    unmount();
-  });
-
   it('connect children', async () => {
     const bamboo = 'Bamboo';
     const is = ' is ';

--- a/components/typography/__tests__/index.test.tsx
+++ b/components/typography/__tests__/index.test.tsx
@@ -396,6 +396,15 @@ describe('Typography', () => {
         expect(onEnd).toHaveBeenCalledTimes(1);
       });
 
+      it('should trigger onStart when type Start', () => {
+        const onStart = jest.fn();
+        const { container: wrapper } = render(<Paragraph editable={{ onStart }}>Bamboo</Paragraph>);
+        fireEvent.click(wrapper.querySelectorAll('.ant-typography-edit')[0]);
+        fireEvent.keyDown(wrapper.querySelector('textarea')!, { keyCode: KeyCode.A });
+        fireEvent.keyUp(wrapper.querySelector('textarea')!, { keyCode: KeyCode.A });
+        expect(onStart).toHaveBeenCalledTimes(1);
+      });
+
       it('should trigger onCancel when type ESC', () => {
         const onCancel = jest.fn();
         const { container: wrapper } = render(

--- a/components/typography/demo/interactive.md
+++ b/components/typography/demo/interactive.md
@@ -16,12 +16,19 @@ Provide additional interactive capacity of editable and copyable.
 ```tsx
 import { CheckOutlined, HighlightOutlined, SmileFilled, SmileOutlined } from '@ant-design/icons';
 import { Divider, Radio, Typography } from 'antd';
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 
 const { Paragraph } = Typography;
 
 const App: React.FC = () => {
   const [editableStr, setEditableStr] = useState('This is an editable text.');
+  const [editableStrWithSuffix, setEditableStrWithSuffix] = useState(
+    'This is a loooooooooooooooooooooooooooooooong editable text with suffix.',
+  );
+  const [editableStrWithSuffixStartPart, editableStrWithSuffixSuffixPart] = useMemo(
+    () => [editableStrWithSuffix.slice(0, -12), editableStrWithSuffix.slice(-12)],
+    [editableStrWithSuffix],
+  );
   const [customIconStr, setCustomIconStr] = useState('Custom Edit icon and replace tooltip text.');
   const [clickTriggerStr, setClickTriggerStr] = useState(
     'Text or icon as trigger - click to start editing.',
@@ -62,6 +69,17 @@ const App: React.FC = () => {
       <Paragraph editable={{ onChange: setEditableStr }}>{editableStr}</Paragraph>
       <Paragraph
         editable={{
+          onChange: setEditableStrWithSuffix,
+          text: editableStrWithSuffix,
+        }}
+        ellipsis={{
+          suffix: editableStrWithSuffixSuffixPart,
+        }}
+      >
+        {editableStrWithSuffixStartPart}
+      </Paragraph>
+      <Paragraph
+        editable={{
           icon: <HighlightOutlined />,
           tooltip: 'click to edit text',
           onChange: setCustomIconStr,
@@ -69,8 +87,7 @@ const App: React.FC = () => {
       >
         {customIconStr}
       </Paragraph>
-      Trigger edit with:{' '}
-      <Radio.Group
+      Trigger edit with: <Radio.Group
         onChange={e => setChooseTrigger(radioToState(e.target.value))}
         value={stateToRadio()}
       >

--- a/components/typography/index.en-US.md
+++ b/components/typography/index.en-US.md
@@ -93,9 +93,10 @@ Basic text writing, including headings, body text, lists, and more.
       editing: boolean,
       maxLength: number,
       autoSize: boolean | { minRows: number, maxRows: number },
-      onStart: function,
+      text: string,
       onChange: function(string),
       onCancel: function,
+      onStart: function,
       onEnd: function,
       triggerType: ('icon' | 'text')[],
       enterIcon: ReactNode,
@@ -108,9 +109,10 @@ Basic text writing, including headings, body text, lists, and more.
 | icon | Custom editable icon | ReactNode | &lt;EditOutlined /> | 4.6.0 |
 | maxLength | `maxLength` attribute of textarea | number | - | 4.4.0 |
 | tooltip | Custom tooltip text, hide when it is false | boolean \| ReactNode | `Edit` | 4.6.0 |
-| onStart | Called when enter editable state | function | - |  |
+| text | Edit text, specify the editing content instead of using the children implicitly | string | - | 4.24.0 |
 | onChange | Called when input at textarea | function(value: string) | - |  |
 | onCancel | Called when type ESC to exit editable state | function | - |  |
+| onStart | Called when enter editable state | function | - |  |
 | onEnd | Called when type ENTER to exit editable state | function | - | 4.14.0 |
 | triggerType | Edit mode trigger - icon, text or both (not specifying icon as trigger hides it) | Array&lt;`icon`\|`text`> | \[`icon`] |  |
 | enterIcon | Custom "enter" icon in the edit field (passing `null` removes the icon) | ReactNode | `<EnterOutlined />` | 4.17.0 |

--- a/components/typography/index.zh-CN.md
+++ b/components/typography/index.zh-CN.md
@@ -94,9 +94,10 @@ cover: https://gw.alipayobjects.com/zos/alicdn/GOM1KQ24O/Typography.svg
       editing: boolean,
       maxLength: number,
       autoSize: boolean | { minRows: number, maxRows: number },
-      onStart: function,
+      text: string,
       onChange: function(string),
       onCancel: function,
+      onStart: function,
       onEnd: function,
       triggerType: ('icon' | 'text')[],
       enterIcon: ReactNode,
@@ -109,10 +110,11 @@ cover: https://gw.alipayobjects.com/zos/alicdn/GOM1KQ24O/Typography.svg
 | icon | 自定义编辑图标 | ReactNode | &lt;EditOutlined /> | 4.6.0 |
 | maxLength | 编辑中文本域最大长度 | number | - | 4.4.0 |
 | tooltip | 自定义提示文本，为 false 时关闭 | boolean \| ReactNode | `编辑` | 4.6.0 |
-| onCancel | 按 ESC 退出编辑状态时触发 | function | - |  |
+| text | 显式地指定编辑文案，为空时将隐式地使用 children | string | - | 4.24.0 |
 | onChange | 文本域编辑时触发 | function(value: string) | - |  |
-| onEnd | 按 ENTER 结束编辑状态时触发 | function | - | 4.14.0 |
+| onCancel | 按 ESC 退出编辑状态时触发 | function | - |  |
 | onStart | 进入编辑中状态时触发 | function | - |  |
+| onEnd | 按 ENTER 结束编辑状态时触发 | function | - | 4.14.0 |
 | triggerType | 编辑模式触发器类型，图标、文本或者两者都设置（不设置图标作为触发器时它会隐藏） | Array&lt;`icon`\|`text`> | \[`icon`] |  |
 | enterIcon | 在编辑段中自定义“enter”图标（传递“null”将删除图标） | ReactNode | `<EnterOutlined />` | 4.17.0 |
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.

Before submitting your pull request, please make sure the checklist below is confirmed.

Your pull requests will be merged after one of the collaborators approve.

Thank you!

-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [x] Demo update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

When we enable the ellipsis and editable features at the same time, the editing text implicitly uses the passed children as the editing content. As the ellipsis usage required, this children element(string type) should omit the suffix part and specify it to ellipsis, this causes when we enter the editing mode the value of the textarea has no this suffix part.

I think we could use the children as the showing content as the old way, and provide a config `text` to set the editing content explicitly. Then we can edit the full content of the `Typograph` and see them with an ellipsis.

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Add `text` config for editable Typograph, support enabling ellipsis and editable at the same time |
| 🇨🇳 Chinese | `Typograph` 增加 `text` 配置，支持同时开启省略与编辑模式时的使用 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
