### PR TITLE
fix(Upload): add flushSync for onChange in control mode

### DIFF
--- a/components/upload/Upload.tsx
+++ b/components/upload/Upload.tsx
@@ -114,7 +114,9 @@ const InternalUpload: React.ForwardRefRenderFunction<unknown, UploadProps> = (pr
       changeInfo.event = event;
     }
 
-    onChange?.(changeInfo);
+    if (onChange) {
+      flushSync(() => onChange(changeInfo));
+    }
   };
 
   const mergedBeforeUpload = async (file: RcFile, fileListArgs: RcFile[]) => {

--- a/components/upload/__tests__/upload.test.tsx
+++ b/components/upload/__tests__/upload.test.tsx
@@ -951,3 +951,50 @@ describe('Upload', () => {
     );
   });
 });
+
+it('Prevent auto batch in control mode', async () => {
+  const mockFile1 = new File(['bamboo'], 'bamboo.png', { type: 'image/png' });
+  const mockFile2 = new File(['light'], 'light.png', { type: 'image/png' });
+
+  const customRequest = jest.fn(async options => {
+    // stop here to make sure new fileList has been set and passed to Upload
+    // eslint-disable-next-line no-promise-executor-return
+    await new Promise(resolve => setTimeout(resolve, 0));
+    options.onProgress({ percent: 0 });
+    const url = Promise.resolve('https://ant.design');
+    options.onProgress({ percent: 100 });
+    options.onSuccess({}, { ...options.file, url });
+  });
+
+  let fileListOut: UploadProps['fileList'] = [];
+
+  const Demo: React.FC = () => {
+    const [fileList, setFileList] = React.useState<UploadFile[]>([]);
+
+    const onChange: UploadProps['onChange'] = async e => {
+      const newFileList = Array.isArray(e) ? e : e.fileList;
+      setFileList(newFileList);
+
+      fileListOut = newFileList;
+    };
+
+    return (
+      <Upload customRequest={customRequest} onChange={onChange} fileList={fileList}>
+        <button type="button">Upload</button>
+      </Upload>
+    );
+  };
+
+  const { container } = render(<Demo />);
+
+  fireEvent.change(container.querySelector('input')!, {
+    target: { files: [mockFile1, mockFile2] },
+  });
+
+  // React 18 is async now
+  await waitFakeTimer();
+
+  fileListOut.forEach(file => {
+    expect(file.status).toBe('done');
+  });
+});


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

新特性请提交至 feature 分支，其余可提交至 master 分支。
在维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

[[English Template / 英文模板](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE.md)]

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

https://github.com/ant-design/ant-design/issues/38545

### 💡 需求背景和解决方案

需求背景:  React版本为v18时, Upload组件在受控模式下并且同时上传多个文件时, onChange里的fileList内容是过期的, 并不是最新的. 原因是React 18中对时间间隔较短的状态更新进行了批量处理。

解决方案: 对传入的onChange函数用flushSync处理.

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | Fix Upload trigger mistake files status when upload multiple files at same time and both in control mode in React 18.[#38545](https://github.com/ant-design/ant-design/issues/38545) |
| 🇨🇳 中文 | 修复 Upload 在 React 18 下并且在受控状态时同时上传多份文件会出现上传状态不正确的问题。[#38545](https://github.com/ant-design/ant-design/issues/38545) |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供