### PR TITLE
chore: improve Form.Item on Require judgment logic

### DIFF
--- a/components/form/FormItem/ItemHolder.tsx
+++ b/components/form/FormItem/ItemHolder.tsx
@@ -52,6 +52,7 @@ export default function ItemHolder(props: ItemHolderProps) {
     hidden,
     children,
     fieldId,
+    required,
     isRequired,
     onSubItemMetaChange,
     ...restProps
@@ -171,7 +172,6 @@ export default function ItemHolder(props: ItemHolderProps) {
           'normalize',
           'noStyle',
           'preserve',
-          'required',
           'requiredMark',
           'rules',
           'shouldUpdate',
@@ -186,9 +186,9 @@ export default function ItemHolder(props: ItemHolderProps) {
         {/* Label */}
         <FormItemLabel
           htmlFor={fieldId}
-          required={isRequired}
           requiredMark={requiredMark}
           {...props}
+          required={required ?? isRequired}
           prefixCls={prefixCls}
         />
         {/* Input Group */}

--- a/components/form/__tests__/index.test.tsx
+++ b/components/form/__tests__/index.test.tsx
@@ -1736,6 +1736,20 @@ describe('Form', () => {
     expect(container.querySelector('.ant-form-item-has-error')).toBeTruthy();
   });
 
+  // https://github.com/ant-design/ant-design/issues/41621
+  it('should not override value when pass `undefined` to require', async () => {
+    // When require is `undefined`, the `isRequire` calculation logic should be preserved
+    const { container } = render(
+      <Form>
+        <Form.Item label="test" name="success" required={undefined} rules={[{ required: true }]}>
+          <Input />
+        </Form.Item>
+      </Form>,
+    );
+
+    expect(container.querySelector('.ant-form-item-required')).toBeTruthy();
+  });
+
   it('validate status should be change in order', async () => {
     const onChange = jest.fn();
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

fix #41621

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     improve `Form.Item` on Require judgment logic       |
| 🇨🇳 Chinese |      改进 `Form.Item` 关于 Require 判断逻辑     |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c37f6f5</samp>

This pull request adds a new feature and fixes a bug for the form component. It enables the user to customize the required mark of the form item label with a new `required` prop, and ensures that the required mark is displayed correctly when the `required` prop is `undefined`. It also updates the test file `components/form/__tests__/index.test.tsx` to cover the new feature and the bug fix.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c37f6f5</samp>

*  Add a new prop `required` to the `ItemHolder` component to indicate whether the form item is required or not ([link](https://github.com/ant-design/ant-design/pull/41623/files?diff=unified&w=0#diff-0669e96d7e08a1ef315d1574f62b339113dc7db6ad1549ac5a649151b105596fR55))
*  Pass the `required` prop from the `ItemHolder` component to the `FormItemLabel` component and use it to override the `isRequired` prop ([link](https://github.com/ant-design/ant-design/pull/41623/files?diff=unified&w=0#diff-0669e96d7e08a1ef315d1574f62b339113dc7db6ad1549ac5a649151b105596fL189-R191))
*  Remove the hard-coded `'required'` string from the `className` of the form item wrapper and use the `required` prop instead ([link](https://github.com/ant-design/ant-design/pull/41623/files?diff=unified&w=0#diff-0669e96d7e08a1ef315d1574f62b339113dc7db6ad1549ac5a649151b105596fL174))
*  Add a new test case to check that the form item label still shows the required mark when the `required` prop is `undefined` and the `rules` prop contains a `required: true` rule in `components/form/__tests__/index.test.tsx` ([link](https://github.com/ant-design/ant-design/pull/41623/files?diff=unified&w=0#diff-f3bb49bfe69c75aa977732eec74dfe67b8b00e00fc5e008c4f1d3835ae296eacR1739-R1752))
