### PR TITLE
style: remove Space font style

### DIFF
--- a/components/space/style/index.tsx
+++ b/components/space/style/index.tsx
@@ -38,10 +38,8 @@ const genSpaceStyle: GenerateStyle<SpaceToken> = (token) => {
           alignItems: 'baseline',
         },
       },
-      [`${componentCls}-item`]: {
-        '&:empty': {
-          display: 'none',
-        },
+      [`${componentCls}-space-item:empty`]: {
+        display: 'none',
       },
     },
   };

--- a/components/space/style/index.tsx
+++ b/components/space/style/index.tsx
@@ -46,7 +46,13 @@ const genSpaceStyle: GenerateStyle<SpaceToken> = (token) => {
 };
 
 // ============================== Export ==============================
-export default genComponentStyleHook('Space', (token) => [
-  genSpaceStyle(token),
-  genSpaceCompactStyle(token),
-]);
+export default genComponentStyleHook(
+  'Space',
+  (token) => [genSpaceStyle(token), genSpaceCompactStyle(token)],
+  () => ({}),
+  {
+    // Space component don't apply extra font style
+    // https://github.com/ant-design/ant-design/issues/40315
+    resetStyle: false,
+  },
+);

--- a/components/space/style/index.tsx
+++ b/components/space/style/index.tsx
@@ -38,7 +38,7 @@ const genSpaceStyle: GenerateStyle<SpaceToken> = (token) => {
           alignItems: 'baseline',
         },
       },
-      [`${componentCls}-space-item:empty`]: {
+      [`${componentCls}-item:empty`]: {
         display: 'none',
       },
     },

--- a/components/theme/util/genComponentStyleHook.ts
+++ b/components/theme/util/genComponentStyleHook.ts
@@ -41,6 +41,9 @@ export default function genComponentStyleHook<ComponentName extends OverrideComp
   getDefaultToken?:
     | OverrideTokenWithoutDerivative[ComponentName]
     | ((token: GlobalToken) => OverrideTokenWithoutDerivative[ComponentName]),
+  options?: {
+    resetStyle?: boolean;
+  },
 ) {
   return (prefixCls: string): UseComponentStyleResult => {
     const [theme, token, hashId] = useToken();
@@ -93,7 +96,10 @@ export default function genComponentStyleHook<ComponentName extends OverrideComp
           overrideComponentToken: token[component],
         });
         flush(component, mergedComponentToken);
-        return [genCommonStyle(token, prefixCls), styleInterpolation];
+        return [
+          options?.resetStyle === false ? null : genCommonStyle(token, prefixCls),
+          styleInterpolation,
+        ];
       }),
       hashId,
     ];


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
close #40315

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

<img width="313" alt="图片" src="https://user-images.githubusercontent.com/507615/230530838-9b594e55-ea60-4ba2-a320-72755740b8be.png">


### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fix Space should not affect font style and font family.          |
| 🇨🇳 Chinese |  修复 Space 影响父元素字体大小和样式的问题。        |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
