### PR TITLE
docs(menu): Optimize demo

### DIFF
--- a/components/menu/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/menu/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -5079,6 +5079,9 @@ Array [
           </ul>
         </div>
       </div>
+      <div
+        style="position: absolute; top: 0px; left: 0px; width: 100%;"
+      />
     </li>
     <li
       class="ant-menu-item ant-menu-item-only-child"

--- a/components/menu/demo/submenu-theme.tsx
+++ b/components/menu/demo/submenu-theme.tsx
@@ -63,6 +63,7 @@ const App: React.FC = () => {
         mode="vertical"
         theme="dark"
         items={items}
+        getPopupContainer={(node) => node.parentNode as HTMLElement}
       />
     </>
   );


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [x] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

close https://github.com/ant-design/ant-design/issues/41408

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

之前的这个 demo 默认打开子菜单，导致其他 menu 切换状态时，这个子菜单就可以出现在其他位置会让人莫名其妙，这里我加上鼠标进出的逻辑，当鼠标进入时设置打开子菜单，鼠标移出时清除打开的子菜单。

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Optimize `submenu-theme` demo          |
| 🇨🇳 Chinese | 优化子菜单主题示例          |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
