### PR TITLE
refactor(Tree): solve circular import

### DIFF
--- a/components/tree/Tree.tsx
+++ b/components/tree/Tree.tsx
@@ -1,12 +1,11 @@
 import HolderOutlined from '@ant-design/icons/HolderOutlined';
 import classNames from 'classnames';
 import type { BasicDataNode, TreeProps as RcTreeProps } from 'rc-tree';
-import RcTree, { TreeNode } from 'rc-tree';
+import RcTree from 'rc-tree';
 import type { DataNode, Key } from 'rc-tree/lib/interface';
 import * as React from 'react';
 import { ConfigContext } from '../config-provider';
 import collapseMotion from '../_util/motion';
-import DirectoryTree from './DirectoryTree';
 import dropIndicatorRender from './utils/dropIndicator';
 import renderSwitcherIcon from './utils/iconUtil';
 
@@ -52,7 +51,7 @@ export interface AntTreeNodeProps {
   [customProp: string]: any;
 }
 
-export interface AntTreeNode extends React.Component<AntTreeNodeProps, {}> {}
+export interface AntTreeNode extends React.Component<AntTreeNodeProps, {}> { }
 
 export interface AntTreeNodeBaseEvent {
   node: AntTreeNode;
@@ -145,21 +144,14 @@ export interface TreeProps<T extends BasicDataNode = DataNode>
   style?: React.CSSProperties;
   showIcon?: boolean;
   icon?:
-    | ((nodeProps: AntdTreeNodeAttribute) => React.ReactNode)
-    | React.ReactNode
-    | RcTreeProps<T>['icon'];
+  | ((nodeProps: AntdTreeNodeAttribute) => React.ReactNode)
+  | React.ReactNode
+  | RcTreeProps<T>['icon'];
   switcherIcon?: SwitcherIcon | RcTreeProps<T>['switcherIcon'];
   prefixCls?: string;
   children?: React.ReactNode;
   blockNode?: boolean;
 }
-
-type CompoundedComponent = (<T extends BasicDataNode | DataNode = DataNode>(
-  props: React.PropsWithChildren<TreeProps<T>> & { ref?: React.Ref<RcTree> },
-) => React.ReactElement) & {
-  TreeNode: typeof TreeNode;
-  DirectoryTree: typeof DirectoryTree;
-};
 
 const Tree = React.forwardRef<RcTree, TreeProps>((props, ref) => {
   const { getPrefixCls, direction, virtual } = React.useContext(ConfigContext);
@@ -242,10 +234,6 @@ const Tree = React.forwardRef<RcTree, TreeProps>((props, ref) => {
       {children}
     </RcTree>
   );
-}) as unknown as CompoundedComponent;
-
-Tree.TreeNode = TreeNode;
-
-Tree.DirectoryTree = DirectoryTree;
+});
 
 export default Tree;

--- a/components/tree/index.tsx
+++ b/components/tree/index.tsx
@@ -1,6 +1,14 @@
-import Tree from './Tree';
+import type RcTree from 'rc-tree';
+import { TreeNode } from 'rc-tree';
+import type { BasicDataNode } from 'rc-tree';
+import type { DataNode } from 'rc-tree/lib/interface';
 
-export { DataNode, EventDataNode } from 'rc-tree/lib/interface';
+import type { TreeProps } from './Tree';
+import TreePure from './Tree';
+import DirectoryTree from './DirectoryTree'
+
+export { DataNode }
+export { EventDataNode } from 'rc-tree/lib/interface';
 export { DirectoryTreeProps, ExpandAction as DirectoryTreeExpandAction } from './DirectoryTree';
 export {
   AntdTreeNodeAttribute,
@@ -12,5 +20,17 @@ export {
   AntTreeNodeSelectedEvent,
   TreeProps,
 } from './Tree';
+
+
+type CompoundedComponent = (<T extends BasicDataNode | DataNode = DataNode>(
+  props: React.PropsWithChildren<TreeProps<T>> & { ref?: React.Ref<RcTree> },
+) => React.ReactElement) & {
+  TreeNode: typeof TreeNode;
+  DirectoryTree: typeof DirectoryTree;
+};
+
+const Tree = TreePure as unknown as CompoundedComponent
+Tree.DirectoryTree = DirectoryTree
+Tree.TreeNode = TreeNode
 
 export default Tree;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.

Before submitting your pull request, please make sure the checklist below is confirmed.

Your pull requests will be merged after one of the collaborators approve.

Thank you!

-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [x] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [x] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->
目前Tree与DirectoryTree存在互相导入的情况，会影响tree shake。
这个PR把原本在Tree.tsx执行的导出修改逻辑移动到了index.ts，在保留现有的组件引入行为的同时，解决这个问题。

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  solve circular import in 'Tree'       |
| 🇨🇳 Chinese |  去除'树'组件中的循环导入         |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [X] Doc is updated/provided or not needed
- [X] Demo is updated/provided or not needed
- [X] TypeScript definition is updated/provided or not needed
- [X] Changelog is provided or not needed
