### PR TITLE
fix: Table children expand icons shouldn't be same line with parent's icon

### DIFF
--- a/components/table/style/expand.tsx
+++ b/components/table/style/expand.tsx
@@ -48,6 +48,7 @@ const genExpandStyle: GenerateStyle<TableToken, CSSObject> = (token) => {
 
       [`${componentCls}-row-indent`]: {
         height: 1,
+        float: 'left',
       },
 
       [`${componentCls}-row-expand-icon`]: {


### PR DESCRIPTION
To fix this issue just replaced `float: left;` and 'margin-top` to 'vertical-align: middle`.

![and design table expand demo](https://user-images.githubusercontent.com/22126563/202742965-afa5bb05-12ce-4b9e-a403-dd99af3f2aeb.png)

Related issue link
fix #38713

