### PR TITLE
refactor(button): convertLegacyProps function moved to buttonHelpers

### DIFF
--- a/components/_util/ActionButton.tsx
+++ b/components/_util/ActionButton.tsx
@@ -2,7 +2,7 @@ import useState from 'rc-util/lib/hooks/useState';
 import * as React from 'react';
 import Button from '../button';
 import type { ButtonProps, LegacyButtonType } from '../button/button';
-import { convertLegacyProps } from '../button/button';
+import { convertLegacyProps } from '../button/buttonHelpers';
 
 export interface ActionButtonProps {
   type?: LegacyButtonType;

--- a/components/button/button.tsx
+++ b/components/button/button.tsx
@@ -17,14 +17,6 @@ import type { ButtonType, ButtonHTMLType, ButtonShape } from './buttonHelpers';
 import type { SizeType } from '../config-provider/SizeContext';
 
 export type LegacyButtonType = ButtonType | 'danger';
-
-export function convertLegacyProps(type?: LegacyButtonType): ButtonProps {
-  if (type === 'danger') {
-    return { danger: true };
-  }
-  return { type };
-}
-
 export interface BaseButtonProps {
   type?: ButtonType;
   icon?: React.ReactNode;

--- a/components/button/buttonHelpers.tsx
+++ b/components/button/buttonHelpers.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { cloneElement, isFragment } from '../_util/reactNode';
-import { ButtonProps, LegacyButtonType } from './button';
+import type { ButtonProps, LegacyButtonType } from './button';
 
 const rxTwoCNChar = /^[\u4e00-\u9fa5]{2}$/;
 export const isTwoCNChar = rxTwoCNChar.test.bind(rxTwoCNChar);

--- a/components/button/buttonHelpers.tsx
+++ b/components/button/buttonHelpers.tsx
@@ -1,8 +1,16 @@
 import React from 'react';
 import { cloneElement, isFragment } from '../_util/reactNode';
+import { ButtonProps, LegacyButtonType } from './button';
 
 const rxTwoCNChar = /^[\u4e00-\u9fa5]{2}$/;
 export const isTwoCNChar = rxTwoCNChar.test.bind(rxTwoCNChar);
+
+export function convertLegacyProps(type?: LegacyButtonType): ButtonProps {
+  if (type === 'danger') {
+    return { danger: true };
+  }
+  return { type };
+}
 
 export function isString(str: any) {
   return typeof str === 'string';

--- a/components/modal/PurePanel.tsx
+++ b/components/modal/PurePanel.tsx
@@ -4,7 +4,7 @@ import { Panel } from 'rc-dialog';
 import type { PanelProps } from 'rc-dialog/lib/Dialog/Content/Panel';
 import * as React from 'react';
 import Button from '../button';
-import { convertLegacyProps } from '../button/button';
+import { convertLegacyProps } from '../button/buttonHelpers';
 import { ConfigContext } from '../config-provider';
 import LocaleReceiver from '../locale/LocaleReceiver';
 import { ConfirmContent } from './ConfirmDialog';

--- a/components/popconfirm/PurePanel.tsx
+++ b/components/popconfirm/PurePanel.tsx
@@ -3,7 +3,7 @@ import ExclamationCircleFilled from '@ant-design/icons/ExclamationCircleFilled';
 import classNames from 'classnames';
 import type { PopconfirmProps } from '.';
 import Button from '../button';
-import { convertLegacyProps } from '../button/button';
+import { convertLegacyProps } from '../button/buttonHelpers';
 import ActionButton from '../_util/ActionButton';
 import LocaleReceiver from '../locale/LocaleReceiver';
 import defaultLocale from '../locale/en_US';


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [x] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

Refactor: Moved convertLegacyProps functions from button.tsx to buttonHelpers.tsx as it is not used in button.tsx component.
 
| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
