### PR TITLE
fix(Descriptions): pass `restProps` to the Descriptions container

### DIFF
--- a/components/descriptions/__tests__/index.test.tsx
+++ b/components/descriptions/__tests__/index.test.tsx
@@ -256,4 +256,15 @@ describe('Descriptions', () => {
     );
     expect(wrapper.container.firstChild).toMatchSnapshot();
   });
+
+  it('should pass data-* and accessibility attributes', () => {
+    const { getByTestId } = render(
+      <Descriptions data-testid="test-id" data-id="12345" aria-describedby="some-label">
+        <Descriptions.Item label="banana">banana</Descriptions.Item>
+      </Descriptions>,
+    );
+    const container = getByTestId('test-id');
+    expect(container).toHaveAttribute('data-id', '12345');
+    expect(container).toHaveAttribute('aria-describedby', 'some-label');
+  });
 });

--- a/components/descriptions/index.tsx
+++ b/components/descriptions/index.tsx
@@ -130,6 +130,7 @@ function Descriptions({
   size,
   labelStyle,
   contentStyle,
+  ...restProps
 }: DescriptionsProps) {
   const { getPrefixCls, direction } = React.useContext(ConfigContext);
   const prefixCls = getPrefixCls('descriptions', customizePrefixCls);
@@ -175,6 +176,7 @@ function Descriptions({
           hashId,
         )}
         style={style}
+        {...restProps}
       >
         {(title || extra) && (
           <div className={`${prefixCls}-header`}>


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

**Problem:** Descriptions container can't get any data-* attributes or accessibility attributes
**Solution:** `restProps` was passed to the Descriptions container

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed props passing in the Descriptions component |
| 🇨🇳 Chinese |  修复 Descriptions 不接受 `data-*` 和 `aria-*` 等属性的问题。         |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
