### PR TITLE
refactor: use React.useContext replace <Context.ConfigConsumer />

### DIFF
--- a/components/cascader/index.tsx
+++ b/components/cascader/index.tsx
@@ -14,7 +14,7 @@ import RcCascader from 'rc-cascader';
 import omit from 'rc-util/lib/omit';
 import * as React from 'react';
 import { ConfigContext } from '../config-provider';
-import defaultRenderEmpty from '../config-provider/defaultRenderEmpty';
+import DefaultRenderEmpty from '../config-provider/defaultRenderEmpty';
 import DisabledContext from '../config-provider/DisabledContext';
 import type { SizeType } from '../config-provider/SizeContext';
 import SizeContext from '../config-provider/SizeContext';
@@ -187,7 +187,9 @@ const Cascader = React.forwardRef((props: CascaderProps<any>, ref: React.Ref<Cas
   }
 
   // =================== No Found ====================
-  const mergedNotFoundContent = notFoundContent || (renderEmpty || defaultRenderEmpty)('Cascader');
+  const mergedNotFoundContent = notFoundContent || renderEmpty?.('Cascader') || (
+    <DefaultRenderEmpty componentName="Cascader" />
+  );
 
   // ==================== Prefix =====================
   const rootPrefixCls = getPrefixCls();

--- a/components/config-provider/defaultRenderEmpty.tsx
+++ b/components/config-provider/defaultRenderEmpty.tsx
@@ -1,34 +1,33 @@
-import * as React from 'react';
+import React, { useContext } from 'react';
+import { ConfigContext } from '.';
 import type { ConfigConsumerProps } from '.';
-import { ConfigConsumer } from '.';
 import Empty from '../empty';
 
-const defaultRenderEmpty = (componentName?: string): React.ReactNode => (
-  <ConfigConsumer>
-    {({ getPrefixCls }: ConfigConsumerProps) => {
-      const prefix = getPrefixCls('empty');
+interface EmptyProps {
+  componentName?: string;
+}
 
-      switch (componentName) {
-        case 'Table':
-        case 'List':
-          return <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} />;
+const DefaultRenderEmpty: React.FC<EmptyProps> = (props) => {
+  const { componentName } = props;
+  const { getPrefixCls } = useContext<ConfigConsumerProps>(ConfigContext);
+  const prefix = getPrefixCls('empty');
+  switch (componentName) {
+    case 'Table':
+    case 'List':
+      return <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} />;
+    case 'Select':
+    case 'TreeSelect':
+    case 'Cascader':
+    case 'Transfer':
+    case 'Mentions':
+      return <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} className={`${prefix}-small`} />;
+    /* istanbul ignore next */
+    default:
+      // Should never hit if we take all the component into consider.
+      return <Empty />;
+  }
+};
 
-        case 'Select':
-        case 'TreeSelect':
-        case 'Cascader':
-        case 'Transfer':
-        case 'Mentions':
-          return <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} className={`${prefix}-small`} />;
+export type RenderEmptyHandler = (componentName?: string) => React.ReactNode;
 
-        /* istanbul ignore next */
-        default:
-          // Should never hit if we take all the component into consider.
-          return <Empty />;
-      }
-    }}
-  </ConfigConsumer>
-);
-
-export type RenderEmptyHandler = typeof defaultRenderEmpty;
-
-export default defaultRenderEmpty;
+export default DefaultRenderEmpty;

