### PR TITLE
fix: onBlur gets triggered when selecting date in RangePicker

### DIFF
--- a/components/date-picker/__tests__/RangePicker.test.tsx
+++ b/components/date-picker/__tests__/RangePicker.test.tsx
@@ -11,7 +11,7 @@ import { closePicker, openPicker, selectCell } from './utils';
 const { RangePicker } = DatePicker;
 
 describe('RangePicker', () => {
-  focusTest(RangePicker, { refFocus: true });
+  focusTest(RangePicker, { refFocus: true, blurDelay: 110 });
 
   beforeEach(() => {
     setMockDate();

--- a/components/date-picker/demo/select-in-range.md
+++ b/components/date-picker/demo/select-in-range.md
@@ -50,6 +50,7 @@ const App: React.FC = () => {
       onCalendarChange={val => setDates(val)}
       onChange={val => setValue(val)}
       onOpenChange={onOpenChange}
+      onBlur={() => console.log('blur has been triggered')}
     />
   );
 };

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "rc-motion": "^2.6.1",
     "rc-notification": "~4.6.0",
     "rc-pagination": "~3.2.0",
-    "rc-picker": "~2.6.11",
+    "rc-picker": "^2.7.0",
     "rc-progress": "~3.4.1",
     "rc-rate": "~2.9.0",
     "rc-resize-observer": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "rc-motion": "^2.6.1",
     "rc-notification": "~4.6.0",
     "rc-pagination": "~3.2.0",
-    "rc-picker": "^2.7.0",
+    "rc-picker": "~2.7.0",
     "rc-progress": "~3.4.1",
     "rc-rate": "~2.9.0",
     "rc-resize-observer": "^1.2.0",

--- a/tests/shared/focusTest.tsx
+++ b/tests/shared/focusTest.tsx
@@ -110,7 +110,7 @@ export default function focusTest(
         expect(blurred).toBeTruthy();
 
         fireEvent.blur(getElement(container));
-        await sleep(0);
+        await sleep(110);
         expect(onBlur).toHaveBeenCalled();
       });
 

--- a/tests/shared/focusTest.tsx
+++ b/tests/shared/focusTest.tsx
@@ -4,7 +4,7 @@ import { sleep, render, fireEvent } from '../utils';
 // eslint-disable-next-line jest/no-export
 export default function focusTest(
   Component: React.ComponentType<any>,
-  { refFocus = false, testLib = false } = {},
+  { refFocus = false, testLib = false, blurDelay = 0 } = {},
 ) {
   describe('focus and blur', () => {
     let focused = false;
@@ -110,7 +110,7 @@ export default function focusTest(
         expect(blurred).toBeTruthy();
 
         fireEvent.blur(getElement(container));
-        await sleep(110);
+        await sleep(blurDelay);
         expect(onBlur).toHaveBeenCalled();
       });
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.

Before submitting your pull request, please make sure the checklist below is confirmed.

Your pull requests will be merged after one of the collaborators approve.

Thank you!

-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [X] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

- fix: #38350

https://github.com/react-component/picker/pull/510

<!--
1. Put the related issue or discussion links here.
-->

### 💡 Background and solution

feat(picker): update picker version

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | update DatePicker version  |
| 🇨🇳 Chinese | 更新日期选择框版本 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [X] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [X] Changelog is provided or not needed
