### PR TITLE
fix: fixed clear icon do not show when component in Space.Compact

### DIFF
--- a/components/select/style/index.tsx
+++ b/components/select/style/index.tsx
@@ -231,6 +231,7 @@ const genBaseStyle: GenerateStyle<SelectToken> = (token) => {
       '&:hover': {
         [`${componentCls}-clear`]: {
           opacity: 1,
+          zIndex: 2,
         },
       },
     },

--- a/components/space/__tests__/space-compact.test.tsx
+++ b/components/space/__tests__/space-compact.test.tsx
@@ -1,9 +1,10 @@
 /* eslint-disable no-console */
 import React from 'react';
+import { waitFor } from '@testing-library/react';
 import Space from '..';
 import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
-import { render } from '../../../tests/utils';
+import { fireEvent, render } from '../../../tests/utils';
 import Input from '../../input';
 import Button from '../../button';
 import AutoComplete from '../../auto-complete';
@@ -246,5 +247,41 @@ describe('Space.Compact', () => {
         ?.querySelector('.ant-btn')
         ?.classList.contains('ant-btn-compact-item'),
     ).toBe(false);
+  });
+
+  [
+    {
+      name: 'AutoComplete',
+      component: AutoComplete,
+      defaultProps: { defaultValue: 'AutoComplete' },
+    },
+    {
+      name: 'Cascader',
+      component: Cascader,
+      defaultProps: { defaultValue: ['Cascader'] },
+    },
+    {
+      name: 'Select',
+      component: Select,
+      defaultProps: { defaultValue: 'Select' },
+    },
+    {
+      name: 'TreeSelect',
+      component: TreeSelect,
+      defaultProps: { defaultValue: 'TreeSelect' },
+    },
+  ].forEach(({ component, name, defaultProps }) => {
+    it(`clear icon is show when allowClear prop is enable for ${name}`, () => {
+      const { container } = render(
+        <Space.Compact>
+          {React.createElement(component as any, { allowClear: true, ...defaultProps })}
+        </Space.Compact>,
+      );
+      const element = container.querySelector(`.ant-select`);
+      fireEvent.mouseEnter(element as Element);
+      waitFor(() => {
+        expect(container.querySelector('.ant-select-clear')).toHaveStyle({ zIndex: 2 });
+      });
+    });
   });
 });


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

#39402 

### 💡 Background and solution

1. clear icon do not show when AutoComplete/Cascader/Select/TreeSelect component in Space.Compact
2. Reproduction link: https://stackblitz.com/edit/react-y56a9n-rbfsyv?file=demo.tsx
3. The following properties are overridden
      ```
      :where(.css-dev-only-do-not-override-1ij74fp).ant-select-compact-item:hover>*, 
      :where(.css-dev-only-do-not-override-1ij74fp).ant-select-compact-item:focus>*, 
      :where(.css-dev-only-do-not-override-1ij74fp).ant-select-compact-item:active>* {
          z-index: 2;
      }
      ```
4. set ` z-index: 2 ` when hovering select element

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    set ` z-index: 2 ` when hovering select element       |
| 🇨🇳 Chinese |     当 hover 时添加 ` z-index: 2 ` 属性     |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
