### PR TITLE
fix: 修复 #40288 带来的 draggable track 失效

### DIFF
--- a/components/slider/style/index.tsx
+++ b/components/slider/style/index.tsx
@@ -170,6 +170,7 @@ const genBaseStyle: GenerateStyle<SliderToken> = (token) => {
       [`${componentCls}-step`]: {
         position: 'absolute',
         background: 'transparent',
+        pointerEvents: 'none',
       },
 
       [`${componentCls}-dot`]: {
@@ -181,6 +182,7 @@ const genBaseStyle: GenerateStyle<SliderToken> = (token) => {
         borderRadius: '50%',
         cursor: 'pointer',
         transition: `border-color ${token.motionDurationSlow}`,
+        pointerEvents: 'auto',
 
         '&-active': {
           borderColor: token.colorPrimaryBorder,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

#40288 slider dot point event wrong
#40679 wrong fix 修复之前导致 BUG 的改动

### 💡 Background and solution

silder 中的 dot 触发范围异常，为 silder-stop 设置 pointer-event：none 导致，之前删除导致其范围拖拽功能失效
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

恢复 silder 的范围拖拽问题，恢复 draggable track 功能
fix the range drag problem of silder, fix the draggable track function
<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     fix slider draggable track      |
| 🇨🇳 Chinese |    恢复 draggable track 功能       |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
