### PR TITLE
fix: calendar onChange only trigger change

### DIFF
--- a/components/calendar/generateCalendar.tsx
+++ b/components/calendar/generateCalendar.tsx
@@ -310,7 +310,7 @@ function generateCalendar<DateType>(generateConfig: GenerateConfig<DateType>) {
           headerRender({
             value: mergedValue,
             type: mergedMode,
-            onChange: onInternalSelect,
+            onChange: triggerChange,
             onTypeChange: triggerModeChange,
           })
         ) : (
@@ -322,7 +322,7 @@ function generateCalendar<DateType>(generateConfig: GenerateConfig<DateType>) {
             fullscreen={fullscreen}
             locale={contextLocale?.lang}
             validRange={validRange}
-            onChange={onInternalSelect}
+            onChange={triggerChange}
             onModeChange={triggerModeChange}
           />
         )}


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link
https://github.com/ant-design/ant-design/issues/39801
<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

The Calendar header (`headerRender` or `CalendarHeader`) onChange call same function with `RCPickerPanel`, `onInternalSelect`.
The `onInternalSelect` call `tirggerChange `and `onSelect`.
It cause date change event trigger `onSelect` without select event.
Therefore I change to the header onChange cal only `triggerChange`

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fix Calendar onSelect trigger when date changed without select |
| 🇨🇳 Chinese |  在没有选择的情况下更改日期时修复Calendar onSelect 触发器  |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c7b6eb9</samp>

Fixed a calendar bug that caused incorrect value display. Refactored `onChange` prop logic in `components/calendar/generateCalendar.tsx`.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c7b6eb9</samp>

* Fix calendar header value update issue (#32843) by changing `onChange` prop of `Header` and `FullCalendar` components from `onInternalSelect` to `triggerChange` ([link](https://github.com/ant-design/ant-design/pull/41553/files?diff=unified&w=0#diff-841e97dfb23daba72a34ee15810c8b36da6464eba16e120739ec6c9636f94fb2L260-R260), [link](https://github.com/ant-design/ant-design/pull/41553/files?diff=unified&w=0#diff-841e97dfb23daba72a34ee15810c8b36da6464eba16e120739ec6c9636f94fb2L272-R272)) in `components/calendar/generateCalendar.tsx`
