### PR TITLE
fix: Tooltip inverting preset colors does not work

### DIFF
--- a/components/tooltip/style/index.ts
+++ b/components/tooltip/style/index.ts
@@ -82,13 +82,24 @@ const genTooltipStyle: GenerateStyle<TooltipToken> = (token) => {
         },
 
         // generator for preset color
-        ...genPresetColor(token, (colorKey, { darkColor }) => ({
+        ...genPresetColor(token, (colorKey, { darkColor, lightColor }) => ({
           [`&${componentCls}-${colorKey}`]: {
             [`${componentCls}-inner`]: {
               backgroundColor: darkColor,
             },
             [`${componentCls}-arrow`]: {
               '--antd-arrow-background-color': darkColor,
+            },
+
+            // Inverse Color
+            '&-inverse': {
+              [`${componentCls}-inner`]: {
+                backgroundColor: lightColor,
+                color: darkColor,
+              },
+              [`${componentCls}-arrow`]: {
+                '--antd-arrow-background-color': lightColor,
+              },
             },
           },
         })),


### PR DESCRIPTION
This reverts commit d89d8cdd9ddd428fffb91f703ae066825d455950.

<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

fix #40072 

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

make it support, preview

![image](https://user-images.githubusercontent.com/32004925/211000784-57862784-e2ef-4380-b74d-16e9385b364d.png)


<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     fix `<Tooltip />` inverting preset colors does not work     |
| 🇨🇳 Chinese |     修复 `<Tooltip />` 不支持预设颜色反转      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
