### PR TITLE
fix: when we apply style resize: none, TextArea should be not resizable when showCount is applied

### DIFF
--- a/components/input/TextArea.tsx
+++ b/components/input/TextArea.tsx
@@ -193,7 +193,7 @@ const TextArea = React.forwardRef<TextAreaRef, TextAreaProps>(
           },
           getStatusClassNames(prefixCls, mergedStatus),
         )}
-        style={showCount ? undefined : style}
+        style={showCount ? { resize: style?.resize } : style}
         prefixCls={prefixCls}
         onCompositionStart={onInternalCompositionStart}
         onChange={handleChange}

--- a/components/input/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/input/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -9748,15 +9748,29 @@ Array [
 `;
 
 exports[`renders ./components/input/demo/textarea-show-count.md extend context correctly 1`] = `
-<div
-  class="ant-input-textarea ant-input-textarea-show-count"
-  data-count="0 / 100"
-  style="height: 120px;"
->
-  <textarea
-    class="ant-input"
-  />
-</div>
+Array [
+  <div
+    class="ant-input-textarea ant-input-textarea-show-count"
+    data-count="0 / 100"
+    style="height: 120px;"
+  >
+    <textarea
+      class="ant-input"
+      placeholder="can resize"
+    />
+  </div>,
+  <div
+    class="ant-input-textarea ant-input-textarea-show-count"
+    data-count="0 / 100"
+    style="height: 120px; resize: none;"
+  >
+    <textarea
+      class="ant-input"
+      placeholder="disable resize"
+      style="resize: none;"
+    />
+  </div>,
+]
 `;
 
 exports[`renders ./components/input/demo/tooltip.md extend context correctly 1`] = `

--- a/components/input/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/input/__tests__/__snapshots__/demo.test.ts.snap
@@ -3529,15 +3529,29 @@ Array [
 `;
 
 exports[`renders ./components/input/demo/textarea-show-count.md correctly 1`] = `
-<div
-  class="ant-input-textarea ant-input-textarea-show-count"
-  data-count="0 / 100"
-  style="height: 120px;"
->
-  <textarea
-    class="ant-input"
-  />
-</div>
+Array [
+  <div
+    class="ant-input-textarea ant-input-textarea-show-count"
+    data-count="0 / 100"
+    style="height: 120px;"
+  >
+    <textarea
+      class="ant-input"
+      placeholder="can resize"
+    />
+  </div>,
+  <div
+    class="ant-input-textarea ant-input-textarea-show-count"
+    data-count="0 / 100"
+    style="height: 120px; resize: none;"
+  >
+    <textarea
+      class="ant-input"
+      placeholder="disable resize"
+      style="resize: none;"
+    />
+  </div>,
+]
 `;
 
 exports[`renders ./components/input/demo/tooltip.md correctly 1`] = `

--- a/components/input/__tests__/textarea.test.tsx
+++ b/components/input/__tests__/textarea.test.tsx
@@ -222,6 +222,13 @@ describe('TextArea', () => {
     );
   });
 
+  it('should disabled trigger onResize', async () => {
+    const { container } = render(<TextArea showCount style={{ resize: 'none' }} />);
+    expect(container.innerHTML).toContain('resize: none;');
+    const { container: container2 } = render(<TextArea showCount />);
+    expect(container2.innerHTML).not.toContain('resize: none;');
+  });
+
   it('should works same as Input', () => {
     const { container: inputContainer, rerender: inputRerender } = render(<Input value="111" />);
     const { container: textareaContainer, rerender: textareaRerender } = render(

--- a/components/input/demo/textarea-show-count.md
+++ b/components/input/demo/textarea-show-count.md
@@ -24,7 +24,22 @@ const onChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
 };
 
 const App: React.FC = () => (
-  <TextArea showCount maxLength={100} style={{ height: 120 }} onChange={onChange} />
+  <>
+    <TextArea
+      showCount
+      maxLength={100}
+      style={{ height: 120 }}
+      onChange={onChange}
+      placeholder="can resize"
+    />
+    <TextArea
+      showCount
+      maxLength={100}
+      style={{ height: 120, resize: 'none' }}
+      onChange={onChange}
+      placeholder="disable resize"
+    />
+  </>
 );
 
 export default App;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.

Before submitting your pull request, please make sure the checklist below is confirmed.

Your pull requests will be merged after one of the collaborators approve.

Thank you!

-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [X] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
- fix: #37849 
<!--
1. Put the related issue or discussion links here.
-->

### 💡 Background and solution

we should accept `resize` in style when textarea apply with `showCount`

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Input.Textarea `style={{ resize: 'none' }}` is not working when `showCount` is applied. |
| 🇨🇳 Chinese | 修复 Input.Textarea 当指定 `showCount` 时 `style={{ resize: 'none' }}` 样式设定失效的问题。 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [X] Doc is updated/provided or not needed
- [X] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [X] Changelog is provided or not needed
