### PR TITLE
fix: disabled DataPicker should not have status style

### DIFF
--- a/components/date-picker/style/index.ts
+++ b/components/date-picker/style/index.ts
@@ -869,14 +869,14 @@ const genPickerStatusStyle: GenerateStyle<PickerToken> = (token) => {
   } = token;
 
   return {
-    [componentCls]: {
-      [`&-status-error${componentCls}`]: {
+    [`${componentCls}:not(${componentCls}-disabled)`]: {
+      [`&${componentCls}-status-error`]: {
         '&, &:not([disabled]):hover': {
           backgroundColor: colorBgContainer,
           borderColor: colorError,
         },
 
-        '&-focused, &:focus': {
+        [`&${componentCls}-focused, &:focus`]: {
           ...genActiveStyle(
             mergeToken<PickerToken>(token, {
               inputBorderActiveColor: colorError,
@@ -891,13 +891,13 @@ const genPickerStatusStyle: GenerateStyle<PickerToken> = (token) => {
         },
       },
 
-      [`&-status-warning${componentCls}`]: {
+      [`&${componentCls}-status-warning`]: {
         '&, &:not([disabled]):hover': {
           backgroundColor: colorBgContainer,
           borderColor: colorWarning,
         },
 
-        '&-focused, &:focus': {
+        [`&${componentCls}-focused, &:focus`]: {
           ...genActiveStyle(
             mergeToken<PickerToken>(token, {
               inputBorderActiveColor: colorWarning,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link
close https://github.com/ant-design/ant-design/issues/40589
<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fix DatePicker that have status style when disabled.         |
| 🇨🇳 Chinese |     修复 DatePicker 组件禁用时状态样式生效的问题。      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
