### PR TITLE
Add support for railStyle prop to Slider component

### DIFF
--- a/components/slider/index.en-US.md
+++ b/components/slider/index.en-US.md
@@ -48,7 +48,8 @@ To input a value in a range.
 | vertical | If true, the slider will be vertical | boolean | false |  |
 | onAfterChange | Fire when onmouseup is fired | (value) => void | - |  |
 | onChange | Callback function that is fired when the user changes the slider's value | (value) => void | - |  |
-| trackStyle | The style of slider track | CSSProperties | - |  |
+| trackStyle | The style of slider track (the active range) | CSSProperties | - |  |
+| railStyle | The style of slider rail (the background) | CSSProperties | - |  |
 | handleStyle | The style of slider handle | CSSProperties | - |  |
 
 ### range

--- a/components/slider/index.tsx
+++ b/components/slider/index.tsx
@@ -77,6 +77,7 @@ export interface SliderSingleProps extends SliderBaseProps {
   onAfterChange?: (value: number) => void;
   handleStyle?: React.CSSProperties;
   trackStyle?: React.CSSProperties;
+  railStyle?: React.CSSProperties;
 }
 
 export interface SliderRangeProps extends SliderBaseProps {
@@ -87,6 +88,7 @@ export interface SliderRangeProps extends SliderBaseProps {
   onAfterChange?: (value: [number, number]) => void;
   handleStyle?: React.CSSProperties[];
   trackStyle?: React.CSSProperties[];
+  railStyle?: React.CSSProperties;
 }
 
 interface SliderRange {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [x] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

close https://github.com/ant-design/ant-design/issues/40578

### 💡 Background and solution

railStyle is a useful prop exposed by rc-slider that antd would benefit from being able to customise.

### 📝 Changelog

Add additional railStyle prop, passed through to rc-slider.  New prop, no breaking changes.

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Add railStyle prop to Slider component.  Ability to customise rail via CSS Properties.        |
| 🇨🇳 Chinese |           |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
