### PR TITLE
chore: optimize Select like component popup logic

### DIFF
--- a/components/cascader/index.tsx
+++ b/components/cascader/index.tsx
@@ -31,6 +31,7 @@ import getIcons from '../select/utils/iconUtil';
 
 import genPurePanel from '../_util/PurePanel';
 import useSelectStyle from '../select/style';
+import useBuiltinPlacements from '../select/useBuiltinPlacements';
 import useShowArrow from '../select/useShowArrow';
 import useStyle from './style';
 
@@ -149,6 +150,7 @@ const Cascader = React.forwardRef((props: CascaderProps<any>, ref: React.Ref<Cas
     getPopupContainer,
     status: customStatus,
     showArrow,
+    builtinPlacements,
     ...rest
   } = props;
 
@@ -274,6 +276,8 @@ const Cascader = React.forwardRef((props: CascaderProps<any>, ref: React.Ref<Cas
     return isRtl ? 'bottomRight' : 'bottomLeft';
   }, [placement, isRtl]);
 
+  const mergedBuiltinPlacements = useBuiltinPlacements(builtinPlacements);
+
   // ==================== Render =====================
   const renderNode = (
     <RcCascader
@@ -295,6 +299,7 @@ const Cascader = React.forwardRef((props: CascaderProps<any>, ref: React.Ref<Cas
       )}
       disabled={mergedDisabled}
       {...(restProps as any)}
+      builtinPlacements={mergedBuiltinPlacements}
       direction={mergedDirection}
       placement={memoPlacement}
       notFoundContent={mergedNotFoundContent}

--- a/components/select/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/select/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -2564,6 +2564,1812 @@ exports[`renders components/select/demo/debug.tsx extend context correctly 1`] =
 </div>
 `;
 
+exports[`renders components/select/demo/debug-flip-shift.tsx extend context correctly 1`] = `
+<div
+  class="ant-select ant-select-single ant-select-show-arrow ant-select-open"
+  style="width: 120px; margin-top: 50vh;"
+>
+  <div
+    class="ant-select-selector"
+  >
+    <span
+      class="ant-select-selection-search"
+    >
+      <input
+        aria-activedescendant="rc_select_TEST_OR_SSR_list_0"
+        aria-autocomplete="list"
+        aria-controls="rc_select_TEST_OR_SSR_list"
+        aria-expanded="true"
+        aria-haspopup="listbox"
+        aria-owns="rc_select_TEST_OR_SSR_list"
+        autocomplete="off"
+        class="ant-select-selection-search-input"
+        id="rc_select_TEST_OR_SSR"
+        readonly=""
+        role="combobox"
+        style="opacity: 0;"
+        type="search"
+        unselectable="on"
+        value=""
+      />
+    </span>
+    <span
+      class="ant-select-selection-placeholder"
+    />
+  </div>
+  <div
+    class="ant-select-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up ant-select-dropdown-placement-bottomLeft"
+    style="left: -1000vw; top: -1000vh; box-sizing: border-box; min-width: 0; width: 0px;"
+  >
+    <div>
+      <div
+        id="rc_select_TEST_OR_SSR_list"
+        role="listbox"
+        style="height: 0px; width: 0px; overflow: hidden;"
+      >
+        <div
+          aria-selected="false"
+          id="rc_select_TEST_OR_SSR_list_0"
+          role="option"
+        >
+          0
+        </div>
+        <div
+          aria-selected="false"
+          id="rc_select_TEST_OR_SSR_list_1"
+          role="option"
+        >
+          1
+        </div>
+      </div>
+      <div
+        class="rc-virtual-list"
+        style="position: relative;"
+      >
+        <div
+          class="rc-virtual-list-holder"
+          style="max-height: 256px; overflow-y: auto;"
+        >
+          <div>
+            <div
+              class="rc-virtual-list-holder-inner"
+              style="display: flex; flex-direction: column;"
+            >
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option ant-select-item-option-active"
+                title="0"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  0
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="1"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  1
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="2"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  2
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="3"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  3
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="4"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  4
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="5"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  5
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="6"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  6
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="7"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  7
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="8"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  8
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="9"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  9
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="10"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  10
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="11"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  11
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="12"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  12
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="13"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  13
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="14"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  14
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="15"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  15
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="16"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  16
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="17"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  17
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="18"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  18
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="19"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  19
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="20"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  20
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="21"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  21
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="22"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  22
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="23"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  23
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="24"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  24
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="25"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  25
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="26"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  26
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="27"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  27
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="28"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  28
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="29"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  29
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="30"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  30
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="31"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  31
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="32"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  32
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="33"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  33
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="34"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  34
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="35"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  35
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="36"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  36
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="37"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  37
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="38"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  38
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="39"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  39
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="40"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  40
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="41"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  41
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="42"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  42
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="43"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  43
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="44"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  44
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="45"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  45
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="46"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  46
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="47"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  47
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="48"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  48
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="49"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  49
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="50"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  50
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="51"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  51
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="52"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  52
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="53"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  53
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="54"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  54
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="55"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  55
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="56"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  56
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="57"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  57
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="58"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  58
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="59"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  59
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="60"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  60
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="61"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  61
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="62"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  62
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="63"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  63
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="64"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  64
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="65"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  65
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="66"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  66
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="67"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  67
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="68"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  68
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="69"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  69
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="70"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  70
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="71"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  71
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="72"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  72
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="73"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  73
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="74"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  74
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="75"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  75
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="76"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  76
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="77"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  77
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="78"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  78
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="79"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  79
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="80"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  80
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="81"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  81
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="82"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  82
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="83"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  83
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="84"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  84
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="85"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  85
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="86"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  86
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="87"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  87
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="88"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  88
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="89"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  89
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="90"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  90
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="91"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  91
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="92"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  92
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="93"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  93
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="94"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  94
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="95"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  95
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="96"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  96
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="97"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  97
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="98"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  98
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+              <div
+                aria-selected="false"
+                class="ant-select-item ant-select-item-option"
+                title="99"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  99
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <span
+    aria-hidden="true"
+    class="ant-select-arrow"
+    style="user-select: none;"
+    unselectable="on"
+  >
+    <span
+      aria-label="down"
+      class="anticon anticon-down ant-select-suffix"
+      role="img"
+    >
+      <svg
+        aria-hidden="true"
+        data-icon="down"
+        fill="currentColor"
+        focusable="false"
+        height="1em"
+        viewBox="64 64 896 896"
+        width="1em"
+      >
+        <path
+          d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+        />
+      </svg>
+    </span>
+  </span>
+</div>
+`;
+
 exports[`renders components/select/demo/hide-selected.tsx extend context correctly 1`] = `
 <div
   class="ant-select ant-select-multiple ant-select-show-arrow ant-select-show-search"

--- a/components/select/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/select/__tests__/__snapshots__/demo.test.tsx.snap
@@ -1232,6 +1232,67 @@ exports[`renders components/select/demo/debug.tsx correctly 1`] = `
 </div>
 `;
 
+exports[`renders components/select/demo/debug-flip-shift.tsx correctly 1`] = `
+<div
+  class="ant-select ant-select-single ant-select-show-arrow"
+  style="width:120px;margin-top:50vh"
+>
+  <div
+    class="ant-select-selector"
+  >
+    <span
+      class="ant-select-selection-search"
+    >
+      <input
+        aria-activedescendant="undefined_list_0"
+        aria-autocomplete="list"
+        aria-controls="undefined_list"
+        aria-expanded="false"
+        aria-haspopup="listbox"
+        aria-owns="undefined_list"
+        autocomplete="off"
+        class="ant-select-selection-search-input"
+        readonly=""
+        role="combobox"
+        style="opacity:0"
+        type="search"
+        unselectable="on"
+        value=""
+      />
+    </span>
+    <span
+      class="ant-select-selection-placeholder"
+    />
+  </div>
+  <span
+    aria-hidden="true"
+    class="ant-select-arrow"
+    style="user-select:none;-webkit-user-select:none"
+    unselectable="on"
+  >
+    <span
+      aria-label="down"
+      class="anticon anticon-down ant-select-suffix"
+      role="img"
+    >
+      <svg
+        aria-hidden="true"
+        data-icon="down"
+        fill="currentColor"
+        focusable="false"
+        height="1em"
+        viewBox="64 64 896 896"
+        width="1em"
+      >
+        <path
+          d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+        />
+      </svg>
+    </span>
+  </span>
+</div>
+`;
+
 exports[`renders components/select/demo/hide-selected.tsx correctly 1`] = `
 <div
   class="ant-select ant-select-multiple ant-select-show-arrow ant-select-show-search"

--- a/components/select/demo/debug-flip-shift.md
+++ b/components/select/demo/debug-flip-shift.md
@@ -1,0 +1,7 @@
+## zh-CN
+
+翻转后如果不够则偏移以供完全的展示。
+
+## en-US
+
+Shift the popup if not enough space after flip.

--- a/components/select/demo/debug-flip-shift.tsx
+++ b/components/select/demo/debug-flip-shift.tsx
@@ -1,0 +1,14 @@
+import { Select } from 'antd';
+import React from 'react';
+
+const App: React.FC = () => (
+  <Select
+    style={{ width: 120, marginTop: '50vh' }}
+    open
+    options={new Array(100).fill(null).map((_, index) => ({
+      value: index,
+    }))}
+  />
+);
+
+export default App;

--- a/components/select/index.en-US.md
+++ b/components/select/index.en-US.md
@@ -43,6 +43,7 @@ Select component to select value from options.
 <code src="./demo/debug.tsx" debug>4.0 Debug</code>
 <code src="./demo/render-panel.tsx" debug>\_InternalPanelDoNotUseOrYouWillBeFired</code>
 <code src="./demo/option-label-center.tsx" debug>Options label Centered</code>
+<code src="./demo/debug-flip-shift.tsx" iframe="200" debug>Flip + Shift</code>
 
 ## API
 

--- a/components/select/index.tsx
+++ b/components/select/index.tsx
@@ -20,6 +20,7 @@ import DefaultRenderEmpty from '../config-provider/defaultRenderEmpty';
 import { FormItemInputContext } from '../form/context';
 import { useCompactItemContext } from '../space/Compact';
 import useStyle from './style';
+import useBuiltinPlacements from './useBuiltinPlacements';
 import useShowArrow from './useShowArrow';
 import getIcons from './utils/iconUtil';
 
@@ -81,6 +82,7 @@ const InternalSelect = <OptionType extends BaseOptionType | DefaultOptionType = 
     notFoundContent,
     status: customStatus,
     showArrow,
+    builtinPlacements,
     ...props
   }: SelectProps<OptionType>,
   ref: React.Ref<BaseSelectRef>,
@@ -188,6 +190,8 @@ const InternalSelect = <OptionType extends BaseOptionType | DefaultOptionType = 
     return direction === 'rtl' ? 'bottomRight' : 'bottomLeft';
   }, [placement, direction]);
 
+  const mergedBuiltinPlacements = useBuiltinPlacements(builtinPlacements);
+
   // ====================== Warning ======================
   if (process.env.NODE_ENV !== 'production') {
     warning(
@@ -210,6 +214,7 @@ const InternalSelect = <OptionType extends BaseOptionType | DefaultOptionType = 
         getTransitionDirection(placement),
         props.transitionName,
       )}
+      builtinPlacements={mergedBuiltinPlacements}
       listHeight={listHeight}
       listItemHeight={listItemHeight}
       mode={mode}

--- a/components/select/index.tsx
+++ b/components/select/index.tsx
@@ -209,12 +209,12 @@ const InternalSelect = <OptionType extends BaseOptionType | DefaultOptionType = 
       dropdownMatchSelectWidth={dropdownMatchSelectWidth}
       showSearch={select?.showSearch}
       {...selectProps}
+      builtinPlacements={mergedBuiltinPlacements}
       transitionName={getTransitionName(
         rootPrefixCls,
         getTransitionDirection(placement),
         props.transitionName,
       )}
-      builtinPlacements={mergedBuiltinPlacements}
       listHeight={listHeight}
       listItemHeight={listItemHeight}
       mode={mode}

--- a/components/select/index.zh-CN.md
+++ b/components/select/index.zh-CN.md
@@ -44,6 +44,7 @@ demo:
 <code src="./demo/debug.tsx" debug>4.0 Debug</code>
 <code src="./demo/render-panel.tsx" debug>\_InternalPanelDoNotUseOrYouWillBeFired</code>
 <code src="./demo/option-label-center.tsx" debug>选项文本居中</code>
+<code src="./demo/debug-flip-shift.tsx" iframe="200" debug>翻转+偏移</code>
 
 ## API
 

--- a/components/select/useBuiltinPlacements.tsx
+++ b/components/select/useBuiltinPlacements.tsx
@@ -1,0 +1,37 @@
+import type { AlignType, BuildInPlacements } from '@rc-component/trigger';
+
+const sharedConfig = {
+  overflow: {
+    adjustX: true,
+    adjustY: true,
+    shiftY: true,
+  },
+  htmlRegion: 'visible' as const,
+};
+
+const defaultBuiltInPlacements: Record<string, AlignType> = {
+  bottomLeft: {
+    ...sharedConfig,
+    points: ['tl', 'bl'],
+    offset: [0, 4],
+  },
+  bottomRight: {
+    ...sharedConfig,
+    points: ['tr', 'br'],
+    offset: [0, 4],
+  },
+  topLeft: {
+    ...sharedConfig,
+    points: ['bl', 'tl'],
+    offset: [0, -4],
+  },
+  topRight: {
+    ...sharedConfig,
+    points: ['br', 'tr'],
+    offset: [0, -4],
+  },
+};
+
+export default function useBuiltinPlacements(buildInPlacements?: BuildInPlacements) {
+  return buildInPlacements || defaultBuiltInPlacements;
+}

--- a/components/tree-select/index.tsx
+++ b/components/tree-select/index.tsx
@@ -19,6 +19,7 @@ import SizeContext from '../config-provider/SizeContext';
 import DefaultRenderEmpty from '../config-provider/defaultRenderEmpty';
 import { FormItemInputContext } from '../form/context';
 import useSelectStyle from '../select/style';
+import useBuiltinPlacements from '../select/useBuiltinPlacements';
 import useShowArrow from '../select/useShowArrow';
 import getIcons from '../select/utils/iconUtil';
 import { useCompactItemContext } from '../space/Compact';
@@ -93,6 +94,7 @@ const InternalTreeSelect = <
     status: customStatus,
     showArrow,
     treeExpandAction,
+    builtinPlacements,
     ...props
   }: TreeSelectProps<ValueType, OptionType>,
   ref: React.Ref<BaseSelectRef>,
@@ -187,6 +189,8 @@ const InternalTreeSelect = <
     return direction === 'rtl' ? 'bottomRight' : 'bottomLeft';
   }, [placement, direction]);
 
+  const mergedBuiltinPlacements = useBuiltinPlacements(builtinPlacements);
+
   const mergedSize = compactSize || customizeSize || size;
   // ===================== Disabled =====================
   const disabled = React.useContext(DisabledContext);
@@ -223,6 +227,7 @@ const InternalTreeSelect = <
       dropdownMatchSelectWidth={dropdownMatchSelectWidth}
       disabled={mergedDisabled}
       {...selectProps}
+      builtinPlacements={mergedBuiltinPlacements}
       ref={ref}
       prefixCls={prefixCls}
       className={mergedClassName}

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "@ctrl/tinycolor": "^3.6.0",
     "@rc-component/mutate-observer": "^1.0.0",
     "@rc-component/tour": "~1.8.0",
-    "@rc-component/trigger": "^1.5.9",
+    "@rc-component/trigger": "^1.7.0",
     "classnames": "^2.2.6",
     "copy-to-clipboard": "^3.2.0",
     "dayjs": "^1.11.1",


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

resolve #35986
resolve #36866

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Optimize Select-like component popup logic. Now always try to display it in the visible area first to reduce the user's extra scrolling cost.        |
| 🇨🇳 Chinese |  优化类 Select 组件弹窗逻辑，现在总是会尝试优先在可视区域展示以减少用户额外滚动成本。         |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fce305c</samp>

This pull request adds the `builtinPlacements` prop to the `Cascader`, `Select`, and `TreeSelect` components to allow users to customize the popup placements. It also refactors the `useBuiltinPlacements` hook to a separate file and uses it in the components to calculate the default placements based on the available space and the overflow and shift options. It updates the `@rc-component/trigger` package to support the `shiftY` option and adds a new demo to showcase the popup placement logic.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at fce305c</samp>

*  Refactor the `useBuiltinPlacements` hook to a separate file and reuse it in the `select`, `cascader`, and `tree-select` components to calculate the popup placements based on the available space and the overflow and shift options ([link](https://github.com/ant-design/ant-design/pull/41619/files?diff=unified&w=0#diff-cf9c6a6fcee364e93144b7afa91b8ff8b85e8bab46a1b602752c25b6c8de55d0R23), [link](https://github.com/ant-design/ant-design/pull/41619/files?diff=unified&w=0#diff-4737f6ef564486c449ec019f2826176d8b8d186088e5e912ad06ad1919b2d804R34), [link](https://github.com/ant-design/ant-design/pull/41619/files?diff=unified&w=0#diff-f4ebf787ec0bc13112f49b0d9a2df0bfa73f8ea80cec9a6c92d311e120fa6ffeR22), [link](https://github.com/ant-design/ant-design/pull/41619/files?diff=unified&w=0#diff-0b6ce329872d35f43327010f3fbb2312a3f77d2d9e6151dfa32624df97ebf386R1-R37)).
