### PR TITLE
fix: Adds role progressbar to Progress component

### DIFF
--- a/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
+++ b/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
@@ -22170,6 +22170,7 @@ exports[`ConfigProvider components Popover prefixCls 1`] = `
 exports[`ConfigProvider components Progress configProvider 1`] = `
 <div
   class="config-progress config-progress-line config-progress-status-normal config-progress-show-info config-progress-default"
+  role="progressbar"
 >
   <div
     class="config-progress-outer"
@@ -22195,6 +22196,7 @@ exports[`ConfigProvider components Progress configProvider 1`] = `
 exports[`ConfigProvider components Progress configProvider componentDisabled 1`] = `
 <div
   class="config-progress config-progress-line config-progress-status-normal config-progress-show-info config-progress-default"
+  role="progressbar"
 >
   <div
     class="config-progress-outer"
@@ -22220,6 +22222,7 @@ exports[`ConfigProvider components Progress configProvider componentDisabled 1`]
 exports[`ConfigProvider components Progress configProvider componentSize large 1`] = `
 <div
   class="config-progress config-progress-line config-progress-status-normal config-progress-show-info config-progress-default"
+  role="progressbar"
 >
   <div
     class="config-progress-outer"
@@ -22245,6 +22248,7 @@ exports[`ConfigProvider components Progress configProvider componentSize large 1
 exports[`ConfigProvider components Progress configProvider componentSize middle 1`] = `
 <div
   class="config-progress config-progress-line config-progress-status-normal config-progress-show-info config-progress-default"
+  role="progressbar"
 >
   <div
     class="config-progress-outer"
@@ -22270,6 +22274,7 @@ exports[`ConfigProvider components Progress configProvider componentSize middle 
 exports[`ConfigProvider components Progress configProvider virtual and dropdownMatchSelectWidth 1`] = `
 <div
   class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default"
+  role="progressbar"
 >
   <div
     class="ant-progress-outer"
@@ -22295,6 +22300,7 @@ exports[`ConfigProvider components Progress configProvider virtual and dropdownM
 exports[`ConfigProvider components Progress normal 1`] = `
 <div
   class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default"
+  role="progressbar"
 >
   <div
     class="ant-progress-outer"
@@ -22320,6 +22326,7 @@ exports[`ConfigProvider components Progress normal 1`] = `
 exports[`ConfigProvider components Progress prefixCls 1`] = `
 <div
   class="prefix-Progress prefix-Progress-line prefix-Progress-status-normal prefix-Progress-show-info prefix-Progress-default"
+  role="progressbar"
 >
   <div
     class="prefix-Progress-outer"

--- a/components/progress/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/progress/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -4,6 +4,7 @@ exports[`renders ./components/progress/demo/circle.md extend context correctly 1
 Array [
   <div
     class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default"
+    role="progressbar"
   >
     <div
       class="ant-progress-inner"
@@ -54,6 +55,7 @@ Array [
   </div>,
   <div
     class="ant-progress ant-progress-circle ant-progress-status-exception ant-progress-show-info ant-progress-default"
+    role="progressbar"
   >
     <div
       class="ant-progress-inner"
@@ -121,6 +123,7 @@ Array [
   </div>,
   <div
     class="ant-progress ant-progress-circle ant-progress-status-success ant-progress-show-info ant-progress-default"
+    role="progressbar"
   >
     <div
       class="ant-progress-inner"
@@ -193,6 +196,7 @@ exports[`renders ./components/progress/demo/circle-dynamic.md extend context cor
 Array [
   <div
     class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default"
+    role="progressbar"
   >
     <div
       class="ant-progress-inner"
@@ -306,6 +310,7 @@ exports[`renders ./components/progress/demo/circle-mini.md extend context correc
 Array [
   <div
     class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default"
+    role="progressbar"
   >
     <div
       class="ant-progress-inner"
@@ -356,6 +361,7 @@ Array [
   </div>,
   <div
     class="ant-progress ant-progress-circle ant-progress-status-exception ant-progress-show-info ant-progress-default"
+    role="progressbar"
   >
     <div
       class="ant-progress-inner"
@@ -423,6 +429,7 @@ Array [
   </div>,
   <div
     class="ant-progress ant-progress-circle ant-progress-status-success ant-progress-show-info ant-progress-default"
+    role="progressbar"
   >
     <div
       class="ant-progress-inner"
@@ -495,6 +502,7 @@ exports[`renders ./components/progress/demo/dashboard.md extend context correctl
 Array [
   <div
     class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default"
+    role="progressbar"
   >
     <div
       class="ant-progress-inner"
@@ -545,6 +553,7 @@ Array [
   </div>,
   <div
     class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default"
+    role="progressbar"
   >
     <div
       class="ant-progress-inner"
@@ -600,6 +609,7 @@ exports[`renders ./components/progress/demo/dynamic.md extend context correctly 
 Array [
   <div
     class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default"
+    role="progressbar"
   >
     <div
       class="ant-progress-outer"
@@ -685,6 +695,7 @@ exports[`renders ./components/progress/demo/format.md extend context correctly 1
 Array [
   <div
     class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default"
+    role="progressbar"
   >
     <div
       class="ant-progress-inner"
@@ -735,6 +746,7 @@ Array [
   </div>,
   <div
     class="ant-progress ant-progress-circle ant-progress-status-success ant-progress-show-info ant-progress-default"
+    role="progressbar"
   >
     <div
       class="ant-progress-inner"
@@ -790,6 +802,7 @@ exports[`renders ./components/progress/demo/gradient-line.md extend context corr
 Array [
   <div
     class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default"
+    role="progressbar"
   >
     <div
       class="ant-progress-outer"
@@ -812,6 +825,7 @@ Array [
   </div>,
   <div
     class="ant-progress ant-progress-line ant-progress-status-active ant-progress-show-info ant-progress-default"
+    role="progressbar"
   >
     <div
       class="ant-progress-outer"
@@ -834,6 +848,7 @@ Array [
   </div>,
   <div
     class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default"
+    role="progressbar"
   >
     <div
       class="ant-progress-inner ant-progress-circle-gradient"
@@ -903,6 +918,7 @@ Array [
   </div>,
   <div
     class="ant-progress ant-progress-circle ant-progress-status-success ant-progress-show-info ant-progress-default"
+    role="progressbar"
   >
     <div
       class="ant-progress-inner ant-progress-circle-gradient"
@@ -994,6 +1010,7 @@ exports[`renders ./components/progress/demo/line.md extend context correctly 1`]
 Array [
   <div
     class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default"
+    role="progressbar"
   >
     <div
       class="ant-progress-outer"
@@ -1016,6 +1033,7 @@ Array [
   </div>,
   <div
     class="ant-progress ant-progress-line ant-progress-status-active ant-progress-show-info ant-progress-default"
+    role="progressbar"
   >
     <div
       class="ant-progress-outer"
@@ -1038,6 +1056,7 @@ Array [
   </div>,
   <div
     class="ant-progress ant-progress-line ant-progress-status-exception ant-progress-show-info ant-progress-default"
+    role="progressbar"
   >
     <div
       class="ant-progress-outer"
@@ -1077,6 +1096,7 @@ Array [
   </div>,
   <div
     class="ant-progress ant-progress-line ant-progress-status-success ant-progress-show-info ant-progress-default"
+    role="progressbar"
   >
     <div
       class="ant-progress-outer"
@@ -1116,6 +1136,7 @@ Array [
   </div>,
   <div
     class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-default"
+    role="progressbar"
   >
     <div
       class="ant-progress-outer"
@@ -1139,6 +1160,7 @@ exports[`renders ./components/progress/demo/line-mini.md extend context correctl
 >
   <div
     class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-small"
+    role="progressbar"
   >
     <div
       class="ant-progress-outer"
@@ -1161,6 +1183,7 @@ exports[`renders ./components/progress/demo/line-mini.md extend context correctl
   </div>
   <div
     class="ant-progress ant-progress-line ant-progress-status-active ant-progress-show-info ant-progress-small"
+    role="progressbar"
   >
     <div
       class="ant-progress-outer"
@@ -1183,6 +1206,7 @@ exports[`renders ./components/progress/demo/line-mini.md extend context correctl
   </div>
   <div
     class="ant-progress ant-progress-line ant-progress-status-exception ant-progress-show-info ant-progress-small"
+    role="progressbar"
   >
     <div
       class="ant-progress-outer"
@@ -1222,6 +1246,7 @@ exports[`renders ./components/progress/demo/line-mini.md extend context correctl
   </div>
   <div
     class="ant-progress ant-progress-line ant-progress-status-success ant-progress-show-info ant-progress-small"
+    role="progressbar"
   >
     <div
       class="ant-progress-outer"
@@ -1266,6 +1291,7 @@ exports[`renders ./components/progress/demo/linecap.md extend context correctly 
 Array [
   <div
     class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default"
+    role="progressbar"
   >
     <div
       class="ant-progress-outer"
@@ -1289,6 +1315,7 @@ Array [
   </div>,
   <div
     class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default"
+    role="progressbar"
   >
     <div
       class="ant-progress-inner"
@@ -1339,6 +1366,7 @@ Array [
   </div>,
   <div
     class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default"
+    role="progressbar"
   >
     <div
       class="ant-progress-inner"
@@ -1394,6 +1422,7 @@ exports[`renders ./components/progress/demo/segment.md extend context correctly 
 Array [
   <div
     class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default"
+    role="progressbar"
   >
     <div
       class="ant-progress-outer"
@@ -1444,6 +1473,7 @@ Array [
   </div>,
   <div
     class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default"
+    role="progressbar"
   >
     <div
       class="ant-progress-inner"
@@ -1518,6 +1548,7 @@ Array [
   </div>,
   <div
     class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default"
+    role="progressbar"
   >
     <div
       class="ant-progress-inner"
@@ -1597,6 +1628,7 @@ exports[`renders ./components/progress/demo/steps.md extend context correctly 1`
 Array [
   <div
     class="ant-progress ant-progress-steps ant-progress-status-normal ant-progress-show-info ant-progress-default"
+    role="progressbar"
   >
     <div
       class="ant-progress-steps-outer"
@@ -1624,6 +1656,7 @@ Array [
   <br />,
   <div
     class="ant-progress ant-progress-steps ant-progress-status-normal ant-progress-show-info ant-progress-default"
+    role="progressbar"
   >
     <div
       class="ant-progress-steps-outer"
@@ -1659,6 +1692,7 @@ Array [
   <br />,
   <div
     class="ant-progress ant-progress-steps ant-progress-status-success ant-progress-show-info ant-progress-small"
+    role="progressbar"
   >
     <div
       class="ant-progress-steps-outer"
@@ -1711,6 +1745,7 @@ Array [
   <br />,
   <div
     class="ant-progress ant-progress-steps ant-progress-status-normal ant-progress-show-info ant-progress-default"
+    role="progressbar"
   >
     <div
       class="ant-progress-steps-outer"

--- a/components/progress/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/progress/__tests__/__snapshots__/demo.test.ts.snap
@@ -4,6 +4,7 @@ exports[`renders ./components/progress/demo/circle.md correctly 1`] = `
 Array [
   <div
     class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default"
+    role="progressbar"
   >
     <div
       class="ant-progress-inner"
@@ -54,6 +55,7 @@ Array [
   </div>,
   <div
     class="ant-progress ant-progress-circle ant-progress-status-exception ant-progress-show-info ant-progress-default"
+    role="progressbar"
   >
     <div
       class="ant-progress-inner"
@@ -121,6 +123,7 @@ Array [
   </div>,
   <div
     class="ant-progress ant-progress-circle ant-progress-status-success ant-progress-show-info ant-progress-default"
+    role="progressbar"
   >
     <div
       class="ant-progress-inner"
@@ -193,6 +196,7 @@ exports[`renders ./components/progress/demo/circle-dynamic.md correctly 1`] = `
 Array [
   <div
     class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default"
+    role="progressbar"
   >
     <div
       class="ant-progress-inner"
@@ -306,6 +310,7 @@ exports[`renders ./components/progress/demo/circle-mini.md correctly 1`] = `
 Array [
   <div
     class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default"
+    role="progressbar"
   >
     <div
       class="ant-progress-inner"
@@ -356,6 +361,7 @@ Array [
   </div>,
   <div
     class="ant-progress ant-progress-circle ant-progress-status-exception ant-progress-show-info ant-progress-default"
+    role="progressbar"
   >
     <div
       class="ant-progress-inner"
@@ -423,6 +429,7 @@ Array [
   </div>,
   <div
     class="ant-progress ant-progress-circle ant-progress-status-success ant-progress-show-info ant-progress-default"
+    role="progressbar"
   >
     <div
       class="ant-progress-inner"
@@ -495,6 +502,7 @@ exports[`renders ./components/progress/demo/dashboard.md correctly 1`] = `
 Array [
   <div
     class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default"
+    role="progressbar"
   >
     <div
       class="ant-progress-inner"
@@ -545,6 +553,7 @@ Array [
   </div>,
   <div
     class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default"
+    role="progressbar"
   >
     <div
       class="ant-progress-inner"
@@ -600,6 +609,7 @@ exports[`renders ./components/progress/demo/dynamic.md correctly 1`] = `
 Array [
   <div
     class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default"
+    role="progressbar"
   >
     <div
       class="ant-progress-outer"
@@ -685,6 +695,7 @@ exports[`renders ./components/progress/demo/format.md correctly 1`] = `
 Array [
   <div
     class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default"
+    role="progressbar"
   >
     <div
       class="ant-progress-inner"
@@ -735,6 +746,7 @@ Array [
   </div>,
   <div
     class="ant-progress ant-progress-circle ant-progress-status-success ant-progress-show-info ant-progress-default"
+    role="progressbar"
   >
     <div
       class="ant-progress-inner"
@@ -790,6 +802,7 @@ exports[`renders ./components/progress/demo/gradient-line.md correctly 1`] = `
 Array [
   <div
     class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default"
+    role="progressbar"
   >
     <div
       class="ant-progress-outer"
@@ -812,6 +825,7 @@ Array [
   </div>,
   <div
     class="ant-progress ant-progress-line ant-progress-status-active ant-progress-show-info ant-progress-default"
+    role="progressbar"
   >
     <div
       class="ant-progress-outer"
@@ -834,6 +848,7 @@ Array [
   </div>,
   <div
     class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default"
+    role="progressbar"
   >
     <div
       class="ant-progress-inner ant-progress-circle-gradient"
@@ -903,6 +918,7 @@ Array [
   </div>,
   <div
     class="ant-progress ant-progress-circle ant-progress-status-success ant-progress-show-info ant-progress-default"
+    role="progressbar"
   >
     <div
       class="ant-progress-inner ant-progress-circle-gradient"
@@ -994,6 +1010,7 @@ exports[`renders ./components/progress/demo/line.md correctly 1`] = `
 Array [
   <div
     class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default"
+    role="progressbar"
   >
     <div
       class="ant-progress-outer"
@@ -1016,6 +1033,7 @@ Array [
   </div>,
   <div
     class="ant-progress ant-progress-line ant-progress-status-active ant-progress-show-info ant-progress-default"
+    role="progressbar"
   >
     <div
       class="ant-progress-outer"
@@ -1038,6 +1056,7 @@ Array [
   </div>,
   <div
     class="ant-progress ant-progress-line ant-progress-status-exception ant-progress-show-info ant-progress-default"
+    role="progressbar"
   >
     <div
       class="ant-progress-outer"
@@ -1077,6 +1096,7 @@ Array [
   </div>,
   <div
     class="ant-progress ant-progress-line ant-progress-status-success ant-progress-show-info ant-progress-default"
+    role="progressbar"
   >
     <div
       class="ant-progress-outer"
@@ -1116,6 +1136,7 @@ Array [
   </div>,
   <div
     class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-default"
+    role="progressbar"
   >
     <div
       class="ant-progress-outer"
@@ -1139,6 +1160,7 @@ exports[`renders ./components/progress/demo/line-mini.md correctly 1`] = `
 >
   <div
     class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-small"
+    role="progressbar"
   >
     <div
       class="ant-progress-outer"
@@ -1161,6 +1183,7 @@ exports[`renders ./components/progress/demo/line-mini.md correctly 1`] = `
   </div>
   <div
     class="ant-progress ant-progress-line ant-progress-status-active ant-progress-show-info ant-progress-small"
+    role="progressbar"
   >
     <div
       class="ant-progress-outer"
@@ -1183,6 +1206,7 @@ exports[`renders ./components/progress/demo/line-mini.md correctly 1`] = `
   </div>
   <div
     class="ant-progress ant-progress-line ant-progress-status-exception ant-progress-show-info ant-progress-small"
+    role="progressbar"
   >
     <div
       class="ant-progress-outer"
@@ -1222,6 +1246,7 @@ exports[`renders ./components/progress/demo/line-mini.md correctly 1`] = `
   </div>
   <div
     class="ant-progress ant-progress-line ant-progress-status-success ant-progress-show-info ant-progress-small"
+    role="progressbar"
   >
     <div
       class="ant-progress-outer"
@@ -1266,6 +1291,7 @@ exports[`renders ./components/progress/demo/linecap.md correctly 1`] = `
 Array [
   <div
     class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default"
+    role="progressbar"
   >
     <div
       class="ant-progress-outer"
@@ -1289,6 +1315,7 @@ Array [
   </div>,
   <div
     class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default"
+    role="progressbar"
   >
     <div
       class="ant-progress-inner"
@@ -1339,6 +1366,7 @@ Array [
   </div>,
   <div
     class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default"
+    role="progressbar"
   >
     <div
       class="ant-progress-inner"
@@ -1394,6 +1422,7 @@ exports[`renders ./components/progress/demo/segment.md correctly 1`] = `
 Array [
   <div
     class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default"
+    role="progressbar"
   >
     <div
       class="ant-progress-outer"
@@ -1420,6 +1449,7 @@ Array [
   </div>,
   <div
     class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default"
+    role="progressbar"
   >
     <div
       class="ant-progress-inner"
@@ -1470,6 +1500,7 @@ Array [
   </div>,
   <div
     class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default"
+    role="progressbar"
   >
     <div
       class="ant-progress-inner"
@@ -1525,6 +1556,7 @@ exports[`renders ./components/progress/demo/steps.md correctly 1`] = `
 Array [
   <div
     class="ant-progress ant-progress-steps ant-progress-status-normal ant-progress-show-info ant-progress-default"
+    role="progressbar"
   >
     <div
       class="ant-progress-steps-outer"
@@ -1552,6 +1584,7 @@ Array [
   <br />,
   <div
     class="ant-progress ant-progress-steps ant-progress-status-normal ant-progress-show-info ant-progress-default"
+    role="progressbar"
   >
     <div
       class="ant-progress-steps-outer"
@@ -1587,6 +1620,7 @@ Array [
   <br />,
   <div
     class="ant-progress ant-progress-steps ant-progress-status-success ant-progress-show-info ant-progress-small"
+    role="progressbar"
   >
     <div
       class="ant-progress-steps-outer"
@@ -1639,6 +1673,7 @@ Array [
   <br />,
   <div
     class="ant-progress ant-progress-steps ant-progress-status-normal ant-progress-show-info ant-progress-default"
+    role="progressbar"
   >
     <div
       class="ant-progress-steps-outer"

--- a/components/progress/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/progress/__tests__/__snapshots__/index.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`Progress render dashboard 295 gapDegree 1`] = `
 <div
   class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default"
+  role="progressbar"
 >
   <div
     class="ant-progress-inner"
@@ -56,6 +57,7 @@ exports[`Progress render dashboard 295 gapDegree 1`] = `
 exports[`Progress render dashboard 296 gapDegree 1`] = `
 <div
   class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default"
+  role="progressbar"
 >
   <div
     class="ant-progress-inner"
@@ -109,6 +111,7 @@ exports[`Progress render dashboard 296 gapDegree 1`] = `
 exports[`Progress render dashboard zero gapDegree 1`] = `
 <div
   class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default"
+  role="progressbar"
 >
   <div
     class="ant-progress-inner"
@@ -162,6 +165,7 @@ exports[`Progress render dashboard zero gapDegree 1`] = `
 exports[`Progress render format 1`] = `
 <div
   class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default"
+  role="progressbar"
 >
   <div
     class="ant-progress-outer"
@@ -191,6 +195,7 @@ exports[`Progress render format 1`] = `
 exports[`Progress render negative progress 1`] = `
 <div
   class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default"
+  role="progressbar"
 >
   <div
     class="ant-progress-outer"
@@ -216,6 +221,7 @@ exports[`Progress render negative progress 1`] = `
 exports[`Progress render negative successPercent 1`] = `
 <div
   class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default"
+  role="progressbar"
 >
   <div
     class="ant-progress-outer"
@@ -245,6 +251,7 @@ exports[`Progress render negative successPercent 1`] = `
 exports[`Progress render normal progress 1`] = `
 <div
   class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default"
+  role="progressbar"
 >
   <div
     class="ant-progress-outer"
@@ -270,6 +277,7 @@ exports[`Progress render normal progress 1`] = `
 exports[`Progress render out-of-range progress 1`] = `
 <div
   class="ant-progress ant-progress-line ant-progress-status-success ant-progress-show-info ant-progress-default"
+  role="progressbar"
 >
   <div
     class="ant-progress-outer"
@@ -312,6 +320,7 @@ exports[`Progress render out-of-range progress 1`] = `
 exports[`Progress render out-of-range progress with info 1`] = `
 <div
   class="ant-progress ant-progress-line ant-progress-status-success ant-progress-show-info ant-progress-default"
+  role="progressbar"
 >
   <div
     class="ant-progress-outer"
@@ -354,6 +363,7 @@ exports[`Progress render out-of-range progress with info 1`] = `
 exports[`Progress render strokeColor 1`] = `
 <div
   class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default"
+  role="progressbar"
 >
   <div
     class="ant-progress-inner"
@@ -407,6 +417,7 @@ exports[`Progress render strokeColor 1`] = `
 exports[`Progress render strokeColor 2`] = `
 <div
   class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default"
+  role="progressbar"
 >
   <div
     class="ant-progress-outer"
@@ -432,6 +443,7 @@ exports[`Progress render strokeColor 2`] = `
 exports[`Progress render strokeColor 3`] = `
 <div
   class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default"
+  role="progressbar"
 >
   <div
     class="ant-progress-outer"
@@ -457,6 +469,7 @@ exports[`Progress render strokeColor 3`] = `
 exports[`Progress render successColor progress 1`] = `
 <div
   class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default"
+  role="progressbar"
 >
   <div
     class="ant-progress-outer"
@@ -486,6 +499,7 @@ exports[`Progress render successColor progress 1`] = `
 exports[`Progress render successColor progress type="circle" 1`] = `
 <div
   class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default"
+  role="progressbar"
 >
   <div
     class="ant-progress-inner"
@@ -539,6 +553,7 @@ exports[`Progress render successColor progress type="circle" 1`] = `
 exports[`Progress render successColor progress type="dashboard" 1`] = `
 <div
   class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default"
+  role="progressbar"
 >
   <div
     class="ant-progress-inner"
@@ -592,6 +607,7 @@ exports[`Progress render successColor progress type="dashboard" 1`] = `
 exports[`Progress render trailColor progress 1`] = `
 <div
   class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default"
+  role="progressbar"
 >
   <div
     class="ant-progress-outer"
@@ -618,6 +634,7 @@ exports[`Progress render trailColor progress 1`] = `
 exports[`Progress rtl render component should be rendered correctly in RTL direction 1`] = `
 <div
   class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default ant-progress-rtl"
+  role="progressbar"
 >
   <div
     class="ant-progress-outer"
@@ -643,6 +660,7 @@ exports[`Progress rtl render component should be rendered correctly in RTL direc
 exports[`Progress should support steps 1`] = `
 <div
   class="ant-progress ant-progress-steps ant-progress-status-normal ant-progress-show-info ant-progress-default"
+  role="progressbar"
 >
   <div
     class="ant-progress-steps-outer"

--- a/components/progress/progress.tsx
+++ b/components/progress/progress.tsx
@@ -176,6 +176,7 @@ const Progress: React.FC<ProgressProps> = (props: ProgressProps) => {
         'successPercent',
       ])}
       className={classString}
+      role="progressbar"
     >
       {progress}
     </div>

--- a/components/steps/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/steps/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -1200,6 +1200,7 @@ Array [
           >
             <div
               class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default"
+              role="progressbar"
             >
               <div
                 class="ant-progress-inner"
@@ -1965,6 +1966,7 @@ exports[`renders ./components/steps/demo/progress.md extend context correctly 1`
         >
           <div
             class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default"
+            role="progressbar"
           >
             <div
               class="ant-progress-inner"
@@ -2206,6 +2208,7 @@ Array [
           >
             <div
               class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default"
+              role="progressbar"
             >
               <div
                 class="ant-progress-inner"
@@ -2387,6 +2390,7 @@ Array [
           >
             <div
               class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default"
+              role="progressbar"
             >
               <div
                 class="ant-progress-inner"
@@ -2568,6 +2572,7 @@ Array [
           >
             <div
               class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default"
+              role="progressbar"
             >
               <div
                 class="ant-progress-inner"
@@ -2749,6 +2754,7 @@ Array [
           >
             <div
               class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default"
+              role="progressbar"
             >
               <div
                 class="ant-progress-inner"

--- a/components/steps/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/steps/__tests__/__snapshots__/demo.test.ts.snap
@@ -1056,6 +1056,7 @@ Array [
           >
             <div
               class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default"
+              role="progressbar"
             >
               <div
                 class="ant-progress-inner"
@@ -1821,6 +1822,7 @@ exports[`renders ./components/steps/demo/progress.md correctly 1`] = `
         >
           <div
             class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default"
+            role="progressbar"
           >
             <div
               class="ant-progress-inner"
@@ -2062,6 +2064,7 @@ Array [
           >
             <div
               class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default"
+              role="progressbar"
             >
               <div
                 class="ant-progress-inner"
@@ -2243,6 +2246,7 @@ Array [
           >
             <div
               class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default"
+              role="progressbar"
             >
               <div
                 class="ant-progress-inner"
@@ -2424,6 +2428,7 @@ Array [
           >
             <div
               class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default"
+              role="progressbar"
             >
               <div
                 class="ant-progress-inner"
@@ -2605,6 +2610,7 @@ Array [
           >
             <div
               class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default"
+              role="progressbar"
             >
               <div
                 class="ant-progress-inner"


### PR DESCRIPTION
[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
close #38444
### 💡 Background and solution
Screen reader doesn't recognize progress component as progress bar. The assistive technology user will be unable to interact with and will be unaware of active and static content that has been rendered.
All data related to Progress current percent value developer can manage with aria-* attributes, but without `role="progressbar"` this is useless.

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix: Adds role progressbar to Progress component          |
| 🇨🇳 Chinese | fix: Adds role progressbar to Progress component           |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
