### PR TITLE
docs: use dumi helmet for pre-render

### DIFF
--- a/.dumi/theme/builtins/ComponentOverview/index.tsx
+++ b/.dumi/theme/builtins/ComponentOverview/index.tsx
@@ -1,6 +1,5 @@
 import React, { useState, memo, useMemo } from 'react';
-import { Helmet } from 'react-helmet-async';
-import { Link, useRouteMeta, useIntl, useSidebarData } from 'dumi';
+import { Link, useRouteMeta, useIntl, useSidebarData, Helmet } from 'dumi';
 import { css } from '@emotion/react';
 import debounce from 'lodash/debounce';
 import { Input, Divider, Row, Col, Card, Typography, Tag, Space } from 'antd';

--- a/.dumi/theme/common/CommonHelmet.tsx
+++ b/.dumi/theme/common/CommonHelmet.tsx
@@ -1,6 +1,5 @@
-import { useRouteMeta } from 'dumi';
+import { useRouteMeta, Helmet } from 'dumi';
 import React, { useMemo } from 'react';
-import { Helmet } from 'react-helmet-async';
 
 const CommonHelmet = () => {
   const meta = useRouteMeta();

--- a/.dumi/theme/common/Helmet.tsx
+++ b/.dumi/theme/common/Helmet.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import type { HelmetProps } from 'react-helmet-async';
-import { Helmet } from 'react-helmet-async';
+import { Helmet } from 'dumi';
 
+type HelmetProps = Helmet['props'];
 export interface WrapHelmetProps extends HelmetProps {
   children?: React.ReactNode;
 }

--- a/.dumi/theme/layouts/DocLayout/index.tsx
+++ b/.dumi/theme/layouts/DocLayout/index.tsx
@@ -1,5 +1,5 @@
 import React, { type FC, useEffect, useMemo, useRef } from 'react';
-import { useOutlet, useSearchParams } from 'dumi';
+import { useOutlet, useSearchParams, Helmet } from 'dumi';
 import Header from 'dumi/theme/slots/Header';
 import Footer from 'dumi/theme/slots/Footer';
 import '../../static/style';
@@ -7,7 +7,6 @@ import useLocation from '../../../hooks/useLocation';
 import SiteContext from '../../slots/SiteContext';
 import ConfigProvider, { DirectionType } from 'antd/es/config-provider';
 import classNames from 'classnames';
-import { Helmet, HelmetProvider } from 'react-helmet-async';
 import useLocale from '../../../hooks/useLocale';
 import zhCN from 'antd/es/locale/zh_CN';
 import { createCache, StyleProvider } from '@ant-design/cssinjs';
@@ -117,32 +116,30 @@ const DocLayout: FC = () => {
   return (
     <StyleProvider cache={styleCache}>
       <SiteContext.Provider value={{ isMobile, direction }}>
-        <HelmetProvider context={{}}>
-          <Helmet encodeSpecialCharacters={false}>
-            <html
-              lang={lang}
-              data-direction={direction}
-              className={classNames({ [`rtl`]: direction === 'rtl' })}
-            />
-            <title>{locale.title}</title>
-            <link
-              sizes="144x144"
-              href="https://gw.alipayobjects.com/zos/antfincdn/UmVnt3t4T0/antd.png"
-            />
-            <meta name="description" content={locale.description} />
-            <meta property="og:title" content={locale.title} />
-            <meta property="og:type" content="website" />
-            <meta
-              property="og:image"
-              content="https://gw.alipayobjects.com/zos/rmsportal/rlpTLlbMzTNYuZGGCVYM.png"
-            />
-          </Helmet>
-          <ConfigProvider locale={lang === 'cn' ? zhCN : undefined} direction={direction}>
-            <GlobalStyles />
-            <Header changeDirection={changeDirection} />
-            {content}
-          </ConfigProvider>
-        </HelmetProvider>
+        <Helmet encodeSpecialCharacters={false}>
+          <html
+            lang={lang}
+            data-direction={direction}
+            className={classNames({ [`rtl`]: direction === 'rtl' })}
+          />
+          <title>{locale.title}</title>
+          <link
+            sizes="144x144"
+            href="https://gw.alipayobjects.com/zos/antfincdn/UmVnt3t4T0/antd.png"
+          />
+          <meta name="description" content={locale.description} />
+          <meta property="og:title" content={locale.title} />
+          <meta property="og:type" content="website" />
+          <meta
+            property="og:image"
+            content="https://gw.alipayobjects.com/zos/rmsportal/rlpTLlbMzTNYuZGGCVYM.png"
+          />
+        </Helmet>
+        <ConfigProvider locale={lang === 'cn' ? zhCN : undefined} direction={direction}>
+          <GlobalStyles />
+          <Header changeDirection={changeDirection} />
+          {content}
+        </ConfigProvider>
       </SiteContext.Provider>
     </StyleProvider>
   );


### PR DESCRIPTION
[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

#38463 

### 💡 Background and solution

Use `Helmet` from dumi for generate tdk in pre-rendered html files

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
