### PR TITLE
WIP: fix: remove default size for Space.Compact

### DIFF
--- a/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
+++ b/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
@@ -15060,7 +15060,7 @@ exports[`ConfigProvider components Dropdown configProvider componentSize large 1
   class="config-space-compact config-space-compact-block config-dropdown-button"
 >
   <button
-    class="config-btn config-btn-default config-btn-compact-item config-btn-compact-first-item"
+    class="config-btn config-btn-default config-btn-lg config-btn-compact-item config-btn-compact-first-item"
     type="button"
   >
     <span>
@@ -15068,7 +15068,7 @@ exports[`ConfigProvider components Dropdown configProvider componentSize large 1
     </span>
   </button>
   <button
-    class="config-btn config-btn-default config-btn-icon-only config-btn-compact-item config-btn-compact-last-item config-dropdown-trigger"
+    class="config-btn config-btn-default config-btn-lg config-btn-icon-only config-btn-compact-item config-btn-compact-last-item config-dropdown-trigger"
     type="button"
   >
     <span

--- a/components/space/Compact.tsx
+++ b/components/space/Compact.tsx
@@ -63,7 +63,7 @@ const Compact: React.FC<SpaceCompactProps> = props => {
   const { getPrefixCls, direction: directionConfig } = React.useContext(ConfigContext);
 
   const {
-    size = 'middle',
+    size,
     direction,
     block,
     prefixCls: customizePrefixCls,

--- a/components/space/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/space/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -785,7 +785,7 @@ exports[`renders ./components/space/demo/compact.md extend context correctly 1`]
     class="ant-space-compact ant-space-compact-block"
   >
     <span
-      class="ant-input-group-wrapper ant-input-search ant-input-search-middle ant-input-compact-item ant-input-compact-first-item"
+      class="ant-input-group-wrapper ant-input-search ant-input-compact-item ant-input-compact-first-item"
       style="width:30%"
     >
       <span
@@ -827,7 +827,7 @@ exports[`renders ./components/space/demo/compact.md extend context correctly 1`]
       </span>
     </span>
     <span
-      class="ant-input-group-wrapper ant-input-search ant-input-search-middle ant-input-compact-item"
+      class="ant-input-group-wrapper ant-input-search ant-input-compact-item"
       style="width:50%"
     >
       <span
@@ -902,7 +902,7 @@ exports[`renders ./components/space/demo/compact.md extend context correctly 1`]
       </span>
     </span>
     <span
-      class="ant-input-group-wrapper ant-input-search ant-input-search-middle ant-input-compact-item ant-input-compact-last-item"
+      class="ant-input-group-wrapper ant-input-search ant-input-compact-item ant-input-compact-last-item"
       style="width:20%"
     >
       <span
@@ -1181,7 +1181,7 @@ exports[`renders ./components/space/demo/compact.md extend context correctly 1`]
       value="input content"
     />
     <div
-      class="ant-picker ant-picker-middle ant-picker-compact-item ant-picker-compact-last-item"
+      class="ant-picker ant-picker-compact-item ant-picker-compact-last-item"
       style="width:50%"
     >
       <div
@@ -1780,7 +1780,7 @@ exports[`renders ./components/space/demo/compact.md extend context correctly 1`]
     class="ant-space-compact ant-space-compact-block"
   >
     <div
-      class="ant-picker ant-picker-range ant-picker-middle ant-picker-compact-item ant-picker-compact-first-item"
+      class="ant-picker ant-picker-range ant-picker-compact-item ant-picker-compact-first-item"
       style="width:70%"
     >
       <div
@@ -2984,7 +2984,7 @@ exports[`renders ./components/space/demo/compact.md extend context correctly 1`]
       value="input content"
     />
     <div
-      class="ant-picker ant-picker-range ant-picker-middle ant-picker-compact-item ant-picker-compact-last-item"
+      class="ant-picker ant-picker-range ant-picker-compact-item ant-picker-compact-last-item"
       style="width:70%"
     >
       <div
@@ -4880,7 +4880,7 @@ exports[`renders ./components/space/demo/compact.md extend context correctly 1`]
     class="ant-space-compact ant-space-compact-block"
   >
     <div
-      class="ant-picker ant-picker-middle ant-picker-compact-item ant-picker-compact-first-item"
+      class="ant-picker ant-picker-compact-item ant-picker-compact-first-item"
       style="width:70%"
     >
       <div
@@ -6272,7 +6272,7 @@ exports[`renders ./components/space/demo/compact.md extend context correctly 1`]
                   class="ant-picker-ok"
                 >
                   <button
-                    class="ant-btn ant-btn-primary ant-btn-compact-item ant-btn-compact-first-item"
+                    class="ant-btn ant-btn-primary ant-btn-sm ant-btn-compact-item ant-btn-compact-first-item"
                     disabled=""
                     type="button"
                   >
@@ -6441,7 +6441,7 @@ exports[`renders ./components/space/demo/compact.md extend context correctly 1`]
     class="ant-space-compact ant-space-compact-block"
   >
     <div
-      class="ant-picker ant-picker-range ant-picker-middle ant-picker-compact-item ant-picker-compact-first-item"
+      class="ant-picker ant-picker-range ant-picker-compact-item ant-picker-compact-first-item"
     >
       <div
         class="ant-picker-input ant-picker-input-active"
@@ -7879,7 +7879,7 @@ exports[`renders ./components/space/demo/compact.md extend context correctly 1`]
                   class="ant-picker-ok"
                 >
                   <button
-                    class="ant-btn ant-btn-primary ant-btn-compact-item ant-btn-compact-first-item"
+                    class="ant-btn ant-btn-primary ant-btn-sm ant-btn-compact-item ant-btn-compact-first-item"
                     disabled=""
                     type="button"
                   >
@@ -9984,7 +9984,7 @@ exports[`renders ./components/space/demo/compact-debug.md extend context correct
       class="ant-space-compact"
     >
       <span
-        class="ant-input-group-wrapper ant-input-search ant-input-search-middle ant-input-compact-item ant-input-compact-first-item"
+        class="ant-input-group-wrapper ant-input-search ant-input-compact-item ant-input-compact-first-item"
       >
         <span
           class="ant-input-wrapper ant-input-group"
@@ -10025,7 +10025,7 @@ exports[`renders ./components/space/demo/compact-debug.md extend context correct
         </span>
       </span>
       <span
-        class="ant-input-group-wrapper ant-input-search ant-input-search-middle ant-input-compact-item"
+        class="ant-input-group-wrapper ant-input-search ant-input-compact-item"
       >
         <span
           class="ant-input-wrapper ant-input-group"
@@ -10680,7 +10680,7 @@ Array [
         class="ant-space-compact"
       >
         <span
-          class="ant-input-group-wrapper ant-input-search ant-input-search-middle ant-input-compact-item"
+          class="ant-input-group-wrapper ant-input-search ant-input-compact-item"
           style="width:110px"
         >
           <span
@@ -10774,7 +10774,7 @@ Array [
       class="ant-space-compact"
     >
       <div
-        class="ant-picker ant-picker-middle ant-picker-compact-item ant-picker-compact-first-item"
+        class="ant-picker ant-picker-compact-item ant-picker-compact-first-item"
       >
         <div
           class="ant-picker-input"
@@ -12165,7 +12165,7 @@ Array [
                     class="ant-picker-ok"
                   >
                     <button
-                      class="ant-btn ant-btn-primary ant-btn-compact-item ant-btn-compact-first-item"
+                      class="ant-btn ant-btn-primary ant-btn-sm ant-btn-compact-item ant-btn-compact-first-item"
                       disabled=""
                       type="button"
                     >

--- a/components/space/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/space/__tests__/__snapshots__/demo.test.ts.snap
@@ -3399,7 +3399,7 @@ Array [
     />
     <span
       class="ant-switch-inner"
-      />
+    />
   </button>,
   <div
     style="box-shadow:0 0 5px green"

--- a/components/space/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/space/__tests__/__snapshots__/demo.test.ts.snap
@@ -504,7 +504,7 @@ exports[`renders ./components/space/demo/compact.md correctly 1`] = `
     class="ant-space-compact ant-space-compact-block"
   >
     <span
-      class="ant-input-group-wrapper ant-input-search ant-input-search-middle ant-input-compact-item ant-input-compact-first-item"
+      class="ant-input-group-wrapper ant-input-search ant-input-compact-item ant-input-compact-first-item"
       style="width:30%"
     >
       <span
@@ -546,7 +546,7 @@ exports[`renders ./components/space/demo/compact.md correctly 1`] = `
       </span>
     </span>
     <span
-      class="ant-input-group-wrapper ant-input-search ant-input-search-middle ant-input-compact-item"
+      class="ant-input-group-wrapper ant-input-search ant-input-compact-item"
       style="width:50%"
     >
       <span
@@ -621,7 +621,7 @@ exports[`renders ./components/space/demo/compact.md correctly 1`] = `
       </span>
     </span>
     <span
-      class="ant-input-group-wrapper ant-input-search ant-input-search-middle ant-input-compact-item ant-input-compact-last-item"
+      class="ant-input-group-wrapper ant-input-search ant-input-compact-item ant-input-compact-last-item"
       style="width:20%"
     >
       <span
@@ -818,7 +818,7 @@ exports[`renders ./components/space/demo/compact.md correctly 1`] = `
       value="input content"
     />
     <div
-      class="ant-picker ant-picker-middle ant-picker-compact-item ant-picker-compact-last-item"
+      class="ant-picker ant-picker-compact-item ant-picker-compact-last-item"
       style="width:50%"
     >
       <div
@@ -863,7 +863,7 @@ exports[`renders ./components/space/demo/compact.md correctly 1`] = `
     class="ant-space-compact ant-space-compact-block"
   >
     <div
-      class="ant-picker ant-picker-range ant-picker-middle ant-picker-compact-item ant-picker-compact-first-item"
+      class="ant-picker ant-picker-range ant-picker-compact-item ant-picker-compact-first-item"
       style="width:70%"
     >
       <div
@@ -970,7 +970,7 @@ exports[`renders ./components/space/demo/compact.md correctly 1`] = `
       value="input content"
     />
     <div
-      class="ant-picker ant-picker-range ant-picker-middle ant-picker-compact-item ant-picker-compact-last-item"
+      class="ant-picker ant-picker-range ant-picker-compact-item ant-picker-compact-last-item"
       style="width:70%"
     >
       <div
@@ -1361,7 +1361,7 @@ exports[`renders ./components/space/demo/compact.md correctly 1`] = `
     class="ant-space-compact ant-space-compact-block"
   >
     <div
-      class="ant-picker ant-picker-middle ant-picker-compact-item ant-picker-compact-first-item"
+      class="ant-picker ant-picker-compact-item ant-picker-compact-first-item"
       style="width:70%"
     >
       <div
@@ -1467,7 +1467,7 @@ exports[`renders ./components/space/demo/compact.md correctly 1`] = `
     class="ant-space-compact ant-space-compact-block"
   >
     <div
-      class="ant-picker ant-picker-range ant-picker-middle ant-picker-compact-item ant-picker-compact-first-item"
+      class="ant-picker ant-picker-range ant-picker-compact-item ant-picker-compact-first-item"
     >
       <div
         class="ant-picker-input ant-picker-input-active"
@@ -2468,7 +2468,7 @@ exports[`renders ./components/space/demo/compact-debug.md correctly 1`] = `
       class="ant-space-compact"
     >
       <span
-        class="ant-input-group-wrapper ant-input-search ant-input-search-middle ant-input-compact-item ant-input-compact-first-item"
+        class="ant-input-group-wrapper ant-input-search ant-input-compact-item ant-input-compact-first-item"
       >
         <span
           class="ant-input-wrapper ant-input-group"
@@ -2509,7 +2509,7 @@ exports[`renders ./components/space/demo/compact-debug.md correctly 1`] = `
         </span>
       </span>
       <span
-        class="ant-input-group-wrapper ant-input-search ant-input-search-middle ant-input-compact-item"
+        class="ant-input-group-wrapper ant-input-search ant-input-compact-item"
       >
         <span
           class="ant-input-wrapper ant-input-group"
@@ -3007,7 +3007,7 @@ Array [
         class="ant-space-compact"
       >
         <span
-          class="ant-input-group-wrapper ant-input-search ant-input-search-middle ant-input-compact-item"
+          class="ant-input-group-wrapper ant-input-search ant-input-compact-item"
           style="width:110px"
         >
           <span
@@ -3101,7 +3101,7 @@ Array [
       class="ant-space-compact"
     >
       <div
-        class="ant-picker ant-picker-middle ant-picker-compact-item ant-picker-compact-first-item"
+        class="ant-picker ant-picker-compact-item ant-picker-compact-first-item"
       >
         <div
           class="ant-picker-input"
@@ -3399,7 +3399,7 @@ Array [
     />
     <span
       class="ant-switch-inner"
-    />
+      />
   </button>,
   <div
     style="box-shadow:0 0 5px green"


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.

Before submitting your pull request, please make sure the checklist below is confirmed.

Your pull requests will be merged after one of the collaborators approve.

Thank you!

-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

修复 Space.Compact 子元素不能单独设置 size 的问题。（虽说 Space.Compact 的子元素应该都是同一种 size ，直接设置在 Space.Compact 上）

```jsx
// 不建议的写法
<Space.Compact block>
    <Input size="large" style={{ width: '20%' }} defaultValue="0571" />
    <Input size="small" style={{ width: '30%' }} defaultValue="26888888" />
</Space.Compact>
```
上述左右 input 一大一小，实际小的会被撑大，如下所示：

![image](https://user-images.githubusercontent.com/8649233/199930587-e4b4b2ab-acfd-41a9-a858-3b7bc1709716.png)

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fixed the problem that the size of Space.Compact child elements cannot be set individually.     |
| 🇨🇳 Chinese |    修复 Space.Compact 子元素不能单独设置 size 的问题。       |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
