### PR TITLE
fix(Radio): Fixed inconsistency between Checkbox and Radio in table when Form is disabled

### DIFF
--- a/components/radio/__tests__/radio.test.tsx
+++ b/components/radio/__tests__/radio.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Radio, { Button, Group } from '..';
+import Form from '../../form';
 import focusTest from '../../../tests/shared/focusTest';
 import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
@@ -32,5 +33,16 @@ describe('Radio', () => {
 
     fireEvent.mouseLeave(container.querySelector('label')!);
     expect(onMouseLeave).toHaveBeenCalled();
+  });
+
+  it('should use own disabled status first', () => {
+    const { container } = render(
+      <Form disabled>
+        <Radio disabled={false} />
+      </Form>,
+    );
+    expect(container.querySelector('.ant-radio-wrapper')).not.toHaveClass(
+      'ant-radio-wrapper-disabled',
+    );
   });
 });

--- a/components/radio/radio.tsx
+++ b/components/radio/radio.tsx
@@ -49,7 +49,7 @@ const InternalRadio: React.ForwardRefRenderFunction<HTMLElement, RadioProps> = (
 
   // ===================== Disabled =====================
   const disabled = React.useContext(DisabledContext);
-  radioProps.disabled = customDisabled || disabled;
+  radioProps.disabled = customDisabled ?? disabled;
 
   if (groupContext) {
     radioProps.name = groupContext.name;


### PR DESCRIPTION

<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
close https://github.com/ant-design/ant-design/issues/40704
### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fixed inconsistency between Checkbox and Radio in table when Form is disabled  |
| 🇨🇳 Chinese |  修复 `Form` 为 `disabled` 时 `Checkbox` 和 `Radio` 表现不一致        |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
