### PR TITLE
fix: Select width getting smaller when search

### DIFF
--- a/components/select/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/select/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -7771,7 +7771,6 @@ exports[`renders components/select/demo/responsive.tsx extend context correctly 
 exports[`renders components/select/demo/search.tsx extend context correctly 1`] = `
 <div
   class="ant-select ant-select-single ant-select-show-arrow ant-select-show-search"
-  style="width: 160px;"
 >
   <div
     class="ant-select-selector"

--- a/components/select/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/select/__tests__/__snapshots__/demo.test.tsx.snap
@@ -2351,7 +2351,6 @@ exports[`renders components/select/demo/responsive.tsx correctly 1`] = `
 exports[`renders components/select/demo/search.tsx correctly 1`] = `
 <div
   class="ant-select ant-select-single ant-select-show-arrow ant-select-show-search"
-  style="width:160px"
 >
   <div
     class="ant-select-selector"

--- a/components/select/demo/search.tsx
+++ b/components/select/demo/search.tsx
@@ -12,7 +12,6 @@ const onSearch = (value: string) => {
 const App: React.FC = () => (
   <Select
     showSearch
-    style={{ width: 160 }}
     placeholder="Select a person"
     optionFilterProp="children"
     onChange={onChange}

--- a/components/select/style/single.tsx
+++ b/components/select/style/single.tsx
@@ -41,7 +41,7 @@ function genSizeStyle(token: SelectToken, suffix?: string): CSSObject {
         `]: {
           padding: 0,
           lineHeight: `${selectHeightWithoutBorder}px`,
-          transition: `all ${token.motionDurationSlow}`,
+          transition: `all ${token.motionDurationSlow}, visibility 0s`,
 
           // Firefox inline-block position calculation is not same as Chrome & Safari. Patch this:
           '@supports (-moz-appearance: meterbar)': {

--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
     "rc-rate": "~2.10.0",
     "rc-resize-observer": "^1.2.0",
     "rc-segmented": "~2.1.2",
-    "rc-select": "14.4.3-0",
+    "rc-select": "~14.4.3",
     "rc-slider": "~10.1.0",
     "rc-steps": "~6.0.0",
     "rc-switch": "~4.0.0",

--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
     "rc-rate": "~2.10.0",
     "rc-resize-observer": "^1.2.0",
     "rc-segmented": "~2.1.2",
-    "rc-select": "~14.4.0",
+    "rc-select": "14.4.3-0",
     "rc-slider": "~10.1.0",
     "rc-steps": "~6.0.0",
     "rc-switch": "~4.0.0",


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
close https://github.com/ant-design/ant-design/issues/27688
close https://github.com/ant-design/ant-design/issues/41530

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

<img width="227" alt="截屏2023-04-10 上午11 25 00" src="https://user-images.githubusercontent.com/507615/230821286-6e18fff7-c2f0-457b-a64d-23c771ef07f4.png">


<img width="218" alt="图片" src="https://user-images.githubusercontent.com/507615/230584492-17839b6b-f8fb-45d4-95e4-a54d13ce25c1.png">

关键改动：https://github.com/react-component/select/pull/936

把 4.x 的改动挪到 5.x 上来：https://github.com/ant-design/ant-design/pull/41646


### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fix Select width becomes 0px when search after select something.      |
| 🇨🇳 Chinese |  修复 Select 在搜索时宽度变为 `0px` 的问题。        |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 370760a</samp>

Updated `rc-select` dependency to fix select component issues. This improved the usability and functionality of the select input in the ant-design library.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 370760a</samp>

* Upgrade `rc-select` dependency to fix select component issues ([link](https://github.com/ant-design/ant-design/pull/41646/files?diff=unified&w=0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L147-R147))
