### PR TITLE
fix(typography): menu item title cannot be centered vertically

### DIFF
--- a/components/menu/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/menu/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -4136,7 +4136,11 @@ Array [
             <span
               class="ant-menu-title-content"
             >
-              Option 3
+              <span
+                class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line"
+              >
+                Ant Design, a design language for background applications, is refined by Ant UED Team
+              </span>
             </span>
           </li>
           <div
@@ -4300,7 +4304,11 @@ Array [
           <span
             class="ant-menu-title-content"
           >
-            Option 3
+            <span
+              class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line"
+            >
+              Ant Design, a design language for background applications, is refined by Ant UED Team
+            </span>
           </span>
         </li>
         <div

--- a/components/menu/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/menu/__tests__/__snapshots__/demo.test.tsx.snap
@@ -1466,7 +1466,28 @@ Array [
           <span
             class="ant-menu-title-content"
           >
-            Option 3
+            <span
+              aria-label="Ant Design, a design language for background applications, is refined by Ant UED Team"
+              class="ant-typography ant-typography-ellipsis ant-typography-single-line"
+            >
+              Ant Design, a design language for background applications, is refined by Ant UED Team
+              <span
+                aria-hidden="true"
+                style="position:fixed;display:block;left:0;top:0;z-index:-9999;visibility:hidden;pointer-events:none;font-size:0;word-break:keep-all;white-space:nowrap"
+              >
+                lg
+              </span>
+              <span
+                aria-hidden="true"
+                style="position:fixed;display:block;left:0;top:0;z-index:-9999;visibility:hidden;pointer-events:none;font-size:0;width:0;white-space:normal;margin:0;padding:0"
+              >
+                <span
+                  aria-hidden="true"
+                >
+                  ...
+                </span>
+              </span>
+            </span>
           </span>
         </li>
         <li

--- a/components/menu/demo/menu-v4.tsx
+++ b/components/menu/demo/menu-v4.tsx
@@ -6,7 +6,7 @@ import {
   SettingOutlined,
 } from '@ant-design/icons';
 import React, { useState } from 'react';
-import { ConfigProvider, Menu, Switch } from 'antd';
+import { ConfigProvider, Menu, Switch, Typography } from 'antd';
 import type { MenuProps } from 'antd/es/menu';
 
 type MenuItem = Required<MenuProps>['items'][number];
@@ -29,7 +29,12 @@ const items: MenuItem[] = [
   getItem('Navigation One', '1', <MailOutlined />),
   getItem('Navigation Two', '2', <CalendarOutlined />),
   getItem('Navigation Two', 'sub1', <AppstoreOutlined />, [
-    getItem('Option 3', '3'),
+    getItem(
+      <Typography.Text ellipsis>
+        Ant Design, a design language for background applications, is refined by Ant UED Team
+      </Typography.Text>,
+      '3',
+    ),
     getItem('Option 4', '4'),
     getItem('Submenu', 'sub1-2', null, [getItem('Option 5', '5'), getItem('Option 6', '6')]),
   ]),

--- a/components/menu/style/index.tsx
+++ b/components/menu/style/index.tsx
@@ -601,6 +601,12 @@ const getBaseStyle: GenerateStyle<MenuToken> = (token) => {
 
         [`${componentCls}-title-content`]: {
           transition: `color ${motionDurationSlow}`,
+
+          // https://github.com/ant-design/ant-design/issues/41143
+          [`> ${antCls}-typography-ellipsis-single-line`]: {
+            display: 'inline',
+            verticalAlign: 'unset',
+          },
         },
 
         [`${componentCls}-item a`]: {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

close https://github.com/ant-design/ant-design/issues/41143
### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->
由于 Typography 设置 ellipsis 时会默认添加 `vertical-align: bottom`，且 Typography 具有默认行高，所以会无法垂直居中，现将 `Menu.Item` 透传，使其能垂直居中，以下是修复前后对比：
修复前：
<img width="472" alt="image" src="https://user-images.githubusercontent.com/112228030/224482193-39043374-41e2-433d-a974-e3da56cad3fb.png">
修复后：
<img width="459" alt="image" src="https://user-images.githubusercontent.com/112228030/224482220-da7ed1be-7a4c-4b21-9c41-ad152cbb903e.png">


### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed Menu.Item nested Typography failing to center vertically when ellipsis is true  |
| 🇨🇳 Chinese | 修复 Menu.Item 嵌套的 Typography 其 ellipsis 为 true 时无法垂直居中         |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
