### PR TITLE
fix: fix tsconfig error in stackblitz

### DIFF
--- a/.dumi/theme/builtins/Previewer/CodePreviewer.tsx
+++ b/.dumi/theme/builtins/Previewer/CodePreviewer.tsx
@@ -209,19 +209,17 @@ const CodePreviewer: React.FC<IPreviewerProps> = (props) => {
       </html>
     `;
 
-  const tsconfig = `
-  {
-    "compilerOptions": {
-      "target": "esnext",
-      "module": "esnext",
-      "esModuleInterop": true,
-      "moduleResolution": "node",
-      "jsx": "react",
-      "jsxFactory": "React.createElement",
-      "jsxFragmentFactory": "React.Fragment"
-    }
-  }
-`;
+  const tsconfig = {
+    compilerOptions: {
+      target: 'esnext',
+      module: 'esnext',
+      esModuleInterop: true,
+      moduleResolution: 'node',
+      jsx: 'react',
+      jsxFactory: 'React.createElement',
+      jsxFragmentFactory: 'React.Fragment',
+    },
+  };
 
   const suffix = codeType === 'tsx' ? 'tsx' : 'js';
 
@@ -369,8 +367,9 @@ createRoot(document.getElementById('container')).render(<Demo />);
       'index.html': html,
     },
   };
+
   if (suffix === 'tsx') {
-    stackblitzPrefillConfig.files['tsconfig.json'] = tsconfig;
+    stackblitzPrefillConfig.files['tsconfig.json'] = JSON.stringify(tsconfig, null, 2);
   }
 
   const backgroundGrey = theme.includes('dark') ? '#303030' : '#f0f2f5';

--- a/.dumi/theme/builtins/Previewer/CodePreviewer.tsx
+++ b/.dumi/theme/builtins/Previewer/CodePreviewer.tsx
@@ -8,26 +8,26 @@ import type { Project } from '@stackblitz/sdk';
 import stackblitzSdk from '@stackblitz/sdk';
 import { Alert, Badge, Space, Tooltip } from 'antd';
 import classNames from 'classnames';
-import LZString from 'lz-string';
-import React, { useContext, useEffect, useRef, useState } from 'react';
-import CopyToClipboard from 'react-copy-to-clipboard';
 import type { IPreviewerProps } from 'dumi';
 import { FormattedMessage, useSiteData } from 'dumi';
-import Prism from 'prismjs';
-import JsonML from 'jsonml.js/lib/utils';
 import toReactElement from 'jsonml-to-react-element';
-import { ping } from '../../utils';
-import ClientOnly from '../../common/ClientOnly';
+import JsonML from 'jsonml.js/lib/utils';
+import LZString from 'lz-string';
+import Prism from 'prismjs';
+import React, { useContext, useEffect, useRef, useState } from 'react';
+import CopyToClipboard from 'react-copy-to-clipboard';
+import useLocation from '../../../hooks/useLocation';
 import BrowserFrame from '../../common/BrowserFrame';
-import EditButton from '../../common/EditButton';
+import ClientOnly from '../../common/ClientOnly';
 import CodePenIcon from '../../common/CodePenIcon';
 import CodePreview from '../../common/CodePreview';
 import CodeSandboxIcon from '../../common/CodeSandboxIcon';
-import RiddleIcon from '../../common/RiddleIcon';
+import EditButton from '../../common/EditButton';
 import ExternalLinkIcon from '../../common/ExternalLinkIcon';
+import RiddleIcon from '../../common/RiddleIcon';
 import type { SiteContextProps } from '../../slots/SiteContext';
 import SiteContext from '../../slots/SiteContext';
-import useLocation from '../../../hooks/useLocation';
+import { ping } from '../../utils';
 
 const { ErrorBoundary } = Alert;
 
@@ -210,16 +210,18 @@ const CodePreviewer: React.FC<IPreviewerProps> = (props) => {
     `;
 
   const tsconfig = `
-    {
-      "compilerOptions": {
-        "jsx": "react-jsx",
-        "target": "esnext",
-        "module": "esnext",
-        "esModuleInterop": true,
-        "moduleResolution": "node",
-      }
+  {
+    "compilerOptions": {
+      "target": "esnext",
+      "module": "esnext",
+      "esModuleInterop": true,
+      "moduleResolution": "node",
+      "jsx": "react",
+      "jsxFactory": "React.createElement",
+      "jsxFragmentFactory": "React.Fragment"
     }
-  `;
+  }
+`;
 
   const suffix = codeType === 'tsx' ? 'tsx' : 'js';
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<img width="519" alt="image" src="https://user-images.githubusercontent.com/49217418/222319650-cda520c3-2c88-4f0a-9070-8928acc18575.png">

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix: fix tsconfig error in stackblitz |
| 🇨🇳 Chinese | fix: 修复 stackblitz 中的报错 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed