### PR TITLE
docs(badge): add debug demo

### DIFF
--- a/components/badge/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/badge/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -1475,6 +1475,202 @@ exports[`renders ./components/badge/demo/offset.md extend context correctly 1`] 
 </span>
 `;
 
+exports[`renders ./components/badge/demo/offset-debug.md extend context correctly 1`] = `
+Array [
+  <form
+    class="ant-form ant-form-horizontal"
+  >
+    <div
+      class="ant-form-item"
+    >
+      <div
+        class="ant-row ant-form-item-row"
+      >
+        <div
+          class="ant-col ant-form-item-label"
+        >
+          <label
+            class=""
+            for="x"
+            title="offsetX"
+          >
+            offsetX
+          </label>
+        </div>
+        <div
+          class="ant-col ant-form-item-control"
+        >
+          <div
+            class="ant-form-item-control-input"
+          >
+            <div
+              class="ant-form-item-control-input-content"
+            >
+              <div
+                class="ant-slider ant-slider-horizontal"
+              >
+                <div
+                  class="ant-slider-rail"
+                />
+                <div
+                  class="ant-slider-track"
+                  style="left:0%;width:60%"
+                />
+                <div
+                  class="ant-slider-step"
+                />
+                <div
+                  aria-disabled="false"
+                  aria-valuemax="50"
+                  aria-valuemin="-50"
+                  aria-valuenow="10"
+                  class="ant-slider-handle"
+                  role="slider"
+                  style="left:60%;transform:translateX(-50%)"
+                  tabindex="0"
+                />
+                <div>
+                  <div
+                    class="ant-tooltip ant-slider-tooltip"
+                    style="opacity:0"
+                  >
+                    <div
+                      class="ant-tooltip-content"
+                    >
+                      <div
+                        class="ant-tooltip-arrow"
+                      >
+                        <span
+                          class="ant-tooltip-arrow-content"
+                        />
+                      </div>
+                      <div
+                        class="ant-tooltip-inner"
+                        role="tooltip"
+                      >
+                        10
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="ant-form-item"
+    >
+      <div
+        class="ant-row ant-form-item-row"
+      >
+        <div
+          class="ant-col ant-form-item-label"
+        >
+          <label
+            class=""
+            for="y"
+            title="offsetY"
+          >
+            offsetY
+          </label>
+        </div>
+        <div
+          class="ant-col ant-form-item-control"
+        >
+          <div
+            class="ant-form-item-control-input"
+          >
+            <div
+              class="ant-form-item-control-input-content"
+            >
+              <div
+                class="ant-slider ant-slider-horizontal"
+              >
+                <div
+                  class="ant-slider-rail"
+                />
+                <div
+                  class="ant-slider-track"
+                  style="left:0%;width:60%"
+                />
+                <div
+                  class="ant-slider-step"
+                />
+                <div
+                  aria-disabled="false"
+                  aria-valuemax="50"
+                  aria-valuemin="-50"
+                  aria-valuenow="10"
+                  class="ant-slider-handle"
+                  role="slider"
+                  style="left:60%;transform:translateX(-50%)"
+                  tabindex="0"
+                />
+                <div>
+                  <div
+                    class="ant-tooltip ant-slider-tooltip"
+                    style="opacity:0"
+                  >
+                    <div
+                      class="ant-tooltip-content"
+                    >
+                      <div
+                        class="ant-tooltip-arrow"
+                      >
+                        <span
+                          class="ant-tooltip-arrow-content"
+                        />
+                      </div>
+                      <div
+                        class="ant-tooltip-inner"
+                        role="tooltip"
+                      >
+                        10
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </form>,
+  <span
+    class="ant-badge"
+  >
+    <span
+      class="ant-avatar ant-avatar-lg ant-avatar-square"
+    >
+      <span
+        class="ant-avatar-string"
+        style="opacity:0"
+      />
+    </span>
+    <sup
+      class="ant-scroll-number ant-badge-count"
+      data-show="true"
+      style="margin-top:10px;right:-10px"
+      title="5"
+    >
+      <span
+        class="ant-scroll-number-only"
+        style="transition:none"
+      >
+        <span
+          class="ant-scroll-number-only-unit current"
+        >
+          5
+        </span>
+      </span>
+    </sup>
+  </span>,
+]
+`;
+
 exports[`renders ./components/badge/demo/overflow.md extend context correctly 1`] = `
 Array [
   <span

--- a/components/badge/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/badge/__tests__/__snapshots__/demo.test.ts.snap
@@ -1475,6 +1475,154 @@ exports[`renders ./components/badge/demo/offset.md correctly 1`] = `
 </span>
 `;
 
+exports[`renders ./components/badge/demo/offset-debug.md correctly 1`] = `
+Array [
+  <form
+    class="ant-form ant-form-horizontal"
+  >
+    <div
+      class="ant-form-item"
+    >
+      <div
+        class="ant-row ant-form-item-row"
+      >
+        <div
+          class="ant-col ant-form-item-label"
+        >
+          <label
+            class=""
+            for="x"
+            title="offsetX"
+          >
+            offsetX
+          </label>
+        </div>
+        <div
+          class="ant-col ant-form-item-control"
+        >
+          <div
+            class="ant-form-item-control-input"
+          >
+            <div
+              class="ant-form-item-control-input-content"
+            >
+              <div
+                class="ant-slider ant-slider-horizontal"
+              >
+                <div
+                  class="ant-slider-rail"
+                />
+                <div
+                  class="ant-slider-track"
+                  style="left:0%;width:60%"
+                />
+                <div
+                  class="ant-slider-step"
+                />
+                <div
+                  aria-disabled="false"
+                  aria-valuemax="50"
+                  aria-valuemin="-50"
+                  aria-valuenow="10"
+                  class="ant-slider-handle"
+                  role="slider"
+                  style="left:60%;transform:translateX(-50%)"
+                  tabindex="0"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="ant-form-item"
+    >
+      <div
+        class="ant-row ant-form-item-row"
+      >
+        <div
+          class="ant-col ant-form-item-label"
+        >
+          <label
+            class=""
+            for="y"
+            title="offsetY"
+          >
+            offsetY
+          </label>
+        </div>
+        <div
+          class="ant-col ant-form-item-control"
+        >
+          <div
+            class="ant-form-item-control-input"
+          >
+            <div
+              class="ant-form-item-control-input-content"
+            >
+              <div
+                class="ant-slider ant-slider-horizontal"
+              >
+                <div
+                  class="ant-slider-rail"
+                />
+                <div
+                  class="ant-slider-track"
+                  style="left:0%;width:60%"
+                />
+                <div
+                  class="ant-slider-step"
+                />
+                <div
+                  aria-disabled="false"
+                  aria-valuemax="50"
+                  aria-valuemin="-50"
+                  aria-valuenow="10"
+                  class="ant-slider-handle"
+                  role="slider"
+                  style="left:60%;transform:translateX(-50%)"
+                  tabindex="0"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </form>,
+  <span
+    class="ant-badge"
+  >
+    <span
+      class="ant-avatar ant-avatar-lg ant-avatar-square"
+    >
+      <span
+        class="ant-avatar-string"
+        style="opacity:0"
+      />
+    </span>
+    <sup
+      class="ant-scroll-number ant-badge-count"
+      data-show="true"
+      style="margin-top:10px;right:-10px"
+      title="5"
+    >
+      <span
+        class="ant-scroll-number-only"
+        style="transition:none"
+      >
+        <span
+          class="ant-scroll-number-only-unit current"
+        >
+          5
+        </span>
+      </span>
+    </sup>
+  </span>,
+]
+`;
+
 exports[`renders ./components/badge/demo/overflow.md correctly 1`] = `
 Array [
   <span

--- a/components/badge/demo/offset-debug.md
+++ b/components/badge/demo/offset-debug.md
@@ -1,0 +1,47 @@
+---
+order: 6
+title:
+  zh-CN: Offset-Debug
+  en-US: Offset-Debug
+debug: true
+---
+
+## zh-CN
+
+调试使用
+
+## en-US
+
+Debug Usage
+
+```tsx
+import { Avatar, Badge, Slider, Form } from 'antd';
+import React from 'react';
+
+const App: React.FC = () => {
+  const [offset, setOffset] = React.useState<[number, number]>([10, 10]);
+
+  return (
+    <>
+      <Form
+        initialValues={{ x: 10, y: 10 }}
+        onValuesChange={(_, { x, y }) => {
+          setOffset([x, y]);
+        }}
+      >
+        <Form.Item label="offsetX" name="x">
+          <Slider min={-50} max={50} />
+        </Form.Item>
+        <Form.Item label="offsetY" name="y">
+          <Slider min={-50} max={50} />
+        </Form.Item>
+      </Form>
+      <Badge count={5} offset={offset}>
+        <Avatar shape="square" size="large" />
+      </Badge>
+    </>
+  );
+};
+
+export default App;
+```


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.

Before submitting your pull request, please make sure the checklist below is confirmed.

Your pull requests will be merged after one of the collaborators approve.

Thank you!

-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [x] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
-->

### 💡 Background and solution

在解决 #38806 问题时，参考 v4 的自定义 `offset` Demo，在设置 `direction=rtl`  时，实际渲染的样式问题。

我们是否应该将这里的 left 也设置为负数? 没有看到有关的测试用例，所以我添加了一个调试 demo
https://github.com/ant-design/ant-design/blob/269afad438753261b883c9b619f98012ac558c65/components/badge/index.tsx#L111

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
