### PR TITLE
refactor(Radio): Gets the disabled state correctly when nested

### DIFF
--- a/components/radio/__tests__/radio.test.tsx
+++ b/components/radio/__tests__/radio.test.tsx
@@ -36,13 +36,22 @@ describe('Radio', () => {
   });
 
   it('should use own disabled status first', () => {
-    const { container } = render(
+    const { getByRole } = render(
       <Form disabled>
         <Radio disabled={false} />
       </Form>,
     );
-    expect(container.querySelector('.ant-radio-wrapper')).not.toHaveClass(
-      'ant-radio-wrapper-disabled',
+    expect(getByRole('radio')).not.toBeDisabled();
+  });
+
+  it('should obtained correctly disabled status', () => {
+    const { getByRole } = render(
+      <Form disabled>
+        <Radio.Group disabled={false}>
+          <Radio />
+        </Radio.Group>
+      </Form>,
     );
+    expect(getByRole('radio')).not.toBeDisabled();
   });
 });

--- a/components/radio/radio.tsx
+++ b/components/radio/radio.tsx
@@ -33,7 +33,6 @@ const InternalRadio: React.ForwardRefRenderFunction<HTMLElement, RadioProps> = (
     rootClassName,
     children,
     style,
-    disabled: customDisabled,
     ...restProps
   } = props;
   const radioPrefixCls = getPrefixCls('radio', customizePrefixCls);
@@ -49,14 +48,15 @@ const InternalRadio: React.ForwardRefRenderFunction<HTMLElement, RadioProps> = (
 
   // ===================== Disabled =====================
   const disabled = React.useContext(DisabledContext);
-  radioProps.disabled = customDisabled ?? disabled;
 
   if (groupContext) {
     radioProps.name = groupContext.name;
     radioProps.onChange = onChange;
     radioProps.checked = props.value === groupContext.value;
-    radioProps.disabled = radioProps.disabled || groupContext.disabled;
+    radioProps.disabled = radioProps.disabled ?? groupContext.disabled;
   }
+
+  radioProps.disabled = radioProps.disabled ?? disabled;
   const wrapperClassString = classNames(
     `${prefixCls}-wrapper`,
     {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [x] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
Improve https://github.com/ant-design/ant-design/pull/40728
close https://github.com/ant-design/ant-design/issues/40704
close https://github.com/ant-design/ant-design/issues/40742

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Gets the disabled state correctly when nested   |
| 🇨🇳 Chinese |  被嵌套时正确获取 `disabled` 状态         |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
