### PR TITLE
fix: form item support comment

### DIFF
--- a/components/form/FormItem/index.tsx
+++ b/components/form/FormItem/index.tsx
@@ -6,18 +6,19 @@ import type { Meta, NamePath } from 'rc-field-form/lib/interface';
 import useState from 'rc-util/lib/hooks/useState';
 import { supportRef } from 'rc-util/lib/ref';
 import * as React from 'react';
-import useFormItemStatus from '../hooks/useFormItemStatus';
-import { ConfigContext } from '../../config-provider';
 import { cloneElement, isValidElement } from '../../_util/reactNode';
 import warning from '../../_util/warning';
-import { FormContext, NoStyleItemContext } from '../context';
+import { ConfigContext } from '../../config-provider';
 import type { FormItemInputProps } from '../FormItemInput';
 import type { FormItemLabelProps, LabelTooltipType } from '../FormItemLabel';
+import { FormContext, NoStyleItemContext } from '../context';
+import useFormItemStatus from '../hooks/useFormItemStatus';
 import useFrameState from '../hooks/useFrameState';
 import useItemRef from '../hooks/useItemRef';
 import { getFieldId, toArray } from '../util';
 import ItemHolder from './ItemHolder';
 
+import useChildren from '../hooks/useChildren';
 import useStyle from '../style';
 
 const NAME_SPLIT = '__SPLIT__';
@@ -110,7 +111,11 @@ function InternalFormItem<Values = any>(props: FormItemProps<Values>): React.Rea
   } = props;
   const { getPrefixCls } = React.useContext(ConfigContext);
   const { name: formName } = React.useContext(FormContext);
-  const isRenderProps = typeof children === 'function';
+
+  const mergedChildren = useChildren(children);
+  console.log('mergedChildren:', mergedChildren);
+
+  const isRenderProps = typeof mergedChildren === 'function';
   const notifyParentMetaChange = React.useContext(NoStyleItemContext);
 
   const { validateTrigger: contextValidateTrigger } = React.useContext(FieldContext);
@@ -232,7 +237,7 @@ function InternalFormItem<Values = any>(props: FormItemProps<Values>): React.Rea
   }
 
   if (!hasName && !isRenderProps && !dependencies) {
-    return wrapSSR(renderLayout(children) as JSX.Element);
+    return wrapSSR(renderLayout(mergedChildren) as JSX.Element);
   }
 
   let variables: Record<string, string> = {};
@@ -287,13 +292,13 @@ function InternalFormItem<Values = any>(props: FormItemProps<Values>): React.Rea
           'Form.Item',
           "`shouldUpdate` and `dependencies` shouldn't be used together. See https://u.ant.design/form-deps.",
         );
