### PR TITLE
chore: fixed `InternalTreeSelect`'s generic signature

### DIFF
--- a/components/tree-select/index.tsx
+++ b/components/tree-select/index.tsx
@@ -66,7 +66,10 @@ export interface TreeSelectProps<
   rootClassName?: string;
 }
 
-const InternalTreeSelect = <OptionType extends BaseOptionType | DefaultOptionType = BaseOptionType>(
+const InternalTreeSelect = <
+  ValueType = any,
+  OptionType extends BaseOptionType | DefaultOptionType = BaseOptionType,
+>(
   {
     prefixCls: customizePrefixCls,
     size: customizeSize,
@@ -92,7 +95,7 @@ const InternalTreeSelect = <OptionType extends BaseOptionType | DefaultOptionTyp
     showArrow,
     treeExpandAction,
     ...props
-  }: TreeSelectProps<OptionType>,
+  }: TreeSelectProps<ValueType, OptionType>,
   ref: React.Ref<BaseSelectRef>,
 ) => {
   const {


### PR DESCRIPTION
The declared signature doesn't match the one to which it is casted later on:
https://github.com/ant-design/ant-design/blob/f7fd474cf8792ea01d03461d407c0edc11828a1c/components/tree-select/index.tsx#L251-L258

This should be a type error but currently, it's accidentally swallowed by TS. Notice how the problem is reported in this [TS playground](https://www.typescriptlang.org/play?#code/JYWwDg9gTgLgBAKjgQwM5wEoFNkGN4BmUEIcARFDvmQNwBQdwAdjFlAXlnACJYcCuAGxgB5MDGAQmAFQCeYLlgAerJgBN0AITRYxEqXIVwA3nThwJMQVgD8ALkxUYAOmx4YAOQhqs9c4OQAIyxBe0d3VycvHz84AGssWTC3fGcAaUTY3AALYEE1SiYw3gFhPUkZeSwAbQBdegBfBmZWdk44bVRdcQrDLlNzNWBUIOs1MMCICGtkJizsrFw40dsHSemcObM4IZHA6wBhBaXJpQmpma2mxhY2DlwuDFxpSiwAZRDFmAAFYjBUAA82wAashBPwsH04ABeFBMWQAGm25QMVTgylUGg6OhRlSMsJKyCEoh6qIUdAAfCZtgA3MEQsKg8GQqqxGCvbjIGDIMK4vp1RrNW5tB5wF5Yd6ffC-CD-IHmJkQqGw2aI5GkvGKFRYdRaHEaqEAHx4fCJZQNaIJpuJfKqlPR2t1mGerw+1mlf0BipZCgRcFtCipxmuPlwAUocAI-CY+AqcAAksKmGDxZL3TAAEzy-0WowYnVYzrdfSauDGwk23NcWFFgNYSkACjAnocqbdXxlcrrFIAlA4Ui4BwBRawgHUweg3Vr3LgAfQAYtAAO7IKBqbAEbDqNjz6OxqQA6R+74wkwNIPbJstuDfPvhVLD0fjstwJhCQSxOAAei-g2GYACWQPGQMcwlQdlmAAc0FKc7naBdl1Xdc+CHJQIAkXADhISAmHHAFvgvcwr1lVAHFvfsnEidwRywMcWBfN9BA-OgQ0WcMuCjGMS0jRC10PY9T2DCkG22QofCgBwEKgFc1w3LdxN3LiKn4m8KToO8pJk5CCFQ9DgEw7CpDwgjJ2USBYDgXApHAsVXSlGANwzU8CF4tQG0TVpk0ENt7IzHsUHQbNvWVOE1XMOsHUxPUugi8trXNEsQorBLejtYTtmbEjWzs9NOy9ekfSwP1u3UmEqQHKj8BouiJzoIA) and how it goes away when you include the commented out property. 