### PR TITLE
fix: Modal嵌套Form关闭之后闪烁

### DIFF
--- a/components/form/demo/form-context.tsx
+++ b/components/form/demo/form-context.tsx
@@ -49,7 +49,7 @@ const ModalForm: React.FC<ModalFormProps> = ({ open, onCancel }) => {
   };
 
   return (
-    <Modal title="Basic Drawer" open={open} onOk={onOk} onCancel={onCancel}>
+    <Modal title="Basic Drawer" destroyOnClose open={open} onOk={onOk} onCancel={onCancel}>
       <Form form={form} layout="vertical" name="userForm">
         <Form.Item name="name" label="User Name" rules={[{ required: true }]}>
           <Input />

--- a/components/form/demo/form-in-modal.tsx
+++ b/components/form/demo/form-in-modal.tsx
@@ -22,6 +22,7 @@ const CollectionCreateForm: React.FC<CollectionCreateFormProps> = ({
   return (
     <Modal
       open={open}
+      destroyOnClose
       title="Create a new collection"
       okText="Create"
       cancelText="Cancel"


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.

Before submitting your pull request, please make sure the checklist below is confirmed.

Your pull requests will be merged after one of the collaborators approve.

Thank you!

-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [x] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

### 点击官网案例中的“New Collection”按钮，弹出弹窗之后关闭弹窗，会出现弹窗闪烁一下。

[https://ant.design/components/form-cn#components-form-demo-form-in-modal](https://ant.design/components/form-cn#components-form-demo-form-in-modal)

![GIF 2022-11-26 19-09-54](https://user-images.githubusercontent.com/26358837/204086121-9a6167da-c0c6-4690-9ccd-1330c3b80f1b.gif)