### PR TITLE
fix: The image preview operation bar is covered during the animation

### DIFF
--- a/components/image/style/index.tsx
+++ b/components/image/style/index.tsx
@@ -56,7 +56,6 @@ export const genPreviewOperationsStyle = (token: ImageToken): CSSObject => {
     modalMaskBg,
     paddingSM,
     imagePreviewOperationDisabledColor,
-    zIndexPopup,
     motionDurationSlow,
   } = token;
 
@@ -66,14 +65,9 @@ export const genPreviewOperationsStyle = (token: ImageToken): CSSObject => {
   return {
     [`${previewCls}-operations`]: {
       ...resetComponent(token),
-      position: 'fixed',
-      insetBlockStart: 0,
-      insetInlineEnd: 0,
-      zIndex: zIndexPopup + 1,
       display: 'flex',
       flexDirection: 'row-reverse',
       alignItems: 'center',
-      width: '100%',
       color: token.imagePreviewOperationColor,
       listStyle: 'none',
       background: operationBg.toRgbString(),
@@ -236,6 +230,13 @@ export const genImagePreviewStyle: GenerateStyle<ImageToken> = (token: ImageToke
 
     // Preview operations & switch
     {
+      [`${componentCls}-preview-operations-wrapper`]: {
+        position: 'fixed',
+        insetBlockStart: 0,
+        insetInlineEnd: 0,
+        zIndex: token.zIndexPopup + 1,
+        width: '100%',
+      },
       '&': [genPreviewOperationsStyle(token), genPreviewSwitchStyle(token)],
     },
   ];


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the image preview operation bar is covered during the animation |
| 🇨🇳 Chinese | 修复图片预览操作条在动态过程中会被高zIndex的元素覆盖 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
