### PR TITLE
docs: correct demo style for tag

### DIFF
--- a/components/tag/demo/colorful-inverse.md
+++ b/components/tag/demo/colorful-inverse.md
@@ -10,4 +10,4 @@ Internal inverse color tag
 .code-box-demo .ant-tag {
   margin-bottom: 8px;
 }
-<style>
+</style>

--- a/components/tag/demo/colorful.md
+++ b/components/tag/demo/colorful.md
@@ -10,4 +10,4 @@ We preset a series of colorful tag styles for use in different situations. You c
 .code-box-demo .ant-tag {
   margin-bottom: 8px;
 }
-<style>
+</style>


### PR DESCRIPTION
[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 💡 Background and solution

修复 tag 部分 demo 样式缺失的问题，原因是 style 闭合标签格式有误，全局搜了下只有 tag 这两个 demo 存在该问题

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
