### PR TITLE
refactor: Breadcrumb separator use `li` instead `span`

### DIFF
--- a/components/breadcrumb/Breadcrumb.tsx
+++ b/components/breadcrumb/Breadcrumb.tsx
@@ -128,6 +128,7 @@ const Breadcrumb: CompoundedComponent = ({
       );
     });
   } else if (children) {
+    const childrenLength = toArray(children).length;
     crumbs = toArray(children).map((element: any, index) => {
       if (!element) {
         return element;
@@ -140,9 +141,9 @@ const Breadcrumb: CompoundedComponent = ({
         'Breadcrumb',
         "Only accepts Breadcrumb.Item and Breadcrumb.Separator as it's children",
       );
-
+      const isLastItem = index === childrenLength - 1;
       return cloneElement(element, {
-        separator,
+        separator: isLastItem ? '' : separator,
         key: index,
       });
     });

--- a/components/breadcrumb/BreadcrumbItem.tsx
+++ b/components/breadcrumb/BreadcrumbItem.tsx
@@ -4,6 +4,7 @@ import warning from '../_util/warning';
 import { ConfigContext } from '../config-provider';
 import type { DropdownProps } from '../dropdown/dropdown';
 import Dropdown from '../dropdown/dropdown';
+import BreadcrumbSeparator from './BreadcrumbSeparator';
 
 export interface BreadcrumbItemProps {
   prefixCls?: string;
@@ -87,11 +88,7 @@ const BreadcrumbItem: CompoundedComponent = (props) => {
     return (
       <>
         <li>{link}</li>
-        {separator && (
-          <li>
-            <span className={`${prefixCls}-separator`}>{separator}</span>{' '}
-          </li>
-        )}
+        {separator && <BreadcrumbSeparator>{children}</BreadcrumbSeparator>}
       </>
     );
   }

--- a/components/breadcrumb/BreadcrumbItem.tsx
+++ b/components/breadcrumb/BreadcrumbItem.tsx
@@ -85,10 +85,14 @@ const BreadcrumbItem: CompoundedComponent = (props) => {
   link = renderBreadcrumbNode(link);
   if (children !== undefined && children !== null) {
     return (
-      <li>
-        {link}
-        {separator && <span className={`${prefixCls}-separator`}>{separator}</span>}
-      </li>
+      <>
+        <li>{link}</li>
+        {separator && (
+          <li>
+            <span className={`${prefixCls}-separator`}>{separator}</span>{' '}
+          </li>
+        )}
+      </>
     );
   }
   return null;

--- a/components/breadcrumb/BreadcrumbItem.tsx
+++ b/components/breadcrumb/BreadcrumbItem.tsx
@@ -88,7 +88,7 @@ const BreadcrumbItem: CompoundedComponent = (props: BreadcrumbItemProps) => {
     return (
       <>
         <li>{link}</li>
-        {separator && <BreadcrumbSeparator>{children}</BreadcrumbSeparator>}
+        {separator && <BreadcrumbSeparator>{separator}</BreadcrumbSeparator>}
       </>
     );
   }

--- a/components/breadcrumb/BreadcrumbItem.tsx
+++ b/components/breadcrumb/BreadcrumbItem.tsx
@@ -1,5 +1,5 @@
-import DownOutlined from '@ant-design/icons/DownOutlined';
 import * as React from 'react';
+import DownOutlined from '@ant-design/icons/DownOutlined';
 import warning from '../_util/warning';
 import { ConfigContext } from '../config-provider';
 import type { DropdownProps } from '../dropdown/dropdown';
@@ -23,7 +23,7 @@ export interface BreadcrumbItemProps {
 type CompoundedComponent = React.FC<BreadcrumbItemProps> & {
   __ANT_BREADCRUMB_ITEM: boolean;
 };
-const BreadcrumbItem: CompoundedComponent = (props) => {
+const BreadcrumbItem: CompoundedComponent = (props: BreadcrumbItemProps) => {
   const {
     prefixCls: customizePrefixCls,
     separator = '/',

--- a/components/breadcrumb/BreadcrumbSeparator.tsx
+++ b/components/breadcrumb/BreadcrumbSeparator.tsx
@@ -12,7 +12,7 @@ const BreadcrumbSeparator: CompoundedComponent = ({ children }) => {
 
   return (
     <li className={`${prefixCls}-separator`} aria-hidden="true">
-      {children || '/'}
+      {children === '' ? children : children || '/'}
     </li>
   );
 };

--- a/components/breadcrumb/__tests__/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/components/breadcrumb/__tests__/__snapshots__/Breadcrumb.test.tsx.snap
@@ -64,12 +64,11 @@ exports[`Breadcrumb should allow Breadcrumb.Item is null or undefined 1`] = `
         Home
       </span>
     </li>
-    <li>
-      <span
-        class="ant-breadcrumb-separator"
-      >
-        /
-      </span>
+    <li
+      aria-hidden="true"
+      class="ant-breadcrumb-separator"
+    >
+      Home
     </li>
   </ol>
 </nav>
@@ -87,12 +86,11 @@ exports[`Breadcrumb should not display Breadcrumb Item when its children is fals
         xxx
       </span>
     </li>
-    <li>
-      <span
-        class="ant-breadcrumb-separator"
-      >
-        /
-      </span>
+    <li
+      aria-hidden="true"
+      class="ant-breadcrumb-separator"
+    >
+      xxx
     </li>
     <li>
       <span
@@ -101,12 +99,11 @@ exports[`Breadcrumb should not display Breadcrumb Item when its children is fals
         yyy
       </span>
     </li>
-    <li>
-      <span
-        class="ant-breadcrumb-separator"
-      >
-        /
-      </span>
+    <li
+      aria-hidden="true"
+      class="ant-breadcrumb-separator"
+    >
+      yyy
     </li>
   </ol>
 </nav>
@@ -128,12 +125,15 @@ exports[`Breadcrumb should render a menu 1`] = `
         </a>
       </span>
     </li>
-    <li>
-      <span
-        class="ant-breadcrumb-separator"
+    <li
+      aria-hidden="true"
+      class="ant-breadcrumb-separator"
+    >
+      <a
+        href="#/index"
       >
-        /
-      </span>
+        home
+      </a>
     </li>
     <li>
       <span
@@ -169,12 +169,15 @@ exports[`Breadcrumb should render a menu 1`] = `
         </span>
       </span>
     </li>
-    <li>
-      <span
-        class="ant-breadcrumb-separator"
+    <li
+      aria-hidden="true"
+      class="ant-breadcrumb-separator"
+    >
+      <a
+        href="#/index/first"
       >
-        /
-      </span>
+        first
+      </a>
     </li>
     <li>
       <span
@@ -187,12 +190,15 @@ exports[`Breadcrumb should render a menu 1`] = `
         </a>
       </span>
     </li>
-    <li>
-      <span
-        class="ant-breadcrumb-separator"
+    <li
+      aria-hidden="true"
+      class="ant-breadcrumb-separator"
+    >
+      <a
+        href="#/index/first/second"
       >
-        /
-      </span>
+        second
+      </a>
     </li>
     <li>
       <span
@@ -201,12 +207,11 @@ exports[`Breadcrumb should render a menu 1`] = `
         <span />
       </span>
     </li>
-    <li>
-      <span
-        class="ant-breadcrumb-separator"
-      >
-        /
-      </span>
+    <li
+      aria-hidden="true"
+      class="ant-breadcrumb-separator"
+    >
+      <span />
     </li>
   </ol>
 </nav>
@@ -224,12 +229,11 @@ exports[`Breadcrumb should support Breadcrumb.Item default separator 1`] = `
         Location
       </span>
     </li>
-    <li>
-      <span
-        class="ant-breadcrumb-separator"
-      >
-        /
-      </span>
+    <li
+      aria-hidden="true"
+      class="ant-breadcrumb-separator"
+    >
+      Location
     </li>
     <span>
       <li>
@@ -239,12 +243,11 @@ exports[`Breadcrumb should support Breadcrumb.Item default separator 1`] = `
           Mock Node
         </span>
       </li>
-      <li>
-        <span
-          class="ant-breadcrumb-separator"
-        >
-          /
-        </span>
+      <li
+        aria-hidden="true"
+        class="ant-breadcrumb-separator"
+      >
+        Mock Node
       </li>
     </span>
     <li>
@@ -254,12 +257,11 @@ exports[`Breadcrumb should support Breadcrumb.Item default separator 1`] = `
         Application Center
       </span>
     </li>
-    <li>
-      <span
-        class="ant-breadcrumb-separator"
-      >
-        /
-      </span>
+    <li
+      aria-hidden="true"
+      class="ant-breadcrumb-separator"
+    >
+      Application Center
     </li>
   </ol>
 </nav>
@@ -277,12 +279,11 @@ exports[`Breadcrumb should support React.Fragment and falsy children 1`] = `
         yyy
       </span>
     </li>
-    <li>
-      <span
-        class="ant-breadcrumb-separator"
-      >
-        /
-      </span>
+    <li
+      aria-hidden="true"
+      class="ant-breadcrumb-separator"
+    >
+      yyy
     </li>
     <li>
       <span
@@ -291,12 +292,11 @@ exports[`Breadcrumb should support React.Fragment and falsy children 1`] = `
         yyy
       </span>
     </li>
-    <li>
-      <span
-        class="ant-breadcrumb-separator"
-      >
-        /
-      </span>
+    <li
+      aria-hidden="true"
+      class="ant-breadcrumb-separator"
+    >
+      yyy
     </li>
     <li>
       <span
@@ -305,12 +305,11 @@ exports[`Breadcrumb should support React.Fragment and falsy children 1`] = `
         yyy
       </span>
     </li>
-    <li>
-      <span
-        class="ant-breadcrumb-separator"
-      >
-        /
-      </span>
+    <li
+      aria-hidden="true"
+      class="ant-breadcrumb-separator"
+    >
+      yyy
     </li>
     0
   </ol>
@@ -331,12 +330,11 @@ exports[`Breadcrumb should support custom attribute 1`] = `
         xxx
       </span>
     </li>
-    <li>
-      <span
-        class="ant-breadcrumb-separator"
-      >
-        /
-      </span>
+    <li
+      aria-hidden="true"
+      class="ant-breadcrumb-separator"
+    >
+      xxx
     </li>
     <li>
       <span
@@ -345,12 +343,11 @@ exports[`Breadcrumb should support custom attribute 1`] = `
         yyy
       </span>
     </li>
-    <li>
-      <span
-        class="ant-breadcrumb-separator"
-      >
-        /
-      </span>
+    <li
+      aria-hidden="true"
+      class="ant-breadcrumb-separator"
+    >
+      yyy
     </li>
   </ol>
 </nav>
@@ -368,12 +365,11 @@ exports[`Breadcrumb should support string \`0\` and number \`0\` 1`] = `
         0
       </span>
     </li>
-    <li>
-      <span
-        class="ant-breadcrumb-separator"
-      >
-        /
-      </span>
+    <li
+      aria-hidden="true"
+      class="ant-breadcrumb-separator"
+    >
+      /
     </li>
     <li>
       <span
@@ -382,12 +378,11 @@ exports[`Breadcrumb should support string \`0\` and number \`0\` 1`] = `
         0
       </span>
     </li>
-    <li>
-      <span
-        class="ant-breadcrumb-separator"
-      >
-        /
-      </span>
+    <li
+      aria-hidden="true"
+      class="ant-breadcrumb-separator"
+    >
+      0
     </li>
   </ol>
 </nav>

--- a/components/breadcrumb/__tests__/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/components/breadcrumb/__tests__/__snapshots__/Breadcrumb.test.tsx.snap
@@ -63,12 +63,11 @@ exports[`Breadcrumb should allow Breadcrumb.Item is null or undefined 1`] = `
       >
         Home
       </span>
-    </li>
-    <li
-      aria-hidden="true"
-      class="ant-breadcrumb-separator"
-    >
-      Home
+      <span
+        class="ant-breadcrumb-separator"
+      >
+        /
+      </span>
     </li>
   </ol>
 </nav>
@@ -85,12 +84,11 @@ exports[`Breadcrumb should not display Breadcrumb Item when its children is fals
       >
         xxx
       </span>
-    </li>
-    <li
-      aria-hidden="true"
-      class="ant-breadcrumb-separator"
-    >
-      xxx
+      <span
+        class="ant-breadcrumb-separator"
+      >
+        /
+      </span>
     </li>
     <li>
       <span
@@ -98,12 +96,11 @@ exports[`Breadcrumb should not display Breadcrumb Item when its children is fals
       >
         yyy
       </span>
-    </li>
-    <li
-      aria-hidden="true"
-      class="ant-breadcrumb-separator"
-    >
-      yyy
+      <span
+        class="ant-breadcrumb-separator"
+      >
+        /
+      </span>
     </li>
   </ol>
 </nav>
@@ -124,16 +121,11 @@ exports[`Breadcrumb should render a menu 1`] = `
           home
         </a>
       </span>
-    </li>
-    <li
-      aria-hidden="true"
-      class="ant-breadcrumb-separator"
-    >
-      <a
-        href="#/index"
+      <span
+        class="ant-breadcrumb-separator"
       >
-        home
-      </a>
+        /
+      </span>
     </li>
     <li>
       <span
@@ -173,11 +165,7 @@ exports[`Breadcrumb should render a menu 1`] = `
       aria-hidden="true"
       class="ant-breadcrumb-separator"
     >
-      <a
-        href="#/index/first"
-      >
-        first
-      </a>
+      /
     </li>
     <li>
       <span
@@ -194,11 +182,7 @@ exports[`Breadcrumb should render a menu 1`] = `
       aria-hidden="true"
       class="ant-breadcrumb-separator"
     >
-      <a
-        href="#/index/first/second"
-      >
-        second
-      </a>
+      /
     </li>
     <li>
       <span
@@ -211,7 +195,7 @@ exports[`Breadcrumb should render a menu 1`] = `
       aria-hidden="true"
       class="ant-breadcrumb-separator"
     >
-      <span />
+      /
     </li>
   </ol>
 </nav>
@@ -233,7 +217,7 @@ exports[`Breadcrumb should support Breadcrumb.Item default separator 1`] = `
       aria-hidden="true"
       class="ant-breadcrumb-separator"
     >
-      Location
+      /
     </li>
     <span>
       <li>
@@ -247,7 +231,7 @@ exports[`Breadcrumb should support Breadcrumb.Item default separator 1`] = `
         aria-hidden="true"
         class="ant-breadcrumb-separator"
       >
-        Mock Node
+        /
       </li>
     </span>
     <li>
@@ -256,12 +240,6 @@ exports[`Breadcrumb should support Breadcrumb.Item default separator 1`] = `
       >
         Application Center
       </span>
-    </li>
-    <li
-      aria-hidden="true"
-      class="ant-breadcrumb-separator"
-    >
-      Application Center
     </li>
   </ol>
 </nav>
@@ -283,7 +261,7 @@ exports[`Breadcrumb should support React.Fragment and falsy children 1`] = `
       aria-hidden="true"
       class="ant-breadcrumb-separator"
     >
-      yyy
+      /
     </li>
     <li>
       <span
@@ -296,7 +274,7 @@ exports[`Breadcrumb should support React.Fragment and falsy children 1`] = `
       aria-hidden="true"
       class="ant-breadcrumb-separator"
     >
-      yyy
+      /
     </li>
     <li>
       <span
@@ -309,7 +287,7 @@ exports[`Breadcrumb should support React.Fragment and falsy children 1`] = `
       aria-hidden="true"
       class="ant-breadcrumb-separator"
     >
-      yyy
+      /
     </li>
     0
   </ol>
@@ -334,7 +312,7 @@ exports[`Breadcrumb should support custom attribute 1`] = `
       aria-hidden="true"
       class="ant-breadcrumb-separator"
     >
-      xxx
+      /
     </li>
     <li>
       <span
@@ -342,12 +320,6 @@ exports[`Breadcrumb should support custom attribute 1`] = `
       >
         yyy
       </span>
-    </li>
-    <li
-      aria-hidden="true"
-      class="ant-breadcrumb-separator"
-    >
-      yyy
     </li>
   </ol>
 </nav>
@@ -377,12 +349,6 @@ exports[`Breadcrumb should support string \`0\` and number \`0\` 1`] = `
       >
         0
       </span>
-    </li>
-    <li
-      aria-hidden="true"
-      class="ant-breadcrumb-separator"
-    >
-      0
     </li>
   </ol>
 </nav>

--- a/components/breadcrumb/__tests__/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/components/breadcrumb/__tests__/__snapshots__/Breadcrumb.test.tsx.snap
@@ -63,6 +63,8 @@ exports[`Breadcrumb should allow Breadcrumb.Item is null or undefined 1`] = `
       >
         Home
       </span>
+    </li>
+    <li>
       <span
         class="ant-breadcrumb-separator"
       >
@@ -84,6 +86,8 @@ exports[`Breadcrumb should not display Breadcrumb Item when its children is fals
       >
         xxx
       </span>
+    </li>
+    <li>
       <span
         class="ant-breadcrumb-separator"
       >
@@ -96,6 +100,8 @@ exports[`Breadcrumb should not display Breadcrumb Item when its children is fals
       >
         yyy
       </span>
+    </li>
+    <li>
       <span
         class="ant-breadcrumb-separator"
       >
@@ -121,6 +127,8 @@ exports[`Breadcrumb should render a menu 1`] = `
           home
         </a>
       </span>
+    </li>
+    <li>
       <span
         class="ant-breadcrumb-separator"
       >
@@ -160,6 +168,8 @@ exports[`Breadcrumb should render a menu 1`] = `
           </svg>
         </span>
       </span>
+    </li>
+    <li>
       <span
         class="ant-breadcrumb-separator"
       >
@@ -176,6 +186,8 @@ exports[`Breadcrumb should render a menu 1`] = `
           second
         </a>
       </span>
+    </li>
+    <li>
       <span
         class="ant-breadcrumb-separator"
       >
@@ -188,6 +200,8 @@ exports[`Breadcrumb should render a menu 1`] = `
       >
         <span />
       </span>
+    </li>
+    <li>
       <span
         class="ant-breadcrumb-separator"
       >
@@ -209,6 +223,8 @@ exports[`Breadcrumb should support Breadcrumb.Item default separator 1`] = `
       >
         Location
       </span>
+    </li>
+    <li>
       <span
         class="ant-breadcrumb-separator"
       >
@@ -222,6 +238,8 @@ exports[`Breadcrumb should support Breadcrumb.Item default separator 1`] = `
         >
           Mock Node
         </span>
+      </li>
+      <li>
         <span
           class="ant-breadcrumb-separator"
         >
@@ -235,6 +253,8 @@ exports[`Breadcrumb should support Breadcrumb.Item default separator 1`] = `
       >
         Application Center
       </span>
+    </li>
+    <li>
       <span
         class="ant-breadcrumb-separator"
       >
@@ -256,6 +276,8 @@ exports[`Breadcrumb should support React.Fragment and falsy children 1`] = `
       >
         yyy
       </span>
+    </li>
+    <li>
       <span
         class="ant-breadcrumb-separator"
       >
@@ -268,6 +290,8 @@ exports[`Breadcrumb should support React.Fragment and falsy children 1`] = `
       >
         yyy
       </span>
+    </li>
+    <li>
       <span
         class="ant-breadcrumb-separator"
       >
@@ -280,6 +304,8 @@ exports[`Breadcrumb should support React.Fragment and falsy children 1`] = `
       >
         yyy
       </span>
+    </li>
+    <li>
       <span
         class="ant-breadcrumb-separator"
       >
@@ -304,6 +330,8 @@ exports[`Breadcrumb should support custom attribute 1`] = `
       >
         xxx
       </span>
+    </li>
+    <li>
       <span
         class="ant-breadcrumb-separator"
       >
@@ -316,6 +344,8 @@ exports[`Breadcrumb should support custom attribute 1`] = `
       >
         yyy
       </span>
+    </li>
+    <li>
       <span
         class="ant-breadcrumb-separator"
       >
@@ -337,6 +367,8 @@ exports[`Breadcrumb should support string \`0\` and number \`0\` 1`] = `
       >
         0
       </span>
+    </li>
+    <li>
       <span
         class="ant-breadcrumb-separator"
       >
@@ -349,6 +381,8 @@ exports[`Breadcrumb should support string \`0\` and number \`0\` 1`] = `
       >
         0
       </span>
+    </li>
+    <li>
       <span
         class="ant-breadcrumb-separator"
       >

--- a/components/breadcrumb/__tests__/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/components/breadcrumb/__tests__/__snapshots__/Breadcrumb.test.tsx.snap
@@ -63,11 +63,6 @@ exports[`Breadcrumb should allow Breadcrumb.Item is null or undefined 1`] = `
       >
         Home
       </span>
-      <span
-        class="ant-breadcrumb-separator"
-      >
-        /
-      </span>
     </li>
   </ol>
 </nav>
@@ -84,22 +79,18 @@ exports[`Breadcrumb should not display Breadcrumb Item when its children is fals
       >
         xxx
       </span>
-      <span
-        class="ant-breadcrumb-separator"
-      >
-        /
-      </span>
+    </li>
+    <li
+      aria-hidden="true"
+      class="ant-breadcrumb-separator"
+    >
+      /
     </li>
     <li>
       <span
         class="ant-breadcrumb-link"
       >
         yyy
-      </span>
-      <span
-        class="ant-breadcrumb-separator"
-      >
-        /
       </span>
     </li>
   </ol>
@@ -121,11 +112,12 @@ exports[`Breadcrumb should render a menu 1`] = `
           home
         </a>
       </span>
-      <span
-        class="ant-breadcrumb-separator"
-      >
-        /
-      </span>
+    </li>
+    <li
+      aria-hidden="true"
+      class="ant-breadcrumb-separator"
+    >
+      /
     </li>
     <li>
       <span

--- a/components/breadcrumb/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/breadcrumb/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -16,7 +16,7 @@ exports[`renders ./components/breadcrumb/demo/basic.tsx extend context correctly
       aria-hidden="true"
       class="ant-breadcrumb-separator"
     >
-      Home
+      /
     </li>
     <li>
       <span
@@ -33,11 +33,7 @@ exports[`renders ./components/breadcrumb/demo/basic.tsx extend context correctly
       aria-hidden="true"
       class="ant-breadcrumb-separator"
     >
-      <a
-        href=""
-      >
-        Application Center
-      </a>
+      /
     </li>
     <li>
       <span
@@ -54,11 +50,7 @@ exports[`renders ./components/breadcrumb/demo/basic.tsx extend context correctly
       aria-hidden="true"
       class="ant-breadcrumb-separator"
     >
-      <a
-        href=""
-      >
-        Application List
-      </a>
+      /
     </li>
     <li>
       <span
@@ -66,12 +58,6 @@ exports[`renders ./components/breadcrumb/demo/basic.tsx extend context correctly
       >
         An Application
       </span>
-    </li>
-    <li
-      aria-hidden="true"
-      class="ant-breadcrumb-separator"
-    >
-      An Application
     </li>
   </ol>
 </nav>
@@ -93,7 +79,7 @@ exports[`renders ./components/breadcrumb/demo/overlay.tsx extend context correct
       aria-hidden="true"
       class="ant-breadcrumb-separator"
     >
-      Ant Design
+      /
     </li>
     <li>
       <span
@@ -110,11 +96,7 @@ exports[`renders ./components/breadcrumb/demo/overlay.tsx extend context correct
       aria-hidden="true"
       class="ant-breadcrumb-separator"
     >
-      <a
-        href=""
-      >
-        Component
-      </a>
+      /
     </li>
     <li>
       <span
@@ -326,11 +308,7 @@ exports[`renders ./components/breadcrumb/demo/overlay.tsx extend context correct
       aria-hidden="true"
       class="ant-breadcrumb-separator"
     >
-      <a
-        href=""
-      >
-        General
-      </a>
+      /
     </li>
     <li>
       <span
@@ -338,12 +316,6 @@ exports[`renders ./components/breadcrumb/demo/overlay.tsx extend context correct
       >
         Button
       </span>
-    </li>
-    <li
-      aria-hidden="true"
-      class="ant-breadcrumb-separator"
-    >
-      Button
     </li>
   </ol>
 </nav>
@@ -365,7 +337,7 @@ exports[`renders ./components/breadcrumb/demo/separator.tsx extend context corre
       aria-hidden="true"
       class="ant-breadcrumb-separator"
     >
-      Home
+      &gt;
     </li>
     <li>
       <a
@@ -379,7 +351,7 @@ exports[`renders ./components/breadcrumb/demo/separator.tsx extend context corre
       aria-hidden="true"
       class="ant-breadcrumb-separator"
     >
-      Application Center
+      &gt;
     </li>
     <li>
       <a
@@ -393,7 +365,7 @@ exports[`renders ./components/breadcrumb/demo/separator.tsx extend context corre
       aria-hidden="true"
       class="ant-breadcrumb-separator"
     >
-      Application List
+      &gt;
     </li>
     <li>
       <span
@@ -401,12 +373,6 @@ exports[`renders ./components/breadcrumb/demo/separator.tsx extend context corre
       >
         An Application
       </span>
-    </li>
-    <li
-      aria-hidden="true"
-      class="ant-breadcrumb-separator"
-    >
-      An Application
     </li>
   </ol>
 </nav>
@@ -504,25 +470,7 @@ exports[`renders ./components/breadcrumb/demo/withIcon.tsx extend context correc
       aria-hidden="true"
       class="ant-breadcrumb-separator"
     >
-      <span
-        aria-label="home"
-        class="anticon anticon-home"
-        role="img"
-      >
-        <svg
-          aria-hidden="true"
-          data-icon="home"
-          fill="currentColor"
-          focusable="false"
-          height="1em"
-          viewBox="64 64 896 896"
-          width="1em"
-        >
-          <path
-            d="M946.5 505L560.1 118.8l-25.9-25.9a31.5 31.5 0 00-44.4 0L77.5 505a63.9 63.9 0 00-18.8 46c.4 35.2 29.7 63.3 64.9 63.3h42.5V940h691.8V614.3h43.4c17.1 0 33.2-6.7 45.3-18.8a63.6 63.6 0 0018.7-45.3c0-17-6.7-33.1-18.8-45.2zM568 868H456V664h112v204zm217.9-325.7V868H632V640c0-22.1-17.9-40-40-40H432c-22.1 0-40 17.9-40 40v228H238.1V542.3h-96l370-369.7 23.1 23.1L882 542.3h-96.1z"
-          />
-        </svg>
-      </span>
+      /
     </li>
     <li>
       <a
@@ -557,28 +505,7 @@ exports[`renders ./components/breadcrumb/demo/withIcon.tsx extend context correc
       aria-hidden="true"
       class="ant-breadcrumb-separator"
     >
-      <span
-        aria-label="user"
-        class="anticon anticon-user"
-        role="img"
-      >
-        <svg
-          aria-hidden="true"
-          data-icon="user"
-          fill="currentColor"
-          focusable="false"
-          height="1em"
-          viewBox="64 64 896 896"
-          width="1em"
-        >
-          <path
-            d="M858.5 763.6a374 374 0 00-80.6-119.5 375.63 375.63 0 00-119.5-80.6c-.4-.2-.8-.3-1.2-.5C719.5 518 760 444.7 760 362c0-137-111-248-248-248S264 225 264 362c0 82.7 40.5 156 102.8 201.1-.4.2-.8.3-1.2.5-44.8 18.9-85 46-119.5 80.6a375.63 375.63 0 00-80.6 119.5A371.7 371.7 0 00136 901.8a8 8 0 008 8.2h60c4.4 0 7.9-3.5 8-7.8 2-77.2 33-149.5 87.8-204.3 56.7-56.7 132-87.9 212.2-87.9s155.5 31.2 212.2 87.9C779 752.7 810 825 812 902.2c.1 4.4 3.6 7.8 8 7.8h60a8 8 0 008-8.2c-1-47.8-10.9-94.3-29.5-138.2zM512 534c-45.9 0-89.1-17.9-121.6-50.4S340 407.9 340 362c0-45.9 17.9-89.1 50.4-121.6S466.1 190 512 190s89.1 17.9 121.6 50.4S684 316.1 684 362c0 45.9-17.9 89.1-50.4 121.6S557.9 534 512 534z"
-          />
-        </svg>
-      </span>
-      <span>
-        Application List
-      </span>
+      /
     </li>
     <li>
       <span
@@ -586,12 +513,6 @@ exports[`renders ./components/breadcrumb/demo/withIcon.tsx extend context correc
       >
         Application
       </span>
-    </li>
-    <li
-      aria-hidden="true"
-      class="ant-breadcrumb-separator"
-    >
-      Application
     </li>
   </ol>
 </nav>

--- a/components/breadcrumb/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/breadcrumb/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -12,12 +12,11 @@ exports[`renders ./components/breadcrumb/demo/basic.tsx extend context correctly
         Home
       </span>
     </li>
-    <li>
-      <span
-        class="ant-breadcrumb-separator"
-      >
-        /
-      </span>
+    <li
+      aria-hidden="true"
+      class="ant-breadcrumb-separator"
+    >
+      Home
     </li>
     <li>
       <span
@@ -30,12 +29,15 @@ exports[`renders ./components/breadcrumb/demo/basic.tsx extend context correctly
         </a>
       </span>
     </li>
-    <li>
-      <span
-        class="ant-breadcrumb-separator"
+    <li
+      aria-hidden="true"
+      class="ant-breadcrumb-separator"
+    >
+      <a
+        href=""
       >
-        /
-      </span>
+        Application Center
+      </a>
     </li>
     <li>
       <span
@@ -48,12 +50,15 @@ exports[`renders ./components/breadcrumb/demo/basic.tsx extend context correctly
         </a>
       </span>
     </li>
-    <li>
-      <span
-        class="ant-breadcrumb-separator"
+    <li
+      aria-hidden="true"
+      class="ant-breadcrumb-separator"
+    >
+      <a
+        href=""
       >
-        /
-      </span>
+        Application List
+      </a>
     </li>
     <li>
       <span
@@ -62,12 +67,11 @@ exports[`renders ./components/breadcrumb/demo/basic.tsx extend context correctly
         An Application
       </span>
     </li>
-    <li>
-      <span
-        class="ant-breadcrumb-separator"
-      >
-        /
-      </span>
+    <li
+      aria-hidden="true"
+      class="ant-breadcrumb-separator"
+    >
+      An Application
     </li>
   </ol>
 </nav>
@@ -85,12 +89,11 @@ exports[`renders ./components/breadcrumb/demo/overlay.tsx extend context correct
         Ant Design
       </span>
     </li>
-    <li>
-      <span
-        class="ant-breadcrumb-separator"
-      >
-        /
-      </span>
+    <li
+      aria-hidden="true"
+      class="ant-breadcrumb-separator"
+    >
+      Ant Design
     </li>
     <li>
       <span
@@ -103,12 +106,15 @@ exports[`renders ./components/breadcrumb/demo/overlay.tsx extend context correct
         </a>
       </span>
     </li>
-    <li>
-      <span
-        class="ant-breadcrumb-separator"
+    <li
+      aria-hidden="true"
+      class="ant-breadcrumb-separator"
+    >
+      <a
+        href=""
       >
-        /
-      </span>
+        Component
+      </a>
     </li>
     <li>
       <span
@@ -316,12 +322,15 @@ exports[`renders ./components/breadcrumb/demo/overlay.tsx extend context correct
         </div>
       </div>
     </li>
-    <li>
-      <span
-        class="ant-breadcrumb-separator"
+    <li
+      aria-hidden="true"
+      class="ant-breadcrumb-separator"
+    >
+      <a
+        href=""
       >
-        /
-      </span>
+        General
+      </a>
     </li>
     <li>
       <span
@@ -330,12 +339,11 @@ exports[`renders ./components/breadcrumb/demo/overlay.tsx extend context correct
         Button
       </span>
     </li>
-    <li>
-      <span
-        class="ant-breadcrumb-separator"
-      >
-        /
-      </span>
+    <li
+      aria-hidden="true"
+      class="ant-breadcrumb-separator"
+    >
+      Button
     </li>
   </ol>
 </nav>
@@ -353,12 +361,11 @@ exports[`renders ./components/breadcrumb/demo/separator.tsx extend context corre
         Home
       </span>
     </li>
-    <li>
-      <span
-        class="ant-breadcrumb-separator"
-      >
-        &gt;
-      </span>
+    <li
+      aria-hidden="true"
+      class="ant-breadcrumb-separator"
+    >
+      Home
     </li>
     <li>
       <a
@@ -368,12 +375,11 @@ exports[`renders ./components/breadcrumb/demo/separator.tsx extend context corre
         Application Center
       </a>
     </li>
-    <li>
-      <span
-        class="ant-breadcrumb-separator"
-      >
-        &gt;
-      </span>
+    <li
+      aria-hidden="true"
+      class="ant-breadcrumb-separator"
+    >
+      Application Center
     </li>
     <li>
       <a
@@ -383,12 +389,11 @@ exports[`renders ./components/breadcrumb/demo/separator.tsx extend context corre
         Application List
       </a>
     </li>
-    <li>
-      <span
-        class="ant-breadcrumb-separator"
-      >
-        &gt;
-      </span>
+    <li
+      aria-hidden="true"
+      class="ant-breadcrumb-separator"
+    >
+      Application List
     </li>
     <li>
       <span
@@ -397,12 +402,11 @@ exports[`renders ./components/breadcrumb/demo/separator.tsx extend context corre
         An Application
       </span>
     </li>
-    <li>
-      <span
-        class="ant-breadcrumb-separator"
-      >
-        &gt;
-      </span>
+    <li
+      aria-hidden="true"
+      class="ant-breadcrumb-separator"
+    >
+      An Application
     </li>
   </ol>
 </nav>
@@ -496,11 +500,28 @@ exports[`renders ./components/breadcrumb/demo/withIcon.tsx extend context correc
         </span>
       </a>
     </li>
-    <li>
+    <li
+      aria-hidden="true"
+      class="ant-breadcrumb-separator"
+    >
       <span
-        class="ant-breadcrumb-separator"
+        aria-label="home"
+        class="anticon anticon-home"
+        role="img"
       >
-        /
+        <svg
+          aria-hidden="true"
+          data-icon="home"
+          fill="currentColor"
+          focusable="false"
+          height="1em"
+          viewBox="64 64 896 896"
+          width="1em"
+        >
+          <path
+            d="M946.5 505L560.1 118.8l-25.9-25.9a31.5 31.5 0 00-44.4 0L77.5 505a63.9 63.9 0 00-18.8 46c.4 35.2 29.7 63.3 64.9 63.3h42.5V940h691.8V614.3h43.4c17.1 0 33.2-6.7 45.3-18.8a63.6 63.6 0 0018.7-45.3c0-17-6.7-33.1-18.8-45.2zM568 868H456V664h112v204zm217.9-325.7V868H632V640c0-22.1-17.9-40-40-40H432c-22.1 0-40 17.9-40 40v228H238.1V542.3h-96l370-369.7 23.1 23.1L882 542.3h-96.1z"
+          />
+        </svg>
       </span>
     </li>
     <li>
@@ -532,11 +553,31 @@ exports[`renders ./components/breadcrumb/demo/withIcon.tsx extend context correc
         </span>
       </a>
     </li>
-    <li>
+    <li
+      aria-hidden="true"
+      class="ant-breadcrumb-separator"
+    >
       <span
-        class="ant-breadcrumb-separator"
+        aria-label="user"
+        class="anticon anticon-user"
+        role="img"
       >
-        /
+        <svg
+          aria-hidden="true"
+          data-icon="user"
+          fill="currentColor"
+          focusable="false"
+          height="1em"
+          viewBox="64 64 896 896"
+          width="1em"
+        >
+          <path
+            d="M858.5 763.6a374 374 0 00-80.6-119.5 375.63 375.63 0 00-119.5-80.6c-.4-.2-.8-.3-1.2-.5C719.5 518 760 444.7 760 362c0-137-111-248-248-248S264 225 264 362c0 82.7 40.5 156 102.8 201.1-.4.2-.8.3-1.2.5-44.8 18.9-85 46-119.5 80.6a375.63 375.63 0 00-80.6 119.5A371.7 371.7 0 00136 901.8a8 8 0 008 8.2h60c4.4 0 7.9-3.5 8-7.8 2-77.2 33-149.5 87.8-204.3 56.7-56.7 132-87.9 212.2-87.9s155.5 31.2 212.2 87.9C779 752.7 810 825 812 902.2c.1 4.4 3.6 7.8 8 7.8h60a8 8 0 008-8.2c-1-47.8-10.9-94.3-29.5-138.2zM512 534c-45.9 0-89.1-17.9-121.6-50.4S340 407.9 340 362c0-45.9 17.9-89.1 50.4-121.6S466.1 190 512 190s89.1 17.9 121.6 50.4S684 316.1 684 362c0 45.9-17.9 89.1-50.4 121.6S557.9 534 512 534z"
+          />
+        </svg>
+      </span>
+      <span>
+        Application List
       </span>
     </li>
     <li>
@@ -546,12 +587,11 @@ exports[`renders ./components/breadcrumb/demo/withIcon.tsx extend context correc
         Application
       </span>
     </li>
-    <li>
-      <span
-        class="ant-breadcrumb-separator"
-      >
-        /
-      </span>
+    <li
+      aria-hidden="true"
+      class="ant-breadcrumb-separator"
+    >
+      Application
     </li>
   </ol>
 </nav>

--- a/components/breadcrumb/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/breadcrumb/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -11,6 +11,8 @@ exports[`renders ./components/breadcrumb/demo/basic.tsx extend context correctly
       >
         Home
       </span>
+    </li>
+    <li>
       <span
         class="ant-breadcrumb-separator"
       >
@@ -27,6 +29,8 @@ exports[`renders ./components/breadcrumb/demo/basic.tsx extend context correctly
           Application Center
         </a>
       </span>
+    </li>
+    <li>
       <span
         class="ant-breadcrumb-separator"
       >
@@ -43,6 +47,8 @@ exports[`renders ./components/breadcrumb/demo/basic.tsx extend context correctly
           Application List
         </a>
       </span>
+    </li>
+    <li>
       <span
         class="ant-breadcrumb-separator"
       >
@@ -55,6 +61,8 @@ exports[`renders ./components/breadcrumb/demo/basic.tsx extend context correctly
       >
         An Application
       </span>
+    </li>
+    <li>
       <span
         class="ant-breadcrumb-separator"
       >
@@ -76,6 +84,8 @@ exports[`renders ./components/breadcrumb/demo/overlay.tsx extend context correct
       >
         Ant Design
       </span>
+    </li>
+    <li>
       <span
         class="ant-breadcrumb-separator"
       >
@@ -92,6 +102,8 @@ exports[`renders ./components/breadcrumb/demo/overlay.tsx extend context correct
           Component
         </a>
       </span>
+    </li>
+    <li>
       <span
         class="ant-breadcrumb-separator"
       >
@@ -303,6 +315,8 @@ exports[`renders ./components/breadcrumb/demo/overlay.tsx extend context correct
           </div>
         </div>
       </div>
+    </li>
+    <li>
       <span
         class="ant-breadcrumb-separator"
       >
@@ -315,6 +329,8 @@ exports[`renders ./components/breadcrumb/demo/overlay.tsx extend context correct
       >
         Button
       </span>
+    </li>
+    <li>
       <span
         class="ant-breadcrumb-separator"
       >
@@ -336,6 +352,8 @@ exports[`renders ./components/breadcrumb/demo/separator.tsx extend context corre
       >
         Home
       </span>
+    </li>
+    <li>
       <span
         class="ant-breadcrumb-separator"
       >
@@ -349,6 +367,8 @@ exports[`renders ./components/breadcrumb/demo/separator.tsx extend context corre
       >
         Application Center
       </a>
+    </li>
+    <li>
       <span
         class="ant-breadcrumb-separator"
       >
@@ -362,6 +382,8 @@ exports[`renders ./components/breadcrumb/demo/separator.tsx extend context corre
       >
         Application List
       </a>
+    </li>
+    <li>
       <span
         class="ant-breadcrumb-separator"
       >
@@ -374,6 +396,8 @@ exports[`renders ./components/breadcrumb/demo/separator.tsx extend context corre
       >
         An Application
       </span>
+    </li>
+    <li>
       <span
         class="ant-breadcrumb-separator"
       >
@@ -471,6 +495,8 @@ exports[`renders ./components/breadcrumb/demo/withIcon.tsx extend context correc
           </svg>
         </span>
       </a>
+    </li>
+    <li>
       <span
         class="ant-breadcrumb-separator"
       >
@@ -505,6 +531,8 @@ exports[`renders ./components/breadcrumb/demo/withIcon.tsx extend context correc
           Application List
         </span>
       </a>
+    </li>
+    <li>
       <span
         class="ant-breadcrumb-separator"
       >
@@ -517,6 +545,8 @@ exports[`renders ./components/breadcrumb/demo/withIcon.tsx extend context correc
       >
         Application
       </span>
+    </li>
+    <li>
       <span
         class="ant-breadcrumb-separator"
       >

--- a/components/breadcrumb/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/breadcrumb/__tests__/__snapshots__/demo.test.ts.snap
@@ -11,6 +11,8 @@ exports[`renders ./components/breadcrumb/demo/basic.tsx correctly 1`] = `
       >
         Home
       </span>
+    </li>
+    <li>
       <span
         class="ant-breadcrumb-separator"
       >
@@ -27,6 +29,8 @@ exports[`renders ./components/breadcrumb/demo/basic.tsx correctly 1`] = `
           Application Center
         </a>
       </span>
+    </li>
+    <li>
       <span
         class="ant-breadcrumb-separator"
       >
@@ -43,6 +47,8 @@ exports[`renders ./components/breadcrumb/demo/basic.tsx correctly 1`] = `
           Application List
         </a>
       </span>
+    </li>
+    <li>
       <span
         class="ant-breadcrumb-separator"
       >
@@ -55,6 +61,8 @@ exports[`renders ./components/breadcrumb/demo/basic.tsx correctly 1`] = `
       >
         An Application
       </span>
+    </li>
+    <li>
       <span
         class="ant-breadcrumb-separator"
       >
@@ -76,6 +84,8 @@ exports[`renders ./components/breadcrumb/demo/overlay.tsx correctly 1`] = `
       >
         Ant Design
       </span>
+    </li>
+    <li>
       <span
         class="ant-breadcrumb-separator"
       >
@@ -92,6 +102,8 @@ exports[`renders ./components/breadcrumb/demo/overlay.tsx correctly 1`] = `
           Component
         </a>
       </span>
+    </li>
+    <li>
       <span
         class="ant-breadcrumb-separator"
       >
@@ -131,6 +143,8 @@ exports[`renders ./components/breadcrumb/demo/overlay.tsx correctly 1`] = `
           </svg>
         </span>
       </span>
+    </li>
+    <li>
       <span
         class="ant-breadcrumb-separator"
       >
@@ -143,6 +157,8 @@ exports[`renders ./components/breadcrumb/demo/overlay.tsx correctly 1`] = `
       >
         Button
       </span>
+    </li>
+    <li>
       <span
         class="ant-breadcrumb-separator"
       >
@@ -164,6 +180,8 @@ exports[`renders ./components/breadcrumb/demo/separator.tsx correctly 1`] = `
       >
         Home
       </span>
+    </li>
+    <li>
       <span
         class="ant-breadcrumb-separator"
       >
@@ -177,6 +195,8 @@ exports[`renders ./components/breadcrumb/demo/separator.tsx correctly 1`] = `
       >
         Application Center
       </a>
+    </li>
+    <li>
       <span
         class="ant-breadcrumb-separator"
       >
@@ -190,6 +210,8 @@ exports[`renders ./components/breadcrumb/demo/separator.tsx correctly 1`] = `
       >
         Application List
       </a>
+    </li>
+    <li>
       <span
         class="ant-breadcrumb-separator"
       >
@@ -202,6 +224,8 @@ exports[`renders ./components/breadcrumb/demo/separator.tsx correctly 1`] = `
       >
         An Application
       </span>
+    </li>
+    <li>
       <span
         class="ant-breadcrumb-separator"
       >
@@ -299,6 +323,8 @@ exports[`renders ./components/breadcrumb/demo/withIcon.tsx correctly 1`] = `
           </svg>
         </span>
       </a>
+    </li>
+    <li>
       <span
         class="ant-breadcrumb-separator"
       >
@@ -333,6 +359,8 @@ exports[`renders ./components/breadcrumb/demo/withIcon.tsx correctly 1`] = `
           Application List
         </span>
       </a>
+    </li>
+    <li>
       <span
         class="ant-breadcrumb-separator"
       >
@@ -345,6 +373,8 @@ exports[`renders ./components/breadcrumb/demo/withIcon.tsx correctly 1`] = `
       >
         Application
       </span>
+    </li>
+    <li>
       <span
         class="ant-breadcrumb-separator"
       >

--- a/components/breadcrumb/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/breadcrumb/__tests__/__snapshots__/demo.test.ts.snap
@@ -16,7 +16,7 @@ exports[`renders ./components/breadcrumb/demo/basic.tsx correctly 1`] = `
       aria-hidden="true"
       class="ant-breadcrumb-separator"
     >
-      Home
+      /
     </li>
     <li>
       <span
@@ -33,11 +33,7 @@ exports[`renders ./components/breadcrumb/demo/basic.tsx correctly 1`] = `
       aria-hidden="true"
       class="ant-breadcrumb-separator"
     >
-      <a
-        href=""
-      >
-        Application Center
-      </a>
+      /
     </li>
     <li>
       <span
@@ -54,11 +50,7 @@ exports[`renders ./components/breadcrumb/demo/basic.tsx correctly 1`] = `
       aria-hidden="true"
       class="ant-breadcrumb-separator"
     >
-      <a
-        href=""
-      >
-        Application List
-      </a>
+      /
     </li>
     <li>
       <span
@@ -66,12 +58,6 @@ exports[`renders ./components/breadcrumb/demo/basic.tsx correctly 1`] = `
       >
         An Application
       </span>
-    </li>
-    <li
-      aria-hidden="true"
-      class="ant-breadcrumb-separator"
-    >
-      An Application
     </li>
   </ol>
 </nav>
@@ -93,7 +79,7 @@ exports[`renders ./components/breadcrumb/demo/overlay.tsx correctly 1`] = `
       aria-hidden="true"
       class="ant-breadcrumb-separator"
     >
-      Ant Design
+      /
     </li>
     <li>
       <span
@@ -110,11 +96,7 @@ exports[`renders ./components/breadcrumb/demo/overlay.tsx correctly 1`] = `
       aria-hidden="true"
       class="ant-breadcrumb-separator"
     >
-      <a
-        href=""
-      >
-        Component
-      </a>
+      /
     </li>
     <li>
       <span
@@ -154,11 +136,7 @@ exports[`renders ./components/breadcrumb/demo/overlay.tsx correctly 1`] = `
       aria-hidden="true"
       class="ant-breadcrumb-separator"
     >
-      <a
-        href=""
-      >
-        General
-      </a>
+      /
     </li>
     <li>
       <span
@@ -166,12 +144,6 @@ exports[`renders ./components/breadcrumb/demo/overlay.tsx correctly 1`] = `
       >
         Button
       </span>
-    </li>
-    <li
-      aria-hidden="true"
-      class="ant-breadcrumb-separator"
-    >
-      Button
     </li>
   </ol>
 </nav>
@@ -193,7 +165,7 @@ exports[`renders ./components/breadcrumb/demo/separator.tsx correctly 1`] = `
       aria-hidden="true"
       class="ant-breadcrumb-separator"
     >
-      Home
+      &gt;
     </li>
     <li>
       <a
@@ -207,7 +179,7 @@ exports[`renders ./components/breadcrumb/demo/separator.tsx correctly 1`] = `
       aria-hidden="true"
       class="ant-breadcrumb-separator"
     >
-      Application Center
+      &gt;
     </li>
     <li>
       <a
@@ -221,7 +193,7 @@ exports[`renders ./components/breadcrumb/demo/separator.tsx correctly 1`] = `
       aria-hidden="true"
       class="ant-breadcrumb-separator"
     >
-      Application List
+      &gt;
     </li>
     <li>
       <span
@@ -229,12 +201,6 @@ exports[`renders ./components/breadcrumb/demo/separator.tsx correctly 1`] = `
       >
         An Application
       </span>
-    </li>
-    <li
-      aria-hidden="true"
-      class="ant-breadcrumb-separator"
-    >
-      An Application
     </li>
   </ol>
 </nav>
@@ -332,25 +298,7 @@ exports[`renders ./components/breadcrumb/demo/withIcon.tsx correctly 1`] = `
       aria-hidden="true"
       class="ant-breadcrumb-separator"
     >
-      <span
-        aria-label="home"
-        class="anticon anticon-home"
-        role="img"
-      >
-        <svg
-          aria-hidden="true"
-          data-icon="home"
-          fill="currentColor"
-          focusable="false"
-          height="1em"
-          viewBox="64 64 896 896"
-          width="1em"
-        >
-          <path
-            d="M946.5 505L560.1 118.8l-25.9-25.9a31.5 31.5 0 00-44.4 0L77.5 505a63.9 63.9 0 00-18.8 46c.4 35.2 29.7 63.3 64.9 63.3h42.5V940h691.8V614.3h43.4c17.1 0 33.2-6.7 45.3-18.8a63.6 63.6 0 0018.7-45.3c0-17-6.7-33.1-18.8-45.2zM568 868H456V664h112v204zm217.9-325.7V868H632V640c0-22.1-17.9-40-40-40H432c-22.1 0-40 17.9-40 40v228H238.1V542.3h-96l370-369.7 23.1 23.1L882 542.3h-96.1z"
-          />
-        </svg>
-      </span>
+      /
     </li>
     <li>
       <a
@@ -385,28 +333,7 @@ exports[`renders ./components/breadcrumb/demo/withIcon.tsx correctly 1`] = `
       aria-hidden="true"
       class="ant-breadcrumb-separator"
     >
-      <span
-        aria-label="user"
-        class="anticon anticon-user"
-        role="img"
-      >
-        <svg
-          aria-hidden="true"
-          data-icon="user"
-          fill="currentColor"
-          focusable="false"
-          height="1em"
-          viewBox="64 64 896 896"
-          width="1em"
-        >
-          <path
-            d="M858.5 763.6a374 374 0 00-80.6-119.5 375.63 375.63 0 00-119.5-80.6c-.4-.2-.8-.3-1.2-.5C719.5 518 760 444.7 760 362c0-137-111-248-248-248S264 225 264 362c0 82.7 40.5 156 102.8 201.1-.4.2-.8.3-1.2.5-44.8 18.9-85 46-119.5 80.6a375.63 375.63 0 00-80.6 119.5A371.7 371.7 0 00136 901.8a8 8 0 008 8.2h60c4.4 0 7.9-3.5 8-7.8 2-77.2 33-149.5 87.8-204.3 56.7-56.7 132-87.9 212.2-87.9s155.5 31.2 212.2 87.9C779 752.7 810 825 812 902.2c.1 4.4 3.6 7.8 8 7.8h60a8 8 0 008-8.2c-1-47.8-10.9-94.3-29.5-138.2zM512 534c-45.9 0-89.1-17.9-121.6-50.4S340 407.9 340 362c0-45.9 17.9-89.1 50.4-121.6S466.1 190 512 190s89.1 17.9 121.6 50.4S684 316.1 684 362c0 45.9-17.9 89.1-50.4 121.6S557.9 534 512 534z"
-          />
-        </svg>
-      </span>
-      <span>
-        Application List
-      </span>
+      /
     </li>
     <li>
       <span
@@ -414,12 +341,6 @@ exports[`renders ./components/breadcrumb/demo/withIcon.tsx correctly 1`] = `
       >
         Application
       </span>
-    </li>
-    <li
-      aria-hidden="true"
-      class="ant-breadcrumb-separator"
-    >
-      Application
     </li>
   </ol>
 </nav>

--- a/components/breadcrumb/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/breadcrumb/__tests__/__snapshots__/demo.test.ts.snap
@@ -12,12 +12,11 @@ exports[`renders ./components/breadcrumb/demo/basic.tsx correctly 1`] = `
         Home
       </span>
     </li>
-    <li>
-      <span
-        class="ant-breadcrumb-separator"
-      >
-        /
-      </span>
+    <li
+      aria-hidden="true"
+      class="ant-breadcrumb-separator"
+    >
+      Home
     </li>
     <li>
       <span
@@ -30,12 +29,15 @@ exports[`renders ./components/breadcrumb/demo/basic.tsx correctly 1`] = `
         </a>
       </span>
     </li>
-    <li>
-      <span
-        class="ant-breadcrumb-separator"
+    <li
+      aria-hidden="true"
+      class="ant-breadcrumb-separator"
+    >
+      <a
+        href=""
       >
-        /
-      </span>
+        Application Center
+      </a>
     </li>
     <li>
       <span
@@ -48,12 +50,15 @@ exports[`renders ./components/breadcrumb/demo/basic.tsx correctly 1`] = `
         </a>
       </span>
     </li>
-    <li>
-      <span
-        class="ant-breadcrumb-separator"
+    <li
+      aria-hidden="true"
+      class="ant-breadcrumb-separator"
+    >
+      <a
+        href=""
       >
-        /
-      </span>
+        Application List
+      </a>
     </li>
     <li>
       <span
@@ -62,12 +67,11 @@ exports[`renders ./components/breadcrumb/demo/basic.tsx correctly 1`] = `
         An Application
       </span>
     </li>
-    <li>
-      <span
-        class="ant-breadcrumb-separator"
-      >
-        /
-      </span>
+    <li
+      aria-hidden="true"
+      class="ant-breadcrumb-separator"
+    >
+      An Application
     </li>
   </ol>
 </nav>
@@ -85,12 +89,11 @@ exports[`renders ./components/breadcrumb/demo/overlay.tsx correctly 1`] = `
         Ant Design
       </span>
     </li>
-    <li>
-      <span
-        class="ant-breadcrumb-separator"
-      >
-        /
-      </span>
+    <li
+      aria-hidden="true"
+      class="ant-breadcrumb-separator"
+    >
+      Ant Design
     </li>
     <li>
       <span
@@ -103,12 +106,15 @@ exports[`renders ./components/breadcrumb/demo/overlay.tsx correctly 1`] = `
         </a>
       </span>
     </li>
-    <li>
-      <span
-        class="ant-breadcrumb-separator"
+    <li
+      aria-hidden="true"
+      class="ant-breadcrumb-separator"
+    >
+      <a
+        href=""
       >
-        /
-      </span>
+        Component
+      </a>
     </li>
     <li>
       <span
@@ -144,12 +150,15 @@ exports[`renders ./components/breadcrumb/demo/overlay.tsx correctly 1`] = `
         </span>
       </span>
     </li>
-    <li>
-      <span
-        class="ant-breadcrumb-separator"
+    <li
+      aria-hidden="true"
+      class="ant-breadcrumb-separator"
+    >
+      <a
+        href=""
       >
-        /
-      </span>
+        General
+      </a>
     </li>
     <li>
       <span
@@ -158,12 +167,11 @@ exports[`renders ./components/breadcrumb/demo/overlay.tsx correctly 1`] = `
         Button
       </span>
     </li>
-    <li>
-      <span
-        class="ant-breadcrumb-separator"
-      >
-        /
-      </span>
+    <li
+      aria-hidden="true"
+      class="ant-breadcrumb-separator"
+    >
+      Button
     </li>
   </ol>
 </nav>
@@ -181,12 +189,11 @@ exports[`renders ./components/breadcrumb/demo/separator.tsx correctly 1`] = `
         Home
       </span>
     </li>
-    <li>
-      <span
-        class="ant-breadcrumb-separator"
-      >
-        &gt;
-      </span>
+    <li
+      aria-hidden="true"
+      class="ant-breadcrumb-separator"
+    >
+      Home
     </li>
     <li>
       <a
@@ -196,12 +203,11 @@ exports[`renders ./components/breadcrumb/demo/separator.tsx correctly 1`] = `
         Application Center
       </a>
     </li>
-    <li>
-      <span
-        class="ant-breadcrumb-separator"
-      >
-        &gt;
-      </span>
+    <li
+      aria-hidden="true"
+      class="ant-breadcrumb-separator"
+    >
+      Application Center
     </li>
     <li>
       <a
@@ -211,12 +217,11 @@ exports[`renders ./components/breadcrumb/demo/separator.tsx correctly 1`] = `
         Application List
       </a>
     </li>
-    <li>
-      <span
-        class="ant-breadcrumb-separator"
-      >
-        &gt;
-      </span>
+    <li
+      aria-hidden="true"
+      class="ant-breadcrumb-separator"
+    >
+      Application List
     </li>
     <li>
       <span
@@ -225,12 +230,11 @@ exports[`renders ./components/breadcrumb/demo/separator.tsx correctly 1`] = `
         An Application
       </span>
     </li>
-    <li>
-      <span
-        class="ant-breadcrumb-separator"
-      >
-        &gt;
-      </span>
+    <li
+      aria-hidden="true"
+      class="ant-breadcrumb-separator"
+    >
+      An Application
     </li>
   </ol>
 </nav>
@@ -324,11 +328,28 @@ exports[`renders ./components/breadcrumb/demo/withIcon.tsx correctly 1`] = `
         </span>
       </a>
     </li>
-    <li>
+    <li
+      aria-hidden="true"
+      class="ant-breadcrumb-separator"
+    >
       <span
-        class="ant-breadcrumb-separator"
+        aria-label="home"
+        class="anticon anticon-home"
+        role="img"
       >
-        /
+        <svg
+          aria-hidden="true"
+          data-icon="home"
+          fill="currentColor"
+          focusable="false"
+          height="1em"
+          viewBox="64 64 896 896"
+          width="1em"
+        >
+          <path
+            d="M946.5 505L560.1 118.8l-25.9-25.9a31.5 31.5 0 00-44.4 0L77.5 505a63.9 63.9 0 00-18.8 46c.4 35.2 29.7 63.3 64.9 63.3h42.5V940h691.8V614.3h43.4c17.1 0 33.2-6.7 45.3-18.8a63.6 63.6 0 0018.7-45.3c0-17-6.7-33.1-18.8-45.2zM568 868H456V664h112v204zm217.9-325.7V868H632V640c0-22.1-17.9-40-40-40H432c-22.1 0-40 17.9-40 40v228H238.1V542.3h-96l370-369.7 23.1 23.1L882 542.3h-96.1z"
+          />
+        </svg>
       </span>
     </li>
     <li>
@@ -360,11 +381,31 @@ exports[`renders ./components/breadcrumb/demo/withIcon.tsx correctly 1`] = `
         </span>
       </a>
     </li>
-    <li>
+    <li
+      aria-hidden="true"
+      class="ant-breadcrumb-separator"
+    >
       <span
-        class="ant-breadcrumb-separator"
+        aria-label="user"
+        class="anticon anticon-user"
+        role="img"
       >
-        /
+        <svg
+          aria-hidden="true"
+          data-icon="user"
+          fill="currentColor"
+          focusable="false"
+          height="1em"
+          viewBox="64 64 896 896"
+          width="1em"
+        >
+          <path
+            d="M858.5 763.6a374 374 0 00-80.6-119.5 375.63 375.63 0 00-119.5-80.6c-.4-.2-.8-.3-1.2-.5C719.5 518 760 444.7 760 362c0-137-111-248-248-248S264 225 264 362c0 82.7 40.5 156 102.8 201.1-.4.2-.8.3-1.2.5-44.8 18.9-85 46-119.5 80.6a375.63 375.63 0 00-80.6 119.5A371.7 371.7 0 00136 901.8a8 8 0 008 8.2h60c4.4 0 7.9-3.5 8-7.8 2-77.2 33-149.5 87.8-204.3 56.7-56.7 132-87.9 212.2-87.9s155.5 31.2 212.2 87.9C779 752.7 810 825 812 902.2c.1 4.4 3.6 7.8 8 7.8h60a8 8 0 008-8.2c-1-47.8-10.9-94.3-29.5-138.2zM512 534c-45.9 0-89.1-17.9-121.6-50.4S340 407.9 340 362c0-45.9 17.9-89.1 50.4-121.6S466.1 190 512 190s89.1 17.9 121.6 50.4S684 316.1 684 362c0 45.9-17.9 89.1-50.4 121.6S557.9 534 512 534z"
+          />
+        </svg>
+      </span>
+      <span>
+        Application List
       </span>
     </li>
     <li>
@@ -374,12 +415,11 @@ exports[`renders ./components/breadcrumb/demo/withIcon.tsx correctly 1`] = `
         Application
       </span>
     </li>
-    <li>
-      <span
-        class="ant-breadcrumb-separator"
-      >
-        /
-      </span>
+    <li
+      aria-hidden="true"
+      class="ant-breadcrumb-separator"
+    >
+      Application
     </li>
   </ol>
 </nav>

--- a/components/breadcrumb/__tests__/__snapshots__/router.test.tsx.snap
+++ b/components/breadcrumb/__tests__/__snapshots__/router.test.tsx.snap
@@ -20,11 +20,7 @@ exports[`react router react router 3 1`] = `
       aria-hidden="true"
       class="ant-breadcrumb-separator"
     >
-      <a
-        href="#/"
-      >
-        Home
-      </a>
+      /
     </li>
     <li>
       <span
@@ -41,11 +37,7 @@ exports[`react router react router 3 1`] = `
       aria-hidden="true"
       class="ant-breadcrumb-separator"
     >
-      <a
-        href="#/apps"
-      >
-        Application List
-      </a>
+      /
     </li>
     <li>
       <span
@@ -62,11 +54,7 @@ exports[`react router react router 3 1`] = `
       aria-hidden="true"
       class="ant-breadcrumb-separator"
     >
-      <a
-        href="#/apps/1"
-      >
-        Application1
-      </a>
+      /
     </li>
     <li>
       <span
@@ -81,9 +69,7 @@ exports[`react router react router 3 1`] = `
       aria-hidden="true"
       class="ant-breadcrumb-separator"
     >
-      <span>
-        Detail
-      </span>
+      /
     </li>
   </ol>
 </nav>

--- a/components/breadcrumb/__tests__/__snapshots__/router.test.tsx.snap
+++ b/components/breadcrumb/__tests__/__snapshots__/router.test.tsx.snap
@@ -16,12 +16,15 @@ exports[`react router react router 3 1`] = `
         </a>
       </span>
     </li>
-    <li>
-      <span
-        class="ant-breadcrumb-separator"
+    <li
+      aria-hidden="true"
+      class="ant-breadcrumb-separator"
+    >
+      <a
+        href="#/"
       >
-        /
-      </span>
+        Home
+      </a>
     </li>
     <li>
       <span
@@ -34,12 +37,15 @@ exports[`react router react router 3 1`] = `
         </a>
       </span>
     </li>
-    <li>
-      <span
-        class="ant-breadcrumb-separator"
+    <li
+      aria-hidden="true"
+      class="ant-breadcrumb-separator"
+    >
+      <a
+        href="#/apps"
       >
-        /
-      </span>
+        Application List
+      </a>
     </li>
     <li>
       <span
@@ -52,12 +58,15 @@ exports[`react router react router 3 1`] = `
         </a>
       </span>
     </li>
-    <li>
-      <span
-        class="ant-breadcrumb-separator"
+    <li
+      aria-hidden="true"
+      class="ant-breadcrumb-separator"
+    >
+      <a
+        href="#/apps/1"
       >
-        /
-      </span>
+        Application1
+      </a>
     </li>
     <li>
       <span
@@ -68,11 +77,12 @@ exports[`react router react router 3 1`] = `
         </span>
       </span>
     </li>
-    <li>
-      <span
-        class="ant-breadcrumb-separator"
-      >
-        /
+    <li
+      aria-hidden="true"
+      class="ant-breadcrumb-separator"
+    >
+      <span>
+        Detail
       </span>
     </li>
   </ol>

--- a/components/breadcrumb/__tests__/__snapshots__/router.test.tsx.snap
+++ b/components/breadcrumb/__tests__/__snapshots__/router.test.tsx.snap
@@ -15,6 +15,8 @@ exports[`react router react router 3 1`] = `
           Home
         </a>
       </span>
+    </li>
+    <li>
       <span
         class="ant-breadcrumb-separator"
       >
@@ -31,6 +33,8 @@ exports[`react router react router 3 1`] = `
           Application List
         </a>
       </span>
+    </li>
+    <li>
       <span
         class="ant-breadcrumb-separator"
       >
@@ -47,6 +51,8 @@ exports[`react router react router 3 1`] = `
           Application1
         </a>
       </span>
+    </li>
+    <li>
       <span
         class="ant-breadcrumb-separator"
       >
@@ -61,6 +67,8 @@ exports[`react router react router 3 1`] = `
           Detail
         </span>
       </span>
+    </li>
+    <li>
       <span
         class="ant-breadcrumb-separator"
       >

--- a/components/breadcrumb/style/index.ts
+++ b/components/breadcrumb/style/index.ts
@@ -54,10 +54,6 @@ const genBreadcrumbStyle: GenerateStyle<BreadcrumbToken, CSSObject> = (token) =>
 
       [`li:last-child`]: {
         color: token.breadcrumbLastItemColor,
-
-        [`& > ${componentCls}-separator`]: {
-          display: 'none',
-        },
       },
 
       [`${componentCls}-separator`]: {

--- a/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
+++ b/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
@@ -1141,12 +1141,11 @@ exports[`ConfigProvider components Breadcrumb configProvider 1`] = `
         Bamboo
       </span>
     </li>
-    <li>
-      <span
-        class="config-breadcrumb-separator"
-      >
-        /
-      </span>
+    <li
+      aria-hidden="true"
+      class="config-breadcrumb-separator"
+    >
+      Bamboo
     </li>
     <li>
       <span
@@ -1155,12 +1154,11 @@ exports[`ConfigProvider components Breadcrumb configProvider 1`] = `
         Light
       </span>
     </li>
-    <li>
-      <span
-        class="config-breadcrumb-separator"
-      >
-        /
-      </span>
+    <li
+      aria-hidden="true"
+      class="config-breadcrumb-separator"
+    >
+      Light
     </li>
   </ol>
 </nav>
@@ -1178,12 +1176,11 @@ exports[`ConfigProvider components Breadcrumb configProvider componentDisabled 1
         Bamboo
       </span>
     </li>
-    <li>
-      <span
-        class="config-breadcrumb-separator"
-      >
-        /
-      </span>
+    <li
+      aria-hidden="true"
+      class="config-breadcrumb-separator"
+    >
+      Bamboo
     </li>
     <li>
       <span
@@ -1192,12 +1189,11 @@ exports[`ConfigProvider components Breadcrumb configProvider componentDisabled 1
         Light
       </span>
     </li>
-    <li>
-      <span
-        class="config-breadcrumb-separator"
-      >
-        /
-      </span>
+    <li
+      aria-hidden="true"
+      class="config-breadcrumb-separator"
+    >
+      Light
     </li>
   </ol>
 </nav>
@@ -1215,12 +1211,11 @@ exports[`ConfigProvider components Breadcrumb configProvider componentSize large
         Bamboo
       </span>
     </li>
-    <li>
-      <span
-        class="config-breadcrumb-separator"
-      >
-        /
-      </span>
+    <li
+      aria-hidden="true"
+      class="config-breadcrumb-separator"
+    >
+      Bamboo
     </li>
     <li>
       <span
@@ -1229,12 +1224,11 @@ exports[`ConfigProvider components Breadcrumb configProvider componentSize large
         Light
       </span>
     </li>
-    <li>
-      <span
-        class="config-breadcrumb-separator"
-      >
-        /
-      </span>
+    <li
+      aria-hidden="true"
+      class="config-breadcrumb-separator"
+    >
+      Light
     </li>
   </ol>
 </nav>
@@ -1252,12 +1246,11 @@ exports[`ConfigProvider components Breadcrumb configProvider componentSize middl
         Bamboo
       </span>
     </li>
-    <li>
-      <span
-        class="config-breadcrumb-separator"
-      >
-        /
-      </span>
+    <li
+      aria-hidden="true"
+      class="config-breadcrumb-separator"
+    >
+      Bamboo
     </li>
     <li>
       <span
@@ -1266,12 +1259,11 @@ exports[`ConfigProvider components Breadcrumb configProvider componentSize middl
         Light
       </span>
     </li>
-    <li>
-      <span
-        class="config-breadcrumb-separator"
-      >
-        /
-      </span>
+    <li
+      aria-hidden="true"
+      class="config-breadcrumb-separator"
+    >
+      Light
     </li>
   </ol>
 </nav>
@@ -1289,12 +1281,11 @@ exports[`ConfigProvider components Breadcrumb configProvider virtual and dropdow
         Bamboo
       </span>
     </li>
-    <li>
-      <span
-        class="ant-breadcrumb-separator"
-      >
-        /
-      </span>
+    <li
+      aria-hidden="true"
+      class="ant-breadcrumb-separator"
+    >
+      Bamboo
     </li>
     <li>
       <span
@@ -1303,12 +1294,11 @@ exports[`ConfigProvider components Breadcrumb configProvider virtual and dropdow
         Light
       </span>
     </li>
-    <li>
-      <span
-        class="ant-breadcrumb-separator"
-      >
-        /
-      </span>
+    <li
+      aria-hidden="true"
+      class="ant-breadcrumb-separator"
+    >
+      Light
     </li>
   </ol>
 </nav>
@@ -1326,12 +1316,11 @@ exports[`ConfigProvider components Breadcrumb normal 1`] = `
         Bamboo
       </span>
     </li>
-    <li>
-      <span
-        class="ant-breadcrumb-separator"
-      >
-        /
-      </span>
+    <li
+      aria-hidden="true"
+      class="ant-breadcrumb-separator"
+    >
+      Bamboo
     </li>
     <li>
       <span
@@ -1340,12 +1329,11 @@ exports[`ConfigProvider components Breadcrumb normal 1`] = `
         Light
       </span>
     </li>
-    <li>
-      <span
-        class="ant-breadcrumb-separator"
-      >
-        /
-      </span>
+    <li
+      aria-hidden="true"
+      class="ant-breadcrumb-separator"
+    >
+      Light
     </li>
   </ol>
 </nav>
@@ -1363,12 +1351,11 @@ exports[`ConfigProvider components Breadcrumb prefixCls 1`] = `
         Bamboo
       </span>
     </li>
-    <li>
-      <span
-        class="prefix-Breadcrumb-separator"
-      >
-        /
-      </span>
+    <li
+      aria-hidden="true"
+      class="ant-breadcrumb-separator"
+    >
+      Bamboo
     </li>
     <li>
       <span
@@ -1377,12 +1364,11 @@ exports[`ConfigProvider components Breadcrumb prefixCls 1`] = `
         Light
       </span>
     </li>
-    <li>
-      <span
-        class="prefix-Breadcrumb-separator"
-      >
-        /
-      </span>
+    <li
+      aria-hidden="true"
+      class="ant-breadcrumb-separator"
+    >
+      Light
     </li>
   </ol>
 </nav>

--- a/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
+++ b/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
@@ -1140,6 +1140,8 @@ exports[`ConfigProvider components Breadcrumb configProvider 1`] = `
       >
         Bamboo
       </span>
+    </li>
+    <li>
       <span
         class="config-breadcrumb-separator"
       >
@@ -1152,6 +1154,8 @@ exports[`ConfigProvider components Breadcrumb configProvider 1`] = `
       >
         Light
       </span>
+    </li>
+    <li>
       <span
         class="config-breadcrumb-separator"
       >
@@ -1173,6 +1177,8 @@ exports[`ConfigProvider components Breadcrumb configProvider componentDisabled 1
       >
         Bamboo
       </span>
+    </li>
+    <li>
       <span
         class="config-breadcrumb-separator"
       >
@@ -1185,6 +1191,8 @@ exports[`ConfigProvider components Breadcrumb configProvider componentDisabled 1
       >
         Light
       </span>
+    </li>
+    <li>
       <span
         class="config-breadcrumb-separator"
       >
@@ -1206,6 +1214,8 @@ exports[`ConfigProvider components Breadcrumb configProvider componentSize large
       >
         Bamboo
       </span>
+    </li>
+    <li>
       <span
         class="config-breadcrumb-separator"
       >
@@ -1218,6 +1228,8 @@ exports[`ConfigProvider components Breadcrumb configProvider componentSize large
       >
         Light
       </span>
+    </li>
+    <li>
       <span
         class="config-breadcrumb-separator"
       >
@@ -1239,6 +1251,8 @@ exports[`ConfigProvider components Breadcrumb configProvider componentSize middl
       >
         Bamboo
       </span>
+    </li>
+    <li>
       <span
         class="config-breadcrumb-separator"
       >
@@ -1251,6 +1265,8 @@ exports[`ConfigProvider components Breadcrumb configProvider componentSize middl
       >
         Light
       </span>
+    </li>
+    <li>
       <span
         class="config-breadcrumb-separator"
       >
@@ -1272,6 +1288,8 @@ exports[`ConfigProvider components Breadcrumb configProvider virtual and dropdow
       >
         Bamboo
       </span>
+    </li>
+    <li>
       <span
         class="ant-breadcrumb-separator"
       >
@@ -1284,6 +1302,8 @@ exports[`ConfigProvider components Breadcrumb configProvider virtual and dropdow
       >
         Light
       </span>
+    </li>
+    <li>
       <span
         class="ant-breadcrumb-separator"
       >
@@ -1305,6 +1325,8 @@ exports[`ConfigProvider components Breadcrumb normal 1`] = `
       >
         Bamboo
       </span>
+    </li>
+    <li>
       <span
         class="ant-breadcrumb-separator"
       >
@@ -1317,6 +1339,8 @@ exports[`ConfigProvider components Breadcrumb normal 1`] = `
       >
         Light
       </span>
+    </li>
+    <li>
       <span
         class="ant-breadcrumb-separator"
       >
@@ -1338,6 +1362,8 @@ exports[`ConfigProvider components Breadcrumb prefixCls 1`] = `
       >
         Bamboo
       </span>
+    </li>
+    <li>
       <span
         class="prefix-Breadcrumb-separator"
       >
@@ -1350,6 +1376,8 @@ exports[`ConfigProvider components Breadcrumb prefixCls 1`] = `
       >
         Light
       </span>
+    </li>
+    <li>
       <span
         class="prefix-Breadcrumb-separator"
       >

--- a/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
+++ b/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
@@ -1145,7 +1145,7 @@ exports[`ConfigProvider components Breadcrumb configProvider 1`] = `
       aria-hidden="true"
       class="config-breadcrumb-separator"
     >
-      Bamboo
+      /
     </li>
     <li>
       <span
@@ -1153,12 +1153,6 @@ exports[`ConfigProvider components Breadcrumb configProvider 1`] = `
       >
         Light
       </span>
-    </li>
-    <li
-      aria-hidden="true"
-      class="config-breadcrumb-separator"
-    >
-      Light
     </li>
   </ol>
 </nav>
@@ -1180,7 +1174,7 @@ exports[`ConfigProvider components Breadcrumb configProvider componentDisabled 1
       aria-hidden="true"
       class="config-breadcrumb-separator"
     >
-      Bamboo
+      /
     </li>
     <li>
       <span
@@ -1188,12 +1182,6 @@ exports[`ConfigProvider components Breadcrumb configProvider componentDisabled 1
       >
         Light
       </span>
-    </li>
-    <li
-      aria-hidden="true"
-      class="config-breadcrumb-separator"
-    >
-      Light
     </li>
   </ol>
 </nav>
@@ -1215,7 +1203,7 @@ exports[`ConfigProvider components Breadcrumb configProvider componentSize large
       aria-hidden="true"
       class="config-breadcrumb-separator"
     >
-      Bamboo
+      /
     </li>
     <li>
       <span
@@ -1223,12 +1211,6 @@ exports[`ConfigProvider components Breadcrumb configProvider componentSize large
       >
         Light
       </span>
-    </li>
-    <li
-      aria-hidden="true"
-      class="config-breadcrumb-separator"
-    >
-      Light
     </li>
   </ol>
 </nav>
@@ -1250,7 +1232,7 @@ exports[`ConfigProvider components Breadcrumb configProvider componentSize middl
       aria-hidden="true"
       class="config-breadcrumb-separator"
     >
-      Bamboo
+      /
     </li>
     <li>
       <span
@@ -1258,12 +1240,6 @@ exports[`ConfigProvider components Breadcrumb configProvider componentSize middl
       >
         Light
       </span>
-    </li>
-    <li
-      aria-hidden="true"
-      class="config-breadcrumb-separator"
-    >
-      Light
     </li>
   </ol>
 </nav>
@@ -1285,7 +1261,7 @@ exports[`ConfigProvider components Breadcrumb configProvider virtual and dropdow
       aria-hidden="true"
       class="ant-breadcrumb-separator"
     >
-      Bamboo
+      /
     </li>
     <li>
       <span
@@ -1293,12 +1269,6 @@ exports[`ConfigProvider components Breadcrumb configProvider virtual and dropdow
       >
         Light
       </span>
-    </li>
-    <li
-      aria-hidden="true"
-      class="ant-breadcrumb-separator"
-    >
-      Light
     </li>
   </ol>
 </nav>
@@ -1320,7 +1290,7 @@ exports[`ConfigProvider components Breadcrumb normal 1`] = `
       aria-hidden="true"
       class="ant-breadcrumb-separator"
     >
-      Bamboo
+      /
     </li>
     <li>
       <span
@@ -1328,12 +1298,6 @@ exports[`ConfigProvider components Breadcrumb normal 1`] = `
       >
         Light
       </span>
-    </li>
-    <li
-      aria-hidden="true"
-      class="ant-breadcrumb-separator"
-    >
-      Light
     </li>
   </ol>
 </nav>
@@ -1355,7 +1319,7 @@ exports[`ConfigProvider components Breadcrumb prefixCls 1`] = `
       aria-hidden="true"
       class="ant-breadcrumb-separator"
     >
-      Bamboo
+      /
     </li>
     <li>
       <span
@@ -1363,12 +1327,6 @@ exports[`ConfigProvider components Breadcrumb prefixCls 1`] = `
       >
         Light
       </span>
-    </li>
-    <li
-      aria-hidden="true"
-      class="ant-breadcrumb-separator"
-    >
-      Light
     </li>
   </ol>
 </nav>

--- a/components/layout/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/layout/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -645,12 +645,11 @@ exports[`renders ./components/layout/demo/fixed.tsx extend context correctly 1`]
             Home
           </span>
         </li>
-        <li>
-          <span
-            class="ant-breadcrumb-separator"
-          >
-            /
-          </span>
+        <li
+          aria-hidden="true"
+          class="ant-breadcrumb-separator"
+        >
+          Home
         </li>
         <li>
           <span
@@ -659,12 +658,11 @@ exports[`renders ./components/layout/demo/fixed.tsx extend context correctly 1`]
             List
           </span>
         </li>
-        <li>
-          <span
-            class="ant-breadcrumb-separator"
-          >
-            /
-          </span>
+        <li
+          aria-hidden="true"
+          class="ant-breadcrumb-separator"
+        >
+          List
         </li>
         <li>
           <span
@@ -673,12 +671,11 @@ exports[`renders ./components/layout/demo/fixed.tsx extend context correctly 1`]
             App
           </span>
         </li>
-        <li>
-          <span
-            class="ant-breadcrumb-separator"
-          >
-            /
-          </span>
+        <li
+          aria-hidden="true"
+          class="ant-breadcrumb-separator"
+        >
+          App
         </li>
       </ol>
     </nav>
@@ -2399,12 +2396,11 @@ exports[`renders ./components/layout/demo/side.tsx extend context correctly 1`] 
               User
             </span>
           </li>
-          <li>
-            <span
-              class="ant-breadcrumb-separator"
-            >
-              /
-            </span>
+          <li
+            aria-hidden="true"
+            class="ant-breadcrumb-separator"
+          >
+            User
           </li>
           <li>
             <span
@@ -2413,12 +2409,11 @@ exports[`renders ./components/layout/demo/side.tsx extend context correctly 1`] 
               Bill
             </span>
           </li>
-          <li>
-            <span
-              class="ant-breadcrumb-separator"
-            >
-              /
-            </span>
+          <li
+            aria-hidden="true"
+            class="ant-breadcrumb-separator"
+          >
+            Bill
           </li>
         </ol>
       </nav>
@@ -3216,12 +3211,11 @@ exports[`renders ./components/layout/demo/top.tsx extend context correctly 1`] =
             Home
           </span>
         </li>
-        <li>
-          <span
-            class="ant-breadcrumb-separator"
-          >
-            /
-          </span>
+        <li
+          aria-hidden="true"
+          class="ant-breadcrumb-separator"
+        >
+          Home
         </li>
         <li>
           <span
@@ -3230,12 +3224,11 @@ exports[`renders ./components/layout/demo/top.tsx extend context correctly 1`] =
             List
           </span>
         </li>
-        <li>
-          <span
-            class="ant-breadcrumb-separator"
-          >
-            /
-          </span>
+        <li
+          aria-hidden="true"
+          class="ant-breadcrumb-separator"
+        >
+          List
         </li>
         <li>
           <span
@@ -3244,12 +3237,11 @@ exports[`renders ./components/layout/demo/top.tsx extend context correctly 1`] =
             App
           </span>
         </li>
-        <li>
-          <span
-            class="ant-breadcrumb-separator"
-          >
-            /
-          </span>
+        <li
+          aria-hidden="true"
+          class="ant-breadcrumb-separator"
+        >
+          App
         </li>
       </ol>
     </nav>
@@ -3495,12 +3487,11 @@ exports[`renders ./components/layout/demo/top-side.tsx extend context correctly 
             Home
           </span>
         </li>
-        <li>
-          <span
-            class="ant-breadcrumb-separator"
-          >
-            /
-          </span>
+        <li
+          aria-hidden="true"
+          class="ant-breadcrumb-separator"
+        >
+          Home
         </li>
         <li>
           <span
@@ -3509,12 +3500,11 @@ exports[`renders ./components/layout/demo/top-side.tsx extend context correctly 
             List
           </span>
         </li>
-        <li>
-          <span
-            class="ant-breadcrumb-separator"
-          >
-            /
-          </span>
+        <li
+          aria-hidden="true"
+          class="ant-breadcrumb-separator"
+        >
+          List
         </li>
         <li>
           <span
@@ -3523,12 +3513,11 @@ exports[`renders ./components/layout/demo/top-side.tsx extend context correctly 
             App
           </span>
         </li>
-        <li>
-          <span
-            class="ant-breadcrumb-separator"
-          >
-            /
-          </span>
+        <li
+          aria-hidden="true"
+          class="ant-breadcrumb-separator"
+        >
+          App
         </li>
       </ol>
     </nav>
@@ -5498,12 +5487,11 @@ exports[`renders ./components/layout/demo/top-side-2.tsx extend context correctl
               Home
             </span>
           </li>
-          <li>
-            <span
-              class="ant-breadcrumb-separator"
-            >
-              /
-            </span>
+          <li
+            aria-hidden="true"
+            class="ant-breadcrumb-separator"
+          >
+            Home
           </li>
           <li>
             <span
@@ -5512,12 +5500,11 @@ exports[`renders ./components/layout/demo/top-side-2.tsx extend context correctl
               List
             </span>
           </li>
-          <li>
-            <span
-              class="ant-breadcrumb-separator"
-            >
-              /
-            </span>
+          <li
+            aria-hidden="true"
+            class="ant-breadcrumb-separator"
+          >
+            List
           </li>
           <li>
             <span
@@ -5526,12 +5513,11 @@ exports[`renders ./components/layout/demo/top-side-2.tsx extend context correctl
               App
             </span>
           </li>
-          <li>
-            <span
-              class="ant-breadcrumb-separator"
-            >
-              /
-            </span>
+          <li
+            aria-hidden="true"
+            class="ant-breadcrumb-separator"
+          >
+            App
           </li>
         </ol>
       </nav>

--- a/components/layout/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/layout/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -649,7 +649,7 @@ exports[`renders ./components/layout/demo/fixed.tsx extend context correctly 1`]
           aria-hidden="true"
           class="ant-breadcrumb-separator"
         >
-          Home
+          /
         </li>
         <li>
           <span
@@ -662,7 +662,7 @@ exports[`renders ./components/layout/demo/fixed.tsx extend context correctly 1`]
           aria-hidden="true"
           class="ant-breadcrumb-separator"
         >
-          List
+          /
         </li>
         <li>
           <span
@@ -670,12 +670,6 @@ exports[`renders ./components/layout/demo/fixed.tsx extend context correctly 1`]
           >
             App
           </span>
-        </li>
-        <li
-          aria-hidden="true"
-          class="ant-breadcrumb-separator"
-        >
-          App
         </li>
       </ol>
     </nav>
@@ -2400,7 +2394,7 @@ exports[`renders ./components/layout/demo/side.tsx extend context correctly 1`] 
             aria-hidden="true"
             class="ant-breadcrumb-separator"
           >
-            User
+            /
           </li>
           <li>
             <span
@@ -2408,12 +2402,6 @@ exports[`renders ./components/layout/demo/side.tsx extend context correctly 1`] 
             >
               Bill
             </span>
-          </li>
-          <li
-            aria-hidden="true"
-            class="ant-breadcrumb-separator"
-          >
-            Bill
           </li>
         </ol>
       </nav>
@@ -3215,7 +3203,7 @@ exports[`renders ./components/layout/demo/top.tsx extend context correctly 1`] =
           aria-hidden="true"
           class="ant-breadcrumb-separator"
         >
-          Home
+          /
         </li>
         <li>
           <span
@@ -3228,7 +3216,7 @@ exports[`renders ./components/layout/demo/top.tsx extend context correctly 1`] =
           aria-hidden="true"
           class="ant-breadcrumb-separator"
         >
-          List
+          /
         </li>
         <li>
           <span
@@ -3236,12 +3224,6 @@ exports[`renders ./components/layout/demo/top.tsx extend context correctly 1`] =
           >
             App
           </span>
-        </li>
-        <li
-          aria-hidden="true"
-          class="ant-breadcrumb-separator"
-        >
-          App
         </li>
       </ol>
     </nav>
@@ -3491,7 +3473,7 @@ exports[`renders ./components/layout/demo/top-side.tsx extend context correctly 
           aria-hidden="true"
           class="ant-breadcrumb-separator"
         >
-          Home
+          /
         </li>
         <li>
           <span
@@ -3504,7 +3486,7 @@ exports[`renders ./components/layout/demo/top-side.tsx extend context correctly 
           aria-hidden="true"
           class="ant-breadcrumb-separator"
         >
-          List
+          /
         </li>
         <li>
           <span
@@ -3512,12 +3494,6 @@ exports[`renders ./components/layout/demo/top-side.tsx extend context correctly 
           >
             App
           </span>
-        </li>
-        <li
-          aria-hidden="true"
-          class="ant-breadcrumb-separator"
-        >
-          App
         </li>
       </ol>
     </nav>
@@ -5491,7 +5467,7 @@ exports[`renders ./components/layout/demo/top-side-2.tsx extend context correctl
             aria-hidden="true"
             class="ant-breadcrumb-separator"
           >
-            Home
+            /
           </li>
           <li>
             <span
@@ -5504,7 +5480,7 @@ exports[`renders ./components/layout/demo/top-side-2.tsx extend context correctl
             aria-hidden="true"
             class="ant-breadcrumb-separator"
           >
-            List
+            /
           </li>
           <li>
             <span
@@ -5512,12 +5488,6 @@ exports[`renders ./components/layout/demo/top-side-2.tsx extend context correctl
             >
               App
             </span>
-          </li>
-          <li
-            aria-hidden="true"
-            class="ant-breadcrumb-separator"
-          >
-            App
           </li>
         </ol>
       </nav>

--- a/components/layout/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/layout/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -644,6 +644,8 @@ exports[`renders ./components/layout/demo/fixed.tsx extend context correctly 1`]
           >
             Home
           </span>
+        </li>
+        <li>
           <span
             class="ant-breadcrumb-separator"
           >
@@ -656,6 +658,8 @@ exports[`renders ./components/layout/demo/fixed.tsx extend context correctly 1`]
           >
             List
           </span>
+        </li>
+        <li>
           <span
             class="ant-breadcrumb-separator"
           >
@@ -668,6 +672,8 @@ exports[`renders ./components/layout/demo/fixed.tsx extend context correctly 1`]
           >
             App
           </span>
+        </li>
+        <li>
           <span
             class="ant-breadcrumb-separator"
           >
@@ -2392,6 +2398,8 @@ exports[`renders ./components/layout/demo/side.tsx extend context correctly 1`] 
             >
               User
             </span>
+          </li>
+          <li>
             <span
               class="ant-breadcrumb-separator"
             >
@@ -2404,6 +2412,8 @@ exports[`renders ./components/layout/demo/side.tsx extend context correctly 1`] 
             >
               Bill
             </span>
+          </li>
+          <li>
             <span
               class="ant-breadcrumb-separator"
             >
@@ -3205,6 +3215,8 @@ exports[`renders ./components/layout/demo/top.tsx extend context correctly 1`] =
           >
             Home
           </span>
+        </li>
+        <li>
           <span
             class="ant-breadcrumb-separator"
           >
@@ -3217,6 +3229,8 @@ exports[`renders ./components/layout/demo/top.tsx extend context correctly 1`] =
           >
             List
           </span>
+        </li>
+        <li>
           <span
             class="ant-breadcrumb-separator"
           >
@@ -3229,6 +3243,8 @@ exports[`renders ./components/layout/demo/top.tsx extend context correctly 1`] =
           >
             App
           </span>
+        </li>
+        <li>
           <span
             class="ant-breadcrumb-separator"
           >
@@ -3478,6 +3494,8 @@ exports[`renders ./components/layout/demo/top-side.tsx extend context correctly 
           >
             Home
           </span>
+        </li>
+        <li>
           <span
             class="ant-breadcrumb-separator"
           >
@@ -3490,6 +3508,8 @@ exports[`renders ./components/layout/demo/top-side.tsx extend context correctly 
           >
             List
           </span>
+        </li>
+        <li>
           <span
             class="ant-breadcrumb-separator"
           >
@@ -3502,6 +3522,8 @@ exports[`renders ./components/layout/demo/top-side.tsx extend context correctly 
           >
             App
           </span>
+        </li>
+        <li>
           <span
             class="ant-breadcrumb-separator"
           >
@@ -5475,6 +5497,8 @@ exports[`renders ./components/layout/demo/top-side-2.tsx extend context correctl
             >
               Home
             </span>
+          </li>
+          <li>
             <span
               class="ant-breadcrumb-separator"
             >
@@ -5487,6 +5511,8 @@ exports[`renders ./components/layout/demo/top-side-2.tsx extend context correctl
             >
               List
             </span>
+          </li>
+          <li>
             <span
               class="ant-breadcrumb-separator"
             >
@@ -5499,6 +5525,8 @@ exports[`renders ./components/layout/demo/top-side-2.tsx extend context correctl
             >
               App
             </span>
+          </li>
+          <li>
             <span
               class="ant-breadcrumb-separator"
             >

--- a/components/layout/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/layout/__tests__/__snapshots__/demo.test.ts.snap
@@ -431,7 +431,7 @@ exports[`renders ./components/layout/demo/fixed.tsx correctly 1`] = `
           aria-hidden="true"
           class="ant-breadcrumb-separator"
         >
-          Home
+          /
         </li>
         <li>
           <span
@@ -444,7 +444,7 @@ exports[`renders ./components/layout/demo/fixed.tsx correctly 1`] = `
           aria-hidden="true"
           class="ant-breadcrumb-separator"
         >
-          List
+          /
         </li>
         <li>
           <span
@@ -452,12 +452,6 @@ exports[`renders ./components/layout/demo/fixed.tsx correctly 1`] = `
           >
             App
           </span>
-        </li>
-        <li
-          aria-hidden="true"
-          class="ant-breadcrumb-separator"
-        >
-          App
         </li>
       </ol>
     </nav>
@@ -1413,7 +1407,7 @@ exports[`renders ./components/layout/demo/side.tsx correctly 1`] = `
             aria-hidden="true"
             class="ant-breadcrumb-separator"
           >
-            User
+            /
           </li>
           <li>
             <span
@@ -1421,12 +1415,6 @@ exports[`renders ./components/layout/demo/side.tsx correctly 1`] = `
             >
               Bill
             </span>
-          </li>
-          <li
-            aria-hidden="true"
-            class="ant-breadcrumb-separator"
-          >
-            Bill
           </li>
         </ol>
       </nav>
@@ -1705,7 +1693,7 @@ exports[`renders ./components/layout/demo/top.tsx correctly 1`] = `
           aria-hidden="true"
           class="ant-breadcrumb-separator"
         >
-          Home
+          /
         </li>
         <li>
           <span
@@ -1718,7 +1706,7 @@ exports[`renders ./components/layout/demo/top.tsx correctly 1`] = `
           aria-hidden="true"
           class="ant-breadcrumb-separator"
         >
-          List
+          /
         </li>
         <li>
           <span
@@ -1726,12 +1714,6 @@ exports[`renders ./components/layout/demo/top.tsx correctly 1`] = `
           >
             App
           </span>
-        </li>
-        <li
-          aria-hidden="true"
-          class="ant-breadcrumb-separator"
-        >
-          App
         </li>
       </ol>
     </nav>
@@ -1866,7 +1848,7 @@ exports[`renders ./components/layout/demo/top-side.tsx correctly 1`] = `
           aria-hidden="true"
           class="ant-breadcrumb-separator"
         >
-          Home
+          /
         </li>
         <li>
           <span
@@ -1879,7 +1861,7 @@ exports[`renders ./components/layout/demo/top-side.tsx correctly 1`] = `
           aria-hidden="true"
           class="ant-breadcrumb-separator"
         >
-          List
+          /
         </li>
         <li>
           <span
@@ -1887,12 +1869,6 @@ exports[`renders ./components/layout/demo/top-side.tsx correctly 1`] = `
           >
             App
           </span>
-        </li>
-        <li
-          aria-hidden="true"
-          class="ant-breadcrumb-separator"
-        >
-          App
         </li>
       </ol>
     </nav>
@@ -2431,7 +2407,7 @@ exports[`renders ./components/layout/demo/top-side-2.tsx correctly 1`] = `
             aria-hidden="true"
             class="ant-breadcrumb-separator"
           >
-            Home
+            /
           </li>
           <li>
             <span
@@ -2444,7 +2420,7 @@ exports[`renders ./components/layout/demo/top-side-2.tsx correctly 1`] = `
             aria-hidden="true"
             class="ant-breadcrumb-separator"
           >
-            List
+            /
           </li>
           <li>
             <span
@@ -2452,12 +2428,6 @@ exports[`renders ./components/layout/demo/top-side-2.tsx correctly 1`] = `
             >
               App
             </span>
-          </li>
-          <li
-            aria-hidden="true"
-            class="ant-breadcrumb-separator"
-          >
-            App
           </li>
         </ol>
       </nav>

--- a/components/layout/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/layout/__tests__/__snapshots__/demo.test.ts.snap
@@ -426,6 +426,8 @@ exports[`renders ./components/layout/demo/fixed.tsx correctly 1`] = `
           >
             Home
           </span>
+        </li>
+        <li>
           <span
             class="ant-breadcrumb-separator"
           >
@@ -438,6 +440,8 @@ exports[`renders ./components/layout/demo/fixed.tsx correctly 1`] = `
           >
             List
           </span>
+        </li>
+        <li>
           <span
             class="ant-breadcrumb-separator"
           >
@@ -450,6 +454,8 @@ exports[`renders ./components/layout/demo/fixed.tsx correctly 1`] = `
           >
             App
           </span>
+        </li>
+        <li>
           <span
             class="ant-breadcrumb-separator"
           >
@@ -1405,6 +1411,8 @@ exports[`renders ./components/layout/demo/side.tsx correctly 1`] = `
             >
               User
             </span>
+          </li>
+          <li>
             <span
               class="ant-breadcrumb-separator"
             >
@@ -1417,6 +1425,8 @@ exports[`renders ./components/layout/demo/side.tsx correctly 1`] = `
             >
               Bill
             </span>
+          </li>
+          <li>
             <span
               class="ant-breadcrumb-separator"
             >
@@ -1695,6 +1705,8 @@ exports[`renders ./components/layout/demo/top.tsx correctly 1`] = `
           >
             Home
           </span>
+        </li>
+        <li>
           <span
             class="ant-breadcrumb-separator"
           >
@@ -1707,6 +1719,8 @@ exports[`renders ./components/layout/demo/top.tsx correctly 1`] = `
           >
             List
           </span>
+        </li>
+        <li>
           <span
             class="ant-breadcrumb-separator"
           >
@@ -1719,6 +1733,8 @@ exports[`renders ./components/layout/demo/top.tsx correctly 1`] = `
           >
             App
           </span>
+        </li>
+        <li>
           <span
             class="ant-breadcrumb-separator"
           >
@@ -1853,6 +1869,8 @@ exports[`renders ./components/layout/demo/top-side.tsx correctly 1`] = `
           >
             Home
           </span>
+        </li>
+        <li>
           <span
             class="ant-breadcrumb-separator"
           >
@@ -1865,6 +1883,8 @@ exports[`renders ./components/layout/demo/top-side.tsx correctly 1`] = `
           >
             List
           </span>
+        </li>
+        <li>
           <span
             class="ant-breadcrumb-separator"
           >
@@ -1877,6 +1897,8 @@ exports[`renders ./components/layout/demo/top-side.tsx correctly 1`] = `
           >
             App
           </span>
+        </li>
+        <li>
           <span
             class="ant-breadcrumb-separator"
           >
@@ -2415,6 +2437,8 @@ exports[`renders ./components/layout/demo/top-side-2.tsx correctly 1`] = `
             >
               Home
             </span>
+          </li>
+          <li>
             <span
               class="ant-breadcrumb-separator"
             >
@@ -2427,6 +2451,8 @@ exports[`renders ./components/layout/demo/top-side-2.tsx correctly 1`] = `
             >
               List
             </span>
+          </li>
+          <li>
             <span
               class="ant-breadcrumb-separator"
             >
@@ -2439,6 +2465,8 @@ exports[`renders ./components/layout/demo/top-side-2.tsx correctly 1`] = `
             >
               App
             </span>
+          </li>
+          <li>
             <span
               class="ant-breadcrumb-separator"
             >

--- a/components/layout/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/layout/__tests__/__snapshots__/demo.test.ts.snap
@@ -427,12 +427,11 @@ exports[`renders ./components/layout/demo/fixed.tsx correctly 1`] = `
             Home
           </span>
         </li>
-        <li>
-          <span
-            class="ant-breadcrumb-separator"
-          >
-            /
-          </span>
+        <li
+          aria-hidden="true"
+          class="ant-breadcrumb-separator"
+        >
+          Home
         </li>
         <li>
           <span
@@ -441,12 +440,11 @@ exports[`renders ./components/layout/demo/fixed.tsx correctly 1`] = `
             List
           </span>
         </li>
-        <li>
-          <span
-            class="ant-breadcrumb-separator"
-          >
-            /
-          </span>
+        <li
+          aria-hidden="true"
+          class="ant-breadcrumb-separator"
+        >
+          List
         </li>
         <li>
           <span
@@ -455,12 +453,11 @@ exports[`renders ./components/layout/demo/fixed.tsx correctly 1`] = `
             App
           </span>
         </li>
-        <li>
-          <span
-            class="ant-breadcrumb-separator"
-          >
-            /
-          </span>
+        <li
+          aria-hidden="true"
+          class="ant-breadcrumb-separator"
+        >
+          App
         </li>
       </ol>
     </nav>
@@ -1412,12 +1409,11 @@ exports[`renders ./components/layout/demo/side.tsx correctly 1`] = `
               User
             </span>
           </li>
-          <li>
-            <span
-              class="ant-breadcrumb-separator"
-            >
-              /
-            </span>
+          <li
+            aria-hidden="true"
+            class="ant-breadcrumb-separator"
+          >
+            User
           </li>
           <li>
             <span
@@ -1426,12 +1422,11 @@ exports[`renders ./components/layout/demo/side.tsx correctly 1`] = `
               Bill
             </span>
           </li>
-          <li>
-            <span
-              class="ant-breadcrumb-separator"
-            >
-              /
-            </span>
+          <li
+            aria-hidden="true"
+            class="ant-breadcrumb-separator"
+          >
+            Bill
           </li>
         </ol>
       </nav>
@@ -1706,12 +1701,11 @@ exports[`renders ./components/layout/demo/top.tsx correctly 1`] = `
             Home
           </span>
         </li>
-        <li>
-          <span
-            class="ant-breadcrumb-separator"
-          >
-            /
-          </span>
+        <li
+          aria-hidden="true"
+          class="ant-breadcrumb-separator"
+        >
+          Home
         </li>
         <li>
           <span
@@ -1720,12 +1714,11 @@ exports[`renders ./components/layout/demo/top.tsx correctly 1`] = `
             List
           </span>
         </li>
-        <li>
-          <span
-            class="ant-breadcrumb-separator"
-          >
-            /
-          </span>
+        <li
+          aria-hidden="true"
+          class="ant-breadcrumb-separator"
+        >
+          List
         </li>
         <li>
           <span
@@ -1734,12 +1727,11 @@ exports[`renders ./components/layout/demo/top.tsx correctly 1`] = `
             App
           </span>
         </li>
-        <li>
-          <span
-            class="ant-breadcrumb-separator"
-          >
-            /
-          </span>
+        <li
+          aria-hidden="true"
+          class="ant-breadcrumb-separator"
+        >
+          App
         </li>
       </ol>
     </nav>
@@ -1870,12 +1862,11 @@ exports[`renders ./components/layout/demo/top-side.tsx correctly 1`] = `
             Home
           </span>
         </li>
-        <li>
-          <span
-            class="ant-breadcrumb-separator"
-          >
-            /
-          </span>
+        <li
+          aria-hidden="true"
+          class="ant-breadcrumb-separator"
+        >
+          Home
         </li>
         <li>
           <span
@@ -1884,12 +1875,11 @@ exports[`renders ./components/layout/demo/top-side.tsx correctly 1`] = `
             List
           </span>
         </li>
-        <li>
-          <span
-            class="ant-breadcrumb-separator"
-          >
-            /
-          </span>
+        <li
+          aria-hidden="true"
+          class="ant-breadcrumb-separator"
+        >
+          List
         </li>
         <li>
           <span
@@ -1898,12 +1888,11 @@ exports[`renders ./components/layout/demo/top-side.tsx correctly 1`] = `
             App
           </span>
         </li>
-        <li>
-          <span
-            class="ant-breadcrumb-separator"
-          >
-            /
-          </span>
+        <li
+          aria-hidden="true"
+          class="ant-breadcrumb-separator"
+        >
+          App
         </li>
       </ol>
     </nav>
@@ -2438,12 +2427,11 @@ exports[`renders ./components/layout/demo/top-side-2.tsx correctly 1`] = `
               Home
             </span>
           </li>
-          <li>
-            <span
-              class="ant-breadcrumb-separator"
-            >
-              /
-            </span>
+          <li
+            aria-hidden="true"
+            class="ant-breadcrumb-separator"
+          >
+            Home
           </li>
           <li>
             <span
@@ -2452,12 +2440,11 @@ exports[`renders ./components/layout/demo/top-side-2.tsx correctly 1`] = `
               List
             </span>
           </li>
-          <li>
-            <span
-              class="ant-breadcrumb-separator"
-            >
-              /
-            </span>
+          <li
+            aria-hidden="true"
+            class="ant-breadcrumb-separator"
+          >
+            List
           </li>
           <li>
             <span
@@ -2466,12 +2453,11 @@ exports[`renders ./components/layout/demo/top-side-2.tsx correctly 1`] = `
               App
             </span>
           </li>
-          <li>
-            <span
-              class="ant-breadcrumb-separator"
-            >
-              /
-            </span>
+          <li
+            aria-hidden="true"
+            class="ant-breadcrumb-separator"
+          >
+            App
           </li>
         </ol>
       </nav>

--- a/components/tour/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/tour/__tests__/__snapshots__/index.test.tsx.snap
@@ -2,15 +2,6 @@
 
 exports[`Tour Primary 1`] = `
 <body>
-  <div
-    style="position: absolute; top: 0px; left: 0px; width: 100%;"
-  />
-  <div
-    style="position: absolute; top: 0px; left: 0px; width: 100%;"
-  />
-  <div
-    style="position: absolute; top: 0px; left: 0px; width: 100%;"
-  />
   <div>
     <button
       disabled=""
@@ -18,69 +9,71 @@ exports[`Tour Primary 1`] = `
     >
       Cover
     </button>
-    <div>
+    <div
+      class="ant-tour ant-tour-placement-bottom"
+      style="left: -1000vw; top: -1000vh; box-sizing: border-box; z-index: 1090;"
+    >
       <div
-        class="ant-tour"
-        style="z-index: 1090; opacity: 0;"
+        class="ant-tour-arrow"
+        style="position: absolute; top: 0px; left: 0px;"
+      />
+      <div
+        class="ant-tour-primary ant-tour-content"
       >
         <div
-          class="ant-tour-primary ant-tour-content"
+          class="ant-tour-arrow"
+        />
+        <div
+          class="ant-tour-inner"
         >
-          <div
-            class="ant-tour-arrow"
-          />
-          <div
-            class="ant-tour-inner"
+          <span
+            aria-label="close"
+            class="anticon anticon-close ant-tour-close"
+            role="img"
+            tabindex="-1"
           >
-            <span
-              aria-label="close"
-              class="anticon anticon-close ant-tour-close"
-              role="img"
-              tabindex="-1"
+            <svg
+              aria-hidden="true"
+              data-icon="close"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
             >
-              <svg
-                aria-hidden="true"
-                data-icon="close"
-                fill="currentColor"
-                focusable="false"
-                height="1em"
-                viewBox="64 64 896 896"
-                width="1em"
-              >
-                <path
-                  d="M563.8 512l262.5-312.9c4.4-5.2.7-13.1-6.1-13.1h-79.8c-4.7 0-9.2 2.1-12.3 5.7L511.6 449.8 295.1 191.7c-3-3.6-7.5-5.7-12.3-5.7H203c-6.8 0-10.5 7.9-6.1 13.1L459.4 512 196.9 824.9A7.95 7.95 0 00203 838h79.8c4.7 0 9.2-2.1 12.3-5.7l216.5-258.1 216.5 258.1c3 3.6 7.5 5.7 12.3 5.7h79.8c6.8 0 10.5-7.9 6.1-13.1L563.8 512z"
-                />
-              </svg>
-            </span>
+              <path
+                d="M563.8 512l262.5-312.9c4.4-5.2.7-13.1-6.1-13.1h-79.8c-4.7 0-9.2 2.1-12.3 5.7L511.6 449.8 295.1 191.7c-3-3.6-7.5-5.7-12.3-5.7H203c-6.8 0-10.5 7.9-6.1 13.1L459.4 512 196.9 824.9A7.95 7.95 0 00203 838h79.8c4.7 0 9.2-2.1 12.3-5.7l216.5-258.1 216.5 258.1c3 3.6 7.5 5.7 12.3 5.7h79.8c6.8 0 10.5-7.9 6.1-13.1L563.8 512z"
+              />
+            </svg>
+          </span>
+          <div
+            class="ant-tour-header"
+          >
             <div
-              class="ant-tour-header"
+              class="ant-tour-title"
             >
-              <div
-                class="ant-tour-title"
-              >
-                primary title
-              </div>
+              primary title
             </div>
+          </div>
+          <div
+            class="ant-tour-description"
+          >
+            primary description.
+          </div>
+          <div
+            class="ant-tour-footer"
+          >
             <div
-              class="ant-tour-description"
+              class="ant-tour-buttons"
             >
-              primary description.
-            </div>
-            <div
-              class="ant-tour-footer"
-            >
-              <div
-                class="ant-tour-buttons"
+              <button
+                class="ant-btn ant-btn-default ant-btn-sm ant-tour-next-btn"
+                type="button"
               >
-                <button
-                  class="ant-btn ant-btn-default ant-btn-sm ant-tour-next-btn"
-                  type="button"
-                >
-                  <span>
-                    Finish
-                  </span>
-                </button>
-              </div>
+                <span>
+                  Finish
+                </span>
+              </button>
             </div>
           </div>
         </div>
@@ -107,8 +100,8 @@ exports[`Tour Primary 1`] = `
           >
             <rect
               fill="white"
-              height="100%"
-              width="100%"
+              height="100vh"
+              width="100vw"
               x="0"
               y="0"
             />
@@ -166,29 +159,11 @@ exports[`Tour Primary 1`] = `
       </svg>
     </div>
   </div>
-  <div
-    style="position: absolute; top: 0px; left: 0px; width: 100%;"
-  />
 </body>
 `;
 
 exports[`Tour basic 1`] = `
 <body>
-  <div
-    style="position: absolute; top: 0px; left: 0px; width: 100%;"
-  />
-  <div
-    style="position: absolute; top: 0px; left: 0px; width: 100%;"
-  />
-  <div
-    style="position: absolute; top: 0px; left: 0px; width: 100%;"
-  />
-  <div
-    style="position: absolute; top: 0px; left: 0px; width: 100%;"
-  />
-  <div
-    style="position: absolute; top: 0px; left: 0px; width: 100%;"
-  />
   <div>
     <div>
       <button
@@ -209,22 +184,12 @@ exports[`Tour basic 1`] = `
         Placement
       </button>
     </div>
-    <div />
   </div>
-  <div
-    style="position: absolute; top: 0px; left: 0px; width: 100%;"
-  />
 </body>
 `;
 
 exports[`Tour button props onClick 1`] = `
 <body>
-  <div
-    style="position: absolute; top: 0px; left: 0px; width: 100%;"
-  />
-  <div
-    style="position: absolute; top: 0px; left: 0px; width: 100%;"
-  />
   <div>
     <span
       id="btnName"
@@ -237,86 +202,80 @@ exports[`Tour button props onClick 1`] = `
     >
       target
     </button>
-    <div />
   </div>
-  <div
-    style="position: absolute; top: 0px; left: 0px; width: 100%;"
-  />
 </body>
 `;
 
 exports[`Tour custom step pre btn & next btn className & style 1`] = `
-<div>
+<div
+  class="ant-tour ant-tour-placement-bottom"
+  style="left: -1000vw; top: -1000vh; box-sizing: border-box; z-index: 1090;"
+>
   <div
-    class="ant-tour"
-    style="z-index: 1090; opacity: 0;"
+    class="ant-tour-content"
   >
     <div
-      class="ant-tour-content"
+      class="ant-tour-inner"
     >
-      <div
-        class="ant-tour-inner"
+      <span
+        aria-label="close"
+        class="anticon anticon-close ant-tour-close"
+        role="img"
+        tabindex="-1"
       >
-        <span
-          aria-label="close"
-          class="anticon anticon-close ant-tour-close"
-          role="img"
-          tabindex="-1"
+        <svg
+          aria-hidden="true"
+          data-icon="close"
+          fill="currentColor"
+          focusable="false"
+          height="1em"
+          viewBox="64 64 896 896"
+          width="1em"
         >
-          <svg
-            aria-hidden="true"
-            data-icon="close"
-            fill="currentColor"
-            focusable="false"
-            height="1em"
-            viewBox="64 64 896 896"
-            width="1em"
-          >
-            <path
-              d="M563.8 512l262.5-312.9c4.4-5.2.7-13.1-6.1-13.1h-79.8c-4.7 0-9.2 2.1-12.3 5.7L511.6 449.8 295.1 191.7c-3-3.6-7.5-5.7-12.3-5.7H203c-6.8 0-10.5 7.9-6.1 13.1L459.4 512 196.9 824.9A7.95 7.95 0 00203 838h79.8c4.7 0 9.2-2.1 12.3-5.7l216.5-258.1 216.5 258.1c3 3.6 7.5 5.7 12.3 5.7h79.8c6.8 0 10.5-7.9 6.1-13.1L563.8 512z"
-            />
-          </svg>
-        </span>
+          <path
+            d="M563.8 512l262.5-312.9c4.4-5.2.7-13.1-6.1-13.1h-79.8c-4.7 0-9.2 2.1-12.3 5.7L511.6 449.8 295.1 191.7c-3-3.6-7.5-5.7-12.3-5.7H203c-6.8 0-10.5 7.9-6.1 13.1L459.4 512 196.9 824.9A7.95 7.95 0 00203 838h79.8c4.7 0 9.2-2.1 12.3-5.7l216.5-258.1 216.5 258.1c3 3.6 7.5 5.7 12.3 5.7h79.8c6.8 0 10.5-7.9 6.1-13.1L563.8 512z"
+          />
+        </svg>
+      </span>
+      <div
+        class="ant-tour-header"
+      >
         <div
-          class="ant-tour-header"
+          class="ant-tour-title"
         >
-          <div
-            class="ant-tour-title"
-          >
-            Show in Center
-          </div>
+          Show in Center
+        </div>
+      </div>
+      <div
+        class="ant-tour-description"
+      >
+        Here is the content of Tour.
+      </div>
+      <div
+        class="ant-tour-footer"
+      >
+        <div
+          class="ant-tour-indicators"
+        >
+          <span
+            class="ant-tour-indicator-active ant-tour-indicator"
+          />
+          <span
+            class="ant-tour-indicator"
+          />
         </div>
         <div
-          class="ant-tour-description"
+          class="ant-tour-buttons"
         >
-          Here is the content of Tour.
-        </div>
-        <div
-          class="ant-tour-footer"
-        >
-          <div
-            class="ant-tour-indicators"
+          <button
+            class="ant-btn ant-btn-primary ant-btn-sm ant-tour-next-btn customClassName"
+            style="background-color: rgb(69, 69, 255);"
+            type="button"
           >
-            <span
-              class="ant-tour-indicator-active ant-tour-indicator"
-            />
-            <span
-              class="ant-tour-indicator"
-            />
-          </div>
-          <div
-            class="ant-tour-buttons"
-          >
-            <button
-              class="ant-btn ant-btn-primary ant-btn-sm ant-tour-next-btn customClassName"
-              style="background-color: rgb(69, 69, 255);"
-              type="button"
-            >
-              <span>
-                Next
-              </span>
-            </button>
-          </div>
+            <span>
+              Next
+            </span>
+          </button>
         </div>
       </div>
     </div>
@@ -335,69 +294,71 @@ exports[`Tour single 1`] = `
     >
       Cover
     </button>
-    <div>
+    <div
+      class="ant-tour ant-tour-placement-bottom"
+      style="left: -1000vw; top: -1000vh; box-sizing: border-box; z-index: 1090;"
+    >
       <div
-        class="ant-tour"
-        style="z-index: 1090; opacity: 0;"
+        class="ant-tour-arrow"
+        style="position: absolute; top: 0px; left: 0px;"
+      />
+      <div
+        class="ant-tour-content"
       >
         <div
-          class="ant-tour-content"
+          class="ant-tour-arrow"
+        />
+        <div
+          class="ant-tour-inner"
         >
-          <div
-            class="ant-tour-arrow"
-          />
-          <div
-            class="ant-tour-inner"
+          <span
+            aria-label="close"
+            class="anticon anticon-close ant-tour-close"
+            role="img"
+            tabindex="-1"
           >
-            <span
-              aria-label="close"
-              class="anticon anticon-close ant-tour-close"
-              role="img"
-              tabindex="-1"
+            <svg
+              aria-hidden="true"
+              data-icon="close"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
             >
-              <svg
-                aria-hidden="true"
-                data-icon="close"
-                fill="currentColor"
-                focusable="false"
-                height="1em"
-                viewBox="64 64 896 896"
-                width="1em"
-              >
-                <path
-                  d="M563.8 512l262.5-312.9c4.4-5.2.7-13.1-6.1-13.1h-79.8c-4.7 0-9.2 2.1-12.3 5.7L511.6 449.8 295.1 191.7c-3-3.6-7.5-5.7-12.3-5.7H203c-6.8 0-10.5 7.9-6.1 13.1L459.4 512 196.9 824.9A7.95 7.95 0 00203 838h79.8c4.7 0 9.2-2.1 12.3-5.7l216.5-258.1 216.5 258.1c3 3.6 7.5 5.7 12.3 5.7h79.8c6.8 0 10.5-7.9 6.1-13.1L563.8 512z"
-                />
-              </svg>
-            </span>
+              <path
+                d="M563.8 512l262.5-312.9c4.4-5.2.7-13.1-6.1-13.1h-79.8c-4.7 0-9.2 2.1-12.3 5.7L511.6 449.8 295.1 191.7c-3-3.6-7.5-5.7-12.3-5.7H203c-6.8 0-10.5 7.9-6.1 13.1L459.4 512 196.9 824.9A7.95 7.95 0 00203 838h79.8c4.7 0 9.2-2.1 12.3-5.7l216.5-258.1 216.5 258.1c3 3.6 7.5 5.7 12.3 5.7h79.8c6.8 0 10.5-7.9 6.1-13.1L563.8 512z"
+              />
+            </svg>
+          </span>
+          <div
+            class="ant-tour-header"
+          >
             <div
-              class="ant-tour-header"
+              class="ant-tour-title"
             >
-              <div
-                class="ant-tour-title"
-              >
-                cover title
-              </div>
+              cover title
             </div>
+          </div>
+          <div
+            class="ant-tour-description"
+          >
+            cover description.
+          </div>
+          <div
+            class="ant-tour-footer"
+          >
             <div
-              class="ant-tour-description"
+              class="ant-tour-buttons"
             >
-              cover description.
-            </div>
-            <div
-              class="ant-tour-footer"
-            >
-              <div
-                class="ant-tour-buttons"
+              <button
+                class="ant-btn ant-btn-primary ant-btn-sm ant-tour-next-btn"
+                type="button"
               >
-                <button
-                  class="ant-btn ant-btn-primary ant-btn-sm ant-tour-next-btn"
-                  type="button"
-                >
-                  <span>
-                    Finish
-                  </span>
-                </button>
-              </div>
+                <span>
+                  Finish
+                </span>
+              </button>
             </div>
           </div>
         </div>
@@ -424,8 +385,8 @@ exports[`Tour single 1`] = `
           >
             <rect
               fill="white"
-              height="100%"
-              width="100%"
+              height="100vh"
+              width="100vw"
               x="0"
               y="0"
             />
@@ -483,26 +444,11 @@ exports[`Tour single 1`] = `
       </svg>
     </div>
   </div>
-  <div
-    style="position: absolute; top: 0px; left: 0px; width: 100%;"
-  />
 </body>
 `;
 
 exports[`Tour step support Primary 1`] = `
 <body>
-  <div
-    style="position: absolute; top: 0px; left: 0px; width: 100%;"
-  />
-  <div
-    style="position: absolute; top: 0px; left: 0px; width: 100%;"
-  />
-  <div
-    style="position: absolute; top: 0px; left: 0px; width: 100%;"
-  />
-  <div
-    style="position: absolute; top: 0px; left: 0px; width: 100%;"
-  />
   <div>
     <button
       disabled=""
@@ -510,87 +456,89 @@ exports[`Tour step support Primary 1`] = `
     >
       Cover
     </button>
-    <div>
+    <div
+      class="ant-tour ant-tour-placement-bottom"
+      style="left: -1000vw; top: -1000vh; box-sizing: border-box; z-index: 1090;"
+    >
       <div
-        class="ant-tour"
-        style="z-index: 1090; opacity: 0;"
+        class="ant-tour-arrow"
+        style="position: absolute; top: 0px; left: 0px;"
+      />
+      <div
+        class="ant-tour-primary ant-tour-content"
       >
         <div
-          class="ant-tour-primary ant-tour-content"
+          class="ant-tour-arrow"
+        />
+        <div
+          class="ant-tour-inner"
         >
-          <div
-            class="ant-tour-arrow"
-          />
-          <div
-            class="ant-tour-inner"
+          <span
+            aria-label="close"
+            class="anticon anticon-close ant-tour-close"
+            role="img"
+            tabindex="-1"
           >
-            <span
-              aria-label="close"
-              class="anticon anticon-close ant-tour-close"
-              role="img"
-              tabindex="-1"
+            <svg
+              aria-hidden="true"
+              data-icon="close"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
             >
-              <svg
-                aria-hidden="true"
-                data-icon="close"
-                fill="currentColor"
-                focusable="false"
-                height="1em"
-                viewBox="64 64 896 896"
-                width="1em"
-              >
-                <path
-                  d="M563.8 512l262.5-312.9c4.4-5.2.7-13.1-6.1-13.1h-79.8c-4.7 0-9.2 2.1-12.3 5.7L511.6 449.8 295.1 191.7c-3-3.6-7.5-5.7-12.3-5.7H203c-6.8 0-10.5 7.9-6.1 13.1L459.4 512 196.9 824.9A7.95 7.95 0 00203 838h79.8c4.7 0 9.2-2.1 12.3-5.7l216.5-258.1 216.5 258.1c3 3.6 7.5 5.7 12.3 5.7h79.8c6.8 0 10.5-7.9 6.1-13.1L563.8 512z"
-                />
-              </svg>
-            </span>
+              <path
+                d="M563.8 512l262.5-312.9c4.4-5.2.7-13.1-6.1-13.1h-79.8c-4.7 0-9.2 2.1-12.3 5.7L511.6 449.8 295.1 191.7c-3-3.6-7.5-5.7-12.3-5.7H203c-6.8 0-10.5 7.9-6.1 13.1L459.4 512 196.9 824.9A7.95 7.95 0 00203 838h79.8c4.7 0 9.2-2.1 12.3-5.7l216.5-258.1 216.5 258.1c3 3.6 7.5 5.7 12.3 5.7h79.8c6.8 0 10.5-7.9 6.1-13.1L563.8 512z"
+              />
+            </svg>
+          </span>
+          <div
+            class="ant-tour-header"
+          >
             <div
-              class="ant-tour-header"
+              class="ant-tour-title"
             >
-              <div
-                class="ant-tour-title"
-              >
-                primary title
-              </div>
+              primary title
+            </div>
+          </div>
+          <div
+            class="ant-tour-description"
+          >
+            primary description.
+          </div>
+          <div
+            class="ant-tour-footer"
+          >
+            <div
+              class="ant-tour-indicators"
+            >
+              <span
+                class="ant-tour-indicator"
+              />
+              <span
+                class="ant-tour-indicator-active ant-tour-indicator"
+              />
             </div>
             <div
-              class="ant-tour-description"
+              class="ant-tour-buttons"
             >
-              primary description.
-            </div>
-            <div
-              class="ant-tour-footer"
-            >
-              <div
-                class="ant-tour-indicators"
+              <button
+                class="ant-btn ant-btn-default ant-btn-sm ant-btn-background-ghost ant-tour-prev-btn"
+                type="button"
               >
-                <span
-                  class="ant-tour-indicator"
-                />
-                <span
-                  class="ant-tour-indicator-active ant-tour-indicator"
-                />
-              </div>
-              <div
-                class="ant-tour-buttons"
+                <span>
+                  Previous
+                </span>
+              </button>
+              <button
+                class="ant-btn ant-btn-default ant-btn-sm ant-tour-next-btn"
+                type="button"
               >
-                <button
-                  class="ant-btn ant-btn-default ant-btn-sm ant-btn-background-ghost ant-tour-prev-btn"
-                  type="button"
-                >
-                  <span>
-                    Previous
-                  </span>
-                </button>
-                <button
-                  class="ant-btn ant-btn-default ant-btn-sm ant-tour-next-btn"
-                  type="button"
-                >
-                  <span>
-                    Finish
-                  </span>
-                </button>
-              </div>
+                <span>
+                  Finish
+                </span>
+              </button>
             </div>
           </div>
         </div>
@@ -617,8 +565,8 @@ exports[`Tour step support Primary 1`] = `
           >
             <rect
               fill="white"
-              height="100%"
-              width="100%"
+              height="100vh"
+              width="100vw"
               x="0"
               y="0"
             />
@@ -676,17 +624,11 @@ exports[`Tour step support Primary 1`] = `
       </svg>
     </div>
   </div>
-  <div
-    style="position: absolute; top: 0px; left: 0px; width: 100%;"
-  />
 </body>
 `;
 
 exports[`Tour steps is empty 1`] = `
 <body>
-  <div
-    style="position: absolute; top: 0px; left: 0px; width: 100%;"
-  />
   <div>
     <button
       disabled=""
@@ -700,9 +642,6 @@ exports[`Tour steps is empty 1`] = `
 
 exports[`Tour steps props indicatorsRender 1`] = `
 <body>
-  <div
-    style="position: absolute; top: 0px; left: 0px; width: 100%;"
-  />
   <div>
     <button
       disabled=""
@@ -710,10 +649,6 @@ exports[`Tour steps props indicatorsRender 1`] = `
     >
       Cover
     </button>
-    <div />
   </div>
-  <div
-    style="position: absolute; top: 0px; left: 0px; width: 100%;"
-  />
 </body>
 `;

--- a/components/tour/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/tour/__tests__/__snapshots__/index.test.tsx.snap
@@ -2,6 +2,15 @@
 
 exports[`Tour Primary 1`] = `
 <body>
+  <div
+    style="position: absolute; top: 0px; left: 0px; width: 100%;"
+  />
+  <div
+    style="position: absolute; top: 0px; left: 0px; width: 100%;"
+  />
+  <div
+    style="position: absolute; top: 0px; left: 0px; width: 100%;"
+  />
   <div>
     <button
       disabled=""
@@ -9,71 +18,69 @@ exports[`Tour Primary 1`] = `
     >
       Cover
     </button>
-    <div
-      class="ant-tour ant-tour-placement-bottom"
-      style="left: -1000vw; top: -1000vh; box-sizing: border-box; z-index: 1090;"
-    >
+    <div>
       <div
-        class="ant-tour-arrow"
-        style="position: absolute; top: 0px; left: 0px;"
-      />
-      <div
-        class="ant-tour-primary ant-tour-content"
+        class="ant-tour"
+        style="z-index: 1090; opacity: 0;"
       >
         <div
-          class="ant-tour-arrow"
-        />
-        <div
-          class="ant-tour-inner"
+          class="ant-tour-primary ant-tour-content"
         >
-          <span
-            aria-label="close"
-            class="anticon anticon-close ant-tour-close"
-            role="img"
-            tabindex="-1"
-          >
-            <svg
-              aria-hidden="true"
-              data-icon="close"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M563.8 512l262.5-312.9c4.4-5.2.7-13.1-6.1-13.1h-79.8c-4.7 0-9.2 2.1-12.3 5.7L511.6 449.8 295.1 191.7c-3-3.6-7.5-5.7-12.3-5.7H203c-6.8 0-10.5 7.9-6.1 13.1L459.4 512 196.9 824.9A7.95 7.95 0 00203 838h79.8c4.7 0 9.2-2.1 12.3-5.7l216.5-258.1 216.5 258.1c3 3.6 7.5 5.7 12.3 5.7h79.8c6.8 0 10.5-7.9 6.1-13.1L563.8 512z"
-              />
-            </svg>
-          </span>
           <div
-            class="ant-tour-header"
-          >
-            <div
-              class="ant-tour-title"
-            >
-              primary title
-            </div>
-          </div>
+            class="ant-tour-arrow"
+          />
           <div
-            class="ant-tour-description"
+            class="ant-tour-inner"
           >
-            primary description.
-          </div>
-          <div
-            class="ant-tour-footer"
-          >
-            <div
-              class="ant-tour-buttons"
+            <span
+              aria-label="close"
+              class="anticon anticon-close ant-tour-close"
+              role="img"
+              tabindex="-1"
             >
-              <button
-                class="ant-btn ant-btn-default ant-btn-sm ant-tour-next-btn"
-                type="button"
+              <svg
+                aria-hidden="true"
+                data-icon="close"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
               >
-                <span>
-                  Finish
-                </span>
-              </button>
+                <path
+                  d="M563.8 512l262.5-312.9c4.4-5.2.7-13.1-6.1-13.1h-79.8c-4.7 0-9.2 2.1-12.3 5.7L511.6 449.8 295.1 191.7c-3-3.6-7.5-5.7-12.3-5.7H203c-6.8 0-10.5 7.9-6.1 13.1L459.4 512 196.9 824.9A7.95 7.95 0 00203 838h79.8c4.7 0 9.2-2.1 12.3-5.7l216.5-258.1 216.5 258.1c3 3.6 7.5 5.7 12.3 5.7h79.8c6.8 0 10.5-7.9 6.1-13.1L563.8 512z"
+                />
+              </svg>
+            </span>
+            <div
+              class="ant-tour-header"
+            >
+              <div
+                class="ant-tour-title"
+              >
+                primary title
+              </div>
+            </div>
+            <div
+              class="ant-tour-description"
+            >
+              primary description.
+            </div>
+            <div
+              class="ant-tour-footer"
+            >
+              <div
+                class="ant-tour-buttons"
+              >
+                <button
+                  class="ant-btn ant-btn-default ant-btn-sm ant-tour-next-btn"
+                  type="button"
+                >
+                  <span>
+                    Finish
+                  </span>
+                </button>
+              </div>
             </div>
           </div>
         </div>
@@ -100,8 +107,8 @@ exports[`Tour Primary 1`] = `
           >
             <rect
               fill="white"
-              height="100vh"
-              width="100vw"
+              height="100%"
+              width="100%"
               x="0"
               y="0"
             />
@@ -159,11 +166,29 @@ exports[`Tour Primary 1`] = `
       </svg>
     </div>
   </div>
+  <div
+    style="position: absolute; top: 0px; left: 0px; width: 100%;"
+  />
 </body>
 `;
 
 exports[`Tour basic 1`] = `
 <body>
+  <div
+    style="position: absolute; top: 0px; left: 0px; width: 100%;"
+  />
+  <div
+    style="position: absolute; top: 0px; left: 0px; width: 100%;"
+  />
+  <div
+    style="position: absolute; top: 0px; left: 0px; width: 100%;"
+  />
+  <div
+    style="position: absolute; top: 0px; left: 0px; width: 100%;"
+  />
+  <div
+    style="position: absolute; top: 0px; left: 0px; width: 100%;"
+  />
   <div>
     <div>
       <button
@@ -184,12 +209,22 @@ exports[`Tour basic 1`] = `
         Placement
       </button>
     </div>
+    <div />
   </div>
+  <div
+    style="position: absolute; top: 0px; left: 0px; width: 100%;"
+  />
 </body>
 `;
 
 exports[`Tour button props onClick 1`] = `
 <body>
+  <div
+    style="position: absolute; top: 0px; left: 0px; width: 100%;"
+  />
+  <div
+    style="position: absolute; top: 0px; left: 0px; width: 100%;"
+  />
   <div>
     <span
       id="btnName"
@@ -202,80 +237,86 @@ exports[`Tour button props onClick 1`] = `
     >
       target
     </button>
+    <div />
   </div>
+  <div
+    style="position: absolute; top: 0px; left: 0px; width: 100%;"
+  />
 </body>
 `;
 
 exports[`Tour custom step pre btn & next btn className & style 1`] = `
-<div
-  class="ant-tour ant-tour-placement-bottom"
-  style="left: -1000vw; top: -1000vh; box-sizing: border-box; z-index: 1090;"
->
+<div>
   <div
-    class="ant-tour-content"
+    class="ant-tour"
+    style="z-index: 1090; opacity: 0;"
   >
     <div
-      class="ant-tour-inner"
+      class="ant-tour-content"
     >
-      <span
-        aria-label="close"
-        class="anticon anticon-close ant-tour-close"
-        role="img"
-        tabindex="-1"
-      >
-        <svg
-          aria-hidden="true"
-          data-icon="close"
-          fill="currentColor"
-          focusable="false"
-          height="1em"
-          viewBox="64 64 896 896"
-          width="1em"
-        >
-          <path
-            d="M563.8 512l262.5-312.9c4.4-5.2.7-13.1-6.1-13.1h-79.8c-4.7 0-9.2 2.1-12.3 5.7L511.6 449.8 295.1 191.7c-3-3.6-7.5-5.7-12.3-5.7H203c-6.8 0-10.5 7.9-6.1 13.1L459.4 512 196.9 824.9A7.95 7.95 0 00203 838h79.8c4.7 0 9.2-2.1 12.3-5.7l216.5-258.1 216.5 258.1c3 3.6 7.5 5.7 12.3 5.7h79.8c6.8 0 10.5-7.9 6.1-13.1L563.8 512z"
-          />
-        </svg>
-      </span>
       <div
-        class="ant-tour-header"
+        class="ant-tour-inner"
       >
-        <div
-          class="ant-tour-title"
+        <span
+          aria-label="close"
+          class="anticon anticon-close ant-tour-close"
+          role="img"
+          tabindex="-1"
         >
-          Show in Center
-        </div>
-      </div>
-      <div
-        class="ant-tour-description"
-      >
-        Here is the content of Tour.
-      </div>
-      <div
-        class="ant-tour-footer"
-      >
-        <div
-          class="ant-tour-indicators"
-        >
-          <span
-            class="ant-tour-indicator-active ant-tour-indicator"
-          />
-          <span
-            class="ant-tour-indicator"
-          />
-        </div>
-        <div
-          class="ant-tour-buttons"
-        >
-          <button
-            class="ant-btn ant-btn-primary ant-btn-sm ant-tour-next-btn customClassName"
-            style="background-color: rgb(69, 69, 255);"
-            type="button"
+          <svg
+            aria-hidden="true"
+            data-icon="close"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
           >
-            <span>
-              Next
-            </span>
-          </button>
+            <path
+              d="M563.8 512l262.5-312.9c4.4-5.2.7-13.1-6.1-13.1h-79.8c-4.7 0-9.2 2.1-12.3 5.7L511.6 449.8 295.1 191.7c-3-3.6-7.5-5.7-12.3-5.7H203c-6.8 0-10.5 7.9-6.1 13.1L459.4 512 196.9 824.9A7.95 7.95 0 00203 838h79.8c4.7 0 9.2-2.1 12.3-5.7l216.5-258.1 216.5 258.1c3 3.6 7.5 5.7 12.3 5.7h79.8c6.8 0 10.5-7.9 6.1-13.1L563.8 512z"
+            />
+          </svg>
+        </span>
+        <div
+          class="ant-tour-header"
+        >
+          <div
+            class="ant-tour-title"
+          >
+            Show in Center
+          </div>
+        </div>
+        <div
+          class="ant-tour-description"
+        >
+          Here is the content of Tour.
+        </div>
+        <div
+          class="ant-tour-footer"
+        >
+          <div
+            class="ant-tour-indicators"
+          >
+            <span
+              class="ant-tour-indicator-active ant-tour-indicator"
+            />
+            <span
+              class="ant-tour-indicator"
+            />
+          </div>
+          <div
+            class="ant-tour-buttons"
+          >
+            <button
+              class="ant-btn ant-btn-primary ant-btn-sm ant-tour-next-btn customClassName"
+              style="background-color: rgb(69, 69, 255);"
+              type="button"
+            >
+              <span>
+                Next
+              </span>
+            </button>
+          </div>
         </div>
       </div>
     </div>
@@ -294,71 +335,69 @@ exports[`Tour single 1`] = `
     >
       Cover
     </button>
-    <div
-      class="ant-tour ant-tour-placement-bottom"
-      style="left: -1000vw; top: -1000vh; box-sizing: border-box; z-index: 1090;"
-    >
+    <div>
       <div
-        class="ant-tour-arrow"
-        style="position: absolute; top: 0px; left: 0px;"
-      />
-      <div
-        class="ant-tour-content"
+        class="ant-tour"
+        style="z-index: 1090; opacity: 0;"
       >
         <div
-          class="ant-tour-arrow"
-        />
-        <div
-          class="ant-tour-inner"
+          class="ant-tour-content"
         >
-          <span
-            aria-label="close"
-            class="anticon anticon-close ant-tour-close"
-            role="img"
-            tabindex="-1"
-          >
-            <svg
-              aria-hidden="true"
-              data-icon="close"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M563.8 512l262.5-312.9c4.4-5.2.7-13.1-6.1-13.1h-79.8c-4.7 0-9.2 2.1-12.3 5.7L511.6 449.8 295.1 191.7c-3-3.6-7.5-5.7-12.3-5.7H203c-6.8 0-10.5 7.9-6.1 13.1L459.4 512 196.9 824.9A7.95 7.95 0 00203 838h79.8c4.7 0 9.2-2.1 12.3-5.7l216.5-258.1 216.5 258.1c3 3.6 7.5 5.7 12.3 5.7h79.8c6.8 0 10.5-7.9 6.1-13.1L563.8 512z"
-              />
-            </svg>
-          </span>
           <div
-            class="ant-tour-header"
-          >
-            <div
-              class="ant-tour-title"
-            >
-              cover title
-            </div>
-          </div>
+            class="ant-tour-arrow"
+          />
           <div
-            class="ant-tour-description"
+            class="ant-tour-inner"
           >
-            cover description.
-          </div>
-          <div
-            class="ant-tour-footer"
-          >
-            <div
-              class="ant-tour-buttons"
+            <span
+              aria-label="close"
+              class="anticon anticon-close ant-tour-close"
+              role="img"
+              tabindex="-1"
             >
-              <button
-                class="ant-btn ant-btn-primary ant-btn-sm ant-tour-next-btn"
-                type="button"
+              <svg
+                aria-hidden="true"
+                data-icon="close"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
               >
-                <span>
-                  Finish
-                </span>
-              </button>
+                <path
+                  d="M563.8 512l262.5-312.9c4.4-5.2.7-13.1-6.1-13.1h-79.8c-4.7 0-9.2 2.1-12.3 5.7L511.6 449.8 295.1 191.7c-3-3.6-7.5-5.7-12.3-5.7H203c-6.8 0-10.5 7.9-6.1 13.1L459.4 512 196.9 824.9A7.95 7.95 0 00203 838h79.8c4.7 0 9.2-2.1 12.3-5.7l216.5-258.1 216.5 258.1c3 3.6 7.5 5.7 12.3 5.7h79.8c6.8 0 10.5-7.9 6.1-13.1L563.8 512z"
+                />
+              </svg>
+            </span>
+            <div
+              class="ant-tour-header"
+            >
+              <div
+                class="ant-tour-title"
+              >
+                cover title
+              </div>
+            </div>
+            <div
+              class="ant-tour-description"
+            >
+              cover description.
+            </div>
+            <div
+              class="ant-tour-footer"
+            >
+              <div
+                class="ant-tour-buttons"
+              >
+                <button
+                  class="ant-btn ant-btn-primary ant-btn-sm ant-tour-next-btn"
+                  type="button"
+                >
+                  <span>
+                    Finish
+                  </span>
+                </button>
+              </div>
             </div>
           </div>
         </div>
@@ -385,8 +424,8 @@ exports[`Tour single 1`] = `
           >
             <rect
               fill="white"
-              height="100vh"
-              width="100vw"
+              height="100%"
+              width="100%"
               x="0"
               y="0"
             />
@@ -444,11 +483,26 @@ exports[`Tour single 1`] = `
       </svg>
     </div>
   </div>
+  <div
+    style="position: absolute; top: 0px; left: 0px; width: 100%;"
+  />
 </body>
 `;
 
 exports[`Tour step support Primary 1`] = `
 <body>
+  <div
+    style="position: absolute; top: 0px; left: 0px; width: 100%;"
+  />
+  <div
+    style="position: absolute; top: 0px; left: 0px; width: 100%;"
+  />
+  <div
+    style="position: absolute; top: 0px; left: 0px; width: 100%;"
+  />
+  <div
+    style="position: absolute; top: 0px; left: 0px; width: 100%;"
+  />
   <div>
     <button
       disabled=""
@@ -456,89 +510,87 @@ exports[`Tour step support Primary 1`] = `
     >
       Cover
     </button>
-    <div
-      class="ant-tour ant-tour-placement-bottom"
-      style="left: -1000vw; top: -1000vh; box-sizing: border-box; z-index: 1090;"
-    >
+    <div>
       <div
-        class="ant-tour-arrow"
-        style="position: absolute; top: 0px; left: 0px;"
-      />
-      <div
-        class="ant-tour-primary ant-tour-content"
+        class="ant-tour"
+        style="z-index: 1090; opacity: 0;"
       >
         <div
-          class="ant-tour-arrow"
-        />
-        <div
-          class="ant-tour-inner"
+          class="ant-tour-primary ant-tour-content"
         >
-          <span
-            aria-label="close"
-            class="anticon anticon-close ant-tour-close"
-            role="img"
-            tabindex="-1"
-          >
-            <svg
-              aria-hidden="true"
-              data-icon="close"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M563.8 512l262.5-312.9c4.4-5.2.7-13.1-6.1-13.1h-79.8c-4.7 0-9.2 2.1-12.3 5.7L511.6 449.8 295.1 191.7c-3-3.6-7.5-5.7-12.3-5.7H203c-6.8 0-10.5 7.9-6.1 13.1L459.4 512 196.9 824.9A7.95 7.95 0 00203 838h79.8c4.7 0 9.2-2.1 12.3-5.7l216.5-258.1 216.5 258.1c3 3.6 7.5 5.7 12.3 5.7h79.8c6.8 0 10.5-7.9 6.1-13.1L563.8 512z"
-              />
-            </svg>
-          </span>
           <div
-            class="ant-tour-header"
+            class="ant-tour-arrow"
+          />
+          <div
+            class="ant-tour-inner"
           >
+            <span
+              aria-label="close"
+              class="anticon anticon-close ant-tour-close"
+              role="img"
+              tabindex="-1"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="close"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M563.8 512l262.5-312.9c4.4-5.2.7-13.1-6.1-13.1h-79.8c-4.7 0-9.2 2.1-12.3 5.7L511.6 449.8 295.1 191.7c-3-3.6-7.5-5.7-12.3-5.7H203c-6.8 0-10.5 7.9-6.1 13.1L459.4 512 196.9 824.9A7.95 7.95 0 00203 838h79.8c4.7 0 9.2-2.1 12.3-5.7l216.5-258.1 216.5 258.1c3 3.6 7.5 5.7 12.3 5.7h79.8c6.8 0 10.5-7.9 6.1-13.1L563.8 512z"
+                />
+              </svg>
+            </span>
             <div
-              class="ant-tour-title"
+              class="ant-tour-header"
             >
-              primary title
-            </div>
-          </div>
-          <div
-            class="ant-tour-description"
-          >
-            primary description.
-          </div>
-          <div
-            class="ant-tour-footer"
-          >
-            <div
-              class="ant-tour-indicators"
-            >
-              <span
-                class="ant-tour-indicator"
-              />
-              <span
-                class="ant-tour-indicator-active ant-tour-indicator"
-              />
+              <div
+                class="ant-tour-title"
+              >
+                primary title
+              </div>
             </div>
             <div
-              class="ant-tour-buttons"
+              class="ant-tour-description"
             >
-              <button
-                class="ant-btn ant-btn-default ant-btn-sm ant-btn-background-ghost ant-tour-prev-btn"
-                type="button"
+              primary description.
+            </div>
+            <div
+              class="ant-tour-footer"
+            >
+              <div
+                class="ant-tour-indicators"
               >
-                <span>
-                  Previous
-                </span>
-              </button>
-              <button
-                class="ant-btn ant-btn-default ant-btn-sm ant-tour-next-btn"
-                type="button"
+                <span
+                  class="ant-tour-indicator"
+                />
+                <span
+                  class="ant-tour-indicator-active ant-tour-indicator"
+                />
+              </div>
+              <div
+                class="ant-tour-buttons"
               >
-                <span>
-                  Finish
-                </span>
-              </button>
+                <button
+                  class="ant-btn ant-btn-default ant-btn-sm ant-btn-background-ghost ant-tour-prev-btn"
+                  type="button"
+                >
+                  <span>
+                    Previous
+                  </span>
+                </button>
+                <button
+                  class="ant-btn ant-btn-default ant-btn-sm ant-tour-next-btn"
+                  type="button"
+                >
+                  <span>
+                    Finish
+                  </span>
+                </button>
+              </div>
             </div>
           </div>
         </div>
@@ -565,8 +617,8 @@ exports[`Tour step support Primary 1`] = `
           >
             <rect
               fill="white"
-              height="100vh"
-              width="100vw"
+              height="100%"
+              width="100%"
               x="0"
               y="0"
             />
@@ -624,11 +676,17 @@ exports[`Tour step support Primary 1`] = `
       </svg>
     </div>
   </div>
+  <div
+    style="position: absolute; top: 0px; left: 0px; width: 100%;"
+  />
 </body>
 `;
 
 exports[`Tour steps is empty 1`] = `
 <body>
+  <div
+    style="position: absolute; top: 0px; left: 0px; width: 100%;"
+  />
   <div>
     <button
       disabled=""
@@ -642,6 +700,9 @@ exports[`Tour steps is empty 1`] = `
 
 exports[`Tour steps props indicatorsRender 1`] = `
 <body>
+  <div
+    style="position: absolute; top: 0px; left: 0px; width: 100%;"
+  />
   <div>
     <button
       disabled=""
@@ -649,6 +710,10 @@ exports[`Tour steps props indicatorsRender 1`] = `
     >
       Cover
     </button>
+    <div />
   </div>
+  <div
+    style="position: absolute; top: 0px; left: 0px; width: 100%;"
+  />
 </body>
 `;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution
https://github.com/ant-design/ant-design/pull/40867#issuecomment-1439365589
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Unify the `span` in `ul` to `li` to make the DOM structure more standardized. Please pay attention to the problems of missing overlay styles and element acquisition    |
| 🇨🇳 Chinese |     规范 Breadcrumb 分隔符的 DOM 结构，从 span 统一为 li 元素，请注意覆盖样式丢失和元素获取的问题     |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
