### PR TITLE
style(Modal): Adopt a better way to break lines

### DIFF
--- a/components/modal/style/index.tsx
+++ b/components/modal/style/index.tsx
@@ -154,7 +154,7 @@ const genModalStyle: GenerateStyle<ModalToken> = (token) => {
           fontWeight: token.fontWeightStrong,
           fontSize: token.modalHeaderTitleFontSize,
           lineHeight: token.modalHeaderTitleLineHeight,
-          wordWrap: 'break-word',
+          wordBreak: 'break-all',
         },
 
         [`${componentCls}-content`]: {
@@ -220,7 +220,7 @@ const genModalStyle: GenerateStyle<ModalToken> = (token) => {
         [`${componentCls}-body`]: {
           fontSize: token.fontSize,
           lineHeight: token.lineHeight,
-          wordWrap: 'break-word',
+          wordBreak: 'break-all',
         },
 
         [`${componentCls}-footer`]: {
@@ -297,7 +297,7 @@ const genModalConfirmStyle: GenerateStyle<ModalToken> = (token) => {
 
           [`+ ${confirmComponentCls}-content`]: {
             marginBlockStart: token.marginXS,
-            flexBasis: "100%",
+            flexBasis: '100%',
           },
         },
 

--- a/components/modal/style/index.tsx
+++ b/components/modal/style/index.tsx
@@ -154,7 +154,7 @@ const genModalStyle: GenerateStyle<ModalToken> = (token) => {
           fontWeight: token.fontWeightStrong,
           fontSize: token.modalHeaderTitleFontSize,
           lineHeight: token.modalHeaderTitleLineHeight,
-          wordBreak: 'break-all',
+          wordWrap: 'break-word',
         },
 
         [`${componentCls}-content`]: {
@@ -220,7 +220,7 @@ const genModalStyle: GenerateStyle<ModalToken> = (token) => {
         [`${componentCls}-body`]: {
           fontSize: token.fontSize,
           lineHeight: token.lineHeight,
-          wordBreak: 'break-all',
+          wordWrap: 'break-word',
         },
 
         [`${componentCls}-footer`]: {
@@ -298,6 +298,7 @@ const genModalConfirmStyle: GenerateStyle<ModalToken> = (token) => {
           [`+ ${confirmComponentCls}-content`]: {
             marginBlockStart: token.marginXS,
             flexBasis: '100%',
+            maxWidth: `calc(100% - ${token.modalConfirmIconSize + token.marginSM}px)`,
           },
         },
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.

Before submitting your pull request, please make sure the checklist below is confirmed.

Your pull requests will be merged after one of the collaborators approve.

Thank you!

-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

[使用 Modal.info(), content 属性中的内容较长时，会超出 Modal 边界
](https://github.com/ant-design/ant-design/issues/39247)

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Add `max-width` to `modal-confirm-content` to achieve a line break effect (a supplement to `non-CJK` text wrapping)    |
| 🇨🇳 Chinese |    给`modal-confirm-content`加上`max-width`，来达到换行效果（算是对非 `CJK` 文字换行的补充）      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
