### PR TITLE
fix: incorrect transform-origin of tooltips

### DIFF
--- a/components/tooltip/index.tsx
+++ b/components/tooltip/index.tsx
@@ -237,14 +237,14 @@ const Tooltip = React.forwardRef<unknown, TooltipProps>((props, ref) => {
 
     const transformOrigin = { top: '50%', left: '50%' };
 
-    if (['top', 'Bottom'].includes(placement)) {
+    if (/top|Bottom/.test(placement)) {
       transformOrigin.top = `${rect.height - align.offset![1]}px`;
-    } else if (['Top', 'bottom'].includes(placement)) {
+    } else if (/Top|bottom/.test(placement)) {
       transformOrigin.top = `${-align.offset![1]}px`;
     }
-    if (['left', 'Right'].includes(placement)) {
+    if (/left|Right/.test(placement)) {
       transformOrigin.left = `${rect.width - align.offset![0]}px`;
-    } else if (['right', 'Left'].includes(placement)) {
+    } else if (/right|Left/.test(placement)) {
       transformOrigin.left = `${-align.offset![0]}px`;
     }
     domNode.style.transformOrigin = `${transformOrigin.left} ${transformOrigin.top}`;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.

Before submitting your pull request, please make sure the checklist below is confirmed.

Your pull requests will be merged after one of the collaborators approve.

Thank you!

-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

For tooltips with a placement value like `topRight` or `bottomLeft`, the previous code would calculate an incorrect transform-origin, which is fixed here.

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed the issue of miscalculated transform-origin for Tooltip with placement values like `topRight` or `bottomLeft`. |
| 🇨🇳 Chinese | 修正了 `placement` 值为 `topRight` 或 `bottomLeft` 时 Tooltip 动画原点计算错误的问题。 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
