### PR TITLE
style: fix TimePicker panel style inside RangePicker

### DIFF
--- a/components/date-picker/style/index.tsx
+++ b/components/date-picker/style/index.tsx
@@ -290,6 +290,7 @@ export const genPanelStyle = (token: SharedPickerToken): CSSObject => {
     pickerPanelCellWidth,
     paddingSM,
     paddingXS,
+    paddingXXS,
     colorBgContainer,
     lineWidth,
     lineType,
@@ -779,7 +780,7 @@ export const genPanelStyle = (token: SharedPickerToken): CSSObject => {
         '&-column': {
           flex: '1 0 auto',
           width: pickerTimePanelColumnWidth,
-          margin: 0,
+          margin: `${paddingXXS}px 0`,
           padding: 0,
           overflowY: 'hidden',
           textAlign: 'start',
@@ -791,10 +792,6 @@ export const genPanelStyle = (token: SharedPickerToken): CSSObject => {
             display: 'block',
             height: pickerTimePanelColumnHeight - pickerTimePanelCellHeight,
             content: '""',
-            [`${componentCls}-datetime-panel &`]: {
-              height:
-                pickerTimePanelColumnHeight - pickerPanelWithoutTimeCellHeight + 2 * lineWidth,
-            },
           },
 
           '&:not(:first-child)': {
@@ -850,6 +847,10 @@ export const genPanelStyle = (token: SharedPickerToken): CSSObject => {
             },
           },
         },
+      },
+      // https://github.com/ant-design/ant-design/issues/39227
+      [`&-datetime-panel ${componentCls}-time-panel-column:after`]: {
+        height: pickerTimePanelColumnHeight - pickerTimePanelCellHeight + paddingXXS * 2,
       },
     },
   };


### PR DESCRIPTION


<!--
First of all, thank you for your contribution! 😄

For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.

Before submitting your pull request, please make sure the checklist below is confirmed.

Your pull requests will be merged after one of the collaborators approve.

Thank you!

-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
-->
close #39223

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

❌ | ✅ 
--- | ---
<img width="502" alt="截屏2022-12-03 23 17 45" src="https://user-images.githubusercontent.com/507615/205448252-6db1d9af-f077-44ed-9e16-f14fea273c5d.png"> | <img width="480" alt="截屏2022-12-03 23 16 54" src="https://user-images.githubusercontent.com/507615/205448246-5fb1b706-cbb5-469a-bca8-f4aca42db9d3.png">

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Fix RangePicker time panel padding style.        |
| 🇨🇳 Chinese | 修复 RangePicker 内时间面板的 padding 样式。          |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
