### PR TITLE
fix(useModal): forward modal config

### DIFF
--- a/components/modal/__tests__/hook.test.tsx
+++ b/components/modal/__tests__/hook.test.tsx
@@ -350,4 +350,21 @@ describe('Modal.hook', () => {
 
     expect(document.body.querySelector('.bamboo')?.textContent).toEqual('好的');
   });
+
+  it('it should call forwarded afterClose', () => {
+    const afterClose = jest.fn();
+    const Demo = () => {
+      const [modal, contextHolder] = Modal.useModal();
+      React.useEffect(() => {
+        modal.confirm({ title: 'Confirm', afterClose });
+      }, []);
+      return contextHolder;
+    };
+
+    render(<Demo />);
+    const btns = document.body.querySelectorAll('.ant-btn');
+    fireEvent.click(btns[btns.length - 1]);
+
+    expect(afterClose).toHaveBeenCalledTimes(1);
+  });
 });

--- a/components/modal/useModal/HookModal.tsx
+++ b/components/modal/useModal/HookModal.tsx
@@ -16,7 +16,7 @@ export interface HookModalRef {
 }
 
 const HookModal: React.ForwardRefRenderFunction<HookModalRef, HookModalProps> = (
-  { afterClose, config },
+  { afterClose: hookAfterClose, config },
   ref,
 ) => {
   const [open, setOpen] = React.useState(true);
@@ -25,6 +25,11 @@ const HookModal: React.ForwardRefRenderFunction<HookModalRef, HookModalProps> = 
 
   const prefixCls = getPrefixCls('modal');
   const rootPrefixCls = getPrefixCls();
+
+  const afterClose = () => {
+    hookAfterClose();
+    innerConfig.afterClose?.();
+  };
 
   const close = (...args: any[]) => {
     setOpen(false);
@@ -59,7 +64,7 @@ const HookModal: React.ForwardRefRenderFunction<HookModalRef, HookModalProps> = 
       okText={
         innerConfig.okText || (mergedOkCancel ? contextLocale?.okText : contextLocale?.justOkText)
       }
-      direction={direction}
+      direction={innerConfig.direction || direction}
       cancelText={innerConfig.cancelText || contextLocale?.cancelText}
     />
   );


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

fix: #41417 

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

Before this PR the config `afterClose` was replaced by `useModal` for holder EL replacement, causes original `afterClose` from user-code was ignored.

Also try to forward `direction`

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    useModal should forward modal config  |
| 🇨🇳 Chinese |  useModal 应透传并优先选择用户设定  |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
