### PR TITLE
fix: Image preview controls should not zoom out

### DIFF
--- a/components/image/style/index.less
+++ b/components/image/style/index.less
@@ -107,10 +107,10 @@
 
     &-operations {
       .reset-component();
-      position: absolute;
+      position: fixed;
       top: 0;
       right: 0;
-      z-index: 1;
+      z-index: @zindex-image + 1;
       display: flex;
       flex-direction: row-reverse;
       align-items: center;
@@ -124,6 +124,11 @@
         margin-left: @control-padding-horizontal;
         padding: @control-padding-horizontal;
         cursor: pointer;
+        transition: all 0.3s;
+
+        &:hover {
+          background: fade(@modal-mask-bg, 20%);
+        }
 
         &-disabled {
           color: @image-preview-operation-disabled-color;
@@ -148,40 +153,48 @@
 
     &-switch-left,
     &-switch-right {
-      position: absolute;
+      position: fixed;
       top: 50%;
-      right: 10px;
-      z-index: 1;
+      right: 8px;
+      z-index: @zindex-image + 1;
       display: flex;
       align-items: center;
       justify-content: center;
       width: 44px;
       height: 44px;
-      margin-top: -22px;
       color: @image-preview-operation-color;
       background: fade(@modal-mask-bg, 10%);
       border-radius: 50%;
+      transform: translateY(-50%);
       cursor: pointer;
+      transition: all 0.3s;
       pointer-events: auto;
 
-      &-disabled {
+      &:hover {
+        background: fade(@modal-mask-bg, 20%);
+      }
+
+      &-disabled,
+      &-disabled:hover {
         color: @image-preview-operation-disabled-color;
+        background: fade(@modal-mask-bg, 10%);
         cursor: not-allowed;
         > .@{iconfont-css-prefix} {
           cursor: not-allowed;
         }
       }
+
       > .@{iconfont-css-prefix} {
         font-size: 18px;
       }
     }
 
     &-switch-left {
-      left: 10px;
+      left: 8px;
     }
 
     &-switch-right {
-      right: 10px;
+      right: 8px;
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "rc-drawer": "~6.0.0",
     "rc-dropdown": "~4.0.0",
     "rc-field-form": "~1.27.0",
-    "rc-image": "~5.9.0",
+    "rc-image": "~5.10.0",
     "rc-input": "~0.1.4",
     "rc-input-number": "~7.3.9",
     "rc-mentions": "~1.10.0",


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.

Before submitting your pull request, please make sure the checklist below is confirmed.

Your pull requests will be merged after one of the collaborators approve.

Thank you!

-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
-->
close https://github.com/ant-design/ant-design/issues/36456 via https://github.com/react-component/image/pull/133

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | - Image preview controls enter animation should not be zooming out. #36456 <br /> - Fix Image preview not showing error images. #38112           |
| 🇨🇳 Chinese |  - 优化 Image 预览图片的工具栏显示动画的效果，现在工具条不再用缩放动画进场。#36456 <br /> - 修复 Image 预览图片没有展现错误图片的问题。#38112         |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
