### PR TITLE
fix: filterOption for transfer shouldn't depend on filterValue #39906

### DIFF
--- a/components/transfer/__tests__/search.test.tsx
+++ b/components/transfer/__tests__/search.test.tsx
@@ -83,6 +83,6 @@ describe('Transfer.Search', () => {
 
     fireEvent.change(container.querySelector('.ant-input')!, { target: { value: ' ' } });
 
-    expect(filterOption).toHaveBeenCalledTimes(dataSource.length);
+    expect(filterOption).toHaveBeenCalledTimes(2*dataSource.length);
   });
 });

--- a/components/transfer/list.tsx
+++ b/components/transfer/list.tsx
@@ -115,6 +115,7 @@ export default class TransferList<
   getFilteredItems(
     dataSource: RecordType[],
     filterValue: string,
+    filterOption?: (filterText: string, item: RecordType) => boolean,
   ): { filteredItems: RecordType[]; filteredRenderItems: RenderedItem<RecordType>[] } {
     const filteredItems: RecordType[] = [];
     const filteredRenderItems: RenderedItem<RecordType>[] = [];
@@ -124,7 +125,7 @@ export default class TransferList<
       const { renderedText } = renderedItem;
 
       // Filter skip
-      if (filterValue && !this.matchFilter(renderedText, item)) {
+      if ((filterValue || filterOption) && !this.matchFilter(renderedText, item)) {
         return null;
       }
 
@@ -322,6 +323,7 @@ export default class TransferList<
       showRemove,
       pagination,
       direction,
+      filterOption,
     } = this.props;
 
     // Custom Layout
@@ -335,7 +337,7 @@ export default class TransferList<
 
     // ====================== Get filtered, checked item list ======================
 
-    const { filteredItems, filteredRenderItems } = this.getFilteredItems(dataSource, filterValue);
+    const { filteredItems, filteredRenderItems } = this.getFilteredItems(dataSource, filterValue, filterOption);
 
     // ================================= List Body =================================
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

See #39906

https://codesandbox.io/s/antd-reproduction-template-forked-jyh2k9?file=/index.js

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

filterOption prop of the Transfer component should be triggered regardless of whether something is entered into the search input.

### 📝 Changelog

No changelog needed.

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
