### PR TITLE
Calendar selectables

### DIFF
--- a/components/calendar/Header.tsx
+++ b/components/calendar/Header.tsx
@@ -5,7 +5,7 @@ import { useContext, useMemo } from 'react';
 import { FormItemInputContext } from '../form/context';
 import { Button, Group } from '../radio';
 import Select from '../select';
-import type { CalendarMode } from './generateCalendar';
+import type { CalendarMode, CalendarSelectable } from './generateCalendar';
 
 const YearSelectOffset = 10;
 const YearSelectTotal = 20;
@@ -18,7 +18,7 @@ interface SharedProps<DateType> {
   locale: Locale;
   fullscreen: boolean;
   divRef: React.RefObject<HTMLDivElement>;
-  onChange: (year: DateType) => void;
+  onChange: (year: DateType, selectType: CalendarSelectable) => void;
 }
 
 function YearSelect<DateType>(props: SharedProps<DateType>) {
@@ -68,7 +68,7 @@ function YearSelect<DateType>(props: SharedProps<DateType>) {
           }
         }
 
-        onChange(newDate);
+        onChange(newDate, 'year');
       }}
       getPopupContainer={() => divRef!.current!}
     />
@@ -110,7 +110,7 @@ function MonthSelect<DateType>(props: SharedProps<DateType>) {
       value={month}
       options={options}
       onChange={(newMonth) => {
-        onChange(generateConfig.setMonth(value, newMonth));
+        onChange(generateConfig.setMonth(value, newMonth), 'month');
       }}
       getPopupContainer={() => divRef!.current!}
     />
@@ -147,7 +147,7 @@ export interface CalendarHeaderProps<DateType> {
   locale: Locale;
   mode: CalendarMode;
   fullscreen: boolean;
-  onChange: (date: DateType) => void;
+  onChange: (date: DateType, selectType: CalendarSelectable) => void;
   onModeChange: (mode: CalendarMode) => void;
 }
 function CalendarHeader<DateType>(props: CalendarHeaderProps<DateType>) {

--- a/components/calendar/__tests__/index.test.tsx
+++ b/components/calendar/__tests__/index.test.tsx
@@ -119,7 +119,7 @@ describe('Calendar', () => {
 
     onSelect.mockReset();
 
-    wrapper.rerender(<Calendar onSelect={onSelect} mode={'month'} selectable={['month']} />);
+    wrapper.rerender(<Calendar onSelect={onSelect} mode='month' selectable={['month']} />);
 
     openSelect(wrapper.container, '.ant-picker-calendar-month-select');
     fireEvent.click(
@@ -195,7 +195,7 @@ describe('Calendar', () => {
 
     onSelect.mockReset();
 
-    wrapper.rerender(<Calendar onSelect={onSelect} mode={'month'} selectable={['date']} />);
+    wrapper.rerender(<Calendar onSelect={onSelect} mode='month' selectable={['date']} />);
 
     openSelect(wrapper.container, '.ant-picker-calendar-month-select');
     fireEvent.click(
@@ -242,9 +242,7 @@ describe('Calendar', () => {
 
     onSelect.mockReset();
 
-    wrapper.rerender(
-      <Calendar onSelect={onSelect} mode={'month'} selectable={['date', 'month']} />,
-    );
+    wrapper.rerender(<Calendar onSelect={onSelect} mode='month' selectable={['date', 'month']} />);
 
     openSelect(wrapper.container, '.ant-picker-calendar-month-select');
     fireEvent.click(
@@ -291,7 +289,7 @@ describe('Calendar', () => {
 
     onSelect.mockReset();
 
-    wrapper.rerender(<Calendar onSelect={onSelect} mode={'month'} selectable={['date', 'year']} />);
+    wrapper.rerender(<Calendar onSelect={onSelect} mode='month' selectable={['date', 'year']} />);
 
     openSelect(wrapper.container, '.ant-picker-calendar-month-select');
     fireEvent.click(
@@ -338,9 +336,7 @@ describe('Calendar', () => {
 
     onSelect.mockReset();
 
-    wrapper.rerender(
-      <Calendar onSelect={onSelect} mode={'month'} selectable={['month', 'year']} />,
-    );
+    wrapper.rerender(<Calendar onSelect={onSelect} mode='month' selectable={['month', 'year']} />);
 
     openSelect(wrapper.container, '.ant-picker-calendar-month-select');
     fireEvent.click(

--- a/components/calendar/__tests__/index.test.tsx
+++ b/components/calendar/__tests__/index.test.tsx
@@ -85,6 +85,270 @@ describe('Calendar', () => {
     MockDate.reset();
   });
 
+  it('only month change should trigger onSelect callback', () => {
+    const onSelect = jest.fn();
+    const { container } = render(
+      <Calendar onSelect={onSelect} defaultValue={Dayjs('2018-02-02')} selectable={['month']} />,
+    );
+
+    fireEvent.click(container.querySelector('[title="2018-02-05"]')!);
+    fireEvent.click(container.querySelector('[title="2018-02-07"]')!);
+    expect(onSelect.mock.calls.length).toBe(0);
+
+    onSelect.mockReset();
+
+    openSelect(container, '.ant-picker-calendar-year-select');
+    fireEvent.click(Array.from(container.querySelectorAll('.ant-select-item-option')).at(2)!);
+    fireEvent.click(Array.from(container.querySelectorAll('.ant-select-item-option')).at(4)!);
+    expect(onSelect.mock.calls.length).toBe(0);
+
+    onSelect.mockReset();
+
+    const wrapper = render(
+      <Calendar
+        onSelect={onSelect}
+        defaultValue={Dayjs('2018-02-02')}
+        mode="year"
+        selectable={['month']}
+      />,
+    );
+
+    fireEvent.click(wrapper.container.querySelector('[title="2018-01"]')!);
+    fireEvent.click(wrapper.container.querySelector('[title="2018-03"]')!);
+    expect(onSelect.mock.calls.length).toBe(2);
+
+    onSelect.mockReset();
+
+    wrapper.rerender(<Calendar onSelect={onSelect} mode={'month'} selectable={['month']} />);
+
+    openSelect(wrapper.container, '.ant-picker-calendar-month-select');
+    fireEvent.click(
+      Array.from(wrapper.container.querySelectorAll('.ant-select-item-option')).at(5)!,
+    );
+    expect(onSelect.mock.calls.length).toBe(1);
+  });
+
+  it('only year change should trigger onSelect callback', () => {
+    const onSelect = jest.fn();
+    const { container } = render(
+      <Calendar onSelect={onSelect} defaultValue={Dayjs('2018-02-02')} selectable={['year']} />,
+    );
+
+    fireEvent.click(container.querySelector('[title="2018-02-05"]')!);
+    fireEvent.click(container.querySelector('[title="2018-02-07"]')!);
+    expect(onSelect.mock.calls.length).toBe(0);
+
+    onSelect.mockReset();
+
+    openSelect(container, '.ant-picker-calendar-year-select');
+    fireEvent.click(Array.from(container.querySelectorAll('.ant-select-item-option')).at(2)!);
+    fireEvent.click(Array.from(container.querySelectorAll('.ant-select-item-option')).at(4)!);
+    expect(onSelect.mock.calls.length).toBe(2);
+
+    onSelect.mockReset();
+
+    const wrapper = render(
+      <Calendar
+        onSelect={onSelect}
+        defaultValue={Dayjs('2018-02-02')}
+        mode="year"
+        selectable={['year']}
+      />,
+    );
+
+    fireEvent.click(wrapper.container.querySelector('[title="2018-01"]')!);
+    fireEvent.click(wrapper.container.querySelector('[title="2018-03"]')!);
+    expect(onSelect.mock.calls.length).toBe(0);
+  });
+
+  it('only date select should trigger onSelect callback', () => {
+    const onSelect = jest.fn();
+    const { container } = render(
+      <Calendar onSelect={onSelect} defaultValue={Dayjs('2018-02-02')} selectable={['date']} />,
+    );
+
+    fireEvent.click(container.querySelector('[title="2018-02-05"]')!);
+    fireEvent.click(container.querySelector('[title="2018-02-07"]')!);
+    expect(onSelect.mock.calls.length).toBe(2);
+
+    onSelect.mockReset();
+
+    openSelect(container, '.ant-picker-calendar-year-select');
+    fireEvent.click(Array.from(container.querySelectorAll('.ant-select-item-option')).at(2)!);
+    fireEvent.click(Array.from(container.querySelectorAll('.ant-select-item-option')).at(4)!);
+    expect(onSelect.mock.calls.length).toBe(0);
+
+    onSelect.mockReset();
+
+    const wrapper = render(
+      <Calendar
+        onSelect={onSelect}
+        defaultValue={Dayjs('2018-02-02')}
+        mode="year"
+        selectable={['date']}
+      />,
+    );
+
+    fireEvent.click(wrapper.container.querySelector('[title="2018-01"]')!);
+    fireEvent.click(wrapper.container.querySelector('[title="2018-03"]')!);
+    expect(onSelect.mock.calls.length).toBe(0);
+
+    onSelect.mockReset();
+
+    wrapper.rerender(<Calendar onSelect={onSelect} mode={'month'} selectable={['date']} />);
+
+    openSelect(wrapper.container, '.ant-picker-calendar-month-select');
+    fireEvent.click(
+      Array.from(wrapper.container.querySelectorAll('.ant-select-item-option')).at(5)!,
+    );
+    expect(onSelect.mock.calls.length).toBe(0);
+  });
+
+  it('only date select and month change should trigger onSelect callback', () => {
+    const onSelect = jest.fn();
+    const { container } = render(
+      <Calendar
+        onSelect={onSelect}
+        defaultValue={Dayjs('2018-02-02')}
+        selectable={['date', 'month']}
+      />,
+    );
+
+    fireEvent.click(container.querySelector('[title="2018-02-05"]')!);
+    fireEvent.click(container.querySelector('[title="2018-02-07"]')!);
+    expect(onSelect.mock.calls.length).toBe(2);
+
+    onSelect.mockReset();
+
+    openSelect(container, '.ant-picker-calendar-year-select');
+    fireEvent.click(Array.from(container.querySelectorAll('.ant-select-item-option')).at(2)!);
+    fireEvent.click(Array.from(container.querySelectorAll('.ant-select-item-option')).at(4)!);
+    expect(onSelect.mock.calls.length).toBe(0);
+
+    onSelect.mockReset();
+
+    const wrapper = render(
+      <Calendar
+        onSelect={onSelect}
+        defaultValue={Dayjs('2018-02-02')}
+        mode="year"
+        selectable={['date', 'month']}
+      />,
+    );
+
+    fireEvent.click(wrapper.container.querySelector('[title="2018-01"]')!);
+    fireEvent.click(wrapper.container.querySelector('[title="2018-03"]')!);
+    expect(onSelect.mock.calls.length).toBe(2);
+
+    onSelect.mockReset();
+
+    wrapper.rerender(
+      <Calendar onSelect={onSelect} mode={'month'} selectable={['date', 'month']} />,
+    );
+
+    openSelect(wrapper.container, '.ant-picker-calendar-month-select');
+    fireEvent.click(
+      Array.from(wrapper.container.querySelectorAll('.ant-select-item-option')).at(5)!,
+    );
+    expect(onSelect.mock.calls.length).toBe(1);
+  });
+
+  it('only date select and year change should trigger onSelect callback', () => {
+    const onSelect = jest.fn();
+    const { container } = render(
+      <Calendar
+        onSelect={onSelect}
+        defaultValue={Dayjs('2018-02-02')}
+        selectable={['date', 'year']}
+      />,
+    );
+
+    fireEvent.click(container.querySelector('[title="2018-02-05"]')!);
+    fireEvent.click(container.querySelector('[title="2018-02-07"]')!);
+    expect(onSelect.mock.calls.length).toBe(2);
+
+    onSelect.mockReset();
+
+    openSelect(container, '.ant-picker-calendar-year-select');
+    fireEvent.click(Array.from(container.querySelectorAll('.ant-select-item-option')).at(2)!);
+    fireEvent.click(Array.from(container.querySelectorAll('.ant-select-item-option')).at(4)!);
+    expect(onSelect.mock.calls.length).toBe(2);
+
+    onSelect.mockReset();
+
+    const wrapper = render(
+      <Calendar
+        onSelect={onSelect}
+        defaultValue={Dayjs('2018-02-02')}
+        mode="year"
+        selectable={['date', 'year']}
+      />,
+    );
+
+    fireEvent.click(wrapper.container.querySelector('[title="2018-01"]')!);
+    fireEvent.click(wrapper.container.querySelector('[title="2018-03"]')!);
+    expect(onSelect.mock.calls.length).toBe(0);
+
+    onSelect.mockReset();
+
+    wrapper.rerender(<Calendar onSelect={onSelect} mode={'month'} selectable={['date', 'year']} />);
+
+    openSelect(wrapper.container, '.ant-picker-calendar-month-select');
+    fireEvent.click(
+      Array.from(wrapper.container.querySelectorAll('.ant-select-item-option')).at(5)!,
+    );
+    expect(onSelect.mock.calls.length).toBe(0);
+  });
+
+  it('only month chnage and year change should trigger onSelect callback', () => {
+    const onSelect = jest.fn();
+    const { container } = render(
+      <Calendar
+        onSelect={onSelect}
+        defaultValue={Dayjs('2018-02-02')}
+        selectable={['month', 'year']}
+      />,
+    );
+
+    fireEvent.click(container.querySelector('[title="2018-02-05"]')!);
+    fireEvent.click(container.querySelector('[title="2018-02-07"]')!);
+    expect(onSelect.mock.calls.length).toBe(0);
+
+    onSelect.mockReset();
+
+    openSelect(container, '.ant-picker-calendar-year-select');
+    fireEvent.click(Array.from(container.querySelectorAll('.ant-select-item-option')).at(2)!);
+    fireEvent.click(Array.from(container.querySelectorAll('.ant-select-item-option')).at(4)!);
+    expect(onSelect.mock.calls.length).toBe(2);
+
+    onSelect.mockReset();
+
+    const wrapper = render(
+      <Calendar
+        onSelect={onSelect}
+        defaultValue={Dayjs('2018-02-02')}
+        mode="year"
+        selectable={['month', 'year']}
+      />,
+    );
+
+    fireEvent.click(wrapper.container.querySelector('[title="2018-01"]')!);
+    fireEvent.click(wrapper.container.querySelector('[title="2018-03"]')!);
+    expect(onSelect.mock.calls.length).toBe(2);
+
+    onSelect.mockReset();
+
+    wrapper.rerender(
+      <Calendar onSelect={onSelect} mode={'month'} selectable={['month', 'year']} />,
+    );
+
+    openSelect(wrapper.container, '.ant-picker-calendar-month-select');
+    fireEvent.click(
+      Array.from(wrapper.container.querySelectorAll('.ant-select-item-option')).at(5)!,
+    );
+    expect(onSelect.mock.calls.length).toBe(1);
+  });
+
   it('only Valid range should be selectable', () => {
     const onSelect = jest.fn();
     const validRange: [Dayjs.Dayjs, Dayjs.Dayjs] = [Dayjs('2018-02-02'), Dayjs('2018-02-18')];

--- a/components/calendar/generateCalendar.tsx
+++ b/components/calendar/generateCalendar.tsx
@@ -35,10 +35,11 @@ export type PickerProps<DateType> =
   | PickerPanelTimeProps<DateType>;
 
 export type CalendarMode = 'year' | 'month';
+export type CalendarSelectable = 'date' | 'year' | 'month';
 export type HeaderRender<DateType> = (config: {
   value: DateType;
   type: CalendarMode;
-  onChange: (date: DateType) => void;
+  onChange: (date: DateType, selectType?: CalendarSelectable) => void;
   onTypeChange: (type: CalendarMode) => void;
 }) => React.ReactNode;
 
@@ -61,6 +62,7 @@ export interface CalendarProps<DateType> {
   fullscreen?: boolean;
   onChange?: (date: DateType) => void;
   onPanelChange?: (date: DateType, mode: CalendarMode) => void;
+  selectable?: CalendarSelectable[];
   onSelect?: (date: DateType) => void;
 }
 
@@ -100,6 +102,7 @@ function generateCalendar<DateType>(generateConfig: GenerateConfig<DateType>) {
       fullscreen = true,
       onChange,
       onPanelChange,
+      selectable,
       onSelect,
     } = props;
     const { getPrefixCls, direction } = React.useContext(ConfigContext);
@@ -165,9 +168,12 @@ function generateCalendar<DateType>(generateConfig: GenerateConfig<DateType>) {
       triggerPanelChange(mergedValue, newMode);
     };
 
-    const onInternalSelect = (date: DateType) => {
+    const onInternalSelect = (date: DateType, selectType?: CalendarSelectable) => {
       triggerChange(date);
 
+      if (selectable && selectable.length > 0 && selectType) {
+        if (!selectable.includes(selectType)) return;
+      }
       onSelect?.(date);
     };
 
@@ -281,7 +287,7 @@ function generateCalendar<DateType>(generateConfig: GenerateConfig<DateType>) {
               generateConfig={generateConfig}
               dateRender={dateRender}
               monthCellRender={(date) => monthRender(date, contextLocale.lang)}
-              onSelect={onInternalSelect}
+              onSelect={(date) => onInternalSelect(date, panelMode === 'date' ? 'date' : 'month')}
               mode={panelMode}
               picker={panelMode}
               disabledDate={mergedDisabledDate}

--- a/components/calendar/index.en-US.md
+++ b/components/calendar/index.en-US.md
@@ -39,7 +39,7 @@ When data is in the form of dates, such as schedules, timetables, prices calenda
 ```
 
 | Property | Description | Type | Default | Version |
-| --- | --- | --- | --- | --- |
+| --- | --- | --- | --- | --- | --- | --- | --- |
 | dateCellRender | Customize the display of the date cell, the returned content will be appended to the cell | function(date: Dayjs): ReactNode | - |  |
 | dateFullCellRender | Customize the display of the date cell, the returned content will override the cell | function(date: Dayjs): ReactNode | - |  |
 | defaultValue | The date selected by default | [dayjs](https://day.js.org/) | - |  |
@@ -54,6 +54,7 @@ When data is in the form of dates, such as schedules, timetables, prices calenda
 | value | The current selected date | [dayjs](https://day.js.org/) | - |  |
 | onChange | Callback for when date changes | function(date: Dayjs) | - |  |
 | onPanelChange | Callback for when panel changes | function(date: Dayjs, mode: string) | - |  |
+| selectable | Make calendar selectable by `date`, `month` and `year` |  | ('date' | 'year' | 'month')[] | - |  |
 | onSelect | Callback for when a date is selected | function(date: Dayjs） | - |  |
 
 ## FAQ

--- a/components/calendar/index.zh-CN.md
+++ b/components/calendar/index.zh-CN.md
@@ -40,7 +40,7 @@ cover: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*nF6_To7pDSAAAAAAAA
 ```
 
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
-| --- | --- | --- | --- | --- |
+| --- | --- | --- | --- | --- | --- | --- | --- |
 | dateCellRender | 自定义渲染日期单元格，返回内容会被追加到单元格 | function(date: Dayjs): ReactNode | - |  |
 | dateFullCellRender | 自定义渲染日期单元格，返回内容覆盖单元格 | function(date: Dayjs): ReactNode | - |  |
 | defaultValue | 默认展示的日期 | [dayjs](https://day.js.org/) | - |  |
@@ -55,6 +55,7 @@ cover: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*nF6_To7pDSAAAAAAAA
 | value | 展示日期 | [dayjs](https://day.js.org/) | - |  |
 | onChange | 日期变化回调 | function(date: Dayjs) | - |  |
 | onPanelChange | 日期面板变化回调 | function(date: Dayjs, mode: string) | - |  |
+| selectable | 使日历可以按`date`、`month`和`year`进行选择 |  | ('date' | 'year' | 'month')[] | - |  |
 | onSelect | 点击选择日期回调 | function(date: Dayjs） | - |  |
 
 ## FAQ


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

https://github.com/ant-design/ant-design/issues/40407

### 💡 Background and solution

When I need to go to a specific date in a year and month different from the current selected date, it will require me to select the date 3 times just to get there. First I have to select the year, then select the month and only then select the day which is exhaustive and unnecessary IMO as it gives a really bad UX.
The issue is that the onSelect callback is called whenever we change the month or year. I propose an api that let you choose when you want the onSelect callback to be called, if it is when we change we change the year, when we change the month or only when change click on a day.

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Make calendar selectable by `date`, `month` and `year`     |
| 🇨🇳 Chinese |      使日历可以按`date`、`month`和`year`进行选择      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
