### PR TITLE
fix: Close icon style problem when the TextArea attribute resize is n…

### DIFF
--- a/components/input/TextArea.tsx
+++ b/components/input/TextArea.tsx
@@ -197,7 +197,7 @@ const TextArea = React.forwardRef<TextAreaRef, TextAreaProps>(
           getStatusClassNames(prefixCls, mergedStatus),
           hashId,
         )}
-        style={showCount ? { resize: style?.resize } : style}
+        style={showCount ? { resize: style?.resize, height: style?.height } : style}
         prefixCls={prefixCls}
         onCompositionStart={onInternalCompositionStart}
         onChange={handleChange}
@@ -256,7 +256,7 @@ const TextArea = React.forwardRef<TextAreaRef, TextAreaProps>(
             className,
             hashId,
           )}
-          style={style}
+          style={style && omit(style, ['height'])}
           data-count={dataCount}
         >
           {textareaNode}

--- a/components/input/style/index.tsx
+++ b/components/input/style/index.tsx
@@ -566,6 +566,7 @@ const genAllowClearStyle = (token: InputToken): CSSObject => {
     '&-textarea-with-clear-btn': {
       padding: '0 !important',
       border: '0 !important',
+      width: 'auto',
 
       [`${componentCls}-clear-icon`]: {
         position: 'absolute',

--- a/components/input/style/index.tsx
+++ b/components/input/style/index.tsx
@@ -899,6 +899,9 @@ const genTextAreaStyle: GenerateStyle<InputToken> = (token) => {
       },
 
       '&-show-count': {
+        display: 'inline-block',
+        width: 'auto',
+
         // https://github.com/ant-design/ant-design/issues/33049
         [`> ${componentCls}`]: {
           height: '100%',


### PR DESCRIPTION
…ot none

<!--
First of all, thank you for your contribution! 😄

For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.

Before submitting your pull request, please make sure the checklist below is confirmed.

Your pull requests will be merged after one of the collaborators approve.

Thank you!

-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

fix #39099 

<!--
1. Put the related issue or discussion links here.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   fix Close icon style problem when the TextArea attribute resize is not none   |
| 🇨🇳 Chinese |   修复了当TextArea属性的resize不是none时关闭图标样式的问题       |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
