### PR TITLE
fix(Table): don't trigger sort when pressing enter in filter dropdown

### DIFF
--- a/components/table/__tests__/Table.sorter.test.tsx
+++ b/components/table/__tests__/Table.sorter.test.tsx
@@ -39,7 +39,7 @@ describe('Table.sorter', () => {
     container
       ?.querySelector('.ant-table-tbody')
       ?.querySelectorAll('tr')
-      ?.forEach(tr => {
+      ?.forEach((tr) => {
         namesList.push(tr.querySelector('td')?.textContent);
       });
     return namesList;
@@ -129,7 +129,7 @@ describe('Table.sorter', () => {
     expect(getNameColumn()?.getAttribute('aria-sort')).toEqual('descending');
   });
 
-  it('sort records with keydown', () => {
+  it('sort records when press enter', () => {
     const { container } = render(createTable());
 
     // ascend
@@ -139,6 +139,30 @@ describe('Table.sorter', () => {
     // descend
     fireEvent.keyDown(container.querySelector('.ant-table-column-sorters')!, { keyCode: 13 });
     expect(renderedNames(container)).toEqual(['Tom', 'Lucy', 'Jack', 'Jerry']);
+  });
+
+  // https://github.com/ant-design/ant-design/issues/38579
+  it('should not sort records when press enter in filter dropdown', () => {
+    const { container } = render(
+      createTable({
+        columns: [
+          {
+            ...column,
+            filters: [{ text: 'J', value: 'J' }],
+            onFilter: (value: any, record: any) => record.name.includes(value),
+            filterDropdownOpen: true,
+          },
+        ],
+      }),
+    );
+
+    // don't trigger ascend
+    fireEvent.keyDown(container.querySelector('.ant-table-filter-dropdown')!, { keyCode: 13 });
+    expect(renderedNames(container)).toEqual(['Jack', 'Lucy', 'Tom', 'Jerry']);
+
+    // don't trigger descend
+    fireEvent.keyDown(container.querySelector('.ant-table-filter-dropdown')!, { keyCode: 13 });
+    expect(renderedNames(container)).toEqual(['Jack', 'Lucy', 'Tom', 'Jerry']);
   });
 
   describe('can be controlled by sortOrder', () => {
@@ -434,7 +458,7 @@ describe('Table.sorter', () => {
     class TableTest extends React.Component {
       state = { pagination: {} };
 
-      onChange: TableProps<any>['onChange'] = pagination => {
+      onChange: TableProps<any>['onChange'] = (pagination) => {
         this.setState({ pagination });
       };
 
@@ -494,7 +518,7 @@ describe('Table.sorter', () => {
         pagination: {},
       };
 
-      onChange: TableProps<any>['onChange'] = pagination => {
+      onChange: TableProps<any>['onChange'] = (pagination) => {
         this.setState({ pagination });
       };
 
@@ -561,7 +585,7 @@ describe('Table.sorter', () => {
         pagination: {},
       };
 
-      onChange: TableProps<any>['onChange'] = pagination => {
+      onChange: TableProps<any>['onChange'] = (pagination) => {
         this.setState({ pagination });
       };
 

--- a/components/table/hooks/useFilter/FilterWrapper.tsx
+++ b/components/table/hooks/useFilter/FilterWrapper.tsx
@@ -1,12 +1,20 @@
 import * as React from 'react';
+import KeyCode from 'rc-util/lib/KeyCode';
 
 export interface FilterDropdownMenuWrapperProps {
   children?: React.ReactNode;
   className?: string;
 }
 
+const onKeyDown: React.KeyboardEventHandler<HTMLDivElement> = (event) => {
+  const { keyCode } = event;
+  if (keyCode === KeyCode.ENTER) {
+    event.stopPropagation();
+  }
+};
+
 const FilterDropdownMenuWrapper = (props: FilterDropdownMenuWrapperProps) => (
-  <div className={props.className} onClick={e => e.stopPropagation()}>
+  <div className={props.className} onClick={(e) => e.stopPropagation()} onKeyDown={onKeyDown}>
     {props.children}
   </div>
 );


### PR DESCRIPTION


<!--
First of all, thank you for your contribution! 😄

For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.

Before submitting your pull request, please make sure the checklist below is confirmed.

Your pull requests will be merged after one of the collaborators approve.

Thank you!

-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
-->
close #38579
close https://github.com/ant-design/ant-design/issues/38392
close https://github.com/ant-design/ant-design/issues/36176

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Fix Table should not trigger sorter when pressing Enter in filter dropdown.        |
| 🇨🇳 Chinese |   修复 Table 在筛选菜单里按回车时会触发排序的问题。 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
