### PR TITLE
fix(Transfer): clicking the checkbox position cannot be unchecked and onSelectChange is triggered twice

### DIFF
--- a/components/checkbox/style/index.tsx
+++ b/components/checkbox/style/index.tsx
@@ -174,6 +174,16 @@ export const genCheckboxStyle: GenerateStyle<CheckboxToken> = (token) => {
           borderColor: token.colorPrimary,
         },
       },
+
+      [`${wrapperCls}:not(${wrapperCls}-disabled)`]: {
+        [`&:hover ${checkboxCls}-checked:not(${checkboxCls}-disabled) ${checkboxCls}-inner`]: {
+          backgroundColor: token.colorPrimaryHover,
+          borderColor: 'transparent',
+        },
+        [`&:hover ${checkboxCls}-checked:not(${checkboxCls}-disabled):after`]: {
+          borderColor: token.colorPrimaryHover,
+        },
+      },
     },
 
     // ==================== Checked ====================
@@ -183,7 +193,6 @@ export const genCheckboxStyle: GenerateStyle<CheckboxToken> = (token) => {
         [`${checkboxCls}-inner`]: {
           backgroundColor: token.colorPrimary,
           borderColor: token.colorPrimary,
-          zIndex: 2,
 
           '&:after': {
             opacity: 1,
@@ -195,7 +204,6 @@ export const genCheckboxStyle: GenerateStyle<CheckboxToken> = (token) => {
         // Checked Effect
         '&:after': {
           position: 'absolute',
-          zIndex: 1,
           top: 0,
           insetInlineStart: 0,
           width: '100%',
@@ -208,6 +216,7 @@ export const genCheckboxStyle: GenerateStyle<CheckboxToken> = (token) => {
           animationTimingFunction: 'ease-in-out',
           animationFillMode: 'backwards',
           content: '""',
+          transition: `all ${token.motionDurationSlow}`,
         },
       },
 
@@ -218,6 +227,9 @@ export const genCheckboxStyle: GenerateStyle<CheckboxToken> = (token) => {
         [`&:hover ${checkboxCls}-inner`]: {
           backgroundColor: token.colorPrimaryHover,
           borderColor: 'transparent',
+        },
+        [`&:hover ${checkboxCls}:after`]: {
+          borderColor: token.colorPrimaryHover,
         },
       },
     },


### PR DESCRIPTION


<!--
First of all, thank you for your contribution! 😄

For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.

Before submitting your pull request, please make sure the checklist below is confirmed.

Your pull requests will be merged after one of the collaborators approve.

Thank you!

-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [X] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
#39030
<!--
1. Put the related issue or discussion links here.
-->

### 💡 Background and solution
该bug由PR #37973 造成, 故移除#37973的代码，并采用其他方式修复#37973想要解决的checkbox 在hover时样式问题
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     fix Transfer clicking the checkbox position cannot be unchecked and onSelectChange is triggered twice      |
| 🇨🇳 Chinese |      修复 Transfer 组件 点击复选框位置不可以取消选中，并触发了两次onSelectChange 问题    |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [X] Doc is updated/provided or not needed
- [X] Demo is updated/provided or not needed
- [X] TypeScript definition is updated/provided or not needed
- [X] Changelog is provided or not needed
