### PR TITLE
fix: Modal.confirm buttons should not be interative when modal is hiding

### DIFF
--- a/components/modal/style/confirm.less
+++ b/components/modal/style/confirm.less
@@ -71,4 +71,9 @@
   &-success &-body > .@{iconfont-css-prefix} {
     color: @success-color;
   }
+
+  // https://github.com/ant-design/ant-design/issues/37329
+  .@{ant-prefix}-zoom-leave .@{confirm-prefix-cls}-btns {
+    pointer-events: none;
+  }
 }


### PR DESCRIPTION




<!--
First of all, thank you for your contribution! 😄

For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.

Before submitting your pull request, please make sure the checklist below is confirmed.

Your pull requests will be merged after one of the collaborators approve.

Thank you!

-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
-->
close #37329
close #37903

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Modal.confirm buttons should not be interative when modal is hiding.         |
| 🇨🇳 Chinese |  修复 Modal.confirm 关闭中确认按钮依旧可能被触发的问题。      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
