### PR TITLE
fix: fix date-picker type error

### DIFF
--- a/components/date-picker/generatePicker/generateRangePicker.tsx
+++ b/components/date-picker/generatePicker/generateRangePicker.tsx
@@ -66,7 +66,7 @@ export default function generateRangePicker<DateType>(generateConfig: GenerateCo
     additionalOverrideProps = {
       ...additionalOverrideProps,
       ...(showTime ? getTimeProps({ format, picker, ...showTime }) : {}),
-      ...(picker === 'time' ? getTimeProps({ format, ...props, picker }) : {}),
+      ...(picker === 'time' ? getTimeProps({ format, ...(props as any), picker }) : {}),
     };
 
     // =================== Warning =====================

--- a/components/date-picker/generatePicker/generateSinglePicker.tsx
+++ b/components/date-picker/generatePicker/generateSinglePicker.tsx
@@ -83,7 +83,7 @@ export default function generatePicker<DateType>(generateConfig: GenerateConfig<
           ...additionalOverrideProps,
           ...(showTime ? getTimeProps({ format, picker: mergedPicker, ...showTime }) : {}),
           ...(mergedPicker === 'time'
-            ? getTimeProps({ format, ...props, picker: mergedPicker })
+            ? getTimeProps({ format, ...(props as any), picker: mergedPicker })
             : {}),
         };
         const rootPrefixCls = getPrefixCls();


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<img width="1112" alt="image" src="https://user-images.githubusercontent.com/49217418/224306587-06199a0f-5dcc-465c-b6b7-8f9592b8cb35.png">

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix: fix date-picker type error |
| 🇨🇳 Chinese | 无需纳入 ChangeLog |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed