### PR TITLE
fix(menu): Render the correct theme when using 'getPopupContainer'

### DIFF
--- a/components/menu/style/index.tsx
+++ b/components/menu/style/index.tsx
@@ -442,10 +442,15 @@ export default (prefixCls: string, injectStyle: boolean): UseComponentStyleResul
         return [];
       }
 
-      const { colorBgElevated, colorPrimary, colorError, colorErrorHover, colorTextLightSolid } =
-        token;
-
-      const { controlHeightLG, fontSize } = token;
+      const {
+        colorBgElevated,
+        colorPrimary,
+        colorError,
+        colorErrorHover,
+        colorTextLightSolid,
+        controlHeightLG,
+        fontSize,
+      } = token;
 
       const menuArrowSize = (fontSize / 7) * 5;
 

--- a/components/menu/style/theme.tsx
+++ b/components/menu/style/theme.tsx
@@ -46,7 +46,7 @@ const getThemeStyle = (token: MenuToken, themeSuffix: string): CSSInterpolation 
   } = token;
 
   return {
-    [`${componentCls}-${themeSuffix}`]: {
+    [`${componentCls}-${themeSuffix}, ${componentCls}-${themeSuffix} > ${componentCls}`]: {
       color: colorItemText,
       background: colorItemBg,
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
ref https://github.com/ant-design/ant-design/pull/41423#issuecomment-1482153807
### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->
当前如果在 Menu 组件中使用 `getPopupContainer` 选中主菜单（`getPopupContainer={(node) => node.parentNode}` ）时子菜单如果设置了 theme ，那么该 theme 将被主菜单 theme 覆盖，修改前后可见下图：
修改前，主菜单 theme 为dark，子菜单 theme 为 light：
![image](https://user-images.githubusercontent.com/112228030/227814173-f8a1fa19-d3ab-4596-a5e5-6091301ba364.png)

修改后
1、主菜单 theme 为 dark，子菜单 theme 为 light：
![image](https://user-images.githubusercontent.com/112228030/227814369-cc5b9174-c573-41b2-8751-5db2c751af5e.png)

2、主菜单 theme 为 light，子菜单 theme 为 dark：
![image](https://user-images.githubusercontent.com/112228030/227814477-0e4497b3-ec53-4aff-a314-151c483ea5fa.png)


### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed submenu themes being overwritten when using `getPopupContainer` to select the main menu  |
| 🇨🇳 Chinese | 修复使用 `getPopupContainer` 选择主菜单时子菜单主题被覆盖           |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
