### PR TITLE
fix(input): textarea style bug

### DIFF
--- a/components/input/style/index.ts
+++ b/components/input/style/index.ts
@@ -890,6 +890,12 @@ const genTextAreaStyle: GenerateStyle<InputToken> = (token) => {
         },
       },
 
+      '&-allow-clear': {
+        [`> ${componentCls}`]: {
+          paddingInlineEnd: paddingLG,
+        },
+      },
+
       [`&-affix-wrapper${textareaPrefixCls}-has-feedback`]: {
         [`${componentCls}`]: {
           paddingInlineEnd: paddingLG,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
close #41125

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
4. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->
![image](https://user-images.githubusercontent.com/67216143/223910346-9d161143-4576-4a5f-bae3-f10b73450bbb.png)


### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  fix style bug         |
| 🇨🇳 Chinese |  修复文字覆盖关闭按钮的问题         |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
