### PR TITLE
fix: Tabs get getPopupContainer from ConfigProvider(#25844)

### DIFF
--- a/components/tabs/index.tsx
+++ b/components/tabs/index.tsx
@@ -44,7 +44,7 @@ function Tabs({
   ...props
 }: TabsProps) {
   const { prefixCls: customizePrefixCls, moreIcon = <EllipsisOutlined /> } = props;
-  const { getPrefixCls, direction } = React.useContext(ConfigContext);
+  const { getPrefixCls, direction, getPopupContainer } = React.useContext(ConfigContext);
   const prefixCls = getPrefixCls('tabs', customizePrefixCls);
 
   let editable: EditableConfig | undefined;
@@ -77,6 +77,7 @@ function Tabs({
         return (
           <RcTabs
             direction={direction}
+            getPopupContainer={getPopupContainer}
             moreTransitionName={`${rootPrefixCls}-slide-up`}
             {...props}
             items={mergedItems}


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

新特性请提交至 feature 分支，其余可提交至 master 分支。
在维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

[[English Template / 英文模板](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE.md)]

### 🤔 这个变动的性质是？
- [x] 日常 bug 修复

### 🔗 相关 Issue

close #25844

### 💡 需求背景和解决方案
rc侧: rc-tabs已支持接收getPopupContainer
antd侧: 从ConfigProvider取getPopupContainer传入
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |   Tabs get getPopupContainer from ConfigProvider  |
| 🇨🇳 中文 |   Tabs组件从 ConfigProvider 取出 getPopupContainer 传入rc-tabs    |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
