### PR TITLE
chore: Form.Item should not support requiredMark

### DIFF
--- a/components/form/FormItem/ItemHolder.tsx
+++ b/components/form/FormItem/ItemHolder.tsx
@@ -186,8 +186,8 @@ export default function ItemHolder(props: ItemHolderProps) {
         {/* Label */}
         <FormItemLabel
           htmlFor={fieldId}
-          requiredMark={requiredMark}
           {...props}
+          requiredMark={requiredMark}
           required={required ?? isRequired}
           prefixCls={prefixCls}
         />

--- a/components/form/FormItem/index.tsx
+++ b/components/form/FormItem/index.tsx
@@ -51,7 +51,7 @@ const MemoInput = React.memo(
 );
 
 export interface FormItemProps<Values = any>
-  extends FormItemLabelProps,
+  extends Omit<FormItemLabelProps, 'requiredMark'>,
     FormItemInputProps,
     RcFieldProps<Values> {
   prefixCls?: string;

--- a/components/form/FormItemLabel.tsx
+++ b/components/form/FormItemLabel.tsx
@@ -38,6 +38,9 @@ export interface FormItemLabelProps {
   label?: React.ReactNode;
   labelAlign?: FormLabelAlign;
   labelCol?: ColProps;
+  /**
+   * @internal Used for pass `requiredMark` from `<Form />`
+   */
   requiredMark?: RequiredMark;
   tooltip?: LabelTooltipType;
 }

--- a/components/form/__tests__/index.test.tsx
+++ b/components/form/__tests__/index.test.tsx
@@ -1797,4 +1797,29 @@ describe('Form', () => {
     expect(onChange).toHaveBeenNthCalledWith(idx++, 'validating');
     expect(onChange).toHaveBeenNthCalledWith(idx++, 'success');
   });
+
+  // https://user-images.githubusercontent.com/32004925/230819163-464fe90d-422d-4a6d-9e35-44a25d4c64f1.png
+  it('should not render `requiredMark` when Form.Item has no required prop', () => {
+    // Escaping TypeScript error
+    const genProps = (value: any) => ({ ...value });
+
+    const { container } = render(
+      <Form name="basic" requiredMark="optional">
+        <Form.Item
+          label="First Name"
+          name="firstName"
+          required
+          {...genProps({ requiredMark: false })}
+        >
+          <Input />
+        </Form.Item>
+        <Form.Item label="Last Name" name="lastName" required {...genProps({ requiredMark: true })}>
+          <Input />
+        </Form.Item>
+      </Form>,
+    );
+
+    expect(container.querySelectorAll('.ant-form-item-required')).toHaveLength(2);
+    expect(container.querySelectorAll('.ant-form-item-required-mark-optional')).toHaveLength(2);
+  });
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

**Background**:
![image](https://user-images.githubusercontent.com/32004925/230823719-672d24ed-dd1b-4b41-8fe5-c35bc6bfc485.png)

**Solution**

修改后 `<Form.Item />` 将不支持修改 `requiredMark` 属性，只能通过 `<Form />` 的 `requiredMark` 统一设置。


<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     fix `Form.Item` accidentally overwriting requiredMark logic error      |
| 🇨🇳 Chinese |     修复 `Form.Item` 意外覆盖 requiredMark 逻辑问题    |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8cce78b</samp>

Refactor the `requiredMark` prop logic in the `Form` component and its children. Remove unnecessary props and add test cases and comments to improve the code quality and readability.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8cce78b</samp>

*  Refactor the logic of handling the `requiredMark` prop in the `Form` and `FormItem` components ([link](https://github.com/ant-design/ant-design/pull/41725/files?diff=unified&w=0#diff-ca241b27784d31abb99a7d491adda5dd50f6969f7d25389fb3513d267835f3aeL54-R54), [link](https://github.com/ant-design/ant-design/pull/41725/files?diff=unified&w=0#diff-0669e96d7e08a1ef315d1574f62b339113dc7db6ad1549ac5a649151b105596fL189-R190), [link](https://github.com/ant-design/ant-design/pull/41725/files?diff=unified&w=0#diff-5224fbae1a1edab62aff695b513c349bd0f22b1745a6d8d7984d495c1b66f051R41-R43))
  - Omit the `requiredMark` prop from the `FormItemProps` interface in `components/form/FormItem/index.tsx` to avoid passing it to the `FormItem` component ([link](https://github.com/ant-design/ant-design/pull/41725/files?diff=unified&w=0#diff-ca241b27784d31abb99a7d491adda5dd50f6969f7d25389fb3513d267835f3aeL54-R54))
  - Remove the `requiredMark` prop from the `FormItemLabel` component in `components/form/FormItem/ItemHolder.tsx` as it is now passed from the `Form` component ([link](https://github.com/ant-design/ant-design/pull/41725/files?diff=unified&w=0#diff-0669e96d7e08a1ef315d1574f62b339113dc7db6ad1549ac5a649151b105596fL189-R190))
  - Add a comment to the `FormItemLabelProps` interface in `components/form/FormItemLabel.tsx` to explain the internal usage of the `requiredMark` prop ([link](https://github.com/ant-design/ant-design/pull/41725/files?diff=unified&w=0#diff-5224fbae1a1edab62aff695b513c349bd0f22b1745a6d8d7984d495c1b66f051R41-R43))
* Add a test case to the `Form` component in `components/form/__tests__/index.test.tsx` to verify that the `requiredMark` prop works as expected when the `Form.Item` component has no `required` prop ([link](https://github.com/ant-design/ant-design/pull/41725/files?diff=unified&w=0#diff-f3bb49bfe69c75aa977732eec74dfe67b8b00e00fc5e008c4f1d3835ae296eacR1800-R1824))
  - Ensure that the `requiredMark` prop does not render when it is not needed ([link](https://github.com/ant-design/ant-design/pull/41725/files?diff=unified&w=0#diff-f3bb49bfe69c75aa977732eec74dfe67b8b00e00fc5e008c4f1d3835ae296eacR1800-R1824))
