### PR TITLE
🦄️ refactor: renderSwitcherIcon => React.FC

### DIFF
--- a/components/tree-select/index.tsx
+++ b/components/tree-select/index.tsx
@@ -24,7 +24,7 @@ import getIcons from '../select/utils/iconUtil';
 import { useCompactItemContext } from '../space/Compact';
 import type { AntTreeNodeProps, TreeProps } from '../tree';
 import type { SwitcherIcon } from '../tree/Tree';
-import renderSwitcherIcon from '../tree/utils/iconUtil';
+import SwitcherIconCom from '../tree/utils/iconUtil';
 import useStyle from './style';
 
 type RawValue = string | number;
@@ -208,6 +208,15 @@ const InternalTreeSelect = <
     hashId,
   );
 
+  const renderSwitcherIcon = (nodeProps: AntTreeNodeProps) => (
+    <SwitcherIconCom
+      prefixCls={treePrefixCls}
+      switcherIcon={switcherIcon}
+      treeNodeProps={nodeProps}
+      showLine={treeLine}
+    />
+  );
+
   const returnNode = (
     <RcTreeSelect
       virtual={virtual}
@@ -228,9 +237,7 @@ const InternalTreeSelect = <
       placement={memoizedPlacement}
       removeIcon={removeIcon}
       clearIcon={clearIcon}
-      switcherIcon={(nodeProps: AntTreeNodeProps) =>
-        renderSwitcherIcon(treePrefixCls, switcherIcon, nodeProps, treeLine)
-      }
+      switcherIcon={renderSwitcherIcon}
       showTreeIcon={treeIcon as any}
       notFoundContent={mergedNotFound}
       getPopupContainer={getPopupContainer || getContextPopupContainer}

--- a/components/tree/Tree.tsx
+++ b/components/tree/Tree.tsx
@@ -5,12 +5,11 @@ import RcTree from 'rc-tree';
 import type { DataNode, Key } from 'rc-tree/lib/interface';
 import type { Component } from 'react';
 import React from 'react';
-import { ConfigContext } from '../config-provider';
 import initCollapseMotion from '../_util/motion';
-import dropIndicatorRender from './utils/dropIndicator';
-import renderSwitcherIcon from './utils/iconUtil';
-
+import { ConfigContext } from '../config-provider';
 import useStyle from './style';
+import dropIndicatorRender from './utils/dropIndicator';
+import SwitcherIconCom from './utils/iconUtil';
 
 export type SwitcherIcon = React.ReactNode | ((props: AntTreeNodeProps) => React.ReactNode);
 export type TreeLeafIcon = React.ReactNode | ((props: AntTreeNodeProps) => React.ReactNode);
@@ -218,6 +217,15 @@ const Tree = React.forwardRef<RcTree, TreeProps>((props, ref) => {
     return mergedDraggable;
   }, [draggable]);
 
+  const renderSwitcherIcon = (nodeProps: AntTreeNodeProps) => (
+    <SwitcherIconCom
+      prefixCls={prefixCls}
+      switcherIcon={switcherIcon}
+      treeNodeProps={nodeProps}
+      showLine={showLine}
+    />
+  );
+
   return wrapSSR(
     <RcTree
       itemHeight={20}
@@ -238,9 +246,7 @@ const Tree = React.forwardRef<RcTree, TreeProps>((props, ref) => {
       direction={direction}
       checkable={checkable ? <span className={`${prefixCls}-checkbox-inner`} /> : checkable}
       selectable={selectable}
-      switcherIcon={(nodeProps: AntTreeNodeProps) =>
-        renderSwitcherIcon(prefixCls, switcherIcon, nodeProps, showLine)
-      }
+      switcherIcon={renderSwitcherIcon}
       draggable={draggableConfig}
     >
       {children}

--- a/components/tree/__tests__/util.test.tsx
+++ b/components/tree/__tests__/util.test.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
+import React from 'react';
 import { calcRangeKeys } from '../utils/dictUtil';
-import renderSwitcherIcon from '../utils/iconUtil';
+import SwitcherIconCom from '../utils/iconUtil';
 
 describe('Tree util', () => {
   describe('calcRangeKeys', () => {
@@ -38,20 +38,16 @@ describe('Tree util', () => {
     });
 
     it('return empty array without startKey and endKey', () => {
-      const keys = calcRangeKeys({
-        treeData,
-        expandedKeys: ['0-0', '0-2', '0-2-0'],
-      });
+      const keys = calcRangeKeys({ treeData, expandedKeys: ['0-0', '0-2', '0-2-0'] });
       expect(keys).toEqual([]);
     });
   });
 
-  describe('renderSwitcherIcon', () => {
+  describe('SwitcherIconCom', () => {
     const prefixCls = 'tree';
-
     it('returns a loading icon when loading', () => {
       const { container } = render(
-        <>{renderSwitcherIcon(prefixCls, undefined, { loading: true }, true)}</>,
+        <SwitcherIconCom prefixCls={prefixCls} treeNodeProps={{ loading: true }} showLine />,
       );
       expect(container.getElementsByClassName(`${prefixCls}-switcher-loading-icon`)).toHaveLength(
         1,
@@ -60,7 +56,11 @@ describe('Tree util', () => {
 
     it('returns nothing when node is a leaf without showLine', () => {
       const { container } = render(
-        <>{renderSwitcherIcon(prefixCls, undefined, { loading: false, isLeaf: true }, false)}</>,
+        <SwitcherIconCom
+          prefixCls={prefixCls}
+          treeNodeProps={{ loading: false, isLeaf: true }}
+          showLine={false}
+        />,
       );
       expect(container).toBeEmptyDOMElement();
     });
@@ -69,16 +69,12 @@ describe('Tree util', () => {
       const testId = 'custom-icon';
       const customLeafIcon = <div data-testid={testId} />;
       const { container } = render(
-        <>
-          {renderSwitcherIcon(
-            prefixCls,
-            undefined,
-            { loading: false, isLeaf: true },
-            { showLeafIcon: customLeafIcon },
-          )}
-        </>,
+        <SwitcherIconCom
+          prefixCls={prefixCls}
+          treeNodeProps={{ loading: false, isLeaf: true }}
+          showLine={{ showLeafIcon: customLeafIcon }}
+        />,
       );
-
       expect(screen.getByTestId(testId)).toBeVisible();
       expect(
         container.getElementsByClassName(`${prefixCls}-switcher-line-custom-icon`),
@@ -90,16 +86,12 @@ describe('Tree util', () => {
       [`${prefixCls}-switcher-leaf-line`, false],
     ])('returns %p element when showLeafIcon is %p', (expectedClassName, showLeafIcon) => {
       const { container } = render(
-        <>
-          {renderSwitcherIcon(
-            prefixCls,
-            undefined,
-            { loading: false, isLeaf: true },
-            { showLeafIcon },
-          )}
-        </>,
+        <SwitcherIconCom
+          prefixCls={prefixCls}
+          treeNodeProps={{ loading: false, isLeaf: true }}
+          showLine={{ showLeafIcon }}
+        />,
       );
-
       expect(container.getElementsByClassName(expectedClassName)).toHaveLength(1);
     });
   });

--- a/components/tree/utils/iconUtil.tsx
+++ b/components/tree/utils/iconUtil.tsx
@@ -6,14 +6,18 @@ import PlusSquareOutlined from '@ant-design/icons/PlusSquareOutlined';
 import classNames from 'classnames';
 import * as React from 'react';
 import { cloneElement, isValidElement } from '../../_util/reactNode';
-import type { AntTreeNodeProps, TreeLeafIcon, SwitcherIcon } from '../Tree';
+import type { AntTreeNodeProps, SwitcherIcon, TreeLeafIcon } from '../Tree';
 
-export default function renderSwitcherIcon(
-  prefixCls: string,
-  switcherIcon: SwitcherIcon,
-  treeNodeProps: AntTreeNodeProps,
-  showLine?: boolean | { showLeafIcon: boolean | TreeLeafIcon },
-): React.ReactNode {
+interface SwitcherIconProps {
+  prefixCls: string;
+  treeNodeProps: AntTreeNodeProps;
+  switcherIcon?: SwitcherIcon;
+  showLine?: boolean | { showLeafIcon: boolean | TreeLeafIcon };
+}
+
+const SwitcherIconCom: React.FC<SwitcherIconProps> = (props) => {
+  const { prefixCls, switcherIcon, treeNodeProps, showLine } = props;
+
   const { isLeaf, expanded, loading } = treeNodeProps;
 
   if (loading) {
@@ -40,7 +44,7 @@ export default function renderSwitcherIcon(
         });
       }
 
-      return leafIcon;
+      return leafIcon as unknown as React.ReactElement;
     }
 
     return showLeafIcon ? (
@@ -61,7 +65,7 @@ export default function renderSwitcherIcon(
   }
 
   if (switcher) {
-    return switcher;
+    return switcher as unknown as React.ReactElement;
   }
 
   if (showLine) {
@@ -72,4 +76,6 @@ export default function renderSwitcherIcon(
     );
   }
   return <CaretDownFilled className={switcherCls} />;
-}
+};
+
+export default SwitcherIconCom;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [x] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 🦄️ refactor: renderSwitcherIcon => React.FC |
| 🇨🇳 Chinese | 将 renderSwitcherIcon 方法重构为 FC |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 085ad66</samp>

The pull request enhances the switcher icon feature for the tree and tree select components, allowing more customization and consistency. It introduces a new component `SwitcherIconCom` to handle the icon rendering logic, and adds a new function `renderSwitcherIcon` in `Tree` and `Select` components to use the custom icon prop. It also refactors and fixes some issues in the test and utility files.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 085ad66</samp>

*  Rename `renderSwitcherIcon` import to `SwitcherIconCom` and change import order in `components/tree-select/index.tsx` and `components/tree/__tests__/util.test.tsx` ([link](https://github.com/ant-design/ant-design/pull/41556/files?diff=unified&w=0#diff-f4ebf787ec0bc13112f49b0d9a2df0bfa73f8ea80cec9a6c92d311e120fa6ffeL27-R27), [link](https://github.com/ant-design/ant-design/pull/41556/files?diff=unified&w=0#diff-01d7846489c88134b30beb21f9af818411ed42422592ac8c1b83c8802b0e973aL1-R4))
*  Change `renderSwitcherIcon` function to `SwitcherIconCom` component and export it as default in `components/tree/utils/iconUtil.tsx` ([link](https://github.com/ant-design/ant-design/pull/41556/files?diff=unified&w=0#diff-da22d6f22f631152c49377ec55ca75e97414b83b5686fcb93e57904e15c19096L9-R20), [link](https://github.com/ant-design/ant-design/pull/41556/files?diff=unified&w=0#diff-da22d6f22f631152c49377ec55ca75e97414b83b5686fcb93e57904e15c19096L43-R47), [link](https://github.com/ant-design/ant-design/pull/41556/files?diff=unified&w=0#diff-da22d6f22f631152c49377ec55ca75e97414b83b5686fcb93e57904e15c19096L64-R68), [link](https://github.com/ant-design/ant-design/pull/41556/files?diff=unified&w=0#diff-da22d6f22f631152c49377ec55ca75e97414b83b5686fcb93e57904e15c19096L75-R81))
*  Add `renderSwitcherIcon` function to `InternalTreeSelect` and `Tree` components to customize switcher icon based on props and node state in `components/tree-select/index.tsx` and `components/tree/Tree.tsx` ([link](https://github.com/ant-design/ant-design/pull/41556/files?diff=unified&w=0#diff-f4ebf787ec0bc13112f49b0d9a2df0bfa73f8ea80cec9a6c92d311e120fa6ffeR211-R219), [link](https://github.com/ant-design/ant-design/pull/41556/files?diff=unified&w=0#diff-cfa7dd13daab065170858e4020c67f79d11b4f6f1aab2c5d6ef13a40f60c72d6R220-R228))
*  Change `switcherIcon` prop of `Select` and `RcTree` components to use `renderSwitcherIcon` function instead of `SwitcherIconCom` component in `components/tree-select/index.tsx` and `components/tree/Tree.tsx` ([link](https://github.com/ant-design/ant-design/pull/41556/files?diff=unified&w=0#diff-f4ebf787ec0bc13112f49b0d9a2df0bfa73f8ea80cec9a6c92d311e120fa6ffeL231-R240), [link](https://github.com/ant-design/ant-design/pull/41556/files?diff=unified&w=0#diff-cfa7dd13daab065170858e4020c67f79d11b4f6f1aab2c5d6ef13a40f60c72d6L241-R249))
*  Change `render` function to use `SwitcherIconCom` component and pass props in `components/tree/__tests__/util.test.tsx` ([link](https://github.com/ant-design/ant-design/pull/41556/files?diff=unified&w=0#diff-01d7846489c88134b30beb21f9af818411ed42422592ac8c1b83c8802b0e973aL63-R63), [link](https://github.com/ant-design/ant-design/pull/41556/files?diff=unified&w=0#diff-01d7846489c88134b30beb21f9af818411ed42422592ac8c1b83c8802b0e973aL72-R77), [link](https://github.com/ant-design/ant-design/pull/41556/files?diff=unified&w=0#diff-01d7846489c88134b30beb21f9af818411ed42422592ac8c1b83c8802b0e973aL93-R94))
*  Change import path of `dropIndicatorRender` and `SwitcherIconCom` to use relative path in `components/tree/Tree.tsx` ([link](https://github.com/ant-design/ant-design/pull/41556/files?diff=unified&w=0#diff-cfa7dd13daab065170858e4020c67f79d11b4f6f1aab2c5d6ef13a40f60c72d6L8-R13))
