### PR TITLE
style: modal content width issue without modal icon

### DIFF
--- a/components/modal/style/index.tsx
+++ b/components/modal/style/index.tsx
@@ -297,6 +297,7 @@ const genModalConfirmStyle: GenerateStyle<ModalToken> = (token) => {
 
           [`+ ${confirmComponentCls}-content`]: {
             marginBlockStart: token.marginXS,
+            width: "100%"
           },
         },
 

--- a/components/modal/style/index.tsx
+++ b/components/modal/style/index.tsx
@@ -297,7 +297,7 @@ const genModalConfirmStyle: GenerateStyle<ModalToken> = (token) => {
 
           [`+ ${confirmComponentCls}-content`]: {
             marginBlockStart: token.marginXS,
-            width: "100%"
+            width: "100%",
           },
         },
 

--- a/components/modal/style/index.tsx
+++ b/components/modal/style/index.tsx
@@ -297,7 +297,7 @@ const genModalConfirmStyle: GenerateStyle<ModalToken> = (token) => {
 
           [`+ ${confirmComponentCls}-content`]: {
             marginBlockStart: token.marginXS,
-            width: "100%",
+            flexBasis: "100%",
           },
         },
 

--- a/components/modal/style/index.tsx
+++ b/components/modal/style/index.tsx
@@ -318,7 +318,6 @@ const genModalConfirmStyle: GenerateStyle<ModalToken> = (token) => {
           // `content` after `icon` should set marginLeft
           [`+ ${confirmComponentCls}-title + ${confirmComponentCls}-content`]: {
             marginInlineStart: token.modalConfirmIconSize + token.marginSM,
-            flexBasis: '100%',
           },
         },
       },


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.

Before submitting your pull request, please make sure the checklist below is confirmed.

Your pull requests will be merged after one of the collaborators approve.

Thank you!

-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [X] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
-->

### 💡 Background and solution

Modal content width is not 100% if modal has no icon.

Default state
![image](https://user-images.githubusercontent.com/12480623/204174083-461678c1-883e-48a6-828f-7f1ec9d99d7a.png)

Error State
![image](https://user-images.githubusercontent.com/12480623/204174138-8b069cf8-1979-4fc4-9e22-ea39ec5b9c65.png)

Solution
![image](https://user-images.githubusercontent.com/12480623/204174191-9ce9ea14-804f-4c73-afbf-d2ba4288cfba.png)


<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Fix Modal.info content width when no icon.     |
| 🇨🇳 Chinese |   修复 Modal.info 没有图标时的 `content` 宽度。      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
