### PR TITLE
fix(breadcrumb): the children in BreadcrumbItem should supports properties other than undefined

### DIFF
--- a/components/breadcrumb/BreadcrumbItem.tsx
+++ b/components/breadcrumb/BreadcrumbItem.tsx
@@ -43,17 +43,19 @@ const BreadcrumbItem: BreadcrumbItemInterface = ({
     return breadcrumbItem;
   };
 
+  const renderChildren = () =>
+    typeof children === 'boolean' || children === null ? `${children}` : children;
   let link;
   if ('href' in restProps) {
     link = (
       <a className={`${prefixCls}-link`} {...restProps}>
-        {children}
+        {renderChildren()}
       </a>
     );
   } else {
     link = (
       <span className={`${prefixCls}-link`} {...restProps}>
-        {children}
+        {renderChildren()}
       </span>
     );
   }

--- a/components/breadcrumb/BreadcrumbItem.tsx
+++ b/components/breadcrumb/BreadcrumbItem.tsx
@@ -60,7 +60,8 @@ const BreadcrumbItem: BreadcrumbItemInterface = ({
 
   // wrap to dropDown
   link = renderBreadcrumbNode(link);
-  if (children) {
+  // fix: #38004
+  if (children !== undefined) {
     return (
       <li>
         {link}

--- a/components/breadcrumb/__tests__/Breadcrumb.test.tsx
+++ b/components/breadcrumb/__tests__/Breadcrumb.test.tsx
@@ -158,15 +158,19 @@ describe('Breadcrumb', () => {
     expect(asFragment().firstChild).toMatchSnapshot();
   });
   // https://github.com/ant-design/ant-design/issues/38004
-  it('should support children of numeric types in BreakcrumbItem', () => {
+  it('The children in BreadcrumbItem should supports properties other than undefined', () => {
     const App: React.FC = () => (
       <span>
         <Breadcrumb.Item>{0}</Breadcrumb.Item>
+        <Breadcrumb.Item>{false}</Breadcrumb.Item>
+        <Breadcrumb.Item>{null}</Breadcrumb.Item>
       </span>
     );
     const { asFragment, container } = render(<App />);
 
-    expect(container.querySelector('.ant-breadcrumb-link')?.textContent).toBe('0');
+    expect(container.querySelectorAll('.ant-breadcrumb-link')[0]?.textContent).toBe('0');
+    expect(container.querySelectorAll('.ant-breadcrumb-link')[1]?.textContent).toBe('false');
+    expect(container.querySelectorAll('.ant-breadcrumb-link')[2]?.textContent).toBe('null');
     expect(asFragment().firstChild).toMatchSnapshot();
   });
 });

--- a/components/breadcrumb/__tests__/Breadcrumb.test.tsx
+++ b/components/breadcrumb/__tests__/Breadcrumb.test.tsx
@@ -157,4 +157,16 @@ describe('Breadcrumb', () => {
     );
     expect(asFragment().firstChild).toMatchSnapshot();
   });
+  // https://github.com/ant-design/ant-design/issues/38004
+  it('should support children of numeric types in BreakcrumbItem', () => {
+    const App: React.FC = () => (
+      <span>
+        <Breadcrumb.Item>{0}</Breadcrumb.Item>
+      </span>
+    );
+    const { asFragment, container } = render(<App />);
+
+    expect(container.querySelector('.ant-breadcrumb-link')?.textContent).toBe('0');
+    expect(asFragment().firstChild).toMatchSnapshot();
+  });
 });

--- a/components/breadcrumb/__tests__/Breadcrumb.test.tsx
+++ b/components/breadcrumb/__tests__/Breadcrumb.test.tsx
@@ -164,10 +164,13 @@ describe('Breadcrumb', () => {
         <Breadcrumb.Item>{0}</Breadcrumb.Item>
         <Breadcrumb.Item>{false}</Breadcrumb.Item>
         <Breadcrumb.Item>{null}</Breadcrumb.Item>
+        <Breadcrumb.Item>{undefined}</Breadcrumb.Item>
+        <Breadcrumb.Item>{}</Breadcrumb.Item>
       </span>
     );
     const { asFragment, container } = render(<App />);
 
+    expect(container.querySelectorAll('.ant-breadcrumb-link').length).toBe(3);
     expect(container.querySelectorAll('.ant-breadcrumb-link')[0]?.textContent).toBe('0');
     expect(container.querySelectorAll('.ant-breadcrumb-link')[1]?.textContent).toBe('false');
     expect(container.querySelectorAll('.ant-breadcrumb-link')[2]?.textContent).toBe('null');

--- a/components/breadcrumb/__tests__/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/components/breadcrumb/__tests__/__snapshots__/Breadcrumb.test.tsx.snap
@@ -1,5 +1,46 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Breadcrumb The children in BreadcrumbItem should supports properties other than undefined 1`] = `
+<span>
+  <li>
+    <span
+      class="ant-breadcrumb-link"
+    >
+      0
+    </span>
+    <span
+      class="ant-breadcrumb-separator"
+    >
+      /
+    </span>
+  </li>
+  <li>
+    <span
+      class="ant-breadcrumb-link"
+    >
+      false
+    </span>
+    <span
+      class="ant-breadcrumb-separator"
+    >
+      /
+    </span>
+  </li>
+  <li>
+    <span
+      class="ant-breadcrumb-link"
+    >
+      null
+    </span>
+    <span
+      class="ant-breadcrumb-separator"
+    >
+      /
+    </span>
+  </li>
+</span>
+`;
+
 exports[`Breadcrumb filter React.Fragment 1`] = `
 <nav
   class="ant-breadcrumb"
@@ -322,21 +363,4 @@ exports[`Breadcrumb should support custom attribute 1`] = `
     </li>
   </ol>
 </nav>
-`;
-
-exports[`Breadcrumb should support number children in BreadcrumbItem 1`] = `
-<span>
-  <li>
-    <span
-      class="ant-breadcrumb-link"
-    >
-      0
-    </span>
-    <span
-      class="ant-breadcrumb-separator"
-    >
-      /
-    </span>
-  </li>
-</span>
 `;

--- a/components/breadcrumb/__tests__/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/components/breadcrumb/__tests__/__snapshots__/Breadcrumb.test.tsx.snap
@@ -323,3 +323,20 @@ exports[`Breadcrumb should support custom attribute 1`] = `
   </ol>
 </nav>
 `;
+
+exports[`Breadcrumb should support number children in BreadcrumbItem 1`] = `
+<span>
+  <li>
+    <span
+      class="ant-breadcrumb-link"
+    >
+      0
+    </span>
+    <span
+      class="ant-breadcrumb-separator"
+    >
+      /
+    </span>
+  </li>
+</span>
+`;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.

Before submitting your pull request, please make sure the checklist below is confirmed.

Your pull requests will be merged after one of the collaborators approve.

Thank you!

-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [X] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

- fix: #38004 
<!--
1. Put the related issue or discussion links here.
-->

### 💡 Background and solution

support children of numeric types in BreakcrumbItem
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | The children in BreadcrumbItem should supports properties other than undefined |
| 🇨🇳 Chinese | `BreadcrumbItem` 的子节点应该支持除了`undefined`之外的其他类型 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [X] Changelog is provided or not needed
