### PR TITLE
fix: Checkbox disabled should support Tooltip

### DIFF
--- a/components/checkbox/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/checkbox/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -159,6 +159,58 @@ Array [
 ]
 `;
 
+exports[`renders ./components/checkbox/demo/debug-disable-popover.tsx extend context correctly 1`] = `
+<div
+  style="padding:56px"
+>
+  <label
+    class="ant-checkbox-wrapper ant-checkbox-wrapper-checked ant-checkbox-wrapper-disabled"
+  >
+    <span
+      class="ant-checkbox ant-checkbox-checked ant-checkbox-disabled"
+    >
+      <input
+        checked=""
+        class="ant-checkbox-input"
+        disabled=""
+        type="checkbox"
+      />
+      <span
+        class="ant-checkbox-inner"
+      />
+    </span>
+  </label>
+  <div>
+    <div
+      class="ant-popover"
+      style="opacity:0"
+    >
+      <div
+        class="ant-popover-content"
+      >
+        <div
+          class="ant-popover-arrow"
+        >
+          <span
+            class="ant-popover-arrow-content"
+          />
+        </div>
+        <div
+          class="ant-popover-inner"
+          role="tooltip"
+        >
+          <div
+            class="ant-popover-inner-content"
+          >
+            xxxx
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`renders ./components/checkbox/demo/debug-line.tsx extend context correctly 1`] = `
 <div>
   <div

--- a/components/checkbox/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/checkbox/__tests__/__snapshots__/demo.test.ts.snap
@@ -159,6 +159,30 @@ Array [
 ]
 `;
 
+exports[`renders ./components/checkbox/demo/debug-disable-popover.tsx correctly 1`] = `
+<div
+  style="padding:56px"
+>
+  <label
+    class="ant-checkbox-wrapper ant-checkbox-wrapper-checked ant-checkbox-wrapper-disabled"
+  >
+    <span
+      class="ant-checkbox ant-checkbox-checked ant-checkbox-disabled"
+    >
+      <input
+        checked=""
+        class="ant-checkbox-input"
+        disabled=""
+        type="checkbox"
+      />
+      <span
+        class="ant-checkbox-inner"
+      />
+    </span>
+  </label>
+</div>
+`;
+
 exports[`renders ./components/checkbox/demo/debug-line.tsx correctly 1`] = `
 <div>
   <div

--- a/components/checkbox/demo/debug-disable-popover.md
+++ b/components/checkbox/demo/debug-disable-popover.md
@@ -1,0 +1,7 @@
+## zh-CN
+
+禁用时鼠标进入、离开触发 Tooltip
+
+## en-US
+
+Disable to show/hide Tooltip

--- a/components/checkbox/demo/debug-disable-popover.tsx
+++ b/components/checkbox/demo/debug-disable-popover.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Checkbox, Popover } from 'antd';
+
+const App: React.FC = () => (
+  <div style={{ padding: 56 }}>
+    <Popover content="xxxx" trigger="hover">
+      <Checkbox disabled checked />
+    </Popover>
+  </div>
+);
+
+export default App;

--- a/components/checkbox/index.en-US.md
+++ b/components/checkbox/index.en-US.md
@@ -24,6 +24,7 @@ Checkbox component.
 <code src="./demo/check-all.tsx">Check all</code>
 <code src="./demo/layout.tsx">Use with Grid</code>
 <code src="./demo/debug-line.tsx" debug>Same line</code>
+<code src="./demo/debug-disable-popover.tsx" debug>Disabled to show Tooltip</code>
 
 ## API
 

--- a/components/checkbox/index.zh-CN.md
+++ b/components/checkbox/index.zh-CN.md
@@ -25,6 +25,7 @@ demo:
 <code src="./demo/check-all.tsx">全选</code>
 <code src="./demo/layout.tsx">布局</code>
 <code src="./demo/debug-line.tsx" debug>同行布局</code>
+<code src="./demo/debug-disable-popover.tsx" debug>禁用下的 Tooltip</code>
 
 ## API
 

--- a/components/checkbox/style/index.tsx
+++ b/components/checkbox/style/index.tsx
@@ -246,6 +246,9 @@ export const genCheckboxStyle: GenerateStyle<CheckboxToken> = (token) => {
         // Wrapper > Checkbox > input
         [`&, ${checkboxCls}-input`]: {
           cursor: 'not-allowed',
+          // Disabled for native input to enable Tooltip event handler
+          // ref: https://github.com/ant-design/ant-design/issues/39822#issuecomment-1365075901
+          pointerEvents: 'none',
         },
 
         // Wrapper > Checkbox > inner


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

fix #39822

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |       Fix Checkbox not support Tooltip or Popover when disabled.    |
| 🇨🇳 Chinese |     修复 Checkbox 禁用时不支持 Tooltip 和 Popover 的问题。     |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
