### PR TITLE
style: fix SubMenu offset 

### DIFF
--- a/components/menu/MenuContext.tsx
+++ b/components/menu/MenuContext.tsx
@@ -1,4 +1,5 @@
 import { createContext } from 'react';
+import type { MenuProps } from 'rc-menu';
 import type { DirectionType } from '../config-provider';
 
 export type MenuTheme = 'light' | 'dark';
@@ -7,6 +8,7 @@ export interface MenuContextProps {
   prefixCls: string;
   inlineCollapsed: boolean;
   direction?: DirectionType;
+  mode?: MenuProps['mode'];
   theme?: MenuTheme;
   firstLevel: boolean;
   /** @internal Safe to remove */

--- a/components/menu/SubMenu.tsx
+++ b/components/menu/SubMenu.tsx
@@ -30,7 +30,7 @@ export interface SubMenuProps {
 function SubMenu(props: SubMenuProps) {
   const { popupClassName, icon, title, theme: customTheme } = props;
   const context = React.useContext(MenuContext);
-  const { prefixCls, inlineCollapsed, theme: contextTheme } = context;
+  const { prefixCls, inlineCollapsed, theme: contextTheme, mode } = context;
 
   const parentPath = useFullPath();
 
@@ -68,10 +68,12 @@ function SubMenu(props: SubMenuProps) {
     [context],
   );
 
+  const popupOffset = mode === 'horizontal' ? [0, 8] : [10, 0];
+
   return (
     <MenuContext.Provider value={contextValue}>
       <RcSubMenu
-        popupOffset={[10, 0]}
+        popupOffset={popupOffset}
         {...omit(props, ['icon'])}
         title={titleNode}
         popupClassName={classNames(

--- a/components/menu/menu.tsx
+++ b/components/menu/menu.tsx
@@ -138,6 +138,7 @@ const InternalMenu = forwardRef<RcMenuRef, InternalMenuProps>((props, ref) => {
       direction,
       firstLevel: true,
       theme,
+      mode: mergedMode,
       disableMenuItemTitleTooltip: _internalDisableMenuItemTitleTooltip,
     }),
     [prefixCls, mergedInlineCollapsed, direction, _internalDisableMenuItemTitleTooltip, theme],


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.

Before submitting your pull request, please make sure the checklist below is confirmed.

Your pull requests will be merged after one of the collaborators approve.

Thank you!

-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
-->
https://github.com/ant-design/ant-design/issues/38463#issuecomment-1318720244

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

https://github.com/ant-design/ant-design/pull/38495 改错了。

![图片](https://user-images.githubusercontent.com/507615/202487229-aec71a63-9581-4690-9f14-032e06ce528a.png)
SubMenu 错位了。

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     --      |
| 🇨🇳 Chinese |   --        |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
