### PR TITLE
type: TimePicker added hourStep type

### DIFF
--- a/components/date-picker/generatePicker/index.tsx
+++ b/components/date-picker/generatePicker/index.tsx
@@ -72,15 +72,19 @@ export function getTimeProps<DateType, DisabledTime>(
 const DataPickerPlacements = ['bottomLeft', 'bottomRight', 'topLeft', 'topRight'] as const;
 type DataPickerPlacement = typeof DataPickerPlacements[number];
 
+const HourStep = [0.5, 1, 1.5, 2, 3, 4, 6, 8, 12] as const;
+type THourStep = typeof HourStep[number];
+
 type InjectDefaultProps<Props> = Omit<
   Props,
-  'locale' | 'generateConfig' | 'hideHeader' | 'components'
+  'locale' | 'generateConfig' | 'hideHeader' | 'components' | 'hourStep'
 > & {
   locale?: PickerLocale;
   size?: SizeType;
   placement?: DataPickerPlacement;
   bordered?: boolean;
   status?: InputStatus;
+  hourStep?: THourStep;
 };
 
 export type PickerLocale = {

--- a/components/time-picker/demo/interval-options.tsx
+++ b/components/time-picker/demo/interval-options.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
 import { TimePicker } from 'antd';
+import React from 'react';
 
-const App: React.FC = () => <TimePicker minuteStep={15} secondStep={10} />;
+const App: React.FC = () => <TimePicker minuteStep={15} secondStep={10} hourStep={1} />;
 
 export default App;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
-  Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
-  Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

fix https://github.com/ant-design/ant-design/issues/40914

### 💡 Background and solution

It is possible to assign any value, even a string, resulting in console warnings and weird values in the component such as a number with 9 decimal spaces

![image](https://user-images.githubusercontent.com/97878479/221547524-b4551749-2426-44d5-ba00-13f9771aa077.png)

Fixed by adding restrictions to posible hour step options

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Refactor hour step to accept only predefined values      |


### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- Doc is updated/provided or not needed
-  Demo is updated/provided or not needed
- TypeScript definition is updated/provided or not needed
-  Changelog is provided or not needed
