### PR TITLE
docs: update luxon docs

### DIFF
--- a/docs/react/use-custom-date-library.en-US.md
+++ b/docs/react/use-custom-date-library.en-US.md
@@ -120,7 +120,6 @@ Code as follows:
 
 ```tsx
 import generatePicker from 'antd/es/date-picker/generatePicker';
-import 'antd/es/date-picker/style/index';
 import dateFnsGenerateConfig from 'rc-picker/lib/generate/dateFns';
 
 const DatePicker = generatePicker<Date>(dateFnsGenerateConfig);
@@ -138,7 +137,6 @@ Create a `src/components/DatePicker.tsx` file, and implement the luxon based pic
 
 ```tsx
 import generatePicker from 'antd/es/date-picker/generatePicker';
-import 'antd/es/date-picker/style/index';
 import type { DateTime } from 'luxon';
 import luxonGenerateConfig from 'rc-picker/lib/generate/luxon';
 
@@ -147,7 +145,7 @@ const DatePicker = generatePicker<DateTime>(luxonGenerateConfig);
 export default DatePicker;
 ```
 
-### Notable differences with day-js
+### Notable differences with dayjs
 
 luxon users should be familiar with the fact that it does not come with a custom implementation for localization. Instead, it relies on the browser's native [Intl API](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl).
 
@@ -162,13 +160,12 @@ It is possible to customize these default luxon behaviors by adjusting the luxon
 
 ```tsx
 import generatePicker from 'antd/es/date-picker/generatePicker';
-import 'antd/es/date-picker/style/index';
 import type { DateTime } from 'luxon';
 import luxonGenerateConfig from 'rc-picker/lib/generate/luxon';
 
 const customLuxonConfig = {
   ...luxonGenerateConfig,
-  getWeekFirstDay: (locale) => {
+  getWeekFirstDay(locale) {
     // Your custom implementation goes here
   },
 };

--- a/docs/react/use-custom-date-library.zh-CN.md
+++ b/docs/react/use-custom-date-library.zh-CN.md
@@ -118,7 +118,6 @@ module.exports = {
 
 ```tsx
 import generatePicker from 'antd/es/date-picker/generatePicker';
-import 'antd/es/date-picker/style/index';
 import dateFnsGenerateConfig from 'rc-picker/es/generate/dateFns';
 
 const DatePicker = generatePicker<Date>(dateFnsGenerateConfig);
@@ -128,7 +127,7 @@ export default DatePicker;
 
 ## 使用 luxon
 
-可以使用 [luxon](https://moment.github.io/luxon/) 代替 dayjs 并支持同样的功能，但它与 dayjs 有一些差异，我们将在下面解释：
+自 `antd 5.4.0` 起，可以使用 [luxon](https://moment.github.io/luxon/) 代替 dayjs 并支持同样的功能，但它与 dayjs 有一些差异，我们将在下面解释：
 
 ### 执行
 
@@ -136,7 +135,6 @@ export default DatePicker;
 
 ```tsx
 import generatePicker from 'antd/es/date-picker/generatePicker';
-import 'antd/es/date-picker/style/index';
 import type { DateTime } from 'luxon';
 import luxonGenerateConfig from 'rc-picker/lib/generate/luxon';
 
@@ -145,7 +143,7 @@ const DatePicker = generatePicker<DateTime>(luxonGenerateConfig);
 export default DatePicker;
 ```
 
-### 与 day.js 的差异
+### 与 dayjs 的差异
 
 luxon 用户应该悉知，它不附带用于本地化的自定义实现。 相反，它依赖于浏览器的本机 [Intl API](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl)。
 
@@ -160,14 +158,13 @@ luxon 用户应该悉知，它不附带用于本地化的自定义实现。 相�
 
 ```tsx
 import generatePicker from 'antd/es/date-picker/generatePicker';
-import 'antd/es/date-picker/style/index';
 import type { DateTime } from 'luxon';
 import luxonGenerateConfig from 'rc-picker/lib/generate/luxon';
 
 const customLuxonConfig = {
   ...luxonGenerateConfig,
-  getWeekFirstDay: (locale) => {
-    // Your custom implementation goes here
+  getWeekFirstDay(locale) {
+    // 在这里编写你的自定义实现
   },
 };
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | update docs |
| 🇨🇳 Chinese | - |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 42aec14</samp>

This pull request improves the documentation for using a custom date library with `antd` in both English and Chinese. It fixes some typos, removes unnecessary code, and enhances the code examples with better syntax and readability. It also adds a note about the minimum required version of `antd` for this feature.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 42aec14</samp>

* Remove unnecessary imports of date-picker style in both English and Chinese versions of the documentation, as they are already imported by the `antd` package ([link](https://github.com/ant-design/ant-design/pull/41615/files?diff=unified&w=0#diff-7d7f99f1d1ed3ea033947dc9c52dd79eaa41231f99f065da31ba79f01daaaf10L123), [link](https://github.com/ant-design/ant-design/pull/41615/files?diff=unified&w=0#diff-7d7f99f1d1ed3ea033947dc9c52dd79eaa41231f99f065da31ba79f01daaaf10L141), [link](https://github.com/ant-design/ant-design/pull/41615/files?diff=unified&w=0#diff-7d7f99f1d1ed3ea033947dc9c52dd79eaa41231f99f065da31ba79f01daaaf10L165), [link](https://github.com/ant-design/ant-design/pull/41615/files?diff=unified&w=0#diff-e506cd45013ef022ee1e0e5d855ee37b6d91d4019e2f32a73c758df5441b108eL121), [link](https://github.com/ant-design/ant-design/pull/41615/files?diff=unified&w=0#diff-e506cd45013ef022ee1e0e5d855ee37b6d91d4019e2f32a73c758df5441b108eL139), [link](https://github.com/ant-design/ant-design/pull/41615/files?diff=unified&w=0#diff-e506cd45013ef022ee1e0e5d855ee37b6d91d4019e2f32a73c758df5441b108eL163))
* Fix typos of `dayjs` library name in both English and Chinese versions of the documentation ([link](https://github.com/ant-design/ant-design/pull/41615/files?diff=unified&w=0#diff-7d7f99f1d1ed3ea033947dc9c52dd79eaa41231f99f065da31ba79f01daaaf10L150-R148), [link](https://github.com/ant-design/ant-design/pull/41615/files?diff=unified&w=0#diff-e506cd45013ef022ee1e0e5d855ee37b6d91d4019e2f32a73c758df5441b108eL148-R146))
* Simplify syntax of `getWeekFirstDay` function in `customLuxonConfig` object in both English and Chinese versions of the documentation, using shorthand method notation instead of arrow function expression ([link](https://github.com/ant-design/ant-design/pull/41615/files?diff=unified&w=0#diff-7d7f99f1d1ed3ea033947dc9c52dd79eaa41231f99f065da31ba79f01daaaf10L171-R168), [link](https://github.com/ant-design/ant-design/pull/41615/files?diff=unified&w=0#diff-e506cd45013ef022ee1e0e5d855ee37b6d91d4019e2f32a73c758df5441b108eL169-R167))
* Add a note in the Chinese version of the documentation, indicating that the support for using `luxon` instead of `dayjs` was added in `antd 5.4.0` ([link](https://github.com/ant-design/ant-design/pull/41615/files?diff=unified&w=0#diff-e506cd45013ef022ee1e0e5d855ee37b6d91d4019e2f32a73c758df5441b108eL131-R130))
