### PR TITLE
fix: Input.Search style in RTL

### DIFF
--- a/components/input/style/rtl.less
+++ b/components/input/style/rtl.less
@@ -182,8 +182,11 @@
     &:hover,
     &:focus {
       + .@{ant-prefix}-input-group-addon .@{search-prefix}-button:not(.@{ant-prefix}-btn-primary) {
-        border-right-color: @input-hover-border-color;
         border-left-color: @border-color-base;
+
+        &:hover {
+          border-left-color: @input-hover-border-color;
+        }
       }
     }
   }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.

Before submitting your pull request, please make sure the checklist below is confirmed.

Your pull requests will be merged after one of the collaborators approve.

Thank you!

-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
-->

### 💡 Background and solution
Background：
RTL 排版中，Input.Search 没有 affix 的时候，input:focus + button:hover 边框有问题。
<img width="1089" alt="image" src="https://user-images.githubusercontent.com/8649233/195353798-61bc6655-dbaf-4588-ba0e-30d8de674066.png">


Solution：
只需要让 button:hover 的时候，border-left-color 依然是蓝色即可。

另外：
RTL 排版中，border-right-color: blue 是没有必要的，因为会被遮住 border-right。
故去掉此行。

<img width="876" alt="image (1)" src="https://user-images.githubusercontent.com/8649233/195353860-0c66d956-0486-4566-ba47-dabe126f6236.png">


### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fix  border style issues for  Input.Search in RTL  |
| 🇨🇳 Chinese |    修复 RTL 下 Input.Search 边框样式问题。       |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
