### PR TITLE
docs: Update Image index.zh-CN.md

### DIFF
--- a/components/image/index.zh-CN.md
+++ b/components/image/index.zh-CN.md
@@ -12,7 +12,7 @@ cover: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*FbOCS6aFMeUAAAAAAA
 ## 何时使用
 
 - 需要展示图片时使用。
-- 加载大图时显示 loading 或加载失败时容错处理。
+- 加载显示大图或加载失败时容错处理。
 
 ## 代码演示
 


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] Site / documentation update



**问题描述：**

在目前的 Antd Image 组件的中文文档中，是这样描述的：

```
何时使用：
需要展示图片时使用。
加载大图时显示 loading 或加载失败时容错处理。
```

根据上面的描述，很容易让人理解成：当加载大图片时会显示 loading 动效。

但实际上 Image 组件并没有显示 loading 动效这个功能，我自己实际项目中测试过了，我也查看了  文档 API ，根本不存在 loading 动效。



<br>

**问题根源：**

于是我查询了一下 Image 的英文文档，发现是这样描述的：

```
When To Use：
When you need to display pictures.
Display when loading a large image or fault tolerant handling when loading fail.
```

请注意 `Display when loading a large image` 中的 `loading` 并不是指 loading 动效，而仅仅指 加载 本身。



<br>

**解决方案：**

所以，我提交了这个 PR ，修改 Image 的中文文档，以纠正歧义。

 