### PR TITLE
feat: DatePicker & Calendar export generate function directly

### DIFF
--- a/components/calendar/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/calendar/__tests__/__snapshots__/index.test.tsx.snap
@@ -2837,3 +2837,949 @@ exports[`Calendar rtl render component should be rendered correctly in RTL direc
   </div>
 </div>
 `;
+
+exports[`Calendar support Calendar.generateCalendar 1`] = `
+<div
+  class="ant-picker-calendar ant-picker-calendar-full"
+>
+  <div
+    class="ant-picker-calendar-header"
+  >
+    <div
+      class="ant-select ant-picker-calendar-year-select ant-select-single ant-select-show-arrow"
+    >
+      <div
+        class="ant-select-selector"
+      >
+        <span
+          class="ant-select-selection-search"
+        >
+          <input
+            aria-activedescendant="rc_select_TEST_OR_SSR_list_0"
+            aria-autocomplete="list"
+            aria-controls="rc_select_TEST_OR_SSR_list"
+            aria-expanded="false"
+            aria-haspopup="listbox"
+            aria-owns="rc_select_TEST_OR_SSR_list"
+            autocomplete="off"
+            class="ant-select-selection-search-input"
+            id="rc_select_TEST_OR_SSR"
+            readonly=""
+            role="combobox"
+            style="opacity: 0;"
+            type="search"
+            unselectable="on"
+            value=""
+          />
+        </span>
+        <span
+          class="ant-select-selection-item"
+          title="2023"
+        >
+          2023
+        </span>
+      </div>
+      <span
+        aria-hidden="true"
+        class="ant-select-arrow"
+        style="user-select: none;"
+        unselectable="on"
+      >
+        <span
+          aria-label="down"
+          class="anticon anticon-down ant-select-suffix"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="down"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+            />
+          </svg>
+        </span>
+      </span>
+    </div>
+    <div
+      class="ant-select ant-picker-calendar-month-select ant-select-single ant-select-show-arrow"
+    >
+      <div
+        class="ant-select-selector"
+      >
+        <span
+          class="ant-select-selection-search"
+        >
+          <input
+            aria-activedescendant="rc_select_TEST_OR_SSR_list_0"
+            aria-autocomplete="list"
+            aria-controls="rc_select_TEST_OR_SSR_list"
+            aria-expanded="false"
+            aria-haspopup="listbox"
+            aria-owns="rc_select_TEST_OR_SSR_list"
+            autocomplete="off"
+            class="ant-select-selection-search-input"
+            id="rc_select_TEST_OR_SSR"
+            readonly=""
+            role="combobox"
+            style="opacity: 0;"
+            type="search"
+            unselectable="on"
+            value=""
+          />
+        </span>
+        <span
+          class="ant-select-selection-item"
+          title="Apr"
+        >
+          Apr
+        </span>
+      </div>
+      <span
+        aria-hidden="true"
+        class="ant-select-arrow"
+        style="user-select: none;"
+        unselectable="on"
+      >
+        <span
+          aria-label="down"
+          class="anticon anticon-down ant-select-suffix"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="down"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+            />
+          </svg>
+        </span>
+      </span>
+    </div>
+    <div
+      class="ant-radio-group ant-radio-group-outline ant-picker-calendar-mode-switch"
+    >
+      <label
+        class="ant-radio-button-wrapper ant-radio-button-wrapper-checked"
+      >
+        <span
+          class="ant-radio-button ant-radio-button-checked"
+        >
+          <input
+            checked=""
+            class="ant-radio-button-input"
+            type="radio"
+            value="month"
+          />
+          <span
+            class="ant-radio-button-inner"
+          />
+        </span>
+        <span>
+          Month
+        </span>
+      </label>
+      <label
+        class="ant-radio-button-wrapper"
+      >
+        <span
+          class="ant-radio-button"
+        >
+          <input
+            class="ant-radio-button-input"
+            type="radio"
+            value="year"
+          />
+          <span
+            class="ant-radio-button-inner"
+          />
+        </span>
+        <span>
+          Year
+        </span>
+      </label>
+    </div>
+  </div>
+  <div
+    class="ant-picker-panel"
+    tabindex="0"
+  >
+    <div
+      class="ant-picker-date-panel"
+    >
+      <div
+        class="ant-picker-body"
+      >
+        <table
+          class="ant-picker-content"
+        >
+          <thead>
+            <tr>
+              <th>
+                Su
+              </th>
+              <th>
+                Mo
+              </th>
+              <th>
+                Tu
+              </th>
+              <th>
+                We
+              </th>
+              <th>
+                Th
+              </th>
+              <th>
+                Fr
+              </th>
+              <th>
+                Sa
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td
+                class="ant-picker-cell"
+                title="2023-03-26"
+              >
+                <div
+                  class="ant-picker-cell-inner ant-picker-calendar-date"
+                >
+                  <div
+                    class="ant-picker-calendar-date-value"
+                  >
+                    26
+                  </div>
+                  <div
+                    class="ant-picker-calendar-date-content"
+                  />
+                </div>
+              </td>
+              <td
+                class="ant-picker-cell"
+                title="2023-03-27"
+              >
+                <div
+                  class="ant-picker-cell-inner ant-picker-calendar-date"
+                >
+                  <div
+                    class="ant-picker-calendar-date-value"
+                  >
+                    27
+                  </div>
+                  <div
+                    class="ant-picker-calendar-date-content"
+                  />
+                </div>
+              </td>
+              <td
+                class="ant-picker-cell"
+                title="2023-03-28"
+              >
+                <div
+                  class="ant-picker-cell-inner ant-picker-calendar-date"
+                >
+                  <div
+                    class="ant-picker-calendar-date-value"
+                  >
+                    28
+                  </div>
+                  <div
+                    class="ant-picker-calendar-date-content"
+                  />
+                </div>
+              </td>
+              <td
+                class="ant-picker-cell"
+                title="2023-03-29"
+              >
+                <div
+                  class="ant-picker-cell-inner ant-picker-calendar-date"
+                >
+                  <div
+                    class="ant-picker-calendar-date-value"
+                  >
+                    29
+                  </div>
+                  <div
+                    class="ant-picker-calendar-date-content"
+                  />
+                </div>
+              </td>
+              <td
+                class="ant-picker-cell"
+                title="2023-03-30"
+              >
+                <div
+                  class="ant-picker-cell-inner ant-picker-calendar-date"
+                >
+                  <div
+                    class="ant-picker-calendar-date-value"
+                  >
+                    30
+                  </div>
+                  <div
+                    class="ant-picker-calendar-date-content"
+                  />
+                </div>
+              </td>
+              <td
+                class="ant-picker-cell ant-picker-cell-end"
+                title="2023-03-31"
+              >
+                <div
+                  class="ant-picker-cell-inner ant-picker-calendar-date"
+                >
+                  <div
+                    class="ant-picker-calendar-date-value"
+                  >
+                    31
+                  </div>
+                  <div
+                    class="ant-picker-calendar-date-content"
+                  />
+                </div>
+              </td>
+              <td
+                class="ant-picker-cell ant-picker-cell-start ant-picker-cell-in-view"
+                title="2023-04-01"
+              >
+                <div
+                  class="ant-picker-cell-inner ant-picker-calendar-date"
+                >
+                  <div
+                    class="ant-picker-calendar-date-value"
+                  >
+                    01
+                  </div>
+                  <div
+                    class="ant-picker-calendar-date-content"
+                  />
+                </div>
+              </td>
+            </tr>
+            <tr>
+              <td
+                class="ant-picker-cell ant-picker-cell-in-view"
+                title="2023-04-02"
+              >
+                <div
+                  class="ant-picker-cell-inner ant-picker-calendar-date"
+                >
+                  <div
+                    class="ant-picker-calendar-date-value"
+                  >
+                    02
+                  </div>
+                  <div
+                    class="ant-picker-calendar-date-content"
+                  />
+                </div>
+              </td>
+              <td
+                class="ant-picker-cell ant-picker-cell-in-view"
+                title="2023-04-03"
+              >
+                <div
+                  class="ant-picker-cell-inner ant-picker-calendar-date"
+                >
+                  <div
+                    class="ant-picker-calendar-date-value"
+                  >
+                    03
+                  </div>
+                  <div
+                    class="ant-picker-calendar-date-content"
+                  />
+                </div>
+              </td>
+              <td
+                class="ant-picker-cell ant-picker-cell-in-view"
+                title="2023-04-04"
+              >
+                <div
+                  class="ant-picker-cell-inner ant-picker-calendar-date"
+                >
+                  <div
+                    class="ant-picker-calendar-date-value"
+                  >
+                    04
+                  </div>
+                  <div
+                    class="ant-picker-calendar-date-content"
+                  />
+                </div>
+              </td>
+              <td
+                class="ant-picker-cell ant-picker-cell-in-view"
+                title="2023-04-05"
+              >
+                <div
+                  class="ant-picker-cell-inner ant-picker-calendar-date"
+                >
+                  <div
+                    class="ant-picker-calendar-date-value"
+                  >
+                    05
+                  </div>
+                  <div
+                    class="ant-picker-calendar-date-content"
+                  />
+                </div>
+              </td>
+              <td
+                class="ant-picker-cell ant-picker-cell-in-view"
+                title="2023-04-06"
+              >
+                <div
+                  class="ant-picker-cell-inner ant-picker-calendar-date"
+                >
+                  <div
+                    class="ant-picker-calendar-date-value"
+                  >
+                    06
+                  </div>
+                  <div
+                    class="ant-picker-calendar-date-content"
+                  />
+                </div>
+              </td>
+              <td
+                class="ant-picker-cell ant-picker-cell-in-view"
+                title="2023-04-07"
+              >
+                <div
+                  class="ant-picker-cell-inner ant-picker-calendar-date"
+                >
+                  <div
+                    class="ant-picker-calendar-date-value"
+                  >
+                    07
+                  </div>
+                  <div
+                    class="ant-picker-calendar-date-content"
+                  />
+                </div>
+              </td>
+              <td
+                class="ant-picker-cell ant-picker-cell-in-view"
+                title="2023-04-08"
+              >
+                <div
+                  class="ant-picker-cell-inner ant-picker-calendar-date"
+                >
+                  <div
+                    class="ant-picker-calendar-date-value"
+                  >
+                    08
+                  </div>
+                  <div
+                    class="ant-picker-calendar-date-content"
+                  />
+                </div>
+              </td>
+            </tr>
+            <tr>
+              <td
+                class="ant-picker-cell ant-picker-cell-in-view"
+                title="2023-04-09"
+              >
+                <div
+                  class="ant-picker-cell-inner ant-picker-calendar-date"
+                >
+                  <div
+                    class="ant-picker-calendar-date-value"
+                  >
+                    09
+                  </div>
+                  <div
+                    class="ant-picker-calendar-date-content"
+                  />
+                </div>
+              </td>
+              <td
+                class="ant-picker-cell ant-picker-cell-in-view"
+                title="2023-04-10"
+              >
+                <div
+                  class="ant-picker-cell-inner ant-picker-calendar-date"
+                >
+                  <div
+                    class="ant-picker-calendar-date-value"
+                  >
+                    10
+                  </div>
+                  <div
+                    class="ant-picker-calendar-date-content"
+                  />
+                </div>
+              </td>
+              <td
+                class="ant-picker-cell ant-picker-cell-in-view"
+                title="2023-04-11"
+              >
+                <div
+                  class="ant-picker-cell-inner ant-picker-calendar-date"
+                >
+                  <div
+                    class="ant-picker-calendar-date-value"
+                  >
+                    11
+                  </div>
+                  <div
+                    class="ant-picker-calendar-date-content"
+                  />
+                </div>
+              </td>
+              <td
+                class="ant-picker-cell ant-picker-cell-in-view ant-picker-cell-today ant-picker-cell-selected"
+                title="2023-04-12"
+              >
+                <div
+                  class="ant-picker-cell-inner ant-picker-calendar-date ant-picker-calendar-date-today"
+                >
+                  <div
+                    class="ant-picker-calendar-date-value"
+                  >
+                    12
+                  </div>
+                  <div
+                    class="ant-picker-calendar-date-content"
+                  />
+                </div>
+              </td>
+              <td
+                class="ant-picker-cell ant-picker-cell-in-view"
+                title="2023-04-13"
+              >
+                <div
+                  class="ant-picker-cell-inner ant-picker-calendar-date"
+                >
+                  <div
+                    class="ant-picker-calendar-date-value"
+                  >
+                    13
+                  </div>
+                  <div
+                    class="ant-picker-calendar-date-content"
+                  />
+                </div>
+              </td>
+              <td
+                class="ant-picker-cell ant-picker-cell-in-view"
+                title="2023-04-14"
+              >
+                <div
+                  class="ant-picker-cell-inner ant-picker-calendar-date"
+                >
+                  <div
+                    class="ant-picker-calendar-date-value"
+                  >
+                    14
+                  </div>
+                  <div
+                    class="ant-picker-calendar-date-content"
+                  />
+                </div>
+              </td>
+              <td
+                class="ant-picker-cell ant-picker-cell-in-view"
+                title="2023-04-15"
+              >
+                <div
+                  class="ant-picker-cell-inner ant-picker-calendar-date"
+                >
+                  <div
+                    class="ant-picker-calendar-date-value"
+                  >
+                    15
+                  </div>
+                  <div
+                    class="ant-picker-calendar-date-content"
+                  />
+                </div>
+              </td>
+            </tr>
+            <tr>
+              <td
+                class="ant-picker-cell ant-picker-cell-in-view"
+                title="2023-04-16"
+              >
+                <div
+                  class="ant-picker-cell-inner ant-picker-calendar-date"
+                >
+                  <div
+                    class="ant-picker-calendar-date-value"
+                  >
+                    16
+                  </div>
+                  <div
+                    class="ant-picker-calendar-date-content"
+                  />
+                </div>
+              </td>
+              <td
+                class="ant-picker-cell ant-picker-cell-in-view"
+                title="2023-04-17"
+              >
+                <div
+                  class="ant-picker-cell-inner ant-picker-calendar-date"
+                >
+                  <div
+                    class="ant-picker-calendar-date-value"
+                  >
+                    17
+                  </div>
+                  <div
+                    class="ant-picker-calendar-date-content"
+                  />
+                </div>
+              </td>
+              <td
+                class="ant-picker-cell ant-picker-cell-in-view"
+                title="2023-04-18"
+              >
+                <div
+                  class="ant-picker-cell-inner ant-picker-calendar-date"
+                >
+                  <div
+                    class="ant-picker-calendar-date-value"
+                  >
+                    18
+                  </div>
+                  <div
+                    class="ant-picker-calendar-date-content"
+                  />
+                </div>
+              </td>
+              <td
+                class="ant-picker-cell ant-picker-cell-in-view"
+                title="2023-04-19"
+              >
+                <div
+                  class="ant-picker-cell-inner ant-picker-calendar-date"
+                >
+                  <div
+                    class="ant-picker-calendar-date-value"
+                  >
+                    19
+                  </div>
+                  <div
+                    class="ant-picker-calendar-date-content"
+                  />
+                </div>
+              </td>
+              <td
+                class="ant-picker-cell ant-picker-cell-in-view"
+                title="2023-04-20"
+              >
+                <div
+                  class="ant-picker-cell-inner ant-picker-calendar-date"
+                >
+                  <div
+                    class="ant-picker-calendar-date-value"
+                  >
+                    20
+                  </div>
+                  <div
+                    class="ant-picker-calendar-date-content"
+                  />
+                </div>
+              </td>
+              <td
+                class="ant-picker-cell ant-picker-cell-in-view"
+                title="2023-04-21"
+              >
+                <div
+                  class="ant-picker-cell-inner ant-picker-calendar-date"
+                >
+                  <div
+                    class="ant-picker-calendar-date-value"
+                  >
+                    21
+                  </div>
+                  <div
+                    class="ant-picker-calendar-date-content"
+                  />
+                </div>
+              </td>
+              <td
+                class="ant-picker-cell ant-picker-cell-in-view"
+                title="2023-04-22"
+              >
+                <div
+                  class="ant-picker-cell-inner ant-picker-calendar-date"
+                >
+                  <div
+                    class="ant-picker-calendar-date-value"
+                  >
+                    22
+                  </div>
+                  <div
+                    class="ant-picker-calendar-date-content"
+                  />
+                </div>
+              </td>
+            </tr>
+            <tr>
+              <td
+                class="ant-picker-cell ant-picker-cell-in-view"
+                title="2023-04-23"
+              >
+                <div
+                  class="ant-picker-cell-inner ant-picker-calendar-date"
+                >
+                  <div
+                    class="ant-picker-calendar-date-value"
+                  >
+                    23
+                  </div>
+                  <div
+                    class="ant-picker-calendar-date-content"
+                  />
+                </div>
+              </td>
+              <td
+                class="ant-picker-cell ant-picker-cell-in-view"
+                title="2023-04-24"
+              >
+                <div
+                  class="ant-picker-cell-inner ant-picker-calendar-date"
+                >
+                  <div
+                    class="ant-picker-calendar-date-value"
+                  >
+                    24
+                  </div>
+                  <div
+                    class="ant-picker-calendar-date-content"
+                  />
+                </div>
+              </td>
+              <td
+                class="ant-picker-cell ant-picker-cell-in-view"
+                title="2023-04-25"
+              >
+                <div
+                  class="ant-picker-cell-inner ant-picker-calendar-date"
+                >
+                  <div
+                    class="ant-picker-calendar-date-value"
+                  >
+                    25
+                  </div>
+                  <div
+                    class="ant-picker-calendar-date-content"
+                  />
+                </div>
+              </td>
+              <td
+                class="ant-picker-cell ant-picker-cell-in-view"
+                title="2023-04-26"
+              >
+                <div
+                  class="ant-picker-cell-inner ant-picker-calendar-date"
+                >
+                  <div
+                    class="ant-picker-calendar-date-value"
+                  >
+                    26
+                  </div>
+                  <div
+                    class="ant-picker-calendar-date-content"
+                  />
+                </div>
+              </td>
+              <td
+                class="ant-picker-cell ant-picker-cell-in-view"
+                title="2023-04-27"
+              >
+                <div
+                  class="ant-picker-cell-inner ant-picker-calendar-date"
+                >
+                  <div
+                    class="ant-picker-calendar-date-value"
+                  >
+                    27
+                  </div>
+                  <div
+                    class="ant-picker-calendar-date-content"
+                  />
+                </div>
+              </td>
+              <td
+                class="ant-picker-cell ant-picker-cell-in-view"
+                title="2023-04-28"
+              >
+                <div
+                  class="ant-picker-cell-inner ant-picker-calendar-date"
+                >
+                  <div
+                    class="ant-picker-calendar-date-value"
+                  >
+                    28
+                  </div>
+                  <div
+                    class="ant-picker-calendar-date-content"
+                  />
+                </div>
+              </td>
+              <td
+                class="ant-picker-cell ant-picker-cell-in-view"
+                title="2023-04-29"
+              >
+                <div
+                  class="ant-picker-cell-inner ant-picker-calendar-date"
+                >
+                  <div
+                    class="ant-picker-calendar-date-value"
+                  >
+                    29
+                  </div>
+                  <div
+                    class="ant-picker-calendar-date-content"
+                  />
+                </div>
+              </td>
+            </tr>
+            <tr>
+              <td
+                class="ant-picker-cell ant-picker-cell-end ant-picker-cell-in-view"
+                title="2023-04-30"
+              >
+                <div
+                  class="ant-picker-cell-inner ant-picker-calendar-date"
+                >
+                  <div
+                    class="ant-picker-calendar-date-value"
+                  >
+                    30
+                  </div>
+                  <div
+                    class="ant-picker-calendar-date-content"
+                  />
+                </div>
+              </td>
+              <td
+                class="ant-picker-cell ant-picker-cell-start"
+                title="2023-05-01"
+              >
+                <div
+                  class="ant-picker-cell-inner ant-picker-calendar-date"
+                >
+                  <div
+                    class="ant-picker-calendar-date-value"
+                  >
+                    01
+                  </div>
+                  <div
+                    class="ant-picker-calendar-date-content"
+                  />
+                </div>
+              </td>
+              <td
+                class="ant-picker-cell"
+                title="2023-05-02"
+              >
+                <div
+                  class="ant-picker-cell-inner ant-picker-calendar-date"
+                >
+                  <div
+                    class="ant-picker-calendar-date-value"
+                  >
+                    02
+                  </div>
+                  <div
+                    class="ant-picker-calendar-date-content"
+                  />
+                </div>
+              </td>
+              <td
+                class="ant-picker-cell"
+                title="2023-05-03"
+              >
+                <div
+                  class="ant-picker-cell-inner ant-picker-calendar-date"
+                >
+                  <div
+                    class="ant-picker-calendar-date-value"
+                  >
+                    03
+                  </div>
+                  <div
+                    class="ant-picker-calendar-date-content"
+                  />
+                </div>
+              </td>
+              <td
+                class="ant-picker-cell"
+                title="2023-05-04"
+              >
+                <div
+                  class="ant-picker-cell-inner ant-picker-calendar-date"
+                >
+                  <div
+                    class="ant-picker-calendar-date-value"
+                  >
+                    04
+                  </div>
+                  <div
+                    class="ant-picker-calendar-date-content"
+                  />
+                </div>
+              </td>
+              <td
+                class="ant-picker-cell"
+                title="2023-05-05"
+              >
+                <div
+                  class="ant-picker-cell-inner ant-picker-calendar-date"
+                >
+                  <div
+                    class="ant-picker-calendar-date-value"
+                  >
+                    05
+                  </div>
+                  <div
+                    class="ant-picker-calendar-date-content"
+                  />
+                </div>
+              </td>
+              <td
+                class="ant-picker-cell"
+                title="2023-05-06"
+              >
+                <div
+                  class="ant-picker-cell-inner ant-picker-calendar-date"
+                >
+                  <div
+                    class="ant-picker-calendar-date-value"
+                  >
+                    06
+                  </div>
+                  <div
+                    class="ant-picker-calendar-date-content"
+                  />
+                </div>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/components/calendar/__tests__/index.test.tsx
+++ b/components/calendar/__tests__/index.test.tsx
@@ -538,4 +538,10 @@ describe('Calendar', () => {
     expect(container.querySelector('.bar')).toBeTruthy();
     errSpy.mockRestore();
   });
+
+  it('support Calendar.generateCalendar', () => {
+    const MyCalendar = Calendar.generateCalendar(dayjsGenerateConfig);
+    const { container } = render(<MyCalendar />);
+    expect(container.firstChild).toMatchSnapshot();
+  });
 });

--- a/components/calendar/index.ts
+++ b/components/calendar/index.ts
@@ -5,5 +5,11 @@ import generateCalendar from './generateCalendar';
 
 const Calendar = generateCalendar<Dayjs>(dayjsGenerateConfig);
 
+export type CalendarType = typeof Calendar & {
+  generateCalendar: typeof generateCalendar;
+};
+
+(Calendar as CalendarType).generateCalendar = generateCalendar;
+
 export type { CalendarProps };
-export default Calendar;
+export default Calendar as CalendarType;

--- a/components/date-picker/__tests__/DatePicker.test.tsx
+++ b/components/date-picker/__tests__/DatePicker.test.tsx
@@ -291,8 +291,8 @@ describe('DatePicker', () => {
   });
 
   it('support DatePicker.generatePicker', () => {
-    const FnsDatePicker = DatePicker.generatePicker(dayJsGenerateConfig);
-    const { container } = render(<FnsDatePicker />);
+    const MyDatePicker = DatePicker.generatePicker(dayJsGenerateConfig);
+    const { container } = render(<MyDatePicker />);
     expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/components/date-picker/__tests__/DatePicker.test.tsx
+++ b/components/date-picker/__tests__/DatePicker.test.tsx
@@ -2,13 +2,14 @@ import dayjs from 'dayjs';
 import 'dayjs/locale/mk'; // to test local in 'prop locale should works' test case
 import customParseFormat from 'dayjs/plugin/customParseFormat';
 import MockDate from 'mockdate';
-import React from 'react';
+import dateFnsGenerateConfig from 'rc-picker/lib/generate/dateFns';
 import type { TriggerProps } from 'rc-trigger';
-import { fireEvent, render } from '../../../tests/utils';
+import React from 'react';
 import DatePicker from '..';
 import focusTest from '../../../tests/shared/focusTest';
-import type { PickerLocale } from '../generatePicker';
+import { fireEvent, render } from '../../../tests/utils';
 import { resetWarned } from '../../_util/warning';
+import type { PickerLocale } from '../generatePicker';
 
 dayjs.extend(customParseFormat);
 
@@ -287,5 +288,11 @@ describe('DatePicker', () => {
     expect(container.querySelector('.legacy')).toBeTruthy();
 
     errSpy.mockRestore();
+  });
+
+  it('support DatePicker.generatePicker', () => {
+    const FnsDatePicker = DatePicker.generatePicker(dateFnsGenerateConfig);
+    const { container } = render(<FnsDatePicker />);
+    expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/components/date-picker/__tests__/DatePicker.test.tsx
+++ b/components/date-picker/__tests__/DatePicker.test.tsx
@@ -2,7 +2,7 @@ import dayjs from 'dayjs';
 import 'dayjs/locale/mk'; // to test local in 'prop locale should works' test case
 import customParseFormat from 'dayjs/plugin/customParseFormat';
 import MockDate from 'mockdate';
-import dateFnsGenerateConfig from 'rc-picker/lib/generate/dateFns';
+import dayJsGenerateConfig from 'rc-picker/lib/generate/dayjs';
 import type { TriggerProps } from 'rc-trigger';
 import React from 'react';
 import DatePicker from '..';
@@ -291,7 +291,7 @@ describe('DatePicker', () => {
   });
 
   it('support DatePicker.generatePicker', () => {
-    const FnsDatePicker = DatePicker.generatePicker(dateFnsGenerateConfig);
+    const FnsDatePicker = DatePicker.generatePicker(dayJsGenerateConfig);
     const { container } = render(<FnsDatePicker />);
     expect(container.firstChild).toMatchSnapshot();
   });

--- a/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
+++ b/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
@@ -1224,3 +1224,45 @@ Array [
   </div>,
 ]
 `;
+
+exports[`DatePicker support DatePicker.generatePicker 1`] = `
+<div
+  class="ant-picker"
+>
+  <div
+    class="ant-picker-input"
+  >
+    <input
+      autocomplete="off"
+      placeholder="Select date"
+      readonly=""
+      size="12"
+      title=""
+      value=""
+    />
+    <span
+      class="ant-picker-suffix"
+    >
+      <span
+        aria-label="calendar"
+        class="anticon anticon-calendar"
+        role="img"
+      >
+        <svg
+          aria-hidden="true"
+          data-icon="calendar"
+          fill="currentColor"
+          focusable="false"
+          height="1em"
+          viewBox="64 64 896 896"
+          width="1em"
+        >
+          <path
+            d="M880 184H712v-64c0-4.4-3.6-8-8-8h-56c-4.4 0-8 3.6-8 8v64H384v-64c0-4.4-3.6-8-8-8h-56c-4.4 0-8 3.6-8 8v64H144c-17.7 0-32 14.3-32 32v664c0 17.7 14.3 32 32 32h736c17.7 0 32-14.3 32-32V216c0-17.7-14.3-32-32-32zm-40 656H184V460h656v380zM184 392V256h128v48c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8v-48h256v48c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8v-48h128v136H184z"
+          />
+        </svg>
+      </span>
+    </span>
+  </div>
+</div>
+`;

--- a/components/date-picker/index.ts
+++ b/components/date-picker/index.ts
@@ -2,9 +2,9 @@ import type { Dayjs } from 'dayjs';
 import dayjsGenerateConfig from 'rc-picker/lib/generate/dayjs';
 import genPurePanel from '../_util/PurePanel';
 import type {
+  RangePickerProps as BaseRangePickerProps,
   PickerDateProps,
   PickerProps,
-  RangePickerProps as BaseRangePickerProps,
 } from './generatePicker';
 import generatePicker from './generatePicker';
 
@@ -15,14 +15,18 @@ export type RangePickerProps = BaseRangePickerProps<Dayjs>;
 
 const DatePicker = generatePicker<Dayjs>(dayjsGenerateConfig);
 
+export type DatePickerType = typeof DatePicker & {
+  _InternalPanelDoNotUseOrYouWillBeFired: typeof PurePanel;
+  _InternalRangePanelDoNotUseOrYouWillBeFired: typeof PureRangePanel;
+  generatePicker: typeof generatePicker;
+};
+
 // We don't care debug panel
 /* istanbul ignore next */
 const PurePanel = genPurePanel(DatePicker, 'picker');
-(DatePicker as any)._InternalPanelDoNotUseOrYouWillBeFired = PurePanel;
+(DatePicker as DatePickerType)._InternalPanelDoNotUseOrYouWillBeFired = PurePanel;
 const PureRangePanel = genPurePanel(DatePicker.RangePicker, 'picker');
-(DatePicker as any)._InternalRangePanelDoNotUseOrYouWillBeFired = PureRangePanel;
+(DatePicker as DatePickerType)._InternalRangePanelDoNotUseOrYouWillBeFired = PureRangePanel;
+(DatePicker as DatePickerType).generatePicker = generatePicker;
 
-export default DatePicker as typeof DatePicker & {
-  _InternalPanelDoNotUseOrYouWillBeFired: typeof PurePanel;
-  _InternalRangePanelDoNotUseOrYouWillBeFired: typeof PureRangePanel;
-};
+export default DatePicker as DatePickerType;

--- a/docs/react/use-custom-date-library.en-US.md
+++ b/docs/react/use-custom-date-library.en-US.md
@@ -20,13 +20,13 @@ Create `src/components/DatePicker.tsx`.
 For example:
 
 ```tsx
-import generatePicker from 'antd/es/date-picker/generatePicker';
+import { DatePicker } from 'antd';
 import type { Moment } from 'moment';
 import momentGenerateConfig from 'rc-picker/lib/generate/moment';
 
-const DatePicker = generatePicker<Moment>(momentGenerateConfig);
+const MyDatePicker = DatePicker.generatePicker<Moment>(momentGenerateConfig);
 
-export default DatePicker;
+export default MyDatePicker;
 ```
 
 ### TimePicker.tsx
@@ -59,13 +59,13 @@ Create `src/components/Calendar.tsx`.
 For example:
 
 ```tsx
-import generateCalendar from 'antd/es/calendar/generateCalendar';
+import { Calendar } from 'antd';
 import type { Moment } from 'moment';
-import momentGenerateConfig from 'rc-picker/lib/generate/moment';
+import momentGenerateConfig from 'rc-picker/es/generate/moment';
 
-const Calendar = generateCalendar<Moment>(momentGenerateConfig);
+const MyCalendar = Calendar.generateCalendar<Moment>(momentGenerateConfig);
 
-export default Calendar;
+export default MyCalendar;
 ```
 
 ### Export Custom component
@@ -119,12 +119,12 @@ Create `src/components/DatePicker.tsx`.
 Code as follows:
 
 ```tsx
-import generatePicker from 'antd/es/date-picker/generatePicker';
+import { DatePicker } from 'antd';
 import dateFnsGenerateConfig from 'rc-picker/lib/generate/dateFns';
 
-const DatePicker = generatePicker<Date>(dateFnsGenerateConfig);
+const MyDatePicker = DatePicker.generatePicker<Date>(dateFnsGenerateConfig);
 
-export default DatePicker;
+export default MyDatePicker;
 ```
 
 ## Use luxon
@@ -136,13 +136,13 @@ Since `antd 5.4.0`, [luxon](https://moment.github.io/luxon/) can be used instead
 Create a `src/components/DatePicker.tsx` file, and implement the luxon based picker as follows:
 
 ```tsx
-import generatePicker from 'antd/es/date-picker/generatePicker';
+import { DatePicker } from 'antd';
 import type { DateTime } from 'luxon';
 import luxonGenerateConfig from 'rc-picker/lib/generate/luxon';
 
-const DatePicker = generatePicker<DateTime>(luxonGenerateConfig);
+const MyDatePicker = DatePicker.generatePicker<DateTime>(luxonGenerateConfig);
 
-export default DatePicker;
+export default MyDatePicker;
 ```
 
 ### Notable differences with dayjs
@@ -159,7 +159,7 @@ This introduces some formatting differences with the other date libraries. As of
 It is possible to customize these default luxon behaviors by adjusting the luxon config:
 
 ```tsx
-import generatePicker from 'antd/es/date-picker/generatePicker';
+import { DatePicker } from 'antd';
 import type { DateTime } from 'luxon';
 import luxonGenerateConfig from 'rc-picker/lib/generate/luxon';
 
@@ -170,9 +170,9 @@ const customLuxonConfig = {
   },
 };
 
-const DatePicker = generatePicker<DateTime>(customLuxonConfig);
+const MyDatePicker = DatePicker.generatePicker<DateTime>(customLuxonConfig);
 
-export default DatePicker;
+export default MyDatePicker;
 ```
 
 Note that by doing such customization, the resulting DatePicker behavior might be altered in unexpected ways, so make sure you are testing for edge cases.

--- a/docs/react/use-custom-date-library.zh-CN.md
+++ b/docs/react/use-custom-date-library.zh-CN.md
@@ -18,13 +18,13 @@ Ant Design 默认使用 [Day.js](https://day.js.org) 来处理时间日期问题
 编写如下代码:
 
 ```tsx
-import generatePicker from 'antd/es/date-picker/generatePicker';
+import { DatePicker } from 'antd';
 import type { Moment } from 'moment';
-import momentGenerateConfig from 'rc-picker/es/generate/moment';
+import momentGenerateConfig from 'rc-picker/lib/generate/moment';
 
-const DatePicker = generatePicker<Moment>(momentGenerateConfig);
+const MyDatePicker = DatePicker.generatePicker<Moment>(momentGenerateConfig);
 
-export default DatePicker;
+export default MyDatePicker;
 ```
 
 ### TimePicker.tsx
@@ -57,13 +57,13 @@ export default TimePicker;
 编写如下代码:
 
 ```tsx
-import generateCalendar from 'antd/es/calendar/generateCalendar';
+import { Calendar } from 'antd';
 import type { Moment } from 'moment';
 import momentGenerateConfig from 'rc-picker/es/generate/moment';
 
-const Calendar = generateCalendar<Moment>(momentGenerateConfig);
+const MyCalendar = Calendar.generateCalendar<Moment>(momentGenerateConfig);
 
-export default Calendar;
+export default MyCalendar;
 ```
 
 #### 导出自定义组件
@@ -117,12 +117,12 @@ module.exports = {
 编写如下代码:
 
 ```tsx
-import generatePicker from 'antd/es/date-picker/generatePicker';
+import { DatePicker } from 'antd';
 import dateFnsGenerateConfig from 'rc-picker/es/generate/dateFns';
 
-const DatePicker = generatePicker<Date>(dateFnsGenerateConfig);
+const MyDatePicker = DatePicker.generatePicker<Date>(dateFnsGenerateConfig);
 
-export default DatePicker;
+export default MyDatePicker;
 ```
 
 ## 使用 luxon
@@ -134,13 +134,13 @@ export default DatePicker;
 创建一个 `DatePicker.tsx` 文件，并定义一个基于 luxon 的 DatePicker 组件：
 
 ```tsx
-import generatePicker from 'antd/es/date-picker/generatePicker';
+import { DatePicker } from 'antd';
 import type { DateTime } from 'luxon';
 import luxonGenerateConfig from 'rc-picker/lib/generate/luxon';
 
-const DatePicker = generatePicker<DateTime>(luxonGenerateConfig);
+const MyDatePicker = DatePicker.generatePicker<DateTime>(luxonGenerateConfig);
 
-export default DatePicker;
+export default MyDatePicker;
 ```
 
 ### 与 dayjs 的差异
@@ -157,7 +157,7 @@ luxon 用户应该悉知，它本身没有 local 的实现。相反，它依赖�
 可以通过调整 luxon 配置来自定义这些默认的 luxon 行为：
 
 ```tsx
-import generatePicker from 'antd/es/date-picker/generatePicker';
+import { DatePicker } from 'antd';
 import type { DateTime } from 'luxon';
 import luxonGenerateConfig from 'rc-picker/lib/generate/luxon';
 
@@ -168,9 +168,9 @@ const customLuxonConfig = {
   },
 };
 
-const DatePicker = generatePicker<DateTime>(customLuxonConfig);
+const MyDatePicker = DatePicker.generatePicker<DateTime>(customLuxonConfig);
 
-export default DatePicker;
+export default MyDatePicker;
 ```
 
 请注意，通过进行此类自定义，生成的 DatePicker 行为可能会以意想不到的方式发生变化，因此请确保你测试过一些边界情况。


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

resolve #41749

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     DatePicker & Calendar export generate function directly now.        |
| 🇨🇳 Chinese |  DatePicker 与 Calendar 直接导出生成自定义日期库组件方法，不再需要通过 module 路径引入使用。     |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e1fff21</samp>

This pull request adds support for custom date libraries in the `DatePicker` and `Calendar` components. It introduces the `generatePicker` and `generateCalendar` methods as static properties on the components, which allow users to create custom components with different date libraries and configurations. It also updates the documentation and tests for these features.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e1fff21</samp>

*  Add `generatePicker` and `generateCalendar` methods as static properties of `DatePicker` and `Calendar` components respectively, to allow users to create custom components with different date libraries ([link](https://github.com/ant-design/ant-design/pull/41773/files?diff=unified&w=0#diff-013735da2a9e27cd090e2a7b89864881fcab5e33ff74b538079f42b82ccd3d24L8-R15), [link](https://github.com/ant-design/ant-design/pull/41773/files?diff=unified&w=0#diff-78eb7aa1662e48dc14665cbcead280795a60503742024dd031b87311186be5eeL18-R32), [link](https://github.com/ant-design/ant-design/pull/41773/files?diff=unified&w=0#diff-0a5821c1b32fdf9bf1d3bb55702937aead9206b6762df0497ff7b030f405a21aR541-R546), [link](https://github.com/ant-design/ant-design/pull/41773/files?diff=unified&w=0#diff-7fdce5d71fac3793bf16cbc035559eeb8d5565c0db96d0b9399b5265a8c471b4R292-R297))
*  Update the import of the `generatePicker` and `generateCalendar` functions in the test files and the documentation files to use the methods from the `DatePicker` and `Calendar` components instead ([link](https://github.com/ant-design/ant-design/pull/41773/files?diff=unified&w=0#diff-7fdce5d71fac3793bf16cbc035559eeb8d5565c0db96d0b9399b5265a8c471b4L5-R12), [link](https://github.com/ant-design/ant-design/pull/41773/files?diff=unified&w=0#diff-7d7f99f1d1ed3ea033947dc9c52dd79eaa41231f99f065da31ba79f01daaaf10L23-R29), [link](https://github.com/ant-design/ant-design/pull/41773/files?diff=unified&w=0#diff-7d7f99f1d1ed3ea033947dc9c52dd79eaa41231f99f065da31ba79f01daaaf10L62-R68), [link](https://github.com/ant-design/ant-design/pull/41773/files?diff=unified&w=0#diff-7d7f99f1d1ed3ea033947dc9c52dd79eaa41231f99f065da31ba79f01daaaf10L122-R127), [link](https://github.com/ant-design/ant-design/pull/41773/files?diff=unified&w=0#diff-7d7f99f1d1ed3ea033947dc9c52dd79eaa41231f99f065da31ba79f01daaaf10L139-R145), [link](https://github.com/ant-design/ant-design/pull/41773/files?diff=unified&w=0#diff-7d7f99f1d1ed3ea033947dc9c52dd79eaa41231f99f065da31ba79f01daaaf10L173-R175), [link](https://github.com/ant-design/ant-design/pull/41773/files?diff=unified&w=0#diff-e506cd45013ef022ee1e0e5d855ee37b6d91d4019e2f32a73c758df5441b108eL21-R27), [link](https://github.com/ant-design/ant-design/pull/41773/files?diff=unified&w=0#diff-e506cd45013ef022ee1e0e5d855ee37b6d91d4019e2f32a73c758df5441b108eL60-R66), [link](https://github.com/ant-design/ant-design/pull/41773/files?diff=unified&w=0#diff-e506cd45013ef022ee1e0e5d855ee37b6d91d4019e2f32a73c758df5441b108eL120-R125), [link](https://github.com/ant-design/ant-design/pull/41773/files?diff=unified&w=0#diff-e506cd45013ef022ee1e0e5d855ee37b6d91d4019e2f32a73c758df5441b108eL137-R143), [link](https://github.com/ant-design/ant-design/pull/41773/files?diff=unified&w=0#diff-e506cd45013ef022ee1e0e5d855ee37b6d91d4019e2f32a73c758df5441b108eL171-R173))
*  Update the import of the `luxonGenerateConfig` from the `rc-picker` library in the documentation files to use the `lib` directory instead of the `es` directory, for consistency with the other date library imports ([link](https://github.com/ant-design/ant-design/pull/41773/files?diff=unified&w=0#diff-7d7f99f1d1ed3ea033947dc9c52dd79eaa41231f99f065da31ba79f01daaaf10L162-R162), [link](https://github.com/ant-design/ant-design/pull/41773/files?diff=unified&w=0#diff-e506cd45013ef022ee1e0e5d855ee37b6d91d4019e2f32a73c758df5441b108eL160-R160))
*  Reorder the import of the types from the `generatePicker` module in the `components/date-picker/index.ts` file, to group the types together and follow the alphabetical order ([link](https://github.com/ant-design/ant-design/pull/41773/files?diff=unified&w=0#diff-78eb7aa1662e48dc14665cbcead280795a60503742024dd031b87311186be5eeL5-R7))
*  Move the assignment of the `_InternalPanelDoNotUseOrYouWillBeFired` and `_InternalRangePanelDoNotUseOrYouWillBeFired` properties to the `DatePicker` component after the type casting, to avoid type errors ([link](https://github.com/ant-design/ant-design/pull/41773/files?diff=unified&w=0#diff-78eb7aa1662e48dc14665cbcead280795a60503742024dd031b87311186be5eeL18-R32))
