### PR TITLE
fix: missing css code in demo code preview

### DIFF
--- a/.dumi/theme/builtins/Previewer/fromDumiProps.tsx
+++ b/.dumi/theme/builtins/Previewer/fromDumiProps.tsx
@@ -86,8 +86,7 @@ export default function fromDumiProps<P extends object>(
       location,
       src: demoUrl,
       expand,
-      // FIXME: confirm is there has any case?
-      highlightedStyle: '',
+      highlightedStyle: meta.style ? Prism.highlight(meta.style, Prism.languages.css, 'css') : '',
     } as P;
 
     return <WrappedComponent {...transformedProps} />;

--- a/.dumi/theme/common/CodePreview.tsx
+++ b/.dumi/theme/common/CodePreview.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import { Tabs } from 'antd';
 
-const { TabPane } = Tabs;
-
 const LANGS = {
   tsx: 'TypeScript',
   jsx: 'JavaScript',
@@ -23,13 +21,15 @@ const CodePreview: React.FC<CodePreviewProps> = ({ toReactComponent, codes, onCo
     content = toReactComponent(['pre', { lang: langList[0], highlighted: codes[langList[0]] }]);
   } else {
     content = (
-      <Tabs centered onChange={onCodeTypeChange}>
-        {langList.map((lang) => (
-          <TabPane tab={LANGS[lang]} key={lang}>
-            {toReactComponent(['pre', { lang, highlighted: codes[lang] }])}
-          </TabPane>
-        ))}
-      </Tabs>
+      <Tabs
+        centered
+        onChange={onCodeTypeChange}
+        items={langList.map((lang) => ({
+          label: LANGS[lang],
+          key: lang,
+          children: toReactComponent(['pre', { lang, highlighted: codes[lang] }]),
+        }))}
+      />
     );
   }
 

--- a/.dumi/theme/plugin.ts
+++ b/.dumi/theme/plugin.ts
@@ -26,7 +26,7 @@ class AntdReactTechStack extends ReactTechStack {
         const description = md.match(
           new RegExp(`(?:^|\\n)## ${locale}([^]+?)(\\n## [a-z]|\\n\`\`\`|\\n<style>|$)`),
         )?.[1];
-        const style = md.match(/\n(?:```css|<style>)\n([^]+?)\n(?:```|<\/style>)/)?.[1];
+        const style = md.match(/\r?\n(?:```css|<style>)\r?\n([^]+?)\r?\n(?:```|<\/style>)/)?.[1];
 
         props.description ??= description?.trim();
         props.style ??= style;

--- a/components/dropdown/index.zh-CN.md
+++ b/components/dropdown/index.zh-CN.md
@@ -54,8 +54,8 @@ demo:
 | overlayStyle | 下拉根元素的样式 | CSSProperties | - |  |
 | placement | 菜单弹出位置：`bottom` `bottomLeft` `bottomRight` `top` `topLeft` `topRight` | string | `bottomLeft` |  |
 | trigger | 触发下拉的行为, 移动端不支持 hover | Array&lt;`click`\|`hover`\|`contextMenu`> | \[`hover`] |  |
-| open | 菜单是否显示，小于 4.23.0 使用 `visible`（[为什么?](/docs/react/faq#why-open)） | boolean | - | 4.23.0 |
-| onOpenChange | 菜单显示状态改变时调用，点击菜单按钮导致的消失不会触发。小于 4.23.0 使用 `onVisibleChange`（[为什么?](/docs/react/faq#why-open)） | (open: boolean) => void | - | 4.23.0 |
+| open | 菜单是否显示，小于 4.23.0 使用 `visible`（[为什么?](/docs/react/faq#弹层类组件为什么要统一至-open-属性)） | boolean | - | 4.23.0 |
+| onOpenChange | 菜单显示状态改变时调用，点击菜单按钮导致的消失不会触发。小于 4.23.0 使用 `onVisibleChange`（[为什么?](/docs/react/faq#弹层类组件为什么要统一至-open-属性)） | (open: boolean) => void | - | 4.23.0 |
 
 ### Dropdown.Button
 

--- a/components/tooltip/index.zh-CN.md
+++ b/components/tooltip/index.zh-CN.md
@@ -53,7 +53,7 @@ demo:
 | overlayInnerStyle | 卡片内容区域的样式对象 | object | - |  |
 | placement | 气泡框位置，可选 `top` `left` `right` `bottom` `topLeft` `topRight` `bottomLeft` `bottomRight` `leftTop` `leftBottom` `rightTop` `rightBottom` | string | `top` |  |
 | trigger | 触发行为，可选 `hover` \| `focus` \| `click` \| `contextMenu`，可使用数组设置多个触发行为 | string \| string\[] | `hover` |  |
-| open | 用于手动控制浮层显隐，小于 4.23.0 使用 `visible`（[为什么?](/docs/react/faq#why-open)） | boolean | false | 4.23.0 |
+| open | 用于手动控制浮层显隐，小于 4.23.0 使用 `visible`（[为什么?](/docs/react/faq#弹层类组件为什么要统一至-open-属性)） | boolean | false | 4.23.0 |
 | zIndex | 设置 Tooltip 的 `z-index` | number | - |  |
 | onOpenChange | 显示隐藏的回调 | (open: boolean) => void | - | 4.23.0 |
 


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

新特性请提交至 feature 分支，其余可提交至 master 分支。
在维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

[[English Template / 英文模板](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE.md)]

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [ ] 日常 bug 修复
- [x] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

window本地启动，Demo缺少css样式

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |     fix: missing css code in demo code preview<br/> fix: missing demo style in windows <br/> fix: change `TabPane` to `Tabs.items` <br /> fix: why-open faq url in zh-CN <br/> fix: append '-cn' suffix to `Link.to` when locale is zh-CN|
| 🇨🇳 中文 |     修复组件demo代码预览缺少css代码问题 <br/> 修复window本地启动时demo缺少样式问题 <br/> 使用`Tabs.items`   代替`TabPane` <br/> 纠正中文文档中why-open地址 <br/> 修复中文页面文档跳转到英文页面问题（当打开中文页面时，为页面的`Link`组件中的url地址自动添加`-cn`后缀） |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供