### PR TITLE
Fix the issue where the clear icon does not show when hovering over the Select series component under the Space component.

### DIFF
--- a/components/button/style/index.tsx
+++ b/components/button/style/index.tsx
@@ -50,8 +50,6 @@ const genSharedButtonStyle: GenerateStyle<ButtonToken, CSSObject> = (token): CSS
         ...genFocusStyle(token),
       },
 
-      ...genCompactItemVerticalStyle(token, componentCls),
-
       // make `btn-icon-only` not too narrow
       '&-icon-only&-compact-item': {
         flex: 'none',
@@ -498,5 +496,6 @@ export default genComponentStyleHook('Button', (token) => {
 
     // Space Compact
     genCompactItemStyle(token, { focus: false }),
+    genCompactItemVerticalStyle(token),
   ];
 });

--- a/components/button/style/index.tsx
+++ b/components/button/style/index.tsx
@@ -50,7 +50,6 @@ const genSharedButtonStyle: GenerateStyle<ButtonToken, CSSObject> = (token): CSS
         ...genFocusStyle(token),
       },
 
-      ...genCompactItemStyle(token, componentCls, { focus: false }),
       ...genCompactItemVerticalStyle(token, componentCls),
 
       // make `btn-icon-only` not too narrow
@@ -496,5 +495,8 @@ export default genComponentStyleHook('Button', (token) => {
 
     // Button Group
     genGroupStyle(buttonToken),
+
+    // Space Compact
+    genCompactItemStyle(token, { focus: false }),
   ];
 });

--- a/components/cascader/style/index.tsx
+++ b/components/cascader/style/index.tsx
@@ -152,7 +152,9 @@ const genBaseStyle: GenerateStyle<CascaderToken> = (token) => {
         direction: 'rtl',
       },
     },
-
+    // =====================================================
+    // ==             Space Compact                       ==
+    // =====================================================
     genCompactItemStyle(token),
   ];
 };

--- a/components/cascader/style/index.tsx
+++ b/components/cascader/style/index.tsx
@@ -32,7 +32,6 @@ const genBaseStyle: GenerateStyle<CascaderToken> = (token) => {
     {
       [componentCls]: {
         width: token.controlWidth,
-        ...genCompactItemStyle(token, componentCls),
       },
     },
     // =====================================================
@@ -153,6 +152,8 @@ const genBaseStyle: GenerateStyle<CascaderToken> = (token) => {
         direction: 'rtl',
       },
     },
+
+    genCompactItemStyle(token),
   ];
 };
 

