### PR TITLE
fix(menu): menu horizontal border bottom when dark

### DIFF
--- a/components/menu/style/theme.tsx
+++ b/components/menu/style/theme.tsx
@@ -154,6 +154,12 @@ const getThemeStyle = (token: MenuToken, themeSuffix: string): CSSInterpolation 
 
       // ====================== Horizontal ======================
       [`&${componentCls}-horizontal`]: {
+        ...(themeSuffix === 'dark'
+          ? {
+              borderBottom: 0,
+            }
+          : {}),
+
         [`> ${componentCls}-item, > ${componentCls}-submenu`]: {
           top: colorActiveBarBorderSize,
           marginTop: -colorActiveBarBorderSize,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.

Before submitting your pull request, please make sure the checklist below is confirmed.

Your pull requests will be merged after one of the collaborators approve.

Thank you!

-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [X] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
-->

Closes: #38734

### 💡 Background and solution
Set the border-bottom of `menu-horizontal` to 0 in the dark mode in the same way as antd@4.X.

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Fix Menu 1px higher when `theme="dark"`.   |
| 🇨🇳 Chinese |  修复 Menu 深色 theme 下高度多了 1px 的问题。  |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [X] Doc is updated/provided or not needed
- [X] Demo is updated/provided or not needed
- [X] TypeScript definition is updated/provided or not needed
- [X] Changelog is provided or not needed
