### PR TITLE
fix(tooltip): add className `${prefixCls}-open` when children className is function

### DIFF
--- a/components/tooltip/__tests__/tooltip.test.tsx
+++ b/components/tooltip/__tests__/tooltip.test.tsx
@@ -545,4 +545,15 @@ describe('Tooltip', () => {
     expect(container.querySelector('.bamboo')).toBeTruthy();
     expect(container.querySelector('.ant-tooltip')).toBeTruthy();
   });
+
+  it('add className `${prefixCls}-open` when children className is function', () => {
+    const HOC = ({ className }: { className: Function }) => <span className={className()} />;
+    const { container } = render(
+      <Tooltip open>
+        <HOC className={() => 'bamboo'} />
+      </Tooltip>,
+    );
+
+    expect(container.querySelector('.bamboo.ant-tooltip-open')).not.toBeNull();
+  });
 });

--- a/components/tooltip/__tests__/tooltip.test.tsx
+++ b/components/tooltip/__tests__/tooltip.test.tsx
@@ -546,7 +546,7 @@ describe('Tooltip', () => {
     expect(container.querySelector('.ant-tooltip')).toBeTruthy();
   });
 
-  it('add className `${prefixCls}-open` when children className is function', () => {
+  it('add className ant-tooltip-open when children className is function', () => {
     const HOC = ({ className }: { className: Function }) => <span className={className()} />;
     const { container } = render(
       <Tooltip open>

--- a/components/tooltip/index.tsx
+++ b/components/tooltip/index.tsx
@@ -4,6 +4,7 @@ import type { placements as Placements } from 'rc-tooltip/lib/placements';
 import type { TooltipProps as RcTooltipProps } from 'rc-tooltip/lib/Tooltip';
 import useMergedState from 'rc-util/lib/hooks/useMergedState';
 import * as React from 'react';
+import flow from 'lodash/flow';
 import { ConfigContext } from '../config-provider';
 import type { PresetColorType } from '../_util/colors';
 import { PresetColorTypes } from '../_util/colors';
@@ -12,7 +13,6 @@ import getPlacements, { AdjustOverflow, PlacementsConfig } from '../_util/placem
 import { cloneElement, isValidElement, isFragment } from '../_util/reactNode';
 import type { LiteralUnion } from '../_util/type';
 import warning from '../_util/warning';
-import flow from 'lodash/flow';
 
 export { AdjustOverflow, PlacementsConfig };
 

--- a/components/tooltip/index.tsx
+++ b/components/tooltip/index.tsx
@@ -12,6 +12,7 @@ import getPlacements, { AdjustOverflow, PlacementsConfig } from '../_util/placem
 import { cloneElement, isValidElement, isFragment } from '../_util/reactNode';
 import type { LiteralUnion } from '../_util/type';
 import warning from '../_util/warning';
+import flow from 'lodash/flow';
 
 export { AdjustOverflow, PlacementsConfig };
 
@@ -280,11 +281,15 @@ const Tooltip = React.forwardRef<unknown, TooltipProps>((props, ref) => {
   );
   const childProps = child.props;
   const childCls =
-    !childProps.className || typeof childProps.className === 'string'
-      ? classNames(childProps.className, {
+    typeof childProps.className === 'function'
+      ? flow(childProps.className, (childClassName: string) =>
+          classNames(childClassName, {
+            [openClassName || `${prefixCls}-open`]: true,
+          }),
+        )
+      : classNames(childProps.className, {
           [openClassName || `${prefixCls}-open`]: true,
-        })
-      : childProps.className;
+        });
 
   const customOverlayClassName = classNames(overlayClassName, {
     [`${prefixCls}-rtl`]: direction === 'rtl',


### PR DESCRIPTION
add className `${prefixCls}-open` when children className is function

<!--
First of all, thank you for your contribution! 😄

For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.

Before submitting your pull request, please make sure the checklist below is confirmed.

Your pull requests will be merged after one of the collaborators approve.

Thank you!

-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |       add className ${prefixCls}-open when children className is function    |
| 🇨🇳 Chinese |      当tooltip子组件classname为函数时，打开时缺少${prefixCls}-open     |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
