### PR TITLE
refactor: adjust refresh Button logic

### DIFF
--- a/components/qrcode/index.tsx
+++ b/components/qrcode/index.tsx
@@ -2,13 +2,13 @@ import { ReloadOutlined } from '@ant-design/icons';
 import classNames from 'classnames';
 import { QRCodeCanvas } from 'qrcode.react';
 import React, { useContext, useMemo } from 'react';
+import warning from '../_util/warning';
 import Button from '../button';
 import type { ConfigConsumerProps } from '../config-provider';
 import { ConfigContext } from '../config-provider';
 import useLocale from '../locale/useLocale';
 import Spin from '../spin';
 import theme from '../theme';
-import warning from '../_util/warning';
 import type { QRCodeProps, QRPropsCanvas } from './interface';
 import useStyle from './style/index';
 
@@ -82,7 +82,7 @@ const QRCode: React.FC<QRCodeProps> = (props) => {
           {status === 'expired' && (
             <>
               <p className={`${prefixCls}-expired`}>{locale?.expired}</p>
-              {typeof onRefresh === 'function' && (
+              {onRefresh && (
                 <Button type="link" icon={<ReloadOutlined />} onClick={onRefresh}>
                   {locale?.refresh}
                 </Button>


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [x] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

在旧的逻辑中，判断 onRefresh 是 function 的时候才会显示刷新按钮，实际上这是不合理的：

1. 在 props 的 ts 定义中，已经规定了onRefresh 是 function，因此在实现中没必要判断
2. 用户如果想显示刷新按钮，但是传入了错误的值，也应该显示出来，否则用户会奇怪 “为什么我明明传了onRefresh，但是并没有显示按钮”
3. 至于类型错误问题，直接由浏览器将错误抛给用户即可，这也是合理的

<!--
1. Describe the problem and the scenario.
4. GIF or snapshot should be provided if includes UI/interactive modification.
5. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | refactor: adjust refresh Button logic |
| 🇨🇳 Chinese | refactor: 调整二维码刷新按钮显示隐藏的逻辑 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed