### PR TITLE
fix: Dropdown accidental opening of container

### DIFF
--- a/components/style/core/motion/slide.less
+++ b/components/style/core/motion/slide.less
@@ -3,6 +3,8 @@
   .make-motion(@name, @keyframeName);
   .@{name}-enter,
   .@{name}-appear {
+    transform: scale(0);
+    transform-origin: 0% 0%;
     opacity: 0;
     animation-timing-function: @ease-out-quint;
   }


### PR DESCRIPTION

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

fix #38379 

### 💡 Background and solution

Dropdown 组件在弹出的瞬间可能存在超出容器，导致底部滚动条出现，之后进入动画帧，滚动条消失

### 📝 Changelog


| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    modify slide.less      |
| 🇨🇳 Chinese |     修改 slide.less     |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
