### PR TITLE
test: Diff of React 17 & 18

### DIFF
--- a/components/__tests__/__snapshots__/setup.test.tsx.snap
+++ b/components/__tests__/__snapshots__/setup.test.tsx.snap
@@ -3,6 +3,9 @@
 exports[`SetUp.Test diff of React 18 & React 17 1`] = `
 NodeList [
   <div>
+  bamboo
+  little
 </div>,
+  <div />,
 ]
 `;

--- a/components/__tests__/__snapshots__/setup.test.tsx.snap
+++ b/components/__tests__/__snapshots__/setup.test.tsx.snap
@@ -1,0 +1,8 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SetUp.Test diff of React 18 & React 17 1`] = `
+NodeList [
+  <div>
+</div>,
+]
+`;

--- a/components/__tests__/setup.test.tsx
+++ b/components/__tests__/setup.test.tsx
@@ -3,7 +3,12 @@ import { render } from '../../tests/utils';
 
 describe('SetUp.Test', () => {
   it('diff of React 18 & React 17', () => {
-    const { container } = render(<div>{['', '', '']}</div>);
+    const { container } = render(
+      <>
+        <div>{['bamboo', '', 'little']}</div>
+        <div>{['', '']}</div>
+      </>,
+    );
     expect(container.childNodes).toMatchSnapshot();
   });
 });

--- a/components/__tests__/setup.test.tsx
+++ b/components/__tests__/setup.test.tsx
@@ -1,0 +1,9 @@
+import * as React from 'react';
+import { render } from '../../tests/utils';
+
+describe('SetUp.Test', () => {
+  it('diff of React 18 & React 17', () => {
+    const { container } = render(<div>{['', '', '']}</div>);
+    expect(container.childNodes).toMatchSnapshot();
+  });
+});

--- a/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
+++ b/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
@@ -17661,7 +17661,7 @@ exports[`ConfigProvider components List prefixCls 1`] = `
 `;
 
 exports[`ConfigProvider components Menu configProvider 1`] = `
