### PR TITLE
refactor: merge preset colors

### DIFF
--- a/components/_util/colors.ts
+++ b/components/_util/colors.ts
@@ -1,3 +1,6 @@
+import type { PresetColorKey } from '../theme/interface';
+import { PresetColors } from '../theme/interface';
+
 export const PresetStatusColorTypes = [
   'success',
   'processing',
@@ -6,32 +9,13 @@ export const PresetStatusColorTypes = [
   'warning',
 ] as const;
 
-export const PresetColorTypes = [
-  'pink',
-  'red',
-  'yellow',
-  'orange',
-  'cyan',
-  'green',
-  'blue',
-  'purple',
-  'geekblue',
-  'magenta',
-  'volcano',
-  'gold',
-  'lime',
-] as const;
-
-type _PresetColorType = typeof PresetColorTypes[number];
-type InversePresetColorType = `${_PresetColorType}-inverse`;
-
-export type PresetColorType = _PresetColorType | InversePresetColorType;
+export type PresetColorType = PresetColorKey | `${PresetColorKey}-inverse`;
 
 export type PresetStatusColorType = typeof PresetStatusColorTypes[number];
 
 export function isPresetColor(color?: any): color is PresetColorType {
-  const inverseColors = PresetColorTypes.map((c) => `${c}-inverse`) as InversePresetColorType[];
-  return [...inverseColors, ...PresetColorTypes].includes(color);
+  const inverseColors = PresetColors.map((c) => `${c}-inverse`);
+  return [...inverseColors, ...PresetColors].includes(color);
 }
 
 export function isPresetStatusColor(color?: any): color is PresetStatusColorType {

--- a/components/_util/colors.ts
+++ b/components/_util/colors.ts
@@ -1,6 +1,9 @@
 import type { PresetColorKey } from '../theme/interface';
 import { PresetColors } from '../theme/interface';
 
+type InverseColor = `${PresetColorKey}-inverse`;
+const inverseColors = PresetColors.map<InverseColor>((color) => `${color}-inverse`);
+
 export const PresetStatusColorTypes = [
   'success',
   'processing',
@@ -9,13 +12,21 @@ export const PresetStatusColorTypes = [
   'warning',
 ] as const;
 
-export type PresetColorType = PresetColorKey | `${PresetColorKey}-inverse`;
+export type PresetColorType = PresetColorKey | InverseColor;
 
 export type PresetStatusColorType = typeof PresetStatusColorTypes[number];
 
-export function isPresetColor(color?: any): color is PresetColorType {
-  const inverseColors = PresetColors.map((c) => `${c}-inverse`);
-  return [...inverseColors, ...PresetColors].includes(color);
+/**
+ * determine if the color keyword belongs to the `Ant Design` {@link PresetColors}.
+ * @param color color to be judged
+ * @param includeInverse whether to include reversed colors
+ */
+export function isPresetColor(color?: any, includeInverse = true) {
+  if (includeInverse) {
+    return [...inverseColors, ...PresetColors].includes(color);
+  }
+
+  return PresetColors.includes(color);
 }
 
 export function isPresetStatusColor(color?: any): color is PresetStatusColorType {

--- a/components/_util/colors.ts
+++ b/components/_util/colors.ts
@@ -22,12 +22,16 @@ export const PresetColorTypes = [
   'lime',
 ] as const;
 
-export type PresetColorType = typeof PresetColorTypes[number];
+type _PresetColorType = typeof PresetColorTypes[number];
+type InversePresetColorType = `${_PresetColorType}-inverse`;
+
+export type PresetColorType = _PresetColorType | InversePresetColorType;
 
 export type PresetStatusColorType = typeof PresetStatusColorTypes[number];
 
 export function isPresetColor(color?: any): color is PresetColorType {
-  return PresetColorTypes.includes(color);
+  const inverseColors = PresetColorTypes.map((c) => `${c}-inverse`) as InversePresetColorType[];
+  return [...inverseColors, ...PresetColorTypes].includes(color);
 }
 
 export function isPresetStatusColor(color?: any): color is PresetStatusColorType {

--- a/components/_util/colors.ts
+++ b/components/_util/colors.ts
@@ -25,3 +25,11 @@ export const PresetColorTypes = [
 export type PresetColorType = typeof PresetColorTypes[number];
 
 export type PresetStatusColorType = typeof PresetStatusColorTypes[number];
+
+export function isPresetColor(color?: any): color is PresetColorType {
+  return PresetColorTypes.includes(color);
+}
+
+export function isPresetStatusColor(color?: any): color is PresetStatusColorType {
+  return PresetStatusColorTypes.includes(color);
+}

--- a/components/badge/Ribbon.tsx
+++ b/components/badge/Ribbon.tsx
@@ -29,7 +29,7 @@ const Ribbon: React.FC<RibbonProps> = function Ribbon({
 }) {
   const { getPrefixCls, direction } = React.useContext(ConfigContext);
   const prefixCls = getPrefixCls('ribbon', customizePrefixCls);
-  const colorInPreset = isPresetColor(color);
+  const colorInPreset = isPresetColor(color, false);
   const ribbonCls = classNames(
     prefixCls,
     `${prefixCls}-placement-${placement}`,

--- a/components/badge/Ribbon.tsx
+++ b/components/badge/Ribbon.tsx
@@ -4,7 +4,7 @@ import { ConfigContext } from '../config-provider';
 import type { PresetColorType } from '../_util/colors';
 import type { LiteralUnion } from '../_util/type';
 import useStyle from './style';
-import { isPresetColor } from './utils';
+import { isPresetColor } from '../_util/colors';
 
 type RibbonPlacement = 'start' | 'end';
 

--- a/components/badge/index.tsx
+++ b/components/badge/index.tsx
@@ -3,13 +3,14 @@ import CSSMotion from 'rc-motion';
 import * as React from 'react';
 import { useMemo, useRef } from 'react';
 import { ConfigContext } from '../config-provider';
-import type { PresetColorType, PresetStatusColorType } from '../_util/colors';
+import type { PresetStatusColorType } from '../_util/colors';
 import { cloneElement } from '../_util/reactNode';
 import type { LiteralUnion } from '../_util/type';
 import Ribbon from './Ribbon';
 import ScrollNumber from './ScrollNumber';
 import useStyle from './style';
 import { isPresetColor } from '../_util/colors';
+import type { PresetColorKey } from '../theme/internal';
 
 export type { ScrollNumberProps } from './ScrollNumber';
 
@@ -30,7 +31,7 @@ export interface BadgeProps {
   scrollNumberPrefixCls?: string;
   className?: string;
   status?: PresetStatusColorType;
-  color?: LiteralUnion<PresetColorType>;
+  color?: LiteralUnion<PresetColorKey>;
   text?: React.ReactNode;
   size?: 'default' | 'small';
   offset?: [number | string, number | string];
@@ -144,15 +145,18 @@ const Badge: CompoundedComponent = ({
           },
         }));
 
+  // InternalColor
+  const isInternalColor = isPresetColor(color, false);
+
   // Shared styles
   const statusCls = classNames({
     [`${prefixCls}-status-dot`]: hasStatus,
     [`${prefixCls}-status-${status}`]: !!status,
-    [`${prefixCls}-status-${color}`]: isPresetColor(color),
+    [`${prefixCls}-status-${color}`]: isInternalColor,
   });
 
   const statusStyle: React.CSSProperties = {};
-  if (color && !isPresetColor(color)) {
+  if (color && !isInternalColor) {
     statusStyle.color = color;
     statusStyle.background = color;
   }
@@ -207,11 +211,11 @@ const Badge: CompoundedComponent = ({
             [`${prefixCls}-multiple-words`]:
               !isDot && displayCount && displayCount.toString().length > 1,
             [`${prefixCls}-status-${status}`]: !!status,
-            [`${prefixCls}-status-${color}`]: isPresetColor(color),
+            [`${prefixCls}-status-${color}`]: isInternalColor,
           });
 
           let scrollNumberStyle: React.CSSProperties = { ...mergedStyle };
-          if (color && !isPresetColor(color)) {
+          if (color && !isInternalColor) {
             scrollNumberStyle = scrollNumberStyle || {};
             scrollNumberStyle.background = color;
           }

--- a/components/badge/index.tsx
+++ b/components/badge/index.tsx
@@ -9,7 +9,7 @@ import type { LiteralUnion } from '../_util/type';
 import Ribbon from './Ribbon';
 import ScrollNumber from './ScrollNumber';
 import useStyle from './style';
-import { isPresetColor } from './utils';
+import { isPresetColor } from '../_util/colors';
 
 export type { ScrollNumberProps } from './ScrollNumber';
 

--- a/components/badge/style/index.ts
+++ b/components/badge/style/index.ts
@@ -73,31 +73,16 @@ const genSharedBadgeStyle: GenerateStyle<BadgeToken> = (token: BadgeToken): CSSO
   const ribbonPrefixCls = `${antCls}-ribbon`;
   const ribbonWrapperPrefixCls = `${antCls}-ribbon-wrapper`;
 
-  const statusPreset = genPresetColor(token, (colorKey, { darkColor, lightColor }) => ({
+  const statusPreset = genPresetColor(token, (colorKey, { darkColor }) => ({
     [`${componentCls}-status-${colorKey}`]: {
       background: darkColor,
-
-      // Inverse color
-      '&-inverse': {
-        background: lightColor,
-      },
     },
   }));
 
-  const statusRibbonPreset = genPresetColor(token, (colorKey, { darkColor, lightColor }) => ({
+  const statusRibbonPreset = genPresetColor(token, (colorKey, { darkColor }) => ({
     [`&${ribbonPrefixCls}-color-${colorKey}`]: {
       background: darkColor,
       color: darkColor,
-
-      // Inverse color
-      '&-inverse': {
-        background: lightColor,
-        color: lightColor,
-
-        [`> ${ribbonPrefixCls}-text`]: {
-          color: darkColor,
-        },
-      },
     },
   }));
 

--- a/components/badge/style/index.ts
+++ b/components/badge/style/index.ts
@@ -1,7 +1,7 @@
 import type { CSSObject } from '@ant-design/cssinjs';
 import { Keyframes } from '@ant-design/cssinjs';
-import type { FullToken, GenerateStyle, PresetColorType } from '../../theme/internal';
-import { genComponentStyleHook, mergeToken, PresetColors } from '../../theme/internal';
+import type { FullToken, GenerateStyle } from '../../theme/internal';
+import { genComponentStyleHook, mergeToken } from '../../theme/internal';
 import { genPresetColor, resetComponent } from '../../style';
 
 interface BadgeToken extends FullToken<'Badge'> {
@@ -73,19 +73,33 @@ const genSharedBadgeStyle: GenerateStyle<BadgeToken> = (token: BadgeToken): CSSO
   const ribbonPrefixCls = `${antCls}-ribbon`;
   const ribbonWrapperPrefixCls = `${antCls}-ribbon-wrapper`;
 
-  const statusPreset = genPresetColor(token, {
-    cssProps: ['backgroundColor'],
-    type: ['default', 'inverse'],
-    defaultSelector: (colorKey) => `${componentCls}-status-${colorKey}-inverse`,
-    inverseSelector: (colorKey) => `${componentCls}-status-${colorKey}`,
-  });
+  const statusPreset = genPresetColor(token, (colorKey, { darkColor, lightColor }) => ({
+    [`${componentCls}-status-${colorKey}`]: {
+      background: darkColor,
 
-  const statusRibbonPreset = genPresetColor(token, {
-    cssProps: ['backgroundColor', 'color'],
-    type: ['default', 'inverse'],
-    defaultSelector: (colorKey) => `&${ribbonPrefixCls}-color-${colorKey}-inverse`,
-    inverseSelector: (colorKey) => `&${ribbonPrefixCls}-color-${colorKey}`,
-  });
+      // Inverse color
+      '&-inverse': {
+        background: lightColor,
+      },
+    },
+  }));
+
+  const statusRibbonPreset = genPresetColor(token, (colorKey, { darkColor, lightColor }) => ({
+    [`&${ribbonPrefixCls}-color-${colorKey}`]: {
+      background: darkColor,
+      color: darkColor,
+
+      // Inverse color
+      '&-inverse': {
+        background: lightColor,
+        color: lightColor,
+
+        [`> ${ribbonPrefixCls}-text`]: {
+          color: darkColor,
+        },
+      },
+    },
+  }));
 
   return {
     [componentCls]: {

--- a/components/badge/style/index.ts
+++ b/components/badge/style/index.ts
@@ -2,7 +2,7 @@ import type { CSSObject } from '@ant-design/cssinjs';
 import { Keyframes } from '@ant-design/cssinjs';
 import type { FullToken, GenerateStyle, PresetColorType } from '../../theme/internal';
 import { genComponentStyleHook, mergeToken, PresetColors } from '../../theme/internal';
-import { resetComponent } from '../../style';
+import { genPresetColor, resetComponent } from '../../style';
 
 interface BadgeToken extends FullToken<'Badge'> {
   badgeFontHeight: number;
@@ -73,28 +73,19 @@ const genSharedBadgeStyle: GenerateStyle<BadgeToken> = (token: BadgeToken): CSSO
   const ribbonPrefixCls = `${antCls}-ribbon`;
   const ribbonWrapperPrefixCls = `${antCls}-ribbon-wrapper`;
 
-  const statusPreset = PresetColors.reduce((prev: CSSObject, colorKey: keyof PresetColorType) => {
-    const darkColor = token[`${colorKey}-6`];
-    return {
-      ...prev,
-      [`${componentCls}-status-${colorKey}`]: {
-        background: darkColor,
-      },
-    };
-  }, {} as CSSObject);
-  const statusRibbonPreset = PresetColors.reduce(
-    (prev: CSSObject, colorKey: keyof PresetColorType) => {
-      const darkColor = token[`${colorKey}-6`];
-      return {
-        ...prev,
-        [`&${ribbonPrefixCls}-color-${colorKey}`]: {
-          background: darkColor,
-          color: darkColor,
-        },
-      };
-    },
-    {} as CSSObject,
-  );
+  const statusPreset = genPresetColor(token, {
+    cssProps: ['backgroundColor'],
+    type: ['default', 'inverse'],
+    defaultSelector: (colorKey) => `${componentCls}-status-${colorKey}-inverse`,
+    inverseSelector: (colorKey) => `${componentCls}-status-${colorKey}`,
+  });
+
+  const statusRibbonPreset = genPresetColor(token, {
+    cssProps: ['backgroundColor', 'color'],
+    type: ['default', 'inverse'],
+    defaultSelector: (colorKey) => `&${ribbonPrefixCls}-color-${colorKey}-inverse`,
+    inverseSelector: (colorKey) => `&${ribbonPrefixCls}-color-${colorKey}`,
+  });
 
   return {
     [componentCls]: {

--- a/components/badge/utils.ts
+++ b/components/badge/utils.ts
@@ -1,6 +1,0 @@
-import { PresetColorTypes } from '../_util/colors';
-
-// eslint-disable-next-line import/prefer-default-export
-export function isPresetColor(color?: string): boolean {
-  return PresetColorTypes.includes(color as any);
-}

--- a/components/style/index.ts
+++ b/components/style/index.ts
@@ -4,6 +4,7 @@ import type { DerivativeToken } from '../theme/internal';
 
 export { operationUnit } from './operationUnit';
 export { roundedArrow } from './roundedArrow';
+export { genPresetColor } from './presetColor';
 
 export const textEllipsis: CSSObject = {
   overflow: 'hidden',

--- a/components/style/presetColor.tsx
+++ b/components/style/presetColor.tsx
@@ -15,11 +15,11 @@ interface CalcColor {
   textColor: string;
 }
 
-type GenCss = (colorKey: PresetColorKey, calcColor: CalcColor) => CSSObject;
+type GenCSS = (colorKey: PresetColorKey, calcColor: CalcColor) => CSSObject;
 
 export function genPresetColor<Token extends TokenWithCommonCls<AliasToken>>(
   token: Token,
-  genCss: GenCss,
+  genCss: GenCSS,
 ): CSSObject {
   return PresetColors.reduce((prev: CSSObject, colorKey: PresetColorKey) => {
     const lightColor = token[`${colorKey}-1`];

--- a/components/style/presetColor.tsx
+++ b/components/style/presetColor.tsx
@@ -1,103 +1,35 @@
 /* eslint-disable import/prefer-default-export */
-
 import type { CSSObject } from '@ant-design/cssinjs';
 import type { AliasToken, PresetColorKey } from '../theme/internal';
 import { PresetColors } from '../theme/internal';
 import type { TokenWithCommonCls } from '../theme/util/genComponentStyleHook';
 
-type CSSProp = 'color' | 'backgroundColor' | 'borderColor';
-
 interface CalcColor {
+  /** token[`${colorKey}-1`] */
   lightColor: string;
+  /** token[`${colorKey}-3`] */
   lightBorderColor: string;
+  /** token[`${colorKey}-6`] */
   darkColor: string;
+  /** token[`${colorKey}-7`] */
   textColor: string;
 }
 
-interface Options {
-  /**
-   * Role and CSS properties
-   * @default ['color', 'backgroundColor']
-   */
-  cssProps?: CSSProp[];
-  /**
-   * Generate default and inverse
-   * @default ['default']
-   */
-  type?: Array<'default' | 'inverse'>;
-
-  /**
-   * default css selector
-   * @default `${token.componentCls}-${colorKey}`
-   */
-  defaultSelector?: (colorKey: PresetColorKey) => string;
-
-  /**
-   * inverse css selector
-   * @default ${defaultSelector(colorKey)}-inverse`
-   */
-  inverseSelector?: (colorKey: PresetColorKey) => string;
-
-  /**
-   * generate other css
-   */
-  genOtherCss?: (colorKey: PresetColorKey, calcColor: CalcColor) => CSSObject;
-}
+type GenCss = (colorKey: PresetColorKey, calcColor: CalcColor) => CSSObject;
 
 export function genPresetColor<Token extends TokenWithCommonCls<AliasToken>>(
   token: Token,
-  options?: Options,
+  genCss: GenCss,
 ): CSSObject {
-  const {
-    cssProps = ['color', 'backgroundColor'],
-    type = ['default'],
-    defaultSelector = (colorKey: PresetColorKey) => `${token.componentCls}-${colorKey}`,
-    inverseSelector = (colorKey: PresetColorKey) => {
-      const allSelector = defaultSelector(colorKey).split(',');
-      return allSelector.map((selector) => `${selector}-inverse`).join(',');
-    },
-    genOtherCss = () => ({}),
-  } = options || {};
-
-  return PresetColors.reduce((prev: Record<string, CSSObject>, colorKey: PresetColorKey) => {
+  return PresetColors.reduce((prev: CSSObject, colorKey: PresetColorKey) => {
     const lightColor = token[`${colorKey}-1`];
     const lightBorderColor = token[`${colorKey}-3`];
     const darkColor = token[`${colorKey}-6`];
     const textColor = token[`${colorKey}-7`];
 
-    const defaultSelectorStr = defaultSelector(colorKey);
-    const inverseSelectorStr = inverseSelector(colorKey);
-
-    prev[defaultSelectorStr] = {};
-    prev[inverseSelectorStr] = {};
-
-    cssProps.forEach((cssProp) => {
-      if (type.includes('default')) {
-        if (cssProp === 'color') {
-          prev[defaultSelectorStr][cssProp] = textColor;
-        }
-        if (cssProp === 'backgroundColor') {
-          prev[defaultSelectorStr][cssProp] = lightColor;
-        }
-        if (cssProp === 'borderColor') {
-          prev[defaultSelectorStr][cssProp] = lightBorderColor;
-        }
-      }
-
-      if (type.includes('inverse')) {
-        if (cssProp === 'color') {
-          prev[inverseSelectorStr][cssProp] = token.colorTextLightSolid;
-        }
-
-        if (['backgroundColor', 'borderColor'].includes(cssProp)) {
-          prev[inverseSelectorStr][cssProp as any] = darkColor;
-        }
-      }
-    });
-
     return {
       ...prev,
-      ...genOtherCss(colorKey, { lightColor, lightBorderColor, darkColor, textColor }),
+      ...genCss(colorKey, { lightColor, lightBorderColor, darkColor, textColor }),
     };
-  }, {});
+  }, {} as CSSObject);
 }

--- a/components/style/presetColor.tsx
+++ b/components/style/presetColor.tsx
@@ -1,0 +1,87 @@
+/* eslint-disable import/prefer-default-export */
+
+import type { CSSObject } from '@ant-design/cssinjs';
+import type { AliasToken, PresetColorKey } from '../theme/internal';
+import { PresetColors } from '../theme/internal';
+import type { TokenWithCommonCls } from '../theme/util/genComponentStyleHook';
+
+type CSSProp = 'color' | 'backgroundColor' | 'borderColor';
+
+interface Options {
+  /**
+   * Role and CSS properties
+   * @default ['color', 'backgroundColor']
+   */
+  cssProps?: CSSProp[];
+  /**
+   * Generate default and inverse
+   * @default ['default']
+   */
+  type?: Array<'default' | 'inverse'>;
+
+  /**
+   * default css selector
+   * @default `${token.componentCls}-${colorKey}`
+   */
+  defaultSelector?: (colorKey: PresetColorKey) => string;
+
+  /**
+   * inverse css selector
+   * @default ${defaultSelector(colorKey)}-inverse`
+   */
+  inverseSelector?: (colorKey: PresetColorKey) => string;
+}
+
+export function genPresetColor<Token extends TokenWithCommonCls<AliasToken>>(
+  token: Token,
+  options?: Options,
+): CSSObject {
+  const {
+    cssProps = ['color', 'backgroundColor'],
+    type = ['default'],
+    defaultSelector = (colorKey: PresetColorKey) => `${token.componentCls}-${colorKey}`,
+    inverseSelector = (colorKey: PresetColorKey) => {
+      const allSelector = defaultSelector(colorKey).split(',');
+      return allSelector.map((selector) => `${selector}-inverse`).join(',');
+    },
+  } = options || {};
+
+  return PresetColors.reduce((prev: Record<string, CSSObject>, colorKey: PresetColorKey) => {
+    const lightColor = token[`${colorKey}-1`];
+    const lightBorderColor = token[`${colorKey}-3`];
+    const darkColor = token[`${colorKey}-6`];
+    const textColor = token[`${colorKey}-7`];
+
+    const defaultSelectorStr = defaultSelector(colorKey);
+    const inverseSelectorStr = inverseSelector(colorKey);
+
+    prev[defaultSelectorStr] = {};
+    prev[inverseSelectorStr] = {};
+
+    cssProps.forEach((cssProp) => {
+      if (type.includes('default')) {
+        if (cssProp === 'color') {
+          prev[defaultSelectorStr][cssProp] = textColor;
+        }
+        if (cssProp === 'backgroundColor') {
+          prev[defaultSelectorStr][cssProp] = lightColor;
+        }
+        if (cssProp === 'borderColor') {
+          prev[defaultSelectorStr][cssProp] = lightBorderColor;
+        }
+      }
+
+      if (type.includes('inverse')) {
+        if (cssProp === 'color') {
+          prev[inverseSelectorStr][cssProp] = token.colorTextLightSolid;
+        }
+
+        if (['backgroundColor', 'borderColor'].includes(cssProp)) {
+          prev[inverseSelectorStr][cssProp as any] = darkColor;
+        }
+      }
+    });
+
+    return prev;
+  }, {});
+}

--- a/components/style/presetColor.tsx
+++ b/components/style/presetColor.tsx
@@ -7,6 +7,13 @@ import type { TokenWithCommonCls } from '../theme/util/genComponentStyleHook';
 
 type CSSProp = 'color' | 'backgroundColor' | 'borderColor';
 
+interface CalcColor {
+  lightColor: string;
+  lightBorderColor: string;
+  darkColor: string;
+  textColor: string;
+}
+
 interface Options {
   /**
    * Role and CSS properties
@@ -30,6 +37,11 @@ interface Options {
    * @default ${defaultSelector(colorKey)}-inverse`
    */
   inverseSelector?: (colorKey: PresetColorKey) => string;
+
+  /**
+   * generate other css
+   */
+  genOtherCss?: (colorKey: PresetColorKey, calcColor: CalcColor) => CSSObject;
 }
 
 export function genPresetColor<Token extends TokenWithCommonCls<AliasToken>>(
@@ -44,6 +56,7 @@ export function genPresetColor<Token extends TokenWithCommonCls<AliasToken>>(
       const allSelector = defaultSelector(colorKey).split(',');
       return allSelector.map((selector) => `${selector}-inverse`).join(',');
     },
+    genOtherCss = () => ({}),
   } = options || {};
 
   return PresetColors.reduce((prev: Record<string, CSSObject>, colorKey: PresetColorKey) => {
@@ -82,6 +95,9 @@ export function genPresetColor<Token extends TokenWithCommonCls<AliasToken>>(
       }
     });
 
-    return prev;
+    return {
+      ...prev,
+      ...genOtherCss(colorKey, { lightColor, lightBorderColor, darkColor, textColor }),
+    };
   }, {});
 }

--- a/components/tag/index.tsx
+++ b/components/tag/index.tsx
@@ -3,7 +3,7 @@ import classNames from 'classnames';
 import * as React from 'react';
 import { ConfigContext } from '../config-provider';
 import type { PresetColorType, PresetStatusColorType } from '../_util/colors';
-import { PresetColorTypes, PresetStatusColorTypes } from '../_util/colors';
+import { isPresetColor, isPresetStatusColor } from '../_util/colors';
 import Wave from '../_util/wave';
 import warning from '../_util/warning';
 import CheckableTag from './CheckableTag';
@@ -24,9 +24,6 @@ export interface TagProps extends React.HTMLAttributes<HTMLSpanElement> {
   style?: React.CSSProperties;
   icon?: React.ReactNode;
 }
-
-const PresetColorRegex = new RegExp(`^(${PresetColorTypes.join('|')})(-inverse)?$`);
-const PresetStatusColorRegex = new RegExp(`^(${PresetStatusColorTypes.join('|')})$`);
 
 export interface TagType
   extends React.ForwardRefExoticComponent<TagProps & React.RefAttributes<HTMLElement>> {
@@ -66,19 +63,13 @@ const InternalTag: React.ForwardRefRenderFunction<HTMLSpanElement, TagProps> = (
     }
   }, [props.visible]);
 
-  const isPresetColor = (): boolean => {
-    if (!color) {
-      return false;
-    }
-    return PresetColorRegex.test(color) || PresetStatusColorRegex.test(color);
-  };
+  const isInternalColor = isPresetColor(color) || isPresetStatusColor(color);
 
   const tagStyle = {
-    backgroundColor: color && !isPresetColor() ? color : undefined,
+    backgroundColor: color && !isInternalColor ? color : undefined,
     ...style,
   };
 
-  const presetColor = isPresetColor();
   const prefixCls = getPrefixCls('tag', customizePrefixCls);
   // Style
   const [wrapSSR, hashId] = useStyle(prefixCls);
@@ -86,8 +77,8 @@ const InternalTag: React.ForwardRefRenderFunction<HTMLSpanElement, TagProps> = (
   const tagClassName = classNames(
     prefixCls,
     {
-      [`${prefixCls}-${color}`]: presetColor,
-      [`${prefixCls}-has-color`]: color && !presetColor,
+      [`${prefixCls}-${color}`]: isInternalColor,
+      [`${prefixCls}-has-color`]: color && !isInternalColor,
       [`${prefixCls}-hidden`]: !visible,
       [`${prefixCls}-rtl`]: direction === 'rtl',
     },

--- a/components/tag/style/index.ts
+++ b/components/tag/style/index.ts
@@ -1,9 +1,9 @@
-import type { CSSInterpolation, CSSObject } from '@ant-design/cssinjs';
+import type { CSSInterpolation } from '@ant-design/cssinjs';
 import type React from 'react';
-import type { FullToken, PresetColorType } from '../../theme/internal';
-import { genComponentStyleHook, mergeToken, PresetColors } from '../../theme/internal';
+import type { FullToken } from '../../theme/internal';
+import { genComponentStyleHook, mergeToken } from '../../theme/internal';
 import capitalize from '../../_util/capitalize';
-import { resetComponent } from '../../style';
+import { genPresetColor, resetComponent } from '../../style';
 
 export interface ComponentToken {}
 
@@ -34,28 +34,6 @@ const genTagStatusStyle = (
     },
   };
 };
-
-// FIXME: special preset colors
-const genTagColorStyle = (token: TagToken): CSSInterpolation =>
-  PresetColors.reduce((prev: CSSObject, colorKey: keyof PresetColorType) => {
-    const lightColor = token[`${colorKey}-1`];
-    const lightBorderColor = token[`${colorKey}-3`];
-    const darkColor = token[`${colorKey}-6`];
-    const textColor = token[`${colorKey}-7`];
-    return {
-      ...prev,
-      [`${token.componentCls}-${colorKey}`]: {
-        color: textColor,
-        background: lightColor,
-        borderColor: lightBorderColor,
-      },
-      [`${token.componentCls}-${colorKey}-inverse`]: {
-        color: token.colorTextLightSolid,
-        background: darkColor,
-        borderColor: darkColor,
-      },
-    };
-  }, {} as CSSObject);
 
 const genBaseStyle = (token: TagToken): CSSInterpolation => {
   const { paddingXXS, lineWidth, tagPaddingHorizontal } = token;
@@ -168,7 +146,11 @@ export default genComponentStyleHook('Tag', (token) => {
 
   return [
     genBaseStyle(tagToken),
-    genTagColorStyle(tagToken),
+    genPresetColor(tagToken, {
+      cssProps: ['color', 'backgroundColor', 'borderColor'],
+      type: ['default', 'inverse'],
+      defaultSelector: (colorKey) => `${tagToken.componentCls}-${colorKey}`,
+    }),
     genTagStatusStyle(tagToken, 'success', 'Success'),
     genTagStatusStyle(tagToken, 'processing', 'Info'),
     genTagStatusStyle(tagToken, 'error', 'Error'),

--- a/components/tag/style/index.ts
+++ b/components/tag/style/index.ts
@@ -35,6 +35,22 @@ const genTagStatusStyle = (
   };
 };
 
+const genPresetStyle = (token: TagToken) =>
+  genPresetColor(token, (colorKey, { textColor, lightBorderColor, lightColor, darkColor }) => ({
+    [`${token.componentCls}-${colorKey}`]: {
+      color: textColor,
+      background: lightColor,
+      borderColor: lightBorderColor,
+
+      // Inverse color
+      '&-inverse': {
+        color: token.colorTextLightSolid,
+        background: darkColor,
+        borderColor: darkColor,
+      },
+    },
+  }));
+
 const genBaseStyle = (token: TagToken): CSSInterpolation => {
   const { paddingXXS, lineWidth, tagPaddingHorizontal } = token;
   const paddingInline = tagPaddingHorizontal - lineWidth;
@@ -146,11 +162,7 @@ export default genComponentStyleHook('Tag', (token) => {
 
   return [
     genBaseStyle(tagToken),
-    genPresetColor(tagToken, {
-      cssProps: ['color', 'backgroundColor', 'borderColor'],
-      type: ['default', 'inverse'],
-      defaultSelector: (colorKey) => `${tagToken.componentCls}-${colorKey}`,
-    }),
+    genPresetStyle(tagToken),
     genTagStatusStyle(tagToken, 'success', 'Success'),
     genTagStatusStyle(tagToken, 'processing', 'Info'),
     genTagStatusStyle(tagToken, 'error', 'Error'),

--- a/components/theme/interface/index.ts
+++ b/components/theme/interface/index.ts
@@ -9,7 +9,7 @@ export type OverrideToken = {
 export type GlobalToken = AliasToken & ComponentTokenMap;
 
 export { PresetColors } from './presetColors';
-export type { PresetColorType, ColorPalettes } from './presetColors';
+export type { PresetColorType, ColorPalettes, PresetColorKey } from './presetColors';
 export type { SeedToken } from './seeds';
 export type {
   MapToken,

--- a/components/theme/interface/presetColors.ts
+++ b/components/theme/interface/presetColors.ts
@@ -14,7 +14,7 @@ export const PresetColors = [
   'gold',
 ] as const;
 
-type PresetColorKey = typeof PresetColors[number];
+export type PresetColorKey = typeof PresetColors[number];
 
 export type PresetColorType = Record<PresetColorKey, string>;
 

--- a/components/theme/internal.ts
+++ b/components/theme/internal.ts
@@ -8,6 +8,7 @@ import type {
   MapToken,
   OverrideToken,
   PresetColorType,
+  PresetColorKey,
   SeedToken,
 } from './interface';
 import { PresetColors } from './interface';
@@ -35,6 +36,7 @@ export type {
   SeedToken,
   AliasToken,
   PresetColorType,
+  PresetColorKey,
   // FIXME: Remove this type
   AliasToken as DerivativeToken,
   FullToken,

--- a/components/tooltip/style/index.ts
+++ b/components/tooltip/style/index.ts
@@ -1,4 +1,3 @@
-import type { CSSObject } from '@ant-design/cssinjs';
 import { initZoomMotion } from '../../style/motion';
 import type { FullToken, GenerateStyle, UseComponentStyleResult } from '../../theme/internal';
 import { genComponentStyleHook, mergeToken } from '../../theme/internal';
@@ -18,30 +17,6 @@ interface TooltipToken extends FullToken<'Tooltip'> {
   tooltipBorderRadius: number;
   tooltipRadiusOuter: number;
 }
-
-const generatorTooltipPresetColor: GenerateStyle<TooltipToken, CSSObject> = (token) => {
-  const { componentCls } = token;
-
-  return {
-    ...genPresetColor(token, {
-      cssProps: ['backgroundColor', 'color'],
-      type: ['default', 'inverse'],
-      defaultSelector: (colorKey) => `&${componentCls}-${colorKey}-inverse ${componentCls}-inner`,
-      inverseSelector: (colorKey) => `&${componentCls}-${colorKey} ${componentCls}-inner`,
-    }),
-    ...genPresetColor(token, {
-      cssProps: [],
-      genOtherCss: (colorKey, calcColor) => ({
-        [`&${componentCls}-${colorKey} ${componentCls}-arrow`]: {
-          '--antd-arrow-background-color': calcColor.darkColor,
-        },
-        [`&${componentCls}-${colorKey}-inverse ${componentCls}-arrow`]: {
-          '--antd-arrow-background-color': calcColor.lightColor,
-        },
-      }),
-    }),
-  };
-};
 
 const genTooltipStyle: GenerateStyle<TooltipToken> = (token) => {
   const {
@@ -107,7 +82,27 @@ const genTooltipStyle: GenerateStyle<TooltipToken> = (token) => {
         },
 
         // generator for preset color
-        ...generatorTooltipPresetColor(token),
+        ...genPresetColor(token, (colorKey, { darkColor, lightColor }) => ({
+          [`&${componentCls}-${colorKey}`]: {
+            [`${componentCls}-inner`]: {
+              backgroundColor: darkColor,
+            },
+            [`${componentCls}-arrow`]: {
+              '--antd-arrow-background-color': darkColor,
+            },
+
+            // Inverse Color
+            '&-inverse': {
+              [`${componentCls}-inner`]: {
+                backgroundColor: lightColor,
+                color: darkColor,
+              },
+              [`${componentCls}-arrow`]: {
+                '--antd-arrow-background-color': lightColor,
+              },
+            },
+          },
+        })),
 
         // RTL
         '&-rtl': {

--- a/components/tooltip/style/index.ts
+++ b/components/tooltip/style/index.ts
@@ -82,24 +82,13 @@ const genTooltipStyle: GenerateStyle<TooltipToken> = (token) => {
         },
 
         // generator for preset color
-        ...genPresetColor(token, (colorKey, { darkColor, lightColor }) => ({
+        ...genPresetColor(token, (colorKey, { darkColor }) => ({
           [`&${componentCls}-${colorKey}`]: {
             [`${componentCls}-inner`]: {
               backgroundColor: darkColor,
             },
             [`${componentCls}-arrow`]: {
               '--antd-arrow-background-color': darkColor,
-            },
-
-            // Inverse Color
-            '&-inverse': {
-              [`${componentCls}-inner`]: {
-                backgroundColor: lightColor,
-                color: darkColor,
-              },
-              [`${componentCls}-arrow`]: {
-                '--antd-arrow-background-color': lightColor,
-              },
             },
           },
         })),

--- a/components/tooltip/style/index.ts
+++ b/components/tooltip/style/index.ts
@@ -1,13 +1,8 @@
 import type { CSSObject } from '@ant-design/cssinjs';
 import { initZoomMotion } from '../../style/motion';
-import type {
-  FullToken,
-  GenerateStyle,
-  PresetColorType,
-  UseComponentStyleResult,
-} from '../../theme/internal';
-import { genComponentStyleHook, mergeToken, PresetColors } from '../../theme/internal';
-import { resetComponent } from '../../style';
+import type { FullToken, GenerateStyle, UseComponentStyleResult } from '../../theme/internal';
+import { genComponentStyleHook, mergeToken } from '../../theme/internal';
+import { genPresetColor, resetComponent } from '../../style';
 import getArrowStyle, { MAX_VERTICAL_CONTENT_RADIUS } from '../../style/placementArrow';
 
 export interface ComponentToken {
@@ -27,18 +22,25 @@ interface TooltipToken extends FullToken<'Tooltip'> {
 const generatorTooltipPresetColor: GenerateStyle<TooltipToken, CSSObject> = (token) => {
   const { componentCls } = token;
 
-  return PresetColors.reduce((previousValue: any, currentValue: keyof PresetColorType) => {
-    const lightColor = token[`${currentValue}-6`];
-    previousValue[`&${componentCls}-${currentValue}`] = {
-      [`${componentCls}-inner`]: {
-        backgroundColor: lightColor,
-      },
-      [`${componentCls}-arrow`]: {
-        '--antd-arrow-background-color': lightColor,
-      },
-    };
-    return previousValue;
-  }, {});
+  return {
+    ...genPresetColor(token, {
+      cssProps: ['backgroundColor', 'color'],
+      type: ['default', 'inverse'],
+      defaultSelector: (colorKey) => `&${componentCls}-${colorKey}-inverse ${componentCls}-inner`,
+      inverseSelector: (colorKey) => `&${componentCls}-${colorKey} ${componentCls}-inner`,
+    }),
+    ...genPresetColor(token, {
+      cssProps: [],
+      genOtherCss: (colorKey, calcColor) => ({
+        [`&${componentCls}-${colorKey} ${componentCls}-arrow`]: {
+          '--antd-arrow-background-color': calcColor.darkColor,
+        },
+        [`&${componentCls}-${colorKey}-inverse ${componentCls}-arrow`]: {
+          '--antd-arrow-background-color': calcColor.lightColor,
+        },
+      }),
+    }),
+  };
 };
 
 const genTooltipStyle: GenerateStyle<TooltipToken> = (token) => {

--- a/components/tooltip/util.ts
+++ b/components/tooltip/util.ts
@@ -2,19 +2,19 @@
 
 import type * as React from 'react';
 import classNames from 'classnames';
-import { PresetColorTypes } from '../_util/colors';
-
-const PresetColorRegex = new RegExp(`^(${PresetColorTypes.join('|')})(-inverse)?$`);
+import { isPresetColor } from '../_util/colors';
 
 export function parseColor(prefixCls: string, color?: string) {
+  const isInternalColor = isPresetColor(color);
+
   const className = classNames({
-    [`${prefixCls}-${color}`]: color && PresetColorRegex.test(color),
+    [`${prefixCls}-${color}`]: color && isInternalColor,
   });
 
   const overlayStyle: React.CSSProperties = {};
   const arrowStyle: React.CSSProperties = {};
 
-  if (color && !PresetColorRegex.test(color)) {
+  if (color && !isInternalColor) {
     overlayStyle.background = color;
     // @ts-ignore
     arrowStyle['--antd-arrow-background-color'] = color;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [x] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<details>
<summary>Outdated</summary>

- [x] 移除 LiteralUnion 类型方法 [type: remove LiteralUnion](https://github.com/ant-design/ant-design/pull/39742/commits/145381c2bcb96ad96adb04cfe92b378fc8b2c084)
- [x] 合并 `theme/interface.ts` 和 `_util/colors.ts` 重复定义的 PresetColor  [chore: merge preset colors](https://github.com/ant-design/ant-design/pull/39742/commits/05040dfb703f60a3ea1715326748c508acbf41a6)
- [x] 原 `<Tooltip />` 和 `<Tag />` 组件支持预设颜色 inverse, 这个 PR 将 `<Badge />` 、`<Badge.Ribbon />` 也支持预设颜色 inverse。


+ `<Badge />` 、`<Badge.Ribbon />` Preview: 

![image](https://user-images.githubusercontent.com/32004925/209275494-8e1db049-ae1a-47a3-8582-9bb4065b11ee.png)


+ 写了一个 antd@5.1.0 关于 presetColor 现状的 demo， https://codesandbox.io/s/antd-presetcolor-6pzjqe

</details>

---
- [x] 合并 `theme/interface.ts` 和 `_util/colors.ts` 重复定义的 PresetColor  [chore: merge preset colors](https://github.com/ant-design/ant-design/pull/39742/commits/12126d15ba9a2537e9e57bab69c5675e780a4896)
- [x] 将预设颜色样式方法抽离为独立方法 [feat: uniform preset colour generation css selector method](https://github.com/ant-design/ant-design/pull/39742/commits/7a8a1b2734c77ccf85d7c90d75d610108952db3c) 
- [x] `<Tooltip />` 和 `<Tag />` 组件 color 类型推导增强

**Before:**
<img width="563" alt="image" src="https://user-images.githubusercontent.com/32004925/210645144-b6026389-fdbd-43d3-9c59-78a639464034.png">

**After:**
<img width="608" alt="image" src="https://user-images.githubusercontent.com/32004925/210645014-9016cb35-b497-4b03-84d6-ead9c4c8db59.png">

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     ---      |
| 🇨🇳 Chinese |     ---      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
