### PR TITLE
feat[#39684]: Tabs alignment option to align tabs on start, center, end

### DIFF
--- a/components/tabs/demo/centered.tsx
+++ b/components/tabs/demo/centered.tsx
@@ -1,19 +1,38 @@
 import React from 'react';
-import { Tabs } from 'antd';
+import type { RadioChangeEvent } from 'antd';
+import { Radio, Tabs } from 'antd';
 
-const App: React.FC = () => (
-  <Tabs
-    defaultActiveKey="1"
-    centered
-    items={new Array(3).fill(null).map((_, i) => {
-      const id = String(i + 1);
-      return {
-        label: `Tab ${id}`,
-        key: id,
-        children: `Content of Tab Pane ${id}`,
-      };
-    })}
-  />
-);
+type TabsAlignment = 'start' | 'center' | 'end';
+
+const App: React.FC = () => {
+  const [tabAlignment, setTabAlignment] = React.useState<TabsAlignment>('end');
+
+  const changeTabAlignment = (e: RadioChangeEvent) => {
+    setTabAlignment(e.target.value);
+  };
+
+  return (
+    <>
+      <Radio.Group value={tabAlignment} onChange={changeTabAlignment}>
+        <Radio.Button value="start">Start</Radio.Button>
+        <Radio.Button value="center">Center</Radio.Button>
+        <Radio.Button value="end">End</Radio.Button>
+      </Radio.Group>
+
+      <Tabs
+        defaultActiveKey="1"
+        align={tabAlignment}
+        items={new Array(3).fill(null).map((_, i) => {
+          const id = String(i + 1);
+          return {
+            label: `Tab ${id}`,
+            key: id,
+            children: `Content of Tab Pane ${id}`,
+          };
+        })}
+      />
+    </>
+  );
+};
 
 export default App;

--- a/components/tabs/index.tsx
+++ b/components/tabs/index.tsx
@@ -19,6 +19,7 @@ import useStyle from './style';
 
 export type TabsType = 'line' | 'card' | 'editable-card';
 export type TabsPosition = 'top' | 'right' | 'bottom' | 'left';
+export type TabsAlignment = 'start' | 'center' | 'end';
 
 export type { TabPaneProps };
 
@@ -27,6 +28,7 @@ export interface TabsProps extends Omit<RcTabsProps, 'editable'> {
   size?: SizeType;
   hideAdd?: boolean;
   centered?: boolean;
+  align?: TabsAlignment;
   addIcon?: React.ReactNode;
   onEdit?: (e: React.MouseEvent | React.KeyboardEvent | string, action: 'add' | 'remove') => void;
   children?: React.ReactNode;
@@ -39,6 +41,7 @@ function Tabs({
   onEdit,
   hideAdd,
   centered,
+  align = 'start',
   addIcon,
   popupClassName,
   children,
@@ -90,7 +93,7 @@ function Tabs({
                 [`${prefixCls}-${size}`]: size,
                 [`${prefixCls}-card`]: ['card', 'editable-card'].includes(type as string),
                 [`${prefixCls}-editable-card`]: type === 'editable-card',
-                [`${prefixCls}-centered`]: centered,
+                [`${prefixCls}-align-${align}`]: align,
               },
               className,
               hashId,

--- a/components/tabs/style/index.tsx
+++ b/components/tabs/style/index.tsx
@@ -850,11 +850,29 @@ const genTabsStyle: GenerateStyle<TabsToken> = (token: TabsToken): CSSObject => 
       },
     },
 
-    [`${componentCls}-centered`]: {
+    [`${componentCls}-align-start`]: {
+      [`> ${componentCls}-nav, > div > ${componentCls}-nav`]: {
+        [`${componentCls}-nav-wrap`]: {
+          [`&:not([class*='${componentCls}-nav-wrap-ping'])`]: {
+            justifyContent: 'start',
+          },
+        },
+      },
+    },
+    [`${componentCls}-align-center`]: {
       [`> ${componentCls}-nav, > div > ${componentCls}-nav`]: {
         [`${componentCls}-nav-wrap`]: {
           [`&:not([class*='${componentCls}-nav-wrap-ping'])`]: {
             justifyContent: 'center',
+          },
+        },
+      },
+    },
+    [`${componentCls}-align-end`]: {
+      [`> ${componentCls}-nav, > div > ${componentCls}-nav`]: {
+        [`${componentCls}-nav-wrap`]: {
+          [`&:not([class*='${componentCls}-nav-wrap-ping'])`]: {
+            justifyContent: 'end',
           },
         },
       },


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [x] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

#39684

### 💡 Background and solution

Currently horizontal Tabs can only be positioned "left" or "center".
by default positioned left, and can positioned center by passing centered={true/false}.
Need to allow "right"  | "center" | "left", while left is default

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Align tabs "start", "center", "end"        |
| 🇨🇳 Chinese |           |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
