### PR TITLE
type: Add placement to NotificationConfig

### DIFF
--- a/components/notification/interface.ts
+++ b/components/notification/interface.ts
@@ -60,6 +60,7 @@ export interface NotificationConfig {
   bottom?: number;
   prefixCls?: string;
   getContainer?: () => HTMLElement;
+  placement?: NotificationPlacement;
   maxCount?: number;
   rtl?: boolean;
 }

--- a/components/notification/useNotification.tsx
+++ b/components/notification/useNotification.tsx
@@ -116,6 +116,7 @@ export function useInternalNotification(
       } = config;
 
       return originOpen({
+        placement: 'topRight',
         ...restConfig,
         content: (
           <PureContent
@@ -127,7 +128,6 @@ export function useInternalNotification(
             btn={btn}
           />
         ),
-        placement,
         className: classNames(type && `${noticePrefixCls}-${type}`, hashId, className),
       });
     };

--- a/components/notification/useNotification.tsx
+++ b/components/notification/useNotification.tsx
@@ -110,7 +110,6 @@ export function useInternalNotification(
         description,
         icon,
         type,
-        placement = 'topRight',
         btn,
         className,
         ...restConfig


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [X] New feature
- [X] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

closes #40907 

### 💡 Background and solution

We are using notification hooks and want to place the notification on the bottom right. But they can only appear in the top right.

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   They can now see notificaiton on the bottom right when notificaiton hooks are being used        |
| 🇨🇳 Chinese |      -     |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [X] Doc is updated/provided or not needed
- [X] Demo is updated/provided or not needed
- [X] TypeScript definition is updated/provided or not needed
- [X] Changelog is provided or not needed
