### PR TITLE
test: fix form test case

### DIFF
--- a/components/form/__tests__/index.test.tsx
+++ b/components/form/__tests__/index.test.tsx
@@ -179,15 +179,15 @@ describe('Form', () => {
       const { container } = render(<Demo />);
 
       await changeValue(0, '1');
-      await waitFakeTimer();
+      await waitFakeTimer(2000);
       expect(container.querySelector('.ant-form-item-explain-error')).toHaveTextContent('aaa');
 
       await changeValue(0, '2');
-      await waitFakeTimer();
+      await waitFakeTimer(2000);
       expect(container.querySelector('.ant-form-item-explain-error')).toHaveTextContent('ccc');
 
       await changeValue(0, '1');
-      await waitFakeTimer();
+      await waitFakeTimer(2000);
       expect(container.querySelector('.ant-form-item-explain-error')).toHaveTextContent('aaa');
     });
   });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.

Before submitting your pull request, please make sure the checklist below is confirmed.

Your pull requests will be merged after one of the collaborators approve.

Thank you!

-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->
还是一直在报错。
<img width="1092" alt="图片" src="https://user-images.githubusercontent.com/507615/198866577-000172df-a0cc-4c3b-b115-85e95bec1aa2.png">

https://github.com/ant-design/ant-design/actions/runs/3354442349/jobs/5558038482


### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     --      |
| 🇨🇳 Chinese |    --       |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
