### PR TITLE
docs: correct search bar space in header

### DIFF
--- a/.dumi/theme/slots/Header/index.tsx
+++ b/.dumi/theme/slots/Header/index.tsx
@@ -43,6 +43,11 @@ const useStyle = () => {
         text-align: center;
       }
 
+      .nav-search-wrapper {
+        flex: auto;
+        display: flex;
+      }
+
       .dumi-default-search-bar {
         border-inline-start: 1px solid rgba(0,0,0,.06);
 
@@ -383,7 +388,9 @@ const Header: React.FC<HeaderProps> = (props) => {
           <Logo {...sharedProps} location={location} />
         </Col>
         <Col {...colProps[1]} css={style.menuRow}>
-          <DumiSearchBar />
+          <div className="nav-search-wrapper">
+            <DumiSearchBar />
+          </div>
           {!isMobile && menu}
         </Col>
       </Row>


### PR DESCRIPTION
[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 💡 Background and solution

修复更换 SearchBar 以后导航头宽度异常的问题

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
