### PR TITLE
fix: Empty style in small width container

### DIFF
--- a/components/empty/style/index.ts
+++ b/components/empty/style/index.ts
@@ -34,6 +34,7 @@ const genSharedEmptyStyle: GenerateStyle<EmptyToken> = (token): CSSObject => {
         },
 
         svg: {
+          maxWidth: '100%',
           height: '100%',
           margin: 'auto',
         },

--- a/components/select/style/dropdown.tsx
+++ b/components/select/style/dropdown.tsx
@@ -84,16 +84,6 @@ const genSingleStyle: GenerateStyle<SelectToken> = (token) => {
           display: 'none',
         },
 
-        '&-empty': {
-          color: token.colorTextDisabled,
-        },
-
-        // ========================= Options =========================
-        [`${selectItemCls}-empty`]: {
-          ...genItemStyle(token),
-          color: token.colorTextDisabled,
-        },
-
         [`${selectItemCls}`]: {
           ...genItemStyle(token),
           cursor: 'pointer',


### PR DESCRIPTION

<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
close #41726

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

| ❌ | ✅ |
| --- | --- |
| <img width="129" alt="图片" src="https://user-images.githubusercontent.com/507615/230821780-4c8e438a-12b5-4441-a994-aec224e5d601.png"> <img width="146" alt="图片" src="https://user-images.githubusercontent.com/507615/230821813-08d4f899-19cf-4641-bc6c-5801f911367a.png"> | <img width="129" alt="图片" src="https://user-images.githubusercontent.com/507615/230822986-e58e7231-f70f-4090-a979-58dd1510ebaf.png"> |


### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Empty style in small width container.          |
| 🇨🇳 Chinese | 修复 Empty 空数据组件在宽度不够的容器内样式错位的问题。          |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b246198</samp>

This pull request updates the style and accessibility of the `Empty` component and its usage in other components. It fixes a bug with the `Empty` component's width, and removes some redundant style rules for the `Select` component's empty state.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b246198</samp>

* Fix empty component overflow bug by adding `maxWidth` property to shared empty style ([link](https://github.com/ant-design/ant-design/pull/41727/files?diff=unified&w=0#diff-19c1cff28e07550d90710c508705cef57f4ccd89959a0db8b1b452e6c6e8173fR37))
* Simplify select component empty state style by removing redundant rules and using shared empty style ([link](https://github.com/ant-design/ant-design/pull/41727/files?diff=unified&w=0#diff-1ac56226dc98c9cd8451c23362f258c0066440108456cb021cfb575da749ea0eL87-L96))
