### PR TITLE
feat: ConfigProvider support select.showSearch

### DIFF
--- a/components/config-provider/__tests__/index.test.tsx
+++ b/components/config-provider/__tests__/index.test.tsx
@@ -7,6 +7,7 @@ import { act, fireEvent, render } from '../../../tests/utils';
 import Button from '../../button';
 import Input from '../../input';
 import Table from '../../table';
+import Select from '../../select';
 
 describe('ConfigProvider', () => {
   mountTest(() => (
@@ -111,6 +112,15 @@ describe('ConfigProvider', () => {
       </ConfigProvider>,
     );
     expect(container.querySelector('input')?.autocomplete).toEqual('off');
+  });
+
+  it('select showSearch', () => {
+    const { container } = render(
+      <ConfigProvider select={{ showSearch: true }}>
+        <Select />
+      </ConfigProvider>,
+    );
+    expect(container.querySelectorAll('.ant-select-show-search').length).toBe(1);
   });
 
   it('render empty', () => {

--- a/components/config-provider/context.tsx
+++ b/components/config-provider/context.tsx
@@ -63,6 +63,9 @@ export interface ConfigConsumerProps {
     colon?: boolean;
   };
   theme?: ThemeConfig;
+  select?: {
+    showSearch?: boolean;
+  };
 }
 
 const defaultGetPrefixCls = (suffixCls?: string, customizePrefixCls?: string) => {

--- a/components/config-provider/index.en-US.md
+++ b/components/config-provider/index.en-US.md
@@ -57,6 +57,7 @@ Some components use dynamic style to support wave effect. You can config `csp` p
 | getTargetContainer | Config Affix, Anchor scroll target container | () => HTMLElement | () => window | 4.2.0 |
 | iconPrefixCls | Set icon prefix className | string | `anticon` | 4.11.0 |
 | input | Set Input common props | { autoComplete?: string } | - | 4.2.0 |
+| select | Set Select common props | { showSearch?: boolean } | - |  |
 | locale | Language package setting, you can find the packages in [antd/locale](http://unpkg.com/antd/locale/) | object | - |  |
 | prefixCls | Set prefix className | string | `ant` |  |
 | renderEmpty | Set empty content of components. Ref [Empty](/components/empty/) | function(componentName: string): ReactNode | - |  |

--- a/components/config-provider/index.tsx
+++ b/components/config-provider/index.tsx
@@ -53,6 +53,7 @@ const PASSED_PROPS: Exclude<keyof ConfigConsumerProps, 'rootPrefixCls' | 'getPre
   'input',
   'pagination',
   'form',
+  'select',
 ];
 
 export interface ConfigProviderProps {
@@ -71,6 +72,9 @@ export interface ConfigProviderProps {
   };
   input?: {
     autoComplete?: string;
+  };
+  select?: {
+    showSearch?: boolean;
   };
   pagination?: {
     showSizeChanger?: boolean;

--- a/components/config-provider/index.zh-CN.md
+++ b/components/config-provider/index.zh-CN.md
@@ -58,6 +58,7 @@ export default () => (
 | getTargetContainer | 配置 Affix、Anchor 滚动监听容器。 | () => HTMLElement | () => window | 4.2.0 |
 | iconPrefixCls | 设置图标统一样式前缀 | string | `anticon` | 4.11.0 |
 | input | 设置 Input 组件的通用属性 | { autoComplete?: string } | - | 4.2.0 |
+| select | 设置 Select 组件的通用属性 | { showSearch?: boolean } | - |  |
 | locale | 语言包配置，语言包可到 [antd/locale](http://unpkg.com/antd/locale/) 目录下寻找 | object | - |  |
 | prefixCls | 设置统一样式前缀 | string | `ant` |  |
 | renderEmpty | 自定义组件空状态。参考 [空状态](/components/empty/) | function(componentName: string): ReactNode | - |  |

--- a/components/select/index.tsx
+++ b/components/select/index.tsx
@@ -91,6 +91,7 @@ const InternalSelect = <OptionType extends BaseOptionType | DefaultOptionType = 
     direction,
     virtual,
     dropdownMatchSelectWidth,
+    select,
   } = React.useContext(ConfigContext);
   const size = React.useContext(SizeContext);
 
@@ -202,6 +203,7 @@ const InternalSelect = <OptionType extends BaseOptionType | DefaultOptionType = 
       ref={ref as any}
       virtual={virtual}
       dropdownMatchSelectWidth={dropdownMatchSelectWidth}
+      showSearch={select?.showSearch}
       {...selectProps}
       transitionName={getTransitionName(
         rootPrefixCls,


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

新特性请提交至 feature 分支，其余可提交至 master 分支。
在维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

[[English Template / 英文模板](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE.md)]

### 🤔 这个变动的性质是？

- [x] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

#### 需求背景

项目中大部分Select组件无论是多选还是单选模式都需要支持搜索，单选模式默认不支持搜索，需要项目中每个Select手动添加，容易遗漏

#### 实现

在`ConfigProvider`增加`select`配置项支持`showSearch`字段

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |     `ConfigProvider` support config `select.showSearch`     |
| 🇨🇳 中文 |      `ConfigProvider`支持配置`select.showSearch`   |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供