### PR TITLE
fix: Textarea blink on first mount

### DIFF
--- a/components/input/TextArea.tsx
+++ b/components/input/TextArea.tsx
@@ -1,7 +1,7 @@
 import classNames from 'classnames';
 import type { TextAreaProps as RcTextAreaProps } from 'rc-textarea';
 import RcTextArea from 'rc-textarea';
-import type ResizableTextArea from 'rc-textarea/lib/ResizableTextArea';
+import type { ResizableTextAreaRef } from 'rc-textarea/lib/ResizableTextArea';
 import useMergedState from 'rc-util/lib/hooks/useMergedState';
 import omit from 'rc-util/lib/omit';
 import * as React from 'react';
@@ -56,7 +56,7 @@ export interface TextAreaProps extends RcTextAreaProps {
 export interface TextAreaRef {
   focus: (options?: InputFocusOptions) => void;
   blur: () => void;
-  resizableTextArea?: ResizableTextArea;
+  resizableTextArea?: ResizableTextAreaRef;
 }
 
 const TextArea = React.forwardRef<TextAreaRef, TextAreaProps>(

--- a/components/input/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/input/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -4928,6 +4928,7 @@ Array [
   <textarea
     class="ant-input"
     placeholder="Autosize height based on content lines"
+    style="height: 0px; resize: none;"
   />,
   <div
     style="margin: 24px 0px;"
@@ -4935,6 +4936,7 @@ Array [
   <textarea
     class="ant-input"
     placeholder="Autosize height with minimum and maximum number of lines"
+    style="height: -24px; resize: none; min-height: -8px; max-height: -24px;"
   />,
   <div
     style="margin: 24px 0px;"
@@ -4942,6 +4944,7 @@ Array [
   <textarea
     class="ant-input"
     placeholder="Controlled autosize"
+    style="height: -20px; resize: none; min-height: -12px; max-height: -20px;"
   />,
 ]
 `;

--- a/components/input/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/input/__tests__/__snapshots__/demo.test.ts.snap
@@ -1145,6 +1145,7 @@ Array [
   <textarea
     class="ant-input"
     placeholder="Autosize height based on content lines"
+    style="height: 0px; resize: none;"
   />,
   <div
     style="margin: 24px 0px;"
@@ -1152,6 +1153,7 @@ Array [
   <textarea
     class="ant-input"
     placeholder="Autosize height with minimum and maximum number of lines"
+    style="height: -24px; resize: none; min-height: -8px; max-height: -24px;"
   />,
   <div
     style="margin: 24px 0px;"
@@ -1159,6 +1161,7 @@ Array [
   <textarea
     class="ant-input"
     placeholder="Controlled autosize"
+    style="height: -20px; resize: none; min-height: -12px; max-height: -20px;"
   />,
 ]
 `;

--- a/components/input/__tests__/textarea.test.tsx
+++ b/components/input/__tests__/textarea.test.tsx
@@ -3,8 +3,8 @@ import type { ChangeEventHandler, TextareaHTMLAttributes } from 'react';
 import React, { useState } from 'react';
 import Input from '..';
 import focusTest from '../../../tests/shared/focusTest';
+import { fireEvent, waitFakeTimer, render, sleep, triggerResize } from '../../../tests/utils';
 import type { RenderOptions } from '../../../tests/utils';
-import { fireEvent, render, sleep, triggerResize } from '../../../tests/utils';
 import type { TextAreaRef } from '../TextArea';
 
 const { TextArea } = Input;
@@ -29,10 +29,13 @@ describe('TextArea', () => {
   });
 
   it('should auto calculate height according to content length', async () => {
+    jest.useFakeTimers();
+
     const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
 
     const ref = React.createRef<TextAreaRef>();
 
+    const onInternalAutoSize = jest.fn();
     const genTextArea = (props = {}) => (
       <TextArea
         value=""
@@ -41,27 +44,29 @@ describe('TextArea', () => {
         wrap="off"
         ref={ref}
         {...props}
+        {...{ onInternalAutoSize }}
       />
     );
 
     const { container, rerender } = render(genTextArea());
-
-    const mockFunc = jest.spyOn(ref.current?.resizableTextArea!, 'resizeTextarea');
+    await waitFakeTimer();
+    expect(onInternalAutoSize).toHaveBeenCalledTimes(1);
 
     rerender(genTextArea({ value: '1111\n2222\n3333' }));
-    // wrapper.setProps({ value: '1111\n2222\n3333' });
-    await sleep(0);
-    expect(mockFunc).toHaveBeenCalledTimes(1);
+    await waitFakeTimer();
+    expect(onInternalAutoSize).toHaveBeenCalledTimes(2);
 
     rerender(genTextArea({ value: '1111' }));
-    // wrapper.setProps({ value: '1111' });
-    await sleep(0);
-    expect(mockFunc).toHaveBeenCalledTimes(2);
+    await waitFakeTimer();
+    expect(onInternalAutoSize).toHaveBeenCalledTimes(3);
 
     expect(container.querySelector('textarea')?.style.overflow).toBeFalsy();
 
     expect(errorSpy).not.toHaveBeenCalled();
     errorSpy.mockRestore();
+
+    jest.clearAllTimers();
+    jest.useRealTimers();
   });
 
   it('should support onPressEnter and onKeyDown', () => {
@@ -188,14 +193,6 @@ describe('TextArea', () => {
     });
   });
 
-  it('when prop value not in this.props, resizeTextarea should be called', async () => {
-    const ref = React.createRef<TextAreaRef>();
-    const { container } = render(<TextArea aria-label="textarea" ref={ref} />);
-    const resizeTextarea = jest.spyOn(ref.current?.resizableTextArea!, 'resizeTextarea');
-    fireEvent.change(container.querySelector('textarea')!, { target: { value: 'test' } });
-    expect(resizeTextarea).toHaveBeenCalled();
-  });
-
   it('handleKeyDown', () => {
     const onPressEnter = jest.fn();
     const onKeyDown = jest.fn();
@@ -209,17 +206,21 @@ describe('TextArea', () => {
   });
 
   it('should trigger onResize', async () => {
+    jest.useFakeTimers();
     const onResize = jest.fn();
     const ref = React.createRef<TextAreaRef>();
-    render(<TextArea ref={ref} onResize={onResize} autoSize />);
-    await sleep(100);
-    const target = ref.current?.resizableTextArea?.textArea!;
-    triggerResize(target);
-    await Promise.resolve();
+    const { container } = render(<TextArea ref={ref} onResize={onResize} autoSize />);
+    await waitFakeTimer();
+
+    triggerResize(container.querySelector('textarea')!);
+    await waitFakeTimer();
 
     expect(onResize).toHaveBeenCalledWith(
       expect.objectContaining({ width: expect.any(Number), height: expect.any(Number) }),
     );
+
+    jest.clearAllTimers();
+    jest.useRealTimers();
   });
 
   it('should works same as Input', () => {

--- a/components/input/__tests__/textarea.test.tsx
+++ b/components/input/__tests__/textarea.test.tsx
@@ -3,7 +3,7 @@ import type { ChangeEventHandler, TextareaHTMLAttributes } from 'react';
 import React, { useState } from 'react';
 import Input from '..';
 import focusTest from '../../../tests/shared/focusTest';
-import { fireEvent, waitFakeTimer, render, sleep, triggerResize } from '../../../tests/utils';
+import { fireEvent, waitFakeTimer, render, sleep, triggerResize, pureRender } from '../../../tests/utils';
 import type { RenderOptions } from '../../../tests/utils';
 import type { TextAreaRef } from '../TextArea';
 
@@ -48,7 +48,7 @@ describe('TextArea', () => {
       />
     );
 
-    const { container, rerender } = render(genTextArea());
+    const { container, rerender } = pureRender(genTextArea());
     await waitFakeTimer();
     expect(onInternalAutoSize).toHaveBeenCalledTimes(1);
 

--- a/components/mentions/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/mentions/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -20,6 +20,7 @@ exports[`renders ./components/mentions/demo/autoSize.md extend context correctly
   <textarea
     class="rc-textarea"
     rows="1"
+    style="height: 0px; resize: none;"
   />
 </div>
 `;

--- a/components/mentions/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/mentions/__tests__/__snapshots__/demo.test.ts.snap
@@ -20,6 +20,7 @@ exports[`renders ./components/mentions/demo/autoSize.md correctly 1`] = `
   <textarea
     class="rc-textarea"
     rows="1"
+    style="height: 0px; resize: none;"
   />
 </div>
 `;

--- a/package.json
+++ b/package.json
@@ -150,7 +150,7 @@
     "rc-switch": "~3.2.0",
     "rc-table": "~7.26.0",
     "rc-tabs": "~12.1.0-alpha.1",
-    "rc-textarea": "~0.3.0",
+    "rc-textarea": "~0.4.3",
     "rc-tooltip": "~5.2.0",
     "rc-tree": "~5.7.0",
     "rc-tree-select": "~5.5.0",

--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "rc-image": "~5.7.0",
     "rc-input": "~0.1.2",
     "rc-input-number": "~7.3.9",
-    "rc-mentions": "~1.9.1",
+    "rc-mentions": "~1.10.0",
     "rc-menu": "~9.6.3",
     "rc-motion": "^2.6.1",
     "rc-notification": "~4.6.0",


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.

Before submitting your pull request, please make sure the checklist below is confirmed.

Your pull requests will be merged after one of the collaborators approve.

Thank you!

-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

fix #36556

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Fix Textarea with `autoSize` blink on the fist mount.       |
| 🇨🇳 Chinese |    修复 Textarea 配置 `autoSize` 在第一次渲染时闪烁的问题。      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
