### PR TITLE
fix(message): call onClose after removeNotice

### DIFF
--- a/components/message/__tests__/type.test.tsx
+++ b/components/message/__tests__/type.test.tsx
@@ -25,7 +25,9 @@ describe('message.typescript', () => {
   });
 
   it('hide', () => {
-    const hide = message.loading('doing...');
+    const onClose = jest.fn();
+    const hide = message.loading('doing...', 0, onClose);
     hide();
+    expect(onClose).toHaveBeenCalled();
   });
 });

--- a/components/message/demo/loading.md
+++ b/components/message/demo/loading.md
@@ -18,7 +18,9 @@ import { Button, message } from 'antd';
 import React from 'react';
 
 const success = () => {
-  const hide = message.loading('Action in progress..', 0);
+  const hide = message.loading('Action in progress..', 0, () => {
+    message.success("loading had closed");
+  });
   // Dismiss manually and asynchronously
   setTimeout(hide, 2500);
 };

--- a/components/message/index.tsx
+++ b/components/message/index.tsx
@@ -184,7 +184,6 @@ function notice(args: ArgsProps): MessageType {
       }
       return resolve(true);
     };
-
     getRCNotificationInstance(args, ({ prefixCls, iconPrefixCls, instance }) => {
       instance.notice(
         getRCNoticeProps({ ...args, key: target, onClose: callback }, prefixCls, iconPrefixCls),
@@ -194,6 +193,7 @@ function notice(args: ArgsProps): MessageType {
   const result: any = () => {
     if (messageInstance) {
       messageInstance.removeNotice(target);
+      args.onClose?.();
     }
   };
   result.then = (filled: ThenableArgument, rejected: ThenableArgument) =>


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.

Before submitting your pull request, please make sure the checklist below is confirmed.

Your pull requests will be merged after one of the collaborators approve.

Thank you!

-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [X] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

- fix: #38524 

<!--
1. Put the related issue or discussion links here.
-->

### 💡 Background and solution

should call onClose after removeNotice

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | should call onClose after removeNotice |
| 🇨🇳 Chinese | 移除消息后应该调用一下`onClose`方法 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [X] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [X] Changelog is provided or not needed
