### PR TITLE
test: simplify rtlTest test case

### DIFF
--- a/components/calendar/__tests__/index.test.tsx
+++ b/components/calendar/__tests__/index.test.tsx
@@ -1,9 +1,9 @@
-import MockDate from 'mockdate';
 import Dayjs from 'dayjs';
 import 'dayjs/locale/zh-cn';
+import MockDate from 'mockdate';
+import { type PickerPanelProps } from 'rc-picker';
 import dayjsGenerateConfig from 'rc-picker/lib/generate/dayjs';
 import type { Locale } from 'rc-picker/lib/interface';
-import { type PickerPanelProps } from 'rc-picker';
 import React from 'react';
 import Calendar from '..';
 import mountTest from '../../../tests/shared/mountTest';
@@ -42,7 +42,7 @@ jest.mock('rc-picker', () => {
 
 describe('Calendar', () => {
   mountTest(Calendar);
-  rtlTest(Calendar, { mockDate: true });
+  rtlTest(Calendar, true);
 
   function openSelect(wrapper: HTMLElement, className: string) {
     fireEvent.mouseDown(wrapper.querySelector(className)!.querySelector('.ant-select-selector')!);

--- a/components/menu/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/menu/__tests__/__snapshots__/index.test.tsx.snap
@@ -329,64 +329,58 @@ exports[`Menu all types must be available in the "items" syntax 1`] = `
 `;
 
 exports[`Menu rtl render component should be rendered correctly in RTL direction 1`] = `
-HTMLCollection [
-  <ul
-    class="ant-menu ant-menu-root ant-menu-vertical ant-menu-light ant-menu-rtl"
-    data-menu-list="true"
-    dir="rtl"
-    role="menu"
-    tabindex="0"
+<ul
+  class="ant-menu ant-menu-root ant-menu-vertical ant-menu-light ant-menu-rtl"
+  data-menu-list="true"
+  dir="rtl"
+  role="menu"
+  tabindex="0"
+>
+  <li
+    class="ant-menu-item"
+    data-menu-id="rc-menu-uuid-test-tmp_key-0"
+    role="menuitem"
+    tabindex="-1"
   >
-    <li
-      class="ant-menu-item"
-      data-menu-id="rc-menu-uuid-test-tmp_key-0"
+    <span
+      class="ant-menu-title-content"
+    />
+  </li>
+  <li
+    class="ant-menu-item-group"
+    role="presentation"
+  >
+    <div
+      class="ant-menu-item-group-title"
+      role="presentation"
+    />
+    <ul
+      class="ant-menu-item-group-list"
+      role="group"
+    />
+  </li>
+  <li
+    class="ant-menu-submenu ant-menu-submenu-vertical"
+    role="none"
+  >
+    <div
+      aria-controls="rc-menu-uuid-test-tmp_key-2-popup"
+      aria-expanded="false"
+      aria-haspopup="true"
+      class="ant-menu-submenu-title"
+      data-menu-id="rc-menu-uuid-test-tmp_key-2"
       role="menuitem"
       tabindex="-1"
     >
       <span
         class="ant-menu-title-content"
       />
-    </li>
-    <li
-      class="ant-menu-item-group"
-      role="presentation"
-    >
-      <div
-        class="ant-menu-item-group-title"
-        role="presentation"
+      <i
+        class="ant-menu-submenu-arrow"
       />
-      <ul
-        class="ant-menu-item-group-list"
-        role="group"
-      />
-    </li>
-    <li
-      class="ant-menu-submenu ant-menu-submenu-vertical"
-      role="none"
-    >
-      <div
-        aria-controls="rc-menu-uuid-test-tmp_key-2-popup"
-        aria-expanded="false"
-        aria-haspopup="true"
-        class="ant-menu-submenu-title"
-        data-menu-id="rc-menu-uuid-test-tmp_key-2"
-        role="menuitem"
-        tabindex="-1"
-      >
-        <span
-          class="ant-menu-title-content"
-        />
-        <i
-          class="ant-menu-submenu-arrow"
-        />
-      </div>
-    </li>
-  </ul>,
-  <div
-    aria-hidden="true"
-    style="display: none;"
-  />,
-]
+    </div>
+  </li>
+</ul>
 `;
 
 exports[`Menu should controlled collapse work 1`] = `

--- a/components/menu/__tests__/index.test.tsx
+++ b/components/menu/__tests__/index.test.tsx
@@ -5,12 +5,12 @@ import {
   PieChartOutlined,
   UserOutlined,
 } from '@ant-design/icons';
-import React, { useState, useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 import type { MenuProps, MenuRef } from '..';
 import Menu from '..';
 import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
-import { fireEvent, render, act } from '../../../tests/utils';
+import { act, fireEvent, render } from '../../../tests/utils';
 import Layout from '../../layout';
 import initCollapseMotion from '../../_util/motion';
 import { noop } from '../../_util/warning';
@@ -133,7 +133,7 @@ describe('Menu', () => {
     </Menu>
   );
 
-  rtlTest(RtlDemo, { componentName: 'menu' });
+  rtlTest(RtlDemo);
 
   let div: HTMLDivElement;
 

--- a/tests/shared/rtlTest.tsx
+++ b/tests/shared/rtlTest.tsx
@@ -1,18 +1,12 @@
-import React from 'react';
 import dayjs from 'dayjs';
 import MockDate from 'mockdate';
-import { render } from '../utils';
+import React from 'react';
 import ConfigProvider from '../../components/config-provider';
+import { render } from '../utils';
 
-interface TestOptions {
-  mockDate?: boolean;
-  componentName?: string;
-}
-
-function rtlTest(Component: React.ComponentType, { mockDate, componentName }: TestOptions = {}) {
-  describe(`rtl render`, () => {
-    it(`component should be rendered correctly in RTL direction`, () => {
-      const isArray = componentName && ['menu'].includes(componentName);
+const rtlTest = (Component: React.ComponentType, mockDate = false) => {
+  describe('rtl render', () => {
+    it('component should be rendered correctly in RTL direction', () => {
       if (mockDate) {
         MockDate.set(dayjs('2000-09-28').valueOf());
       }
@@ -21,13 +15,13 @@ function rtlTest(Component: React.ComponentType, { mockDate, componentName }: Te
           <Component />
         </ConfigProvider>,
       );
-      expect(isArray ? container.children : container.firstChild).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
       if (mockDate) {
         MockDate.reset();
       }
     });
   });
-}
+};
 
 // eslint-disable-next-line jest/no-export
 export default rtlTest;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

因为 `enzyme` 和 `testing-lib` 在生成 `snap` 的时候内部实现有差异，所以在当初进行测试库迁移的时候，为了保持 `snap` 中 dom 结构不发生变化，对 menu 组件进行了单独处理。

但是实际上 menu 组件和其它组件应该是同一套逻辑，在生成 snap 的时候也应该用同样的方法，所以删除了兼容写法。

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | test: simplify rtlTest test case |
| 🇨🇳 Chinese | test: 不纳入 Change Log |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed