### PR TITLE
fix: passthrough backtop float button rest props

### DIFF
--- a/components/float-button/BackTop.tsx
+++ b/components/float-button/BackTop.tsx
@@ -3,7 +3,7 @@ import classNames from 'classnames';
 import CSSMotion from 'rc-motion';
 import addEventListener from 'rc-util/lib/Dom/addEventListener';
 import useMergedState from 'rc-util/lib/hooks/useMergedState';
-import React, { memo, useContext, useEffect, useMemo, useRef } from 'react';
+import React, { memo, useContext, useEffect, useRef } from 'react';
 import FloatButton, { floatButtonPrefixCls } from './FloatButton';
 import type { ConfigConsumerProps } from '../config-provider';
 import { ConfigContext } from '../config-provider';
@@ -11,7 +11,7 @@ import getScroll from '../_util/getScroll';
 import scrollTo from '../_util/scrollTo';
 import { throttleByAnimationFrame } from '../_util/throttleByAnimationFrame';
 import FloatButtonGroupContext from './context';
-import type { BackTopProps, FloatButtonContentProps, FloatButtonShape } from './interface';
+import type { BackTopProps, FloatButtonShape } from './interface';
 import useStyle from './style';
 
 const BackTop: React.FC<BackTopProps> = props => {
@@ -22,10 +22,10 @@ const BackTop: React.FC<BackTopProps> = props => {
     shape = 'circle',
     visibilityHeight = 400,
     icon = <VerticalAlignTopOutlined />,
-    description,
     target,
     onClick,
     duration = 450,
+    ...restProps
   } = props;
 
   const [visible, setVisible] = useMergedState(false, { value: props.visible });
@@ -80,10 +80,7 @@ const BackTop: React.FC<BackTopProps> = props => {
 
   const mergeShape = groupShape || shape;
 
-  const contentProps = useMemo<FloatButtonContentProps>(
-    () => ({ prefixCls, description, icon, type, shape: mergeShape }),
-    [prefixCls, description, icon, type, mergeShape],
-  );
+  const contentProps = { prefixCls, icon, type, shape: mergeShape, ...restProps };
 
   return wrapSSR(
     <CSSMotion visible={visible} motionName={`${rootPrefixCls}-fade`}>

--- a/components/float-button/__tests__/back-top.test.tsx
+++ b/components/float-button/__tests__/back-top.test.tsx
@@ -44,4 +44,10 @@ describe('BackTop', () => {
     fireEvent.click(container.querySelector('.ant-float-btn')!);
     expect(onClick).toHaveBeenCalled();
   });
+
+  it('pass style to float button', () => {
+    const { container } = render(<BackTop style={{ color: 'red' }} visible target={undefined} />);
+    const btn = container.querySelector('.ant-float-btn')!;
+    expect(btn).toHaveAttribute('style', 'color: red;');
+  });
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.

Before submitting your pull request, please make sure the checklist below is confirmed.

Your pull requests will be merged after one of the collaborators approve.

Thank you!

-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
-->

### 💡 Background and solution

FloatButton.BackTop swallow the rest props like `tooltip` `style`. This PR passthroughs all rest props to FloatButton.

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix: passthrough backtop float button rest props |
| 🇨🇳 Chinese | fix: 透传 FloatButton.BackTop 剩余属性 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
