### PR TITLE
bugfix/radio_disable_style

### DIFF
--- a/components/radio/style/index.tsx
+++ b/components/radio/style/index.tsx
@@ -105,6 +105,7 @@ const getRadioBasicStyle: GenerateStyle<RadioToken> = (token) => {
 
       '&-disabled': {
         cursor: 'not-allowed',
+        color: token.colorTextDisabled,
       },
 
       '&::after': {
@@ -227,7 +228,7 @@ const getRadioBasicStyle: GenerateStyle<RadioToken> = (token) => {
           },
         },
 
-        '&-input': {
+        [`${componentCls}-input`]: {
           cursor: 'not-allowed',
         },
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

![image](https://user-images.githubusercontent.com/33312687/212694388-6ba1bba7-fc2a-4cea-9ea2-d65533c72f91.png)

As shown in the picture when Radio is `disabled`, its text color and cursor are wrong.
I checked the code and the `&-input` selector was wrongly moved from **less** to **cssinjs**.
Before moving to **cssinjs** it was `.@{radio-prefix-cls}-input`.

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | :lipstick: Fix Radio displaying wrong text color & cursor when `disabled` |
| 🇨🇳 Chinese | :lipstick: 修复 Radio 在 `disabled` 时显示错误的文本颜色和光标 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
