### PR TITLE
chore: merge master into feature

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -61,3 +61,18 @@ Describe changes from the user side, and list all potential break changes or oth
 - [ ] Demo is updated/provided or not needed
 - [ ] TypeScript definition is updated/provided or not needed
 - [ ] Changelog is provided or not needed
+
+---
+
+<!--
+Below are template for copilot to generate CR message.
+Please DO NOT modify it.
+-->
+
+### 🚀 Summary
+
+copilot:summary
+
+### 🔍 Walkthrough
+
+copilot:walkthrough

--- a/.github/PULL_REQUEST_TEMPLATE/pr_cn.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pr_cn.md
@@ -61,3 +61,17 @@
 - [ ] 代码演示已提供或无须提供
 - [ ] TypeScript 定义已补充或无须补充
 - [ ] Changelog 已提供或无须提供
+
+---
+
+<!--
+以下为 copilot 自动生成的 CR 结果，请勿修改
+-->
+
+### 🚀 概述
+
+copilot:summary
+
+### 🔍 实现细节
+
+copilot:walkthrough

--- a/components/breadcrumb/index.en-US.md
+++ b/components/breadcrumb/index.en-US.md
@@ -40,7 +40,7 @@ return <Breadcrumb routes={[{ breadcrumbName: 'sample' }]} />;
 <code src="./demo/react-router.tsx" iframe="200">react-router V6</code>
 <code src="./demo/separator.tsx">Configuring the Separator</code>
 <code src="./demo/overlay.tsx">Bread crumbs with drop down menu</code>
-<code src="./demo/separator-component.tsx">Configuring the Separator</code>
+<code src="./demo/separator-component.tsx">Configuring the Separator Independently</code>
 <code src="./demo/debug-routes.tsx">Debug Routes</code>
 
 ## API

--- a/components/breadcrumb/index.zh-CN.md
+++ b/components/breadcrumb/index.zh-CN.md
@@ -41,7 +41,7 @@ return <Breadcrumb routes={[{ breadcrumbName: 'sample' }]} />;
 <code src="./demo/react-router.tsx" iframe="200">react-router V6</code>
 <code src="./demo/separator.tsx">分隔符</code>
 <code src="./demo/overlay.tsx">带下拉菜单的面包屑</code>
-<code src="./demo/separator-component.tsx">分隔符</code>
+<code src="./demo/separator-component.tsx">独立的分隔符</code>
 <code src="./demo/debug-routes.tsx">Debug Routes</code>
 
 ## API

--- a/components/cascader/index.tsx
+++ b/components/cascader/index.tsx
@@ -7,30 +7,31 @@ import type {
   DefaultOptionType,
   FieldNames,
   MultipleCascaderProps as RcMultipleCascaderProps,
-  ShowSearchType,
   SingleCascaderProps as RcSingleCascaderProps,
+  ShowSearchType,
 } from 'rc-cascader';
 import RcCascader from 'rc-cascader';
+import type { Placement } from 'rc-select/lib/BaseSelect';
 import omit from 'rc-util/lib/omit';
 import * as React from 'react';
 import { ConfigContext } from '../config-provider';
-import DefaultRenderEmpty from '../config-provider/defaultRenderEmpty';
 import DisabledContext from '../config-provider/DisabledContext';
 import type { SizeType } from '../config-provider/SizeContext';
 import SizeContext from '../config-provider/SizeContext';
+import DefaultRenderEmpty from '../config-provider/defaultRenderEmpty';
 import { useCompactItemContext } from '../space/Compact';
 
-import { FormItemInputContext } from '../form/context';
-import getIcons from '../select/utils/iconUtil';
 import type { SelectCommonPlacement } from '../_util/motion';
 import { getTransitionDirection, getTransitionName } from '../_util/motion';
 import type { InputStatus } from '../_util/statusUtils';
 import { getMergedStatus, getStatusClassNames } from '../_util/statusUtils';
 import warning from '../_util/warning';
+import { FormItemInputContext } from '../form/context';
+import getIcons from '../select/utils/iconUtil';
 
+import genPurePanel from '../_util/PurePanel';
 import useSelectStyle from '../select/style';
 import useShowArrow from '../select/useShowArrow';
-import genPurePanel from '../_util/PurePanel';
 import useStyle from './style';
 
 // Align the design since we use `rc-select` in root. This help:
@@ -85,7 +86,7 @@ const defaultSearchRender: ShowSearchType['render'] = (inputValue, path, prefixC
       optionList.push(' / ');
     }
 
