### PR TITLE
fix(Dropdown): Focus outline being blocked by other elements

### DIFF
--- a/components/button/style/index.ts
+++ b/components/button/style/index.ts
@@ -520,7 +520,7 @@ export default genComponentStyleHook('Button', (token) => {
     genGroupStyle(buttonToken),
 
     // Space Compact
-    genCompactItemStyle(token, { focus: false }),
+    genCompactItemStyle(token),
     genCompactItemVerticalStyle(token),
   ];
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
close https://github.com/ant-design/ant-design/issues/41175

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->
当前在 `Space.Compact` 内的按钮，使用 `Tab` 聚焦的话，聚焦轮廓会被其他元素遮挡 。下图为修改前后对比。
修改前：
<img width="571" alt="image" src="https://user-images.githubusercontent.com/112228030/225618849-9f3cbe27-4eed-4420-8817-c5046ca9263c.png">

修改后：
<img width="495" alt="image" src="https://user-images.githubusercontent.com/112228030/225619520-50bcec0b-97b2-4ede-8523-370dd7d2314a.png">



### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fixed dropdown button focus outline being blocked by other elements   |
| 🇨🇳 Chinese | 修复下拉按钮的聚焦轮廓被其他元素遮挡          |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
