### PR TITLE
fix: deleted margin of the last indicator

### DIFF
--- a/components/tour/style/index.ts
+++ b/components/tour/style/index.ts
@@ -139,7 +139,9 @@ const genBaseStyle: GenerateStyle<TourToken> = (token) => {
                 display: 'inline-block',
                 borderRadius: '50%',
                 background: colorFill,
-                marginInlineEnd: indicatorHeight,
+                '&:not(:last-child)': {
+                  marginInlineEnd: indicatorHeight,
+                },
                 '&-active': {
                   background: colorPrimary,
                 },


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<img width="333" alt="image" src="https://user-images.githubusercontent.com/49217418/217413121-c4d857cc-e7e6-4780-91bd-a75028fd31fb.png">

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix: deleted margin of the last indicator |
| 🇨🇳 Chinese | fix: 删除了最后一个指示器的 margin |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed