### PR TITLE
fix: Tabs active style in compact mode

### DIFF
--- a/components/style/themes/compact.less
+++ b/components/style/themes/compact.less
@@ -53,7 +53,7 @@
 @dropdown-line-height: 18px;
 
 // Menu
-@menu-item-padding: 0 12px;
+@menu-item-padding-horizontal: 12px;
 @menu-horizontal-line-height: 38px;
 @menu-inline-toplevel-item-height: 32px;
 @menu-item-height: 32px;


### PR DESCRIPTION
[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

Fix [#38221](https://github.com/ant-design/ant-design/issues/38212)

### 💡 Background and solution

Problem: The submenu::after pseudo-element have the wrong width in compact mode.
Solution: Set `@menu-item-padding-horizontal` less variable instead of `@menu-item-padding` in `compact.less`.

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the submenu::after pseudo-element width |
| 🇨🇳 Chinese | 修复 submenu::after 伪元素宽度 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
