### PR TITLE
fix: switcherIcon cannot be hidden

### DIFF
--- a/components/tree/__tests__/index.test.tsx
+++ b/components/tree/__tests__/index.test.tsx
@@ -185,4 +185,16 @@ describe('Tree', () => {
       expect(nodeDraggable).toHaveBeenCalledWith(dragTreeData[0]);
     });
   });
+
+  it('hidden switcherIcon', () => {
+    const { container } = render(
+      <Tree defaultExpandAll switcherIcon={() => null}>
+        <TreeNode icon="icon">
+          <TreeNode title="node1" icon="icon" key="0-0-2" />
+          <TreeNode title="node2" key="0-0-3" />
+        </TreeNode>
+      </Tree>,
+    );
+    expect(container.querySelectorAll('ant-tree-switcher').length).toBe(0);
+  });
 });

--- a/components/tree/__tests__/index.test.tsx
+++ b/components/tree/__tests__/index.test.tsx
@@ -187,14 +187,27 @@ describe('Tree', () => {
   });
 
   it('hidden switcherIcon', () => {
-    const { container } = render(
-      <Tree defaultExpandAll switcherIcon={() => null}>
-        <TreeNode icon="icon">
-          <TreeNode title="node1" icon="icon" key="0-0-2" />
-          <TreeNode title="node2" key="0-0-3" />
-        </TreeNode>
-      </Tree>,
-    );
-    expect(container.querySelectorAll('ant-tree-switcher').length).toBe(0);
+    it('use `switcherIcon={() => null}`', () => {
+      const { container } = render(
+        <Tree defaultExpandAll switcherIcon={() => null}>
+          <TreeNode icon="icon">
+            <TreeNode title="node1" icon="icon" key="0-0-2" />
+            <TreeNode title="node2" key="0-0-3" />
+          </TreeNode>
+        </Tree>,
+      );
+      expect(container.querySelectorAll('.ant-tree-switcher').length).toBe(0);
+    });
+    it('use `switcherIcon={null}`', () => {
+      const { container } = render(
+        <Tree defaultExpandAll switcherIcon={null}>
+          <TreeNode icon="icon">
+            <TreeNode title="node1" icon="icon" key="0-0-2" />
+            <TreeNode title="node2" key="0-0-3" />
+          </TreeNode>
+        </Tree>,
+      );
+      expect(container.querySelectorAll('.ant-tree-switcher').length).toBe(0);
+    });
   });
 });

--- a/components/tree/__tests__/index.test.tsx
+++ b/components/tree/__tests__/index.test.tsx
@@ -186,7 +186,7 @@ describe('Tree', () => {
     });
   });
 
-  it('hidden switcherIcon', () => {
+  describe('hidden switcherIcon', () => {
     it('use `switcherIcon={() => null}`', () => {
       const { container } = render(
         <Tree defaultExpandAll switcherIcon={() => null}>
@@ -196,7 +196,9 @@ describe('Tree', () => {
           </TreeNode>
         </Tree>,
       );
-      expect(container.querySelectorAll('.ant-tree-switcher').length).toBe(0);
+      container.querySelectorAll('.ant-tree-switcher').forEach((el) => {
+        expect(el.children.length).toBe(0);
+      });
     });
     it('use `switcherIcon={null}`', () => {
       const { container } = render(
@@ -207,7 +209,9 @@ describe('Tree', () => {
           </TreeNode>
         </Tree>,
       );
-      expect(container.querySelectorAll('.ant-tree-switcher').length).toBe(0);
+      container.querySelectorAll('.ant-tree-switcher').forEach((el) => {
+        expect(el.children.length).toBe(0);
+      });
     });
   });
 });

--- a/components/tree/utils/iconUtil.tsx
+++ b/components/tree/utils/iconUtil.tsx
@@ -64,7 +64,7 @@ const SwitcherIconCom: React.FC<SwitcherIconProps> = (props) => {
     });
   }
 
-  if (switcher !== undefined || typeof switcherIcon === 'function') {
+  if (switcher !== undefined) {
     return switcher as unknown as React.ReactElement;
   }
 

--- a/components/tree/utils/iconUtil.tsx
+++ b/components/tree/utils/iconUtil.tsx
@@ -64,7 +64,7 @@ const SwitcherIconCom: React.FC<SwitcherIconProps> = (props) => {
     });
   }
 
-  if (switcher) {
+  if (switcher || typeof switcherIcon === 'function') {
     return switcher as unknown as React.ReactElement;
   }
 

--- a/components/tree/utils/iconUtil.tsx
+++ b/components/tree/utils/iconUtil.tsx
@@ -64,7 +64,7 @@ const SwitcherIconCom: React.FC<SwitcherIconProps> = (props) => {
     });
   }
 
-  if (switcher || typeof switcherIcon === 'function') {
+  if (switcher !== undefined || typeof switcherIcon === 'function') {
     return switcher as unknown as React.ReactElement;
   }
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

fix #41705 

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix switcherIcon cannot be hidden  |
| 🇨🇳 Chinese |  修复switcherIcon无法隐藏  |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9dd721c</samp>

This pull request fixes issue #32841 by allowing the `switcherIcon` prop of the `Tree` component to accept a function that can return a custom icon or null. It also adds a test case to verify the functionality of the prop.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9dd721c</samp>

* Fix issue #32841 by allowing switcherIcon prop to hide or customize tree node icons ([link](https://github.com/ant-design/ant-design/pull/41708/files?diff=unified&w=0#diff-da22d6f22f631152c49377ec55ca75e97414b83b5686fcb93e57904e15c19096L67-R67), [link](https://github.com/ant-design/ant-design/pull/41708/files?diff=unified&w=0#diff-532a06c009c07c3f70338f01f6db867a000491f718b25e64085acda42823ca04R188-R199))
  - Modify getSwitcherIcon function in `iconUtil.tsx` to return switcherIcon prop as a React element if it is a function ([link](https://github.com/ant-design/ant-design/pull/41708/files?diff=unified&w=0#diff-da22d6f22f631152c49377ec55ca75e97414b83b5686fcb93e57904e15c19096L67-R67))
  - Add test case in `index.test.tsx` to verify that switcherIcon prop can return null to hide switcher icons ([link](https://github.com/ant-design/ant-design/pull/41708/files?diff=unified&w=0#diff-532a06c009c07c3f70338f01f6db867a000491f718b25e64085acda42823ca04R188-R199))
