### PR TITLE
fix: use before to avoid conflict with primary basic animation effect

### DIFF
--- a/components/button/style/index.tsx
+++ b/components/button/style/index.tsx
@@ -62,7 +62,7 @@ const genSharedButtonStyle: GenerateStyle<ButtonToken, CSSObject> = (token): CSS
         '&:not([disabled]) + &:not([disabled])': {
           position: 'relative',
 
-          '&:after': {
+          '&:before': {
             position: 'absolute',
             top: -token.lineWidth,
             insetInlineStart: -token.lineWidth,
@@ -80,7 +80,7 @@ const genSharedButtonStyle: GenerateStyle<ButtonToken, CSSObject> = (token): CSS
           '&:not([disabled]) + &:not([disabled])': {
             position: 'relative',
 
-            '&:after': {
+            '&:before': {
               position: 'absolute',
               top: -token.lineWidth,
               insetInlineStart: -token.lineWidth,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.

Before submitting your pull request, please make sure the checklist below is confirmed.

Your pull requests will be merged after one of the collaborators approve.

Thank you!

-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
-->

### 💡 Background and solution





#### Before

https://user-images.githubusercontent.com/8649233/205481421-96a1f22d-a02e-4f9c-89a7-80b6ab37ce20.mov

#### After
https://user-images.githubusercontent.com/8649233/205481358-83f042d4-b913-4507-afed-6ddb62254c83.mov

### 📝 Changelog
<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    use `:before` to avoid conflict with primary basic animation effect     |
| 🇨🇳 Chinese |    使用 `:before` 避免与 primary button 点击动画样式冲突      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
