### PR TITLE
feat: add useConfig hook to ConfigProvider

### DIFF
--- a/components/config-provider/__tests__/useConfig.test.tsx
+++ b/components/config-provider/__tests__/useConfig.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ConfigProvider from '..';
 import Form from '../../form';
 import { render } from '../../../tests/utils';
+import { resetWarned } from '../../_util/warning';
 
 describe('ConfigProvider.useConfig', () => {
   it('useConfig - componentSize', () => {
@@ -38,5 +39,25 @@ describe('ConfigProvider.useConfig', () => {
     );
 
     expect(disabled).toBe(true);
+  });
+
+  it('deprecated SizeContext', () => {
+    resetWarned();
+
+    const App: React.FC = () => {
+      const { SizeContext } = ConfigProvider;
+      const ctx = React.useContext(SizeContext);
+
+      return <div>{ctx}</div>;
+    };
+
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    render(<App />);
+
+    expect(errSpy).toHaveBeenCalledWith(
+      'Warning: [antd: ConfigProvider] ConfigProvider.SizeContext is deprecated. Please use `ConfigProvider.useConfig().componentSize` instead.',
+    );
+    errSpy.mockRestore();
   });
 });

--- a/components/config-provider/__tests__/useConfig.test.tsx
+++ b/components/config-provider/__tests__/useConfig.test.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import ConfigProvider from '..';
+import Form from '../../form';
+import { render } from '../../../tests/utils';
+
+describe('ConfigProvider.useConfig', () => {
+  it('useConfig - componentSize', () => {
+    let size: string | undefined = undefined;
+
+    const App: React.FC = () => {
+      const { componentSize } = ConfigProvider.useConfig();
+      size = componentSize;
+
+      return null;
+    };
+
+    render(
+      <ConfigProvider componentSize='small'>
+        <App />
+      </ConfigProvider>,
+    );
+
+    expect(size).toBe('small');
+  });
+
+  it('useConfig - componentDisabled', () => {
+    let disabled: boolean | undefined = undefined;
+    const App: React.FC = () => {
+      const { componentDisabled } = ConfigProvider.useConfig();
+      disabled = componentDisabled;
+      return null;
+    };
+
+    render(
+      <Form disabled>
+        <App />
+      </Form>,
+    );
+
+    expect(disabled).toBe(true);
+  });
+});

--- a/components/config-provider/__tests__/useConfig.test.tsx
+++ b/components/config-provider/__tests__/useConfig.test.tsx
@@ -5,7 +5,7 @@ import { render } from '../../../tests/utils';
 
 describe('ConfigProvider.useConfig', () => {
   it('useConfig - componentSize', () => {
-    let size: string | undefined = undefined;
+    let size;
 
     const App: React.FC = () => {
       const { componentSize } = ConfigProvider.useConfig();
@@ -24,7 +24,7 @@ describe('ConfigProvider.useConfig', () => {
   });
 
   it('useConfig - componentDisabled', () => {
-    let disabled: boolean | undefined = undefined;
+    let disabled;
     const App: React.FC = () => {
       const { componentDisabled } = ConfigProvider.useConfig();
       disabled = componentDisabled;

--- a/components/config-provider/demo/useConfig.md
+++ b/components/config-provider/demo/useConfig.md
@@ -1,0 +1,7 @@
+## zh-CN
+
+获取父级 `Provider` 的值。如 `DisabledContextProvider`、`SizeContextProvider`。
+
+## en-US
+
+Get the value of the parent `Provider`. Such as `DisabledContextProvider`, `SizeContextProvider`.

--- a/components/config-provider/demo/useConfig.tsx
+++ b/components/config-provider/demo/useConfig.tsx
@@ -1,0 +1,53 @@
+import React, { useState } from 'react';
+import { Checkbox, ConfigProvider, Divider, Form, Input, Radio, Space } from 'antd';
+import type { SizeType } from 'antd/es/config-provider/SizeContext';
+
+const ConfigDisplay = () => {
+  const { componentDisabled, componentSize } = ConfigProvider.useConfig();
+
+  return (
+    <>
+      <Form.Item label="componentSize value">
+        <Input value={componentSize} />
+      </Form.Item>
+      <Form.Item label="componentDisabled value">
+        <Input value={String(componentDisabled)} disabled={componentDisabled} />
+      </Form.Item>
+    </>
+  );
+};
+
+const App: React.FC = () => {
+  const [componentSize, setComponentSize] = useState<SizeType>('small');
+  const [disabled, setDisabled] = useState<boolean>(true);
+
+  return (
+    <div>
+      <Space>
+        <Radio.Group
+          value={componentSize}
+          onChange={(e) => {
+            setComponentSize(e.target.value);
+          }}
+        >
+          <Radio.Button value="small">Small</Radio.Button>
+          <Radio.Button value="middle">Middle</Radio.Button>
+          <Radio.Button value="large">Large</Radio.Button>
+        </Radio.Group>
+        <Checkbox checked={disabled} onChange={(e) => setDisabled(e.target.checked)}>
+          Form disabled
+        </Checkbox>
+      </Space>
+      <Divider />
+      <ConfigProvider componentSize={componentSize}>
+        <div className="example">
+          <Form disabled={disabled}>
+            <ConfigDisplay />
+          </Form>
+        </div>
+      </ConfigProvider>
+    </div>
+  );
+};
+
+export default App;

--- a/components/config-provider/hooks/useConfig.ts
+++ b/components/config-provider/hooks/useConfig.ts
@@ -1,0 +1,15 @@
+import { useContext } from 'react';
+import DisabledContext from '../DisabledContext';
+import SizeContext from '../SizeContext';
+
+function useConfig() {
+  const componentDisabled = useContext(DisabledContext);
+  const componentSize = useContext(SizeContext);
+
+  return {
+    componentDisabled,
+    componentSize,
+  };
+}
+
+export default useConfig;

--- a/components/config-provider/index.en-US.md
+++ b/components/config-provider/index.en-US.md
@@ -79,21 +79,21 @@ ConfigProvider.config({
 });
 ```
 
-### ConfigProvider.useConfig() `5.2.0+`
+### ConfigProvider.useConfig() `5.3.0+`
 
 Available since `5.2.0`. Get the value of the parent `Provider`. Such as `DisabledContextProvider`, `SizeContextProvider`.
 
 ```jsx
 const {
-  componentDisabled, // 5.2.0+
-  componentSize, // 5.2.0+
+  componentDisabled, // 5.3.0+
+  componentSize, // 5.3.0+
 } = ConfigProvider.useConfig();
 ```
 
 | 返回值 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
-| componentDisabled | antd component disabled state | boolean | - | 5.2.0 |
-| componentSize | antd component size state | `small` \| `middle` \| `large` | - | 5.2.0 |
+| componentDisabled | antd component disabled state | boolean | - | 5.3.0 |
+| componentSize | antd component size state | `small` \| `middle` \| `large` | - | 5.3.0 |
 
 ## FAQ
 

--- a/components/config-provider/index.en-US.md
+++ b/components/config-provider/index.en-US.md
@@ -43,7 +43,7 @@ Some components use dynamic style to support wave effect. You can config `csp` p
 <code src="./demo/size.tsx">Component size</code>
 <code src="./demo/theme.tsx">Theme</code>
 <code src="./demo/prefixCls.tsx" debug>prefixCls</code>
-<code src="./demo/useConfig.tsx">useConfig</code>
+<code src="./demo/useConfig.tsx" debug>useConfig</code>
 
 ## API
 

--- a/components/config-provider/index.en-US.md
+++ b/components/config-provider/index.en-US.md
@@ -79,18 +79,21 @@ ConfigProvider.config({
 });
 ```
 
-### ConfigProvider.useConfig()
+### ConfigProvider.useConfig() `5.2.0+`
 
-Get the value of the parent `Provider`. Such as `DisabledContextProvider`, `SizeContextProvider`.
+Available since `5.2.0`. Get the value of the parent `Provider`. Such as `DisabledContextProvider`, `SizeContextProvider`.
 
 ```jsx
-const { componentDisabled, componentSize } = ConfigProvider.useConfig();
+const {
+  componentDisabled, // 5.2.0+
+  componentSize, // 5.2.0+
+} = ConfigProvider.useConfig();
 ```
 
 | 返回值 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
-| componentDisabled | antd component disabled state | boolean | - |  |
-| componentSize | antd component size state | `small` \| `middle` \| `large` | - |  |
+| componentDisabled | antd component disabled state | boolean | - | 5.2.0 |
+| componentSize | antd component size state | `small` \| `middle` \| `large` | - | 5.2.0 |
 
 ## FAQ
 

--- a/components/config-provider/index.en-US.md
+++ b/components/config-provider/index.en-US.md
@@ -43,6 +43,7 @@ Some components use dynamic style to support wave effect. You can config `csp` p
 <code src="./demo/size.tsx">Component size</code>
 <code src="./demo/theme.tsx">Theme</code>
 <code src="./demo/prefixCls.tsx" debug>prefixCls</code>
+<code src="./demo/useConfig.tsx">useConfig</code>
 
 ## API
 
@@ -77,6 +78,19 @@ ConfigProvider.config({
   iconPrefixCls: 'anticon', // 4.17.0+
 });
 ```
+
+### ConfigProvider.useConfig()
+
+Get the value of the parent `Provider`. Such as `DisabledContextProvider`, `SizeContextProvider`.
+
+```jsx
+const { componentDisabled, componentSize } = ConfigProvider.useConfig();
+```
+
+| 返回值 | 说明 | 类型 | 默认值 | 版本 |
+| --- | --- | --- | --- | --- |
+| componentDisabled | antd component disabled state | boolean | - |  |
+| componentSize | antd component size state | `small` \| `middle` \| `large` | - |  |
 
 ## FAQ
 

--- a/components/config-provider/index.tsx
+++ b/components/config-provider/index.tsx
@@ -22,6 +22,8 @@ import useTheme from './hooks/useTheme';
 import type { SizeType } from './SizeContext';
 import SizeContext, { SizeContextProvider } from './SizeContext';
 import useStyle from './style';
+import useConfig from './hooks/useConfig';
+import warning from '../_util/warning';
 
 export {
   type RenderEmptyHandler,
@@ -311,8 +313,10 @@ const ProviderChildren: React.FC<ProviderChildrenProps> = (props) => {
 const ConfigProvider: React.FC<ConfigProviderProps> & {
   /** @private internal Usage. do not use in your production */
   ConfigContext: typeof ConfigContext;
+  /** @deprecated Please use `ConfigProvider.useConfig().componentSize` instead */
   SizeContext: typeof SizeContext;
   config: typeof setGlobalConfig;
+  useConfig: typeof useConfig;
 } = (props) => (
   <LocaleReceiver>
     {(_, __, legacyLocale) => (
@@ -328,6 +332,18 @@ const ConfigProvider: React.FC<ConfigProviderProps> & {
 ConfigProvider.ConfigContext = ConfigContext;
 ConfigProvider.SizeContext = SizeContext;
 ConfigProvider.config = setGlobalConfig;
+ConfigProvider.useConfig = useConfig;
+
+Object.defineProperty(ConfigProvider, 'SizeContext', {
+  get: () => {
+    warning(
+      false,
+      'ConfigProvider',
+      'ConfigProvider.SizeContext is deprecated. Please use `ConfigProvider.useConfig().componentSize` instead',
+    );
+    return ConfigProvider.SizeContext;
+  },
+});
 
 if (process.env.NODE_ENV !== 'production') {
   ConfigProvider.displayName = 'ConfigProvider';

--- a/components/config-provider/index.tsx
+++ b/components/config-provider/index.tsx
@@ -341,7 +341,7 @@ Object.defineProperty(ConfigProvider, 'SizeContext', {
       'ConfigProvider',
       'ConfigProvider.SizeContext is deprecated. Please use `ConfigProvider.useConfig().componentSize` instead',
     );
-    return ConfigProvider.SizeContext;
+    return SizeContext;
   },
 });
 

--- a/components/config-provider/index.tsx
+++ b/components/config-provider/index.tsx
@@ -339,7 +339,7 @@ Object.defineProperty(ConfigProvider, 'SizeContext', {
     warning(
       false,
       'ConfigProvider',
-      'ConfigProvider.SizeContext is deprecated. Please use `ConfigProvider.useConfig().componentSize` instead',
+      'ConfigProvider.SizeContext is deprecated. Please use `ConfigProvider.useConfig().componentSize` instead.',
     );
     return SizeContext;
   },

--- a/components/config-provider/index.zh-CN.md
+++ b/components/config-provider/index.zh-CN.md
@@ -44,6 +44,7 @@ export default Demo;
 <code src="./demo/size.tsx">组件尺寸</code>
 <code src="./demo/theme.tsx">主题</code>
 <code src="./demo/prefixCls.tsx" debug>前缀</code>
+<code src="./demo/useConfig.tsx">useConfig</code>
 
 ## API
 
@@ -78,6 +79,19 @@ ConfigProvider.config({
   iconPrefixCls: 'anticon', // 4.17.0+
 });
 ```
+
+### ConfigProvider.useConfig()
+
+获取父级 `Provider` 的值。如 `DisabledContextProvider`、`SizeContextProvider`
+
+```jsx
+const { componentDisabled, componentSize } = ConfigProvider.useConfig();
+```
+
+| 返回值            | 说明              | 类型                           | 默认值 | 版本 |
+| ----------------- | ----------------- | ------------------------------ | ------ | ---- |
+| componentDisabled | antd 组件禁用状态 | boolean                        | -      |      |
+| componentSize     | antd 组件大小状态 | `small` \| `middle` \| `large` | -      |      |
 
 ## FAQ
 

--- a/components/config-provider/index.zh-CN.md
+++ b/components/config-provider/index.zh-CN.md
@@ -80,22 +80,22 @@ ConfigProvider.config({
 });
 ```
 
-### ConfigProvider.useConfig() `5.2.0+`
+### ConfigProvider.useConfig() `5.3.0+`
 
 `5.2.0` 版本后可用。获取父级 `Provider` 的值。如 `DisabledContextProvider`、`SizeContextProvider`。
 
 ```jsx
 const {
-  componentDisabled, // 5.2.0+
-  componentSize, // 5.2.0+
+  componentDisabled, // 5.3.0+
+  componentSize, // 5.3.0+
 } = ConfigProvider.useConfig();
 ```
 
 <!-- prettier-ignore -->
 | 返回值 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
-| componentDisabled | antd 组件禁用状态 | boolean | - | 5.2.0 |
-| componentSize | antd 组件大小状态 | `small` \| `middle` \| `large` | - | 5.2.0 |
+| componentDisabled | antd 组件禁用状态 | boolean | - | 5.3.0 |
+| componentSize | antd 组件大小状态 | `small` \| `middle` \| `large` | - | 5.3.0 |
 
 ## FAQ
 

--- a/components/config-provider/index.zh-CN.md
+++ b/components/config-provider/index.zh-CN.md
@@ -80,19 +80,22 @@ ConfigProvider.config({
 });
 ```
 
-### ConfigProvider.useConfig()
+### ConfigProvider.useConfig() `5.2.0+`
 
-获取父级 `Provider` 的值。如 `DisabledContextProvider`、`SizeContextProvider`
+`5.2.0` 版本后可用。获取父级 `Provider` 的值。如 `DisabledContextProvider`、`SizeContextProvider`。
 
 ```jsx
-const { componentDisabled, componentSize } = ConfigProvider.useConfig();
+const {
+  componentDisabled, // 5.2.0+
+  componentSize, // 5.2.0+
+} = ConfigProvider.useConfig();
 ```
 
 <!-- prettier-ignore -->
 | 返回值 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
-| componentDisabled | antd 组件禁用状态 | boolean | - |  |
-| componentSize | antd 组件大小状态 | `small` \| `middle` \| `large` | - |  |
+| componentDisabled | antd 组件禁用状态 | boolean | - | 5.2.0 |
+| componentSize | antd 组件大小状态 | `small` \| `middle` \| `large` | - | 5.2.0 |
 
 ## FAQ
 

--- a/components/config-provider/index.zh-CN.md
+++ b/components/config-provider/index.zh-CN.md
@@ -44,7 +44,7 @@ export default Demo;
 <code src="./demo/size.tsx">组件尺寸</code>
 <code src="./demo/theme.tsx">主题</code>
 <code src="./demo/prefixCls.tsx" debug>前缀</code>
-<code src="./demo/useConfig.tsx">useConfig</code>
+<code src="./demo/useConfig.tsx" debug>useConfig</code>
 
 ## API
 

--- a/components/config-provider/index.zh-CN.md
+++ b/components/config-provider/index.zh-CN.md
@@ -88,10 +88,11 @@ ConfigProvider.config({
 const { componentDisabled, componentSize } = ConfigProvider.useConfig();
 ```
 
-| 返回值            | 说明              | 类型                           | 默认值 | 版本 |
-| ----------------- | ----------------- | ------------------------------ | ------ | ---- |
-| componentDisabled | antd 组件禁用状态 | boolean                        | -      |      |
-| componentSize     | antd 组件大小状态 | `small` \| `middle` \| `large` | -      |      |
+<!-- prettier-ignore -->
+| 返回值 | 说明 | 类型 | 默认值 | 版本 |
+| --- | --- | --- | --- | --- |
+| componentDisabled | antd 组件禁用状态 | boolean | - |  |
+| componentSize | antd 组件大小状态 | `small` \| `middle` \| `large` | - |  |
 
 ## FAQ
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

https://github.com/ant-design/ant-design/discussions/40025
<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

There are too many Context export from ConfigProvider like ConfigContext or SizeContext, it's not well maintain if need more Context export.

ref https://github.com/ant-design/ant-design/pull/39648

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      add useConfig hook to ConfigProvider  for get  antd ContextProvider value    |
| 🇨🇳 Chinese |      给 ConfigProvider 新增 useConfig  获取 antd 的 ContextProvider 值   |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
