### PR TITLE
fix: ConfirmDialog passing wrong footer prop

### DIFF
--- a/components/input-number/style/index.ts
+++ b/components/input-number/style/index.ts
@@ -263,6 +263,10 @@ const genInputNumberStyles: GenerateStyle<InputNumberToken> = (token: InputNumbe
           [`${componentCls}-handler-wrap`]: {
             display: 'none',
           },
+
+          [`${componentCls}-input`]: {
+            color: 'inherit',
+          },
         },
 
         [`

--- a/components/input-number/style/index.ts
+++ b/components/input-number/style/index.ts
@@ -263,10 +263,6 @@ const genInputNumberStyles: GenerateStyle<InputNumberToken> = (token: InputNumbe
           [`${componentCls}-handler-wrap`]: {
             display: 'none',
           },
-
-          [`${componentCls}-input`]: {
-            color: 'inherit',
-          },
         },
 
         [`

--- a/components/modal/ConfirmDialog.tsx
+++ b/components/modal/ConfirmDialog.tsx
@@ -185,7 +185,7 @@ const ConfirmDialog: React.FC<ConfirmDialogProps> = (props) => {
         onCancel={() => close?.({ triggerCancel: true })}
         open={open}
         title=""
-        footer=""
+        footer={null}
         transitionName={getTransitionName(rootPrefixCls, 'zoom', props.transitionName)}
         maskTransitionName={getTransitionName(rootPrefixCls, 'fade', props.maskTransitionName)}
         mask={mask}

--- a/components/modal/__tests__/__snapshots__/confirm.test.tsx.snap
+++ b/components/modal/__tests__/__snapshots__/confirm.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`Modal.confirm triggers callbacks correctly footer confirm should render
       >
         <span
           aria-label="exclamation-circle"
-          class="anticon anticon-exclamation-circle"
+          class="bamboo bamboo-exclamation-circle"
           role="img"
         >
           <svg

--- a/components/modal/__tests__/__snapshots__/confirm.test.tsx.snap
+++ b/components/modal/__tests__/__snapshots__/confirm.test.tsx.snap
@@ -1,0 +1,48 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Modal.confirm triggers callbacks correctly footer confirm should render the footer when footer is set 1`] = `
+<div
+  class="ant-modal-content"
+>
+  <div
+    class="ant-modal-body"
+  >
+    <div
+      class="ant-modal-confirm-body-wrapper"
+    >
+      <div
+        class="ant-modal-confirm-body"
+      >
+        <span
+          aria-label="exclamation-circle"
+          class="bamboo bamboo-exclamation-circle"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="exclamation-circle"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm-32 232c0-4.4 3.6-8 8-8h48c4.4 0 8 3.6 8 8v272c0 4.4-3.6 8-8 8h-48c-4.4 0-8-3.6-8-8V296zm32 440a48.01 48.01 0 010-96 48.01 48.01 0 010 96z"
+            />
+          </svg>
+        </span>
+        <div
+          class="ant-modal-confirm-content"
+        >
+          hai
+        </div>
+      </div>
+      hai
+    </div>
+  </div>
+  <div
+    class="ant-modal-footer"
+  />
+</div>
+`;

--- a/components/modal/__tests__/__snapshots__/confirm.test.tsx.snap
+++ b/components/modal/__tests__/__snapshots__/confirm.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`Modal.confirm triggers callbacks correctly footer confirm should render
       >
         <span
           aria-label="exclamation-circle"
-          class="bamboo bamboo-exclamation-circle"
+          class="anticon anticon-exclamation-circle"
           role="img"
         >
           <svg
@@ -41,8 +41,5 @@ exports[`Modal.confirm triggers callbacks correctly footer confirm should render
       hai
     </div>
   </div>
-  <div
-    class="ant-modal-footer"
-  />
 </div>
 `;

--- a/components/modal/__tests__/confirm.test.tsx
+++ b/components/modal/__tests__/confirm.test.tsx
@@ -803,4 +803,30 @@ describe('Modal.confirm triggers callbacks correctly', () => {
     await waitFakeTimer();
     expect($$('.custom-modal-footer')).toHaveLength(1);
   });
+
+  // https://github.com/ant-design/ant-design/issues/41170
+  describe('footer', () => {
+    (['confirm', 'info', 'success', 'warning', 'error'] as const).forEach((type) => {
+      it(`${type} should not render the footer in the default`, async () => {
+        Modal[type]({
+          content: 'hai',
+        });
+
+        await waitFakeTimer();
+
+        expect(document.querySelector(`.ant-modal-footer`)).toBeFalsy();
+      });
+    });
+
+    it('confirm should render the footer when footer is set', async () => {
+      Modal.confirm({
+        content: 'hai',
+        footer: 'hai',
+      });
+
+      await waitFakeTimer();
+
+      expect(document.querySelector(`.ant-modal-content`)).toMatchSnapshot();
+    });
+  });
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
Fixes #41170 

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->
`<ConfirmDialog>` component was passing an empty string as a `footer` prop to the `<Dialog>` component.

That was wrong as `<Dialog>` component is rendering that empty string in a `<div>` element wrapper that has a margin-top attribute as shown in the screenshot in the referenced issue. 
`<ConfirmDialog>` should pass a `null` value for footer prop. That way a footer wrapper `div` won't be rendered.

BEFORE CHANGE: 
![image](https://user-images.githubusercontent.com/11903509/224337784-42d12fd6-773a-4412-b3e2-07c82d9472b7.png)

AFTER CHANGE:
![image](https://user-images.githubusercontent.com/11903509/224338035-d04a75ec-feb7-4945-959f-657e3ece550b.png)


### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | [Modal] Fixed too large bottom margin when using `confirm()` to open a Modal |
| 🇨🇳 Chinese | [Modal] 修复使用 `confirm()` 打开 Modal 时下边距过大的问题   |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
