### PR TITLE
style(List.Item.Meta): Avatar and title are not aligned

### DIFF
--- a/components/list/__tests__/Item.test.tsx
+++ b/components/list/__tests__/Item.test.tsx
@@ -230,4 +230,20 @@ describe('List Item Layout', () => {
     rerender(getDom(5));
     expect(loadId).toEqual([1, 3, 5]);
   });
+
+  it('List.Item.Meta title should have no default margin', () => {
+    const { container } = render(
+      <List
+        dataSource={[{ id: 1, title: `ant design` }]}
+        renderItem={(item) => (
+          <List.Item>
+            <List.Item.Meta title={item.title} />
+          </List.Item>
+        )}
+      />,
+    );
+
+    const title = container.querySelector('.ant-list-item-meta-title');
+    expect(title && getComputedStyle(title).margin).toEqual('0px 0px 4px 0px');
+  });
 });

--- a/components/list/style/index.ts
+++ b/components/list/style/index.ts
@@ -187,7 +187,7 @@ const genBaseStyle: GenerateStyle<ListToken> = (token) => {
           },
 
           [`${componentCls}-item-meta-title`]: {
-            marginBottom: token.marginXXS,
+            margin: `0 0 ${token.marginXXS}px 0`,
             color: colorText,
             fontSize: token.fontSize,
             lineHeight: token.lineHeight,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
close https://github.com/ant-design/ant-design/issues/41684
### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->
问题是由于 List.Item.Meta 的 title 具有默认的 margin，如下图：
![image](https://user-images.githubusercontent.com/112228030/230407675-6c5ba619-7a36-42e7-aabf-c31e376ccd31.png)
![image](https://user-images.githubusercontent.com/112228030/230411423-69c42080-81be-4dfe-a6f5-c9e46769a4ce.png)

导致单独使用 List.Item.Meta 时会出现 avatar 和 title 不对齐的情况，去除默认边距后：
![image](https://user-images.githubusercontent.com/112228030/230412131-0c01bdfc-56c0-4981-83ea-56dfa0414c37.png)

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix `List.Item.Meta` avatar and title are not aligned           |
| 🇨🇳 Chinese | 修复 `List.Item.Meta` 的 avatar 和  title 不对齐          |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1b0ba1b</samp>

Fix the alignment issue of the List.Item.Meta title component by removing its default margin in the block direction. Add a test case to verify the fix. The affected files are `components/list/__tests__/Item.test.tsx` and `components/list/style/index.ts`.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1b0ba1b</samp>

* Remove the default margin in the block direction for the `List.Item.Meta` title component to align it with the avatar and content ([link](https://github.com/ant-design/ant-design/pull/41688/files?diff=unified&w=0#diff-8ed8eddb13b4537df4b99afb831a6d4be1bef5a7d3b3cc4ddac6b3d1307e87a4R194-R195), [link](https://github.com/ant-design/ant-design/pull/41688/files?diff=unified&w=0#diff-0f9e40dbdcbef8c914eb8f29eaa92d7ebda6f130356f613e0082467ad407b6d6R233-R252))
