### PR TITLE
feat(CheckableTag): add disabled state

### DIFF
--- a/components/tag/CheckableTag.tsx
+++ b/components/tag/CheckableTag.tsx
@@ -16,6 +16,7 @@ export interface CheckableTagProps {
   children?: React.ReactNode;
   onChange?: (checked: boolean) => void;
   onClick?: (e: React.MouseEvent<HTMLSpanElement, MouseEvent>) => void;
+  disabled?: boolean;
 }
 
 const CheckableTag: React.FC<CheckableTagProps> = ({
@@ -24,11 +25,15 @@ const CheckableTag: React.FC<CheckableTagProps> = ({
   checked,
   onChange,
   onClick,
+  disabled = false,
   ...restProps
 }) => {
   const { getPrefixCls } = React.useContext(ConfigContext);
 
   const handleClick = (e: React.MouseEvent<HTMLSpanElement, MouseEvent>) => {
+    if (disabled) {
+      return;
+    }
     onChange?.(!checked);
     onClick?.(e);
   };
@@ -42,6 +47,7 @@ const CheckableTag: React.FC<CheckableTagProps> = ({
     {
       [`${prefixCls}-checkable`]: true,
       [`${prefixCls}-checkable-checked`]: checked,
+      [`${prefixCls}-checkable-disabled`]: disabled,
     },
     className,
     hashId,

--- a/components/tag/__tests__/index.test.tsx
+++ b/components/tag/__tests__/index.test.tsx
@@ -164,6 +164,17 @@ describe('Tag', () => {
       fireEvent.click(container.querySelectorAll('.ant-tag')[0]);
       expect(onChange).toHaveBeenCalledWith(true);
     });
+
+    it('support disabled', () => {
+      const disabled = true;
+      const onChange = jest.fn();
+      const { container } = render(
+        <Tag.CheckableTag checked={false} onChange={onChange} disabled={disabled} />,
+      );
+      expect(container.querySelector('.ant-tag-checkable-disabled')).toBeTruthy();
+      fireEvent.click(container.querySelectorAll('.ant-tag')[0]);
+      expect(onChange).not.toHaveBeenCalledWith(true);
+    });
   });
   it('should onClick is undefined', async () => {
     const { container } = render(<Tag onClick={undefined} />);

--- a/components/tag/index.en-US.md
+++ b/components/tag/index.en-US.md
@@ -47,3 +47,4 @@ Tag for categorizing or markup.
 | -------- | ----------------------------------------------- | ----------------- | ------- |
 | checked  | Checked status of Tag                           | boolean           | false   |
 | onChange | Callback executed when Tag is checked/unchecked | (checked) => void | -       |
+| disabled | Disabled state of checkable tag                 | boolean           | false   |

--- a/components/tag/style/index.ts
+++ b/components/tag/style/index.ts
@@ -108,13 +108,23 @@ const genBaseStyle = (token: TagToken): CSSInterpolation => {
         borderColor: 'transparent',
         cursor: 'pointer',
 
-        [`&:not(${componentCls}-checkable-checked):hover`]: {
-          color: token.colorPrimary,
-          backgroundColor: token.colorFillSecondary,
+        [`&:not(${componentCls}-checkable-checked):not(${componentCls}-checkable-disabled):hover`]:
+          {
+            color: token.colorPrimary,
+            backgroundColor: token.colorFillSecondary,
+          },
+
+        [`&:active:not(${componentCls}-checkable-disabled), &-checked`]: {
+          color: token.colorTextLightSolid,
         },
 
-        '&:active, &-checked': {
-          color: token.colorTextLightSolid,
+        '&-disabled': {
+          color: token.colorTextDisabled,
+          cursor: 'not-allowed',
+
+          '&:hover': {
+            cursor: 'not-allowed',
+          },
         },
 
         '&-checked': {
@@ -124,7 +134,7 @@ const genBaseStyle = (token: TagToken): CSSInterpolation => {
           },
         },
 
-        '&:active': {
+        [`&:active:not(${componentCls}-checkable-disabled)`]: {
           backgroundColor: token.colorPrimaryActive,
         },
       },


### PR DESCRIPTION
[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

### 💡 Background and solution

We're using Antd in our project. Dev and Designers team faced the problem that Checkable Tag has no native disabled state but we really need it to implement important feature.

To resolve this I propose to add disabled state as it implemented for many of your components of this kind

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |CheckableTag component add `disabled` option|
| 🇨🇳 Chinese | |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
