### PR TITLE
FormItem hidden may be function

### DIFF
--- a/components/form/FormItem/index.tsx
+++ b/components/form/FormItem/index.tsx
@@ -110,8 +110,9 @@ function InternalFormItem<Values = any>(props: FormItemProps<Values>): React.Rea
     help,
   } = props;
   const { getPrefixCls } = React.useContext(ConfigContext);
-  const { name: formName } = React.useContext(FormContext);
+  const { name: formName, form } = React.useContext(FormContext);
   const isRenderProps = typeof children === 'function';
+  const isHiddenFunc = typeof hidden === 'function';
   const notifyParentMetaChange = React.useContext(NoStyleItemContext);
 
   const { validateTrigger: contextValidateTrigger } = React.useContext(FieldContext);
@@ -210,7 +211,8 @@ function InternalFormItem<Values = any>(props: FormItemProps<Values>): React.Rea
     fieldId?: string,
     isRequired?: boolean,
   ): React.ReactNode {
-    if (noStyle && !hidden) {
+    const isNeedHide = isHiddenFunc ? hidden(form) : hidden;
+    if (noStyle && !isNeedHide) {
       return baseChildren;
     }
 
@@ -218,6 +220,7 @@ function InternalFormItem<Values = any>(props: FormItemProps<Values>): React.Rea
       <ItemHolder
         key="row"
         {...props}
+        hidden={isNeedHide}
         className={classNames(className, hashId)}
         prefixCls={prefixCls}
         fieldId={fieldId}

--- a/components/form/FormItem/index.tsx
+++ b/components/form/FormItem/index.tsx
@@ -29,6 +29,7 @@ interface FieldError {
 
 const ValidateStatuses = ['success', 'warning', 'error', 'validating', ''] as const;
 export type ValidateStatus = typeof ValidateStatuses[number];
+export type FormItemHiddenType<Values = any> = boolean | ((form: FormInstance<Values>) => boolean);
 
 type RenderChildren<Values = any> = (form: FormInstance<Values>) => React.ReactNode;
 type RcFieldProps<Values = any> = Omit<FieldProps<Values>, 'children'>;
@@ -64,7 +65,7 @@ export interface FormItemProps<Values = any>
   hasFeedback?: boolean;
   validateStatus?: ValidateStatus;
   required?: boolean;
-  hidden?: boolean;
+  hidden?: FormItemHiddenType<Values>;
   initialValue?: any;
   messageVariables?: Record<string, string>;
   tooltip?: LabelTooltipType;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution
If you need hide/show `FormItem` depending value another `FormItem` you can use `hidden` like a function with `FormInstance` which return `boolean`.
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |FormItem hidden may be function|
| 🇨🇳 Chinese |隱藏的 FormItem 可能是函數|

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7ce4bb7</samp>

Enhance `FormItem` component to support dynamic `hidden` prop and expose visibility to context.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7ce4bb7</samp>

*  Add a new type alias `FormItemHiddenType` that can be either a boolean or a function that takes a form instance and returns a boolean ([link](https://github.com/ant-design/ant-design/pull/41736/files?diff=unified&w=0#diff-ca241b27784d31abb99a7d491adda5dd50f6969f7d25389fb3513d267835f3aeR32))
*  Use the new type `FormItemHiddenType` for the `hidden` prop of the `FormItem` component, which controls whether the form item is visible or not ([link](https://github.com/ant-design/ant-design/pull/41736/files?diff=unified&w=0#diff-ca241b27784d31abb99a7d491adda5dd50f6969f7d25389fb3513d267835f3aeL67-R68))
*  Obtain the form instance from the `FormContext` and check whether the `hidden` prop is a function or not in the `InternalFormItem` function, which is the internal implementation of the `FormItem` component ([link](https://github.com/ant-design/ant-design/pull/41736/files?diff=unified&w=0#diff-ca241b27784d31abb99a7d491adda5dd50f6969f7d25389fb3513d267835f3aeL112-R115))
*  Compute the visibility of the form item by calling the `hidden` prop function with the form instance, if it is a function, or using the `hidden` prop value, if it is a boolean, in the `renderLayout` function, which is responsible for rendering the layout of the form item ([link](https://github.com/ant-design/ant-design/pull/41736/files?diff=unified&w=0#diff-ca241b27784d31abb99a7d491adda5dd50f6969f7d25389fb3513d267835f3aeL212-R215))
*  Pass the computed visibility of the form item to the `FormItemContext.Provider` component, which provides the context for the form item children, and export the `useFormItemContext` hook, which allows the children components to access the visibility of the form item ([link](https://github.com/ant-design/ant-design/pull/41736/files?diff=unified&w=0#diff-ca241b27784d31abb99a7d491adda5dd50f6969f7d25389fb3513d267835f3aeR223))
