### PR TITLE
docs: improve icon copied style

### DIFF
--- a/.dumi/theme/common/GlobalStyles.tsx
+++ b/.dumi/theme/common/GlobalStyles.tsx
@@ -1280,6 +1280,7 @@ const GlobalStyles = () => {
                 width: 100%;
                 height: 100%;
                 color: #fff;
+                background: #1677ff;
                 line-height: 110px;
                 text-align: center;
                 opacity: 0;
@@ -1288,7 +1289,6 @@ const GlobalStyles = () => {
               }
 
               &.copied::after {
-                top: -10px;
                 opacity: 1;
               }
             }


### PR DESCRIPTION
Fixed the click text display issue

<!--
First of all, thank you for your contribution! 😄

For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.

Before submitting your pull request, please make sure the checklist below is confirmed.

Your pull requests will be merged after one of the collaborators approve.

Thank you!

-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Icon component page style optimization. Original: After clicking, moving the mouse away will show white text that is not clear, now: white text and blue background appear after clicking      |
| 🇨🇳 Chinese |     图标组件页面样式优化。原：点击之后移开鼠标会显示白色文字看不清，现：点击之后出现白色文字以及蓝色背景     |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
