### PR TITLE
fix(Input.Search): pressing enter key don't trigger `onSearch` while …

### DIFF
--- a/components/input/Search.tsx
+++ b/components/input/Search.tsx
@@ -75,7 +75,7 @@ const Search = React.forwardRef<InputRef, SearchProps>((props, ref) => {
   };
 
   const onPressEnter = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (composedRef.current) {
+    if (composedRef.current || loading) {
       return;
     }
     onSearch(e);

--- a/components/input/__tests__/Search.test.tsx
+++ b/components/input/__tests__/Search.test.tsx
@@ -161,6 +161,15 @@ describe('Input.Search', () => {
     expect(asFragmentWithEnterButton().firstChild).toMatchSnapshot();
   });
 
+  it('should not trigger onSearch when press enter while loading', () => {
+    const onSearch = jest.fn();
+    const { container } = render(
+      <Search loading onSearch={onSearch} />,
+    );
+    fireEvent.keyDown(container.querySelector('input')!, { key: 'Enter', keyCode: 13 });
+    expect(onSearch).not.toHaveBeenCalled();
+  });
+
   it('should support addonAfter and suffix for loading', () => {
     const { asFragment } = render(<Search loading suffix="suffix" addonAfter="addonAfter" />);
     const { asFragment: asFragmentWithEnterButton } = render(


### PR DESCRIPTION
…loading (#38575)

<!--
First of all, thank you for your contribution! 😄

For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.

Before submitting your pull request, please make sure the checklist below is confirmed.

Your pull requests will be merged after one of the collaborators approve.

Thank you!

-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
-->
close https://github.com/ant-design/ant-design/issues/38575

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->
`Input.Search` should not trigger `onSearch` while loading.

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fix Input.Search should not trigger `onSearch` while loading.   |
| 🇨🇳 Chinese |  修复 Input.Search `loading` 时触发 `onSearch` 的问题。    |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
