### PR TITLE
fix: missing locale in pacakge

### DIFF
--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
     "throttle-debounce": "^5.0.0"
   },
   "devDependencies": {
-    "@ant-design/tools": "^17.0.0-alpha.5",
+    "@ant-design/tools": "^17.0.0-alpha.7",
     "@babel/eslint-plugin": "^7.19.1",
     "@emotion/babel-preset-css-prop": "^11.10.0",
     "@emotion/css": "^11.10.5",

--- a/scripts/post-script.js
+++ b/scripts/post-script.js
@@ -27,6 +27,7 @@ const DEPRECIATED_VERSION = {
   '5.0.6': ['https://github.com/ant-design/ant-design/issues/39807'],
   '5.1.0': ['https://github.com/react-component/drawer/pull/370'],
   '5.1.2': ['https://github.com/ant-design/ant-design/issues/39949'],
+  '5.1.3': ['https://github.com/ant-design/ant-design/issues/40113'],
 };
 
 function matchDeprecated(version) {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link
close https://github.com/ant-design/ant-design/issues/40113
<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution
glob 不支持正则语法，https://github.com/ant-design/antd-tools/commit/274f30767bf4b9f09016ad84f321772f8e069833
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Fix missing locale file.        |
| 🇨🇳 Chinese |    修复 locale 文件丢失的问题。       |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
