### PR TITLE
fix(Input): should not have value prop on input after click toggle icon

### DIFF
--- a/components/input/Input.tsx
+++ b/components/input/Input.tsx
@@ -172,7 +172,7 @@ const Input = forwardRef<InputRef, InputProps>((props, ref) => {
   }, [inputHasPrefixSuffix]);
 
   // ===================== Remove Password value =====================
-  const removePasswordTimeout = useRemovePasswordTimeout(inputRef);
+  const removePasswordTimeout = useRemovePasswordTimeout(inputRef, true);
 
   const handleBlur = (e: React.FocusEvent<HTMLInputElement>) => {
     removePasswordTimeout();

--- a/components/input/Input.tsx
+++ b/components/input/Input.tsx
@@ -13,6 +13,7 @@ import { FormItemInputContext, NoFormStyle } from '../form/context';
 import type { InputStatus } from '../_util/statusUtils';
 import { getMergedStatus, getStatusClassNames } from '../_util/statusUtils';
 import warning from '../_util/warning';
+import useRemovePasswordTimeout from './hooks/useRemovePasswordTimeout';
 import { hasPrefixSuffix } from './utils';
 
 export interface InputFocusOptions extends FocusOptions {
@@ -171,25 +172,7 @@ const Input = forwardRef<InputRef, InputProps>((props, ref) => {
   }, [inputHasPrefixSuffix]);
 
   // ===================== Remove Password value =====================
-  const removePasswordTimeoutRef = useRef<number[]>([]);
-  const removePasswordTimeout = () => {
-    removePasswordTimeoutRef.current.push(
-      window.setTimeout(() => {
-        if (
-          inputRef.current?.input &&
-          inputRef.current?.input.getAttribute('type') === 'password' &&
-          inputRef.current?.input.hasAttribute('value')
-        ) {
-          inputRef.current?.input.removeAttribute('value');
-        }
-      }),
-    );
-  };
-
-  useEffect(() => {
-    removePasswordTimeout();
-    return () => removePasswordTimeoutRef.current.forEach(item => window.clearTimeout(item));
-  }, []);
+  const removePasswordTimeout = useRemovePasswordTimeout(inputRef);
 
   const handleBlur = (e: React.FocusEvent<HTMLInputElement>) => {
     removePasswordTimeout();

--- a/components/input/Password.tsx
+++ b/components/input/Password.tsx
@@ -31,7 +31,7 @@ const Password = React.forwardRef<InputRef, PasswordProps>((props, ref) => {
   const inputRef = useRef<InputRef>(null);
 
   // Remove Password value
-  const removePasswordTimeout = useRemovePasswordTimeout(inputRef, true);
+  const removePasswordTimeout = useRemovePasswordTimeout(inputRef);
 
   const onVisibleChange = () => {
     const { disabled } = props;

--- a/components/input/Password.tsx
+++ b/components/input/Password.tsx
@@ -2,10 +2,12 @@ import EyeInvisibleOutlined from '@ant-design/icons/EyeInvisibleOutlined';
 import EyeOutlined from '@ant-design/icons/EyeOutlined';
 import classNames from 'classnames';
 import omit from 'rc-util/lib/omit';
+import { composeRef } from 'rc-util/lib/ref';
 import * as React from 'react';
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import type { ConfigConsumerProps } from '../config-provider';
 import { ConfigConsumer } from '../config-provider';
+import useRemovePasswordTimeout from './hooks/useRemovePasswordTimeout';
 import type { InputProps, InputRef } from './Input';
 import Input from './Input';
 
@@ -26,11 +28,18 @@ const ActionMap: Record<string, string> = {
 
 const Password = React.forwardRef<InputRef, PasswordProps>((props, ref) => {
   const [visible, setVisible] = useState(false);
+  const inputRef = useRef<InputRef>(null);
+
+  // Remove Password value
+  const removePasswordTimeout = useRemovePasswordTimeout(inputRef, true);
 
   const onVisibleChange = () => {
     const { disabled } = props;
     if (disabled) {
       return;
+    }
+    if (visible) {
+      removePasswordTimeout();
     }
     setVisible(prevState => !prevState);
   };
@@ -87,7 +96,7 @@ const Password = React.forwardRef<InputRef, PasswordProps>((props, ref) => {
       omittedProps.size = size;
     }
 
-    return <Input ref={ref} {...omittedProps} />;
+    return <Input ref={composeRef(ref, inputRef)} {...omittedProps} />;
   };
 
   return <ConfigConsumer>{renderPassword}</ConfigConsumer>;

--- a/components/input/__tests__/Password.test.tsx
+++ b/components/input/__tests__/Password.test.tsx
@@ -108,4 +108,17 @@ describe('Input.Password', () => {
     await sleep();
     expect(container.querySelector('input')?.getAttribute('value')).toBeFalsy();
   });
+
+  it('should not show value attribute in input element after toggle visibility', async () => {
+    const { container } = render(<Input.Password />);
+    fireEvent.change(container.querySelector('input')!, { target: { value: 'value' } });
+    await sleep();
+    expect(container.querySelector('input')?.getAttribute('value')).toBeFalsy();
+    fireEvent.click(container.querySelector('.ant-input-password-icon')!);
+    await sleep();
+    expect(container.querySelector('input')?.getAttribute('value')).toBeTruthy();
+    fireEvent.click(container.querySelector('.ant-input-password-icon')!);
+    await sleep();
+    expect(container.querySelector('input')?.getAttribute('value')).toBeFalsy();
+  });
 });

--- a/components/input/hooks/useRemovePasswordTimeout.ts
+++ b/components/input/hooks/useRemovePasswordTimeout.ts
@@ -3,7 +3,7 @@ import type { InputRef } from '../Input';
 
 export default function useRemovePasswordTimeout(
   inputRef: React.RefObject<InputRef>,
-  triggerByIcon?: boolean,
+  triggerOnMount?: boolean,
 ) {
   const removePasswordTimeoutRef = useRef<number[]>([]);
   const removePasswordTimeout = () => {
@@ -21,7 +21,7 @@ export default function useRemovePasswordTimeout(
   };
 
   useEffect(() => {
-    if (!triggerByIcon) {
+    if (!triggerOnMount) {
       removePasswordTimeout();
     }
 

--- a/components/input/hooks/useRemovePasswordTimeout.ts
+++ b/components/input/hooks/useRemovePasswordTimeout.ts
@@ -21,7 +21,7 @@ export default function useRemovePasswordTimeout(
   };
 
   useEffect(() => {
-    if (!triggerOnMount) {
+    if (triggerOnMount) {
       removePasswordTimeout();
     }
 

--- a/components/input/hooks/useRemovePasswordTimeout.ts
+++ b/components/input/hooks/useRemovePasswordTimeout.ts
@@ -1,0 +1,32 @@
+import { useEffect, useRef } from 'react';
+import type { InputRef } from '../Input';
+
+export default function useRemovePasswordTimeout(
+  inputRef: React.RefObject<InputRef>,
+  triggerByIcon?: boolean,
+) {
+  const removePasswordTimeoutRef = useRef<number[]>([]);
+  const removePasswordTimeout = () => {
+    removePasswordTimeoutRef.current.push(
+      window.setTimeout(() => {
+        if (
+          inputRef.current?.input &&
+          inputRef.current?.input.getAttribute('type') === 'password' &&
+          inputRef.current?.input.hasAttribute('value')
+        ) {
+          inputRef.current?.input.removeAttribute('value');
+        }
+      }),
+    );
+  };
+
+  useEffect(() => {
+    if (!triggerByIcon) {
+      removePasswordTimeout();
+    }
+
+    return () => removePasswordTimeoutRef.current.forEach(item => window.clearTimeout(item));
+  }, []);
+
+  return removePasswordTimeout;
+}


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.

Before submitting your pull request, please make sure the checklist below is confirmed.

Your pull requests will be merged after one of the collaborators approve.

Thank you!

-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Input.Password that should not have value prop on input after click toggle icon          |
| 🇨🇳 Chinese |  修复 Input.Password 在点击隐藏按钮后 input 上会有 value 属性的问题         |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
