### PR TITLE
Bugfix/checkbox style

### DIFF
--- a/components/checkbox/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/checkbox/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -437,6 +437,24 @@ Array [
     class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled"
   >
     <span
+      class="ant-checkbox ant-checkbox-indeterminate ant-checkbox-disabled"
+    >
+      <input
+        aria-checked="mixed"
+        class="ant-checkbox-input"
+        disabled=""
+        type="checkbox"
+      />
+      <span
+        class="ant-checkbox-inner"
+      />
+    </span>
+  </label>,
+  <br />,
+  <label
+    class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled"
+  >
+    <span
       class="ant-checkbox ant-checkbox-checked ant-checkbox-disabled"
     >
       <input

--- a/components/checkbox/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/checkbox/__tests__/__snapshots__/demo.test.ts.snap
@@ -409,6 +409,24 @@ Array [
     class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled"
   >
     <span
+      class="ant-checkbox ant-checkbox-indeterminate ant-checkbox-disabled"
+    >
+      <input
+        aria-checked="mixed"
+        class="ant-checkbox-input"
+        disabled=""
+        type="checkbox"
+      />
+      <span
+        class="ant-checkbox-inner"
+      />
+    </span>
+  </label>,
+  <br />,
+  <label
+    class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled"
+  >
+    <span
       class="ant-checkbox ant-checkbox-checked ant-checkbox-disabled"
     >
       <input

--- a/components/checkbox/demo/disabled.tsx
+++ b/components/checkbox/demo/disabled.tsx
@@ -5,6 +5,8 @@ const App: React.FC = () => (
   <>
     <Checkbox defaultChecked={false} disabled />
     <br />
+    <Checkbox indeterminate disabled />
+    <br />
     <Checkbox defaultChecked disabled />
   </>
 );

--- a/components/checkbox/style/index.ts
+++ b/components/checkbox/style/index.ts
@@ -269,7 +269,7 @@ export const genCheckboxStyle: GenerateStyle<CheckboxToken> = (token) => {
           color: token.colorTextDisabled,
         },
 
-        [`&, ${checkboxCls}-indeterminate, ${checkboxCls}-inner:after`]: {
+        [`&${checkboxCls}-indeterminate ${checkboxCls}-inner::after`]: {
           background: token.colorTextDisabled,
         },
       },

--- a/components/checkbox/style/index.ts
+++ b/components/checkbox/style/index.ts
@@ -257,7 +257,6 @@ export const genCheckboxStyle: GenerateStyle<CheckboxToken> = (token) => {
           borderColor: token.colorBorder,
 
           '&:after': {
-            background: token.colorTextDisabled,
             borderColor: token.colorTextDisabled,
           },
         },
@@ -268,6 +267,10 @@ export const genCheckboxStyle: GenerateStyle<CheckboxToken> = (token) => {
 
         '& + span': {
           color: token.colorTextDisabled,
+        },
+
+        [`&, ${checkboxCls}-indeterminate, ${checkboxCls}-inner:after`]: {
+          background: token.colorTextDisabled,
         },
       },
     },

--- a/components/checkbox/style/index.ts
+++ b/components/checkbox/style/index.ts
@@ -257,6 +257,7 @@ export const genCheckboxStyle: GenerateStyle<CheckboxToken> = (token) => {
           borderColor: token.colorBorder,
 
           '&:after': {
+            background: token.colorTextDisabled,
             borderColor: token.colorTextDisabled,
           },
         },


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [x] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

![image](https://user-images.githubusercontent.com/33312687/210340021-48e1efeb-75a4-49ae-9fa9-104a0aeab074.png)

When using Checkbox with both `disabled` and `indeterminate` props, the background color of Checkbox remains blue instead of gray for disabled.

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Checkbox style with `disabled` and `indeterminate`. |
| 🇨🇳 Chinese | 修复 Checkbox 同时开启 `disabled` 和 `indeterminate` 时的样式问题。  |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
