### PR TITLE
fix: typo in deDE

### DIFF
--- a/components/locale/de_DE.ts
+++ b/components/locale/de_DE.ts
@@ -124,7 +124,7 @@ const localeValues: Locale = {
         range: 'Die Anzahl an ${label} muss zwischen ${min} und ${max} liegen',
       },
       pattern: {
-        mismatch: '${label} enspricht nicht dem ${pattern} Muster',
+        mismatch: '${label} entspricht nicht dem ${pattern} Muster',
       },
     },
   },


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [x] Other (about what?):  Typo in locale

### 🔗 Related issue link


### 💡 Background and solution


### 📝 Changelog

- fixed typo in German locale

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  fixed typo in German locale  |
| 🇨🇳 Chinese | 修复德语本地化文案。           |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3a09e26</samp>

Fix typo in German validation message for pattern mismatch. Update `components/locale/de_DE.ts` file with correct spelling.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3a09e26</samp>

* Fix typo in German translation of pattern mismatch message ([link](https://github.com/ant-design/ant-design/pull/41780/files?diff=unified&w=0#diff-bf5d0701649117509333c62e254e743e03f7d52176dca30bb76ccb3055e83ff0L127-R127))
