### PR TITLE
fix: checkbox选中不正常问题

### DIFF
--- a/components/checkbox/Checkbox.tsx
+++ b/components/checkbox/Checkbox.tsx
@@ -98,6 +98,13 @@ const InternalCheckbox: React.ForwardRefRenderFunction<CheckboxRef, CheckboxProp
   const [wrapSSR, hashId] = useStyle(prefixCls);
 
   const checkboxProps: CheckboxProps = { ...restProps };
+
+  React.useEffect(() => {
+    if (checkboxProps.checked === undefined || checkboxProps.checked === null) {
+      checkboxProps.checked = restProps.defaultChecked;
+    }
+  }, []);
+
   if (checkboxGroup && !skipGroup) {
     checkboxProps.onChange = (...args) => {
       if (restProps.onChange) {

--- a/components/checkbox/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/checkbox/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -159,6 +159,25 @@ Array [
 ]
 `;
 
+exports[`renders components/checkbox/demo/debug-defaultChecked.tsx extend context correctly 1`] = `
+<label
+  class="ant-checkbox-wrapper"
+>
+  <span
+    class="ant-checkbox ant-checkbox-checked"
+  >
+    <input
+      checked=""
+      class="ant-checkbox-input"
+      type="checkbox"
+    />
+    <span
+      class="ant-checkbox-inner"
+    />
+  </span>
+</label>
+`;
+
 exports[`renders components/checkbox/demo/debug-disable-popover.tsx extend context correctly 1`] = `
 <div
   style="padding: 56px;"

--- a/components/checkbox/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/checkbox/__tests__/__snapshots__/demo.test.tsx.snap
@@ -159,6 +159,25 @@ Array [
 ]
 `;
 
+exports[`renders components/checkbox/demo/debug-defaultChecked.tsx correctly 1`] = `
+<label
+  class="ant-checkbox-wrapper"
+>
+  <span
+    class="ant-checkbox ant-checkbox-checked"
+  >
+    <input
+      checked=""
+      class="ant-checkbox-input"
+      type="checkbox"
+    />
+    <span
+      class="ant-checkbox-inner"
+    />
+  </span>
+</label>
+`;
+
 exports[`renders components/checkbox/demo/debug-disable-popover.tsx correctly 1`] = `
 <div
   style="padding:56px"

--- a/components/checkbox/demo/debug-defaultChecked.md
+++ b/components/checkbox/demo/debug-defaultChecked.md
@@ -1,0 +1,7 @@
+## zh-CN
+
+当 CheckBox 中属性 checked 值为 undefined,defaultChecked 值为 true ,该 checkbox 应该被选中
+
+## en-US
+
+When the checked value of the CheckBox attribute is undefined and the defaultChecked value is true, the checkbox should be checked

--- a/components/checkbox/demo/debug-defaultChecked.tsx
+++ b/components/checkbox/demo/debug-defaultChecked.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import { Checkbox } from 'antd';
+
+const App: React.FC = () => <Checkbox checked={undefined} defaultChecked />;
+
+export default App;

--- a/components/checkbox/index.en-US.md
+++ b/components/checkbox/index.en-US.md
@@ -26,6 +26,7 @@ Checkbox component.
 <code src="./demo/layout.tsx">Use with Grid</code>
 <code src="./demo/debug-line.tsx" debug>Same line</code>
 <code src="./demo/debug-disable-popover.tsx" debug>Disabled to show Tooltip</code>
+<code src="./demo/debug-defaultChecked.tsx" debug>should be checked</code>
 
 ## API
 

--- a/components/checkbox/index.zh-CN.md
+++ b/components/checkbox/index.zh-CN.md
@@ -27,6 +27,7 @@ demo:
 <code src="./demo/layout.tsx">布局</code>
 <code src="./demo/debug-line.tsx" debug>同行布局</code>
 <code src="./demo/debug-disable-popover.tsx" debug>禁用下的 Tooltip</code>
+<code src="./demo/debug-defaultChecked.tsx" debug>应该被选中</code>
 
 ## API
 


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
新特性请提交至 feature 分支，其余可提交至 master 分支。
在维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

[[English Template / 英文模板](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE.md?plain=1)]

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 工作流程
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

 fix: https://github.com/ant-design/ant-design/issues/35130

### 💡 需求背景和解决方案


1. 当 CheckBox 中checked 属性值为 undefined,defaultChecked 值为 true ,该 checkbox 应该被选中。但实际情况未选中

### 📝 更新日志



| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |   Make the Checkbox component and the native Checkbox have the same state in the same environment       |
| 🇨🇳 中文 |  使Checkbox组件 和原生Checkbox 在同样环境下，状态一致  |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供

---

<!--
以下为 copilot 自动生成的 CR 结果，请勿修改
-->

### 🚀 概述

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 370e2f9</samp>

This pull request fixes a bug where the checkbox component would not be checked if the `checked` prop was undefined and the `defaultChecked` prop was true. It also adds a demo file and a code example to the documentation to illustrate the bug and the expected behavior.

### 🔍 实现细节

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 370e2f9</samp>

* Fix a bug where the checkbox component would not be checked if the checked prop was undefined and the defaultChecked prop was true ([link](https://github.com/ant-design/ant-design/pull/41794/files?diff=unified&w=0#diff-e5138148a71ae8aea8e59e4b8934815b003ff8836bbb6ca6dc91d41aef32ef86R101-R107))
* Add code examples to the English and Chinese documentation of the checkbox component that link to the bug demonstration file and show the expected output ([link](https://github.com/ant-design/ant-design/pull/41794/files?diff=unified&w=0#diff-5b7813283fde6431f10030c6ace1984dc18e77251c8809423c1b41232a92466fR29), [link](https://github.com/ant-design/ant-design/pull/41794/files?diff=unified&w=0#diff-e387f360a3bed763861e56375e36712dacf05631b3466b2236a084bf4d074a9cR30))