### PR TITLE
fix: Pass custom prefixCls to Typography from Base (#38580)

### DIFF
--- a/components/typography/Base/index.tsx
+++ b/components/typography/Base/index.tsx
@@ -277,7 +277,7 @@ const Base = React.forwardRef<HTMLElement, BlockProps>((props, ref) => {
   const cssLineClamp = mergedEnableEllipsis && rows > 1 && cssEllipsis;
 
   // >>>>> Expand
-  const onExpandClick: React.MouseEventHandler<HTMLElement> = e => {
+  const onExpandClick: React.MouseEventHandler<HTMLElement> = (e) => {
     setExpanded(true);
     ellipsisConfig.onExpand?.(e);
   };
@@ -510,6 +510,7 @@ const Base = React.forwardRef<HTMLElement, BlockProps>((props, ref) => {
               },
               className,
             )}
+            prefixCls={customizePrefixCls}
             style={{
               ...style,
               WebkitLineClamp: cssLineClamp ? rows : undefined,

--- a/components/typography/__tests__/prefixCls.test.tsx
+++ b/components/typography/__tests__/prefixCls.test.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { render } from '../../../tests/utils';
+
+import Base from '../Base';
+
+describe('Typography keep prefixCls', () => {
+  describe('Base', () => {
+    it('should support className when has prefix', () => {
+      const { container: wrapper } = render(
+        <Base component="p" prefixCls="custom-prefixCls" className="custom-class">
+          test prefixCls
+        </Base>,
+      );
+      expect(
+        (wrapper.firstChild as HTMLElement)?.className.includes('custom-prefixCls'),
+      ).toBeTruthy();
+      expect((wrapper.firstChild as HTMLElement)?.className.includes('custom-class')).toBeTruthy();
+    });
+  });
+});


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
fix #38580 

### 💡 Background and solution
**Problem:** Custom `prefixCls` was not passed to Typography component from Base, so any Typography components was having `ant-typography` className.
**Solution:** Pass prop from Base to Typography


### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  pass `prefixCls` from `typography/Base`  to  `typography/Typography`  |
| 🇨🇳 Chinese | 將 `prefixCls` 從 `typography/Base` 傳遞到 `typography/Typography` |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
