### PR TITLE
feat: add Modal.open for modal method

### DIFF
--- a/components/modal/ConfirmDialog.tsx
+++ b/components/modal/ConfirmDialog.tsx
@@ -38,8 +38,8 @@ const ConfirmDialog = (props: ConfirmDialogProps) => {
     wrapClassName,
     rootPrefixCls,
     iconPrefixCls,
+    type,
     bodyStyle,
-    closable = false,
     closeIcon,
     modalRender,
     focusTriggerAfterClose,
@@ -61,19 +61,20 @@ const ConfirmDialog = (props: ConfirmDialogProps) => {
 
   // 支持传入{ icon: null }来隐藏`Modal.confirm`默认的Icon
   const okType = props.okType || 'primary';
-  const contentPrefixCls = `${prefixCls}-confirm`;
+  const contentPrefixCls = props.type ? `${prefixCls}-confirm` : prefixCls;
   // 默认为 true，保持向下兼容
   const okCancel = 'okCancel' in props ? props.okCancel! : true;
-  const width = props.width || 416;
+  const width = props.width || (props.type ? 416 : 520);
   const style = props.style || {};
   const mask = props.mask === undefined ? true : props.mask;
+  const closable = props.closable === undefined ? !props.type : props.closable;
   // 默认为 false，保持旧版默认行为
-  const maskClosable = props.maskClosable === undefined ? false : props.maskClosable;
+  const maskClosable = props.maskClosable === undefined ? !props.type : props.maskClosable;
   const autoFocusButton = props.autoFocusButton === null ? false : props.autoFocusButton || 'ok';
 
   const classString = classNames(
     contentPrefixCls,
-    `${contentPrefixCls}-${props.type}`,
+    { [`${contentPrefixCls}-${props.type}`]: props.type },
     { [`${contentPrefixCls}-rtl`]: direction === 'rtl' },
     props.className,
   );
@@ -90,6 +91,27 @@ const ConfirmDialog = (props: ConfirmDialogProps) => {
     </ActionButton>
   );
 
+  const renderTitle =
+    props.title === undefined ? null : (
+      <span className={`${contentPrefixCls}-title`}>{props.title}</span>
+    );
+
+  const renderFooter = (
+    <>
+      {cancelButton}
+      <ActionButton
+        type={okType}
+        actionFn={onOk}
+        close={close}
+        autoFocus={autoFocusButton === 'ok'}
+        buttonProps={okButtonProps}
+        prefixCls={`${rootPrefixCls}-btn`}
+      >
+        {okText}
+      </ActionButton>
+    </>
+  );
+
   return (
     <ConfigProvider prefixCls={rootPrefixCls} iconPrefixCls={iconPrefixCls} direction={direction}>
       <Dialog
@@ -101,8 +123,8 @@ const ConfirmDialog = (props: ConfirmDialogProps) => {
         )}
         onCancel={() => close?.({ triggerCancel: true })}
         open={open || visible}
-        title=""
-        footer=""
+        title={type ? '' : props.title}
+        footer={type ? '' : renderFooter}
         transitionName={getTransitionName(rootPrefixCls, 'zoom', props.transitionName)}
         maskTransitionName={getTransitionName(rootPrefixCls, 'fade', props.maskTransitionName)}
         mask={mask}
@@ -121,28 +143,18 @@ const ConfirmDialog = (props: ConfirmDialogProps) => {
         modalRender={modalRender}
         focusTriggerAfterClose={focusTriggerAfterClose}
       >
-        <div className={`${contentPrefixCls}-body-wrapper`}>
-          <div className={`${contentPrefixCls}-body`}>
-            {icon}
-            {props.title === undefined ? null : (
-              <span className={`${contentPrefixCls}-title`}>{props.title}</span>
-            )}
-            <div className={`${contentPrefixCls}-content`}>{props.content}</div>
+        {props.type ? (
+          <div className={`${contentPrefixCls}-body-wrapper`}>
+            <div className={`${contentPrefixCls}-body`}>
+              {icon}
+              {renderTitle}
+              <div className={`${contentPrefixCls}-content`}>{props.content}</div>
+            </div>
+            <div className={`${contentPrefixCls}-btns`}>{renderFooter}</div>
           </div>
-          <div className={`${contentPrefixCls}-btns`}>
-            {cancelButton}
-            <ActionButton
-              type={okType}
-              actionFn={onOk}
-              close={close}
-              autoFocus={autoFocusButton === 'ok'}
-              buttonProps={okButtonProps}
-              prefixCls={`${rootPrefixCls}-btn`}
-            >
-              {okText}
-            </ActionButton>
-          </div>
-        </div>
+        ) : (
+          props.content
+        )}
       </Dialog>
     </ConfigProvider>
   );

--- a/components/modal/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/modal/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -198,6 +198,19 @@ exports[`renders ./components/modal/demo/info.md extend context correctly 1`] = 
       type="button"
     >
       <span>
+        Open
+      </span>
+    </button>
+  </div>
+  <div
+    class="ant-space-item"
+    style="margin-right:8px;padding-bottom:8px"
+  >
+    <button
+      class="ant-btn ant-btn-default"
+      type="button"
+    >
+      <span>
         Info
       </span>
     </button>
@@ -230,7 +243,7 @@ exports[`renders ./components/modal/demo/info.md extend context correctly 1`] = 
   </div>
   <div
     class="ant-space-item"
-    style="padding-bottom:8px"
+    style="margin-right:8px;padding-bottom:8px"
   >
     <button
       class="ant-btn ant-btn-default"
@@ -238,6 +251,19 @@ exports[`renders ./components/modal/demo/info.md extend context correctly 1`] = 
     >
       <span>
         Warning
+      </span>
+    </button>
+  </div>
+  <div
+    class="ant-space-item"
+    style="padding-bottom:8px"
+  >
+    <button
+      class="ant-btn ant-btn-default"
+      type="button"
+    >
+      <span>
+        Trigger Info Modal with Open Method
       </span>
     </button>
   </div>

--- a/components/modal/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/modal/__tests__/__snapshots__/demo.test.ts.snap
@@ -198,6 +198,19 @@ exports[`renders ./components/modal/demo/info.md correctly 1`] = `
       type="button"
     >
       <span>
+        Open
+      </span>
+    </button>
+  </div>
+  <div
+    class="ant-space-item"
+    style="margin-right:8px;padding-bottom:8px"
+  >
+    <button
+      class="ant-btn ant-btn-default"
+      type="button"
+    >
+      <span>
         Info
       </span>
     </button>
@@ -230,7 +243,7 @@ exports[`renders ./components/modal/demo/info.md correctly 1`] = `
   </div>
   <div
     class="ant-space-item"
-    style="padding-bottom:8px"
+    style="margin-right:8px;padding-bottom:8px"
   >
     <button
       class="ant-btn ant-btn-default"
@@ -238,6 +251,19 @@ exports[`renders ./components/modal/demo/info.md correctly 1`] = `
     >
       <span>
         Warning
+      </span>
+    </button>
+  </div>
+  <div
+    class="ant-space-item"
+    style="padding-bottom:8px"
+  >
+    <button
+      class="ant-btn ant-btn-default"
+      type="button"
+    >
+      <span>
+        Trigger Info Modal with Open Method
       </span>
     </button>
   </div>

--- a/components/modal/__tests__/hook.test.tsx
+++ b/components/modal/__tests__/hook.test.tsx
@@ -17,7 +17,7 @@ jest.mock('rc-motion');
 describe('Modal.hook', () => {
   // Inject CSSMotion to replace with No transition support
   const MockCSSMotion = genCSSMotion(false);
-  Object.keys(MockCSSMotion).forEach(key => {
+  Object.keys(MockCSSMotion).forEach((key) => {
     // @ts-ignore
     CSSMotion[key] = MockCSSMotion[key];
   });
@@ -36,7 +36,7 @@ describe('Modal.hook', () => {
               instance = modal.confirm({
                 content: (
                   <Context.Consumer>
-                    {name => <div className="test-hook">{name}</div>}
+                    {(name) => <div className="test-hook">{name}</div>}
                   </Context.Consumer>
                 ),
               });
@@ -138,6 +138,44 @@ describe('Modal.hook', () => {
     expect(cancelCount).toEqual(2); // click modal wrapper, trigger onCancel
   });
 
+  it('modal.open should trigger onCancel', () => {
+    let cancelCount = 0;
+    const Demo = () => {
+      const [modal, contextHolder] = Modal.useModal();
+
+      const openBrokenModal = React.useCallback(() => {
+        modal.open({
+          okType: 'default',
+          maskClosable: true,
+          okCancel: true,
+          onCancel: () => {
+            cancelCount += 1;
+          },
+          content: 'Hello!',
+        });
+      }, [modal]);
+
+      return (
+        <div className="App">
+          {contextHolder}
+          <div className="open-hook-modal-btn" onClick={openBrokenModal}>
+            Test hook modal
+          </div>
+        </div>
+      );
+    };
+
+    const { container } = render(<Demo />);
+
+    fireEvent.click(container.querySelectorAll('.open-hook-modal-btn')[0]);
+    fireEvent.click(document.body.querySelectorAll('.ant-modal-footer .ant-btn')[0]);
+    expect(cancelCount).toEqual(1); // click cancel btn, trigger onCancel
+
+    fireEvent.click(container.querySelectorAll('.open-hook-modal-btn')[0]);
+    fireEvent.click(document.body.querySelectorAll('.ant-modal-wrap')[0]);
+    expect(cancelCount).toEqual(2); // click modal wrapper, trigger onCancel
+  });
+
   it('update before render', () => {
     const Demo = () => {
       const [modal, contextHolder] = Modal.useModal();
@@ -213,7 +251,7 @@ describe('Modal.hook', () => {
           closable: true,
           keyboard: true,
           maskClosable: true,
-          onCancel: close => mockFn(close),
+          onCancel: (close) => mockFn(close),
         });
       }, [modal]);
 
@@ -283,7 +321,7 @@ describe('Modal.hook', () => {
 
     expect(document.body.querySelectorAll('.ant-modal-confirm-confirm')).toHaveLength(1);
 
-    mockFn.mockImplementation(close => close());
+    mockFn.mockImplementation((close) => close());
 
     // Click the Cancel button to close (valid)
     fireEvent.click(document.body.querySelectorAll('.ant-modal-confirm-btns > .ant-btn')[0]);

--- a/components/modal/confirm.tsx
+++ b/components/modal/confirm.tsx
@@ -24,7 +24,7 @@ export type ModalFunc = (props: ModalFuncProps) => {
   update: (configUpdate: ConfigUpdate) => void;
 };
 
-export type ModalStaticFunctions = Record<NonNullable<ModalFuncProps['type']>, ModalFunc>;
+export type ModalStaticFunctions = Record<NonNullable<ModalFuncProps['type'] | 'open'>, ModalFunc>;
 
 export default function confirm(config: ModalFuncProps) {
   const container = document.createDocumentFragment();
@@ -33,7 +33,7 @@ export default function confirm(config: ModalFuncProps) {
   let timeoutId: NodeJS.Timeout;
 
   function destroy(...args: any[]) {
-    const triggerCancel = args.some(param => param && param.triggerCancel);
+    const triggerCancel = args.some((param) => param && param.triggerCancel);
     if (config.onCancel && triggerCancel) {
       config.onCancel(() => {}, ...args.slice(1));
     }
@@ -119,6 +119,13 @@ export default function confirm(config: ModalFuncProps) {
   return {
     destroy: close,
     update,
+  };
+}
+
+export function withDefault(props: ModalFuncProps): ModalFuncProps {
+  return {
+    okCancel: true,
+    ...props,
   };
 }
 

--- a/components/modal/demo/info.md
+++ b/components/modal/demo/info.md
@@ -17,8 +17,33 @@ In the various types of information modal dialog, only one button to close dialo
 import { Button, Modal, Space } from 'antd';
 import React from 'react';
 
+const open = () => {
+  Modal.open({
+    title: 'This is a modal message',
+    content: (
+      <div>
+        <p>You can use Modal.open to invoke modal with same styles like Modal Component</p>
+      </div>
+    ),
+  });
+};
+
 const info = () => {
   Modal.info({
+    title: 'This is a notification message',
+    content: (
+      <div>
+        <p>some messages...some messages...</p>
+        <p>some messages...some messages...</p>
+      </div>
+    ),
+    onOk() {},
+  });
+};
+
+const openInfo = () => {
+  Modal.open({
+    type: 'info',
     title: 'This is a notification message',
     content: (
       <div>
@@ -38,6 +63,7 @@ const success = () => {
 
 const error = () => {
   Modal.error({
+    type: 'success',
     title: 'This is an error message',
     content: 'some messages...some messages...',
   });
@@ -52,10 +78,12 @@ const warning = () => {
 
 const App: React.FC = () => (
   <Space wrap>
+    <Button onClick={open}>Open</Button>
     <Button onClick={info}>Info</Button>
     <Button onClick={success}>Success</Button>
     <Button onClick={error}>Error</Button>
     <Button onClick={warning}>Warning</Button>
+    <Button onClick={openInfo}>Trigger Info Modal with Open Method</Button>
   </Space>
 );
 

--- a/components/modal/index.tsx
+++ b/components/modal/index.tsx
@@ -1,6 +1,7 @@
 import type { ModalStaticFunctions } from './confirm';
 import confirm, {
   modalGlobalConfig,
+  withDefault,
   withConfirm,
   withError,
   withInfo,
@@ -28,6 +29,16 @@ type ModalType = typeof OriginModal &
 const Modal = OriginModal as ModalType;
 
 Modal.useModal = useModal;
+
+Modal.open = function openFn(props: ModalFuncProps) {
+  if (
+    props.type &&
+    ['info', 'success', 'error', 'warn', 'warning', 'confirm'].includes(props.type)
+  ) {
+    return Modal[props.type](props);
+  }
+  return confirm(withDefault(props));
+};
 
 Modal.info = function infoFn(props: ModalFuncProps) {
   return confirm(withInfo(props));

--- a/components/modal/index.zh-CN.md
+++ b/components/modal/index.zh-CN.md
@@ -58,6 +58,7 @@ cover: https://gw.alipayobjects.com/zos/alicdn/3StSdUlSH/Modal.svg
 
 包括：
 
+- `Modal.open`
 - `Modal.info`
 - `Modal.success`
 - `Modal.error`

--- a/components/modal/useModal/index.tsx
+++ b/components/modal/useModal/index.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import usePatchElement from '../../_util/hooks/usePatchElement';
 import type { ModalStaticFunctions } from '../confirm';
-import { withConfirm, withError, withInfo, withSuccess, withWarn } from '../confirm';
+import { withConfirm, withDefault, withError, withInfo, withSuccess, withWarn } from '../confirm';
 import type { ModalFuncProps } from '../Modal';
 import type { HookModalRef } from './HookModal';
 import HookModal from './HookModal';
@@ -36,7 +36,7 @@ export default function useModal(): [Omit<ModalStaticFunctions, 'warn'>, React.R
   React.useEffect(() => {
     if (actionQueue.length) {
       const cloneQueue = [...actionQueue];
-      cloneQueue.forEach(action => {
+      cloneQueue.forEach((action) => {
         action();
       });
 
@@ -75,7 +75,7 @@ export default function useModal(): [Omit<ModalStaticFunctions, 'warn'>, React.R
             if (modalRef.current) {
               destroyAction();
             } else {
-              setActionQueue(prev => [...prev, destroyAction]);
+              setActionQueue((prev) => [...prev, destroyAction]);
             }
           },
           update: (newConfig: ModalFuncProps) => {
@@ -86,7 +86,7 @@ export default function useModal(): [Omit<ModalStaticFunctions, 'warn'>, React.R
             if (modalRef.current) {
               updateAction();
             } else {
-              setActionQueue(prev => [...prev, updateAction]);
+              setActionQueue((prev) => [...prev, updateAction]);
             }
           },
         };
@@ -101,6 +101,7 @@ export default function useModal(): [Omit<ModalStaticFunctions, 'warn'>, React.R
       error: getConfirmFunc(withError),
       warning: getConfirmFunc(withWarn),
       confirm: getConfirmFunc(withConfirm),
+      open: getConfirmFunc(withDefault),
     }),
     [],
   );


### PR DESCRIPTION
### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 💡 Background and solution

Add `Modal.open` method to support invoke modal with the same styles like `Modal` component.
You can code like this
```typescript
Modal.open({
    title: 'This is a modal message',
    content: (
      <div>
        <p>You can use Modal.open to invoke modal with same styles like Modal Component</p>
      </div>
    ),
});
```
This `open` method is compatible with the original methods, just provide the `type` prop to invoke the modal like this
```typescript
Modal.open({
    type: 'info',
    title: 'This is a notification message',
    content: (
      <div>
        <p>some messages...some messages...</p>
        <p>some messages...some messages...</p>
      </div>
    ),
    onOk() {},
});
```
and you will get

![antd-modal-min](https://user-images.githubusercontent.com/9403654/202233871-0c22eae6-5017-41b4-8911-0d405bf23bfe.gif)

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    add Modal.open method       |
| 🇨🇳 Chinese |    增加 Modal.open 方法      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
