### PR TITLE
fix: Tabs inkBar in StrictMode

### DIFF
--- a/components/card/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/card/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -764,6 +764,7 @@ Array [
             >
               <div
                 class="ant-tabs-tab ant-tabs-tab-active"
+                data-node-key="tab1"
               >
                 <div
                   aria-disabled="false"
@@ -777,6 +778,7 @@ Array [
               </div>
               <div
                 class="ant-tabs-tab"
+                data-node-key="tab2"
               >
                 <div
                   aria-disabled="false"
@@ -900,6 +902,7 @@ Array [
             >
               <div
                 class="ant-tabs-tab"
+                data-node-key="article"
               >
                 <div
                   aria-disabled="false"
@@ -913,6 +916,7 @@ Array [
               </div>
               <div
                 class="ant-tabs-tab ant-tabs-tab-active"
+                data-node-key="app"
               >
                 <div
                   aria-disabled="false"
@@ -926,6 +930,7 @@ Array [
               </div>
               <div
                 class="ant-tabs-tab"
+                data-node-key="project"
               >
                 <div
                   aria-disabled="false"

--- a/components/card/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/card/__tests__/__snapshots__/demo.test.ts.snap
@@ -764,6 +764,7 @@ Array [
             >
               <div
                 class="ant-tabs-tab ant-tabs-tab-active"
+                data-node-key="tab1"
               >
                 <div
                   aria-disabled="false"
@@ -777,6 +778,7 @@ Array [
               </div>
               <div
                 class="ant-tabs-tab"
+                data-node-key="tab2"
               >
                 <div
                   aria-disabled="false"
@@ -881,6 +883,7 @@ Array [
             >
               <div
                 class="ant-tabs-tab"
+                data-node-key="article"
               >
                 <div
                   aria-disabled="false"
@@ -894,6 +897,7 @@ Array [
               </div>
               <div
                 class="ant-tabs-tab ant-tabs-tab-active"
+                data-node-key="app"
               >
                 <div
                   aria-disabled="false"
@@ -907,6 +911,7 @@ Array [
               </div>
               <div
                 class="ant-tabs-tab"
+                data-node-key="project"
               >
                 <div
                   aria-disabled="false"

--- a/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
+++ b/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
@@ -28743,6 +28743,7 @@ exports[`ConfigProvider components Tabs configProvider 1`] = `
       >
         <div
           class="config-tabs-tab config-tabs-tab-active"
+          data-node-key="Light"
         >
           <div
             aria-controls="rc-tabs-test-panel-Light"
@@ -28832,6 +28833,7 @@ exports[`ConfigProvider components Tabs configProvider componentDisabled 1`] = `
       >
         <div
           class="config-tabs-tab config-tabs-tab-active"
+          data-node-key="Light"
         >
           <div
             aria-controls="rc-tabs-test-panel-Light"
@@ -28921,6 +28923,7 @@ exports[`ConfigProvider components Tabs configProvider componentSize large 1`] =
       >
         <div
           class="config-tabs-tab config-tabs-tab-active"
+          data-node-key="Light"
         >
           <div
             aria-controls="rc-tabs-test-panel-Light"
@@ -29010,6 +29013,7 @@ exports[`ConfigProvider components Tabs configProvider componentSize middle 1`] 
       >
         <div
           class="config-tabs-tab config-tabs-tab-active"
+          data-node-key="Light"
         >
           <div
             aria-controls="rc-tabs-test-panel-Light"
@@ -29099,6 +29103,7 @@ exports[`ConfigProvider components Tabs configProvider virtual and dropdownMatch
       >
         <div
           class="ant-tabs-tab ant-tabs-tab-active"
+          data-node-key="Light"
         >
           <div
             aria-controls="rc-tabs-test-panel-Light"
@@ -29188,6 +29193,7 @@ exports[`ConfigProvider components Tabs normal 1`] = `
       >
         <div
           class="ant-tabs-tab ant-tabs-tab-active"
+          data-node-key="Light"
         >
           <div
             aria-controls="rc-tabs-test-panel-Light"
@@ -29277,6 +29283,7 @@ exports[`ConfigProvider components Tabs prefixCls 1`] = `
       >
         <div
           class="prefix-Tabs-tab prefix-Tabs-tab-active"
+          data-node-key="Light"
         >
           <div
             aria-controls="rc-tabs-test-panel-Light"

--- a/components/tabs/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/tabs/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -79,6 +79,7 @@ Array [
         >
           <div
             class="ant-tabs-tab ant-tabs-tab-active"
+            data-node-key="1"
           >
             <div
               aria-selected="true"
@@ -91,6 +92,7 @@ Array [
           </div>
           <div
             class="ant-tabs-tab"
+            data-node-key="2"
           >
             <div
               aria-selected="false"
@@ -103,6 +105,7 @@ Array [
           </div>
           <div
             class="ant-tabs-tab"
+            data-node-key="3"
           >
             <div
               aria-selected="false"
@@ -211,6 +214,7 @@ exports[`renders ./components/tabs/demo/basic.tsx extend context correctly 1`] =
       >
         <div
           class="ant-tabs-tab ant-tabs-tab-active"
+          data-node-key="1"
         >
           <div
             aria-selected="true"
@@ -223,6 +227,7 @@ exports[`renders ./components/tabs/demo/basic.tsx extend context correctly 1`] =
         </div>
         <div
           class="ant-tabs-tab"
+          data-node-key="2"
         >
           <div
             aria-selected="false"
@@ -235,6 +240,7 @@ exports[`renders ./components/tabs/demo/basic.tsx extend context correctly 1`] =
         </div>
         <div
           class="ant-tabs-tab"
+          data-node-key="3"
         >
           <div
             aria-selected="false"
@@ -341,6 +347,7 @@ exports[`renders ./components/tabs/demo/card.tsx extend context correctly 1`] = 
       >
         <div
           class="ant-tabs-tab ant-tabs-tab-active"
+          data-node-key="1"
         >
           <div
             aria-selected="true"
@@ -353,6 +360,7 @@ exports[`renders ./components/tabs/demo/card.tsx extend context correctly 1`] = 
         </div>
         <div
           class="ant-tabs-tab"
+          data-node-key="2"
         >
           <div
             aria-selected="false"
@@ -365,6 +373,7 @@ exports[`renders ./components/tabs/demo/card.tsx extend context correctly 1`] = 
         </div>
         <div
           class="ant-tabs-tab"
+          data-node-key="3"
         >
           <div
             aria-selected="false"
@@ -474,6 +483,7 @@ exports[`renders ./components/tabs/demo/card-top.tsx extend context correctly 1`
         >
           <div
             class="ant-tabs-tab ant-tabs-tab-active"
+            data-node-key="1"
           >
             <div
               aria-selected="true"
@@ -486,6 +496,7 @@ exports[`renders ./components/tabs/demo/card-top.tsx extend context correctly 1`
           </div>
           <div
             class="ant-tabs-tab"
+            data-node-key="2"
           >
             <div
               aria-selected="false"
@@ -498,6 +509,7 @@ exports[`renders ./components/tabs/demo/card-top.tsx extend context correctly 1`
           </div>
           <div
             class="ant-tabs-tab"
+            data-node-key="3"
           >
             <div
               aria-selected="false"
@@ -619,6 +631,7 @@ exports[`renders ./components/tabs/demo/centered.tsx extend context correctly 1`
       >
         <div
           class="ant-tabs-tab ant-tabs-tab-active"
+          data-node-key="1"
         >
           <div
             aria-selected="true"
@@ -631,6 +644,7 @@ exports[`renders ./components/tabs/demo/centered.tsx extend context correctly 1`
         </div>
         <div
           class="ant-tabs-tab"
+          data-node-key="2"
         >
           <div
             aria-selected="false"
@@ -643,6 +657,7 @@ exports[`renders ./components/tabs/demo/centered.tsx extend context correctly 1`
         </div>
         <div
           class="ant-tabs-tab"
+          data-node-key="3"
         >
           <div
             aria-selected="false"
@@ -762,6 +777,7 @@ exports[`renders ./components/tabs/demo/custom-add-trigger.tsx extend context co
         >
           <div
             class="ant-tabs-tab ant-tabs-tab-with-remove ant-tabs-tab-active"
+            data-node-key="1"
           >
             <div
               aria-selected="true"
@@ -800,6 +816,7 @@ exports[`renders ./components/tabs/demo/custom-add-trigger.tsx extend context co
           </div>
           <div
             class="ant-tabs-tab ant-tabs-tab-with-remove"
+            data-node-key="2"
           >
             <div
               aria-selected="false"
@@ -936,6 +953,7 @@ exports[`renders ./components/tabs/demo/custom-tab-bar.tsx extend context correc
           >
             <div
               class="ant-tabs-tab ant-tabs-tab-active"
+              data-node-key="1"
             >
               <div
                 aria-selected="true"
@@ -948,6 +966,7 @@ exports[`renders ./components/tabs/demo/custom-tab-bar.tsx extend context correc
             </div>
             <div
               class="ant-tabs-tab"
+              data-node-key="2"
             >
               <div
                 aria-selected="false"
@@ -960,6 +979,7 @@ exports[`renders ./components/tabs/demo/custom-tab-bar.tsx extend context correc
             </div>
             <div
               class="ant-tabs-tab"
+              data-node-key="3"
             >
               <div
                 aria-selected="false"
@@ -1073,6 +1093,7 @@ exports[`renders ./components/tabs/demo/custom-tab-bar-node.tsx extend context c
         >
           <div
             class="ant-tabs-tab ant-tabs-tab-active"
+            data-node-key="1"
           >
             <div
               aria-selected="true"
@@ -1090,6 +1111,7 @@ exports[`renders ./components/tabs/demo/custom-tab-bar-node.tsx extend context c
         >
           <div
             class="ant-tabs-tab"
+            data-node-key="2"
           >
             <div
               aria-selected="false"
@@ -1107,6 +1129,7 @@ exports[`renders ./components/tabs/demo/custom-tab-bar-node.tsx extend context c
         >
           <div
             class="ant-tabs-tab"
+            data-node-key="3"
           >
             <div
               aria-selected="false"
@@ -1214,6 +1237,7 @@ exports[`renders ./components/tabs/demo/disabled.tsx extend context correctly 1`
       >
         <div
           class="ant-tabs-tab ant-tabs-tab-active"
+          data-node-key="1"
         >
           <div
             aria-selected="true"
@@ -1226,6 +1250,7 @@ exports[`renders ./components/tabs/demo/disabled.tsx extend context correctly 1`
         </div>
         <div
           class="ant-tabs-tab ant-tabs-tab-disabled"
+          data-node-key="2"
         >
           <div
             aria-disabled="true"
@@ -1238,6 +1263,7 @@ exports[`renders ./components/tabs/demo/disabled.tsx extend context correctly 1`
         </div>
         <div
           class="ant-tabs-tab"
+          data-node-key="3"
         >
           <div
             aria-selected="false"
@@ -1344,6 +1370,7 @@ exports[`renders ./components/tabs/demo/editable-card.tsx extend context correct
       >
         <div
           class="ant-tabs-tab ant-tabs-tab-with-remove ant-tabs-tab-active"
+          data-node-key="1"
         >
           <div
             aria-selected="true"
@@ -1382,6 +1409,7 @@ exports[`renders ./components/tabs/demo/editable-card.tsx extend context correct
         </div>
         <div
           class="ant-tabs-tab ant-tabs-tab-with-remove"
+          data-node-key="2"
         >
           <div
             aria-selected="false"
@@ -1420,6 +1448,7 @@ exports[`renders ./components/tabs/demo/editable-card.tsx extend context correct
         </div>
         <div
           class="ant-tabs-tab"
+          data-node-key="3"
         >
           <div
             aria-selected="false"
@@ -1589,6 +1618,7 @@ Array [
         >
           <div
             class="ant-tabs-tab ant-tabs-tab-active"
+            data-node-key="1"
           >
             <div
               aria-selected="true"
@@ -1601,6 +1631,7 @@ Array [
           </div>
           <div
             class="ant-tabs-tab"
+            data-node-key="2"
           >
             <div
               aria-selected="false"
@@ -1613,6 +1644,7 @@ Array [
           </div>
           <div
             class="ant-tabs-tab"
+            data-node-key="3"
           >
             <div
               aria-selected="false"
@@ -1796,6 +1828,7 @@ Array [
         >
           <div
             class="ant-tabs-tab ant-tabs-tab-active"
+            data-node-key="1"
           >
             <div
               aria-selected="true"
@@ -1808,6 +1841,7 @@ Array [
           </div>
           <div
             class="ant-tabs-tab"
+            data-node-key="2"
           >
             <div
               aria-selected="false"
@@ -1820,6 +1854,7 @@ Array [
           </div>
           <div
             class="ant-tabs-tab"
+            data-node-key="3"
           >
             <div
               aria-selected="false"
@@ -1939,6 +1974,7 @@ exports[`renders ./components/tabs/demo/icon.tsx extend context correctly 1`] = 
       >
         <div
           class="ant-tabs-tab"
+          data-node-key="1"
         >
           <div
             aria-selected="false"
@@ -1974,6 +2010,7 @@ exports[`renders ./components/tabs/demo/icon.tsx extend context correctly 1`] = 
         </div>
         <div
           class="ant-tabs-tab ant-tabs-tab-active"
+          data-node-key="2"
         >
           <div
             aria-selected="true"
@@ -2766,6 +2803,7 @@ exports[`renders ./components/tabs/demo/nest.tsx extend context correctly 1`] = 
         >
           <div
             class="ant-tabs-tab ant-tabs-tab-active"
+            data-node-key="1"
           >
             <div
               aria-selected="true"
@@ -2778,6 +2816,7 @@ exports[`renders ./components/tabs/demo/nest.tsx extend context correctly 1`] = 
           </div>
           <div
             class="ant-tabs-tab"
+            data-node-key="2"
           >
             <div
               aria-selected="false"
@@ -2877,6 +2916,7 @@ exports[`renders ./components/tabs/demo/nest.tsx extend context correctly 1`] = 
                 >
                   <div
                     class="ant-tabs-tab"
+                    data-node-key="0"
                   >
                     <div
                       aria-selected="false"
@@ -2889,6 +2929,7 @@ exports[`renders ./components/tabs/demo/nest.tsx extend context correctly 1`] = 
                   </div>
                   <div
                     class="ant-tabs-tab ant-tabs-tab-active"
+                    data-node-key="1"
                   >
                     <div
                       aria-selected="true"
@@ -2901,6 +2942,7 @@ exports[`renders ./components/tabs/demo/nest.tsx extend context correctly 1`] = 
                   </div>
                   <div
                     class="ant-tabs-tab"
+                    data-node-key="2"
                   >
                     <div
                       aria-selected="false"
@@ -2913,6 +2955,7 @@ exports[`renders ./components/tabs/demo/nest.tsx extend context correctly 1`] = 
                   </div>
                   <div
                     class="ant-tabs-tab"
+                    data-node-key="3"
                   >
                     <div
                       aria-selected="false"
@@ -2925,6 +2968,7 @@ exports[`renders ./components/tabs/demo/nest.tsx extend context correctly 1`] = 
                   </div>
                   <div
                     class="ant-tabs-tab"
+                    data-node-key="4"
                   >
                     <div
                       aria-selected="false"
@@ -2937,6 +2981,7 @@ exports[`renders ./components/tabs/demo/nest.tsx extend context correctly 1`] = 
                   </div>
                   <div
                     class="ant-tabs-tab"
+                    data-node-key="5"
                   >
                     <div
                       aria-selected="false"
@@ -2949,6 +2994,7 @@ exports[`renders ./components/tabs/demo/nest.tsx extend context correctly 1`] = 
                   </div>
                   <div
                     class="ant-tabs-tab"
+                    data-node-key="6"
                   >
                     <div
                       aria-selected="false"
@@ -2961,6 +3007,7 @@ exports[`renders ./components/tabs/demo/nest.tsx extend context correctly 1`] = 
                   </div>
                   <div
                     class="ant-tabs-tab"
+                    data-node-key="7"
                   >
                     <div
                       aria-selected="false"
@@ -2973,6 +3020,7 @@ exports[`renders ./components/tabs/demo/nest.tsx extend context correctly 1`] = 
                   </div>
                   <div
                     class="ant-tabs-tab"
+                    data-node-key="8"
                   >
                     <div
                       aria-selected="false"
@@ -2985,6 +3033,7 @@ exports[`renders ./components/tabs/demo/nest.tsx extend context correctly 1`] = 
                   </div>
                   <div
                     class="ant-tabs-tab"
+                    data-node-key="9"
                   >
                     <div
                       aria-selected="false"
@@ -2997,6 +3046,7 @@ exports[`renders ./components/tabs/demo/nest.tsx extend context correctly 1`] = 
                   </div>
                   <div
                     class="ant-tabs-tab"
+                    data-node-key="10"
                   >
                     <div
                       aria-selected="false"
@@ -3009,6 +3059,7 @@ exports[`renders ./components/tabs/demo/nest.tsx extend context correctly 1`] = 
                   </div>
                   <div
                     class="ant-tabs-tab"
+                    data-node-key="11"
                   >
                     <div
                       aria-selected="false"
@@ -3021,6 +3072,7 @@ exports[`renders ./components/tabs/demo/nest.tsx extend context correctly 1`] = 
                   </div>
                   <div
                     class="ant-tabs-tab"
+                    data-node-key="12"
                   >
                     <div
                       aria-selected="false"
@@ -3033,6 +3085,7 @@ exports[`renders ./components/tabs/demo/nest.tsx extend context correctly 1`] = 
                   </div>
                   <div
                     class="ant-tabs-tab"
+                    data-node-key="13"
                   >
                     <div
                       aria-selected="false"
@@ -3045,6 +3098,7 @@ exports[`renders ./components/tabs/demo/nest.tsx extend context correctly 1`] = 
                   </div>
                   <div
                     class="ant-tabs-tab"
+                    data-node-key="14"
                   >
                     <div
                       aria-selected="false"
@@ -3057,6 +3111,7 @@ exports[`renders ./components/tabs/demo/nest.tsx extend context correctly 1`] = 
                   </div>
                   <div
                     class="ant-tabs-tab"
+                    data-node-key="15"
                   >
                     <div
                       aria-selected="false"
@@ -3069,6 +3124,7 @@ exports[`renders ./components/tabs/demo/nest.tsx extend context correctly 1`] = 
                   </div>
                   <div
                     class="ant-tabs-tab"
+                    data-node-key="16"
                   >
                     <div
                       aria-selected="false"
@@ -3081,6 +3137,7 @@ exports[`renders ./components/tabs/demo/nest.tsx extend context correctly 1`] = 
                   </div>
                   <div
                     class="ant-tabs-tab"
+                    data-node-key="17"
                   >
                     <div
                       aria-selected="false"
@@ -3093,6 +3150,7 @@ exports[`renders ./components/tabs/demo/nest.tsx extend context correctly 1`] = 
                   </div>
                   <div
                     class="ant-tabs-tab"
+                    data-node-key="18"
                   >
                     <div
                       aria-selected="false"
@@ -3105,6 +3163,7 @@ exports[`renders ./components/tabs/demo/nest.tsx extend context correctly 1`] = 
                   </div>
                   <div
                     class="ant-tabs-tab"
+                    data-node-key="19"
                   >
                     <div
                       aria-selected="false"
@@ -3313,6 +3372,7 @@ Array [
         >
           <div
             class="ant-tabs-tab ant-tabs-tab-active"
+            data-node-key="1"
           >
             <div
               aria-selected="true"
@@ -3325,6 +3385,7 @@ Array [
           </div>
           <div
             class="ant-tabs-tab"
+            data-node-key="2"
           >
             <div
               aria-selected="false"
@@ -3337,6 +3398,7 @@ Array [
           </div>
           <div
             class="ant-tabs-tab"
+            data-node-key="3"
           >
             <div
               aria-selected="false"
@@ -3509,6 +3571,7 @@ exports[`renders ./components/tabs/demo/size.tsx extend context correctly 1`] = 
         >
           <div
             class="ant-tabs-tab ant-tabs-tab-active"
+            data-node-key="1"
           >
             <div
               aria-selected="true"
@@ -3521,6 +3584,7 @@ exports[`renders ./components/tabs/demo/size.tsx extend context correctly 1`] = 
           </div>
           <div
             class="ant-tabs-tab"
+            data-node-key="2"
           >
             <div
               aria-selected="false"
@@ -3533,6 +3597,7 @@ exports[`renders ./components/tabs/demo/size.tsx extend context correctly 1`] = 
           </div>
           <div
             class="ant-tabs-tab"
+            data-node-key="3"
           >
             <div
               aria-selected="false"
@@ -3636,6 +3701,7 @@ exports[`renders ./components/tabs/demo/size.tsx extend context correctly 1`] = 
         >
           <div
             class="ant-tabs-tab ant-tabs-tab-active"
+            data-node-key="1"
           >
             <div
               aria-selected="true"
@@ -3648,6 +3714,7 @@ exports[`renders ./components/tabs/demo/size.tsx extend context correctly 1`] = 
           </div>
           <div
             class="ant-tabs-tab"
+            data-node-key="2"
           >
             <div
               aria-selected="false"
@@ -3660,6 +3727,7 @@ exports[`renders ./components/tabs/demo/size.tsx extend context correctly 1`] = 
           </div>
           <div
             class="ant-tabs-tab"
+            data-node-key="3"
           >
             <div
               aria-selected="false"
@@ -3813,6 +3881,7 @@ exports[`renders ./components/tabs/demo/slide.tsx extend context correctly 1`] =
         >
           <div
             class="ant-tabs-tab"
+            data-node-key="0"
           >
             <div
               aria-disabled="false"
@@ -3826,6 +3895,7 @@ exports[`renders ./components/tabs/demo/slide.tsx extend context correctly 1`] =
           </div>
           <div
             class="ant-tabs-tab ant-tabs-tab-active"
+            data-node-key="1"
           >
             <div
               aria-disabled="false"
@@ -3839,6 +3909,7 @@ exports[`renders ./components/tabs/demo/slide.tsx extend context correctly 1`] =
           </div>
           <div
             class="ant-tabs-tab"
+            data-node-key="2"
           >
             <div
               aria-disabled="false"
@@ -3852,6 +3923,7 @@ exports[`renders ./components/tabs/demo/slide.tsx extend context correctly 1`] =
           </div>
           <div
             class="ant-tabs-tab"
+            data-node-key="3"
           >
             <div
               aria-disabled="false"
@@ -3865,6 +3937,7 @@ exports[`renders ./components/tabs/demo/slide.tsx extend context correctly 1`] =
           </div>
           <div
             class="ant-tabs-tab"
+            data-node-key="4"
           >
             <div
               aria-disabled="false"
@@ -3878,6 +3951,7 @@ exports[`renders ./components/tabs/demo/slide.tsx extend context correctly 1`] =
           </div>
           <div
             class="ant-tabs-tab"
+            data-node-key="5"
           >
             <div
               aria-disabled="false"
@@ -3891,6 +3965,7 @@ exports[`renders ./components/tabs/demo/slide.tsx extend context correctly 1`] =
           </div>
           <div
             class="ant-tabs-tab"
+            data-node-key="6"
           >
             <div
               aria-disabled="false"
@@ -3904,6 +3979,7 @@ exports[`renders ./components/tabs/demo/slide.tsx extend context correctly 1`] =
           </div>
           <div
             class="ant-tabs-tab"
+            data-node-key="7"
           >
             <div
               aria-disabled="false"
@@ -3917,6 +3993,7 @@ exports[`renders ./components/tabs/demo/slide.tsx extend context correctly 1`] =
           </div>
           <div
             class="ant-tabs-tab"
+            data-node-key="8"
           >
             <div
               aria-disabled="false"
@@ -3930,6 +4007,7 @@ exports[`renders ./components/tabs/demo/slide.tsx extend context correctly 1`] =
           </div>
           <div
             class="ant-tabs-tab"
+            data-node-key="9"
           >
             <div
               aria-disabled="false"
@@ -3943,6 +4021,7 @@ exports[`renders ./components/tabs/demo/slide.tsx extend context correctly 1`] =
           </div>
           <div
             class="ant-tabs-tab"
+            data-node-key="10"
           >
             <div
               aria-disabled="false"
@@ -3956,6 +4035,7 @@ exports[`renders ./components/tabs/demo/slide.tsx extend context correctly 1`] =
           </div>
           <div
             class="ant-tabs-tab"
+            data-node-key="11"
           >
             <div
               aria-disabled="false"
@@ -3969,6 +4049,7 @@ exports[`renders ./components/tabs/demo/slide.tsx extend context correctly 1`] =
           </div>
           <div
             class="ant-tabs-tab"
+            data-node-key="12"
           >
             <div
               aria-disabled="false"
@@ -3982,6 +4063,7 @@ exports[`renders ./components/tabs/demo/slide.tsx extend context correctly 1`] =
           </div>
           <div
             class="ant-tabs-tab"
+            data-node-key="13"
           >
             <div
               aria-disabled="false"
@@ -3995,6 +4077,7 @@ exports[`renders ./components/tabs/demo/slide.tsx extend context correctly 1`] =
           </div>
           <div
             class="ant-tabs-tab"
+            data-node-key="14"
           >
             <div
               aria-disabled="false"
@@ -4008,6 +4091,7 @@ exports[`renders ./components/tabs/demo/slide.tsx extend context correctly 1`] =
           </div>
           <div
             class="ant-tabs-tab"
+            data-node-key="15"
           >
             <div
               aria-disabled="false"
@@ -4021,6 +4105,7 @@ exports[`renders ./components/tabs/demo/slide.tsx extend context correctly 1`] =
           </div>
           <div
             class="ant-tabs-tab"
+            data-node-key="16"
           >
             <div
               aria-disabled="false"
@@ -4034,6 +4119,7 @@ exports[`renders ./components/tabs/demo/slide.tsx extend context correctly 1`] =
           </div>
           <div
             class="ant-tabs-tab"
+            data-node-key="17"
           >
             <div
               aria-disabled="false"
@@ -4047,6 +4133,7 @@ exports[`renders ./components/tabs/demo/slide.tsx extend context correctly 1`] =
           </div>
           <div
             class="ant-tabs-tab"
+            data-node-key="18"
           >
             <div
               aria-disabled="false"
@@ -4060,6 +4147,7 @@ exports[`renders ./components/tabs/demo/slide.tsx extend context correctly 1`] =
           </div>
           <div
             class="ant-tabs-tab"
+            data-node-key="19"
           >
             <div
               aria-disabled="false"
@@ -4073,6 +4161,7 @@ exports[`renders ./components/tabs/demo/slide.tsx extend context correctly 1`] =
           </div>
           <div
             class="ant-tabs-tab"
+            data-node-key="20"
           >
             <div
               aria-disabled="false"
@@ -4086,6 +4175,7 @@ exports[`renders ./components/tabs/demo/slide.tsx extend context correctly 1`] =
           </div>
           <div
             class="ant-tabs-tab"
+            data-node-key="21"
           >
             <div
               aria-disabled="false"
@@ -4099,6 +4189,7 @@ exports[`renders ./components/tabs/demo/slide.tsx extend context correctly 1`] =
           </div>
           <div
             class="ant-tabs-tab"
+            data-node-key="22"
           >
             <div
               aria-disabled="false"
@@ -4112,6 +4203,7 @@ exports[`renders ./components/tabs/demo/slide.tsx extend context correctly 1`] =
           </div>
           <div
             class="ant-tabs-tab"
+            data-node-key="23"
           >
             <div
               aria-disabled="false"
@@ -4125,6 +4217,7 @@ exports[`renders ./components/tabs/demo/slide.tsx extend context correctly 1`] =
           </div>
           <div
             class="ant-tabs-tab"
+            data-node-key="24"
           >
             <div
               aria-disabled="false"
@@ -4138,6 +4231,7 @@ exports[`renders ./components/tabs/demo/slide.tsx extend context correctly 1`] =
           </div>
           <div
             class="ant-tabs-tab"
+            data-node-key="25"
           >
             <div
               aria-disabled="false"
@@ -4151,6 +4245,7 @@ exports[`renders ./components/tabs/demo/slide.tsx extend context correctly 1`] =
           </div>
           <div
             class="ant-tabs-tab"
+            data-node-key="26"
           >
             <div
               aria-disabled="false"
@@ -4164,6 +4259,7 @@ exports[`renders ./components/tabs/demo/slide.tsx extend context correctly 1`] =
           </div>
           <div
             class="ant-tabs-tab"
+            data-node-key="27"
           >
             <div
               aria-disabled="false"
@@ -4177,6 +4273,7 @@ exports[`renders ./components/tabs/demo/slide.tsx extend context correctly 1`] =
           </div>
           <div
             class="ant-tabs-tab ant-tabs-tab-disabled"
+            data-node-key="28"
           >
             <div
               aria-disabled="true"
@@ -4189,6 +4286,7 @@ exports[`renders ./components/tabs/demo/slide.tsx extend context correctly 1`] =
           </div>
           <div
             class="ant-tabs-tab"
+            data-node-key="29"
           >
             <div
               aria-disabled="false"

--- a/components/tabs/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/tabs/__tests__/__snapshots__/demo.test.ts.snap
@@ -79,6 +79,7 @@ Array [
         >
           <div
             class="ant-tabs-tab ant-tabs-tab-active"
+            data-node-key="1"
           >
             <div
               aria-selected="true"
@@ -91,6 +92,7 @@ Array [
           </div>
           <div
             class="ant-tabs-tab"
+            data-node-key="2"
           >
             <div
               aria-selected="false"
@@ -103,6 +105,7 @@ Array [
           </div>
           <div
             class="ant-tabs-tab"
+            data-node-key="3"
           >
             <div
               aria-selected="false"
@@ -192,6 +195,7 @@ exports[`renders ./components/tabs/demo/basic.tsx correctly 1`] = `
       >
         <div
           class="ant-tabs-tab ant-tabs-tab-active"
+          data-node-key="1"
         >
           <div
             aria-selected="true"
@@ -204,6 +208,7 @@ exports[`renders ./components/tabs/demo/basic.tsx correctly 1`] = `
         </div>
         <div
           class="ant-tabs-tab"
+          data-node-key="2"
         >
           <div
             aria-selected="false"
@@ -216,6 +221,7 @@ exports[`renders ./components/tabs/demo/basic.tsx correctly 1`] = `
         </div>
         <div
           class="ant-tabs-tab"
+          data-node-key="3"
         >
           <div
             aria-selected="false"
@@ -303,6 +309,7 @@ exports[`renders ./components/tabs/demo/card.tsx correctly 1`] = `
       >
         <div
           class="ant-tabs-tab ant-tabs-tab-active"
+          data-node-key="1"
         >
           <div
             aria-selected="true"
@@ -315,6 +322,7 @@ exports[`renders ./components/tabs/demo/card.tsx correctly 1`] = `
         </div>
         <div
           class="ant-tabs-tab"
+          data-node-key="2"
         >
           <div
             aria-selected="false"
@@ -327,6 +335,7 @@ exports[`renders ./components/tabs/demo/card.tsx correctly 1`] = `
         </div>
         <div
           class="ant-tabs-tab"
+          data-node-key="3"
         >
           <div
             aria-selected="false"
@@ -417,6 +426,7 @@ exports[`renders ./components/tabs/demo/card-top.tsx correctly 1`] = `
         >
           <div
             class="ant-tabs-tab ant-tabs-tab-active"
+            data-node-key="1"
           >
             <div
               aria-selected="true"
@@ -429,6 +439,7 @@ exports[`renders ./components/tabs/demo/card-top.tsx correctly 1`] = `
           </div>
           <div
             class="ant-tabs-tab"
+            data-node-key="2"
           >
             <div
               aria-selected="false"
@@ -441,6 +452,7 @@ exports[`renders ./components/tabs/demo/card-top.tsx correctly 1`] = `
           </div>
           <div
             class="ant-tabs-tab"
+            data-node-key="3"
           >
             <div
               aria-selected="false"
@@ -543,6 +555,7 @@ exports[`renders ./components/tabs/demo/centered.tsx correctly 1`] = `
       >
         <div
           class="ant-tabs-tab ant-tabs-tab-active"
+          data-node-key="1"
         >
           <div
             aria-selected="true"
@@ -555,6 +568,7 @@ exports[`renders ./components/tabs/demo/centered.tsx correctly 1`] = `
         </div>
         <div
           class="ant-tabs-tab"
+          data-node-key="2"
         >
           <div
             aria-selected="false"
@@ -567,6 +581,7 @@ exports[`renders ./components/tabs/demo/centered.tsx correctly 1`] = `
         </div>
         <div
           class="ant-tabs-tab"
+          data-node-key="3"
         >
           <div
             aria-selected="false"
@@ -667,6 +682,7 @@ exports[`renders ./components/tabs/demo/custom-add-trigger.tsx correctly 1`] = `
         >
           <div
             class="ant-tabs-tab ant-tabs-tab-with-remove ant-tabs-tab-active"
+            data-node-key="1"
           >
             <div
               aria-selected="true"
@@ -705,6 +721,7 @@ exports[`renders ./components/tabs/demo/custom-add-trigger.tsx correctly 1`] = `
           </div>
           <div
             class="ant-tabs-tab ant-tabs-tab-with-remove"
+            data-node-key="2"
           >
             <div
               aria-selected="false"
@@ -822,6 +839,7 @@ exports[`renders ./components/tabs/demo/custom-tab-bar.tsx correctly 1`] = `
           >
             <div
               class="ant-tabs-tab ant-tabs-tab-active"
+              data-node-key="1"
             >
               <div
                 aria-selected="true"
@@ -834,6 +852,7 @@ exports[`renders ./components/tabs/demo/custom-tab-bar.tsx correctly 1`] = `
             </div>
             <div
               class="ant-tabs-tab"
+              data-node-key="2"
             >
               <div
                 aria-selected="false"
@@ -846,6 +865,7 @@ exports[`renders ./components/tabs/demo/custom-tab-bar.tsx correctly 1`] = `
             </div>
             <div
               class="ant-tabs-tab"
+              data-node-key="3"
             >
               <div
                 aria-selected="false"
@@ -940,6 +960,7 @@ exports[`renders ./components/tabs/demo/custom-tab-bar-node.tsx correctly 1`] = 
         >
           <div
             class="ant-tabs-tab ant-tabs-tab-active"
+            data-node-key="1"
           >
             <div
               aria-selected="true"
@@ -957,6 +978,7 @@ exports[`renders ./components/tabs/demo/custom-tab-bar-node.tsx correctly 1`] = 
         >
           <div
             class="ant-tabs-tab"
+            data-node-key="2"
           >
             <div
               aria-selected="false"
@@ -974,6 +996,7 @@ exports[`renders ./components/tabs/demo/custom-tab-bar-node.tsx correctly 1`] = 
         >
           <div
             class="ant-tabs-tab"
+            data-node-key="3"
           >
             <div
               aria-selected="false"
@@ -1062,6 +1085,7 @@ exports[`renders ./components/tabs/demo/disabled.tsx correctly 1`] = `
       >
         <div
           class="ant-tabs-tab ant-tabs-tab-active"
+          data-node-key="1"
         >
           <div
             aria-selected="true"
@@ -1074,6 +1098,7 @@ exports[`renders ./components/tabs/demo/disabled.tsx correctly 1`] = `
         </div>
         <div
           class="ant-tabs-tab ant-tabs-tab-disabled"
+          data-node-key="2"
         >
           <div
             aria-disabled="true"
@@ -1086,6 +1111,7 @@ exports[`renders ./components/tabs/demo/disabled.tsx correctly 1`] = `
         </div>
         <div
           class="ant-tabs-tab"
+          data-node-key="3"
         >
           <div
             aria-selected="false"
@@ -1173,6 +1199,7 @@ exports[`renders ./components/tabs/demo/editable-card.tsx correctly 1`] = `
       >
         <div
           class="ant-tabs-tab ant-tabs-tab-with-remove ant-tabs-tab-active"
+          data-node-key="1"
         >
           <div
             aria-selected="true"
@@ -1211,6 +1238,7 @@ exports[`renders ./components/tabs/demo/editable-card.tsx correctly 1`] = `
         </div>
         <div
           class="ant-tabs-tab ant-tabs-tab-with-remove"
+          data-node-key="2"
         >
           <div
             aria-selected="false"
@@ -1249,6 +1277,7 @@ exports[`renders ./components/tabs/demo/editable-card.tsx correctly 1`] = `
         </div>
         <div
           class="ant-tabs-tab"
+          data-node-key="3"
         >
           <div
             aria-selected="false"
@@ -1399,6 +1428,7 @@ Array [
         >
           <div
             class="ant-tabs-tab ant-tabs-tab-active"
+            data-node-key="1"
           >
             <div
               aria-selected="true"
@@ -1411,6 +1441,7 @@ Array [
           </div>
           <div
             class="ant-tabs-tab"
+            data-node-key="2"
           >
             <div
               aria-selected="false"
@@ -1423,6 +1454,7 @@ Array [
           </div>
           <div
             class="ant-tabs-tab"
+            data-node-key="3"
           >
             <div
               aria-selected="false"
@@ -1587,6 +1619,7 @@ Array [
         >
           <div
             class="ant-tabs-tab ant-tabs-tab-active"
+            data-node-key="1"
           >
             <div
               aria-selected="true"
@@ -1599,6 +1632,7 @@ Array [
           </div>
           <div
             class="ant-tabs-tab"
+            data-node-key="2"
           >
             <div
               aria-selected="false"
@@ -1611,6 +1645,7 @@ Array [
           </div>
           <div
             class="ant-tabs-tab"
+            data-node-key="3"
           >
             <div
               aria-selected="false"
@@ -1711,6 +1746,7 @@ exports[`renders ./components/tabs/demo/icon.tsx correctly 1`] = `
       >
         <div
           class="ant-tabs-tab"
+          data-node-key="1"
         >
           <div
             aria-selected="false"
@@ -1746,6 +1782,7 @@ exports[`renders ./components/tabs/demo/icon.tsx correctly 1`] = `
         </div>
         <div
           class="ant-tabs-tab ant-tabs-tab-active"
+          data-node-key="2"
         >
           <div
             aria-selected="true"
@@ -2085,6 +2122,7 @@ exports[`renders ./components/tabs/demo/nest.tsx correctly 1`] = `
         >
           <div
             class="ant-tabs-tab ant-tabs-tab-active"
+            data-node-key="1"
           >
             <div
               aria-selected="true"
@@ -2097,6 +2135,7 @@ exports[`renders ./components/tabs/demo/nest.tsx correctly 1`] = `
           </div>
           <div
             class="ant-tabs-tab"
+            data-node-key="2"
           >
             <div
               aria-selected="false"
@@ -2177,6 +2216,7 @@ exports[`renders ./components/tabs/demo/nest.tsx correctly 1`] = `
                 >
                   <div
                     class="ant-tabs-tab"
+                    data-node-key="0"
                   >
                     <div
                       aria-selected="false"
@@ -2189,6 +2229,7 @@ exports[`renders ./components/tabs/demo/nest.tsx correctly 1`] = `
                   </div>
                   <div
                     class="ant-tabs-tab ant-tabs-tab-active"
+                    data-node-key="1"
                   >
                     <div
                       aria-selected="true"
@@ -2201,6 +2242,7 @@ exports[`renders ./components/tabs/demo/nest.tsx correctly 1`] = `
                   </div>
                   <div
                     class="ant-tabs-tab"
+                    data-node-key="2"
                   >
                     <div
                       aria-selected="false"
@@ -2213,6 +2255,7 @@ exports[`renders ./components/tabs/demo/nest.tsx correctly 1`] = `
                   </div>
                   <div
                     class="ant-tabs-tab"
+                    data-node-key="3"
                   >
                     <div
                       aria-selected="false"
@@ -2225,6 +2268,7 @@ exports[`renders ./components/tabs/demo/nest.tsx correctly 1`] = `
                   </div>
                   <div
                     class="ant-tabs-tab"
+                    data-node-key="4"
                   >
                     <div
                       aria-selected="false"
@@ -2237,6 +2281,7 @@ exports[`renders ./components/tabs/demo/nest.tsx correctly 1`] = `
                   </div>
                   <div
                     class="ant-tabs-tab"
+                    data-node-key="5"
                   >
                     <div
                       aria-selected="false"
@@ -2249,6 +2294,7 @@ exports[`renders ./components/tabs/demo/nest.tsx correctly 1`] = `
                   </div>
                   <div
                     class="ant-tabs-tab"
+                    data-node-key="6"
                   >
                     <div
                       aria-selected="false"
@@ -2261,6 +2307,7 @@ exports[`renders ./components/tabs/demo/nest.tsx correctly 1`] = `
                   </div>
                   <div
                     class="ant-tabs-tab"
+                    data-node-key="7"
                   >
                     <div
                       aria-selected="false"
@@ -2273,6 +2320,7 @@ exports[`renders ./components/tabs/demo/nest.tsx correctly 1`] = `
                   </div>
                   <div
                     class="ant-tabs-tab"
+                    data-node-key="8"
                   >
                     <div
                       aria-selected="false"
@@ -2285,6 +2333,7 @@ exports[`renders ./components/tabs/demo/nest.tsx correctly 1`] = `
                   </div>
                   <div
                     class="ant-tabs-tab"
+                    data-node-key="9"
                   >
                     <div
                       aria-selected="false"
@@ -2297,6 +2346,7 @@ exports[`renders ./components/tabs/demo/nest.tsx correctly 1`] = `
                   </div>
                   <div
                     class="ant-tabs-tab"
+                    data-node-key="10"
                   >
                     <div
                       aria-selected="false"
@@ -2309,6 +2359,7 @@ exports[`renders ./components/tabs/demo/nest.tsx correctly 1`] = `
                   </div>
                   <div
                     class="ant-tabs-tab"
+                    data-node-key="11"
                   >
                     <div
                       aria-selected="false"
@@ -2321,6 +2372,7 @@ exports[`renders ./components/tabs/demo/nest.tsx correctly 1`] = `
                   </div>
                   <div
                     class="ant-tabs-tab"
+                    data-node-key="12"
                   >
                     <div
                       aria-selected="false"
@@ -2333,6 +2385,7 @@ exports[`renders ./components/tabs/demo/nest.tsx correctly 1`] = `
                   </div>
                   <div
                     class="ant-tabs-tab"
+                    data-node-key="13"
                   >
                     <div
                       aria-selected="false"
@@ -2345,6 +2398,7 @@ exports[`renders ./components/tabs/demo/nest.tsx correctly 1`] = `
                   </div>
                   <div
                     class="ant-tabs-tab"
+                    data-node-key="14"
                   >
                     <div
                       aria-selected="false"
@@ -2357,6 +2411,7 @@ exports[`renders ./components/tabs/demo/nest.tsx correctly 1`] = `
                   </div>
                   <div
                     class="ant-tabs-tab"
+                    data-node-key="15"
                   >
                     <div
                       aria-selected="false"
@@ -2369,6 +2424,7 @@ exports[`renders ./components/tabs/demo/nest.tsx correctly 1`] = `
                   </div>
                   <div
                     class="ant-tabs-tab"
+                    data-node-key="16"
                   >
                     <div
                       aria-selected="false"
@@ -2381,6 +2437,7 @@ exports[`renders ./components/tabs/demo/nest.tsx correctly 1`] = `
                   </div>
                   <div
                     class="ant-tabs-tab"
+                    data-node-key="17"
                   >
                     <div
                       aria-selected="false"
@@ -2393,6 +2450,7 @@ exports[`renders ./components/tabs/demo/nest.tsx correctly 1`] = `
                   </div>
                   <div
                     class="ant-tabs-tab"
+                    data-node-key="18"
                   >
                     <div
                       aria-selected="false"
@@ -2405,6 +2463,7 @@ exports[`renders ./components/tabs/demo/nest.tsx correctly 1`] = `
                   </div>
                   <div
                     class="ant-tabs-tab"
+                    data-node-key="19"
                   >
                     <div
                       aria-selected="false"
@@ -2594,6 +2653,7 @@ Array [
         >
           <div
             class="ant-tabs-tab ant-tabs-tab-active"
+            data-node-key="1"
           >
             <div
               aria-selected="true"
@@ -2606,6 +2666,7 @@ Array [
           </div>
           <div
             class="ant-tabs-tab"
+            data-node-key="2"
           >
             <div
               aria-selected="false"
@@ -2618,6 +2679,7 @@ Array [
           </div>
           <div
             class="ant-tabs-tab"
+            data-node-key="3"
           >
             <div
               aria-selected="false"
@@ -2771,6 +2833,7 @@ exports[`renders ./components/tabs/demo/size.tsx correctly 1`] = `
         >
           <div
             class="ant-tabs-tab ant-tabs-tab-active"
+            data-node-key="1"
           >
             <div
               aria-selected="true"
@@ -2783,6 +2846,7 @@ exports[`renders ./components/tabs/demo/size.tsx correctly 1`] = `
           </div>
           <div
             class="ant-tabs-tab"
+            data-node-key="2"
           >
             <div
               aria-selected="false"
@@ -2795,6 +2859,7 @@ exports[`renders ./components/tabs/demo/size.tsx correctly 1`] = `
           </div>
           <div
             class="ant-tabs-tab"
+            data-node-key="3"
           >
             <div
               aria-selected="false"
@@ -2879,6 +2944,7 @@ exports[`renders ./components/tabs/demo/size.tsx correctly 1`] = `
         >
           <div
             class="ant-tabs-tab ant-tabs-tab-active"
+            data-node-key="1"
           >
             <div
               aria-selected="true"
@@ -2891,6 +2957,7 @@ exports[`renders ./components/tabs/demo/size.tsx correctly 1`] = `
           </div>
           <div
             class="ant-tabs-tab"
+            data-node-key="2"
           >
             <div
               aria-selected="false"
@@ -2903,6 +2970,7 @@ exports[`renders ./components/tabs/demo/size.tsx correctly 1`] = `
           </div>
           <div
             class="ant-tabs-tab"
+            data-node-key="3"
           >
             <div
               aria-selected="false"
@@ -3037,6 +3105,7 @@ exports[`renders ./components/tabs/demo/slide.tsx correctly 1`] = `
         >
           <div
             class="ant-tabs-tab"
+            data-node-key="0"
           >
             <div
               aria-disabled="false"
@@ -3050,6 +3119,7 @@ exports[`renders ./components/tabs/demo/slide.tsx correctly 1`] = `
           </div>
           <div
             class="ant-tabs-tab ant-tabs-tab-active"
+            data-node-key="1"
           >
             <div
               aria-disabled="false"
@@ -3063,6 +3133,7 @@ exports[`renders ./components/tabs/demo/slide.tsx correctly 1`] = `
           </div>
           <div
             class="ant-tabs-tab"
+            data-node-key="2"
           >
             <div
               aria-disabled="false"
@@ -3076,6 +3147,7 @@ exports[`renders ./components/tabs/demo/slide.tsx correctly 1`] = `
           </div>
           <div
             class="ant-tabs-tab"
+            data-node-key="3"
           >
             <div
               aria-disabled="false"
@@ -3089,6 +3161,7 @@ exports[`renders ./components/tabs/demo/slide.tsx correctly 1`] = `
           </div>
           <div
             class="ant-tabs-tab"
+            data-node-key="4"
           >
             <div
               aria-disabled="false"
@@ -3102,6 +3175,7 @@ exports[`renders ./components/tabs/demo/slide.tsx correctly 1`] = `
           </div>
           <div
             class="ant-tabs-tab"
+            data-node-key="5"
           >
             <div
               aria-disabled="false"
@@ -3115,6 +3189,7 @@ exports[`renders ./components/tabs/demo/slide.tsx correctly 1`] = `
           </div>
           <div
             class="ant-tabs-tab"
+            data-node-key="6"
           >
             <div
               aria-disabled="false"
@@ -3128,6 +3203,7 @@ exports[`renders ./components/tabs/demo/slide.tsx correctly 1`] = `
           </div>
           <div
             class="ant-tabs-tab"
+            data-node-key="7"
           >
             <div
               aria-disabled="false"
@@ -3141,6 +3217,7 @@ exports[`renders ./components/tabs/demo/slide.tsx correctly 1`] = `
           </div>
           <div
             class="ant-tabs-tab"
+            data-node-key="8"
           >
             <div
               aria-disabled="false"
@@ -3154,6 +3231,7 @@ exports[`renders ./components/tabs/demo/slide.tsx correctly 1`] = `
           </div>
           <div
             class="ant-tabs-tab"
+            data-node-key="9"
           >
             <div
               aria-disabled="false"
@@ -3167,6 +3245,7 @@ exports[`renders ./components/tabs/demo/slide.tsx correctly 1`] = `
           </div>
           <div
             class="ant-tabs-tab"
+            data-node-key="10"
           >
             <div
               aria-disabled="false"
@@ -3180,6 +3259,7 @@ exports[`renders ./components/tabs/demo/slide.tsx correctly 1`] = `
           </div>
           <div
             class="ant-tabs-tab"
+            data-node-key="11"
           >
             <div
               aria-disabled="false"
@@ -3193,6 +3273,7 @@ exports[`renders ./components/tabs/demo/slide.tsx correctly 1`] = `
           </div>
           <div
             class="ant-tabs-tab"
+            data-node-key="12"
           >
             <div
               aria-disabled="false"
@@ -3206,6 +3287,7 @@ exports[`renders ./components/tabs/demo/slide.tsx correctly 1`] = `
           </div>
           <div
             class="ant-tabs-tab"
+            data-node-key="13"
           >
             <div
               aria-disabled="false"
@@ -3219,6 +3301,7 @@ exports[`renders ./components/tabs/demo/slide.tsx correctly 1`] = `
           </div>
           <div
             class="ant-tabs-tab"
+            data-node-key="14"
           >
             <div
               aria-disabled="false"
@@ -3232,6 +3315,7 @@ exports[`renders ./components/tabs/demo/slide.tsx correctly 1`] = `
           </div>
           <div
             class="ant-tabs-tab"
+            data-node-key="15"
           >
             <div
               aria-disabled="false"
@@ -3245,6 +3329,7 @@ exports[`renders ./components/tabs/demo/slide.tsx correctly 1`] = `
           </div>
           <div
             class="ant-tabs-tab"
+            data-node-key="16"
           >
             <div
               aria-disabled="false"
@@ -3258,6 +3343,7 @@ exports[`renders ./components/tabs/demo/slide.tsx correctly 1`] = `
           </div>
           <div
             class="ant-tabs-tab"
+            data-node-key="17"
           >
             <div
               aria-disabled="false"
@@ -3271,6 +3357,7 @@ exports[`renders ./components/tabs/demo/slide.tsx correctly 1`] = `
           </div>
           <div
             class="ant-tabs-tab"
+            data-node-key="18"
           >
             <div
               aria-disabled="false"
@@ -3284,6 +3371,7 @@ exports[`renders ./components/tabs/demo/slide.tsx correctly 1`] = `
           </div>
           <div
             class="ant-tabs-tab"
+            data-node-key="19"
           >
             <div
               aria-disabled="false"
@@ -3297,6 +3385,7 @@ exports[`renders ./components/tabs/demo/slide.tsx correctly 1`] = `
           </div>
           <div
             class="ant-tabs-tab"
+            data-node-key="20"
           >
             <div
               aria-disabled="false"
@@ -3310,6 +3399,7 @@ exports[`renders ./components/tabs/demo/slide.tsx correctly 1`] = `
           </div>
           <div
             class="ant-tabs-tab"
+            data-node-key="21"
           >
             <div
               aria-disabled="false"
@@ -3323,6 +3413,7 @@ exports[`renders ./components/tabs/demo/slide.tsx correctly 1`] = `
           </div>
           <div
             class="ant-tabs-tab"
+            data-node-key="22"
           >
             <div
               aria-disabled="false"
@@ -3336,6 +3427,7 @@ exports[`renders ./components/tabs/demo/slide.tsx correctly 1`] = `
           </div>
           <div
             class="ant-tabs-tab"
+            data-node-key="23"
           >
             <div
               aria-disabled="false"
@@ -3349,6 +3441,7 @@ exports[`renders ./components/tabs/demo/slide.tsx correctly 1`] = `
           </div>
           <div
             class="ant-tabs-tab"
+            data-node-key="24"
           >
             <div
               aria-disabled="false"
@@ -3362,6 +3455,7 @@ exports[`renders ./components/tabs/demo/slide.tsx correctly 1`] = `
           </div>
           <div
             class="ant-tabs-tab"
+            data-node-key="25"
           >
             <div
               aria-disabled="false"
@@ -3375,6 +3469,7 @@ exports[`renders ./components/tabs/demo/slide.tsx correctly 1`] = `
           </div>
           <div
             class="ant-tabs-tab"
+            data-node-key="26"
           >
             <div
               aria-disabled="false"
@@ -3388,6 +3483,7 @@ exports[`renders ./components/tabs/demo/slide.tsx correctly 1`] = `
           </div>
           <div
             class="ant-tabs-tab"
+            data-node-key="27"
           >
             <div
               aria-disabled="false"
@@ -3401,6 +3497,7 @@ exports[`renders ./components/tabs/demo/slide.tsx correctly 1`] = `
           </div>
           <div
             class="ant-tabs-tab ant-tabs-tab-disabled"
+            data-node-key="28"
           >
             <div
               aria-disabled="true"
@@ -3413,6 +3510,7 @@ exports[`renders ./components/tabs/demo/slide.tsx correctly 1`] = `
           </div>
           <div
             class="ant-tabs-tab"
+            data-node-key="29"
           >
             <div
               aria-disabled="false"

--- a/components/tabs/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/tabs/__tests__/__snapshots__/index.test.tsx.snap
@@ -45,6 +45,7 @@ exports[`Tabs rtl render component should be rendered correctly in RTL direction
       >
         <div
           class="ant-tabs-tab ant-tabs-tab-active"
+          data-node-key="xx"
         >
           <div
             aria-controls="rc-tabs-test-panel-xx"
@@ -134,6 +135,7 @@ exports[`Tabs tabBarGutter should work 1`] = `
       >
         <div
           class="ant-tabs-tab ant-tabs-tab-active"
+          data-node-key="null"
         >
           <div
             aria-controls="rc-tabs-test-panel-null"
@@ -146,6 +148,7 @@ exports[`Tabs tabBarGutter should work 1`] = `
         </div>
         <div
           class="ant-tabs-tab ant-tabs-tab-active"
+          data-node-key="null"
           style="margin-left: 0px;"
         >
           <div
@@ -159,6 +162,7 @@ exports[`Tabs tabBarGutter should work 1`] = `
         </div>
         <div
           class="ant-tabs-tab ant-tabs-tab-active"
+          data-node-key="null"
           style="margin-left: 0px;"
         >
           <div
@@ -263,6 +267,7 @@ exports[`Tabs tabBarGutter should work 2`] = `
       >
         <div
           class="ant-tabs-tab ant-tabs-tab-active"
+          data-node-key="null"
         >
           <div
             aria-controls="rc-tabs-test-panel-null"
@@ -275,6 +280,7 @@ exports[`Tabs tabBarGutter should work 2`] = `
         </div>
         <div
           class="ant-tabs-tab ant-tabs-tab-active"
+          data-node-key="null"
           style="margin-top: 0px;"
         >
           <div
@@ -288,6 +294,7 @@ exports[`Tabs tabBarGutter should work 2`] = `
         </div>
         <div
           class="ant-tabs-tab ant-tabs-tab-active"
+          data-node-key="null"
           style="margin-top: 0px;"
         >
           <div
@@ -392,6 +399,7 @@ exports[`Tabs tabPosition remove card 1`] = `
       >
         <div
           class="ant-tabs-tab ant-tabs-tab-active"
+          data-node-key="1"
         >
           <div
             aria-controls="rc-tabs-test-panel-1"

--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "rc-steps": "~6.0.0-alpha.2",
     "rc-switch": "~4.0.0",
     "rc-table": "~7.28.2",
-    "rc-tabs": "~12.5.0",
+    "rc-tabs": "~12.5.1",
     "rc-textarea": "~0.4.5",
     "rc-tooltip": "~5.2.0",
     "rc-tree": "~5.7.0",

--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "rc-steps": "~6.0.0-alpha.2",
     "rc-switch": "~4.0.0",
     "rc-table": "~7.28.2",
-    "rc-tabs": "~12.4.2",
+    "rc-tabs": "~12.5.0",
     "rc-textarea": "~0.4.5",
     "rc-tooltip": "~5.2.0",
     "rc-tree": "~5.7.0",


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

fix #39631
fix #39494

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fix Tabs inkBar not show in StrictMode.      |
| 🇨🇳 Chinese |    修复 Tabs inkBar 在 StrictMode 下不展示的问题。    |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
