### PR TITLE
fix: textarea reset style

### DIFF
--- a/components/input/style/index.tsx
+++ b/components/input/style/index.tsx
@@ -180,12 +180,7 @@ export const genBasicInputStyle = (token: InputToken): CSSObject => ({
     lineHeight: token.lineHeight,
     verticalAlign: 'bottom',
     transition: `all ${token.motionDurationSlow}, height 0s`,
-  },
-
-  '&-textarea': {
-    '&-rtl': {
-      direction: 'rtl',
-    },
+    resize: 'vertical',
   },
 
   // Size
@@ -196,7 +191,12 @@ export const genBasicInputStyle = (token: InputToken): CSSObject => ({
     ...genInputSmallStyle(token),
   },
 
+  // RTL
   '&-rtl': {
+    direction: 'rtl',
+  },
+
+  '&-textarea-rtl': {
     direction: 'rtl',
   },
 });


### PR DESCRIPTION


<!--
First of all, thank you for your contribution! 😄

For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.

Before submitting your pull request, please make sure the checklist below is confirmed.

Your pull requests will be merged after one of the collaborators approve.

Thank you!

-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
-->
close #39099
close #39113

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Fix Input.TextArea resize behavior by adding reset style.        |
| 🇨🇳 Chinese |  修复 Input.TextArea 没有重置样式导致 resize 行为和 4.x 不一致的问题。         |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
