### PR TITLE
fix: CP nonce should work on cssinjs

### DIFF
--- a/components/config-provider/__tests__/nonce.test.tsx
+++ b/components/config-provider/__tests__/nonce.test.tsx
@@ -1,8 +1,10 @@
+import { createCache, StyleProvider } from '@ant-design/cssinjs';
 import { SmileOutlined } from '@ant-design/icons';
 import IconContext from '@ant-design/icons/lib/components/Context';
 import React from 'react';
-import { render } from '../../../tests/utils';
 import ConfigProvider from '..';
+import { render } from '../../../tests/utils';
+import Button from '../../button';
 
 describe('ConfigProvider.Icon', () => {
   beforeEach(() => {
@@ -61,5 +63,22 @@ describe('ConfigProvider.Icon', () => {
     expect(container.querySelector('.bamboo-smile')).toBeTruthy();
     expect(styleNode?.nonce).toEqual('light');
     expect(container.querySelector('#csp')?.innerHTML).toEqual('light');
+  });
+
+  it('cssinjs should support nonce', () => {
+    render(
+      <StyleProvider cache={createCache()}>
+        <ConfigProvider csp={{ nonce: 'bamboo' }}>
+          <Button />
+        </ConfigProvider>
+      </StyleProvider>,
+    );
+
+    const styleList = Array.from(document.querySelectorAll('style'));
+
+    expect(styleList.length).toBeTruthy();
+    styleList.forEach((style) => {
+      expect(style.nonce).toEqual('bamboo');
+    });
   });
 });

--- a/components/config-provider/index.tsx
+++ b/components/config-provider/index.tsx
@@ -206,7 +206,7 @@ const ProviderChildren: React.FC<ProviderChildrenProps> = (props) => {
   const shouldWrapSSR = iconPrefixCls !== parentContext.iconPrefixCls;
   const csp = customCsp || parentContext.csp;
 
-  const wrapSSR = useStyle(iconPrefixCls);
+  const wrapSSR = useStyle(iconPrefixCls, csp);
 
   const mergedTheme = useTheme(theme, parentContext.theme);
 

--- a/components/config-provider/style/index.ts
+++ b/components/config-provider/style/index.ts
@@ -1,12 +1,20 @@
 import { useStyleRegister } from '@ant-design/cssinjs';
+import type { CSPConfig } from '..';
 import { resetIcon } from '../../style';
 import { useToken } from '../../theme/internal';
 
-const useStyle = (iconPrefixCls: string) => {
+const useStyle = (iconPrefixCls: string, csp?: CSPConfig) => {
   const [theme, token] = useToken();
+
   // Generate style for icons
   return useStyleRegister(
-    { theme, token, hashId: '', path: ['ant-design-icons', iconPrefixCls] },
+    {
+      theme,
+      token,
+      hashId: '',
+      path: ['ant-design-icons', iconPrefixCls],
+      nonce: () => csp?.nonce!,
+    },
     () => [
       {
         [`.${iconPrefixCls}`]: {

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
   ],
   "dependencies": {
     "@ant-design/colors": "^7.0.0",
-    "@ant-design/cssinjs": "^1.5.6",
+    "@ant-design/cssinjs": "^1.7.1",
     "@ant-design/icons": "^5.0.0",
     "@ant-design/react-slick": "~1.0.0",
     "@babel/runtime": "^7.18.3",


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

fix #40355

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fix ConfigProvider `nonce` not working on CSS-in-JS style.     |
| 🇨🇳 Chinese |      修复 ConfigProvider `nonce` 对 CSS-in-JS 样式不生效的问题。     |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
