### PR TITLE
fix(Form): Feedback does not automatically deduce the correct state

### DIFF
--- a/components/form/FormItem/ItemHolder.tsx
+++ b/components/form/FormItem/ItemHolder.tsx
@@ -109,14 +109,13 @@ export default function ItemHolder(props: ItemHolderProps) {
 
   const formItemStatusContext = React.useMemo<FormItemStatusContextProps>(() => {
     let feedbackIcon: React.ReactNode;
-    const desplayValidateStatus = getValidateState(true);
     if (hasFeedback) {
-      const IconNode = desplayValidateStatus && iconMap[desplayValidateStatus];
+      const IconNode = mergedValidateStatus && iconMap[mergedValidateStatus];
       feedbackIcon = IconNode ? (
         <span
           className={classNames(
             `${itemPrefixCls}-feedback-icon`,
-            `${itemPrefixCls}-feedback-icon-${desplayValidateStatus}`,
+            `${itemPrefixCls}-feedback-icon-${mergedValidateStatus}`,
           )}
         >
           <IconNode />

--- a/components/form/__tests__/index.test.tsx
+++ b/components/form/__tests__/index.test.tsx
@@ -1688,6 +1688,54 @@ describe('Form', () => {
     expect(container.querySelectorAll('.ant-form-item-has-feedback').length).toBe(1);
     expect(container.querySelectorAll('.ant-form-item-has-success').length).toBe(1);
   });
+
+  it('feedback should automatically derive the correct state', async () => {
+    const Demo: React.FC = () => {
+      const [form] = Form.useForm();
+
+      return (
+        <Form form={form}>
+          <Form.Item name="success" initialValue="test" hasFeedback rules={[{ required: true }]}>
+            <Input />
+          </Form.Item>
+          <Form.Item
+            name="validating"
+            hasFeedback
+            rules={[
+              {
+                validator: () =>
+                  new Promise((resolve) => {
+                    setTimeout(() => resolve(true), 2000);
+                  }),
+              },
+            ]}
+          >
+            <Input />
+          </Form.Item>
+          <Form.Item name="warning" hasFeedback rules={[{ required: true, warningOnly: true }]}>
+            <Input />
+          </Form.Item>
+          <Form.Item name="error" hasFeedback rules={[{ required: true }]}>
+            <Input />
+          </Form.Item>
+          <Button onClick={() => form.submit()} className="submit-button">
+            Submit
+          </Button>
+        </Form>
+      );
+    };
+    const { container } = render(<Demo />);
+
+    fireEvent.click(container.querySelector('.submit-button')!);
+
+    await waitFakeTimer(50);
+
+    expect(container.querySelector('.ant-form-item-has-success')).toBeTruthy();
+    expect(container.querySelector('.ant-form-item-is-validating')).toBeTruthy();
+    expect(container.querySelector('.ant-form-item-has-warning')).toBeTruthy();
+    expect(container.querySelector('.ant-form-item-has-error')).toBeTruthy();
+  });
+
   it('validate status should be change in order', async () => {
     const onChange = jest.fn();
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
fix https://github.com/ant-design/ant-design/issues/41577

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->
当前设置 `hasFeedback` 后，最终状态为 `success` 或者传入的 `validateStatus`，如下图：
![image](https://user-images.githubusercontent.com/112228030/229330330-84250689-94f0-47dc-9ab2-dc2bbb5071ed.png)

修复后：
![image](https://user-images.githubusercontent.com/112228030/229330228-15b298ab-bb81-422e-b8f8-e1b6e1ea5c03.png)


### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix `feedback` not automatically deducing the correct state           |
| 🇨🇳 Chinese | 修复 `feedback` 不会自动推导出正确的状态           |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d136d5c</samp>

This pull request adds a test case and fixes a bug for the feedback icon of form items. The changes ensure that the icon correctly shows the validation status derived from the `rules` prop, including the `warningOnly` option.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d136d5c</samp>

* Fix feedback icon bug for form items with rules prop ([link](https://github.com/ant-design/ant-design/pull/41594/files?diff=unified&w=0#diff-0669e96d7e08a1ef315d1574f62b339113dc7db6ad1549ac5a649151b105596fL112-R118), [link](https://github.com/ant-design/ant-design/pull/41594/files?diff=unified&w=0#diff-f3bb49bfe69c75aa977732eec74dfe67b8b00e00fc5e008c4f1d3835ae296eacR1691-R1738))