-        if (Array.isArray(children) && hasName) {
+        if (Array.isArray(mergedChildren) && hasName) {
           warning(
             false,
             'Form.Item',
             'A `Form.Item` with a `name` prop must have a single child element. For information on how to render more complex form items, see https://u.ant.design/complex-form-item.',
           );
-          childNode = children;
+          childNode = mergedChildren;
         } else if (isRenderProps && (!(shouldUpdate || dependencies) || hasName)) {
           warning(
             !!(shouldUpdate || dependencies),
@@ -311,14 +316,14 @@ function InternalFormItem<Values = any>(props: FormItemProps<Values>): React.Rea
             'Form.Item',
             'Must set `name` or use a render function when `dependencies` is set.',
           );
-        } else if (isValidElement(children)) {
+        } else if (isValidElement(mergedChildren)) {
           warning(
-            children.props.defaultValue === undefined,
+            mergedChildren.props.defaultValue === undefined,
             'Form.Item',
             '`defaultValue` will not work on controlled Field. You should use `initialValues` of Form instead.',
           );
 
-          const childProps = { ...children.props, ...mergedControl };
+          const childProps = { ...mergedChildren.props, ...mergedControl };
           if (!childProps.id) {
             childProps.id = fieldId;
           }
@@ -342,8 +347,8 @@ function InternalFormItem<Values = any>(props: FormItemProps<Values>): React.Rea
             childProps['aria-required'] = 'true';
           }
 
-          if (supportRef(children)) {
-            childProps.ref = getItemRef(mergedName, children);
+          if (supportRef(mergedChildren)) {
+            childProps.ref = getItemRef(mergedName, mergedChildren);
           }
 
           // We should keep user origin event handler
@@ -355,7 +360,7 @@ function InternalFormItem<Values = any>(props: FormItemProps<Values>): React.Rea
           triggers.forEach((eventName) => {
             childProps[eventName] = (...args: any[]) => {
               mergedControl[eventName]?.(...args);
-              children.props[eventName]?.(...args);
+              mergedChildren.props[eventName]?.(...args);
             };
           });
 
@@ -369,21 +374,21 @@ function InternalFormItem<Values = any>(props: FormItemProps<Values>): React.Rea
           childNode = (
             <MemoInput
               value={mergedControl[props.valuePropName || 'value']}
-              update={children}
+              update={mergedChildren}
               childProps={watchingChildProps}
             >
-              {cloneElement(children, childProps)}
+              {cloneElement(mergedChildren, childProps)}
             </MemoInput>
           );
         } else if (isRenderProps && (shouldUpdate || dependencies) && !hasName) {
-          childNode = children(context);
+          childNode = mergedChildren(context);
         } else {
           warning(
             !mergedName.length,
             'Form.Item',
             '`name` is only used for validate React element. If you are using Form.Item as layout display, please remove `name` instead.',
           );
-          childNode = children as React.ReactNode;
+          childNode = mergedChildren as React.ReactNode;
         }
 
         return renderLayout(childNode, fieldId, isRequired);

--- a/components/form/FormItem/index.tsx
+++ b/components/form/FormItem/index.tsx
@@ -113,7 +113,6 @@ function InternalFormItem<Values = any>(props: FormItemProps<Values>): React.Rea
   const { name: formName } = React.useContext(FormContext);
 
   const mergedChildren = useChildren(children);
-  console.log('mergedChildren:', mergedChildren);
 
   const isRenderProps = typeof mergedChildren === 'function';
   const notifyParentMetaChange = React.useContext(NoStyleItemContext);

--- a/components/form/__tests__/index.test.tsx
+++ b/components/form/__tests__/index.test.tsx
@@ -8,6 +8,7 @@ import Form from '..';
 import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
 import { fireEvent, pureRender, render, screen, waitFakeTimer } from '../../../tests/utils';
+import { resetWarned } from '../../_util/warning';
 import Button from '../../button';
 import Cascader from '../../cascader';
 import Checkbox from '../../checkbox';
@@ -1459,7 +1460,7 @@ describe('Form', () => {
     render(
       <Modal open>
         <Form>
-          <Form.Item help='This is a help message'>
+          <Form.Item help="This is a help message">
             <Input />
           </Form.Item>
         </Form>
@@ -1547,7 +1548,7 @@ describe('Form', () => {
       const [form] = Form.useForm();
 
       return (
-        <Form form={form} name='test-form'>
+        <Form form={form} name="test-form">
           <Form.Item name="error" rules={[{ required: true, message: 'This is a error message.' }]}>
             <ErrorItem />
           </Form.Item>
@@ -1858,5 +1859,23 @@ describe('Form', () => {
 
     expect(container.querySelectorAll('.ant-form-item-required')).toHaveLength(2);
     expect(container.querySelectorAll('.ant-form-item-required-mark-optional')).toHaveLength(2);
+  });
+
+  it('children support comment', () => {
+    resetWarned();
+
+    const { container } = render(
+      <Form initialValues={{ name: 'bamboo', age: '14' }}>
+        <Form.Item name="name">
+          {/* Comment here */}
+          <Input />
+        </Form.Item>
+        <Form.Item name="age">{[null, <Input key="input" />]}</Form.Item>
+      </Form>,
+    );
+
+    expect(container.querySelectorAll('input')[0].value).toEqual('bamboo');
+    expect(container.querySelectorAll('input')[1].value).toEqual('14');
+    expect(errorSpy).not.toHaveBeenCalled();
   });
 });

--- a/components/form/hooks/useChildren.ts
+++ b/components/form/hooks/useChildren.ts
@@ -1,7 +1,9 @@
 import toArray from 'rc-util/lib/Children/toArray';
 import type { FormItemProps } from '../FormItem';
 
-export default function useChildren(children?: FormItemProps['children']) {
+export default function useChildren(
+  children?: FormItemProps['children'],
+): FormItemProps['children'] {
   if (typeof children === 'function') {
     return children;
   }

--- a/components/form/hooks/useChildren.ts
+++ b/components/form/hooks/useChildren.ts
@@ -1,0 +1,11 @@
+import toArray from 'rc-util/lib/Children/toArray';
+import type { FormItemProps } from '../FormItem';
+
+export default function useChildren(children?: FormItemProps['children']) {
+  if (typeof children === 'function') {
+    return children;
+  }
+
+  const childList = toArray(children);
+  return childList.length <= 1 ? childList[0] : childList;
+}


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

resolve #41769

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |       Optimize Form field binding, now will ignore comments in Form.Item as subcomponents.    |
| 🇨🇳 Chinese |      优化 Form 字段绑定，现在会忽略在 Form.Item 内的注释不再作为子组件进行绑定。      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7d5da61</samp>

The pull request introduces a new custom hook `useChildren` to handle the `children` prop of `Form.Item` more consistently and avoid potential bugs or warnings. It also updates the `Form.Item` component to use the hook and refactors the test file `components/form/__tests__/index.test.tsx` to follow the code style guide and add a new test case.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7d5da61</samp>

*  Import `resetWarned` function and use it to reset warning state before each test case in `components/form/__tests__/index.test.tsx` ([link](https://github.com/ant-design/ant-design/pull/41771/files?diff=unified&w=0#diff-f3bb49bfe69c75aa977732eec74dfe67b8b00e00fc5e008c4f1d3835ae296eacR11))
*  Replace single quotes with double quotes for JSX attributes in `components/form/__tests__/index.test.tsx` ([link](https://github.com/ant-design/ant-design/pull/41771/files?diff=unified&w=0#diff-f3bb49bfe69c75aa977732eec74dfe67b8b00e00fc5e008c4f1d3835ae296eacL1462-R1463), [link](https://github.com/ant-design/ant-design/pull/41771/files?diff=unified&w=0#diff-f3bb49bfe69c75aa977732eec74dfe67b8b00e00fc5e008c4f1d3835ae296eacL1550-R1551))
*  Add new test case `children support comment` to check the functionality of `useChildren` hook in `components/form/__tests__/index.test.tsx` ([link](https://github.com/ant-design/ant-design/pull/41771/files?diff=unified&w=0#diff-f3bb49bfe69c75aa977732eec74dfe67b8b00e00fc5e008c4f1d3835ae296eacR1863-R1880))
*  Reorder import statements alphabetically in `components/form/FormItem/index.tsx` ([link](https://github.com/ant-design/ant-design/pull/41771/files?diff=unified&w=0#diff-ca241b27784d31abb99a7d491adda5dd50f6969f7d25389fb3513d267835f3aeL9-R15))
*  Import `useChildren` hook from `components/form/hooks/useChildren.ts` and use it to convert `children` prop to a single or array element or a render function in `components/form/FormItem/index.tsx` ([link](https://github.com/ant-design/ant-design/pull/41771/files?diff=unified&w=0#diff-ca241b27784d31abb99a7d491adda5dd50f6969f7d25389fb3513d267835f3aeR21), [link](https://github.com/ant-design/ant-design/pull/41771/files?diff=unified&w=0#diff-ca241b27784d31abb99a7d491adda5dd50f6969f7d25389fb3513d267835f3aeL113-R118))
  - layout rendering ([link](https://github.com/ant-design/ant-design/pull/41771/files?diff=unified&w=0#diff-ca241b27784d31abb99a7d491adda5dd50f6969f7d25389fb3513d267835f3aeL235-R240))
  - warning condition for array children with name prop ([link](https://github.com/ant-design/ant-design/pull/41771/files?diff=unified&w=0#diff-ca241b27784d31abb99a7d491adda5dd50f6969f7d25389fb3513d267835f3aeL290-R295))
  - assignment of `childNode` and warning condition for render function with name prop or no dependencies ([link](https://github.com/ant-design/ant-design/pull/41771/files?diff=unified&w=0#diff-ca241b27784d31abb99a7d491adda5dd50f6969f7d25389fb3513d267835f3aeL296-R301))
  - element validation and warning for `defaultValue` prop ([link](https://github.com/ant-design/ant-design/pull/41771/files?diff=unified&w=0#diff-ca241b27784d31abb99a7d491adda5dd50f6969f7d25389fb3513d267835f3aeL314-R326))
  - ref attachment and `getItemRef` function call ([link](https://github.com/ant-design/ant-design/pull/41771/files?diff=unified&w=0#diff-ca241b27784d31abb99a7d491adda5dd50f6969f7d25389fb3513d267835f3aeL345-R351))
  - event handler binding and call ([link](https://github.com/ant-design/ant-design/pull/41771/files?diff=unified&w=0#diff-ca241b27784d31abb99a7d491adda5dd50f6969f7d25389fb3513d267835f3aeL358-R363))
  - `MemoInput` component and condition for render function with no name prop but dependencies ([link](https://github.com/ant-design/ant-design/pull/41771/files?diff=unified&w=0#diff-ca241b27784d31abb99a7d491adda5dd50f6969f7d25389fb3513d267835f3aeL372-R384))
  - warning condition for name prop with invalid element or function and assignment of `childNode` ([link](https://github.com/ant-design/ant-design/pull/41771/files?diff=unified&w=0#diff-ca241b27784d31abb99a7d491adda5dd50f6969f7d25389fb3513d267835f3aeL386-R391))
*  Add new file `components/form/hooks/useChildren.ts` that exports `useChildren` hook to handle different types of `children` prop for `Form.Item` component ([link](https://github.com/ant-design/ant-design/pull/41771/files?diff=unified&w=0#diff-bcff919efcf0dcb42c694395467c0b7700162e1ffbfda4f7092b06e53f8ab60fR1-R11))
