### PR TITLE
fix(dumi): use important when setting code style

### DIFF
--- a/.dumi/theme/common/GlobalStyles.tsx
+++ b/.dumi/theme/common/GlobalStyles.tsx
@@ -1154,9 +1154,9 @@ const GlobalStyles = () => {
               margin: 0;
 
               code {
-                background: ${token.colorBgContainer};
-                border: none;
-                box-shadow: unset;
+                background: ${token.colorBgContainer} !important;
+                border: none !important;
+                box-shadow: unset !important;
               }
             }
 

--- a/.dumi/theme/common/GlobalStyles.tsx
+++ b/.dumi/theme/common/GlobalStyles.tsx
@@ -1046,6 +1046,13 @@ const GlobalStyles = () => {
                 margin: 0;
                 padding: 0;
                 background: ${token.colorBgContainer};
+                width: auto;
+
+                code {
+                  background: ${token.colorBgContainer};
+                  border: none;
+                  box-shadow: unset;
+                }
               }
 
               &:not(:first-child) {
@@ -1147,17 +1154,6 @@ const GlobalStyles = () => {
             .highlight-wrapper:hover &-codesandbox,
             .highlight-wrapper:hover &-riddle {
               opacity: 1;
-            }
-
-            pre {
-              width: auto;
-              margin: 0;
-
-              code {
-                background: ${token.colorBgContainer} !important;
-                border: none !important;
-                box-shadow: unset !important;
-              }
             }
 
             &-debug {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.

Before submitting your pull request, please make sure the checklist below is confirmed.

Your pull requests will be merged after one of the collaborators approve.

Thank you!

-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [X] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
-->

Similar to this issue: #38680

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->
The ones provided by the prism override the styles we set manually.

<img width="1439" alt="image" src="https://user-images.githubusercontent.com/22126563/202687848-e9fb927c-3296-4419-a8ed-25f7ec487442.png">

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Mandatory styling via `!important` to prevent styles from being overwritten by prism     |
| 🇨🇳 Chinese |      通过 !important 强制设置样式以防止样式被 prism 覆盖     |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [X] Doc is updated/provided or not needed
- [X] Demo is updated/provided or not needed
- [X] TypeScript definition is updated/provided or not needed
- [X] Changelog is provided or not needed
