### PR TITLE
exctract onChange from TableRowSelection to type

### DIFF
--- a/components/table/interface.ts
+++ b/components/table/interface.ts
@@ -160,6 +160,12 @@ export interface SelectionItem {
   onSelect?: SelectionItemSelectFn;
 }
 
+export type SelectionOnChangeFn<T> = (
+  selectedRowKeys: Key[],
+  selectedRows: T[],
+  info: { type: RowSelectMethod }
+) => void;
+
 export type SelectionSelectFn<T> = (
   record: T,
   selected: boolean,
@@ -175,7 +181,7 @@ export interface TableRowSelection<T> {
   type?: RowSelectionType;
   selectedRowKeys?: Key[];
   defaultSelectedRowKeys?: Key[];
-  onChange?: (selectedRowKeys: Key[], selectedRows: T[], info: { type: RowSelectMethod }) => void;
+  onChange?: SelectionOnChangeFn<T>;
   getCheckboxProps?: (record: T) => Partial<Omit<CheckboxProps, 'checked' | 'defaultChecked'>>;
   onSelect?: SelectionSelectFn<T>;
   /** @deprecated This function is deprecated and should use `onChange` instead */


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |exctract onChange from TableRowSelection to type|
| 🇨🇳 Chinese |從 Table RowSelection 中提取 onChange 以鍵入|

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 99d6349</samp>

Refactor the `onChange` type of `TableRowSelection` in `components/table/interface.ts` to use a type alias. This makes the code more concise and clear.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 99d6349</samp>

*  Define a new type alias `SelectionOnChangeFn` for the `onChange` callback function of the `TableRowSelection` interface ([link](https://github.com/ant-design/ant-design/pull/41732/files?diff=unified&w=0#diff-3fee134a410a783dfd5f6f89b1a8f7e7eb1ba8e332aeaf4cafdefc4c723088e9R163-R168))
*  Simplify the type annotation of the `onChange` property of the `TableRowSelection` interface by using the new type alias `SelectionOnChangeFn` ([link](https://github.com/ant-design/ant-design/pull/41732/files?diff=unified&w=0#diff-3fee134a410a783dfd5f6f89b1a8f7e7eb1ba8e332aeaf4cafdefc4c723088e9L178-R184))