--- a/components/date-picker/style/index.tsx
+++ b/components/date-picker/style/index.tsx
@@ -973,11 +973,6 @@ const genPickerStyle: GenerateStyle<PickerToken> = (token) => {
         borderRadius,
         transition: `border ${motionDurationMid}, box-shadow ${motionDurationMid}`,
 
-        // Space.Compact
-        ...genCompactItemStyle(token, componentCls, {
-          focusElCls: `${componentCls}-focused`,
-        }),
-
         '&:hover, &-focused': {
           ...genHoverStyle(token),
         },
@@ -1426,7 +1421,13 @@ export default genComponentStyleHook(
       initInputToken<FullToken<'DatePicker'>>(token),
       initPickerPanelToken(token),
     );
-    return [genPickerStyle(pickerToken), genPickerStatusStyle(pickerToken)];
+    return [
+      genPickerStyle(pickerToken),
+      genPickerStatusStyle(pickerToken),
+      genCompactItemStyle(token, {
+        focusElCls: `${token.componentCls}-focused`,
+      }),
+    ];
   },
   (token) => ({
     presetsWidth: 120,

--- a/components/date-picker/style/index.tsx
+++ b/components/date-picker/style/index.tsx
@@ -1424,6 +1424,9 @@ export default genComponentStyleHook(
     return [
       genPickerStyle(pickerToken),
       genPickerStatusStyle(pickerToken),
+      // =====================================================
+      // ==             Space Compact                       ==
+      // =====================================================
       genCompactItemStyle(token, {
         focusElCls: `${token.componentCls}-focused`,
       }),

--- a/components/input-number/style/index.tsx
+++ b/components/input-number/style/index.tsx
@@ -397,6 +397,9 @@ export default genComponentStyleHook(
     return [
       genInputNumberStyles(inputNumberToken),
       genAffixWrapperStyles(inputNumberToken),
+      // =====================================================
+      // ==             Space Compact                       ==
+      // =====================================================
       genCompactItemStyle(inputNumberToken),
     ];
   },

--- a/components/input-number/style/index.tsx
+++ b/components/input-number/style/index.tsx
@@ -63,8 +63,6 @@ const genInputNumberStyles: GenerateStyle<InputNumberToken> = (token: InputNumbe
         border: `${lineWidth}px ${lineType} ${colorBorder}`,
         borderRadius,
 
-        ...genCompactItemStyle(token, componentCls),
-
         '&-rtl': {
           direction: 'rtl',
 
@@ -396,7 +394,11 @@ export default genComponentStyleHook(
   'InputNumber',
   (token) => {
     const inputNumberToken = initInputToken<FullToken<'InputNumber'>>(token);
-    return [genInputNumberStyles(inputNumberToken), genAffixWrapperStyles(inputNumberToken)];
+    return [
+      genInputNumberStyles(inputNumberToken),
+      genAffixWrapperStyles(inputNumberToken),
+      genCompactItemStyle(inputNumberToken),
+    ];
   },
   (token) => ({
     controlWidth: 90,

--- a/components/input/style/index.tsx
+++ b/components/input/style/index.tsx
@@ -504,7 +504,7 @@ export const genInputGroupStyle = (token: InputToken): CSSObject => {
 };
 
 const genInputStyle: GenerateStyle<InputToken> = (token: InputToken) => {
-  const { prefixCls, componentCls, controlHeightSM, lineWidth } = token;
+  const { componentCls, controlHeightSM, lineWidth } = token;
 
   const FIXED_CHROME_COLOR_HEIGHT = 16;
   const colorSmallPadding = (controlHeightSM - lineWidth * 2 - FIXED_CHROME_COLOR_HEIGHT) / 2;
@@ -514,7 +514,6 @@ const genInputStyle: GenerateStyle<InputToken> = (token: InputToken) => {
       ...resetComponent(token),
       ...genBasicInputStyle(token),
       ...genStatusStyle(token),
-      ...genCompactItemStyle(token, prefixCls),
 
       '&[type="color"]': {
         height: token.controlHeight,
@@ -933,5 +932,6 @@ export default genComponentStyleHook('Input', (token) => {
     genAffixStyle(inputToken),
     genGroupStyle(inputToken),
     genSearchInputStyle(inputToken),
+    genCompactItemStyle(inputToken),
   ];
 });

--- a/components/input/style/index.tsx
+++ b/components/input/style/index.tsx
@@ -932,6 +932,9 @@ export default genComponentStyleHook('Input', (token) => {
     genAffixStyle(inputToken),
     genGroupStyle(inputToken),
     genSearchInputStyle(inputToken),
+    // =====================================================
+    // ==             Space Compact                       ==
+    // =====================================================
     genCompactItemStyle(inputToken),
   ];
 });

--- a/components/select/style/index.tsx
+++ b/components/select/style/index.tsx
@@ -244,6 +244,19 @@ const genBaseStyle: GenerateStyle<SelectToken> = (token) => {
   };
 };
 
+const genSelectCompactStyle: GenerateStyle<SelectToken> = (token) => {
+  const { componentCls } = token;
+  return {
+    [componentCls]: {
+      // Space.Compact
+      ...genCompactItemStyle(token, componentCls, {
+        borderElCls: `${componentCls}-selector`,
+        focusElCls: `${componentCls}-focused`,
+      }),
+    },
+  };
+};
+
 // ============================== Styles ==============================
 const genSelectStyle: GenerateStyle<SelectToken> = (token) => {
   const { componentCls } = token;
@@ -262,11 +275,6 @@ const genSelectStyle: GenerateStyle<SelectToken> = (token) => {
         '&&-in-form-item': {
           width: '100%',
         },
-        // Space.Compact
-        ...genCompactItemStyle(token, componentCls, {
-          borderElCls: `${componentCls}-selector`,
-          focusElCls: `${componentCls}-focused`,
-        }),
       },
     },
 
@@ -320,6 +328,10 @@ const genSelectStyle: GenerateStyle<SelectToken> = (token) => {
       }),
       true,
     ),
+    // =====================================================
+    // ==                    Compact                      ==
+    // =====================================================
+    genSelectCompactStyle(token),
   ];
 };
 

--- a/components/select/style/index.tsx
+++ b/components/select/style/index.tsx
@@ -244,19 +244,6 @@ const genBaseStyle: GenerateStyle<SelectToken> = (token) => {
   };
 };
 
-const genSelectCompactStyle: GenerateStyle<SelectToken> = (token) => {
-  const { componentCls } = token;
-  return {
-    [componentCls]: {
-      // Space.Compact
-      ...genCompactItemStyle(token, componentCls, {
-        borderElCls: `${componentCls}-selector`,
-        focusElCls: `${componentCls}-focused`,
-      }),
-    },
-  };
-};
-
 // ============================== Styles ==============================
 const genSelectStyle: GenerateStyle<SelectToken> = (token) => {
   const { componentCls } = token;
@@ -331,7 +318,10 @@ const genSelectStyle: GenerateStyle<SelectToken> = (token) => {
     // =====================================================
     // ==                    Compact                      ==
     // =====================================================
-    genSelectCompactStyle(token),
+    genCompactItemStyle(token, {
+      borderElCls: `${componentCls}-selector`,
+      focusElCls: `${componentCls}-focused`,
+    }),
   ];
 };
 

--- a/components/select/style/index.tsx
+++ b/components/select/style/index.tsx
@@ -316,7 +316,7 @@ const genSelectStyle: GenerateStyle<SelectToken> = (token) => {
       true,
     ),
     // =====================================================
-    // ==                    Compact                      ==
+    // ==             Space Compact                       ==
     // =====================================================
     genCompactItemStyle(token, {
       borderElCls: `${componentCls}-selector`,

--- a/components/space/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/space/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -448,7 +448,7 @@ exports[`renders ./components/space/demo/compact.tsx extend context correctly 1`
     class="ant-space-compact ant-space-compact-block"
   >
     <div
-      class="ant-select ant-select-compact-item ant-select-compact-first-item ant-select-single ant-select-show-arrow"
+      class="ant-select ant-select-compact-item ant-select-compact-first-item ant-select-single ant-select-allow-clear ant-select-show-arrow"
     >
       <div
         class="ant-select-selector"
@@ -587,6 +587,32 @@ exports[`renders ./components/space/demo/compact.tsx extend context correctly 1`
           </svg>
         </span>
       </span>
+      <span
+        aria-hidden="true"
+        class="ant-select-clear"
+        style="user-select:none;-webkit-user-select:none"
+        unselectable="on"
+      >
+        <span
+          aria-label="close-circle"
+          class="anticon anticon-close-circle"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="close-circle"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm165.4 618.2l-66-.3L512 563.4l-99.3 118.4-66.1.3c-4.4 0-8-3.5-8-8 0-1.9.7-3.7 1.9-5.2l130.1-155L340.5 359a8.32 8.32 0 01-1.9-5.2c0-4.4 3.6-8 8-8l66.1.3L512 464.6l99.3-118.4 66-.3c4.4 0 8 3.5 8 8 0 1.9-.7 3.7-1.9 5.2L553.5 514l130 155c1.2 1.5 1.9 3.3 1.9 5.2 0 4.4-3.6 8-8 8z"
+            />
+          </svg>
+        </span>
+      </span>
     </div>
     <input
       class="ant-input ant-input-compact-item ant-input-compact-last-item"
@@ -600,7 +626,7 @@ exports[`renders ./components/space/demo/compact.tsx extend context correctly 1`
     class="ant-space-compact ant-space-compact-block"
   >
     <div
-      class="ant-select ant-select-compact-item ant-select-compact-first-item ant-select-multiple ant-select-show-search"
+      class="ant-select ant-select-compact-item ant-select-compact-first-item ant-select-multiple ant-select-allow-clear ant-select-show-search"
       style="width:50%"
     >
       <div
@@ -778,6 +804,32 @@ exports[`renders ./components/space/demo/compact.tsx extend context correctly 1`
           </div>
         </div>
       </div>
+      <span
+        aria-hidden="true"
+        class="ant-select-clear"
+        style="user-select:none;-webkit-user-select:none"
+        unselectable="on"
+      >
+        <span
+          aria-label="close-circle"
+          class="anticon anticon-close-circle"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="close-circle"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm165.4 618.2l-66-.3L512 563.4l-99.3 118.4-66.1.3c-4.4 0-8-3.5-8-8 0-1.9.7-3.7 1.9-5.2l130.1-155L340.5 359a8.32 8.32 0 01-1.9-5.2c0-4.4 3.6-8 8-8l66.1.3L512 464.6l99.3-118.4 66-.3c4.4 0 8 3.5 8 8 0 1.9-.7 3.7-1.9 5.2L553.5 514l130 155c1.2 1.5 1.9 3.3 1.9 5.2 0 4.4-3.6 8-8 8z"
+            />
+          </svg>
+        </span>
+      </span>
     </div>
     <input
       class="ant-input ant-input-compact-item ant-input-compact-last-item"
@@ -7977,7 +8029,7 @@ exports[`renders ./components/space/demo/compact.tsx extend context correctly 1`
                 <div
                   aria-hidden="true"
                   class="ant-select-tree-treenode"
-                  style="position:absolute;pointer-events:none;visibility:hidden;height:0;overflow:hidden;border:0;padding:0"
+                  style="position:absolute;pointer-events:none;visibility:hidden;height:0;overflow:hidden"
                 >
                   <div
                     class="ant-select-tree-indent"

--- a/components/space/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/space/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -8029,7 +8029,7 @@ exports[`renders ./components/space/demo/compact.tsx extend context correctly 1`
                 <div
                   aria-hidden="true"
                   class="ant-select-tree-treenode"
-                  style="position:absolute;pointer-events:none;visibility:hidden;height:0;overflow:hidden"
+                  style="position:absolute;pointer-events:none;visibility:hidden;height:0;overflow:hidden;border:0;padding:0"
                 >
                   <div
                     class="ant-select-tree-indent"

--- a/components/space/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/space/__tests__/__snapshots__/demo.test.ts.snap
@@ -341,7 +341,7 @@ exports[`renders ./components/space/demo/compact.tsx correctly 1`] = `
     class="ant-space-compact ant-space-compact-block"
   >
     <div
-      class="ant-select ant-select-compact-item ant-select-compact-first-item ant-select-single ant-select-show-arrow"
+      class="ant-select ant-select-compact-item ant-select-compact-first-item ant-select-single ant-select-allow-clear ant-select-show-arrow"
     >
       <div
         class="ant-select-selector"
@@ -398,6 +398,32 @@ exports[`renders ./components/space/demo/compact.tsx correctly 1`] = `
           </svg>
         </span>
       </span>
+      <span
+        aria-hidden="true"
+        class="ant-select-clear"
+        style="user-select:none;-webkit-user-select:none"
+        unselectable="on"
+      >
+        <span
+          aria-label="close-circle"
+          class="anticon anticon-close-circle"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="close-circle"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm165.4 618.2l-66-.3L512 563.4l-99.3 118.4-66.1.3c-4.4 0-8-3.5-8-8 0-1.9.7-3.7 1.9-5.2l130.1-155L340.5 359a8.32 8.32 0 01-1.9-5.2c0-4.4 3.6-8 8-8l66.1.3L512 464.6l99.3-118.4 66-.3c4.4 0 8 3.5 8 8 0 1.9-.7 3.7-1.9 5.2L553.5 514l130 155c1.2 1.5 1.9 3.3 1.9 5.2 0 4.4-3.6 8-8 8z"
+            />
+          </svg>
+        </span>
+      </span>
     </div>
     <input
       class="ant-input ant-input-compact-item ant-input-compact-last-item"
@@ -411,7 +437,7 @@ exports[`renders ./components/space/demo/compact.tsx correctly 1`] = `
     class="ant-space-compact ant-space-compact-block"
   >
     <div
-      class="ant-select ant-select-compact-item ant-select-compact-first-item ant-select-multiple ant-select-show-search"
+      class="ant-select ant-select-compact-item ant-select-compact-first-item ant-select-multiple ant-select-allow-clear ant-select-show-search"
       style="width:50%"
     >
       <div
@@ -493,6 +519,32 @@ exports[`renders ./components/space/demo/compact.tsx correctly 1`] = `
           </div>
         </div>
       </div>
+      <span
+        aria-hidden="true"
+        class="ant-select-clear"
+        style="user-select:none;-webkit-user-select:none"
+        unselectable="on"
+      >
+        <span
+          aria-label="close-circle"
+          class="anticon anticon-close-circle"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="close-circle"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm165.4 618.2l-66-.3L512 563.4l-99.3 118.4-66.1.3c-4.4 0-8-3.5-8-8 0-1.9.7-3.7 1.9-5.2l130.1-155L340.5 359a8.32 8.32 0 01-1.9-5.2c0-4.4 3.6-8 8-8l66.1.3L512 464.6l99.3-118.4 66-.3c4.4 0 8 3.5 8 8 0 1.9-.7 3.7-1.9 5.2L553.5 514l130 155c1.2 1.5 1.9 3.3 1.9 5.2 0 4.4-3.6 8-8 8z"
+            />
+          </svg>
+        </span>
+      </span>
     </div>
     <input
       class="ant-input ant-input-compact-item ant-input-compact-last-item"

--- a/components/space/demo/compact.tsx
+++ b/components/space/demo/compact.tsx
@@ -45,7 +45,7 @@ const App: React.FC = () => (
     </Space.Compact>
     <br />
     <Space.Compact block>
-      <Select defaultValue="Zhejiang">
+      <Select defaultValue="Zhejiang" allowClear>
         <Option value="Zhejiang">Zhejiang</Option>
         <Option value="Jiangsu">Jiangsu</Option>
       </Select>
@@ -53,7 +53,7 @@ const App: React.FC = () => (
     </Space.Compact>
     <br />
     <Space.Compact block>
-      <Select mode="multiple" defaultValue="Zhejianggggg" style={{ width: '50%' }}>
+      <Select allowClear mode="multiple" defaultValue="Zhejianggggg" style={{ width: '50%' }}>
         <Option value="Zhejianggggg">Zhejianggggg</Option>
         <Option value="Jiangsu">Jiangsu</Option>
       </Select>

--- a/components/style/compact-item-vertical.tsx
+++ b/components/style/compact-item-vertical.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable import/prefer-default-export */
 import type { CSSInterpolation, CSSObject } from '@ant-design/cssinjs';
 import type { DerivativeToken, FullToken } from '../theme/internal';
-import { OverrideComponent } from '../theme/util/genComponentStyleHook';
+import type { OverrideComponent } from '../theme/util/genComponentStyleHook';
 
 function compactItemVerticalBorder(token: DerivativeToken): CSSObject {
   return {

--- a/components/style/compact-item-vertical.tsx
+++ b/components/style/compact-item-vertical.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable import/prefer-default-export */
-import type { CSSObject } from '@ant-design/cssinjs';
-import type { DerivativeToken } from '../theme/internal';
+import type { CSSInterpolation, CSSObject } from '@ant-design/cssinjs';
+import type { DerivativeToken, FullToken } from '../theme/internal';
+import { OverrideComponent } from '../theme/util/genComponentStyleHook';
 
 function compactItemVerticalBorder(token: DerivativeToken): CSSObject {
   return {
@@ -43,11 +44,13 @@ function compactItemBorderVerticalRadius(prefixCls: string): CSSObject {
   };
 }
 
-export function genCompactItemVerticalStyle(token: DerivativeToken, prefixCls: string): CSSObject {
+export function genCompactItemVerticalStyle<T extends OverrideComponent>(
+  token: FullToken<T>,
+): CSSInterpolation {
   return {
-    '&-compact-vertical': {
+    [`${token.componentCls}-compact-vertical`]: {
       ...compactItemVerticalBorder(token),
-      ...compactItemBorderVerticalRadius(prefixCls),
+      ...compactItemBorderVerticalRadius(token.componentCls),
     },
   };
 }

--- a/components/style/compact-item.tsx
+++ b/components/style/compact-item.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable import/prefer-default-export */
-import type { CSSObject } from '@ant-design/cssinjs';
-import type { DerivativeToken } from '../theme/internal';
+import type { CSSInterpolation, CSSObject } from '@ant-design/cssinjs';
+import type { DerivativeToken, FullToken } from '../theme/internal';
+import { OverrideComponent } from '../theme/util/genComponentStyleHook';
 
 interface CompactItemOptions {
   focus?: boolean;
@@ -75,15 +76,14 @@ function compactItemBorderRadius(prefixCls: string, options: CompactItemOptions)
   };
 }
 
-export function genCompactItemStyle(
-  token: DerivativeToken,
-  prefixCls: string,
+export function genCompactItemStyle<T extends OverrideComponent>(
+  token: FullToken<T>,
   options: CompactItemOptions = { focus: true },
-): CSSObject {
+): CSSInterpolation {
   return {
-    '&-compact': {
+    [`${token.componentCls}-compact`]: {
       ...compactItemBorder(token, options),
-      ...compactItemBorderRadius(prefixCls, options),
+      ...compactItemBorderRadius(token.componentCls, options),
     },
   };
 }

--- a/components/style/compact-item.tsx
+++ b/components/style/compact-item.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable import/prefer-default-export */
 import type { CSSInterpolation, CSSObject } from '@ant-design/cssinjs';
 import type { DerivativeToken, FullToken } from '../theme/internal';
-import { OverrideComponent } from '../theme/util/genComponentStyleHook';
+import type { OverrideComponent } from '../theme/util/genComponentStyleHook';
 
 interface CompactItemOptions {
   focus?: boolean;


### PR DESCRIPTION
…lect series component hovers under the Space component

<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

fix #39402

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Fix the issue where the clear icon does not show when hovering over the Select series component under the Space component.        |
| 🇨🇳 Chinese |    修复 Space 组件下 Select 系列组件 hover 时 clear icon 不显示的问题。       |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
