### PR TITLE
fix(Timeline): Fixed the Timeline item className error

### DIFF
--- a/components/timeline/TimelineItemList.tsx
+++ b/components/timeline/TimelineItemList.tsx
@@ -52,13 +52,16 @@ const TimelineItemList: React.FC<TimelineProps & { hashId: string; direction?: s
     .map((item: TimelineItemProps, idx: number) => {
       const pendingClass = idx === itemsCount - 2 ? lastCls : '';
       const readyClass = idx === itemsCount - 1 ? lastCls : '';
+      const { className: itemClassName, ...itemProps } = item;
+
       return (
         <TimelineItem
+          {...itemProps}
           className={classNames([
+            itemClassName,
             !reverse && !!pending ? pendingClass : readyClass,
             getPositionCls(item?.position ?? '', idx),
           ])}
-          {...item}
           /* eslint-disable-next-line react/no-array-index-key */
           key={item?.key || idx}
         />

--- a/components/timeline/__tests__/index.test.tsx
+++ b/components/timeline/__tests__/index.test.tsx
@@ -215,6 +215,21 @@ describe('TimeLine', () => {
     expect(container.querySelectorAll('li.ant-timeline-item')[0]).not.toHaveClass('timelineBox');
   });
 
+  it('TimeLineItem className should correctly', () => {
+    const { container } = render(
+      <TimeLine
+        items={[
+          {
+            className: 'test',
+            children: 'foo',
+          },
+        ]}
+      />,
+    );
+
+    expect(container.querySelector('.test')).not.toBeNull();
+  });
+
   describe('prop: color', () => {
     const presetColors = ['blue', 'red', 'green', 'gray'];
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
close https://github.com/ant-design/ant-design/issues/40833
### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed the Timeline item className error          |
| 🇨🇳 Chinese | 修复 `Timeline` 的 item 其 className 错误           |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
