### PR TITLE
docs: use react-intl from dumi

### DIFF
--- a/.dumi/theme/builtins/ComponentOverview/index.tsx
+++ b/.dumi/theme/builtins/ComponentOverview/index.tsx
@@ -1,8 +1,7 @@
 import React, { useState, memo } from 'react';
 import { Helmet } from 'react-helmet-async';
-import { Link, useAppData, useLocation, useRouteMeta } from 'dumi';
+import { Link, useAppData, useLocation, useRouteMeta, useIntl } from 'dumi';
 import { css } from '@emotion/react';
-import { useIntl } from 'react-intl';
 import debounce from 'lodash/debounce';
 import { Input, Divider, Row, Col, Card, Typography, Tag, Space } from 'antd';
 import { SearchOutlined } from '@ant-design/icons';

--- a/.dumi/theme/builtins/Previewer/fromDumiProps.tsx
+++ b/.dumi/theme/builtins/Previewer/fromDumiProps.tsx
@@ -6,7 +6,7 @@ import toReactComponent from 'jsonml-to-react-element';
 // @ts-ignore
 import Prism from 'prismjs';
 import { useLocation } from 'dumi';
-import { useIntl, type IPreviewerProps } from 'dumi/theme';
+import { useIntl, type IPreviewerProps } from 'dumi';
 import { ping } from '../../utils';
 
 let pingDeferrer: PromiseLike<boolean>;

--- a/.dumi/theme/builtins/Previewer/index.jsx
+++ b/.dumi/theme/builtins/Previewer/index.jsx
@@ -7,7 +7,7 @@ import LZString from 'lz-string';
 import React from 'react';
 import CopyToClipboard from 'react-copy-to-clipboard';
 import ReactDOM from 'react-dom';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage } from 'dumi';
 import BrowserFrame from '../../common/BrowserFrame';
 import EditButton from '../../common/EditButton';
 import CodePenIcon from '../../common/CodePenIcon';

--- a/.dumi/theme/slots/Footer/index.tsx
+++ b/.dumi/theme/slots/Footer/index.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import RcFooter from 'rc-footer';
-import { Link } from 'dumi';
+import { Link, FormattedMessage } from 'dumi';
 import type { FooterColumn } from 'rc-footer/lib/column';
-import { FormattedMessage } from 'react-intl';
 import {
   AntDesignOutlined,
   BgColorsOutlined,

--- a/.dumi/theme/slots/Header/More.tsx
+++ b/.dumi/theme/slots/Header/More.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import type { MenuProps } from 'antd';
 import { Dropdown, Menu, Button } from 'antd';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage } from 'dumi';
 import { DownOutlined } from '@ant-design/icons';
 import type { SharedProps } from './interface';
 

--- a/.dumi/theme/slots/Header/Navigation.tsx
+++ b/.dumi/theme/slots/Header/Navigation.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import classNames from 'classnames';
-import { FormattedMessage } from 'react-intl';
-import { Link, useLocation } from 'dumi';
+import { Link, useLocation, FormattedMessage } from 'dumi';
 import type { MenuProps } from 'antd';
 import { MenuOutlined } from '@ant-design/icons';
 import { Menu } from 'antd';

--- a/.dumi/theme/slots/Header/index.tsx
+++ b/.dumi/theme/slots/Header/index.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, useIntl } from 'dumi';
 import classNames from 'classnames';
 import { Button, Col, Modal, Popover, Row, Select } from 'antd';
 import { MenuOutlined } from '@ant-design/icons';
@@ -139,6 +139,7 @@ interface HeaderState {
 }
 
 const Header: React.FC<HeaderProps> = props => {
+  const intl = useIntl();
   const { changeDirection } = props;
   const [, lang] = useLocale();
 

--- a/package.json
+++ b/package.json
@@ -273,7 +273,6 @@
     "react-helmet-async": "~1.3.0",
     "react-highlight-words": "^0.18.0",
     "react-infinite-scroll-component": "^6.1.0",
-    "react-intl": "^6.0.1",
     "react-resizable": "^3.0.1",
     "react-router-dom": "^6.0.2",
     "react-sortable-hoc": "^2.0.0",


### PR DESCRIPTION
[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 💡 Background and solution

文档相关组件统一使用 dumi 导出的 react-intl 相关方法，避免多实例风险

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | --        |
| 🇨🇳 Chinese | --        |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
