### PR TITLE
style: add codeFontFamily for Typography elements

### DIFF
--- a/components/theme/interface/seeds.ts
+++ b/components/theme/interface/seeds.ts
@@ -67,10 +67,17 @@ export interface SeedToken extends PresetColorType {
 
   /**
    * @nameZH 字体
-   * @nameEN FontFamily
+   * @nameEN Font family for default text
    * @desc Ant Design 的字体家族中优先使用系统默认的界面字体，同时提供了一套利于屏显的备用字体库，来维护在不同平台以及浏览器的显示下，字体始终保持良好的易读性和可读性，体现了友好、稳定和专业的特性。
    */
   fontFamily: string;
+
+  /**
+   * @nameZH 代码字体
+   * @nameEN Font family for code text
+   * @desc 代码字体，用于 Typography 内的 code、pre 和 kbd 类型的元素
+   */
+  codeFontFamily: string;
 
   /**
    * @nameZH 默认字号

--- a/components/theme/themes/seed.ts
+++ b/components/theme/themes/seed.ts
@@ -34,6 +34,7 @@ const seedToken: SeedToken = {
   fontFamily: `-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial,
 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol',
 'Noto Color Emoji'`,
+  codeFontFamily: `'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace`,
   fontSize: 14,
 
   // Line

--- a/components/typography/style/index.tsx
+++ b/components/typography/style/index.tsx
@@ -94,7 +94,7 @@ const genTypographyStyle: GenerateStyle<TypographyToken> = (token) => {
         },
       },
 
-      ...getResetStyles(),
+      ...getResetStyles(token),
 
       ...getLinkStyles(token),
 

--- a/components/typography/style/mixins.tsx
+++ b/components/typography/style/mixins.tsx
@@ -13,7 +13,6 @@ import type { TypographyToken } from '.';
 import { initInputToken } from '../../input/style';
 import type { GenerateStyle } from '../../theme/internal';
 import { operationUnit } from '../../style';
-import { Token } from 'prismjs';
 
 // eslint-disable-next-line import/prefer-default-export
 const getTitleStyle = (

--- a/components/typography/style/mixins.tsx
+++ b/components/typography/style/mixins.tsx
@@ -13,6 +13,7 @@ import type { TypographyToken } from '.';
 import { initInputToken } from '../../input/style';
 import type { GenerateStyle } from '../../theme/internal';
 import { operationUnit } from '../../style';
+import { Token } from 'prismjs';
 
 // eslint-disable-next-line import/prefer-default-export
 const getTitleStyle = (
@@ -83,12 +84,13 @@ export const getLinkStyles: GenerateStyle<TypographyToken, CSSObject> = (token) 
   };
 };
 
-export const getResetStyles = (): CSSObject => ({
+export const getResetStyles: GenerateStyle<TypographyToken, CSSObject> = (token): CSSObject => ({
   code: {
     margin: '0 0.2em',
     paddingInline: '0.4em',
     paddingBlock: '0.2em 0.1em',
     fontSize: '85%',
+    fontFamily: token.codeFontFamily,
     background: 'rgba(150, 150, 150, 0.1)',
     border: '1px solid rgba(100, 100, 100, 0.2)',
     borderRadius: 3,
@@ -99,6 +101,7 @@ export const getResetStyles = (): CSSObject => ({
     paddingInline: '0.4em',
     paddingBlock: '0.15em 0.1em',
     fontSize: '90%',
+    fontFamily: token.codeFontFamily,
     background: 'rgba(150, 150, 150, 0.06)',
     border: '1px solid rgba(100, 100, 100, 0.2)',
     borderBottomWidth: 2,
@@ -162,6 +165,7 @@ export const getResetStyles = (): CSSObject => ({
     background: 'rgba(150, 150, 150, 0.1)',
     border: '1px solid rgba(100, 100, 100, 0.2)',
     borderRadius: 3,
+    fontFamily: token.codeFontFamily,
 
     // Compatible for marked
     code: {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [x] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->
close https://github.com/ant-design/ant-design/issues/39790

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Adds Design token `codeFontFamily` and apply to Typography `code` `kbd` `pre` elements.        |
| 🇨🇳 Chinese | 新增 Design token `codeFontFamily` 并应用到 Typography 的 `code` `kbd` `pre` 等元素上。         |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
