### PR TITLE
fix: Layout throw warning of suffixCls

### DIFF
--- a/components/layout/__tests__/index.test.tsx
+++ b/components/layout/__tests__/index.test.tsx
@@ -1,11 +1,11 @@
+import { UserOutlined } from '@ant-design/icons';
 import React, { useState } from 'react';
 import { act } from 'react-dom/test-utils';
-import { UserOutlined } from '@ant-design/icons';
 import Layout from '..';
 import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
-import Menu from '../../menu';
 import { fireEvent, render } from '../../../tests/utils';
+import Menu from '../../menu';
 
 const { Sider, Content, Footer, Header } = Layout;
 
@@ -319,6 +319,7 @@ describe('Sider', () => {
 
   (['Layout', 'Header', 'Footer', 'Sider'] as const).forEach((tag) => {
     const ComponentMap = { Layout, Header, Footer, Sider };
+
     it(`should get ${tag} element from ref`, () => {
       const ref = React.createRef<HTMLDivElement>();
       const onSelect = jest.fn();

--- a/components/layout/__tests__/warning.test.tsx
+++ b/components/layout/__tests__/warning.test.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import Layout from '..';
+import { render } from '../../../tests/utils';
+
+const { Sider, Footer, Header } = Layout;
+
+describe('Layout.Warning', () => {
+  (['Layout', 'Header', 'Footer', 'Sider'] as const).forEach((tag) => {
+    const ComponentMap = { Layout, Header, Footer, Sider };
+
+    // Since react will not throw warning for same message.
+    // We create a new test suite here
+    it(`not warning of non-element attr on ${tag}`, () => {
+      /**
+       * Should not call:
+       * Warning: React does not recognize the `suffixCls` prop on a DOM element.
+       * If you intentionally want it to appear in the DOM as a custom attribute,
+       * spell it as lowercase `suffixcls` instead.
+       * If you accidentally passed it from a parent component,
+       * remove it from the DOM element.
+       */
+      const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      const Component = ComponentMap[tag];
+      render(<Component>{tag}</Component>);
+
+      expect(errorSpy).not.toHaveBeenCalled();
+      errorSpy.mockRestore();
+    });
+  });
+});

--- a/components/layout/layout.tsx
+++ b/components/layout/layout.tsx
@@ -1,4 +1,5 @@
 import classNames from 'classnames';
+import omit from 'rc-util/lib/omit';
 import * as React from 'react';
 import { ConfigContext } from '../config-provider';
 import useStyle from './style';
@@ -75,8 +76,6 @@ const BasicLayout = React.forwardRef<HTMLElement, BasicPropsWithTagName>((props,
   const [siders, setSiders] = React.useState<string[]>([]);
 
   const {
-    // Not use. Only omit this
-    suffixCls,
     prefixCls: customizePrefixCls,
     className,
     rootClassName,
@@ -85,6 +84,8 @@ const BasicLayout = React.forwardRef<HTMLElement, BasicPropsWithTagName>((props,
     tagName: Tag,
     ...others
   } = props;
+
+  const passedProps = omit(others, ['suffixCls']);
 
   const { getPrefixCls } = React.useContext(ConfigContext);
   const prefixCls = getPrefixCls('layout', customizePrefixCls);
@@ -117,7 +118,7 @@ const BasicLayout = React.forwardRef<HTMLElement, BasicPropsWithTagName>((props,
 
   return wrapSSR(
     <LayoutContext.Provider value={contextValue}>
-      <Tag ref={ref} className={classString} {...others}>
+      <Tag ref={ref} className={classString} {...passedProps}>
         {children}
       </Tag>
     </LayoutContext.Provider>,

--- a/components/layout/layout.tsx
+++ b/components/layout/layout.tsx
@@ -75,6 +75,8 @@ const BasicLayout = React.forwardRef<HTMLElement, BasicPropsWithTagName>((props,
   const [siders, setSiders] = React.useState<string[]>([]);
 
   const {
+    // Not use. Only omit this
+    suffixCls,
     prefixCls: customizePrefixCls,
     className,
     rootClassName,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

fix #40968

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Fix Layout throw `React does not recognize the `suffixCls` prop on a DOM element` warning.     |
| 🇨🇳 Chinese |     修复 Layout 报错 `React does not recognize the `suffixCls` prop on a DOM element` 的问题。     |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
