### PR TITLE
fix: table header shadow issue (#28096)

### DIFF
--- a/components/table/style/index.less
+++ b/components/table/style/index.less
@@ -655,7 +655,7 @@
       position: absolute;
       top: 0;
       bottom: 0;
-      z-index: @zindex-table-fixed;
+      z-index: calc(@table-sticky-zindex + 1);
       width: 30px;
       transition: box-shadow 0.3s;
       content: '';


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.

Before submitting your pull request, please make sure the checklist below is confirmed.

Your pull requests will be merged after one of the collaborators approve.

Thank you!

-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

https://github.com/ant-design/ant-design/issues/28096

<!--
1. Put the related issue or discussion links here.
-->

### 💡 Background and solution

The shadow of container should be visible on table header when `<Table />` has a property "sticky", 
<img width="327" alt="image" src="https://user-images.githubusercontent.com/55272688/195795639-14d8297f-e000-47ca-90c0-45dc07c23e25.png">

which as like `<Table />` did not set "sticky".
<img width="368" alt="image" src="https://user-images.githubusercontent.com/55272688/195797690-5ae05aeb-3542-45bb-813f-77e0952ddaff.png">


<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |        Fix shadow issues when user set table has sticky property but set fixed colum.   |
| 🇨🇳 Chinese |      修复具备 sticky 属性和scroll 属性的 Table 在水平滚动过程中，右侧(或左侧)阴影被头覆盖的情况     |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
