### PR TITLE
feat(ConfigProvider): attach DisableContext to ConfigProvider

### DIFF
--- a/components/config-provider/index.tsx
+++ b/components/config-provider/index.tsx
@@ -16,7 +16,7 @@ import type { ConfigConsumerProps, CSPConfig, DirectionType, Theme, ThemeConfig 
 import { ConfigConsumer, ConfigContext, defaultIconPrefixCls } from './context';
 import { registerTheme } from './cssVariables';
 import type { RenderEmptyHandler } from './defaultRenderEmpty';
-import { DisabledContextProvider } from './DisabledContext';
+import DisabledContext, { DisabledContextProvider } from './DisabledContext';
 import useTheme from './hooks/useTheme';
 import type { SizeType } from './SizeContext';
 import SizeContext, { SizeContextProvider } from './SizeContext';
@@ -29,6 +29,7 @@ export {
   type CSPConfig,
   type DirectionType,
   type ConfigConsumerProps,
+  DisabledContext,
 };
 export { defaultIconPrefixCls };
 
@@ -310,6 +311,7 @@ const ConfigProvider: React.FC<ConfigProviderProps> & {
   ConfigContext: typeof ConfigContext;
   SizeContext: typeof SizeContext;
   config: typeof setGlobalConfig;
+  DisabledContext: typeof DisabledContext;
 } = (props) => (
   <LocaleReceiver>
     {(_, __, legacyLocale) => (
@@ -325,5 +327,6 @@ const ConfigProvider: React.FC<ConfigProviderProps> & {
 ConfigProvider.ConfigContext = ConfigContext;
 ConfigProvider.SizeContext = SizeContext;
 ConfigProvider.config = setGlobalConfig;
+ConfigProvider.DisabledContext = DisabledContext;
 
 export default ConfigProvider;

--- a/components/form/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/form/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -5169,6 +5169,42 @@ Array [
         </div>
       </div>
     </div>
+    <div
+      class="ant-form-item"
+    >
+      <div
+        class="ant-row ant-form-item-row"
+      >
+        <div
+          class="ant-col ant-col-4 ant-form-item-label"
+        >
+          <label
+            class=""
+            title="custom field"
+          >
+            custom field
+          </label>
+        </div>
+        <div
+          class="ant-col ant-col-14 ant-form-item-control"
+        >
+          <div
+            class="ant-form-item-control-input"
+          >
+            <div
+              class="ant-form-item-control-input-content"
+            >
+              <input
+                class="ant-input ant-input-disabled"
+                disabled=""
+                type="text"
+                value=""
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
   </form>,
 ]
 `;

--- a/components/form/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/form/__tests__/__snapshots__/demo.test.ts.snap
@@ -2642,6 +2642,42 @@ Array [
         </div>
       </div>
     </div>
+    <div
+      class="ant-form-item"
+    >
+      <div
+        class="ant-row ant-form-item-row"
+      >
+        <div
+          class="ant-col ant-col-4 ant-form-item-label"
+        >
+          <label
+            class=""
+            title="custom field"
+          >
+            custom field
+          </label>
+        </div>
+        <div
+          class="ant-col ant-col-14 ant-form-item-control"
+        >
+          <div
+            class="ant-form-item-control-input"
+          >
+            <div
+              class="ant-form-item-control-input-content"
+            >
+              <input
+                class="ant-input ant-input-disabled"
+                disabled=""
+                type="text"
+                value=""
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
   </form>,
 ]
 `;

--- a/components/form/demo/disabled.md
+++ b/components/form/demo/disabled.md
@@ -2,6 +2,10 @@
 
 设置表单组件禁用，仅对 antd 组件有效。
 
+自定义组件可以通过 `ConfigProvider.DisabledContext` 获取父级 Form 组件 的禁用状态。
+
 ## en-US
 
 Set component disabled, only works for antd components.
+
+Custom components can get the disabled state of the parent Form component via `ConfigProvider.DisabledContext`.

--- a/components/form/demo/disabled.tsx
+++ b/components/form/demo/disabled.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useContext, useState } from 'react';
 import { PlusOutlined } from '@ant-design/icons';
 import {
   Form,
@@ -13,10 +13,21 @@ import {
   Switch,
   Checkbox,
   Upload,
+  ConfigProvider,
 } from 'antd';
 
+const { DisabledContext } = ConfigProvider;
 const { RangePicker } = DatePicker;
 const { TextArea } = Input;
+
+const CustomizedFormControls = () => {
+  const disabled = useContext(DisabledContext);
+  return (
+    <Form.Item label="custom field">
+      <Input disabled={disabled} />
+    </Form.Item>
+  );
+};
 
 const FormDisabledDemo = () => {
   const [componentDisabled, setComponentDisabled] = useState<boolean>(true);
@@ -105,6 +116,7 @@ const FormDisabledDemo = () => {
         <Form.Item label="Button">
           <Button>Button</Button>
         </Form.Item>
+        <CustomizedFormControls />
       </Form>
     </>
   );


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
close https://github.com/ant-design/ant-design/issues/39545



### 💡 Background and solution

目前自定义表单组件中要获取父级 Form 组件的禁用状态的话，需要从dist代码中获取 DisabledContext ，希望能将这个 API 导出以方便使用。

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      attach DisableContext to ConfigProvider for accessing the API easily     |
| 🇨🇳 Chinese |     将 DisableContext 挂到 ConfigProvider 以方便调用     |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