-    let label = (node as any)[fieldNames.label!];
+    let label = node[fieldNames.label!];
     const type = typeof label;
     if (type === 'string' || type === 'number') {
       label = highlightKeyword(String(label), lower, prefixCls);
@@ -266,12 +267,12 @@ const Cascader = React.forwardRef((props: CascaderProps<any>, ref: React.Ref<Cas
   });
 
   // ===================== Placement =====================
-  const getPlacement = () => {
+  const memoPlacement = React.useMemo<Placement>(() => {
     if (placement !== undefined) {
       return placement;
     }
     return isRtl ? 'bottomRight' : 'bottomLeft';
-  };
+  }, [placement, isRtl]);
 
   // ==================== Render =====================
   const renderNode = (
@@ -295,7 +296,7 @@ const Cascader = React.forwardRef((props: CascaderProps<any>, ref: React.Ref<Cas
       disabled={mergedDisabled}
       {...(restProps as any)}
       direction={mergedDirection}
-      placement={getPlacement()}
+      placement={memoPlacement}
       notFoundContent={mergedNotFoundContent}
       allowClear={allowClear}
       showSearch={mergedShowSearch}

--- a/components/checkbox/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/checkbox/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -410,6 +410,25 @@ exports[`renders components/checkbox/demo/debug-line.tsx extend context correctl
       </span>
     </label>
   </div>
+  <label
+    class="ant-checkbox-wrapper"
+  >
+    <span
+      class="ant-checkbox"
+    >
+      <input
+        class="ant-checkbox-input"
+        type="checkbox"
+        value=""
+      />
+      <span
+        class="ant-checkbox-inner"
+      />
+    </span>
+    <span>
+      Aligned
+    </span>
+  </label>
 </div>
 `;
 

--- a/components/checkbox/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/checkbox/__tests__/__snapshots__/demo.test.tsx.snap
@@ -383,6 +383,24 @@ exports[`renders components/checkbox/demo/debug-line.tsx correctly 1`] = `
       </span>
     </label>
   </div>
+  <label
+    class="ant-checkbox-wrapper"
+  >
+    <span
+      class="ant-checkbox"
+    >
+      <input
+        class="ant-checkbox-input"
+        type="checkbox"
+      />
+      <span
+        class="ant-checkbox-inner"
+      />
+    </span>
+    <span>
+      Aligned
+    </span>
+  </label>
 </div>
 `;
 

--- a/components/checkbox/demo/debug-line.tsx
+++ b/components/checkbox/demo/debug-line.tsx
@@ -1,5 +1,5 @@
+import { Checkbox, ConfigProvider, Radio, Space } from 'antd';
 import React from 'react';
-import { Checkbox, Radio, Space } from 'antd';
 
 const sharedStyle: React.CSSProperties = {
   border: '1px solid red',
@@ -43,6 +43,16 @@ const App: React.FC = () => (
       <div>Bamboo</div>
       <Radio value="little">Little</Radio>
     </div>
+
+    <ConfigProvider
+      theme={{
+        token: {
+          controlHeight: 48,
+        },
+      }}
+    >
+      <Checkbox>Aligned</Checkbox>
+    </ConfigProvider>
   </div>
 );
 

--- a/components/checkbox/style/index.ts
+++ b/components/checkbox/style/index.ts
@@ -71,11 +71,18 @@ export const genCheckboxStyle: GenerateStyle<CheckboxToken> = (token) => {
       [checkboxCls]: {
         ...resetComponent(token),
 
-        top: '0.2em',
         position: 'relative',
         whiteSpace: 'nowrap',
         lineHeight: 1,
         cursor: 'pointer',
+
+        alignSelf: 'start',
+        // https://github.com/ant-design/ant-design/issues/41564
+        // Since `checkboxSize` is dynamic which should align with the text box,
+        // We need do calculation here for offset.
+        transform: `translate(0, ${
+          (token.lineHeight * token.fontSize) / 2 - token.checkboxSize / 2
+        }px)`,
 
         // Wrapper > Checkbox > input
         [`${checkboxCls}-input`]: {
@@ -83,7 +90,7 @@ export const genCheckboxStyle: GenerateStyle<CheckboxToken> = (token) => {
           // Since baseline align will get additional space offset,
           // we need to move input to top to make it align with text.
           // Ref: https://github.com/ant-design/ant-design/issues/38926#issuecomment-1486137799
-          inset: `-0.2em 0`,
+          inset: 0,
           zIndex: 1,
           cursor: 'pointer',
           opacity: 0,

--- a/components/collapse/Collapse.tsx
+++ b/components/collapse/Collapse.tsx
@@ -6,13 +6,13 @@ import * as React from 'react';
 
 import toArray from 'rc-util/lib/Children/toArray';
 import omit from 'rc-util/lib/omit';
-import { ConfigContext } from '../config-provider';
 import initCollapseMotion from '../_util/motion';
 import { cloneElement } from '../_util/reactNode';
 import warning from '../_util/warning';
-import type { CollapsibleType } from './CollapsePanel';
+import { ConfigContext } from '../config-provider';
 import type { SizeType } from '../config-provider/SizeContext';
 import SizeContext from '../config-provider/SizeContext';
+import type { CollapsibleType } from './CollapsePanel';
 import CollapsePanel from './CollapsePanel';
 
 import useStyle from './style';
@@ -66,6 +66,8 @@ const Collapse = React.forwardRef<HTMLDivElement, CollapseProps>((props, ref) =>
     ghost,
     size: customizeSize,
     expandIconPosition = 'start',
+    children,
+    expandIcon,
   } = props;
 
   const mergedSize = customizeSize || size || 'middle';
@@ -89,7 +91,6 @@ const Collapse = React.forwardRef<HTMLDivElement, CollapseProps>((props, ref) =>
   }, [expandIconPosition]);
 
   const renderExpandIcon = (panelProps: PanelProps = {}) => {
-    const { expandIcon } = props;
     const icon = (
       expandIcon ? (
         expandIcon(panelProps)
@@ -121,22 +122,23 @@ const Collapse = React.forwardRef<HTMLDivElement, CollapseProps>((props, ref) =>
     leavedClassName: `${prefixCls}-content-hidden`,
   };
 
-  const getItems = () => {
-    const { children } = props;
-    return toArray(children).map((child: React.ReactElement, index: number) => {
-      if (child.props?.disabled) {
-        const key = child.key || String(index);
-        const { disabled, collapsible } = child.props;
-        const childProps: CollapseProps & { key: React.Key } = {
-          ...omit(child.props, ['disabled']),
-          key,
-          collapsible: collapsible ?? (disabled ? 'disabled' : undefined),
-        };
-        return cloneElement(child, childProps);
-      }
-      return child;
-    });
-  };
+  const items = React.useMemo<React.ReactNode[]>(
+    () =>
+      toArray(children).map<React.ReactNode>((child, index) => {
+        if (child.props?.disabled) {
+          const key = child.key ?? String(index);
+          const { disabled, collapsible } = child.props;
+          const childProps: CollapseProps & { key: React.Key } = {
+            ...omit(child.props, ['disabled']),
+            key,
+            collapsible: collapsible ?? (disabled ? 'disabled' : undefined),
+          };
+          return cloneElement(child, childProps);
+        }
+        return child;
+      }),
+    [children],
+  );
 
   return wrapSSR(
     <RcCollapse
@@ -147,7 +149,7 @@ const Collapse = React.forwardRef<HTMLDivElement, CollapseProps>((props, ref) =>
       prefixCls={prefixCls}
       className={collapseClassName}
     >
-      {getItems()}
+      {items}
     </RcCollapse>,
   );
 });

--- a/components/drawer/DrawerPanel.tsx
+++ b/components/drawer/DrawerPanel.tsx
@@ -1,7 +1,7 @@
-import * as React from 'react';
 import CloseOutlined from '@ant-design/icons/CloseOutlined';
-import type { DrawerProps as RCDrawerProps } from 'rc-drawer';
 import classNames from 'classnames';
+import type { DrawerProps as RCDrawerProps } from 'rc-drawer';
+import * as React from 'react';
 
 export interface DrawerPanelProps {
   prefixCls: string;
@@ -22,18 +22,15 @@ export interface DrawerPanelProps {
   children?: React.ReactNode;
 }
 
-export default function DrawerPanel(props: DrawerPanelProps) {
+const DrawerPanel: React.FC<DrawerPanelProps> = (props) => {
   const {
     prefixCls,
-
     title,
     footer,
     extra,
-
     closable = true,
     closeIcon = <CloseOutlined />,
     onClose,
-
     headerStyle,
     drawerStyle,
     bodyStyle,
@@ -47,17 +44,16 @@ export default function DrawerPanel(props: DrawerPanelProps) {
     </button>
   );
 
-  function renderHeader() {
+  const headerNode = React.useMemo<React.ReactNode>(() => {
     if (!title && !closable) {
       return null;
     }
-
     return (
       <div
+        style={headerStyle}
         className={classNames(`${prefixCls}-header`, {
           [`${prefixCls}-header-close-only`]: closable && !title && !extra,
         })}
-        style={headerStyle}
       >
         <div className={`${prefixCls}-header-title`}>
           {closeIconNode}
@@ -66,28 +62,29 @@ export default function DrawerPanel(props: DrawerPanelProps) {
         {extra && <div className={`${prefixCls}-extra`}>{extra}</div>}
       </div>
     );
-  }
+  }, [closable, closeIconNode, extra, headerStyle, prefixCls, title]);
 
-  function renderFooter() {
+  const footerNode = React.useMemo<React.ReactNode>(() => {
     if (!footer) {
       return null;
     }
-
     const footerClassName = `${prefixCls}-footer`;
     return (
       <div className={footerClassName} style={footerStyle}>
         {footer}
       </div>
     );
-  }
+  }, [footer, footerStyle, prefixCls]);
 
   return (
-    <div className={`${prefixCls}-wrapper-body`} style={{ ...drawerStyle }}>
-      {renderHeader()}
+    <div className={`${prefixCls}-wrapper-body`} style={drawerStyle}>
+      {headerNode}
       <div className={`${prefixCls}-body`} style={bodyStyle}>
         {children}
       </div>
-      {renderFooter()}
+      {footerNode}
     </div>
   );
-}
+};
+
+export default DrawerPanel;

--- a/components/form/FormItem/ItemHolder.tsx
+++ b/components/form/FormItem/ItemHolder.tsx
@@ -5,6 +5,7 @@ import LoadingOutlined from '@ant-design/icons/LoadingOutlined';
 import classNames from 'classnames';
 import type { Meta } from 'rc-field-form/lib/interface';
 import useLayoutEffect from 'rc-util/lib/hooks/useLayoutEffect';
+import isVisible from 'rc-util/lib/Dom/isVisible';
 import omit from 'rc-util/lib/omit';
 import * as React from 'react';
 import type { FormItemProps, ValidateStatus } from '.';
@@ -65,14 +66,17 @@ export default function ItemHolder(props: ItemHolderProps) {
   const debounceWarnings = useDebounce(warnings);
   const hasHelp = help !== undefined && help !== null;
   const hasError = !!(hasHelp || errors.length || warnings.length);
+  const isOnScreen = !!itemRef.current && isVisible(itemRef.current);
   const [marginBottom, setMarginBottom] = React.useState<number | null>(null);
 
   useLayoutEffect(() => {
     if (hasError && itemRef.current) {
+      // The element must be part of the DOMTree to use getComputedStyle
+      // https://stackoverflow.com/questions/35360711/getcomputedstyle-returns-a-cssstyledeclaration-but-all-properties-are-empty-on-a
       const itemStyle = getComputedStyle(itemRef.current);
       setMarginBottom(parseInt(itemStyle.marginBottom, 10));
     }
-  }, [hasError]);
+  }, [hasError, isOnScreen]);
 
   const onErrorVisibleChanged = (nextVisible: boolean) => {
     if (!nextVisible) {

--- a/components/form/__tests__/index.test.tsx
+++ b/components/form/__tests__/index.test.tsx
@@ -1418,6 +1418,20 @@ describe('Form', () => {
     expect(container.querySelector('.drawer-select')?.className).not.toContain('status-error');
   });
 
+  it('should be set up correctly marginBottom', () => {
+    render(
+      <Modal open>
+        <Form>
+          <Form.Item help='This is a help message'>
+            <Input />
+          </Form.Item>
+        </Form>
+      </Modal>,
+    );
+
+    expect(document.querySelector('.ant-form-item-margin-offset')).toBeTruthy();
+  });
+
   it('Form.Item.useStatus should work', async () => {
     const {
       Item: { useStatus },
@@ -1498,6 +1512,7 @@ describe('Form', () => {
       marginBottom: -24,
     });
   });
+
   it('form child components should be given priority to own disabled props when it in a disabled form', () => {
     const props = {
       name: 'file',

--- a/components/mentions/index.tsx
+++ b/components/mentions/index.tsx
@@ -8,14 +8,14 @@ import type {
 import { composeRef } from 'rc-util/lib/ref';
 // eslint-disable-next-line import/no-named-as-default
 import * as React from 'react';
-import { ConfigContext } from '../config-provider';
-import DefaultRenderEmpty from '../config-provider/defaultRenderEmpty';
-import { FormItemInputContext } from '../form/context';
-import Spin from '../spin';
 import genPurePanel from '../_util/PurePanel';
 import type { InputStatus } from '../_util/statusUtils';
 import { getMergedStatus, getStatusClassNames } from '../_util/statusUtils';
 import warning from '../_util/warning';
+import { ConfigContext } from '../config-provider';
+import DefaultRenderEmpty from '../config-provider/defaultRenderEmpty';
+import { FormItemInputContext } from '../form/context';
+import Spin from '../spin';
 
 import useStyle from './style';
 
@@ -81,7 +81,7 @@ const InternalMentions: React.ForwardRefRenderFunction<MentionsRef, MentionProps
   ref,
 ) => {
   const [focused, setFocused] = React.useState(false);
-  const innerRef = React.useRef<MentionsRef>();
+  const innerRef = React.useRef<MentionsRef>(null);
   const mergedRef = composeRef(ref, innerRef);
 
   // =================== Warning =====================
@@ -123,7 +123,7 @@ const InternalMentions: React.ForwardRefRenderFunction<MentionsRef, MentionProps
     return renderEmpty?.('Select') || <DefaultRenderEmpty componentName="Select" />;
   }, [notFoundContent, renderEmpty]);
 
-  const getOptions = () => {
+  const mentionOptions = React.useMemo<React.ReactNode>(() => {
     if (loading) {
       return (
         <Option value="ANTD_SEARCHING" disabled>
@@ -131,9 +131,8 @@ const InternalMentions: React.ForwardRefRenderFunction<MentionsRef, MentionProps
         </Option>
       );
     }
-
     return children;
-  };
+  }, [loading, children]);
 
   const mergedOptions = loading
     ? [
@@ -176,14 +175,12 @@ const InternalMentions: React.ForwardRefRenderFunction<MentionsRef, MentionProps
       onFocus={onFocus}
       onBlur={onBlur}
       dropdownClassName={classNames(popupClassName, rootClassName, hashId)}
-      ref={mergedRef as any}
+      ref={mergedRef}
       options={mergedOptions}
       suffix={hasFeedback && feedbackIcon}
-      classes={{
-        affixWrapper: classNames(hashId, className),
-      }}
+      classes={{ affixWrapper: classNames(hashId, className) }}
     >
-      {getOptions()}
+      {mentionOptions}
     </RcMentions>
   );
 

--- a/components/popconfirm/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/popconfirm/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -98,11 +98,14 @@ Array [
 
 exports[`renders components/popconfirm/demo/basic.tsx extend context correctly 1`] = `
 Array [
-  <a
-    href="#"
+  <button
+    class="ant-btn ant-btn-link"
+    type="button"
   >
-    Delete
-  </a>,
+    <span>
+      Delete
+    </span>
+  </button>,
   <div
     class="ant-popover ant-zoom-big-appear ant-zoom-big-appear-prepare ant-zoom-big ant-popconfirm ant-popover-placement-top"
     style="left: -1000vw; top: -1000vh; box-sizing: border-box;"
@@ -191,11 +194,14 @@ Array [
 
 exports[`renders components/popconfirm/demo/dynamic-trigger.tsx extend context correctly 1`] = `
 <div>
-  <a
-    href="#"
+  <button
+    class="ant-btn ant-btn-link"
+    type="button"
   >
-    Delete a task
-  </a>
+    <span>
+      Delete a task
+    </span>
+  </button>
   <div
     class="ant-popover ant-zoom-big-appear ant-zoom-big-appear-prepare ant-zoom-big ant-popconfirm ant-popover-placement-top"
     style="left: -1000vw; top: -1000vh; box-sizing: border-box;"
@@ -307,11 +313,14 @@ exports[`renders components/popconfirm/demo/dynamic-trigger.tsx extend context c
 
 exports[`renders components/popconfirm/demo/icon.tsx extend context correctly 1`] = `
 Array [
-  <a
-    href="#"
+  <button
+    class="ant-btn ant-btn-link"
+    type="button"
   >
-    Delete
-  </a>,
+    <span>
+      Delete
+    </span>
+  </button>,
   <div
     class="ant-popover ant-zoom-big-appear ant-zoom-big-appear-prepare ant-zoom-big ant-popconfirm ant-popover-placement-top"
     style="left: -1000vw; top: -1000vh; box-sizing: border-box;"
@@ -404,11 +413,14 @@ Array [
 
 exports[`renders components/popconfirm/demo/locale.tsx extend context correctly 1`] = `
 Array [
-  <a
-    href="#"
+  <button
+    class="ant-btn ant-btn-link"
+    type="button"
   >
-    Delete
-  </a>,
+    <span>
+      Delete
+    </span>
+  </button>,
   <div
     class="ant-popover ant-zoom-big-appear ant-zoom-big-appear-prepare ant-zoom-big ant-popconfirm ant-popover-placement-top"
     style="left: -1000vw; top: -1000vh; box-sizing: border-box;"

--- a/components/popconfirm/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/popconfirm/__tests__/__snapshots__/demo.test.tsx.snap
@@ -12,20 +12,26 @@ exports[`renders components/popconfirm/demo/async.tsx correctly 1`] = `
 `;
 
 exports[`renders components/popconfirm/demo/basic.tsx correctly 1`] = `
-<a
-  href="#"
+<button
+  class="ant-btn ant-btn-link"
+  type="button"
 >
-  Delete
-</a>
+  <span>
+    Delete
+  </span>
+</button>
 `;
 
 exports[`renders components/popconfirm/demo/dynamic-trigger.tsx correctly 1`] = `
 <div>
-  <a
-    href="#"
+  <button
+    class="ant-btn ant-btn-link"
+    type="button"
   >
-    Delete a task
-  </a>
+    <span>
+      Delete a task
+    </span>
+  </button>
   <br />
   <br />
   Whether directly execute：
@@ -53,19 +59,25 @@ exports[`renders components/popconfirm/demo/dynamic-trigger.tsx correctly 1`] = 
 `;
 
 exports[`renders components/popconfirm/demo/icon.tsx correctly 1`] = `
-<a
-  href="#"
+<button
+  class="ant-btn ant-btn-link"
+  type="button"
 >
-  Delete
-</a>
+  <span>
+    Delete
+  </span>
+</button>
 `;
 
 exports[`renders components/popconfirm/demo/locale.tsx correctly 1`] = `
-<a
-  href="#"
+<button
+  class="ant-btn ant-btn-link"
+  type="button"
 >
-  Delete
-</a>
+  <span>
+    Delete
+  </span>
+</button>
 `;
 
 exports[`renders components/popconfirm/demo/placement.tsx correctly 1`] = `

--- a/components/popconfirm/demo/basic.tsx
+++ b/components/popconfirm/demo/basic.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { message, Popconfirm } from 'antd';
+import { Button, message, Popconfirm } from 'antd';
 
 const confirm = (e: React.MouseEvent<HTMLElement>) => {
   console.log(e);
@@ -20,7 +20,7 @@ const App: React.FC = () => (
     okText="Yes"
     cancelText="No"
   >
-    <a href="#">Delete</a>
+    <Button type="link">Delete</Button>
   </Popconfirm>
 );
 

--- a/components/popconfirm/demo/dynamic-trigger.tsx
+++ b/components/popconfirm/demo/dynamic-trigger.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { message, Popconfirm, Switch } from 'antd';
+import { Button, message, Popconfirm, Switch } from 'antd';
 
 const App: React.FC = () => {
   const [open, setOpen] = useState(false);
@@ -45,7 +45,7 @@ const App: React.FC = () => {
         okText="Yes"
         cancelText="No"
       >
-        <a href="#">Delete a task</a>
+        <Button type="link">Delete a task</Button>
       </Popconfirm>
       <br />
       <br />

--- a/components/popconfirm/demo/icon.tsx
+++ b/components/popconfirm/demo/icon.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { QuestionCircleOutlined } from '@ant-design/icons';
-import { Popconfirm } from 'antd';
+import { Button, Popconfirm } from 'antd';
 
 const App: React.FC = () => (
   <Popconfirm
@@ -8,7 +8,7 @@ const App: React.FC = () => (
     description="Are you sure to delete this task?"
     icon={<QuestionCircleOutlined style={{ color: 'red' }} />}
   >
-    <a href="#">Delete</a>
+    <Button type="link">Delete</Button>
   </Popconfirm>
 );
 

--- a/components/popconfirm/demo/locale.tsx
+++ b/components/popconfirm/demo/locale.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Popconfirm } from 'antd';
+import { Button, Popconfirm } from 'antd';
 
 const App: React.FC = () => (
   <Popconfirm
@@ -8,7 +8,7 @@ const App: React.FC = () => (
     okText="Yes"
     cancelText="No"
   >
-    <a href="#">Delete</a>
+    <Button type="link">Delete</Button>
   </Popconfirm>
 );
 

--- a/components/select/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/select/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -5946,6 +5946,7 @@ exports[`renders components/select/demo/responsive.tsx extend context correctly 
 exports[`renders components/select/demo/search.tsx extend context correctly 1`] = `
 <div
   class="ant-select ant-select-single ant-select-show-arrow ant-select-show-search"
+  style="width: 160px;"
 >
   <div
     class="ant-select-selector"

--- a/components/select/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/select/__tests__/__snapshots__/demo.test.tsx.snap
@@ -2270,6 +2270,7 @@ exports[`renders components/select/demo/responsive.tsx correctly 1`] = `
 exports[`renders components/select/demo/search.tsx correctly 1`] = `
 <div
   class="ant-select ant-select-single ant-select-show-arrow ant-select-show-search"
+  style="width:160px"
 >
   <div
     class="ant-select-selector"

--- a/components/select/demo/search.tsx
+++ b/components/select/demo/search.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import { Select } from 'antd';
+import React from 'react';
 
 const onChange = (value: string) => {
   console.log(`selected ${value}`);
@@ -12,6 +12,7 @@ const onSearch = (value: string) => {
 const App: React.FC = () => (
   <Select
     showSearch
+    style={{ width: 160 }}
     placeholder="Select a person"
     optionFilterProp="children"
     onChange={onChange}

--- a/components/select/index.tsx
+++ b/components/select/index.tsx
@@ -6,23 +6,22 @@ import type { OptionProps } from 'rc-select/lib/Option';
 import type { BaseOptionType, DefaultOptionType } from 'rc-select/lib/Select';
 import omit from 'rc-util/lib/omit';
 import * as React from 'react';
+import genPurePanel from '../_util/PurePanel';
 import type { SelectCommonPlacement } from '../_util/motion';
 import { getTransitionDirection, getTransitionName } from '../_util/motion';
 import type { InputStatus } from '../_util/statusUtils';
 import { getMergedStatus, getStatusClassNames } from '../_util/statusUtils';
+import warning from '../_util/warning';
 import { ConfigContext } from '../config-provider';
 import DisabledContext from '../config-provider/DisabledContext';
 import type { SizeType } from '../config-provider/SizeContext';
 import SizeContext from '../config-provider/SizeContext';
 import DefaultRenderEmpty from '../config-provider/defaultRenderEmpty';
 import { FormItemInputContext } from '../form/context';
-import getIcons from './utils/iconUtil';
-
-import genPurePanel from '../_util/PurePanel';
-import warning from '../_util/warning';
 import { useCompactItemContext } from '../space/Compact';
 import useStyle from './style';
 import useShowArrow from './useShowArrow';
+import getIcons from './utils/iconUtil';
 
 type RawValue = string | number;
 
@@ -201,7 +200,7 @@ const InternalSelect = <OptionType extends BaseOptionType | DefaultOptionType = 
   // ====================== Render =======================
   return wrapSSR(
     <RcSelect<any, any>
-      ref={ref as any}
+      ref={ref}
       virtual={virtual}
       dropdownMatchSelectWidth={dropdownMatchSelectWidth}
       showSearch={select?.showSearch}

--- a/components/select/index.tsx
+++ b/components/select/index.tsx
@@ -6,21 +6,21 @@ import type { OptionProps } from 'rc-select/lib/Option';
 import type { BaseOptionType, DefaultOptionType } from 'rc-select/lib/Select';
 import omit from 'rc-util/lib/omit';
 import * as React from 'react';
-import { ConfigContext } from '../config-provider';
-import DefaultRenderEmpty from '../config-provider/defaultRenderEmpty';
-import DisabledContext from '../config-provider/DisabledContext';
-import type { SizeType } from '../config-provider/SizeContext';
-import SizeContext from '../config-provider/SizeContext';
-import { FormItemInputContext } from '../form/context';
 import type { SelectCommonPlacement } from '../_util/motion';
 import { getTransitionDirection, getTransitionName } from '../_util/motion';
 import type { InputStatus } from '../_util/statusUtils';
 import { getMergedStatus, getStatusClassNames } from '../_util/statusUtils';
+import { ConfigContext } from '../config-provider';
+import DisabledContext from '../config-provider/DisabledContext';
+import type { SizeType } from '../config-provider/SizeContext';
+import SizeContext from '../config-provider/SizeContext';
+import DefaultRenderEmpty from '../config-provider/defaultRenderEmpty';
+import { FormItemInputContext } from '../form/context';
 import getIcons from './utils/iconUtil';
 
-import { useCompactItemContext } from '../space/Compact';
 import genPurePanel from '../_util/PurePanel';
 import warning from '../_util/warning';
+import { useCompactItemContext } from '../space/Compact';
 import useStyle from './style';
 import useShowArrow from './useShowArrow';
 
@@ -182,12 +182,12 @@ const InternalSelect = <OptionType extends BaseOptionType | DefaultOptionType = 
   );
 
   // ===================== Placement =====================
-  const getPlacement = (): SelectCommonPlacement => {
+  const memoPlacement = React.useMemo<SelectCommonPlacement>(() => {
     if (placement !== undefined) {
       return placement;
     }
     return direction === 'rtl' ? 'bottomRight' : 'bottomLeft';
-  };
+  }, [placement, direction]);
 
   // ====================== Warning ======================
   if (process.env.NODE_ENV !== 'production') {
@@ -213,9 +213,9 @@ const InternalSelect = <OptionType extends BaseOptionType | DefaultOptionType = 
       )}
       listHeight={listHeight}
       listItemHeight={listItemHeight}
-      mode={mode as any}
+      mode={mode}
       prefixCls={prefixCls}
-      placement={getPlacement()}
+      placement={memoPlacement}
       direction={direction}
       inputIcon={suffixIcon}
       menuItemSelectedIcon={itemIcon}

--- a/components/slider/SliderTooltip.tsx
+++ b/components/slider/SliderTooltip.tsx
@@ -18,7 +18,7 @@ const SliderTooltip = React.forwardRef<unknown, TooltipProps>((props, ref) => {
 
   function keepAlign() {
     rafRef.current = raf(() => {
-      innerRef.current?.forcePopupAlign();
+      innerRef.current?.forceAlign();
       rafRef.current = null;
     });
   }

--- a/components/slider/__tests__/index.test.tsx
+++ b/components/slider/__tests__/index.test.tsx
@@ -133,14 +133,14 @@ describe('Slider', () => {
     expect(container).toMatchSnapshot();
   });
 
-  it('should keepAlign by calling forcePopupAlign', async () => {
+  it('should keepAlign by calling forceAlign', async () => {
     const ref = React.createRef<any>();
     render(<SliderTooltip title="30" open ref={ref} />);
-    ref.current.forcePopupAlign = jest.fn();
+    ref.current.forceAlign = jest.fn();
     act(() => {
       jest.runAllTimers();
     });
-    expect(ref.current.forcePopupAlign).toHaveBeenCalled();
+    expect(ref.current.forceAlign).toHaveBeenCalled();
   });
 
   it('tipFormatter should not crash with undefined value', () => {

--- a/components/tooltip/__tests__/tooltip.test.tsx
+++ b/components/tooltip/__tests__/tooltip.test.tsx
@@ -1,5 +1,6 @@
 import { spyElementPrototype } from 'rc-util/lib/test/domHook';
 import React from 'react';
+import { act } from 'react-dom/test-utils';
 import type { TooltipPlacement } from '..';
 import Tooltip from '..';
 import mountTest from '../../../tests/shared/mountTest';
@@ -589,5 +590,17 @@ describe('Tooltip', () => {
       </Tooltip>,
     );
     expect(container).toMatchSnapshot();
+  });
+
+  it('use ref.current.forcePopupAlign', async () => {
+    const ref = React.createRef<any>();
+    const error = jest.spyOn(console, 'error').mockImplementation(() => {});
+    render(<Tooltip open ref={ref} />);
+    act(() => {
+      ref.current.forcePopupAlign();
+      jest.runAllTimers();
+    });
+    expect(error).toHaveBeenCalled();
+    error.mockRestore();
   });
 });

--- a/components/tour/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/tour/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -84,9 +84,6 @@ Array [
       class="ant-tour-content"
     >
       <div
-        class="ant-tour-arrow"
-      />
-      <div
         class="ant-tour-inner"
       >
         <span
@@ -250,9 +247,6 @@ Array [
       class="ant-tour-content"
     >
       <div
-        class="ant-tour-arrow"
-      />
-      <div
         class="ant-tour-inner"
       >
         <span
@@ -401,9 +395,6 @@ Array [
     <div
       class="ant-tour-content"
     >
-      <div
-        class="ant-tour-arrow"
-      />
       <div
         class="ant-tour-inner"
       >
@@ -567,9 +558,6 @@ Array [
     <div
       class="ant-tour-primary ant-tour-content"
     >
-      <div
-        class="ant-tour-arrow"
-      />
       <div
         class="ant-tour-inner"
       >

--- a/components/tour/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/tour/__tests__/__snapshots__/index.test.tsx.snap
@@ -21,9 +21,6 @@ exports[`Tour Primary 1`] = `
         class="ant-tour-primary ant-tour-content"
       >
         <div
-          class="ant-tour-arrow"
-        />
-        <div
           class="ant-tour-inner"
         >
           <span
@@ -306,9 +303,6 @@ exports[`Tour single 1`] = `
         class="ant-tour-content"
       >
         <div
-          class="ant-tour-arrow"
-        />
-        <div
           class="ant-tour-inner"
         >
           <span
@@ -467,9 +461,6 @@ exports[`Tour step support Primary 1`] = `
       <div
         class="ant-tour-primary ant-tour-content"
       >
-        <div
-          class="ant-tour-arrow"
-        />
         <div
           class="ant-tour-inner"
         >

--- a/components/tour/panelRender.tsx
+++ b/components/tour/panelRender.tsx
@@ -33,7 +33,6 @@ const TourPanel: React.FC<TourPanelProps> = ({ stepProps, current, type, indicat
     nextButtonProps,
     prevButtonProps,
     type: stepType,
-    arrow,
     className,
   } = stepProps;
 
@@ -102,7 +101,6 @@ const TourPanel: React.FC<TourPanelProps> = ({ stepProps, current, type, indicat
         `${prefixCls}-content`,
       )}
     >
-      {arrow && <div className={`${prefixCls}-arrow`} key="arrow" />}
       <div className={`${prefixCls}-inner`}>
         <CloseOutlined className={`${prefixCls}-close`} onClick={onClose} />
         {coverNode}

--- a/components/tree-select/index.tsx
+++ b/components/tree-select/index.tsx
@@ -24,7 +24,7 @@ import getIcons from '../select/utils/iconUtil';
 import { useCompactItemContext } from '../space/Compact';
 import type { AntTreeNodeProps, TreeProps } from '../tree';
 import type { SwitcherIcon } from '../tree/Tree';
-import renderSwitcherIcon from '../tree/utils/iconUtil';
+import SwitcherIconCom from '../tree/utils/iconUtil';
 import useStyle from './style';
 
 type RawValue = string | number;
@@ -208,6 +208,15 @@ const InternalTreeSelect = <
     hashId,
   );
 
+  const renderSwitcherIcon = (nodeProps: AntTreeNodeProps) => (
+    <SwitcherIconCom
+      prefixCls={treePrefixCls}
+      switcherIcon={switcherIcon}
+      treeNodeProps={nodeProps}
+      showLine={treeLine}
+    />
+  );
+
   const returnNode = (
     <RcTreeSelect
       virtual={virtual}
@@ -228,9 +237,7 @@ const InternalTreeSelect = <
       placement={memoizedPlacement}
       removeIcon={removeIcon}
       clearIcon={clearIcon}
-      switcherIcon={(nodeProps: AntTreeNodeProps) =>
-        renderSwitcherIcon(treePrefixCls, switcherIcon, nodeProps, treeLine)
-      }
+      switcherIcon={renderSwitcherIcon}
       showTreeIcon={treeIcon as any}
       notFoundContent={mergedNotFound}
       getPopupContainer={getPopupContainer || getContextPopupContainer}

--- a/components/tree-select/index.tsx
+++ b/components/tree-select/index.tsx
@@ -1,32 +1,31 @@
 import classNames from 'classnames';
 import type { BaseSelectRef } from 'rc-select';
+import type { Placement } from 'rc-select/lib/BaseSelect';
 import type { TreeSelectProps as RcTreeSelectProps } from 'rc-tree-select';
 import RcTreeSelect, { SHOW_ALL, SHOW_CHILD, SHOW_PARENT, TreeNode } from 'rc-tree-select';
 import type { BaseOptionType, DefaultOptionType } from 'rc-tree-select/lib/TreeSelect';
 import omit from 'rc-util/lib/omit';
 import * as React from 'react';
-import type { Placement } from 'rc-select/lib/BaseSelect';
-import { ConfigContext } from '../config-provider';
-import DefaultRenderEmpty from '../config-provider/defaultRenderEmpty';
-import DisabledContext from '../config-provider/DisabledContext';
-import type { SizeType } from '../config-provider/SizeContext';
-import SizeContext from '../config-provider/SizeContext';
-import { FormItemInputContext } from '../form/context';
 import genPurePanel from '../_util/PurePanel';
-import useSelectStyle from '../select/style';
-import getIcons from '../select/utils/iconUtil';
-import type { AntTreeNodeProps, TreeProps } from '../tree';
-import type { SwitcherIcon } from '../tree/Tree';
-import renderSwitcherIcon from '../tree/utils/iconUtil';
 import type { SelectCommonPlacement } from '../_util/motion';
 import { getTransitionDirection, getTransitionName } from '../_util/motion';
 import type { InputStatus } from '../_util/statusUtils';
 import { getMergedStatus, getStatusClassNames } from '../_util/statusUtils';
-import { useCompactItemContext } from '../space/Compact';
 import warning from '../_util/warning';
-
-import useStyle from './style';
+import { ConfigContext } from '../config-provider';
+import DisabledContext from '../config-provider/DisabledContext';
+import type { SizeType } from '../config-provider/SizeContext';
+import SizeContext from '../config-provider/SizeContext';
+import DefaultRenderEmpty from '../config-provider/defaultRenderEmpty';
+import { FormItemInputContext } from '../form/context';
+import useSelectStyle from '../select/style';
 import useShowArrow from '../select/useShowArrow';
+import getIcons from '../select/utils/iconUtil';
+import { useCompactItemContext } from '../space/Compact';
+import type { AntTreeNodeProps, TreeProps } from '../tree';
+import type { SwitcherIcon } from '../tree/Tree';
+import renderSwitcherIcon from '../tree/utils/iconUtil';
+import useStyle from './style';
 
 type RawValue = string | number;
 
@@ -215,7 +214,7 @@ const InternalTreeSelect = <
       dropdownMatchSelectWidth={dropdownMatchSelectWidth}
       disabled={mergedDisabled}
       {...selectProps}
-      ref={ref as any}
+      ref={ref}
       prefixCls={prefixCls}
       className={mergedClassName}
       listHeight={listHeight}

--- a/components/tree/Tree.tsx
+++ b/components/tree/Tree.tsx
@@ -5,12 +5,11 @@ import RcTree from 'rc-tree';
 import type { DataNode, Key } from 'rc-tree/lib/interface';
 import type { Component } from 'react';
 import React from 'react';
-import { ConfigContext } from '../config-provider';
 import initCollapseMotion from '../_util/motion';
-import dropIndicatorRender from './utils/dropIndicator';
-import renderSwitcherIcon from './utils/iconUtil';
-
+import { ConfigContext } from '../config-provider';
 import useStyle from './style';
+import dropIndicatorRender from './utils/dropIndicator';
+import SwitcherIconCom from './utils/iconUtil';
 
 export type SwitcherIcon = React.ReactNode | ((props: AntTreeNodeProps) => React.ReactNode);
 export type TreeLeafIcon = React.ReactNode | ((props: AntTreeNodeProps) => React.ReactNode);
@@ -218,6 +217,15 @@ const Tree = React.forwardRef<RcTree, TreeProps>((props, ref) => {
     return mergedDraggable;
   }, [draggable]);
 
+  const renderSwitcherIcon = (nodeProps: AntTreeNodeProps) => (
+    <SwitcherIconCom
+      prefixCls={prefixCls}
+      switcherIcon={switcherIcon}
+      treeNodeProps={nodeProps}
+      showLine={showLine}
+    />
+  );
+
   return wrapSSR(
     <RcTree
       itemHeight={20}
@@ -238,9 +246,7 @@ const Tree = React.forwardRef<RcTree, TreeProps>((props, ref) => {
       direction={direction}
       checkable={checkable ? <span className={`${prefixCls}-checkbox-inner`} /> : checkable}
       selectable={selectable}
-      switcherIcon={(nodeProps: AntTreeNodeProps) =>
-        renderSwitcherIcon(prefixCls, switcherIcon, nodeProps, showLine)
-      }
+      switcherIcon={renderSwitcherIcon}
       draggable={draggableConfig}
     >
       {children}

--- a/components/tree/__tests__/util.test.tsx
+++ b/components/tree/__tests__/util.test.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
+import React from 'react';
 import { calcRangeKeys } from '../utils/dictUtil';
-import renderSwitcherIcon from '../utils/iconUtil';
+import SwitcherIconCom from '../utils/iconUtil';
 
 describe('Tree util', () => {
   describe('calcRangeKeys', () => {
@@ -38,20 +38,16 @@ describe('Tree util', () => {
     });
 
     it('return empty array without startKey and endKey', () => {
-      const keys = calcRangeKeys({
-        treeData,
-        expandedKeys: ['0-0', '0-2', '0-2-0'],
-      });
+      const keys = calcRangeKeys({ treeData, expandedKeys: ['0-0', '0-2', '0-2-0'] });
       expect(keys).toEqual([]);
     });
   });
 
-  describe('renderSwitcherIcon', () => {
+  describe('SwitcherIconCom', () => {
     const prefixCls = 'tree';
-
     it('returns a loading icon when loading', () => {
       const { container } = render(
-        <>{renderSwitcherIcon(prefixCls, undefined, { loading: true }, true)}</>,
+        <SwitcherIconCom prefixCls={prefixCls} treeNodeProps={{ loading: true }} showLine />,
       );
       expect(container.getElementsByClassName(`${prefixCls}-switcher-loading-icon`)).toHaveLength(
         1,
@@ -60,7 +56,11 @@ describe('Tree util', () => {
 
     it('returns nothing when node is a leaf without showLine', () => {
       const { container } = render(
-        <>{renderSwitcherIcon(prefixCls, undefined, { loading: false, isLeaf: true }, false)}</>,
+        <SwitcherIconCom
+          prefixCls={prefixCls}
+          treeNodeProps={{ loading: false, isLeaf: true }}
+          showLine={false}
+        />,
       );
       expect(container).toBeEmptyDOMElement();
     });
@@ -69,16 +69,12 @@ describe('Tree util', () => {
       const testId = 'custom-icon';
       const customLeafIcon = <div data-testid={testId} />;
       const { container } = render(
-        <>
-          {renderSwitcherIcon(
-            prefixCls,
-            undefined,
-            { loading: false, isLeaf: true },
-            { showLeafIcon: customLeafIcon },
-          )}
-        </>,
+        <SwitcherIconCom
+          prefixCls={prefixCls}
+          treeNodeProps={{ loading: false, isLeaf: true }}
+          showLine={{ showLeafIcon: customLeafIcon }}
+        />,
       );
-
       expect(screen.getByTestId(testId)).toBeVisible();
       expect(
         container.getElementsByClassName(`${prefixCls}-switcher-line-custom-icon`),
@@ -90,16 +86,12 @@ describe('Tree util', () => {
       [`${prefixCls}-switcher-leaf-line`, false],
     ])('returns %p element when showLeafIcon is %p', (expectedClassName, showLeafIcon) => {
       const { container } = render(
-        <>
-          {renderSwitcherIcon(
-            prefixCls,
-            undefined,
-            { loading: false, isLeaf: true },
-            { showLeafIcon },
-          )}
-        </>,
+        <SwitcherIconCom
+          prefixCls={prefixCls}
+          treeNodeProps={{ loading: false, isLeaf: true }}
+          showLine={{ showLeafIcon }}
+        />,
       );
-
       expect(container.getElementsByClassName(expectedClassName)).toHaveLength(1);
     });
   });

--- a/components/tree/utils/iconUtil.tsx
+++ b/components/tree/utils/iconUtil.tsx
@@ -6,14 +6,18 @@ import PlusSquareOutlined from '@ant-design/icons/PlusSquareOutlined';
 import classNames from 'classnames';
 import * as React from 'react';
 import { cloneElement, isValidElement } from '../../_util/reactNode';
-import type { AntTreeNodeProps, TreeLeafIcon, SwitcherIcon } from '../Tree';
+import type { AntTreeNodeProps, SwitcherIcon, TreeLeafIcon } from '../Tree';
 
-export default function renderSwitcherIcon(
-  prefixCls: string,
-  switcherIcon: SwitcherIcon,
-  treeNodeProps: AntTreeNodeProps,
-  showLine?: boolean | { showLeafIcon: boolean | TreeLeafIcon },
-): React.ReactNode {
+interface SwitcherIconProps {
+  prefixCls: string;
+  treeNodeProps: AntTreeNodeProps;
+  switcherIcon?: SwitcherIcon;
+  showLine?: boolean | { showLeafIcon: boolean | TreeLeafIcon };
+}
+
+const SwitcherIconCom: React.FC<SwitcherIconProps> = (props) => {
+  const { prefixCls, switcherIcon, treeNodeProps, showLine } = props;
+
   const { isLeaf, expanded, loading } = treeNodeProps;
 
   if (loading) {
@@ -40,7 +44,7 @@ export default function renderSwitcherIcon(
         });
       }
 
-      return leafIcon;
+      return leafIcon as unknown as React.ReactElement;
     }
 
     return showLeafIcon ? (
@@ -61,7 +65,7 @@ export default function renderSwitcherIcon(
   }
 
   if (switcher) {
-    return switcher;
+    return switcher as unknown as React.ReactElement;
   }
 
   if (showLine) {
@@ -72,4 +76,6 @@ export default function renderSwitcherIcon(
     );
   }
   return <CaretDownFilled className={switcherCls} />;
-}
+};
+
+export default SwitcherIconCom;

--- a/package.json
+++ b/package.json
@@ -272,7 +272,7 @@
     "remark-cli": "^11.0.0",
     "remark-lint": "^9.0.0",
     "remark-preset-lint-recommended": "^6.0.0",
-    "rome": "^11.0.0",
+    "rome": "^12.0.0",
     "semver": "^7.3.5",
     "simple-git": "^3.0.0",
     "size-limit": "^8.1.0",

--- a/tests/shared/demoTest.tsx
+++ b/tests/shared/demoTest.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable react/jsx-no-constructed-context-values */
 import { createCache, StyleProvider } from '@ant-design/cssinjs';
 import glob from 'glob';
+import path from 'path';
 import * as React from 'react';
 import { renderToString } from 'react-dom/server';
 import { render } from '../utils';
@@ -20,8 +21,9 @@ export type Options = {
 
 function baseText(doInject: boolean, component: string, options: Options = {}) {
   const files = glob.globSync(`./components/${component}/demo/*.tsx`);
-
   files.forEach((file) => {
+    // to compatible windows path
+    file = file.split(path.sep).join('/');
     const testMethod =
       options.skip === true ||
       (Array.isArray(options.skip) && options.skip.some((c) => file.includes(c)))


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [x] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    --       |
| 🇨🇳 Chinese |   --        |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fd4cab7</samp>

This pull request updates, improves, and fixes various components and demos of the ant-design library. It enhances the performance, customizability, accessibility, and code quality of the components by using memoization, utilities, props, and flexbox. It also adds new features such as the `token` prop for the checkbox component and the `separatorComponent` prop for the breadcrumb component. It follows some conventions and best practices for TypeScript, React, and ant-design. It also adds templates for copilot to generate pull request summaries and walkthroughs in English and Chinese.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at fd4cab7</samp>

*  Add templates for copilot to generate summaries and walkthroughs of pull requests in English and Chinese ([link](https://github.com/ant-design/ant-design/pull/41585/files?diff=unified&w=0#diff-18813c86948efc57e661623d7ba48ff94325c9b5421ec9177f724922dd553a35R64-R78), [link](https://github.com/ant-design/ant-design/pull/41585/files?diff=unified&w=0#diff-01e0405c37ba25be0b9a335536626378e8defa04d3285eac7439ef984058ffa4R64-R77))
*  Demonstrate how to customize the separator of the breadcrumb component with the new `separatorComponent` prop in both languages ([link](https://github.com/ant-design/ant-design/pull/41585/files?diff=unified&w=0#diff-893bcd53601541ad21b7b34644e1606526e6a1fb419750b3494662cd190782a1L43-R43), [link](https://github.com/ant-design/ant-design/pull/41585/files?diff=unified&w=0#diff-2b4604b027d70368b5422346bc06c7ed38e652ed57cd80d1ed355307d620419aL44-R44))
*  Import the correct type for the `placement` prop of the select component from the updated `rc-select` dependency ([link](https://github.com/ant-design/ant-design/pull/41585/files?diff=unified&w=0#diff-4737f6ef564486c449ec019f2826176d8b8d186088e5e912ad06ad1919b2d804L10-R23))
*  Support the new `hasFeedback` and `feedbackIcon` props of the select component by importing and using the form and select utilities ([link](https://github.com/ant-design/ant-design/pull/41585/files?diff=unified&w=0#diff-4737f6ef564486c449ec019f2826176d8b8d186088e5e912ad06ad1919b2d804L30-R34))
*  Simplify the expression for getting the label of a node in the cascader component by using the `fieldNames` type directly ([link](https://github.com/ant-design/ant-design/pull/41585/files?diff=unified&w=0#diff-4737f6ef564486c449ec019f2826176d8b8d186088e5e912ad06ad1919b2d804L88-R89))
*  Memoize the calculation of the placement for the cascader component and the select component to avoid unnecessary re-rendering and improve performance ([link](https://github.com/ant-design/ant-design/pull/41585/files?diff=unified&w=0#diff-4737f6ef564486c449ec019f2826176d8b8d186088e5e912ad06ad1919b2d804L269-R275), [link](https://github.com/ant-design/ant-design/pull/41585/files?diff=unified&w=0#diff-4737f6ef564486c449ec019f2826176d8b8d186088e5e912ad06ad1919b2d804L298-R299), [link](https://github.com/ant-design/ant-design/pull/41585/files?diff=unified&w=0#diff-cf9c6a6fcee364e93144b7afa91b8ff8b85e8bab46a1b602752c25b6c8de55d0L185-R189), [link](https://github.com/ant-design/ant-design/pull/41585/files?diff=unified&w=0#diff-cf9c6a6fcee364e93144b7afa91b8ff8b85e8bab46a1b602752c25b6c8de55d0L216-R217))
*  Remove the `top` style from the checkbox component and use flexbox and calculation to align it with the text box based on the new `token` prop ([link](https://github.com/ant-design/ant-design/pull/41585/files?diff=unified&w=0#diff-c624f3acd6eb939a50b97d0fe9f815bd0dd657eb19797790a8e7b1755ee550efL74), [link](https://github.com/ant-design/ant-design/pull/41585/files?diff=unified&w=0#diff-c624f3acd6eb939a50b97d0fe9f815bd0dd657eb19797790a8e7b1755ee550efR79-R86), [link](https://github.com/ant-design/ant-design/pull/41585/files?diff=unified&w=0#diff-c624f3acd6eb939a50b97d0fe9f815bd0dd657eb19797790a8e7b1755ee550efL86-R93))
*  Demonstrate how to adjust the control height of the checkbox component with the `token` prop and a custom theme ([link](https://github.com/ant-design/ant-design/pull/41585/files?diff=unified&w=0#diff-97b787afa8f6dec869cf8e78a17ea86e2923a8f80347fdd3810160e9b1c66588L1-R2), [link](https://github.com/ant-design/ant-design/pull/41585/files?diff=unified&w=0#diff-97b787afa8f6dec869cf8e78a17ea86e2923a8f80347fdd3810160e9b1c66588R46-R55))
*  Reorder the imports in the collapse component, the drawer panel component, the dropdown component, the mentions component, and the select demo to follow the convention of importing types and utilities first, then components and contexts ([link](https://github.com/ant-design/ant-design/pull/41585/files?diff=unified&w=0#diff-3541251bb31318316b91e1f6710b646bd92edaff4318ca790c6401bea6962fc9L9-R15), [link](https://github.com/ant-design/ant-design/pull/41585/files?diff=unified&w=0#diff-93e3b026986cf56379143412817a4077a256d276a567a550593b2526310d1a69L1-R4), [link](https://github.com/ant-design/ant-design/pull/41585/files?diff=unified&w=0#diff-978b29ecd5429963a073f5adfa7ded79d88d23850853c9fb6d453a82047365beL13-R20), [link](https://github.com/ant-design/ant-design/pull/41585/files?diff=unified&w=0#diff-70d5a1401a2836d63ffd091fbcd5e9f43de05c2f404265a51a366862e1e157b6L11-R18), [link](https://github.com/ant-design/ant-design/pull/41585/files?diff=unified&w=0#diff-afa7ef26baef50a04b87596ea3f6836afae235ebd564b1f5a7be7099ca0c27bdL1-R2))
*  Destructure the `children` prop in the collapse component and the `menu`, `arrow`, and `prefixCls` props in the dropdown component to use them directly ([link](https://github.com/ant-design/ant-design/pull/41585/files?diff=unified&w=0#diff-3541251bb31318316b91e1f6710b646bd92edaff4318ca790c6401bea6962fc9R69-R70), [link](https://github.com/ant-design/ant-design/pull/41585/files?diff=unified&w=0#diff-978b29ecd5429963a073f5adfa7ded79d88d23850853c9fb6d453a82047365beR96-R118))
*  Remove the unused `overlay` prop from the collapse component and the dropdown component to avoid confusion and potential bugs ([link](https://github.com/ant-design/ant-design/pull/41585/files?diff=unified&w=0#diff-3541251bb31318316b91e1f6710b646bd92edaff4318ca790c6401bea6962fc9L92), [link](https://github.com/ant-design/ant-design/pull/41585/files?diff=unified&w=0#diff-978b29ecd5429963a073f5adfa7ded79d88d23850853c9fb6d453a82047365beL242))
*  Memoize the rendering of the collapse panels, the header node and the footer node in the drawer panel component, the mention options and the children in the mentions component, and the transition name for the dropdown component to avoid unnecessary re-rendering and improve performance ([link](https://github.com/ant-design/ant-design/pull/41585/files?diff=unified&w=0#diff-3541251bb31318316b91e1f6710b646bd92edaff4318ca790c6401bea6962fc9L124-R141), [link](https://github.com/ant-design/ant-design/pull/41585/files?diff=unified&w=0#diff-3541251bb31318316b91e1f6710b646bd92edaff4318ca790c6401bea6962fc9L150-R152), [link](https://github.com/ant-design/ant-design/pull/41585/files?diff=unified&w=0#diff-93e3b026986cf56379143412817a4077a256d276a567a550593b2526310d1a69L50-R56), [link](https://github.com/ant-design/ant-design/pull/41585/files?diff=unified&w=0#diff-93e3b026986cf56379143412817a4077a256d276a567a550593b2526310d1a69L69-R70), [link](https://github.com/ant-design/ant-design/pull/41585/files?diff=unified&w=0#diff-70d5a1401a2836d63ffd091fbcd5e9f43de05c2f404265a51a366862e1e157b6L126-R126), [link](https://github.com/ant-design/ant-design/pull/41585/files?diff=unified&w=0#diff-70d5a1401a2836d63ffd091fbcd5e9f43de05c2f404265a51a366862e1e157b6L134-R135), [link](https://github.com/ant-design/ant-design/pull/41585/files?diff=unified&w=0#diff-978b29ecd5429963a073f5adfa7ded79d88d23850853c9fb6d453a82047365beL121-R146))
*  Convert the `DrawerPanel` component from a function declaration to a function expression and add a default export for it ([link](https://github.com/ant-design/ant-design/pull/41585/files?diff=unified&w=0#diff-93e3b026986cf56379143412817a4077a256d276a567a550593b2526310d1a69L25-R33), [link](https://github.com/ant-design/ant-design/pull/41585/files?diff=unified&w=0#diff-93e3b026986cf56379143412817a4077a256d276a567a550593b2526310d1a69L82-R90))
*  Remove some unused props from the dropdown component to avoid confusion and potential bugs ([link](https://github.com/ant-design/ant-design/pull/41585/files?diff=unified&w=0#diff-978b29ecd5429963a073f5adfa7ded79d88d23850853c9fb6d453a82047365beL150-R173))
*  Use the `genPurePanel` utility to generate a pure panel component for the dropdown component with the new `purePanel` prop ([link](https://github.com/ant-design/ant-design/pull/41585/files?diff=unified&w=0#diff-978b29ecd5429963a073f5adfa7ded79d88d23850853c9fb6d453a82047365beR8-R12))
*  Add a null value to the initial ref of the mentions component to follow the TypeScript type definition ([link](https://github.com/ant-design/ant-design/pull/41585/files?diff=unified&w=0#diff-70d5a1401a2836d63ffd091fbcd5e9f43de05c2f404265a51a366862e1e157b6L84-R84))
*  Remove the unnecessary type casting for the ref prop of the select component to follow the TypeScript type definition ([link](https://github.com/ant-design/ant-design/pull/41585/files?diff=unified&w=0#diff-cf9c6a6fcee364e93144b7afa91b8ff8b85e8bab46a1b602752c25b6c8de55d0L204-R203))
*  Add a test case for the form component to verify that it sets up the margin bottom correctly when there is a help message ([link](https://github.com/ant-design/ant-design/pull/41585/files?diff=unified&w=0#diff-f3bb49bfe69c75aa977732eec74dfe67b8b00e00fc5e008c4f1d3835ae296eacR1421-R1434))
*  Import and use the `isVisible` utility from the `rc-util` library to check the visibility of the form item element ([link](https://github.com/ant-design/ant-design/pull/41585/files?diff=unified&w=0#diff-0669e96d7e08a1ef315d1574f62b339113dc7db6ad1549ac5a649151b105596fR8))
*  Add a state variable to store the visibility of the form item element and use it to trigger the `useLayoutEffect` hook that sets the margin bottom of the element ([link](https://github.com/ant-design/ant-design/pull/41585/files?diff=unified&w=0#diff-0669e96d7e08a1ef315d1574f62b339113dc7db6ad1549ac5a649151b105596fL68-R79))
*  Replace the `a` element with the `Button` component in the checkbox demo, the popconfirm demos, and the select demo to improve the user interface and accessibility ([link](https://github.com/ant-design/ant-design/pull/41585/files?diff=unified&w=0#diff-97b787afa8f6dec869cf8e78a17ea86e2923a8f80347fdd3810160e9b1c66588L1-R2),  [link](https://github.com/ant-design/ant-design/pull/41585/files?diff=unified&w=0#diff-661442229d2d6d561e8842c81f83c4baa43ab7d6071a6d1ddc2f91427a4a8d8bL2-R2), [link](https://github.com/ant-design/ant-design/pull/41585/files?diff=unified&w=0#diff-661442229d2d6d561e8842c81f83c4baa43ab7d6071a6d1ddc2f91427a4a8d8bL23-R23), [link](https://github.com/ant-design/ant-design/pull/41585/files?diff=unified&w=0#diff-875fcb50b8b6f5fc48a4ba54dffdf71ac9fc4c0c553415de0ca836af4f2c6349L2-R2), [link](https://github.com/ant-design/ant-design/pull/41585/files?diff=unified&w=0#diff-875fcb50b8b6f5fc48a4ba54dffdf71ac9fc4c0c553415de0ca836af4f2c6349L48-R48), [link](https://github.com/ant-design/ant-design/pull/41585/files?diff=unified&w=0#diff-6b357e8694b3776456d247762954cc0b721b1f91009a8f3efdc1a562bd1dbf66L3-R3), [link](https://github.com/ant-design/ant-design/pull/41585/files?diff=unified&w=0#diff-6b357e8694b3776456d247762954cc0b721b1f91009a8f3efdc1a562bd1dbf66L11-R11), [link](https://github.com/ant-design/ant-design/pull/41585/files?diff=unified&w=0#diff-d7f0a163fc26f16c7f2e8d0dcd98a084b3989d8323aa69ebb5f6dca3e4feb844L2-R2), [link](https://github.com/ant-design/ant-design/pull/41585/files?diff=unified&w=0#diff-d7f0a163fc26f16c7f2e8d0dcd98a084b3989d8323aa69ebb5f6dca3e4feb844L11-R11), [link](https://github.com/ant-design/ant-design/pull/41585/files?diff=unified&w=0#diff-afa7ef26baef50a04b87596ea3f6836afae235ebd564b1f5a7be7099ca0c27bdR15))
*  Replace the `forcePopupAlign` method with the `forceAlign` method in the slider tooltip component to use the correct method name for the `Trigger` component ([link](https://github.com/ant-design/ant-design/pull/41585/files?diff=unified&w=0#diff-fcd4af359a451a2a3eb4f0d0e9d052cf0f1a10d32cc2c9033988cea681ce88a0L21-R21))
*  Add a style prop to the select component in the select demo to set a fixed width for it ([link](https://github.com/ant-design/ant-design/pull/41585/files?diff=unified&w=0#diff-afa7ef26baef50a04b87596ea3f6836afae235ebd564b1f5a7be7099ca0c27bdR15))
*  Remove an empty line from the test file to follow the code style and formatting rules ([link](https://github.com/ant-design/ant-design/pull/41585/files?diff=unified&w=0#diff-f3bb49bfe69c75aa977732eec74dfe67b8b00e00fc5e008c4f1d3835ae296eacR1515))
