### PR TITLE
feat(Form.Item): useStatus supports get error messages and warning messages

### DIFF
--- a/components/form/FormItem/ItemHolder.tsx
+++ b/components/form/FormItem/ItemHolder.tsx
@@ -123,6 +123,7 @@ export default function ItemHolder(props: ItemHolderProps) {
     return {
       status: mergedValidateStatus,
       errors,
+      warnings,
       hasFeedback,
       feedbackIcon,
       isFormItemInput: true,

--- a/components/form/FormItem/ItemHolder.tsx
+++ b/components/form/FormItem/ItemHolder.tsx
@@ -122,6 +122,7 @@ export default function ItemHolder(props: ItemHolderProps) {
 
     return {
       status: mergedValidateStatus,
+      errors,
       hasFeedback,
       feedbackIcon,
       isFormItemInput: true,

--- a/components/form/__tests__/index.test.tsx
+++ b/components/form/__tests__/index.test.tsx
@@ -1477,6 +1477,53 @@ describe('Form', () => {
     );
   });
 
+  it('Form.Item.useStatus should supports get error messages and warning messages', async () => {
+    const {
+      Item: { useStatus },
+    } = Form;
+
+    const ErrorItem: React.FC = () => {
+      const { errors } = useStatus();
+      return <div className="test-error">{errors[0]}</div>;
+    };
+
+    const WarningItem: React.FC = () => {
+      const { warnings } = useStatus();
+      return <div className="test-warning">{warnings[0]}</div>;
+    };
+
+    const Demo: React.FC = () => {
+      const [form] = Form.useForm();
+
+      return (
+        <Form form={form} name='test-form'>
+          <Form.Item name="error" rules={[{ required: true, message: 'This is a error message.' }]}>
+            <ErrorItem />
+          </Form.Item>
+          <Form.Item
+            name="warning"
+            rules={[{ required: true, message: 'This is a warning message.', warningOnly: true }]}
+          >
+            <WarningItem />
+          </Form.Item>
+          <Button onClick={() => form.submit()} className="submit-button">
+            Submit
+          </Button>
+        </Form>
+      );
+    };
+
+    const { container } = render(<Demo />);
+
+    fireEvent.click(container.querySelector('.submit-button')!);
+    await waitFakeTimer();
+
+    expect(container.querySelector('.test-error')).toHaveTextContent('This is a error message.');
+    expect(container.querySelector('.test-warning')).toHaveTextContent(
+      'This is a warning message.',
+    );
+  });
+
   it('item customize margin', async () => {
     const computeSpy = jest
       .spyOn(window, 'getComputedStyle')

--- a/components/form/context.tsx
+++ b/components/form/context.tsx
@@ -57,6 +57,7 @@ export const FormItemPrefixContext = React.createContext<FormItemPrefixContextPr
 export interface FormItemStatusContextProps {
   isFormItemInput?: boolean;
   status?: ValidateStatus;
+  errors?: React.ReactNode[];
   hasFeedback?: boolean;
   feedbackIcon?: ReactNode;
 }

--- a/components/form/context.tsx
+++ b/components/form/context.tsx
@@ -58,6 +58,7 @@ export interface FormItemStatusContextProps {
   isFormItemInput?: boolean;
   status?: ValidateStatus;
   errors?: React.ReactNode[];
+  warnings?: React.ReactNode[];
   hasFeedback?: boolean;
   feedbackIcon?: ReactNode;
 }

--- a/components/form/hooks/useFormItemStatus.ts
+++ b/components/form/hooks/useFormItemStatus.ts
@@ -5,10 +5,11 @@ import warning from '../../_util/warning';
 
 type UseFormItemStatus = () => {
   status?: ValidateStatus;
+  errors: React.ReactNode[];
 };
 
 const useFormItemStatus: UseFormItemStatus = () => {
-  const { status } = useContext(FormItemInputContext);
+  const { status, errors = [] } = useContext(FormItemInputContext);
 
   warning(
     status !== undefined,
@@ -16,7 +17,7 @@ const useFormItemStatus: UseFormItemStatus = () => {
     'Form.Item.useStatus should be used under Form.Item component. For more information: https://u.ant.design/form-item-usestatus',
   );
 
-  return { status };
+  return { status, errors };
 };
 
 // Only used for compatible package. Not promise this will work on future version.

--- a/components/form/hooks/useFormItemStatus.ts
+++ b/components/form/hooks/useFormItemStatus.ts
@@ -6,10 +6,11 @@ import warning from '../../_util/warning';
 type UseFormItemStatus = () => {
   status?: ValidateStatus;
   errors: React.ReactNode[];
+  warnings: React.ReactNode[];
 };
 
 const useFormItemStatus: UseFormItemStatus = () => {
-  const { status, errors = [] } = useContext(FormItemInputContext);
+  const { status, errors = [], warnings = [] } = useContext(FormItemInputContext);
 
   warning(
     status !== undefined,
@@ -17,7 +18,7 @@ const useFormItemStatus: UseFormItemStatus = () => {
     'Form.Item.useStatus should be used under Form.Item component. For more information: https://u.ant.design/form-item-usestatus',
   );
 
-  return { status, errors };
+  return { status, errors, warnings };
 };
 
 // Only used for compatible package. Not promise this will work on future version.

--- a/components/form/index.en-US.md
+++ b/components/form/index.en-US.md
@@ -401,14 +401,24 @@ const Demo = () => {
 
 ### Form.Item.useStatus
 
-`type Form.useFormItemStatus = (): { status: ValidateStatus | undefined }`
+`type Form.Item.useStatus = (): { status: ValidateStatus | undefined, errors: ReactNode[] }`
 
-Added in `4.22.0`. Could be used to get validate status of Form.Item. If this hook is not used under Form.Item, `status` would be `undefined`:
+Added in `4.22.0`. Could be used to get validate status of Form.Item. If this hook is not used under Form.Item, `status` would be `undefined`. Added `error` in `5.4.0`, Could be used to get error messages of Form.Item:
 
 ```tsx
 const CustomInput = ({ value, onChange }) => {
-  const { status } = Form.Item.useStatus();
-  return <input value={value} onChange={onChange} className={`custom-input-${status}`} />;
+  const { status, errors } = Form.Item.useStatus();
+  return (
+    <Input
+      suffix={
+        status === 'error' && (
+          <Tooltip open title={errors[0]}>
+            <ExclamationCircleOutlined />
+          </Tooltip>
+        )
+      }
+    />
+  );
 };
 
 export default () => (

--- a/components/form/index.en-US.md
+++ b/components/form/index.en-US.md
@@ -401,9 +401,9 @@ const Demo = () => {
 
 ### Form.Item.useStatus
 
-`type Form.Item.useStatus = (): { status: ValidateStatus | undefined, errors: ReactNode[] }`
+`type Form.Item.useStatus = (): { status: ValidateStatus | undefined, errors: ReactNode[], warnings: ReactNode[] }`
 
-Added in `4.22.0`. Could be used to get validate status of Form.Item. If this hook is not used under Form.Item, `status` would be `undefined`. Added `error` in `5.4.0`, Could be used to get error messages of Form.Item:
+Added in `4.22.0`. Could be used to get validate status of Form.Item. If this hook is not used under Form.Item, `status` would be `undefined`. Added `error` and `warnings` in `5.4.0`, Could be used to get error messages and warning messages of Form.Item:
 
 ```tsx
 const CustomInput = ({ value, onChange }) => {

--- a/components/form/index.en-US.md
+++ b/components/form/index.en-US.md
@@ -409,14 +409,11 @@ Added in `4.22.0`. Could be used to get validate status of Form.Item. If this ho
 const CustomInput = ({ value, onChange }) => {
   const { status, errors } = Form.Item.useStatus();
   return (
-    <Input
-      suffix={
-        status === 'error' && (
-          <Tooltip open title={errors[0]}>
-            <ExclamationCircleOutlined />
-          </Tooltip>
-        )
-      }
+    <input
+      value={value}
+      onChange={onChange}
+      className={`custom-input-${status}`}
+      placeholder={(errors.length && errors[0]) || ''}
     />
   );
 };

--- a/components/form/index.zh-CN.md
+++ b/components/form/index.zh-CN.md
@@ -400,9 +400,9 @@ const Demo = () => {
 
 ### Form.Item.useStatus
 
-`type Form.Item.useStatus = (): { status: ValidateStatus | undefined, errors: ReactNode[] }`
+`type Form.Item.useStatus = (): { status: ValidateStatus | undefined, errors: ReactNode[], warnings: ReactNode[] }`
 
-`4.22.0` 新增，可用于获取当前 Form.Item 的校验状态，如果上层没有 Form.Item，`status` 将会返回 `undefined`。`5.4.0` 新增 `errors`，可用于获取当前 Form.Item 的错误信息：
+`4.22.0` 新增，可用于获取当前 Form.Item 的校验状态，如果上层没有 Form.Item，`status` 将会返回 `undefined`。`5.4.0` 新增 `errors` 和 `warnings`，可用于获取当前 Form.Item 的错误信息和警告信息：
 
 ```tsx
 const CustomInput = ({ value, onChange }) => {

--- a/components/form/index.zh-CN.md
+++ b/components/form/index.zh-CN.md
@@ -400,14 +400,24 @@ const Demo = () => {
 
 ### Form.Item.useStatus
 
-`type Form.Item.useStatus = (): { status: ValidateStatus | undefined }`
+`type Form.Item.useStatus = (): { status: ValidateStatus | undefined, errors: ReactNode[] }`
 
-`4.22.0` 新增，可用于获取当前 Form.Item 的校验状态，如果上层没有 Form.Item，`status` 将会返回 `undefined`：
+`4.22.0` 新增，可用于获取当前 Form.Item 的校验状态，如果上层没有 Form.Item，`status` 将会返回 `undefined`。`5.4.0` 新增 `errors`，可用于获取当前 Form.Item 的错误信息：
 
 ```tsx
 const CustomInput = ({ value, onChange }) => {
-  const { status } = Form.Item.useStatus();
-  return <input value={value} onChange={onChange} className={`custom-input-${status}`} />;
+  const { status, errors } = Form.Item.useStatus();
+  return (
+    <Input
+      suffix={
+        status === 'error' && (
+          <Tooltip open title={errors[0]}>
+            <ExclamationCircleOutlined />
+          </Tooltip>
+        )
+      }
+    />
+  );
 };
 
 export default () => (

--- a/components/form/index.zh-CN.md
+++ b/components/form/index.zh-CN.md
@@ -408,14 +408,11 @@ const Demo = () => {
 const CustomInput = ({ value, onChange }) => {
   const { status, errors } = Form.Item.useStatus();
   return (
-    <Input
-      suffix={
-        status === 'error' && (
-          <Tooltip open title={errors[0]}>
-            <ExclamationCircleOutlined />
-          </Tooltip>
-        )
-      }
+    <input
+      value={value}
+      onChange={onChange}
+      className={`custom-input-${status}`}
+      placeholder={(errors.length && errors[0]) || ''}
     />
   );
 };


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
close https://github.com/ant-design/ant-design/issues/41503

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Form.Item.useStatus supports get error messages  |
| 🇨🇳 Chinese |`Form.Item.useStatus` 支持获取错误信息           |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 00522be</samp>

Add `errors` field to `Form.Item.useStatus` hook to expose form item error messages. Update the documentation and the components that use the hook to reflect the new field. Add examples of how to use the `errors` field to display tooltips.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 00522be</samp>

*  Add `errors` field to `FormItemStatusContextProps` interface and `useFormItemStatus` hook to pass and return the error messages of the form item ([link](https://github.com/ant-design/ant-design/pull/41554/files?diff=unified&w=0#diff-dd4af975179f53bbabb7df046daec948d8fa4edfc012ef190b20a2de743e3ca9R60), [link](https://github.com/ant-design/ant-design/pull/41554/files?diff=unified&w=0#diff-695a491f0bc194a3a9a3df933126955a401a931e7890e5a4d375862aeac41062L8-R12), [link](https://github.com/ant-design/ant-design/pull/41554/files?diff=unified&w=0#diff-695a491f0bc194a3a9a3df933126955a401a931e7890e5a4d375862aeac41062L19-R20))
*  Add `errors` prop to `ItemHolder` component to render the error messages of the form item ([link](https://github.com/ant-design/ant-design/pull/41554/files?diff=unified&w=0#diff-0669e96d7e08a1ef315d1574f62b339113dc7db6ad1549ac5a649151b105596fR125))
*  Update the documentation of `Form.Item.useStatus` hook in English and Chinese to include the `errors` field and an example of using it to display a tooltip ([link](https://github.com/ant-design/ant-design/pull/41554/files?diff=unified&w=0#diff-28baad7eca32a14feb2ed5fdcee826cb1d27ee818bcbcaa6c9a8ed368c9b16e5L404-R421), [link](https://github.com/ant-design/ant-design/pull/41554/files?diff=unified&w=0#diff-f17ef6685c42eb193b5735088ef3c54e36aca982b8464077915301cabb1d4b8fL403-R420))
