### PR TITLE
虚拟滚动列表中的Parameters<typeof Table>[0]改为泛型传参

### DIFF
--- a/components/table/demo/virtual-list.md
+++ b/components/table/demo/virtual-list.md
@@ -15,7 +15,7 @@ Integrate virtual scroll with `react-window` to achieve a high performance table
 
 ```tsx
 import { Table  } from 'antd';
-import type { TableProps } from 'antd'
+import type { TableProps } from 'antd';
 import classNames from 'classnames';
 import ResizeObserver from 'rc-resize-observer';
 import React, { useEffect, useRef, useState } from 'react';

--- a/components/table/demo/virtual-list.md
+++ b/components/table/demo/virtual-list.md
@@ -14,14 +14,14 @@ title:
 Integrate virtual scroll with `react-window` to achieve a high performance table of 100,000 data.
 
 ```tsx
-import { Table } from 'antd';
+import { Table  } from 'antd';
+import type { TableProps } from 'antd'
 import classNames from 'classnames';
 import ResizeObserver from 'rc-resize-observer';
 import React, { useEffect, useRef, useState } from 'react';
 import { VariableSizeGrid as Grid } from 'react-window';
-import { TableProps } from 'antd/es'
 
-const VirtualTable = <RecordType extends object>(props: Partial<TableProps<RecordType>>) => {
+const VirtualTable = <RecordType extends object>(props: TableProps<RecordType>) => {
   const { columns, scroll } = props;
   const [tableWidth, setTableWidth] = useState(0);
 

--- a/components/table/demo/virtual-list.md
+++ b/components/table/demo/virtual-list.md
@@ -20,7 +20,7 @@ import ResizeObserver from 'rc-resize-observer';
 import React, { useEffect, useRef, useState } from 'react';
 import { VariableSizeGrid as Grid } from 'react-window';
 
-const VirtualTable = (props: Parameters<typeof Table>[0]) => {
+const VirtualTable = <RecordType extends object>(props: Partial<TableProps<RecordType>>) => {
   const { columns, scroll } = props;
   const [tableWidth, setTableWidth] = useState(0);
 

--- a/components/table/demo/virtual-list.md
+++ b/components/table/demo/virtual-list.md
@@ -19,6 +19,7 @@ import classNames from 'classnames';
 import ResizeObserver from 'rc-resize-observer';
 import React, { useEffect, useRef, useState } from 'react';
 import { VariableSizeGrid as Grid } from 'react-window';
+import { TableProps } from 'antd/es'
 
 const VirtualTable = <RecordType extends object>(props: Partial<TableProps<RecordType>>) => {
   const { columns, scroll } = props;


### PR DESCRIPTION
[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

### 💡 Background and solution

目前虚拟滚动列表的props为Parameters<typeof Table>[0]，在封装的VirtualTable上层传入datasource类型，但是column中render的类型永远为object。改为泛型传参，可以定义通过datasource定义RecordType的值。

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  虚拟滚动列表中的Parameters<typeof Table>[0]改为泛型传参         |
| 🇨🇳 Chinese |   virtualtable example use generic instead of  'Parameters<typeof Table>[0]'   |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