-HTMLCollection [
+Array [
   <ul
     class="config-menu config-menu-root config-menu-inline config-menu-light"
     data-menu-list="true"
@@ -17738,7 +17738,7 @@ HTMLCollection [
 `;
 
 exports[`ConfigProvider components Menu configProvider componentDisabled 1`] = `
-HTMLCollection [
+Array [
   <ul
     class="config-menu config-menu-root config-menu-inline config-menu-light"
     data-menu-list="true"
@@ -17815,7 +17815,7 @@ HTMLCollection [
 `;
 
 exports[`ConfigProvider components Menu configProvider componentSize large 1`] = `
-HTMLCollection [
+Array [
   <ul
     class="config-menu config-menu-root config-menu-inline config-menu-light"
     data-menu-list="true"
@@ -17892,7 +17892,7 @@ HTMLCollection [
 `;
 
 exports[`ConfigProvider components Menu configProvider componentSize middle 1`] = `
-HTMLCollection [
+Array [
   <ul
     class="config-menu config-menu-root config-menu-inline config-menu-light"
     data-menu-list="true"
@@ -17969,7 +17969,7 @@ HTMLCollection [
 `;
 
 exports[`ConfigProvider components Menu configProvider virtual and dropdownMatchSelectWidth 1`] = `
-HTMLCollection [
+Array [
   <ul
     class="ant-menu ant-menu-root ant-menu-inline ant-menu-light"
     data-menu-list="true"
@@ -18046,7 +18046,7 @@ HTMLCollection [
 `;
 
 exports[`ConfigProvider components Menu normal 1`] = `
-HTMLCollection [
+Array [
   <ul
     class="ant-menu ant-menu-root ant-menu-inline ant-menu-light"
     data-menu-list="true"
@@ -18123,7 +18123,7 @@ HTMLCollection [
 `;
 
 exports[`ConfigProvider components Menu prefixCls 1`] = `
-HTMLCollection [
+Array [
   <ul
     class="prefix-Menu prefix-Menu-root prefix-Menu-inline prefix-Menu-light"
     data-menu-list="true"
@@ -29333,7 +29333,7 @@ exports[`ConfigProvider components Tags prefixCls 1`] = `
 `;
 
 exports[`ConfigProvider components TimePicker configProvider 1`] = `
-HTMLCollection [
+Array [
   <div
     class="config-picker"
   >
@@ -30746,7 +30746,7 @@ HTMLCollection [
 `;
 
 exports[`ConfigProvider components TimePicker configProvider componentDisabled 1`] = `
-HTMLCollection [
+Array [
   <div
     class="config-picker config-picker-disabled"
   >
@@ -30794,7 +30794,7 @@ HTMLCollection [
 `;
 
 exports[`ConfigProvider components TimePicker configProvider componentSize large 1`] = `
-HTMLCollection [
+Array [
   <div
     class="config-picker config-picker-large"
   >
@@ -32207,7 +32207,7 @@ HTMLCollection [
 `;
 
 exports[`ConfigProvider components TimePicker configProvider componentSize middle 1`] = `
-HTMLCollection [
+Array [
   <div
     class="config-picker config-picker-middle"
   >
@@ -33620,7 +33620,7 @@ HTMLCollection [
 `;
 
 exports[`ConfigProvider components TimePicker configProvider virtual and dropdownMatchSelectWidth 1`] = `
-HTMLCollection [
+Array [
   <div
     class="ant-picker"
   >
@@ -35033,7 +35033,7 @@ HTMLCollection [
 `;
 
 exports[`ConfigProvider components TimePicker normal 1`] = `
-HTMLCollection [
+Array [
   <div
     class="ant-picker"
   >
@@ -36446,7 +36446,7 @@ HTMLCollection [
 `;
 
 exports[`ConfigProvider components TimePicker prefixCls 1`] = `
-HTMLCollection [
+Array [
   <div
     class="prefix-TimePicker"
   >
@@ -38013,7 +38013,7 @@ exports[`ConfigProvider components Timeline prefixCls 1`] = `
 `;
 
 exports[`ConfigProvider components Tooltip configProvider 1`] = `
-HTMLCollection [
+Array [
   <span
     class="config-tooltip-open"
   >
@@ -38042,7 +38042,7 @@ HTMLCollection [
 `;
 
 exports[`ConfigProvider components Tooltip configProvider componentDisabled 1`] = `
-HTMLCollection [
+Array [
   <span
     class="config-tooltip-open"
   >
@@ -38071,7 +38071,7 @@ HTMLCollection [
 `;
 
 exports[`ConfigProvider components Tooltip configProvider componentSize large 1`] = `
-HTMLCollection [
+Array [
   <span
     class="config-tooltip-open"
   >
@@ -38100,7 +38100,7 @@ HTMLCollection [
 `;
 
 exports[`ConfigProvider components Tooltip configProvider componentSize middle 1`] = `
-HTMLCollection [
+Array [
   <span
     class="config-tooltip-open"
   >
@@ -38129,7 +38129,7 @@ HTMLCollection [
 `;
 
 exports[`ConfigProvider components Tooltip configProvider virtual and dropdownMatchSelectWidth 1`] = `
-HTMLCollection [
+Array [
   <span
     class="ant-tooltip-open"
   >
@@ -38158,7 +38158,7 @@ HTMLCollection [
 `;
 
 exports[`ConfigProvider components Tooltip normal 1`] = `
-HTMLCollection [
+Array [
   <span
     class="ant-tooltip-open"
   >
@@ -38187,7 +38187,7 @@ HTMLCollection [
 `;
 
 exports[`ConfigProvider components Tooltip prefixCls 1`] = `
-HTMLCollection [
+Array [
   <span
     class="prefix-Tooltip-open"
   >

--- a/components/space/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/space/__tests__/__snapshots__/index.test.tsx.snap
@@ -29,7 +29,7 @@ exports[`Space should render correct with children 1`] = `
 `;
 
 exports[`Space should render width ConfigProvider 1`] = `
-HTMLCollection [
+Array [
   <div
     class="ant-space ant-space-horizontal ant-space-align-center"
   >
@@ -91,7 +91,7 @@ HTMLCollection [
 `;
 
 exports[`Space should render width rtl 1`] = `
-HTMLCollection [
+Array [
   <div
     class="ant-space ant-space-horizontal ant-space-rtl ant-space-align-center"
   >

--- a/tests/setupAfterEnv.ts
+++ b/tests/setupAfterEnv.ts
@@ -26,6 +26,13 @@ if (process.env.LIB_DIR === 'dist') {
 }
 
 function cleanup(node: HTMLElement) {
+  const childList = Array.from(node.childNodes);
+  node.innerHTML = '';
+  childList.forEach((child) => {
+    if (!(child instanceof Text) || child.textContent) {
+      node.appendChild(child);
+    }
+  });
   return node;
 }
 

--- a/tests/setupAfterEnv.ts
+++ b/tests/setupAfterEnv.ts
@@ -37,7 +37,7 @@ function formatHTML(nodes: any) {
     cloneNodes = cleanup(nodes.cloneNode(true));
   }
 
-  const htmlContent = format(nodes, {
+  const htmlContent = format(cloneNodes, {
     plugins: [plugins.DOMCollection, plugins.DOMElement],
   });
 

--- a/tests/setupAfterEnv.ts
+++ b/tests/setupAfterEnv.ts
@@ -38,7 +38,7 @@ function cleanup(node: HTMLElement) {
 
 function formatHTML(nodes: any) {
   let cloneNodes: any;
-  if (nodes instanceof HTMLCollection || nodes instanceof NodeList) {
+  if (Array.isArray(nodes) || nodes instanceof HTMLCollection || nodes instanceof NodeList) {
     cloneNodes = Array.from(nodes).map((node) => cleanup(node.cloneNode(true) as any));
   } else {
     cloneNodes = cleanup(nodes.cloneNode(true));

--- a/tests/setupAfterEnv.ts
+++ b/tests/setupAfterEnv.ts
@@ -1,7 +1,7 @@
-import { toHaveNoViolations } from 'jest-axe';
 import '@testing-library/jest-dom';
-import format, { plugins } from 'pretty-format';
+import { toHaveNoViolations } from 'jest-axe';
 import jsdom from 'jsdom';
+import format, { plugins } from 'pretty-format';
 import { defaultConfig } from '../components/theme/internal';
 
 // Not use dynamic hashed for test env since version will change hash dynamically.
@@ -25,7 +25,18 @@ if (process.env.LIB_DIR === 'dist') {
   });
 }
 
+function cleanup(node: HTMLElement) {
+  return node;
+}
+
 function formatHTML(nodes: any) {
+  let cloneNodes: any;
+  if (nodes instanceof HTMLCollection || nodes instanceof NodeList) {
+    cloneNodes = Array.from(nodes).map((node) => cleanup(node.cloneNode(true) as any));
+  } else {
+    cloneNodes = cleanup(nodes.cloneNode(true));
+  }
+
   const htmlContent = format(nodes, {
     plugins: [plugins.DOMCollection, plugins.DOMElement],
   });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

Test snapshot between React 17 & 18 has little difference with empty text render:

```tsx
<div>{''}</div>
```

In 17 will be:
```text
<div>
</div>
```


In 18 will be:
```text
<div />
```

This PR will clean up empty text for snapshot

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    -       |
| 🇨🇳 Chinese |      -     |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ed6a3b1</samp>

This pull request updates the test setup and adds a new test case for React 18 compatibility. It improves the code style of `setupAfterEnv.ts` and checks the rendering behavior of empty strings and arrays in `setup.test.tsx`.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ed6a3b1</samp>

* Add a new test file `setup.test.tsx` to check the rendering of empty strings and arrays in React 18 and React 17 ([link](https://github.com/ant-design/ant-design/pull/41739/files?diff=unified&w=0#diff-afde09e1e50cd931c7b9f864991f97d825410fb20cf51fed435ac69c973d3e53R1-R14))
* Modify the `formatHTML` function in `tests/setupAfterEnv.ts` to remove empty text nodes from the HTML output before formatting it ([link](https://github.com/ant-design/ant-design/pull/41739/files?diff=unified&w=0#diff-f4c2534ed06e6886ef68a9d8a1349f63cd614fda345e286edf1cefc5516ad541L28-R47))
* Reorder the import statements in `tests/setupAfterEnv.ts` to follow the convention of importing external modules before internal modules ([link](https://github.com/ant-design/ant-design/pull/41739/files?diff=unified&w=0#diff-f4c2534ed06e6886ef68a9d8a1349f63cd614fda345e286edf1cefc5516ad541L1-R4))
