### PR TITLE
fix(Modal): combine and forward the `ConfigContext` for `ConfirmDialog`

### DIFF
--- a/components/modal/ConfirmDialog.tsx
+++ b/components/modal/ConfirmDialog.tsx
@@ -9,6 +9,7 @@ import LocaleReceiver from '../locale-provider/LocaleReceiver';
 import ActionButton from '../_util/ActionButton';
 import { getTransitionName } from '../_util/motion';
 import warning from '../_util/warning';
+import useCombineConfigContext from './hooks/useCombineConfigContext';
 import type { ModalFuncProps, ModalLocale } from './Modal';
 import Dialog from './Modal';
 
@@ -173,8 +174,15 @@ const ConfirmDialog = (props: ConfirmDialogProps) => {
     props.className,
   );
 
+  // Connect the content of `ConfigContext`
+  const confirmDialogConfigContext = useCombineConfigContext({
+    prefixCls: rootPrefixCls,
+    iconPrefixCls,
+    direction,
+  });
+
   return (
-    <ConfigProvider prefixCls={rootPrefixCls} iconPrefixCls={iconPrefixCls} direction={direction}>
+    <ConfigProvider {...confirmDialogConfigContext}>
       <Dialog
         prefixCls={prefixCls}
         className={classString}

--- a/components/modal/hooks/useCombineConfigContext.ts
+++ b/components/modal/hooks/useCombineConfigContext.ts
@@ -1,0 +1,16 @@
+import { useContext, useMemo } from 'react';
+import type { ConfigProviderProps } from '../../config-provider';
+import { ConfigContext } from '../../config-provider';
+
+export default function useCombineConfigContext(config: ConfigProviderProps) {
+  const upperConfigContext = useContext(ConfigContext);
+  const combinedConfigContext = useMemo<ConfigProviderProps>(
+    () => ({
+      ...upperConfigContext,
+      ...config,
+    }),
+    [upperConfigContext, config],
+  );
+
+  return combinedConfigContext;
+}


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

https://github.com/ant-design/ant-design/issues/39400

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

#### Background

According to the description of the issue above, the `ConfirmDialog` implementation in the `Modal` component has a partial context value forwarding issue.

#### Solution

Considering `ConfirmDialog` will be called and rendered by `Modal.methods` or `Modal.useModal`, I have done the following measures to solve the problem that the `ConfigProvider` in `ConfirmDialog` is not synchronized with the upper `ConfigContext` value:

1. Get context values from `ConfigContext` via `useContext` hook from React.
2. Combine and return the value pass in by the caller of the hook and the values from `ConfigContext`.
3. Pack those logic into one hook for better maintainability, here I named `useCombineConfigContext`.
4. Use `useCombineConfigContext` hook in `ConfirmDialog`.

It should make the content rendered by `ConfirmDialog` use the value of `ConfigContext` correctly, such as `Button` component use `autoInsertSpaceInButton` property.
In addition, because the Modal upper layer created by `Modal.methods()` has no `ConfigContext`, it does not affect the original logic.
<!--
1. Describe the problem and the scenario.
6. GIF or snapshot should be provided if includes UI/interactive modification.
7. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed the modal created by `Modal.useModal()` fails to consume upper `ConfigContext` correctly. |
| 🇨🇳 Chinese | 修复 `Modal.useModal()` 创建的模态框未能正确消费上层 `ConfigContext` 的问题。 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
