### PR TITLE
fix: fix 'span' to 'li'

### DIFF
--- a/components/breadcrumb/BreadcrumbSeparator.tsx
+++ b/components/breadcrumb/BreadcrumbSeparator.tsx
@@ -10,7 +10,11 @@ const BreadcrumbSeparator: CompoundedComponent = ({ children }) => {
   const { getPrefixCls } = React.useContext(ConfigContext);
   const prefixCls = getPrefixCls('breadcrumb');
 
-  return <span className={`${prefixCls}-separator`}>{children || '/'}</span>;
+  return (
+    <li className={`${prefixCls}-separator`} aria-hidden="true">
+      {children || '/'}
+    </li>
+  );
 };
 
 BreadcrumbSeparator.__ANT_BREADCRUMB_SEPARATOR = true;

--- a/components/breadcrumb/__tests__/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/components/breadcrumb/__tests__/__snapshots__/Breadcrumb.test.tsx.snap
@@ -12,11 +12,12 @@ exports[`Breadcrumb filter React.Fragment 1`] = `
         Location
       </span>
     </li>
-    <span
+    <li
+      aria-hidden="true"
       class="ant-breadcrumb-separator"
     >
       :
-    </span>
+    </li>
     <li>
       <a
         class="ant-breadcrumb-link"
@@ -25,11 +26,12 @@ exports[`Breadcrumb filter React.Fragment 1`] = `
         Application Center
       </a>
     </li>
-    <span
+    <li
+      aria-hidden="true"
       class="ant-breadcrumb-separator"
     >
       /
-    </span>
+    </li>
   </ol>
 </nav>
 `;

--- a/components/breadcrumb/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/breadcrumb/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -426,11 +426,12 @@ exports[`renders ./components/breadcrumb/demo/separator-component.tsx extend con
         Location
       </span>
     </li>
-    <span
+    <li
+      aria-hidden="true"
       class="ant-breadcrumb-separator"
     >
       :
-    </span>
+    </li>
     <li>
       <a
         class="ant-breadcrumb-link"
@@ -439,11 +440,12 @@ exports[`renders ./components/breadcrumb/demo/separator-component.tsx extend con
         Application Center
       </a>
     </li>
-    <span
+    <li
+      aria-hidden="true"
       class="ant-breadcrumb-separator"
     >
       /
-    </span>
+    </li>
     <li>
       <a
         class="ant-breadcrumb-link"
@@ -452,11 +454,12 @@ exports[`renders ./components/breadcrumb/demo/separator-component.tsx extend con
         Application List
       </a>
     </li>
-    <span
+    <li
+      aria-hidden="true"
       class="ant-breadcrumb-separator"
     >
       /
-    </span>
+    </li>
     <li>
       <span
         class="ant-breadcrumb-link"

--- a/components/breadcrumb/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/breadcrumb/__tests__/__snapshots__/demo.test.ts.snap
@@ -224,11 +224,12 @@ exports[`renders ./components/breadcrumb/demo/separator-component.tsx correctly 
         Location
       </span>
     </li>
-    <span
+    <li
+      aria-hidden="true"
       class="ant-breadcrumb-separator"
     >
       :
-    </span>
+    </li>
     <li>
       <a
         class="ant-breadcrumb-link"
@@ -237,11 +238,12 @@ exports[`renders ./components/breadcrumb/demo/separator-component.tsx correctly 
         Application Center
       </a>
     </li>
-    <span
+    <li
+      aria-hidden="true"
       class="ant-breadcrumb-separator"
     >
       /
-    </span>
+    </li>
     <li>
       <a
         class="ant-breadcrumb-link"
@@ -250,11 +252,12 @@ exports[`renders ./components/breadcrumb/demo/separator-component.tsx correctly 
         Application List
       </a>
     </li>
-    <span
+    <li
+      aria-hidden="true"
       class="ant-breadcrumb-separator"
     >
       /
-    </span>
+    </li>
     <li>
       <span
         class="ant-breadcrumb-link"


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    fix 'span' to 'li'      |
| 🇨🇳 Chinese |     修改'Separator'的dom由'span'改为''li''       |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
