### PR TITLE
fix(Breadcrumb Item): support Breadcrumb Item onClick and className

### DIFF
--- a/components/breadcrumb/Breadcrumb.tsx
+++ b/components/breadcrumb/Breadcrumb.tsx
@@ -33,6 +33,8 @@ export interface BreadcrumbItemType {
   menu?: BreadcrumbItemProps['menu'];
   /** @deprecated Please use `menu` instead */
   overlay?: React.ReactNode;
+  onClick?: React.MouseEventHandler<HTMLAnchorElement | HTMLSpanElement>;
+  className?: string;
 }
 export interface BreadcrumbSeparatorType {
   type: 'separator';
@@ -167,6 +169,10 @@ const Breadcrumb: CompoundedComponent = (props) => {
         itemProps.overlay = overlay as any;
       }
 
+      if (item.className) {
+        itemProps.className = item.className;
+      }
+
       let { href } = item;
       if (paths.length && mergedPath !== undefined) {
         href = `#/${paths.join('/')}`;
@@ -182,6 +188,7 @@ const Breadcrumb: CompoundedComponent = (props) => {
           })}
           href={href}
           separator={isLastItem ? '' : separator}
+          onClick={item.onClick ?? undefined}
         >
           {mergedItemRender(item as BreadcrumbItemType, params, itemRenderRoutes, paths)}
         </BreadcrumbItem>

--- a/components/breadcrumb/Breadcrumb.tsx
+++ b/components/breadcrumb/Breadcrumb.tsx
@@ -147,7 +147,7 @@ const Breadcrumb: CompoundedComponent = (props) => {
     const itemRenderRoutes: any = items || legacyRoutes;
 
     crumbs = mergedItems.map((item, index) => {
-      const { path, key, type, menu, overlay, separator: itemSeparator } = item;
+      const { path, key, type, menu, overlay, separator: itemSeparator, onClick } = item;
       const mergedPath = getPath(params, path);
 
       if (mergedPath !== undefined) {
@@ -188,7 +188,7 @@ const Breadcrumb: CompoundedComponent = (props) => {
           })}
           href={href}
           separator={isLastItem ? '' : separator}
-          onClick={item.onClick ?? undefined}
+          onClick={onClick}
         >
           {mergedItemRender(item as BreadcrumbItemType, params, itemRenderRoutes, paths)}
         </BreadcrumbItem>

--- a/components/breadcrumb/__tests__/Breadcrumb.test.tsx
+++ b/components/breadcrumb/__tests__/Breadcrumb.test.tsx
@@ -329,4 +329,32 @@ describe('Breadcrumb', () => {
     expect(errSpy).not.toHaveBeenCalled();
     errSpy.mockRestore();
   });
+
+  // https://github.com/ant-design/ant-design/issues/41274
+  it('should support Breadcrumb Item onClick and className', () => {
+    const onClick = jest.fn();
+    const { container } = render(
+      <Breadcrumb
+        items={[
+          {
+            title: 'Home',
+          },
+          {
+            title: 'Application Center',
+            onClick,
+            className: 'chinese',
+          },
+          {
+            title: <a href="#">Application List</a>,
+            onClick,
+            className: 'chinese',
+          },
+          {
+            title: 'An Application',
+          },
+        ]}
+      />,
+    );
+    expect(container.firstChild).toMatchSnapshot();
+  });
 });

--- a/components/breadcrumb/__tests__/Breadcrumb.test.tsx
+++ b/components/breadcrumb/__tests__/Breadcrumb.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import accessibilityTest from '../../../tests/shared/accessibilityTest';
 import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
-import { render } from '../../../tests/utils';
+import { render, fireEvent } from '../../../tests/utils';
 import { resetWarned } from '../../_util/warning';
 import type { ItemType } from '../Breadcrumb';
 import Breadcrumb from '../index';
@@ -337,24 +337,16 @@ describe('Breadcrumb', () => {
       <Breadcrumb
         items={[
           {
-            title: 'Home',
-          },
-          {
             title: 'Application Center',
             onClick,
-            className: 'chinese',
-          },
-          {
-            title: <a href="#">Application List</a>,
-            onClick,
-            className: 'chinese',
-          },
-          {
-            title: 'An Application',
+            className: 'item-test-class',
           },
         ]}
       />,
     );
+    fireEvent.click(container.querySelector('.item-test-class')!);
+    expect(onClick).toHaveBeenCalled();
+    expect(container.querySelector('.item-test-class')).toBeTruthy();
     expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/components/breadcrumb/__tests__/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/components/breadcrumb/__tests__/__snapshots__/Breadcrumb.test.tsx.snap
@@ -216,52 +216,9 @@ exports[`Breadcrumb should support Breadcrumb Item onClick and className 1`] = `
   <ol>
     <li>
       <span
-        class="ant-breadcrumb-link"
-      >
-        Home
-      </span>
-    </li>
-    <li
-      aria-hidden="true"
-      class="ant-breadcrumb-separator"
-    >
-      /
-    </li>
-    <li>
-      <span
-        class="chinese"
+        class="item-test-class"
       >
         Application Center
-      </span>
-    </li>
-    <li
-      aria-hidden="true"
-      class="ant-breadcrumb-separator"
-    >
-      /
-    </li>
-    <li>
-      <span
-        class="chinese"
-      >
-        <a
-          href="#"
-        >
-          Application List
-        </a>
-      </span>
-    </li>
-    <li
-      aria-hidden="true"
-      class="ant-breadcrumb-separator"
-    >
-      /
-    </li>
-    <li>
-      <span
-        class="ant-breadcrumb-link"
-      >
-        An Application
       </span>
     </li>
   </ol>

--- a/components/breadcrumb/__tests__/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/components/breadcrumb/__tests__/__snapshots__/Breadcrumb.test.tsx.snap
@@ -209,6 +209,65 @@ exports[`Breadcrumb should render correct 1`] = `
 </nav>
 `;
 
+exports[`Breadcrumb should support Breadcrumb Item onClick and className 1`] = `
+<nav
+  class="ant-breadcrumb"
+>
+  <ol>
+    <li>
+      <span
+        class="ant-breadcrumb-link"
+      >
+        Home
+      </span>
+    </li>
+    <li
+      aria-hidden="true"
+      class="ant-breadcrumb-separator"
+    >
+      /
+    </li>
+    <li>
+      <span
+        class="chinese"
+      >
+        Application Center
+      </span>
+    </li>
+    <li
+      aria-hidden="true"
+      class="ant-breadcrumb-separator"
+    >
+      /
+    </li>
+    <li>
+      <span
+        class="chinese"
+      >
+        <a
+          href="#"
+        >
+          Application List
+        </a>
+      </span>
+    </li>
+    <li
+      aria-hidden="true"
+      class="ant-breadcrumb-separator"
+    >
+      /
+    </li>
+    <li>
+      <span
+        class="ant-breadcrumb-link"
+      >
+        An Application
+      </span>
+    </li>
+  </ol>
+</nav>
+`;
+
 exports[`Breadcrumb should support Breadcrumb.Item default separator 1`] = `
 <nav
   class="ant-breadcrumb"


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
close #41274
close #41283

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     support Breadcrumb Item onClick and className      |
| 🇨🇳 Chinese |     Breadcrumb Item支持onClick和className     |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
