### PR TITLE
fix: Result should hide icon when it is falsy

### DIFF
--- a/components/result/__tests__/index.test.tsx
+++ b/components/result/__tests__/index.test.tsx
@@ -67,4 +67,11 @@ describe('Result', () => {
 
     warnSpy.mockRestore();
   });
+
+  it('should hide icon by setting icon to false or null', () => {
+    const { container } = render(<Result title="404" icon={null} />);
+    expect(container.querySelectorAll('.ant-result-icon')).toHaveLength(0);
+    const { container: container2 } = render(<Result title="404" icon={false} />);
+    expect(container2.querySelectorAll('.ant-result-icon')).toHaveLength(0);
+  });
 });

--- a/components/result/index.tsx
+++ b/components/result/index.tsx
@@ -73,9 +73,14 @@ const Icon: React.FC<IconProps> = ({ prefixCls, icon, status }) => {
       </div>
     );
   }
+
   const iconNode = React.createElement(
     IconMap[status as Exclude<ResultStatusType, ExceptionStatusType>],
   );
+
+  if (icon === null || icon === false) {
+    return null;
+  }
 
   return <div className={className}>{icon || iconNode}</div>;
 };


### PR DESCRIPTION


<!--
First of all, thank you for your contribution! 😄

For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.

Before submitting your pull request, please make sure the checklist below is confirmed.

Your pull requests will be merged after one of the collaborators approve.

Thank you!

-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
-->
close #38484

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Result should hide icon when it is falsy.         |
| 🇨🇳 Chinese | 修复 Result `icon` 为 `null` 时图标没有隐藏的问题。         |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
