### PR TITLE
fix: The image preview operations are occluded

### DIFF
--- a/components/image/style/index.less
+++ b/components/image/style/index.less
@@ -105,16 +105,19 @@
       z-index: @zindex-image;
     }
 
-    &-operations {
-      .reset-component();
+    &-operations-wrapper {
       position: fixed;
       top: 0;
       right: 0;
       z-index: @zindex-image + 1;
+      width: 100%;
+    }
+
+    &-operations {
+      .reset-component();
       display: flex;
       flex-direction: row-reverse;
       align-items: center;
-      width: 100%;
       color: @image-preview-operation-color;
       list-style: none;
       background: fade(@modal-mask-bg, 10%);

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "rc-drawer": "~6.0.0",
     "rc-dropdown": "~4.0.0",
     "rc-field-form": "~1.27.0",
-    "rc-image": "~5.10.0",
+    "rc-image": "~5.11.0",
     "rc-input": "~0.1.4",
     "rc-input-number": "~7.3.9",
     "rc-mentions": "~1.10.0",


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.

Before submitting your pull request, please make sure the checklist below is confirmed.

Your pull requests will be merged after one of the collaborators approve.

Thank you!

-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed the image preview operation being blocked |
| 🇨🇳 Chinese | 修复图像预览操作条被遮挡 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
