### PR TITLE
WIP feat(collapse): support items

### DIFF
--- a/components/collapse/Collapse.tsx
+++ b/components/collapse/Collapse.tsx
@@ -145,13 +145,9 @@ const Collapse = React.forwardRef<HTMLDivElement, CollapseProps>((props, ref) =>
     if (Array.isArray(items)) {
       return items.map((item, index) => {
         const key = item.key || String(index);
-        const { disabled, collapsible, content, ...restItemProps } = item;
+        const { content, ...restItemProps } = item;
         return (
-          <CollapsePanel
-            key={key}
-            collapsible={collapsible ?? (disabled ? 'disabled' : undefined)}
-            {...restItemProps}
-          >
+          <CollapsePanel key={key} {...restItemProps}>
             {content}
           </CollapsePanel>
         );

--- a/components/collapse/Collapse.tsx
+++ b/components/collapse/Collapse.tsx
@@ -6,11 +6,12 @@ import * as React from 'react';
 
 import toArray from 'rc-util/lib/Children/toArray';
 import omit from 'rc-util/lib/omit';
+import type { CollapsibleType } from 'rc-collapse/es/interface';
 import { ConfigContext } from '../config-provider';
 import initCollapseMotion from '../_util/motion';
 import { cloneElement } from '../_util/reactNode';
 import warning from '../_util/warning';
-import type { CollapsibleType } from './CollapsePanel';
+import type { CollapsePanelProps } from './CollapsePanel';
 import type { SizeType } from '../config-provider/SizeContext';
 import SizeContext from '../config-provider/SizeContext';
 import CollapsePanel from './CollapsePanel';
@@ -20,6 +21,22 @@ import useStyle from './style';
 /** @deprecated Please use `start` | `end` instead */
 type ExpandIconPositionLegacy = 'left' | 'right';
 export type ExpandIconPosition = 'start' | 'end' | ExpandIconPositionLegacy | undefined;
+
+type ItemType = Pick<
+  CollapsePanelProps,
+  | 'expandIcon'
+  | 'header'
+  | 'extra'
+  | 'disabled'
+  | 'collapsible'
+  | 'onItemClick'
+  // css motion
+  | 'forceRender'
+  | 'destroyInactivePanel'
+> & {
+  key?: React.Key;
+  content?: React.ReactNode;
+};
 
 export interface CollapseProps {
   activeKey?: Array<string | number> | string | number;
@@ -43,7 +60,7 @@ export interface CollapseProps {
    * Collapse item content
    * @since 5.4.0
    */
-  items: any[];
+  items?: ItemType[];
 }
 
 interface PanelProps {
@@ -127,7 +144,22 @@ const Collapse = React.forwardRef<HTMLDivElement, CollapseProps>((props, ref) =>
   };
 
   const getItems = () => {
-    const { children } = props;
+    const { children, items } = props;
+    if (Array.isArray(items)) {
+      return items.map((item, index) => {
+        const key = item.key || String(index);
+        const { disabled, collapsible, content, ...restItemProps } = item;
+        return (
+          <CollapsePanel
+            key={key}
+            collapsible={collapsible ?? (disabled ? 'disabled' : undefined)}
+            {...restItemProps}
+          >
+            {content}
+          </CollapsePanel>
+        );
+      });
+    }
     return toArray(children).map((child: React.ReactElement, index: number) => {
       if (child.props?.disabled) {
         const key = child.key || String(index);
@@ -163,7 +195,7 @@ if (process.env.NODE_ENV !== 'production') {
 
 export default Object.assign(Collapse, {
   /**
-   * @deprecated Please use Collapse.items instead
+   * @deprecated Please use `<Collapse items={[]} />` instead
    */
   Panel: CollapsePanel,
 });

--- a/components/collapse/Collapse.tsx
+++ b/components/collapse/Collapse.tsx
@@ -22,7 +22,7 @@ import useStyle from './style';
 type ExpandIconPositionLegacy = 'left' | 'right';
 export type ExpandIconPosition = 'start' | 'end' | ExpandIconPositionLegacy | undefined;
 
-type ItemType = Pick<
+export type ItemType = Pick<
   CollapsePanelProps,
   | 'expandIcon'
   | 'header'

--- a/components/collapse/Collapse.tsx
+++ b/components/collapse/Collapse.tsx
@@ -29,7 +29,6 @@ export type ItemType = Pick<
   // | 'disabled' /** FIXME: deprecated, need export? */
   | 'collapsible'
   | 'showArrow'
-  | 'onItemClick'
   | 'forceRender'
 > & {
   key?: React.Key;

--- a/components/collapse/Collapse.tsx
+++ b/components/collapse/Collapse.tsx
@@ -39,6 +39,11 @@ export interface CollapseProps {
   size?: SizeType;
   collapsible?: CollapsibleType;
   children?: React.ReactNode;
+  /**
+   * Collapse item content
+   * @since 5.4.0
+   */
+  items: any[];
 }
 
 interface PanelProps {
@@ -156,4 +161,9 @@ if (process.env.NODE_ENV !== 'production') {
   Collapse.displayName = 'Collapse';
 }
 
-export default Object.assign(Collapse, { Panel: CollapsePanel });
+export default Object.assign(Collapse, {
+  /**
+   * @deprecated Please use Collapse.items instead
+   */
+  Panel: CollapsePanel,
+});

--- a/components/collapse/Collapse.tsx
+++ b/components/collapse/Collapse.tsx
@@ -24,15 +24,13 @@ export type ExpandIconPosition = 'start' | 'end' | ExpandIconPositionLegacy | un
 
 export type ItemType = Pick<
   CollapsePanelProps,
-  | 'expandIcon'
   | 'header'
   | 'extra'
-  | 'disabled'
+  // | 'disabled' /** FIXME: deprecated, need export? */
   | 'collapsible'
+  | 'showArrow'
   | 'onItemClick'
-  // css motion
   | 'forceRender'
-  | 'destroyInactivePanel'
 > & {
   key?: React.Key;
   content?: React.ReactNode;

--- a/components/collapse/CollapsePanel.tsx
+++ b/components/collapse/CollapsePanel.tsx
@@ -1,15 +1,26 @@
 import classNames from 'classnames';
 import RcCollapse from 'rc-collapse';
 import * as React from 'react';
-import type { CollapsePanelProps as RCcollapsePanelProps } from 'rc-collapse';
 import { ConfigContext } from '../config-provider';
 import warning from '../_util/warning';
 
-export type CollapsePanelProps = RCcollapsePanelProps & {
+export type CollapsibleType = 'header' | 'icon' | 'disabled';
+
+export interface CollapsePanelProps {
+  key: string | number;
+  header: React.ReactNode;
   /** @deprecated Use `collapsible="disabled"` instead */
   disabled?: boolean;
-};
-
+  className?: string;
+  style?: React.CSSProperties;
+  showArrow?: boolean;
+  prefixCls?: string;
+  forceRender?: boolean;
+  id?: string;
+  extra?: React.ReactNode;
+  collapsible?: CollapsibleType;
+  children?: React.ReactNode;
+}
 const CollapsePanel = React.forwardRef<HTMLDivElement, CollapsePanelProps>((props, ref) => {
   warning(
     !('disabled' in props),

--- a/components/collapse/CollapsePanel.tsx
+++ b/components/collapse/CollapsePanel.tsx
@@ -1,26 +1,15 @@
 import classNames from 'classnames';
 import RcCollapse from 'rc-collapse';
 import * as React from 'react';
+import type { CollapsePanelProps as RCcollapsePanelProps } from 'rc-collapse';
 import { ConfigContext } from '../config-provider';
 import warning from '../_util/warning';
 
-export type CollapsibleType = 'header' | 'icon' | 'disabled';
-
-export interface CollapsePanelProps {
-  key: string | number;
-  header: React.ReactNode;
+export type CollapsePanelProps = RCcollapsePanelProps & {
   /** @deprecated Use `collapsible="disabled"` instead */
   disabled?: boolean;
-  className?: string;
-  style?: React.CSSProperties;
-  showArrow?: boolean;
-  prefixCls?: string;
-  forceRender?: boolean;
-  id?: string;
-  extra?: React.ReactNode;
-  collapsible?: CollapsibleType;
-  children?: React.ReactNode;
-}
+};
+
 const CollapsePanel = React.forwardRef<HTMLDivElement, CollapsePanelProps>((props, ref) => {
   warning(
     !('disabled' in props),

--- a/components/collapse/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/collapse/__tests__/__snapshots__/index.test.tsx.snap
@@ -57,6 +57,138 @@ exports[`Collapse could override default openMotion 1`] = `
 </div>
 `;
 
+exports[`Collapse should render a items 1`] = `
+<div
+  class="ant-collapse ant-collapse-icon-position-start"
+>
+  <div
+    class="ant-collapse-item"
+  >
+    <div
+      aria-disabled="false"
+      aria-expanded="false"
+      class="ant-collapse-header"
+      role="button"
+      tabindex="0"
+    >
+      <div
+        class="ant-collapse-expand-icon"
+      >
+        <span
+          aria-label="right"
+          class="anticon anticon-right ant-collapse-arrow"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="right"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+            />
+          </svg>
+        </span>
+      </div>
+      <span
+        class="ant-collapse-header-text"
+      >
+        My header 1
+      </span>
+    </div>
+  </div>
+  <div
+    class="ant-collapse-item"
+  >
+    <div
+      aria-disabled="false"
+      aria-expanded="false"
+      class="ant-collapse-header"
+      role="button"
+      tabindex="0"
+    >
+      <div
+        class="ant-collapse-expand-icon"
+      >
+        <span
+          aria-label="right"
+          class="anticon anticon-right ant-collapse-arrow"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="right"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+            />
+          </svg>
+        </span>
+      </div>
+      <span
+        class="ant-collapse-header-text"
+      >
+        My header 2
+      </span>
+    </div>
+  </div>
+  <div
+    class="ant-collapse-item ant-collapse-item-disabled"
+  >
+    <div
+      aria-disabled="true"
+      aria-expanded="false"
+      class="ant-collapse-header"
+      role="button"
+      tabindex="-1"
+    >
+      <div
+        class="ant-collapse-expand-icon"
+      >
+        <span
+          aria-label="right"
+          class="anticon anticon-right ant-collapse-arrow"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="right"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+            />
+          </svg>
+        </span>
+      </div>
+      <span
+        class="ant-collapse-header-text"
+      >
+        My header 3
+      </span>
+      <div
+        class="ant-collapse-extra"
+      >
+        extra
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Collapse should render extra node of panel 1`] = `
 <div
   class="ant-collapse ant-collapse-icon-position-start"

--- a/components/collapse/__tests__/index.test.tsx
+++ b/components/collapse/__tests__/index.test.tsx
@@ -211,7 +211,7 @@ describe('Collapse', () => {
     });
   });
 
-  it.only('should render a items', () => {
+  it('should render a items', () => {
     const itemClick = jest.fn();
 
     const items: ItemType[] = [
@@ -223,13 +223,12 @@ describe('Collapse', () => {
       {
         header: 'My header 2',
         content: 'Ant Design Collapse 2',
-        expandIcon: () => 'icon',
       },
       {
         header: 'My header 3',
         content: 'Ant Design Collapse 3',
         extra: 'extra',
-        disabled: true,
+        collapsible: 'disabled',
         onItemClick: itemClick,
       },
     ];

--- a/components/collapse/__tests__/index.test.tsx
+++ b/components/collapse/__tests__/index.test.tsx
@@ -212,13 +212,10 @@ describe('Collapse', () => {
   });
 
   it('should render a items', () => {
-    const itemClick = jest.fn();
-
     const items: ItemType[] = [
       {
         header: 'My header 1',
         content: 'Ant Design Collapse 1',
-        onItemClick: itemClick,
       },
       {
         header: 'My header 2',
@@ -229,21 +226,11 @@ describe('Collapse', () => {
         content: 'Ant Design Collapse 3',
         extra: 'extra',
         collapsible: 'disabled',
-        onItemClick: itemClick,
       },
     ];
 
     const { container } = render(<Collapse items={items} />);
 
     expect(container.firstChild).toMatchSnapshot();
-    const itemsElements = container.querySelectorAll('.ant-collapse-header');
-
-    // click
-    fireEvent.click(itemsElements[0]);
-    expect(itemClick).toHaveBeenCalledTimes(1);
-
-    // click disabled
-    fireEvent.click(itemsElements[2]);
-    expect(itemClick).toHaveBeenCalledTimes(1);
   });
 });

--- a/components/collapse/__tests__/index.test.tsx
+++ b/components/collapse/__tests__/index.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { act } from 'react-dom/test-utils';
 import { waitFakeTimer, render, fireEvent } from '../../../tests/utils';
 import { resetWarned } from '../../_util/warning';
+import type { ItemType } from '../Collapse';
 
 describe('Collapse', () => {
   // eslint-disable-next-line global-require
@@ -208,5 +209,42 @@ describe('Collapse', () => {
         expect(container.querySelector('.ant-collapse-icon-position-end')).toBeTruthy();
       });
     });
+  });
+
+  it.only('should render a items', () => {
+    const itemClick = jest.fn();
+
+    const items: ItemType[] = [
+      {
+        header: 'My header 1',
+        content: 'Ant Design Collapse 1',
+        onItemClick: itemClick,
+      },
+      {
+        header: 'My header 2',
+        content: 'Ant Design Collapse 2',
+        expandIcon: () => 'icon',
+      },
+      {
+        header: 'My header 3',
+        content: 'Ant Design Collapse 3',
+        extra: 'extra',
+        disabled: true,
+        onItemClick: itemClick,
+      },
+    ];
+
+    const { container } = render(<Collapse items={items} />);
+
+    expect(container.firstChild).toMatchSnapshot();
+    const itemsElements = container.querySelectorAll('.ant-collapse-header');
+
+    // click
+    fireEvent.click(itemsElements[0]);
+    expect(itemClick).toHaveBeenCalledTimes(1);
+
+    // click disabled
+    fireEvent.click(itemsElements[2]);
+    expect(itemClick).toHaveBeenCalledTimes(1);
   });
 });

--- a/components/collapse/demo/basic.tsx
+++ b/components/collapse/demo/basic.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import { Collapse } from 'antd';
 
-const { Panel } = Collapse;
-
 const text = `
   A dog is a type of domesticated animal.
   Known for its loyalty and faithfulness,
@@ -15,17 +13,27 @@ const App: React.FC = () => {
   };
 
   return (
-    <Collapse defaultActiveKey={['1']} onChange={onChange}>
-      <Panel header="This is panel header 1" key="1">
-        <p>{text}</p>
-      </Panel>
-      <Panel header="This is panel header 2" key="2">
-        <p>{text}</p>
-      </Panel>
-      <Panel header="This is panel header 3" key="3">
-        <p>{text}</p>
-      </Panel>
-    </Collapse>
+    <Collapse
+      defaultActiveKey={['1']}
+      onChange={onChange}
+      items={[
+        {
+          key: '1',
+          header: 'This is panel header 1',
+          content: <p>{text}</p>,
+        },
+        {
+          key: '2',
+          header: 'This is panel header 2',
+          content: <p>{text}</p>,
+        },
+        {
+          key: '3',
+          header: 'This is panel header 3',
+          content: <p>{text}</p>,
+        },
+      ]}
+    />
   );
 };
 

--- a/components/collapse/index.en-US.md
+++ b/components/collapse/index.en-US.md
@@ -13,6 +13,29 @@ A content area which can be collapsed and expanded.
 - Can be used to group or hide complex regions to keep the page clean.
 - `Accordion` is a special kind of `Collapse`, which allows only one panel to be expanded at a time.
 
+```jsx
+// works when >=5.4.0, recommended ✅
+return (
+  <Collapse
+    items={[
+      { key: '1', header: 'My header 1', content: 'Ant Design Collapse 1' },
+      { key: '2', header: 'My header 2', content: 'Ant Design Collapse 2' },
+    ]}
+  />
+);
+// works when <5.4.0, deprecated when >=5.4.0 🙅🏻‍♀️
+return (
+  <Collapse>
+    <Collapse.Panel key="1" header="My header 1">
+      Ant Design Collapse 1
+    </Collapse.Panel>
+    <Collapse.Panel key="2" header="My header 2">
+      Ant Design Collapse 2
+    </Collapse.Panel>
+  </Collapse>
+);
+```
+
 ## Examples
 
 <!-- prettier-ignore -->

--- a/components/collapse/index.en-US.md
+++ b/components/collapse/index.en-US.md
@@ -15,23 +15,12 @@ A content area which can be collapsed and expanded.
 
 ```jsx
 // works when >=5.4.0, recommended ✅
-return (
-  <Collapse
-    items={[
-      { key: '1', header: 'My header 1', content: 'Ant Design Collapse 1' },
-      { key: '2', header: 'My header 2', content: 'Ant Design Collapse 2' },
-    ]}
-  />
-);
+return <Collapse items={[{ header: 'My header', content: 'Ant Design Collapse' }]} />;
+
 // works when <5.4.0, deprecated when >=5.4.0 🙅🏻‍♀️
 return (
   <Collapse>
-    <Collapse.Panel key="1" header="My header 1">
-      Ant Design Collapse 1
-    </Collapse.Panel>
-    <Collapse.Panel key="2" header="My header 2">
-      Ant Design Collapse 2
-    </Collapse.Panel>
+    <Collapse.Panel header="My header">Ant Design Collapse</Collapse.Panel>
   </Collapse>
 );
 ```
@@ -66,6 +55,7 @@ return (
 | expandIconPosition | Set expand icon position | `start` \| `end` | - | 4.21.0 |
 | ghost | Make the collapse borderless and its background transparent | boolean | false | 4.4.0 |
 | size | Set the size of collapse | `large` \| `middle` \| `small` | `middle` | 5.2.0 |
+| items | Collapse item content | - | 5.4.0 |
 | onChange | Callback function executed when active panel is changed | function | - |  |
 
 ### Collapse.Panel

--- a/components/collapse/index.zh-CN.md
+++ b/components/collapse/index.zh-CN.md
@@ -14,6 +14,29 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*sir-TK0HkWcAAA
 - 对复杂区域进行分组和隐藏，保持页面的整洁。
 - `手风琴` 是一种特殊的折叠面板，只允许单个内容区域展开。
 
+```jsx
+// >=5.4.0 可用，推荐的写法 ✅
+return (
+  <Collapse
+    items={[
+      { key: '1', header: 'My header 1', content: 'Ant Design Collapse 1' },
+      { key: '2', header: 'My header 2', content: 'Ant Design Collapse 2' },
+    ]}
+  />
+);
+// <5.4.0 可用，>=5.4.0 时不推荐 🙅🏻‍♀️
+return (
+  <Collapse>
+    <Collapse.Panel key="1" header="My header 1">
+      Ant Design Collapse 1
+    </Collapse.Panel>
+    <Collapse.Panel key="2" header="My header 2">
+      Ant Design Collapse 2
+    </Collapse.Panel>
+  </Collapse>
+);
+```
+
 ## 代码演示
 
 <!-- prettier-ignore -->

--- a/components/collapse/index.zh-CN.md
+++ b/components/collapse/index.zh-CN.md
@@ -16,23 +16,12 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*sir-TK0HkWcAAA
 
 ```jsx
 // >=5.4.0 可用，推荐的写法 ✅
-return (
-  <Collapse
-    items={[
-      { key: '1', header: 'My header 1', content: 'Ant Design Collapse 1' },
-      { key: '2', header: 'My header 2', content: 'Ant Design Collapse 2' },
-    ]}
-  />
-);
+return <Collapse items={[{ header: 'My header', content: 'Ant Design Collapse' }]} />;
+
 // <5.4.0 可用，>=5.4.0 时不推荐 🙅🏻‍♀️
 return (
   <Collapse>
-    <Collapse.Panel key="1" header="My header 1">
-      Ant Design Collapse 1
-    </Collapse.Panel>
-    <Collapse.Panel key="2" header="My header 2">
-      Ant Design Collapse 2
-    </Collapse.Panel>
+    <Collapse.Panel header="My header">Ant Design Collapse</Collapse.Panel>
   </Collapse>
 );
 ```
@@ -67,6 +56,7 @@ return (
 | expandIconPosition | 设置图标位置 | `start` \| `end` | - | 4.21.0 |
 | ghost | 使折叠面板透明且无边框 | boolean | false | 4.4.0 |
 | size | 设置折叠面板大小 | `large` \| `middle` \| `small` | `middle` | 5.2.0 |
+| items | 折叠内容 | - | 5.4.0 |
 | onChange | 切换面板的回调 | function | - |  |
 
 ### Collapse.Panel


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    `<Collapse />`  support items  props  |
| 🇨🇳 Chinese |    `<Collapse />`  支持 items 属性      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 565a34f</samp>

### Summary
🧪✨📝

<!--
1.  🧪 - This emoji represents testing or experimentation, and can be used for the first change, which added a test case for the new `items` prop of the `Collapse` component.
2.  ✨ - This emoji represents a new feature or enhancement, and can be used for the second change, which added the `items` prop to the `Collapse` component and deprecated the `Panel` property.
3.  📝 - This emoji represents documentation or writing, and can be used for the third, fourth, and fifth changes, which updated the demo, the documentation file, and the Chinese documentation for the `Collapse` component.
-->
Enhanced the `Collapse` component to accept an `items` prop that simplifies creating collapsible panels from an array of data. Deprecated the `Panel` children in favor of the `items` prop. Updated the documentation and demos to reflect the new API. Added a new `collapsible` prop to control the panel behavior.

> _Oh we're the coders of the `Collapse` component_
> _We make it easy to render panels from content_
> _We added the `items` prop and deprecated `Panel`_
> _So heave away, me hearties, heave away and sail_

### Walkthrough
*  Add `items` prop to `Collapse` component to allow passing an array of panel props and content instead of using `Panel` children ([link](https://github.com/ant-design/ant-design/pull/41491/files?diff=unified&w=0#diff-3541251bb31318316b91e1f6710b646bd92edaff4318ca790c6401bea6962fc9R25-R37), [link](https://github.com/ant-design/ant-design/pull/41491/files?diff=unified&w=0#diff-3541251bb31318316b91e1f6710b646bd92edaff4318ca790c6401bea6962fc9R56-R60), [link](https://github.com/ant-design/ant-design/pull/41491/files?diff=unified&w=0#diff-3541251bb31318316b91e1f6710b646bd92edaff4318ca790c6401bea6962fc9L125-R155), [link](https://github.com/ant-design/ant-design/pull/41491/files?diff=unified&w=0#diff-80196f1c3a222b13f4be47d5ed6461a8767e35482104430410405c1bc047af75R58), [link](https://github.com/ant-design/ant-design/pull/41491/files?diff=unified&w=0#diff-d54c8a5b222ce1fa0e8d1043fc79b037bc9eb27d38bd30409d690c8275ac2c62R59))
*  Mark `Panel` property of `Collapse` component as deprecated and warn users to use `items` prop instead ([link](https://github.com/ant-design/ant-design/pull/41491/files?diff=unified&w=0#diff-3541251bb31318316b91e1f6710b646bd92edaff4318ca790c6401bea6962fc9L159-R194), [link](https://github.com/ant-design/ant-design/pull/41491/files?diff=unified&w=0#diff-80196f1c3a222b13f4be47d5ed6461a8767e35482104430410405c1bc047af75R16-R27), [link](https://github.com/ant-design/ant-design/pull/41491/files?diff=unified&w=0#diff-d54c8a5b222ce1fa0e8d1043fc79b037bc9eb27d38bd30409d690c8275ac2c62R17-R28))
*  Change import of `CollapsibleType` from `./CollapsePanel` to `rc-collapse/es/interface` to avoid circular dependency ([link](https://github.com/ant-design/ant-design/pull/41491/files?diff=unified&w=0#diff-3541251bb31318316b91e1f6710b646bd92edaff4318ca790c6401bea6962fc9L9-R14))
*  Add test case for `Collapse` component with `items` prop ([link](https://github.com/ant-design/ant-design/pull/41491/files?diff=unified&w=0#diff-7ae79cbc67cfccab3a9408bdf76b42ff922c78f24fbac4979e76551749d7b378R5), [link](https://github.com/ant-design/ant-design/pull/41491/files?diff=unified&w=0#diff-7ae79cbc67cfccab3a9408bdf76b42ff922c78f24fbac4979e76551749d7b378R213-R235))


