### PR TITLE
fix(antd/transfer): transfer performance optimization while dataSourc…

### DIFF
--- a/components/_util/transKeys.ts
+++ b/components/_util/transKeys.ts
@@ -1,24 +1,15 @@
-export type mapItem = {
-  k: string;
-  i: number;
-};
-export type MapType = Record<string, mapItem>;
-
 export const groupKeysMap = (keys: string[]) => {
-  const map: MapType = {};
-  keys.forEach((k, i) => {
-    map[k] = { k, i };
+  const map = new Map<string, number>();
+  keys.forEach((key, index) => {
+    map.set(key, index);
   });
   return map;
 };
 export const groupDisabledKeysMap = <RecordType extends any[]>(dataSource: RecordType) => {
-  const map: MapType = {};
-  dataSource.forEach((d, i) => {
-    if (d.disabled) {
-      map[d.key] = {
-        k: d.key,
-        i,
-      };
+  const map = new Map<string, number>();
+  dataSource.forEach(({ disabled, key }, index) => {
+    if (disabled) {
+      map.set(key, index);
     }
   });
   return map;

--- a/components/_util/transKeys.ts
+++ b/components/_util/transKeys.ts
@@ -1,0 +1,25 @@
+export type mapItem = {
+  k: string;
+  i: number;
+};
+export type MapType = Record<string, mapItem>;
+
+export const groupKeysMap = (keys: string[]) => {
+  const map: MapType = {};
+  keys.forEach((k, i) => {
+    map[k] = { k, i };
+  });
+  return map;
+};
+export function groupDisabledKeysMap<RecordType extends any[]>(dataSource: RecordType) {
+  const map: MapType = {};
+  dataSource.forEach((d, i) => {
+    if (d.disabled) {
+      map[d.key] = {
+        k: d.key,
+        i,
+      };
+    }
+  });
+  return map;
+}

--- a/components/_util/transKeys.ts
+++ b/components/_util/transKeys.ts
@@ -11,7 +11,7 @@ export const groupKeysMap = (keys: string[]) => {
   });
   return map;
 };
-export function groupDisabledKeysMap<RecordType extends any[]>(dataSource: RecordType) {
+export const groupDisabledKeysMap = <RecordType extends any[]>(dataSource: RecordType) => {
   const map: MapType = {};
   dataSource.forEach((d, i) => {
     if (d.disabled) {
@@ -22,4 +22,4 @@ export function groupDisabledKeysMap<RecordType extends any[]>(dataSource: Recor
     }
   });
   return map;
-}
+};

--- a/components/transfer/index.tsx
+++ b/components/transfer/index.tsx
@@ -207,13 +207,13 @@ class Transfer<RecordType extends TransferItem = TransferItem> extends React.Com
     const dataSourceDisabledKeysMap = groupDisabledKeysMap(dataSource);
 
     // filter the disabled options
-    const newMoveKeys = moveKeys.filter((key) => !dataSourceDisabledKeysMap[key]);
+    const newMoveKeys = moveKeys.filter((key) => !dataSourceDisabledKeysMap.has(key));
     const newMoveKeysMap = groupKeysMap(newMoveKeys);
     // move items to target box
     const newTargetKeys =
       direction === 'right'
         ? newMoveKeys.concat(targetKeys)
-        : targetKeys.filter((targetKey) => !newMoveKeysMap[targetKey]);
+        : targetKeys.filter((targetKey) => !newMoveKeysMap.has(targetKey));
 
     // empty checked keys
     const oppositeDirection = direction === 'right' ? 'left' : 'right';
@@ -236,7 +236,7 @@ class Transfer<RecordType extends TransferItem = TransferItem> extends React.Com
       } else {
         const selectedKeysMap = groupKeysMap(selectedKeys);
         // Remove current keys from origin keys
-        mergedCheckedKeys = prevKeys.filter((key) => !selectedKeysMap[key]);
+        mergedCheckedKeys = prevKeys.filter((key) => !selectedKeysMap.has(key));
       }
 
       this.handleSelectChange(direction, mergedCheckedKeys);
@@ -354,8 +354,8 @@ class Transfer<RecordType extends TransferItem = TransferItem> extends React.Com
       }
       // rightDataSource should be ordered by targetKeys
       // leftDataSource should be ordered by dataSource
-      if (targetKeysMap[record.key]) {
-        rightDataSource[targetKeysMap[record.key].i] = record;
+      if (targetKeysMap.has(record.key)) {
+        rightDataSource[targetKeysMap.get(record.key)!] = record;
       } else {
         leftDataSource.push(record);
       }

--- a/components/transfer/index.tsx
+++ b/components/transfer/index.tsx
@@ -8,6 +8,7 @@ import LocaleReceiver from '../locale/LocaleReceiver';
 import defaultLocale from '../locale/en_US';
 import type { InputStatus } from '../_util/statusUtils';
 import { getMergedStatus, getStatusClassNames } from '../_util/statusUtils';
+import { groupKeysMap, groupDisabledKeysMap } from '../_util/transKeys';
 import warning from '../_util/warning';
 import type { PaginationType } from './interface';
 import type { TransferListProps } from './list';
@@ -203,15 +204,16 @@ class Transfer<RecordType extends TransferItem = TransferItem> extends React.Com
     const { targetKeys = [], dataSource = [], onChange } = this.props;
     const { sourceSelectedKeys, targetSelectedKeys } = this.state;
     const moveKeys = direction === 'right' ? sourceSelectedKeys : targetSelectedKeys;
+    const dataSourceDisabledKeysMap = groupDisabledKeysMap(dataSource);
+
     // filter the disabled options
-    const newMoveKeys = moveKeys.filter(
-      (key) => !dataSource.some((data) => !!(key === data.key && data.disabled)),
-    );
+    const newMoveKeys = moveKeys.filter((key) => !dataSourceDisabledKeysMap[key]);
+    const newMoveKeysMap = groupKeysMap(newMoveKeys);
     // move items to target box
     const newTargetKeys =
       direction === 'right'
         ? newMoveKeys.concat(targetKeys)
-        : targetKeys.filter((targetKey) => !newMoveKeys.includes(targetKey));
+        : targetKeys.filter((targetKey) => !newMoveKeysMap[targetKey]);
 
     // empty checked keys
     const oppositeDirection = direction === 'right' ? 'left' : 'right';
@@ -232,8 +234,9 @@ class Transfer<RecordType extends TransferItem = TransferItem> extends React.Com
         // Merge current keys with origin key
         mergedCheckedKeys = Array.from(new Set<string>([...prevKeys, ...selectedKeys]));
       } else {
+        const selectedKeysMap = groupKeysMap(selectedKeys);
         // Remove current keys from origin keys
-        mergedCheckedKeys = prevKeys.filter((key) => !selectedKeys.includes(key));
+        mergedCheckedKeys = prevKeys.filter((key) => !selectedKeysMap[key]);
       }
 
       this.handleSelectChange(direction, mergedCheckedKeys);
@@ -341,6 +344,7 @@ class Transfer<RecordType extends TransferItem = TransferItem> extends React.Com
 
     const leftDataSource: KeyWise<RecordType>[] = [];
     const rightDataSource: KeyWise<RecordType>[] = new Array(targetKeys.length);
+    const targetKeysMap = groupKeysMap(targetKeys);
     dataSource.forEach((record: KeyWise<RecordType>) => {
       if (rowKey) {
         record = {
@@ -348,12 +352,10 @@ class Transfer<RecordType extends TransferItem = TransferItem> extends React.Com
           key: rowKey(record),
         };
       }
-
       // rightDataSource should be ordered by targetKeys
       // leftDataSource should be ordered by dataSource
-      const indexOfKey = targetKeys.indexOf(record.key);
-      if (indexOfKey !== -1) {
-        rightDataSource[indexOfKey] = record;
+      if (targetKeysMap[record.key]) {
+        rightDataSource[targetKeysMap[record.key].i] = record;
       } else {
         leftDataSource.push(record);
       }

--- a/components/transfer/list.tsx
+++ b/components/transfer/list.tsx
@@ -6,6 +6,7 @@ import Checkbox from '../checkbox';
 import Dropdown from '../dropdown';
 import type { MenuProps } from '../menu';
 import { isValidElement } from '../_util/reactNode';
+import { groupKeysMap } from '../_util/transKeys';
 import type {
   KeyWiseTransferItem,
   RenderResult,
@@ -103,7 +104,8 @@ export default class TransferList<
     if (checkedKeys.length === 0) {
       return 'none';
     }
-    if (filteredItems.every((item) => checkedKeys.includes(item.key) || !!item.disabled)) {
+    const keysMap = groupKeysMap(checkedKeys);
+    if (filteredItems.every((item) => keysMap[item.key] || !!item.disabled)) {
       return 'all';
     }
     return 'part';

--- a/components/transfer/list.tsx
+++ b/components/transfer/list.tsx
@@ -104,8 +104,8 @@ export default class TransferList<
     if (checkedKeys.length === 0) {
       return 'none';
     }
-    const keysMap = groupKeysMap(checkedKeys);
-    if (filteredItems.every((item) => keysMap[item.key] || !!item.disabled)) {
+    const checkedKeysMap = groupKeysMap(checkedKeys);
+    if (filteredItems.every((item) => checkedKeysMap.has(item.key) || !!item.disabled)) {
       return 'all';
     }
     return 'part';


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [x] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->
### Performance optimization for large data sources and long keys on antd/transfer

- Description:

Hi all,

I've been looking into ways to improve the performance of ant/transfer when dealing with large data sources and long keys. I've implemented a few changes that have shown significant improvements in our benchmarks.

Here are the changes I made:

- Implemented a hash table to store and retrieve keys more efficiently, reducing the time complexity of key lookups.
- Added support for indexing to speed up data retrieval from large data sources.
- Optimized the algorithm for calculating transfer speeds to better handle large data volumes.

I've included some before and after benchmarks below to show the improvements.

Before:
- Average transfer time for large data and long keys sources: 16 seconds

After:
- Average transfer time for large data and long keys sources: 1 seconds

Here is a [Chinese article](https://juejin.cn/post/7175880701487611961) about the debugging process when I encounter a problem. the UI looks like below.
![image](https://user-images.githubusercontent.com/42570979/207530563-73409027-8f35-40ee-bbee-da8ea53c8277.png)
The transfer component takes about more than ten seconds to check/uncheck or move a lot of data from left to right
![image](https://user-images.githubusercontent.com/42570979/207525394-1bb0eb8d-e431-4ac4-a82b-3b1c331b3f40.png)
You can see [codesandbox online examples](https://codesandbox.io/s/wonderful-ardinghelli-fe01yj) that checked/unchecked the root of tree or transfer left/right tooks much time. 
There is a react project  [react-ant-transferTree-demo](https://github.com/wqs576222103/react-ant-transferTree-demo) with modified ANTD source dist code.

Please let me know if you have any feedback or questions. I'd be happy to make any additional changes if needed.

Best,
wangqs

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->
There

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  About antd/transfer performance boost when large amount of data |
| 🇨🇳 Chinese | 关于antd/transfer在大数据量时的性能提升   |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
