### PR TITLE
fix(Tour):Styles are determined based on  `props' type`  and `TourStepProps' type`

### DIFF
--- a/components/tour/index.tsx
+++ b/components/tour/index.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { useContext, useMemo, useState } from 'react';
 import RCTour from '@rc-component/tour';
 import classNames from 'classnames';
 import panelRender from './panelRender';
@@ -23,19 +23,30 @@ const Tour: React.ForwardRefRenderFunction<HTMLDivElement, TourProps> & {
   const prefixCls = getPrefixCls('tour', customizePrefixCls);
   const [wrapSSR, hashId] = useStyle(prefixCls);
 
+  const [curStepIndex, setCurStepIndex] = useState<TourProps['current']>(current);
+
+  const isShowPrimaryStyle = useMemo(() => {
+    if (typeof curStepIndex === 'number' && steps?.length) {
+      return type === 'primary' || steps[curStepIndex].type === 'primary';
+    }
+    return type === 'primary';
+  }, [type, curStepIndex]);
+
   const customClassName = classNames(
     {
       [`${prefixCls}-rtl`]: direction === 'rtl',
     },
     {
-      [`${prefixCls}-primary`]: type === 'primary',
+      [`${prefixCls}-primary`]: isShowPrimaryStyle,
     },
     hashId,
     rootClassName,
   );
 
-  const mergedRenderPanel = (stepProps: TourStepProps, stepCurrent: number) =>
-    panelRender(stepProps, stepCurrent, type);
+  const mergedRenderPanel = (stepProps: TourStepProps, stepCurrent: number) => {
+    setCurStepIndex(stepCurrent);
+    return panelRender(stepProps, stepCurrent, stepProps.type);
+  };
 
   return wrapSSR(
     <RCTour


### PR DESCRIPTION
…e 'type' of 'StepItemProps'

<!--
First of all, thank you for your contribution! 😄

For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.

Before submitting your pull request, please make sure the checklist below is confirmed.

Your pull requests will be merged after one of the collaborators approve.

Thank you!

-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

[[Antd v5] Tour组件: TourStep 设置 type=‘primary’ 无效](https://github.com/ant-design/ant-design/issues/39307)

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Styles are determined based on  `props' type`  and `TourStepProps' type`        |
| 🇨🇳 Chinese |    样式根据`props`的`type`和`TourStepProps`的`type`共同决定       |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
