### PR TITLE
docs: add demo token inspection

### DIFF
--- a/.dumi/theme/builtins/DemoWrapper/index.tsx
+++ b/.dumi/theme/builtins/DemoWrapper/index.tsx
@@ -1,7 +1,14 @@
 import React, { useContext, useState } from 'react';
 import { DumiDemoGrid, FormattedMessage } from 'dumi';
 import { Tooltip } from 'antd';
-import { BugFilled, BugOutlined, CodeFilled, CodeOutlined } from '@ant-design/icons';
+import {
+  BugFilled,
+  BugOutlined,
+  CodeFilled,
+  CodeOutlined,
+  ExperimentFilled,
+  ExperimentOutlined,
+} from '@ant-design/icons';
 import classNames from 'classnames';
 import DemoContext from '../../slots/DemoContext';
 
@@ -9,6 +16,7 @@ const DemoWrapper: typeof DumiDemoGrid = ({ items }) => {
   const { showDebug, setShowDebug } = useContext(DemoContext);
 
   const [expandAll, setExpandAll] = useState(false);
+  const [showToken, setShowToken] = useState(process.env.NODE_ENV === 'development');
 
   const expandTriggerClass = classNames('code-box-expand-trigger', {
     'code-box-expand-trigger-active': expandAll,
@@ -20,6 +28,10 @@ const DemoWrapper: typeof DumiDemoGrid = ({ items }) => {
 
   const handleExpandToggle = () => {
     setExpandAll(!expandAll);
+  };
+
+  const handleTokenToggle = () => {
+    setShowToken(!showToken);
   };
 
   const demos = React.useMemo(
@@ -42,10 +54,11 @@ const DemoWrapper: typeof DumiDemoGrid = ({ items }) => {
              * @see https://github.com/ant-design/ant-design/pull/40130#issuecomment-1380208762
              */
             originDebug: debug,
+            showToken,
           },
         });
       }, [] as typeof items),
-    [expandAll, showDebug],
+    [expandAll, showDebug, showToken],
   );
 
   return (
@@ -73,9 +86,22 @@ const DemoWrapper: typeof DumiDemoGrid = ({ items }) => {
             <BugOutlined className={expandTriggerClass} onClick={handleVisibleToggle} />
           )}
         </Tooltip>
+        <Tooltip
+          title={
+            <FormattedMessage
+              id={`app.component.examples.${showToken ? 'hideToken' : 'showToken'}`}
+            />
+          }
+        >
+          {showToken ? (
+            <ExperimentFilled className={expandTriggerClass} onClick={handleTokenToggle} />
+          ) : (
+            <ExperimentOutlined className={expandTriggerClass} onClick={handleTokenToggle} />
+          )}
+        </Tooltip>
       </span>
       {/* FIXME: find a new way instead of `key` to trigger re-render */}
-      <DumiDemoGrid items={demos} key={`${expandAll}${showDebug}`} />
+      <DumiDemoGrid items={demos} key={`${expandAll}${showDebug}${showToken}`} />
     </div>
   );
 };

--- a/.dumi/theme/builtins/Previewer/CodePreviewer.tsx
+++ b/.dumi/theme/builtins/Previewer/CodePreviewer.tsx
@@ -1,13 +1,12 @@
 import {
   CheckOutlined,
-  InfoCircleOutlined,
   LinkOutlined,
   SnippetsOutlined,
   ThunderboltOutlined,
 } from '@ant-design/icons';
 import type { Project } from '@stackblitz/sdk';
 import stackblitzSdk from '@stackblitz/sdk';
-import { Alert, Badge, ConfigProvider, Divider, Popover, Space, Tag, Tooltip } from 'antd';
+import { Alert, Badge, ConfigProvider, Divider, Space, Tag, Tooltip } from 'antd';
 import classNames from 'classnames';
 import { FormattedMessage, Link, useSiteData } from 'dumi';
 import toReactElement from 'jsonml-to-react-element';

