### PR TITLE
🐞 fix: pagination `hover` and `active` style error when size=small

### DIFF
--- a/components/pagination/Pagination.tsx
+++ b/components/pagination/Pagination.tsx
@@ -55,49 +55,51 @@ const Pagination: React.FC<PaginationProps> = ({
 
   const mergedShowSizeChanger = showSizeChanger ?? pagination.showSizeChanger;
 
-  const getIconsProps = () => {
+  const iconsProps = React.useMemo<Record<PropertyKey, React.ReactNode>>(() => {
     const ellipsis = <span className={`${prefixCls}-item-ellipsis`}>•••</span>;
-    let prevIcon = (
+    const prevIcon = (
       <button className={`${prefixCls}-item-link`} type="button" tabIndex={-1}>
-        <LeftOutlined />
+        {direction === 'rtl' ? <RightOutlined /> : <LeftOutlined />}
       </button>
     );
-    let nextIcon = (
+    const nextIcon = (
       <button className={`${prefixCls}-item-link`} type="button" tabIndex={-1}>
-        <RightOutlined />
+        {direction === 'rtl' ? <LeftOutlined /> : <RightOutlined />}
       </button>
     );
-    let jumpPrevIcon = (
+    const jumpPrevIcon = (
       <a className={`${prefixCls}-item-link`}>
-        {/* You can use transition effects in the container :) */}
         <div className={`${prefixCls}-item-container`}>
-          <DoubleLeftOutlined className={`${prefixCls}-item-link-icon`} />
+          {direction === 'rtl' ? (
+            <DoubleRightOutlined className={`${prefixCls}-item-link-icon`} />
+          ) : (
+            <DoubleLeftOutlined className={`${prefixCls}-item-link-icon`} />
+          )}
           {ellipsis}
         </div>
       </a>
     );
-    let jumpNextIcon = (
+    const jumpNextIcon = (
       <a className={`${prefixCls}-item-link`}>
-        {/* You can use transition effects in the container :) */}
         <div className={`${prefixCls}-item-container`}>
-          <DoubleRightOutlined className={`${prefixCls}-item-link-icon`} />
+          {direction === 'rtl' ? (
+            <DoubleLeftOutlined className={`${prefixCls}-item-link-icon`} />
+          ) : (
+            <DoubleRightOutlined className={`${prefixCls}-item-link-icon`} />
+          )}
           {ellipsis}
         </div>
       </a>
     );
-    // change arrows direction in right-to-left direction
-    if (direction === 'rtl') {
-      [prevIcon, nextIcon] = [nextIcon, prevIcon];
-      [jumpPrevIcon, jumpNextIcon] = [jumpNextIcon, jumpPrevIcon];
-    }
     return { prevIcon, nextIcon, jumpPrevIcon, jumpNextIcon };
-  };
+  }, [direction, prefixCls]);
 
   const [contextLocale] = useLocale('Pagination', enUS);
 
   const locale = { ...contextLocale, ...customLocale };
 
   const isSmall = size === 'small' || !!(xs && !size && responsive);
+
   const selectPrefixCls = getPrefixCls('select', customizeSelectPrefixCls);
   const extendedClassName = classNames(
     {
@@ -111,7 +113,7 @@ const Pagination: React.FC<PaginationProps> = ({
 
   return wrapSSR(
     <RcPagination
-      {...getIconsProps()}
+      {...iconsProps}
       {...restProps}
       prefixCls={prefixCls}
       selectPrefixCls={selectPrefixCls}

--- a/components/pagination/style/index.tsx
+++ b/components/pagination/style/index.tsx
@@ -57,7 +57,16 @@ const genPaginationDisabledStyle: GenerateStyle<PaginationToken, CSSObject> = (t
 
     [`&${componentCls}-disabled`]: {
       cursor: 'not-allowed',
-
+      [`&${componentCls}-mini`]: {
+        [`
+          &:hover ${componentCls}-item:not(${componentCls}-item-active),
+          &:active ${componentCls}-item:not(${componentCls}-item-active),
+          &:hover ${componentCls}-item-link,
+          &:active ${componentCls}-item-link
+        `]: {
+          backgroundColor: 'transparent',
+        },
+      },
       [`${componentCls}-item`]: {
         cursor: 'not-allowed',
 
@@ -137,6 +146,9 @@ const genPaginationMiniStyle: GenerateStyle<PaginationToken, CSSObject> = (token
       '&:hover': {
         backgroundColor: token.colorBgTextHover,
       },
+      '&:active': {
+        backgroundColor: token.colorBgTextActive,
+      },
     },
 
     [`&${componentCls}-mini ${componentCls}-prev, &${componentCls}-mini ${componentCls}-next`]: {
@@ -144,6 +156,15 @@ const genPaginationMiniStyle: GenerateStyle<PaginationToken, CSSObject> = (token
       height: token.paginationItemSizeSM,
       margin: 0,
       lineHeight: `${token.paginationItemSizeSM}px`,
+      [`&:hover ${componentCls}-item-link`]: {
+        backgroundColor: token.colorBgTextHover,
+      },
+      [`&:active ${componentCls}-item-link`]: {
+        backgroundColor: token.colorBgTextActive,
+      },
+      [`&${componentCls}-disabled:hover ${componentCls}-item-link`]: {
+        backgroundColor: 'transparent',
+      },
     },
 
     [`


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 🐞 fix: fix: pagination `hover` and `active` style error when size=small |
| 🇨🇳 Chinese | 分页器组件 size=small 的时候，分页按钮 active 样式丢失、上一页下一页按钮 hover 和 active 样式丢失 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed