### PR TITLE
fix: Popconfirm loading should finish

### DIFF
--- a/components/_util/ActionButton.tsx
+++ b/components/_util/ActionButton.tsx
@@ -62,6 +62,7 @@ const ActionButton: React.FC<ActionButtonProps> = (props) => {
     setLoading(true);
     returnValueOfOnOk!.then(
       (...args: any[]) => {
+        setLoading(false, true);
         onInternalClose(...args);
         clickedRef.current = false;
       },

--- a/components/modal/style/index.tsx
+++ b/components/modal/style/index.tsx
@@ -1,9 +1,9 @@
 import type React from 'react';
+import { clearFix, genFocusStyle, resetComponent } from '../../style';
 import { initFadeMotion, initZoomMotion } from '../../style/motion';
 import type { AliasToken, FullToken, GenerateStyle } from '../../theme/internal';
 import { genComponentStyleHook, mergeToken } from '../../theme/internal';
 import type { TokenWithCommonCls } from '../../theme/util/genComponentStyleHook';
-import { clearFix, genFocusStyle, resetComponent } from '../../style';
 
 /** Component only token. Which will handle additional calculation of alias token */
 export interface ComponentToken {
@@ -47,18 +47,24 @@ function box(position: React.CSSProperties['position']): React.CSSProperties {
 }
 
 export const genModalMaskStyle: GenerateStyle<TokenWithCommonCls<AliasToken>> = (token) => {
-  const { componentCls } = token;
+  const { componentCls, antCls } = token;
 
   return [
     {
       [`${componentCls}-root`]: {
-        [`${componentCls}${token.antCls}-zoom-enter, ${componentCls}${token.antCls}-zoom-appear`]: {
+        [`${componentCls}${antCls}-zoom-enter, ${componentCls}${antCls}-zoom-appear`]: {
           // reset scale avoid mousePosition bug
           transform: 'none',
           opacity: 0,
           animationDuration: token.motionDurationSlow,
           // https://github.com/ant-design/ant-design/issues/11777
           userSelect: 'none',
+        },
+
+        // https://github.com/ant-design/ant-design/issues/37329
+        // https://github.com/ant-design/ant-design/issues/40272
+        [`${componentCls}${antCls}-zoom-leave ${componentCls}-content`]: {
+          pointerEvents: 'none',
         },
 
         [`${componentCls}-mask`]: {
@@ -348,11 +354,6 @@ const genModalConfirmStyle: GenerateStyle<ModalToken> = (token) => {
 
     [`${confirmComponentCls}-success ${confirmComponentCls}-body > ${token.iconCls}`]: {
       color: token.colorSuccess,
-    },
-
-    // https://github.com/ant-design/ant-design/issues/37329
-    [`${componentCls}-zoom-leave ${componentCls}-btns`]: {
-      pointerEvents: 'none',
     },
   };
 };

--- a/scripts/post-script.js
+++ b/scripts/post-script.js
@@ -29,6 +29,9 @@ const DEPRECIATED_VERSION = {
   '5.1.2': ['https://github.com/ant-design/ant-design/issues/39949'],
   '5.1.3': ['https://github.com/ant-design/ant-design/issues/40113'],
   '5.1.4': ['https://github.com/ant-design/ant-design/issues/40186'],
+  '>= 5.2.3 <= 5.3.0': [
+    'https://github.com/ant-design/ant-design/pull/40719#issuecomment-1453418135',
+  ],
 };
 
 function matchDeprecated(version) {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

ref #40719

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fix Popconfirm using `Promise` to close will not exist `loading` state even when open again.       |
| 🇨🇳 Chinese |   修复 Popconfirm 使用 `Promise` 关闭时再次打开仍然是 `loading` 状态的问题。        |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
