### PR TITLE
fix: Table filter do not persist filter status when filter dropdown is visible

### DIFF
--- a/components/table/__tests__/Table.filter.test.tsx
+++ b/components/table/__tests__/Table.filter.test.tsx
@@ -2815,7 +2815,7 @@ describe('Table.filter', () => {
     // Table data changes while the dropdown is open and a user is setting filters.
     rerender(createTable({ ...tableProps, dataSource: [{ name: 'Foo' }] }));
 
-    // The checkbox is now checked.
+    // The checkbox is still checked.
     expect(container.querySelector<HTMLInputElement>('input[type="checkbox"]')!.checked).toEqual(
       true,
     );

--- a/components/table/__tests__/Table.filter.test.tsx
+++ b/components/table/__tests__/Table.filter.test.tsx
@@ -2777,4 +2777,47 @@ describe('Table.filter', () => {
 
     expect(renderedNames(container)).toEqual(['Jack']);
   });
+
+  it.only('changes to table data should not reset the filter dropdown state being changed by a user', () => {
+    const tableProps = {
+      key: 'stabletable',
+      rowKey: 'name',
+      dataSource: [],
+      columns: [
+        {
+          title: 'Name',
+          dataIndex: 'name',
+          filteredValue: [], // User is controlling filteredValue. It begins with no items checked.
+          filters: [{ text: 'J', value: 'J' }],
+          onFilter: (value: any, record: any) => record.name.includes(value),
+        },
+      ],
+    };
+
+    const { container, rerender } = render(createTable(tableProps));
+
+    // User opens filter Dropdown.
+    fireEvent.click(container.querySelector('.ant-dropdown-trigger.ant-table-filter-trigger')!);
+
+    // There is one checkbox and it begins unchecked.
+    expect(container.querySelector<HTMLInputElement>('input[type="checkbox"]')!.checked).toEqual(
+      false,
+    );
+
+    // User checks it.
+    fireEvent.click(container.querySelector('input[type="checkbox"]')!);
+
+    // The checkbox is now checked.
+    expect(container.querySelector<HTMLInputElement>('input[type="checkbox"]')!.checked).toEqual(
+      true,
+    );
+
+    // Table data changes while the dropdown is open and a user is setting filters.
+    rerender(createTable({ ...tableProps, dataSource: [{ name: 'Foo' }] }));
+
+    // The checkbox is now checked.
+    expect(container.querySelector<HTMLInputElement>('input[type="checkbox"]')!.checked).toEqual(
+      true,
+    );
+  });
 });

--- a/components/table/__tests__/Table.filter.test.tsx
+++ b/components/table/__tests__/Table.filter.test.tsx
@@ -2778,7 +2778,7 @@ describe('Table.filter', () => {
     expect(renderedNames(container)).toEqual(['Jack']);
   });
 
-  it.only('changes to table data should not reset the filter dropdown state being changed by a user', () => {
+  it('changes to table data should not reset the filter dropdown state being changed by a user', () => {
     const tableProps = {
       key: 'stabletable',
       rowKey: 'name',

--- a/components/table/hooks/useFilter/index.tsx
+++ b/components/table/hooks/useFilter/index.tsx
@@ -215,7 +215,10 @@ function useFilter<RecordType>({
   FilterState<RecordType>[],
   Record<string, FilterValue | null>,
 ] {
-  const mergedColumns = getMergedColumns(rawMergedColumns || []);
+  const mergedColumns = React.useMemo(
+    () => getMergedColumns(rawMergedColumns || []),
+    [rawMergedColumns],
+  );
 
   const [filterStates, setFilterStates] = React.useState<FilterState<RecordType>[]>(() =>
     collectFilterStates(mergedColumns, true),


### PR DESCRIPTION
Bug Fix

### 🔗 Related issue link

fix #36946

### 💡 Background and solution

There was a regression for Antd3 as described in #36946. If a user has the Filter Dropdown open for a table, and is making changes to it, if that table receives new data, the user's progress gets reset.

This is a very simple fix: memoize the result of a pure function, depending on the one argument passed to it. This way, the result is stable, causing a later `useMemo` not to unnecessarily run.

Details:
- If `mergedColumns` is not stable, then `mergeFilterStates` gets re-run every time. Meaning its `useMemo` is broken (https://github.com/ant-design/ant-design/blob/master/components/table/hooks/useFilter/index.tsx#L224)

- If `mergeFilterStates` always returns a new object, even if its equal, then `filterState` is always different (https://github.com/ant-design/ant-design/blob/master/components/table/hooks/useFilter/index.tsx#L87). This is a prop passed to `FilterDropdown`.

- If that's always different, then `propFilteredKeys` is always different (https://github.com/ant-design/ant-design/blob/master/components/table/hooks/useFilter/FilterDropdown.tsx#L184)

- If `propFilteredKeys` is always different then  this `useEffect` will always call `onSelectKeys` even when there is no need to. (https://github.com/ant-design/ant-design/blob/master/components/table/hooks/useFilter/FilterDropdown.tsx#L202)

- Calling `onSelectKeys` with the same selection every time should be a no-op (the useEffect should not run!) but it does, causing  `setFilteredKeysSync` to always be run (https://github.com/ant-design/ant-design/blob/master/components/table/hooks/useFilter/FilterDropdown.tsx#L188)

- Which forces an update on `setFilteredKeysSync` (https://github.com/ant-design/ant-design/blob/master/components/table/hooks/useFilter/FilterDropdown.tsx#L185)

- Which causes a reset of internal state of which checkboxes are checked.   That is, the user was making changes to which checkboxes were checked, and the component overwrote that with the incoming filtered keys.  

This only happens with a managed component.


### 📝 Changelog

Unsaved edits to the selections in the FilterDropdown are no-longer reset if unrelated Table props change during use.

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
