### PR TITLE
docs(ConfigProvider): update ConfigProvider demo

### DIFF
--- a/components/config-provider/demo/locale.tsx
+++ b/components/config-provider/demo/locale.tsx
@@ -130,7 +130,7 @@ const Page: React.FC = () => {
         </Select>
         <DatePicker />
         <TimePicker />
-        <RangePicker style={{ width: 220 }} />
+        <RangePicker />
       </Space>
       <Space wrap>
         <Button type="primary" onClick={showModal}>

--- a/components/config-provider/demo/locale.tsx
+++ b/components/config-provider/demo/locale.tsx
@@ -130,7 +130,7 @@ const Page: React.FC = () => {
         </Select>
         <DatePicker />
         <TimePicker />
-        <RangePicker style={{ width: 200 }} />
+        <RangePicker style={{ width: 220 }} />
       </Space>
       <Space wrap>
         <Button type="primary" onClick={showModal}>


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [x] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution
<img width="1068" alt="image" src="https://user-images.githubusercontent.com/50540241/222687135-521840a3-c2a8-42d4-801f-34f2498625e1.png">

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |        update ConfigProvider demo    |
| 🇨🇳 Chinese |       更新 ConfigProvider 案例     |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
