### PR TITLE
docs: override debug prop when show all demo

### DIFF
--- a/.dumi/theme/builtins/DemoWrapper/index.tsx
+++ b/.dumi/theme/builtins/DemoWrapper/index.tsx
@@ -25,7 +25,12 @@ const DemoWrapper: typeof DumiDemoGrid = ({ items }) => {
   const visibleDemos = showDebug ? items : items.filter((item) => !item.previewerProps.debug);
   const filteredItems = visibleDemos.map((item) => ({
     ...item,
-    previewerProps: { ...item.previewerProps, expand: expandAll, debug: false },
+    previewerProps: {
+      ...item.previewerProps,
+      expand: expandAll,
+      // always override debug property, because dumi will hide debug demo in production
+      debug: false,
+    },
   }));
 
   return (

--- a/.dumi/theme/builtins/DemoWrapper/index.tsx
+++ b/.dumi/theme/builtins/DemoWrapper/index.tsx
@@ -25,7 +25,7 @@ const DemoWrapper: typeof DumiDemoGrid = ({ items }) => {
   const visibleDemos = showDebug ? items : items.filter((item) => !item.previewerProps.debug);
   const filteredItems = visibleDemos.map((item) => ({
     ...item,
-    previewerProps: { ...item.previewerProps, expand: expandAll },
+    previewerProps: { ...item.previewerProps, expand: expandAll, debug: false },
   }));
 
   return (


### PR DESCRIPTION
[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 💡 Background and solution

dumi 下个版本将会在 production 环境中隐藏 debug demo，与之前 dumi v1 用法保持一致，所以 antd 在选择展示所有 demo 时要覆写一下 debug 属性，避免被 dumi 隐藏

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | --        |
| 🇨🇳 Chinese | --        |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
