### PR TITLE
fix: textarea attr(data-count) style

### DIFF
--- a/components/input/style/index.tsx
+++ b/components/input/style/index.tsx
@@ -911,6 +911,12 @@ const genTextAreaStyle: GenerateStyle<InputToken> = (token) => {
           float: 'right',
         },
       },
+
+      '&-rtl': {
+        '&::after': {
+          float: 'left',
+        },
+      },
     },
   };
 };

--- a/components/input/style/index.tsx
+++ b/components/input/style/index.tsx
@@ -904,15 +904,11 @@ const genTextAreaStyle: GenerateStyle<InputToken> = (token) => {
         },
 
         '&::after': {
-          position: 'absolute',
-          bottom: 0,
-          insetInlineEnd: 0,
           color: token.colorTextDescription,
           whiteSpace: 'nowrap',
           content: 'attr(data-count)',
           pointerEvents: 'none',
-          display: 'block',
-          transform: 'translateY(100%)',
+          float: 'right',
         },
       },
     },


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.

Before submitting your pull request, please make sure the checklist below is confirmed.

Your pull requests will be merged after one of the collaborators approve.

Thank you!

-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

fixed: #39119 

<!--
1. Put the related issue or discussion links here.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fixed the style of data-count when the resize of TextArea property is not none      |
| 🇨🇳 Chinese |    修复了当TextArea属性的resize不是none时 data-count 的样式      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