--- a/.dumi/theme/builtins/Previewer/CodePreviewer.tsx
+++ b/.dumi/theme/builtins/Previewer/CodePreviewer.tsx
@@ -36,14 +36,12 @@ const { ErrorBoundary } = Alert;
 
 const locales = {
   cn: {
-    hoverToken: '鼠标悬浮以查看 Design Token 影响范围',
-    customizeTheme: '定制主题',
-    howToUseToken: '使用 Design Token ',
+    hoverToken: '鼠标悬浮以查看 Design Token 影响范围。',
+    howToUseToken: '如何使用 Design Token',
   },
   en: {
-    hoverToken: 'Hover to see what is changed by Design Token',
-    customizeTheme: 'customize theme',
-    howToUseToken: 'Use Design Token to ',
+    hoverToken: 'Hover to see what is changed by Design Token.',
+    howToUseToken: 'How to use Design Token',
   },
 };
 
@@ -420,7 +418,13 @@ createRoot(document.getElementById('container')).render(<Demo />);
       <section className="code-box-demo" style={codeBoxDemoStyle}>
         <ErrorBoundary>
           <React.StrictMode>
-            <ConfigProvider theme={activeToken && { token: { [activeToken]: token.colorWarning } }}>
+            <ConfigProvider
+              theme={
+                activeToken && activeToken.startsWith('color')
+                  ? { token: { [activeToken]: token.colorWarning } }
+                  : undefined
+              }
+            >
               {liveDemo.current}
             </ConfigProvider>
             {showToken && hasToken && (
@@ -428,20 +432,9 @@ createRoot(document.getElementById('container')).render(<Demo />);
                 <Divider />
                 <div style={{ color: token.colorTextDescription, marginBottom: 12 }}>
                   {locale.hoverToken}
-                  <Popover
-                    content={
-                      <span>
-                        {locale.howToUseToken}
-                        <Link
-                          to={getLocalizedPathname('/docs/react/customize-theme', lang === 'cn')}
-                        >
-                          {locale.customizeTheme}
-                        </Link>
-                      </span>
-                    }
-                  >
-                    <InfoCircleOutlined style={{ marginLeft: 8 }} />
-                  </Popover>
+                  <Link to={getLocalizedPathname('/docs/react/customize-theme', lang === 'cn')}>
+                    {locale.howToUseToken}
+                  </Link>
                 </div>
                 {tokens?.split(',').map((item) => (
                   <Tag

--- a/.dumi/theme/builtins/Previewer/CodePreviewer.tsx
+++ b/.dumi/theme/builtins/Previewer/CodePreviewer.tsx
@@ -1,14 +1,15 @@
 import {
   CheckOutlined,
+  InfoCircleOutlined,
   LinkOutlined,
   SnippetsOutlined,
   ThunderboltOutlined,
 } from '@ant-design/icons';
 import type { Project } from '@stackblitz/sdk';
 import stackblitzSdk from '@stackblitz/sdk';
-import { Alert, Badge, ConfigProvider, Divider, Space, Tag, Tooltip } from 'antd';
+import { Alert, Badge, ConfigProvider, Divider, Popover, Space, Tag, Tooltip } from 'antd';
 import classNames from 'classnames';
-import { FormattedMessage, useSiteData } from 'dumi';
+import { FormattedMessage, Link, useSiteData } from 'dumi';
 import toReactElement from 'jsonml-to-react-element';
 import JsonML from 'jsonml.js/lib/utils';
 import LZString from 'lz-string';
@@ -26,11 +27,25 @@ import ExternalLinkIcon from '../../common/ExternalLinkIcon';
 import RiddleIcon from '../../common/RiddleIcon';
 import type { SiteContextProps } from '../../slots/SiteContext';
 import SiteContext from '../../slots/SiteContext';
-import { ping } from '../../utils';
+import { getLocalizedPathname, ping } from '../../utils';
 import type { AntdPreviewerProps } from '.';
 import useSiteToken from '../../../hooks/useSiteToken';
+import useLocale from '../../../hooks/useLocale';
 
 const { ErrorBoundary } = Alert;
+
+const locales = {
+  cn: {
+    hoverToken: '鼠标悬浮以查看 Design Token 影响范围',
+    customizeTheme: '定制主题',
+    howToUseToken: '使用 Design Token ',
+  },
+  en: {
+    hoverToken: 'Hover to see what is changed by Design Token',
+    customizeTheme: 'customize theme',
+    howToUseToken: 'Use Design Token to ',
+  },
+};
 
 function toReactComponent(jsonML: any) {
   return toReactElement(jsonML, [
@@ -113,6 +128,7 @@ const CodePreviewer: React.FC<AntdPreviewerProps> = (props) => {
   const { pkg } = useSiteData();
   const location = useLocation();
   const { token } = useSiteToken();
+  const [locale, lang] = useLocale(locales);
 
   const entryCode = asset.dependencies['index.tsx'].value;
   const showRiddleButton = useShowRiddleButton();
@@ -411,7 +427,21 @@ createRoot(document.getElementById('container')).render(<Demo />);
               <>
                 <Divider />
                 <div style={{ color: token.colorTextDescription, marginBottom: 12 }}>
-                  Hover token to see what changed.
+                  {locale.hoverToken}
+                  <Popover
+                    content={
+                      <span>
+                        {locale.howToUseToken}
+                        <Link
+                          to={getLocalizedPathname('/docs/react/customize-theme', lang === 'cn')}
+                        >
+                          {locale.customizeTheme}
+                        </Link>
+                      </span>
+                    }
+                  >
+                    <InfoCircleOutlined style={{ marginLeft: 8 }} />
+                  </Popover>
                 </div>
                 {tokens?.split(',').map((item) => (
                   <Tag

--- a/.dumi/theme/builtins/Previewer/index.tsx
+++ b/.dumi/theme/builtins/Previewer/index.tsx
@@ -7,6 +7,8 @@ import DesignPreviewer from './DesignPreviewer';
 
 export interface AntdPreviewerProps extends IPreviewerProps {
   originDebug?: IPreviewerProps['debug'];
+  tokens?: string;
+  showToken?: boolean;
 }
 
 const Previewer: FC<AntdPreviewerProps> = ({ ...props }) => {

--- a/.dumi/theme/locales/en-US.json
+++ b/.dumi/theme/locales/en-US.json
@@ -20,6 +20,8 @@
   "app.component.examples.collapse": "Collapse all code",
   "app.component.examples.visible": "Expand debug examples",
   "app.component.examples.hide": "Collapse debug examples",
+  "app.component.examples.showToken": "Show demo tokens",
+  "app.component.examples.hideToken": "hide demo tokens",
   "app.component.examples.openDemoNotReact18": "Open Demo with React < 18",
   "app.component.examples.openDemoWithReact18": "Open Demo with React 18",
   "app.demo.debug": "Debug only, won't display at online",

--- a/.dumi/theme/locales/zh-CN.json
+++ b/.dumi/theme/locales/zh-CN.json
@@ -20,6 +20,8 @@
   "app.component.examples.collapse": "收起全部代码",
   "app.component.examples.visible": "显示调试专用演示",
   "app.component.examples.hide": "隐藏调试专用演示",
+  "app.component.examples.showToken": "显示演示相关 token",
+  "app.component.examples.hideToken": "隐藏演示相关 token",
   "app.component.examples.openDemoNotReact18": "使用 React 18 以下版本打开 Demo",
   "app.component.examples.openDemoWithReact18": "使用 React 18 打开 Demo",
   "app.demo.debug": "此演示仅供调试，线上不会展示",

--- a/components/button/demo/basic.tsx
+++ b/components/button/demo/basic.tsx
@@ -1,3 +1,6 @@
+/**
+tokens: colorText, colorPrimary
+ */
 import React from 'react';
 import { Button, Space } from 'antd';
 

--- a/components/button/demo/icon.tsx
+++ b/components/button/demo/icon.tsx
@@ -1,3 +1,6 @@
+/**
+ * tokens: colorText, colorBorder
+ */
 import React from 'react';
 import { SearchOutlined } from '@ant-design/icons';
 import { Button, Tooltip, Space } from 'antd';


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

- DemoWrapper 加了一个开关来控制是否展示 token
![image](https://user-images.githubusercontent.com/27722486/231125248-e79927d1-1c67-41de-98c9-e3cf01e83095.png)
- Demo 添加了 token 栏，hover 可高亮变化
![image](https://user-images.githubusercontent.com/27722486/231347571-7b356764-4df7-4ea1-afb8-20e30b18d524.png)
- 在 demo 代码中手动维护 meta，用于导出供编辑器消费
![image](https://user-images.githubusercontent.com/27722486/231125952-9e0bed71-1bf3-4dcb-bf96-021d2aa19667.png)





<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     -      |
| 🇨🇳 Chinese |     -      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8eb9e26</samp>

Added a feature to show and hide demo tokens in the demo wrapper and code previewer components. Demo tokens are special comments that define the props and values used in the demo code. This feature helps developers to inspect and customize the demo code more easily. Updated the button demo and the locale files to support this feature.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8eb9e26</samp>

*  Add a toggle button for showing or hiding demo tokens in the `DemoWrapper` component ([link](https://github.com/ant-design/ant-design/pull/41752/files?diff=unified&w=0#diff-e250ab9968952b8b565c98a89135c6b333a4dfaa67406881265a78f047a21cf6L4-R11), [link](https://github.com/ant-design/ant-design/pull/41752/files?diff=unified&w=0#diff-e250ab9968952b8b565c98a89135c6b333a4dfaa67406881265a78f047a21cf6R19), [link](https://github.com/ant-design/ant-design/pull/41752/files?diff=unified&w=0#diff-e250ab9968952b8b565c98a89135c6b333a4dfaa67406881265a78f047a21cf6R33-R36), [link](https://github.com/ant-design/ant-design/pull/41752/files?diff=unified&w=0#diff-e250ab9968952b8b565c98a89135c6b333a4dfaa67406881265a78f047a21cf6L45-R61), [link](https://github.com/ant-design/ant-design/pull/41752/files?diff=unified&w=0#diff-e250ab9968952b8b565c98a89135c6b333a4dfaa67406881265a78f047a21cf6L76-R104))
*  Import icons and tooltip text for the toggle button from `@ant-design/icons` and `locales` files ([link](https://github.com/ant-design/ant-design/pull/41752/files?diff=unified&w=0#diff-e250ab9968952b8b565c98a89135c6b333a4dfaa67406881265a78f047a21cf6L4-R11), [link](https://github.com/ant-design/ant-design/pull/41752/files?diff=unified&w=0#diff-77dff52935aad07ad5a5a47203c59f4d583e74034fd4695d189bd0c632b86e4bR23-R24), [link](https://github.com/ant-design/ant-design/pull/41752/files?diff=unified&w=0#diff-b823a78cf4beb8e8ede2c847a6fdfab8b61870bf9deffb35ec6fb7133384e281R23-R24))
*  Add a feature to highlight demo tokens in the live demo and display token tags below the code preview in the `CodePreviewer` component ([link](https://github.com/ant-design/ant-design/pull/41752/files?diff=unified&w=0#diff-54c90701ed595205ea2cd4286b1cd0ee8b2f01f77a23088e0108feda7af2d65fL9-R9), [link](https://github.com/ant-design/ant-design/pull/41752/files?diff=unified&w=0#diff-54c90701ed595205ea2cd4286b1cd0ee8b2f01f77a23088e0108feda7af2d65fR31), [link](https://github.com/ant-design/ant-design/pull/41752/files?diff=unified&w=0#diff-54c90701ed595205ea2cd4286b1cd0ee8b2f01f77a23088e0108feda7af2d65fL108-R115), [link](https://github.com/ant-design/ant-design/pull/41752/files?diff=unified&w=0#diff-54c90701ed595205ea2cd4286b1cd0ee8b2f01f77a23088e0108feda7af2d65fR136-R137), [link](https://github.com/ant-design/ant-design/pull/41752/files?diff=unified&w=0#diff-54c90701ed595205ea2cd4286b1cd0ee8b2f01f77a23088e0108feda7af2d65fL387-R428))
*  Import `ConfigProvider`, `Divider`, `Tag` and `useSiteToken` from `antd` and `hooks` to support the token highlighting feature ([link](https://github.com/ant-design/ant-design/pull/41752/files?diff=unified&w=0#diff-54c90701ed595205ea2cd4286b1cd0ee8b2f01f77a23088e0108feda7af2d65fL9-R9))
*  Pass the `tokens` and `showToken` props from the `Previewer` component to the `CodePreviewer` component ([link](https://github.com/ant-design/ant-design/pull/41752/files?diff=unified&w=0#diff-d4c2b096e898ee55c192cd1d13952ec5c5be4c1ff563d0ccaba74d8555e19adaR10-R11))
*  Define demo tokens for the basic button example in the `basic.tsx` file using the `tokens` comment ([link](https://github.com/ant-design/ant-design/pull/41752/files?diff=unified&w=0#diff-21525389d523cfebbe85bbc0d2314d68040a17a68c9ca757bb31f30331872e60R1-R3))
