### PR TITLE
fix: forcePopupAlign is align to forceAlign instead

### DIFF
--- a/components/slider/SliderTooltip.tsx
+++ b/components/slider/SliderTooltip.tsx
@@ -18,7 +18,7 @@ const SliderTooltip = React.forwardRef<unknown, TooltipProps>((props, ref) => {
 
   function keepAlign() {
     rafRef.current = raf(() => {
-      innerRef.current?.forcePopupAlign();
+      innerRef.current?.forceAlign();
       rafRef.current = null;
     });
   }

--- a/components/slider/__tests__/index.test.tsx
+++ b/components/slider/__tests__/index.test.tsx
@@ -133,14 +133,14 @@ describe('Slider', () => {
     expect(container).toMatchSnapshot();
   });
 
-  it('should keepAlign by calling forcePopupAlign', async () => {
+  it('should keepAlign by calling forceAlign', async () => {
     const ref = React.createRef<any>();
     render(<SliderTooltip title="30" open ref={ref} />);
-    ref.current.forcePopupAlign = jest.fn();
+    ref.current.forceAlign = jest.fn();
     act(() => {
       jest.runAllTimers();
     });
-    expect(ref.current.forcePopupAlign).toHaveBeenCalled();
+    expect(ref.current.forceAlign).toHaveBeenCalled();
   });
 
   it('tipFormatter should not crash with undefined value', () => {

--- a/components/tooltip/__tests__/tooltip.test.tsx
+++ b/components/tooltip/__tests__/tooltip.test.tsx
@@ -592,14 +592,15 @@ describe('Tooltip', () => {
     expect(container).toMatchSnapshot();
   });
 
-  it('forcePopupAlign can be called', async () => {
+  it('use ref.current.forcePopupAlign', async () => {
     const ref = React.createRef<any>();
+    const error = jest.spyOn(console, 'error').mockImplementation(() => {});
     render(<Tooltip open ref={ref} />);
-    ref.current.forcePopupAlign = jest.fn();
     act(() => {
-      ref.current.forcePopupAlign()
+      ref.current.forcePopupAlign();
       jest.runAllTimers();
     });
-    expect(ref.current.forcePopupAlign).toHaveBeenCalled();
+    expect(error).toHaveBeenCalled();
+    error.mockRestore();
   });
 });

--- a/components/tooltip/__tests__/tooltip.test.tsx
+++ b/components/tooltip/__tests__/tooltip.test.tsx
@@ -1,5 +1,6 @@
 import { spyElementPrototype } from 'rc-util/lib/test/domHook';
 import React from 'react';
+import { act } from 'react-dom/test-utils';
 import type { TooltipPlacement } from '..';
 import Tooltip from '..';
 import mountTest from '../../../tests/shared/mountTest';
@@ -589,5 +590,16 @@ describe('Tooltip', () => {
       </Tooltip>,
     );
     expect(container).toMatchSnapshot();
+  });
+
+  it('forcePopupAlign can be called', async () => {
+    const ref = React.createRef<any>();
+    render(<Tooltip open ref={ref} />);
+    ref.current.forcePopupAlign = jest.fn();
+    act(() => {
+      ref.current.forcePopupAlign()
+      jest.runAllTimers();
+    });
+    expect(ref.current.forcePopupAlign).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [x] Other (about what?)

### 🔗 Related issue link

close https://github.com/ant-design/ant-design/issues/41532

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    forcePopupAlign is align to forceAlign instead       |
| 🇨🇳 Chinese |     “forcePopupAlign”改为“forceAlign”      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ef929c7</samp>

Rename `forcePopupAlign` to `forceAlign` in `SliderTooltip` component and update test case. This improves the consistency and clarity of the code and ensures the test case passes.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ef929c7</samp>

*  Rename `forcePopupAlign` method to `forceAlign` in `SliderTooltip` component to match the underlying `Align` component from `rc-align` ([link](https://github.com/ant-design/ant-design/pull/41540/files?diff=unified&w=0#diff-fcd4af359a451a2a3eb4f0d0e9d052cf0f1a10d32cc2c9033988cea681ce88a0L21-R21))
*  Update test case for `SliderTooltip` component to use `forceAlign` method instead of `forcePopupAlign` method and verify that it is called when `keepAlign` function is triggered ([link](https://github.com/ant-design/ant-design/pull/41540/files?diff=unified&w=0#diff-0109698c15bdf20cfbc3ebbf6d97cca423b37639651868154216f3c19c4520c2L136-R143))
