### PR TITLE
fix: table expandable row header has no top left border radius 

### DIFF
--- a/components/table/__tests__/Table.expand.test.tsx
+++ b/components/table/__tests__/Table.expand.test.tsx
@@ -105,10 +105,10 @@ describe('Table.expand', () => {
       );
 
       // header has td element (a11y): https://github.com/react-component/table/pull/859
-      const tdNodeList = container.querySelectorAll('td');
+      const tdNodeList = container.querySelectorAll('tbody td');
 
-      expect(tdNodeList[2].textContent).toEqual('bamboo');
-      expect(tdNodeList[3].querySelector('.ant-table-row-expand-icon')).toBeTruthy();
+      expect(tdNodeList[0].textContent).toEqual('bamboo');
+      expect(tdNodeList[1].querySelector('.ant-table-row-expand-icon')).toBeTruthy();
     });
 
     it('work with selection', () => {
@@ -123,10 +123,10 @@ describe('Table.expand', () => {
           rowSelection={{}}
         />,
       );
-      const tdNodeList = container.querySelectorAll('td');
-      expect(tdNodeList[2].querySelector('.ant-checkbox-input')).toBeTruthy();
-      expect(tdNodeList[3].textContent).toEqual('bamboo');
-      expect(tdNodeList[4].querySelector('.ant-table-row-expand-icon')).toBeTruthy();
+      const tdNodeList = container.querySelectorAll('tbody td');
+      expect(tdNodeList[0].querySelector('.ant-checkbox-input')).toBeTruthy();
+      expect(tdNodeList[1].textContent).toEqual('bamboo');
+      expect(tdNodeList[2].querySelector('.ant-table-row-expand-icon')).toBeTruthy();
     });
   });
 });

--- a/components/table/style/radius.tsx
+++ b/components/table/style/radius.tsx
@@ -36,11 +36,11 @@ const genRadiusStyle: GenerateStyle<TableToken, CSSObject> = (token) => {
           borderStartEndRadius: tableRadius,
 
           'table > thead > tr:first-child': {
-            'th:first-child': {
+            '> *:first-child': {
               borderStartStartRadius: tableRadius,
             },
 
-            'th:last-child': {
+            '> *:last-child': {
               borderStartEndRadius: tableRadius,
             },
           },


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link
fix https://github.com/ant-design/ant-design/issues/39769

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   table expandable row header has no top left border radius     |
| 🇨🇳 Chinese |     Table 可扩展行标题没有左上边框半径      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
