### PR TITLE
fix(form): fix `useFormItemStatus` get access to window error when sever-side-rendering

### DIFF
--- a/components/form/hooks/useFormItemStatus.ts
+++ b/components/form/hooks/useFormItemStatus.ts
@@ -15,7 +15,7 @@ const useFormItemStatus: UseFormItemStatus = () => {
     warning(
       status !== undefined,
       'Form.Item',
-      `Form.Item.useStatus should be used under Form.Item component. For more information: ${window.location.protocol}//${window.location.host}/components/form-cn/#Form.Item.useStatus`,
+      `Form.Item.useStatus should be used under Form.Item component. For more information: https://ant.design/components/form#formitemusestatus,
     );
   }
 

--- a/components/form/hooks/useFormItemStatus.ts
+++ b/components/form/hooks/useFormItemStatus.ts
@@ -10,11 +10,14 @@ type UseFormItemStatus = () => {
 const useFormItemStatus: UseFormItemStatus = () => {
   const { status } = useContext(FormItemInputContext);
 
-  warning(
-    status !== undefined,
-    'Form.Item',
-    `Form.Item.useStatus should be used under Form.Item component. For more information: ${window.location.protocol}//${window.location.host}/components/form-cn/#Form.Item.useStatus`,
-  );
+  const isClient = typeof window !== 'undefined'
+  if (isClient) {
+    warning(
+      status !== undefined,
+      'Form.Item',
+      `Form.Item.useStatus should be used under Form.Item component. For more information: ${window.location.protocol}//${window.location.host}/components/form-cn/#Form.Item.useStatus`,
+    );
+  }
 
   return { status };
 };

--- a/components/form/hooks/useFormItemStatus.ts
+++ b/components/form/hooks/useFormItemStatus.ts
@@ -10,14 +10,11 @@ type UseFormItemStatus = () => {
 const useFormItemStatus: UseFormItemStatus = () => {
   const { status } = useContext(FormItemInputContext);
 
-  const isClient = typeof window !== 'undefined'
-  if (isClient) {
-    warning(
-      status !== undefined,
-      'Form.Item',
-      `Form.Item.useStatus should be used under Form.Item component. For more information: https://ant.design/components/form#formitemusestatus,
-    );
-  }
+  warning(
+    status !== undefined,
+    'Form.Item',
+    'Form.Item.useStatus should be used under Form.Item component. For more information: https://u.ant.design/form-item-usestatus',
+  );
 
   return { status };
 };


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

新特性请提交至 feature 分支，其余可提交至 master 分支。
在维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

[[English Template / 英文模板](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE.md?plain=1)]

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 工作流程
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue
fix #40976

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
1. 在SSR场景下, useFormItemStatus 对`window`的访问导致SSR渲染失败的问题
2. 参考工程中其他地方,首先判断typeof window是否为`undefined`, 来判断当前是否处于client
3. 只有在客户端, 才会执行warning

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文fix: fix bug of server error from `useFromItemStatus` in SSR mode         |
| 🇨🇳 中文解决在SSR场景下, useFormItemStatus 对`window`的访问导致SSR渲染失败的问题 |          |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
