### PR TITLE
docs(Notification): completing descriptions of missing props

### DIFF
--- a/components/notification/index.en-US.md
+++ b/components/notification/index.en-US.md
@@ -61,7 +61,7 @@ The properties of config are as follows:
 | top | Distance from the top of the viewport, when `placement` is `topRight` or `topLeft` (unit: pixels) | number | 24 |
 | onClick | Specify a function that will be called when the notification is clicked | function | - |
 | onClose | Trigger when notification closed | function | - |
-| props | Props passed down | Object | An object that can contain `data-*`, `aria-*`, or `role` props, to be put on the notification `div`. This currently only allows `data-testid` instead of `data-*` in TypeScript. See https://github.com/microsoft/TypeScript/issues/28960. |
+| props | An object that can contain `data-*`, `aria-*`, or `role` props, to be put on the notification `div`. This currently only allows `data-testid` instead of `data-*` in TypeScript. See https://github.com/microsoft/TypeScript/issues/28960. | Object | - |
 
 `notification` also provides a global `config()` method that can be used for specifying the default options. Once this method is used, all the notification boxes will take into account these globally defined options when displaying.
 

--- a/components/notification/index.zh-CN.md
+++ b/components/notification/index.zh-CN.md
@@ -62,7 +62,7 @@ config 参数如下：
 | top | 消息从顶部弹出时，距离顶部的位置，单位像素 | number | 24 |
 | onClick | 点击通知时触发的回调函数 | function | - |
 | onClose | 当通知关闭时触发 | function | - |
-| props | 透传至通知 `div` 上的 props 对象，支持传入 `data-*` `aria-*` 或 `role` 作为对象的属性。 需要注意的是，虽然在 TypeScript 类型中声明的类型支持传入 `data-*` 作为对象的属性，但目前只允许传入 `data-testid` 作为对象的属性。 详见 https://github.com/microsoft/TypeScript/issues/28960 | Object | - |
+| props | 透传至通知 `div` 上的 props 对象，支持传入 `data-*` `aria-*` 或 `role` 作为对象的属性。需要注意的是，虽然在 TypeScript 类型中声明的类型支持传入 `data-*` 作为对象的属性，但目前只允许传入 `data-testid` 作为对象的属性。 详见 https://github.com/microsoft/TypeScript/issues/28960 | Object | - |
 
 ### 全局配置
 

--- a/components/notification/index.zh-CN.md
+++ b/components/notification/index.zh-CN.md
@@ -62,6 +62,7 @@ config 参数如下：
 | top | 消息从顶部弹出时，距离顶部的位置，单位像素 | number | 24 |
 | onClick | 点击通知时触发的回调函数 | function | - |
 | onClose | 当通知关闭时触发 | function | - |
+| props | 透传至通知 `div` 上的 props 对象，支持传入 `data-*` `aria-*` 或 `role` 作为对象的属性。 需要注意的是，虽然在 TypeScript 类型中声明的类型支持传入 `data-*` 作为对象的属性，但目前只允许传入 `data-testid` 作为对象的属性。 详见 https://github.com/microsoft/TypeScript/issues/28960 | Object | - |
 
 ### 全局配置
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
#37710

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

Seems to only update the English docs for the Notification component after #37710.

1. The Chinese docs of the Notification component lacks information about the `props` prop.
2. Description of the `props` prop in the English docs could be placed in the wrong field. (Seems like it should go in the `Description` instead of the `Default` field)

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Support for `data-testid` on Notification component |
| 🇨🇳 Chinese | 支持通知组件上的 `data-testid` |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 661a6cb</samp>

Updated the documentation of `components/notification` to fix the table format of the `props` parameter in the English version and add the `props` parameter description to the Chinese version.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 661a6cb</samp>

* Move the `props` parameter description to the third column in the English documentation of `notification.open` method ([link](https://github.com/ant-design/ant-design/pull/41671/files?diff=unified&w=0#diff-9b1700ccbd4da0f60742ae024592c27e0118d7307f5a9ed69a91c560c374749fL64-R64)) and add the same description to the Chinese documentation ([link](https://github.com/ant-design/ant-design/pull/41671/files?diff=unified&w=0#diff-9954e364a4a4121f77d3f9f87225ef361d39c004720443dd896bb31cfe3c6d22R65)) in `components/notification/index.en-US.md` and `components/notification/index.zh-CN.md` respectively, to improve readability, consistency, and localization of the API table
