### PR TITLE
style: textarea should avtive when focused

### DIFF
--- a/components/input/ClearableLabeledInput.tsx
+++ b/components/input/ClearableLabeledInput.tsx
@@ -78,6 +78,7 @@ class ClearableLabeledInput extends React.Component<ClearableInputProps> {
       value,
       allowClear,
       className,
+      focused,
       style,
       direction,
       bordered,
@@ -101,6 +102,7 @@ class ClearableLabeledInput extends React.Component<ClearableInputProps> {
         hasFeedback,
       ),
       {
+        [`${prefixCls}-affix-wrapper-focused`]: focused,
         [`${prefixCls}-affix-wrapper-rtl`]: direction === 'rtl',
         [`${prefixCls}-affix-wrapper-borderless`]: !bordered,
         // className will go to addon wrapper

--- a/components/input/TextArea.tsx
+++ b/components/input/TextArea.tsx
@@ -73,6 +73,8 @@ const TextArea = React.forwardRef<TextAreaRef, TextAreaProps>(
       onCompositionStart,
       onCompositionEnd,
       onChange,
+      onFocus,
+      onBlur,
       status: customStatus,
       ...props
     },
@@ -97,6 +99,7 @@ const TextArea = React.forwardRef<TextAreaRef, TextAreaProps>(
     const clearableInputRef = React.useRef<ClearableLabeledInput>(null);
 
     const [compositing, setCompositing] = React.useState(false);
+    const [focused, setFocused] = React.useState(false);
     const oldCompositionValueRef = React.useRef<string>();
     const oldSelectionStartRef = React.useRef<number>(0);
 
@@ -163,6 +166,20 @@ const TextArea = React.forwardRef<TextAreaRef, TextAreaProps>(
       resolveOnChange(e.currentTarget, e, onChange, triggerValue);
     };
 
+    const handleBlur = (e: React.FocusEvent<HTMLTextAreaElement>) => {
+      setFocused(false);
+      onBlur?.(e);
+    };
+
+    const handleFocus = (e: React.FocusEvent<HTMLTextAreaElement>) => {
+      setFocused(true);
+      onFocus?.(e);
+    };
+
+    React.useEffect(() => {
+      setFocused((prev) => !mergedDisabled && prev);
+    }, [mergedDisabled]);
+
     // ============================== Reset ===============================
     const handleReset = (e: React.MouseEvent<HTMLElement, MouseEvent>) => {
       handleSetValue('');
@@ -197,6 +214,8 @@ const TextArea = React.forwardRef<TextAreaRef, TextAreaProps>(
         prefixCls={prefixCls}
         onCompositionStart={onInternalCompositionStart}
         onChange={handleChange}
+        onBlur={handleBlur}
+        onFocus={handleFocus}
         onCompositionEnd={onInternalCompositionEnd}
         ref={innerRef}
       />
@@ -213,6 +232,7 @@ const TextArea = React.forwardRef<TextAreaRef, TextAreaProps>(
     const textareaNode = (
       <ClearableLabeledInput
         disabled={mergedDisabled}
+        focused={focused}
         {...props}
         prefixCls={prefixCls}
         direction={direction}

--- a/components/input/__tests__/__snapshots__/textarea.test.tsx.snap
+++ b/components/input/__tests__/__snapshots__/textarea.test.tsx.snap
@@ -34,7 +34,7 @@ exports[`TextArea allowClear should change type when click 1`] = `
 
 exports[`TextArea allowClear should change type when click 2`] = `
 <span
-  class="ant-input-affix-wrapper ant-input-affix-wrapper-textarea-with-clear-btn"
+  class="ant-input-affix-wrapper ant-input-affix-wrapper-textarea-with-clear-btn ant-input-affix-wrapper-focused"
 >
   <textarea
     class="ant-input"

--- a/components/input/__tests__/textarea.test.tsx
+++ b/components/input/__tests__/textarea.test.tsx
@@ -574,4 +574,14 @@ describe('TextArea allowClear', () => {
 
     textareaSpy.mockRestore();
   });
+
+  it('should have correct className when onFocus and onBlur', () => {
+    const { container } = render(<TextArea allowClear />);
+
+    fireEvent.focus(container.querySelector('textarea')!);
+    expect(container.querySelector('.ant-input-affix-wrapper-focused')).toBeTruthy();
+
+    fireEvent.blur(container.querySelector('textarea')!);
+    expect(container.querySelector('.ant-input-affix-wrapper-focused')).toBeFalsy();
+  });
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

https://github.com/ant-design/ant-design/issues/41164

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     textarea should avtive when focused      |
| 🇨🇳 Chinese |     textarea 应该在聚焦时保持高亮      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
