### PR TITLE
fix: confirm modal firing onOk event twice

### DIFF
--- a/components/_util/ActionButton.tsx
+++ b/components/_util/ActionButton.tsx
@@ -36,7 +36,6 @@ const ActionButton: React.FC<ActionButtonProps> = (props) => {
   const clickedRef = React.useRef<boolean>(false);
   const buttonRef = React.useRef<HTMLButtonElement | HTMLAnchorElement>(null);
   const [loading, setLoading] = useState<ButtonProps['loading']>(false);
-  const [waitingPromise, setWaitingPromise] = useState(false);
 
   const onInternalClose = (...args: any[]) => {
     close?.(...args);
@@ -60,11 +59,9 @@ const ActionButton: React.FC<ActionButtonProps> = (props) => {
     if (!isThenable(returnValueOfOnOk)) {
       return;
     }
-    setWaitingPromise(true);
     setLoading(true);
     returnValueOfOnOk!.then(
       (...args: any[]) => {
-        setLoading(false, true);
         onInternalClose(...args);
         clickedRef.current = false;
       },
@@ -72,7 +69,6 @@ const ActionButton: React.FC<ActionButtonProps> = (props) => {
         // See: https://github.com/ant-design/ant-design/issues/6183
         setLoading(false, true);
         clickedRef.current = false;
-        setWaitingPromise(false);
         return Promise.reject(e);
       },
     );
@@ -114,7 +110,6 @@ const ActionButton: React.FC<ActionButtonProps> = (props) => {
       {...convertLegacyProps(type)}
       onClick={onClick}
       loading={loading}
-      disabled={waitingPromise}
       prefixCls={prefixCls}
       {...buttonProps}
       ref={buttonRef}

--- a/components/_util/ActionButton.tsx
+++ b/components/_util/ActionButton.tsx
@@ -36,6 +36,7 @@ const ActionButton: React.FC<ActionButtonProps> = (props) => {
   const clickedRef = React.useRef<boolean>(false);
   const buttonRef = React.useRef<HTMLButtonElement | HTMLAnchorElement>(null);
   const [loading, setLoading] = useState<ButtonProps['loading']>(false);
+  const [waitingPromise, setWaitingPromise] = useState(false);
 
   const onInternalClose = (...args: any[]) => {
     close?.(...args);
@@ -59,6 +60,7 @@ const ActionButton: React.FC<ActionButtonProps> = (props) => {
     if (!isThenable(returnValueOfOnOk)) {
       return;
     }
+    setWaitingPromise(true);
     setLoading(true);
     returnValueOfOnOk!.then(
       (...args: any[]) => {
@@ -70,6 +72,7 @@ const ActionButton: React.FC<ActionButtonProps> = (props) => {
         // See: https://github.com/ant-design/ant-design/issues/6183
         setLoading(false, true);
         clickedRef.current = false;
+        setWaitingPromise(false);
         return Promise.reject(e);
       },
     );
@@ -111,6 +114,7 @@ const ActionButton: React.FC<ActionButtonProps> = (props) => {
       {...convertLegacyProps(type)}
       onClick={onClick}
       loading={loading}
+      disabled={waitingPromise}
       prefixCls={prefixCls}
       {...buttonProps}
       ref={buttonRef}

--- a/components/button/button.tsx
+++ b/components/button/button.tsx
@@ -2,19 +2,19 @@
 import classNames from 'classnames';
 import omit from 'rc-util/lib/omit';
 import * as React from 'react';
-import warning from '../_util/warning';
-import Wave from '../_util/wave';
 import { ConfigContext } from '../config-provider';
 import DisabledContext from '../config-provider/DisabledContext';
 import SizeContext from '../config-provider/SizeContext';
 import { useCompactItemContext } from '../space/Compact';
+import warning from '../_util/warning';
+import Wave from '../_util/wave';
 import Group, { GroupSizeContext } from './button-group';
 import { isTwoCNChar, isUnBorderedButtonType, spaceChildren } from './buttonHelpers';
 import LoadingIcon from './LoadingIcon';
 import useStyle from './style';
 
-import type { ButtonType, ButtonHTMLType, ButtonShape } from './buttonHelpers';
 import type { SizeType } from '../config-provider/SizeContext';
+import type { ButtonHTMLType, ButtonShape, ButtonType } from './buttonHelpers';
 
 export type LegacyButtonType = ButtonType | 'danger';
 

--- a/components/modal/__tests__/confirm.test.tsx
+++ b/components/modal/__tests__/confirm.test.tsx
@@ -7,7 +7,7 @@ import * as React from 'react';
 import TestUtils from 'react-dom/test-utils';
 import type { ModalFuncProps } from '..';
 import Modal from '..';
-import { waitFakeTimer, act, sleep } from '../../../tests/utils';
+import { act, waitFakeTimer } from '../../../tests/utils';
 import ConfigProvider from '../../config-provider';
 import type { ModalFunc } from '../confirm';
 import destroyFns from '../destroyFns';
@@ -95,11 +95,8 @@ describe('Modal.confirm triggers callbacks correctly', () => {
   };
   /* eslint-enable */
 
-  beforeAll(() => {
-    jest.useFakeTimers();
-  });
-
   beforeEach(() => {
+    jest.useFakeTimers();
     (global as any).injectPromise = false;
     (global as any).rejectPromise = null;
   });
@@ -204,16 +201,34 @@ describe('Modal.confirm triggers callbacks correctly', () => {
   });
 
   it('should not fire twice onOk when button is pressed twice', async () => {
-    const onOk = jest.fn(() => Promise.resolve(''));
+    let resolveFn: VoidFunction;
+    const onOk = jest.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveFn = resolve;
+        }),
+    );
     await open({
       onOk,
     });
 
-    await sleep();
-    $$('.ant-btn-primary')[0].click();
+    // Load will not clickable
+    await waitFakeTimer();
+    for (let i = 0; i < 10; i += 1) {
+      act(() => {
+        $$('.ant-btn-primary')[0].click();
+      });
+    }
+    expect(onOk).toHaveBeenCalledTimes(1);
 
-    await sleep();
-    $$('.ant-btn-primary')[0].click();
+    // Resolve this promise
+    resolveFn!();
+    await Promise.resolve();
+
+    // Resolve still can not clickable
+    act(() => {
+      $$('.ant-btn-primary')[0].click();
+    });
 
     expect(onOk).toHaveBeenCalledTimes(1);
   });

--- a/components/modal/__tests__/confirm.test.tsx
+++ b/components/modal/__tests__/confirm.test.tsx
@@ -7,7 +7,7 @@ import * as React from 'react';
 import TestUtils from 'react-dom/test-utils';
 import type { ModalFuncProps } from '..';
 import Modal from '..';
-import { waitFakeTimer, act } from '../../../tests/utils';
+import { waitFakeTimer, act, sleep } from '../../../tests/utils';
 import ConfigProvider from '../../config-provider';
 import type { ModalFunc } from '../confirm';
 import destroyFns from '../destroyFns';
@@ -201,6 +201,21 @@ describe('Modal.confirm triggers callbacks correctly', () => {
 
     expect($$(`.ant-modal-confirm-confirm`)).toHaveLength(0);
     expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not fire twice onOk when button is pressed twice', async () => {
+    const onOk = jest.fn(() => Promise.resolve(''));
+    await open({
+      onOk,
+    });
+
+    await sleep();
+    $$('.ant-btn-primary')[0].click();
+
+    await sleep();
+    $$('.ant-btn-primary')[0].click();
+
+    expect(onOk).toHaveBeenCalledTimes(1);
   });
 
   it('should not hide confirm when onOk return Promise.resolve', async () => {


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

fix #40272 

### 💡 Background and solution
This is my first contribution guys :smile:, not sure if I'm missing something!
 
We have a render when the confirm button using promise finished loading and can be clickable again, letting the user trigger onOk function for a second time 
The solution was set a disabled state when the button is loading, if the promise resolves we close de modal with the button disabled, if the promise rejects we remove the disabled from the button.


<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog
Changed the onOk button behavior to be disabled when a promise is pending



| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   fix: confirm modal firing onOk event twice        |
| 🇨🇳 Chinese |   修复: confirm modal onOk 可能触发两次的问题        |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