--- a/components/list/index.tsx
+++ b/components/list/index.tsx
@@ -144,14 +144,6 @@ function List<T>({
 
   const prefixCls = getPrefixCls('list', customizePrefixCls);
 
-  const renderEmptyFunc = (): React.ReactNode => (
-    <div className={`${prefixCls}-empty-text`}>
-      {(locale && locale.emptyText) || renderEmpty?.('List') || (
-        <DefaultRenderEmpty componentName="List" />
-      )}
-    </div>
-  );
-
   // Style
   const [wrapSSR, hashId] = useStyle(prefixCls);
 
@@ -270,7 +262,13 @@ function List<T>({
       <ul className={`${prefixCls}-items`}>{items}</ul>
     );
   } else if (!children && !isLoading) {
-    childrenContent = renderEmptyFunc();
+    childrenContent = (
+      <div className={`${prefixCls}-empty-text`}>
+        {(locale && locale.emptyText) || renderEmpty?.('List') || (
+          <DefaultRenderEmpty componentName="List" />
+        )}
+      </div>
+    );
   }
 
   const paginationPosition = paginationProps.position || 'bottom';

--- a/components/list/index.tsx
+++ b/components/list/index.tsx
@@ -1,9 +1,8 @@
 import classNames from 'classnames';
 // eslint-disable-next-line import/no-named-as-default
 import * as React from 'react';
-import type { RenderEmptyHandler } from '../config-provider';
 import { ConfigContext } from '../config-provider';
-import defaultRenderEmpty from '../config-provider/defaultRenderEmpty';
+import DefaultRenderEmpty from '../config-provider/defaultRenderEmpty';
 import { Row } from '../grid';
 import useBreakpoint from '../grid/hooks/useBreakpoint';
 import type { PaginationConfig } from '../pagination';
@@ -143,13 +142,16 @@ function List<T>({
 
   const isSomethingAfterLastItem = () => !!(loadMore || pagination || footer);
 
-  const renderEmptyFunc = (prefixCls: string, renderEmptyHandler: RenderEmptyHandler) => (
+  const prefixCls = getPrefixCls('list', customizePrefixCls);
+
+  const renderEmptyFunc = (): React.ReactNode => (
     <div className={`${prefixCls}-empty-text`}>
-      {(locale && locale.emptyText) || renderEmptyHandler('List')}
+      {(locale && locale.emptyText) || renderEmpty?.('List') || (
+        <DefaultRenderEmpty componentName="List" />
+      )}
     </div>
   );
 
-  const prefixCls = getPrefixCls('list', customizePrefixCls);
   // Style
   const [wrapSSR, hashId] = useStyle(prefixCls);
 
@@ -253,7 +255,7 @@ function List<T>({
     }
   }, [grid?.column, currentBreakpoint]);
 
-  let childrenContent = isLoading && <div style={{ minHeight: 53 }} />;
+  let childrenContent: React.ReactNode = isLoading && <div style={{ minHeight: 53 }} />;
   if (splitDataSource.length > 0) {
     const items = splitDataSource.map((item: T, index: number) => renderInnerItem(item, index));
     childrenContent = grid ? (
@@ -268,7 +270,7 @@ function List<T>({
       <ul className={`${prefixCls}-items`}>{items}</ul>
     );
   } else if (!children && !isLoading) {
-    childrenContent = renderEmptyFunc(prefixCls, renderEmpty || defaultRenderEmpty);
+    childrenContent = renderEmptyFunc();
   }
 
   const paginationPosition = paginationProps.position || 'bottom';

--- a/components/mentions/index.tsx
+++ b/components/mentions/index.tsx
@@ -9,7 +9,7 @@ import { composeRef } from 'rc-util/lib/ref';
 // eslint-disable-next-line import/no-named-as-default
 import * as React from 'react';
 import { ConfigContext } from '../config-provider';
-import defaultRenderEmpty from '../config-provider/defaultRenderEmpty';
+import DefaultRenderEmpty from '../config-provider/defaultRenderEmpty';
 import { FormItemInputContext } from '../form/context';
 import genPurePanel from '../_util/PurePanel';
 import Spin from '../spin';
@@ -118,13 +118,12 @@ const InternalMentions: React.ForwardRefRenderFunction<MentionsRef, MentionProps
     setFocused(false);
   };
 
-  const getNotFoundContent = () => {
+  const notFoundContentEle = React.useMemo<React.ReactNode>(() => {
     if (notFoundContent !== undefined) {
       return notFoundContent;
     }
-
-    return (renderEmpty || defaultRenderEmpty)('Select');
-  };
+    return renderEmpty?.('Select') || <DefaultRenderEmpty componentName="Select" />;
+  }, [notFoundContent, renderEmpty]);
 
   const getOptions = () => {
     if (loading) {
@@ -148,12 +147,7 @@ const InternalMentions: React.ForwardRefRenderFunction<MentionsRef, MentionProps
       ]
     : options;
 
-  const getFilterOption = (): any => {
-    if (loading) {
-      return loadingFilterOption;
-    }
-    return filterOption;
-  };
+  const mentionsfilterOption = loading ? loadingFilterOption : filterOption;
 
   const prefixCls = getPrefixCls('mentions', customizePrefixCls);
 
@@ -174,12 +168,12 @@ const InternalMentions: React.ForwardRefRenderFunction<MentionsRef, MentionProps
   const mentions = (
     <RcMentions
       prefixCls={prefixCls}
-      notFoundContent={getNotFoundContent()}
+      notFoundContent={notFoundContentEle}
       className={mergedClassName}
       disabled={disabled}
       direction={direction}
       {...restProps}
-      filterOption={getFilterOption()}
+      filterOption={mentionsfilterOption}
       onFocus={onFocus}
       onBlur={onBlur}
       dropdownClassName={classNames(popupClassName, hashId)}

--- a/components/select/index.tsx
+++ b/components/select/index.tsx
@@ -8,7 +8,7 @@ import type { BaseOptionType, DefaultOptionType } from 'rc-select/lib/Select';
 import omit from 'rc-util/lib/omit';
 import * as React from 'react';
 import { ConfigContext } from '../config-provider';
-import defaultRenderEmpty from '../config-provider/defaultRenderEmpty';
+import DefaultRenderEmpty from '../config-provider/defaultRenderEmpty';
 import DisabledContext from '../config-provider/DisabledContext';
 import type { SizeType } from '../config-provider/SizeContext';
 import SizeContext from '../config-provider/SizeContext';
@@ -135,7 +135,7 @@ const InternalSelect = <OptionType extends BaseOptionType | DefaultOptionType = 
   } else if (mode === 'combobox') {
     mergedNotFound = null;
   } else {
-    mergedNotFound = (renderEmpty || defaultRenderEmpty)('Select');
+    mergedNotFound = renderEmpty?.('Select') || <DefaultRenderEmpty componentName="Select" />;
   }
 
   // ===================== Icons =====================

--- a/components/table/InternalTable.tsx
+++ b/components/table/InternalTable.tsx
@@ -6,7 +6,7 @@ import omit from 'rc-util/lib/omit';
 import * as React from 'react';
 import type { ConfigConsumerProps } from '../config-provider/context';
 import { ConfigContext } from '../config-provider/context';
-import defaultRenderEmpty from '../config-provider/defaultRenderEmpty';
+import DefaultRenderEmpty from '../config-provider/defaultRenderEmpty';
 import type { SizeType } from '../config-provider/SizeContext';
 import SizeContext from '../config-provider/SizeContext';
 import useBreakpoint from '../grid/hooks/useBreakpoint';
@@ -519,6 +519,11 @@ function InternalTable<RecordType extends object = any>(
     className,
     hashId,
   );
+
+  const emptyText = (locale && locale.emptyText) || renderEmpty?.('Table') || (
+    <DefaultRenderEmpty componentName="Table" />
+  );
+
   return wrapSSR(
     <div ref={ref} className={wrapperClassNames} style={style}>
       <Spin spinning={false} {...spinProps}>
@@ -538,7 +543,7 @@ function InternalTable<RecordType extends object = any>(
           data={pageData}
           rowKey={getRowKey}
           rowClassName={internalRowClassName}
-          emptyText={(locale && locale.emptyText) || (renderEmpty || defaultRenderEmpty)('Table')}
+          emptyText={emptyText}
           // Internal
           internalHooks={INTERNAL_HOOKS}
           internalRefs={internalRefs as any}

--- a/components/transfer/index.tsx
+++ b/components/transfer/index.tsx
@@ -1,9 +1,9 @@
 import classNames from 'classnames';
 import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import type { ChangeEvent, CSSProperties } from 'react';
-import type { ConfigConsumerProps, RenderEmptyHandler } from '../config-provider';
+import type { ConfigConsumerProps } from '../config-provider';
 import { ConfigContext } from '../config-provider';
-import defaultRenderEmpty from '../config-provider/defaultRenderEmpty';
+import DefaultRenderEmpty from '../config-provider/defaultRenderEmpty';
 import type { FormItemStatusContextProps } from '../form/context';
 import { FormItemInputContext } from '../form/context';
 import LocaleReceiver from '../locale/LocaleReceiver';
@@ -201,12 +201,6 @@ const Transfer = <RecordType extends TransferItem = TransferItem>(
   const getTitles = (transferLocale: TransferLocale): React.ReactNode[] =>
     titles ?? transferLocale.titles ?? [];
 
-  const getLocale = (transferLocale: TransferLocale, renderEmpty: RenderEmptyHandler) => ({
-    ...transferLocale,
-    notFoundContent: renderEmpty('Transfer'),
-    ...locale,
-  });
-
   const handleLeftScroll = (e: React.SyntheticEvent<HTMLUListElement>) => {
     onScroll?.('left', e);
   };
@@ -338,6 +332,12 @@ const Transfer = <RecordType extends TransferItem = TransferItem>(
   const { getPrefixCls, renderEmpty, direction } = configContext;
   const { hasFeedback, status } = formItemContext;
 
+  const getLocale = (transferLocale: TransferLocale) => ({
+    ...transferLocale,
+    notFoundContent: renderEmpty?.('Transfer') || <DefaultRenderEmpty componentName="Transfer" />,
+    ...locale,
+  });
+
   const prefixCls = getPrefixCls('transfer', customizePrefixCls);
   const mergedStatus = getMergedStatus(status, customStatus);
   const mergedPagination = !children && pagination;
@@ -359,7 +359,7 @@ const Transfer = <RecordType extends TransferItem = TransferItem>(
   return (
     <LocaleReceiver componentName="Transfer" defaultLocale={defaultLocale.Transfer}>
       {(contextLocale) => {
-        const listLocale = getLocale(contextLocale, renderEmpty || defaultRenderEmpty);
+        const listLocale = getLocale(contextLocale);
         const [leftTitle, rightTitle] = getTitles(listLocale);
         return (
           <TransferFC prefixCls={prefixCls} className={cls} style={style}>

--- a/components/transfer/list.tsx
+++ b/components/transfer/list.tsx
@@ -238,7 +238,7 @@ const TransferList = <RecordType extends KeyWiseTransferItem>(
 
   const checkBox = (
     <Checkbox
-      disabled={dataSource.length === 0 || props.disabled}
+      disabled={dataSource.length === 0 || disabled}
       checked={checkStatus === 'all'}
       indeterminate={checkStatus === 'part'}
       className={`${prefixCls}-checkbox`}

--- a/components/tree-select/index.tsx
+++ b/components/tree-select/index.tsx
@@ -5,8 +5,9 @@ import RcTreeSelect, { SHOW_ALL, SHOW_CHILD, SHOW_PARENT, TreeNode } from 'rc-tr
 import type { BaseOptionType, DefaultOptionType } from 'rc-tree-select/lib/TreeSelect';
 import omit from 'rc-util/lib/omit';
 import * as React from 'react';
+import type { Placement } from 'rc-select/lib/BaseSelect';
 import { ConfigContext } from '../config-provider';
-import defaultRenderEmpty from '../config-provider/defaultRenderEmpty';
+import DefaultRenderEmpty from '../config-provider/defaultRenderEmpty';
 import DisabledContext from '../config-provider/DisabledContext';
 import type { SizeType } from '../config-provider/SizeContext';
 import SizeContext from '../config-provider/SizeContext';
@@ -160,7 +161,7 @@ const InternalTreeSelect = <OptionType extends BaseOptionType | DefaultOptionTyp
   if (notFoundContent !== undefined) {
     mergedNotFound = notFoundContent;
   } else {
-    mergedNotFound = (renderEmpty || defaultRenderEmpty)('Select');
+    mergedNotFound = renderEmpty?.('Select') || <DefaultRenderEmpty componentName="Select" />;
   }
 
   // ==================== Render =====================
@@ -173,13 +174,11 @@ const InternalTreeSelect = <OptionType extends BaseOptionType | DefaultOptionTyp
   ]);
 
   // ===================== Placement =====================
-  const getPlacement = () => {
+  const getPlacement = (): Placement => {
     if (placement !== undefined) {
       return placement;
     }
-    return direction === 'rtl'
-      ? ('bottomRight' as SelectCommonPlacement)
-      : ('bottomLeft' as SelectCommonPlacement);
+    return direction === 'rtl' ? 'bottomRight' : 'bottomLeft';
   };
 
   const mergedSize = compactSize || customizeSize || size;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [x] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

- 将 defaultRenderEmpty 函数改成 react 组件
- 使用 useContext 代替 Consumer
- 在调用的地方将函数调用改成组件调用
- 顺便优化了一点 type 类型

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | chore: use React.useContext replace <Context.ConfigConsumer /> |
| 🇨🇳 Chinese | chore: 使用 useContext 代替 Consumer |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed