### PR TITLE
style(Tree): aria-hidden="true" padding remove

### DIFF
--- a/components/tree/style/index.tsx
+++ b/components/tree/style/index.tsx
@@ -136,6 +136,10 @@ export const genBaseStyle = (prefixCls: string, token: TreeToken): CSSObject => 
         padding: `0 0 ${treeNodePadding}px 0`,
         outline: 'none',
 
+        '&[aria-hidden="true"]': {
+          padding: 0,
+        },
+
         '&-rtl': {
           direction: 'rtl',
         },


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.

Before submitting your pull request, please make sure the checklist below is confirmed.

Your pull requests will be merged after one of the collaborators approve.

Thank you!

-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
-->

### 💡 Background and solution
当一个容器组件里有多个Tree组件，并设置了overflow: auto的时候，当某个Tree组件超出高度时，除了这个容器，body也会有一个滚动条，导致这个现象的原因是原本height为0的节点，因为ant-tree-treenode的padding导致占据了高度，导致高度溢出
![image](https://user-images.githubusercontent.com/23733571/205316171-0ed0a161-4d15-4459-a275-67dc664d93ae.png)

复现：https://codesandbox.io/s/cranky-vaughan-7zdlr1?file=/src/App.js
切换为rc-tree时没有这个问题，因为rc-tree没有为这个节点设置另外padding
https://codesandbox.io/s/cranky-vaughan-7zdlr1?file=/src/styles.css:0-73
将这个注释打开就不会有双滚动条了

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese | 移除掉aria-hidden="true"节点的padding          |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
