### PR TITLE
Bugfix/typography

### DIFF
--- a/components/typography/Base/index.tsx
+++ b/components/typography/Base/index.tsx
@@ -139,6 +139,7 @@ const Base = React.forwardRef<HTMLElement, BlockProps>((props, ref) => {
 
   const typographyRef = React.useRef<HTMLElement>(null);
   const editIconRef = React.useRef<HTMLDivElement>(null);
+  const nodeRef = React.useRef<HTMLElement>(null);
 
   // ============================ MISC ============================
   const prefixCls = getPrefixCls('typography', customizePrefixCls);
@@ -339,6 +340,28 @@ const Base = React.forwardRef<HTMLElement, BlockProps>((props, ref) => {
     };
   }, [cssEllipsis, mergedEnableEllipsis]);
 
+  React.useEffect(() => {
+    const nodeElement = nodeRef.current;
+
+    if (nodeElement && restProps.code) {
+      const isOverflow = nodeElement.offsetWidth < nodeElement.scrollWidth;
+      const codeElement = nodeElement.childNodes[0] as HTMLElement;
+
+      if (isOverflow && mergedEnableEllipsis) {
+        codeElement.style.display = 'block';
+        codeElement.style.overflow = 'hidden';
+        codeElement.style.textOverflow = 'ellipsis';
+      } else {
+        if (codeElement.style.cssText) {
+          codeElement.style.display = '';
+          codeElement.style.overflow = '';
+          codeElement.style.textOverflow = '';
+        }
+      }
+    }
+  }),
+    [mergedEnableEllipsis];
+
   // ========================== Tooltip ===========================
   let tooltipProps: TooltipProps = {};
   if (ellipsisConfig.tooltip === true) {
@@ -518,7 +541,7 @@ const Base = React.forwardRef<HTMLElement, BlockProps>((props, ref) => {
               WebkitLineClamp: cssLineClamp ? rows : undefined,
             }}
             component={component}
-            ref={composeRef(resizeRef, typographyRef, ref)}
+            ref={composeRef(resizeRef, typographyRef, ref, restProps.code ? nodeRef : null)}
             direction={direction}
             onClick={triggerType.includes('text') ? onEditClick : undefined}
             aria-label={topAriaLabel?.toString()}
@@ -550,7 +573,6 @@ const Base = React.forwardRef<HTMLElement, BlockProps>((props, ref) => {
                     {renderEllipsis(needEllipsis)}
                   </>,
                 );
-
                 return wrappedContext;
               }}
             </Ellipsis>


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

fix #40261

### 💡 Background and solution

The border-right disappears when using the overflow code element. The issue here is that the code element is a non-replaced inline element,  it does not have a defined height or width. When overflow occurs, it can cause layout issues. 

To fix this problem, I added a `useRef()` to a code element and used `useEffect()` to check if the code element is overflowing. Then, I override the styles and change the code element to `block`.

This bug fix can only be fixed if the row is set to 1, a complete resolution of the issue may require consideration of the design or choosing a different format for displaying the code element.


### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Fix code tag overflow border-right style error        |
| 🇨🇳 Chinese |   修复 code 标签溢出 border-right 样式错误    |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
