### PR TITLE
fix: submenu style

### DIFF
--- a/components/menu/style/index.tsx
+++ b/components/menu/style/index.tsx
@@ -1,4 +1,5 @@
 import { TinyColor } from '@ctrl/tinycolor';
+import type { CSSObject } from '@ant-design/cssinjs';
 import { genCollapseMotion, initSlideMotion, initZoomMotion } from '../../style/motion';
 import type { FullToken, GenerateStyle, UseComponentStyleResult } from '../../theme/internal';
 import { genComponentStyleHook, mergeToken } from '../../theme/internal';
@@ -66,6 +67,135 @@ export interface MenuToken extends FullToken<'Menu'> {
   menuSubMenuBg: string;
 }
 
+const genMenuItemStyle = (token: MenuToken): CSSObject => {
+  const {
+    componentCls,
+    fontSize,
+    motionDurationSlow,
+    motionDurationMid,
+    motionEaseInOut,
+    motionEaseOut,
+    iconCls,
+    controlHeightSM,
+  } = token;
+
+  return {
+    // >>>>> Item
+    [`${componentCls}-item, ${componentCls}-submenu-title`]: {
+      position: 'relative',
+      display: 'block',
+      margin: 0,
+      whiteSpace: 'nowrap',
+      cursor: 'pointer',
+      transition: [
+        `border-color ${motionDurationSlow}`,
+        `background ${motionDurationSlow}`,
+        `padding ${motionDurationSlow} ${motionEaseInOut}`,
+      ].join(','),
+
+      [`${componentCls}-item-icon, ${iconCls}`]: {
+        minWidth: fontSize,
+        fontSize,
+        transition: [
+          `font-size ${motionDurationMid} ${motionEaseOut}`,
+          `margin ${motionDurationSlow} ${motionEaseInOut}`,
+          `color ${motionDurationSlow}`,
+        ].join(','),
+
+        '+ span': {
+          marginInlineStart: controlHeightSM - fontSize,
+          opacity: 1,
+          transition: [
+            `opacity ${motionDurationSlow} ${motionEaseInOut}`,
+            `margin ${motionDurationSlow}`,
+            `color ${motionDurationSlow}`,
+          ].join(','),
+        },
+      },
+
+      [`${componentCls}-item-icon`]: {
+        ...resetIcon(),
+      },
+
+      [`&${componentCls}-item-only-child`]: {
+        [`> ${iconCls}, > ${componentCls}-item-icon`]: {
+          marginInlineEnd: 0,
+        },
+      },
+    },
+
+    // Disabled state sets text to gray and nukes hover/tab effects
+    [`${componentCls}-item-disabled, ${componentCls}-submenu-disabled`]: {
+      background: 'none !important',
+      cursor: 'not-allowed',
+
+      '&::after': {
+        borderColor: 'transparent !important',
+      },
+
+      a: {
+        color: 'inherit !important',
+      },
+
+      [`> ${componentCls}-submenu-title`]: {
+        color: 'inherit !important',
+        cursor: 'not-allowed',
+      },
+    },
+  };
+};
+
+const genSubMenuArrowStyle = (token: MenuToken): CSSObject => {
+  const {
+    componentCls,
+    motionDurationSlow,
+    motionEaseInOut,
+    borderRadius,
+    menuArrowSize,
+    menuArrowOffset,
+  } = token;
+
+  return {
+    [`${componentCls}-submenu`]: {
+      [`&-expand-icon, &-arrow`]: {
+        position: 'absolute',
+        top: '50%',
+        insetInlineEnd: token.margin,
+        width: menuArrowSize,
+        color: 'currentcolor',
+        transform: 'translateY(-50%)',
+        transition: `transform ${motionDurationSlow} ${motionEaseInOut}`,
+      },
+
+      '&-arrow': {
+        // →
+        '&::before, &::after': {
+          position: 'absolute',
+          width: menuArrowSize * 0.6,
+          height: menuArrowSize * 0.15,
+          backgroundColor: 'currentcolor',
+          borderRadius,
+          transition: [
+            `background ${motionDurationSlow} ${motionEaseInOut}`,
+            `transform ${motionDurationSlow} ${motionEaseInOut}`,
+            `top ${motionDurationSlow} ${motionEaseInOut}`,
+            `color ${motionDurationSlow} ${motionEaseInOut}`,
+          ].join(','),
+          content: '""',
+        },
+
+        '&::before': {
+          transform: `rotate(45deg) translateY(-${menuArrowOffset})`,
+        },
+
+        '&::after': {
+          transform: `rotate(-45deg) translateY(${menuArrowOffset})`,
+        },
+      },
+    },
+  };
+};
+
 // =============================== Base ===============================
 const getBaseStyle: GenerateStyle<MenuToken> = (token) => {
   const {
@@ -75,19 +205,15 @@ const getBaseStyle: GenerateStyle<MenuToken> = (token) => {
     motionDurationSlow,
     motionDurationMid,
     motionEaseInOut,
-    motionEaseOut,
     lineHeight,
     paddingXS,
     padding,
     colorSplit,
     lineWidth,
-    iconCls,
     zIndexPopup,
-    borderRadius,
     borderRadiusLG,
     radiusSubMenuItem,
     menuArrowSize,
-    controlHeightSM,
     menuArrowOffset,
     lineType,
     menuPanelMaskInset,
@@ -206,69 +332,8 @@ const getBaseStyle: GenerateStyle<MenuToken> = (token) => {
           },
         },
 
-        // >>>>> Item
-        [`${componentCls}-item, ${componentCls}-submenu-title`]: {
-          position: 'relative',
-          display: 'block',
-          margin: 0,
-          // paddingInline: menuItemPaddingInline,
-          whiteSpace: 'nowrap',
-          cursor: 'pointer',
-          transition: [
-            `border-color ${motionDurationSlow}`,
-            `background ${motionDurationSlow}`,
-            `padding ${motionDurationSlow} ${motionEaseInOut}`,
-          ].join(','),
-
-          [`${componentCls}-item-icon, ${iconCls}`]: {
-            minWidth: fontSize,
-            fontSize,
-            transition: [
-              `font-size ${motionDurationMid} ${motionEaseOut}`,
-              `margin ${motionDurationSlow} ${motionEaseInOut}`,
-              `color ${motionDurationSlow}`,
-            ].join(','),
-
-            '+ span': {
-              marginInlineStart: controlHeightSM - fontSize,
-              opacity: 1,
-              transition: [
-                `opacity ${motionDurationSlow} ${motionEaseInOut}`,
-                `margin ${motionDurationSlow}`,
-                `color ${motionDurationSlow}`,
-              ].join(','),
-            },
-          },
-
-          [`${componentCls}-item-icon`]: {
-            ...resetIcon(),
-          },
-
-          [`&${componentCls}-item-only-child`]: {
-            [`> ${iconCls}, > ${componentCls}-item-icon`]: {
-              marginInlineEnd: 0,
-            },
-          },
-        },
-
-        // Disabled state sets text to gray and nukes hover/tab effects
-        [`${componentCls}-item-disabled, ${componentCls}-submenu-disabled`]: {
-          background: 'none !important',
-          cursor: 'not-allowed',
-
-          '&::after': {
-            borderColor: 'transparent !important',
-          },
-
-          a: {
-            color: 'inherit !important',
-          },
-
-          [`> ${componentCls}-submenu-title`]: {
-            color: 'inherit !important',
-            cursor: 'not-allowed',
-          },
-        },
+        // Item
+        ...genMenuItemStyle(token),
 
         [`${componentCls}-item-group`]: {
           [`${componentCls}-item-group-list`]: {
@@ -312,7 +377,10 @@ const getBaseStyle: GenerateStyle<MenuToken> = (token) => {
           [`> ${componentCls}`]: {
             borderRadius: borderRadiusLG,
 
-            [`> ${componentCls}-item`]: {
+            ...genMenuItemStyle(token),
+            ...genSubMenuArrowStyle(token),
+
+            [`${componentCls}-item, ${componentCls}-submenu > ${componentCls}-submenu-title`]: {
               borderRadius: radiusSubMenuItem,
             },
 
@@ -322,43 +390,7 @@ const getBaseStyle: GenerateStyle<MenuToken> = (token) => {
           },
         },
 
-        [`${componentCls}-submenu`]: {
-          [`&-expand-icon, &-arrow`]: {
-            position: 'absolute',
-            top: '50%',
-            insetInlineEnd: token.margin,
-            width: menuArrowSize,
-            color: 'currentcolor',
-            transform: 'translateY(-50%)',
-            transition: `transform ${motionDurationSlow} ${motionEaseInOut}`,
-          },
-
-          '&-arrow': {
-            // →
-            '&::before, &::after': {
-              position: 'absolute',
-              width: menuArrowSize * 0.6,
-              height: menuArrowSize * 0.15,
-              backgroundColor: 'currentcolor',
-              borderRadius,
-              transition: [
-                `background ${motionDurationSlow} ${motionEaseInOut}`,
-                `transform ${motionDurationSlow} ${motionEaseInOut}`,
-                `top ${motionDurationSlow} ${motionEaseInOut}`,
-                `color ${motionDurationSlow} ${motionEaseInOut}`,
-              ].join(','),
-              content: '""',
-            },
-
-            '&::before': {
-              transform: `rotate(45deg) translateY(-${menuArrowOffset})`,
-            },
-
-            '&::after': {
-              transform: `rotate(-45deg) translateY(${menuArrowOffset})`,
-            },
-          },
-        },
+        ...genSubMenuArrowStyle(token),
 
         [`&-inline-collapsed ${componentCls}-submenu-arrow,
         &-inline ${componentCls}-submenu-arrow`]: {

--- a/components/menu/style/vertical.tsx
+++ b/components/menu/style/vertical.tsx
@@ -10,11 +10,11 @@ const getVerticalInlineStyle: GenerateStyle<MenuToken, CSSObject> = (token) => {
     itemMarginInline,
     padding,
     menuArrowSize,
-    fontSize,
+    marginXS,
     marginXXS,
   } = token;
 
-  const paddingWithArrow = menuArrowSize + fontSize;
+  const paddingWithArrow = padding + menuArrowSize + marginXS;
 
   return {
     [`${componentCls}-item`]: {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.

Before submitting your pull request, please make sure the checklist below is confirmed.

Your pull requests will be merged after one of the collaborators approve.

Thank you!

-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
https://github.com/ant-design/ant-design/issues/39007
<!--
1. Put the related issue or discussion links here.
-->

### 💡 Background and solution
![image](https://user-images.githubusercontent.com/27722486/204529763-ae67c17c-6667-4dc6-8d2d-f641bdfad939.png)
修复 icon 和 箭头样式错误，以及圆角、禁用样式等等都不对的问题。

submenu 偏移的问题在 antd 比较难解，原因是这里的二级菜单是 overflow 自动创建的，mode 默认还是 horizontal，所以导致三级菜单的偏移是 Y 轴的。需要在 rc-menu 层把这个问题解了，计划和 Menu 重构一起做。
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Fix Menu Submenu style when overflowed.       |
| 🇨🇳 Chinese |    修复 Menu 溢出时下拉菜单的样式问题。       |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
