### PR TITLE
fix(cascader): cascader dropdown placement using isRtl

### DIFF
--- a/components/cascader/index.tsx
+++ b/components/cascader/index.tsx
@@ -272,9 +272,7 @@ const Cascader = React.forwardRef((props: CascaderProps<any>, ref: React.Ref<Cas
     if (placement !== undefined) {
       return placement;
     }
-    return isRtl
-      ? ('bottomRight' as SelectCommonPlacement)
-      : ('bottomLeft' as SelectCommonPlacement);
+    return isRtl ? 'bottomRight' : 'bottomLeft';
   };
 
   // ==================== Render =====================

--- a/components/cascader/index.tsx
+++ b/components/cascader/index.tsx
@@ -272,7 +272,7 @@ const Cascader = React.forwardRef((props: CascaderProps<any>, ref: React.Ref<Cas
     if (placement !== undefined) {
       return placement;
     }
-    return direction === 'rtl'
+    return isRtl
       ? ('bottomRight' as SelectCommonPlacement)
       : ('bottomLeft' as SelectCommonPlacement);
   };


### PR DESCRIPTION
### 🤔 This is a ...

- [x] Component style update

### 💡 Background and solution

cascader dropdown is opening on left in rtl direction
![Screenshot from 2023-01-09 14-03-11](https://user-images.githubusercontent.com/36244081/211288584-375ea81a-0d6b-4a77-8078-1c7d2b9bcb15.png)

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix cascader dropdown placement in rtl directiuon and remove extra type assertion |
| 🇨🇳 Chinese |  修复 rtl 方向的级联下拉菜单放置并删除额外的类型断言 |


