### PR TITLE
refactor(BreadcrumbItem): MenuItem support for customized key

### DIFF
--- a/components/breadcrumb/BreadcrumbItem.tsx
+++ b/components/breadcrumb/BreadcrumbItem.tsx
@@ -13,6 +13,7 @@ export interface SeparatorType {
 
 type MenuType = NonNullable<DropdownProps['menu']>;
 interface MenuItem {
+  key?: string;
   title?: React.ReactNode;
   label?: React.ReactNode;
   path?: string;
@@ -71,7 +72,7 @@ const BreadcrumbItem: CompoundedComponent = (props: BreadcrumbItemProps) => {
         const { items, ...menuProps } = menu! || {};
         mergeDropDownProps.menu = {
           ...menuProps,
-          items: items?.map(({ title, label, path, ...itemProps }, index) => {
+          items: items?.map(({ key, title, label, path, ...itemProps }, index) => {
             let mergedLabel: React.ReactNode = label ?? title;
 
             if (path) {
@@ -80,7 +81,7 @@ const BreadcrumbItem: CompoundedComponent = (props: BreadcrumbItemProps) => {
 
             return {
               ...itemProps,
-              key: index,
+              key: key ?? index,
               label: mergedLabel as string,
             };
           }),

--- a/components/breadcrumb/__tests__/Breadcrumb.test.tsx
+++ b/components/breadcrumb/__tests__/Breadcrumb.test.tsx
@@ -291,6 +291,28 @@ describe('Breadcrumb', () => {
     expect(asFragment().firstChild).toMatchSnapshot();
   });
 
+  it('should support Breadcrumb.Item customized menu items key', async () => {
+    const key = 'test-key';
+    const { container } = render(
+      <Breadcrumb>
+        <Breadcrumb.Item
+          dropdownProps={{
+            open: true,
+          }}
+          menu={{
+            items: [{ key }],
+          }}
+        >
+          test-item
+        </Breadcrumb.Item>
+      </Breadcrumb>,
+    );
+
+    const item = container.querySelector('.ant-dropdown-menu-item');
+
+    expect(item?.getAttribute('data-menu-id')?.endsWith(key)).toBeTruthy();
+  });
+
   it('should support string `0` and number `0`', () => {
     const { container } = render(
       <Breadcrumb


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [x] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
close https://github.com/ant-design/ant-design/issues/41432
### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  `MenuItem` support for customized key          |
| 🇨🇳 Chinese |  `MenuItem` 支持自定义 key          |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
